### PR TITLE
Do not automatically retry upload after 3 failures

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -7,7 +7,7 @@ data model as well as any custom migrations.
 @jklausa 2019-08-19
 - `AbstractPost`: Addded a  `confirmedChangesHash`  and  `confirmedChangesTimestamp`  properties. 
 @leandroalonso 2019-09-27
--`AbstractPost`: Added `autoUploadFailureCount` property.
+-`AbstractPost`: Added `autoUploadAttemptsCount` property.
 
 ## WordPress 90
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -6,6 +6,8 @@ data model as well as any custom migrations.
 ## WordPress 91
 @jklausa 2019-08-19
 - `AbstractPost`: Addded a  `confirmedChangesHash`  and  `confirmedChangesTimestamp`  properties. 
+@leandroalonso 2019-09-27
+-`AbstractPost`: Added `autoUploadFailureCount` property.
 
 ## WordPress 90
 

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -44,7 +44,9 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
  This array will contain a list of revision IDs.
  */
 @property (nonatomic, strong, nullable) NSArray *revisions;
-
+/**
+ The default value of autoUploadAttemptsCount is 0.
+*/
 @property (nonatomic, strong, nonnull) NSNumber *autoUploadAttemptsCount;
 
 // Revision management

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -45,7 +45,7 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
  */
 @property (nonatomic, strong, nullable) NSArray *revisions;
 
-@property (nonatomic, strong, nonnull) NSNumber *autoUploadFailureCount;
+@property (nonatomic, strong, nonnull) NSNumber *autoUploadAttemptsCount;
 
 // Revision management
 - (AbstractPost *)createRevision;

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -45,6 +45,8 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
  */
 @property (nonatomic, strong, nullable) NSArray *revisions;
 
+@property (nonatomic, strong, nonnull) NSNumber *autoUploadFailureCount;
+
 // Revision management
 - (AbstractPost *)createRevision;
 - (void)deleteRevision;

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -29,7 +29,7 @@ final class PostAutoUploadInteractor {
         guard post.isFailed,
             let status = post.status,
             PostAutoUploadInteractor.allowedStatuses.contains(status),
-        post.autoUploadFailureCount.intValue < maxNumberOfAttempts else {
+            post.autoUploadAttemptsCount.intValue < maxNumberOfAttempts else {
                 return .nothing
         }
 

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -15,6 +15,8 @@ final class PostAutoUploadInteractor {
 
     private static let allowedStatuses: [BasePost.Status] = [.draft, .publish]
 
+    private let maxNumberOfAttempts = 3
+
     /// Returns what action should be executed when we retry a failed upload.
     ///
     /// In some cases, we do not want to automatically upload a post if the user has not
@@ -26,7 +28,8 @@ final class PostAutoUploadInteractor {
     func autoUploadAction(for post: AbstractPost) -> AutoUploadAction {
         guard post.isFailed,
             let status = post.status,
-            PostAutoUploadInteractor.allowedStatuses.contains(status) else {
+            PostAutoUploadInteractor.allowedStatuses.contains(status),
+        post.autoUploadFailureCount.intValue < maxNumberOfAttempts else {
                 return .nothing
         }
 

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -15,7 +15,7 @@ final class PostAutoUploadInteractor {
 
     private static let allowedStatuses: [BasePost.Status] = [.draft, .publish]
 
-    let maxNumberOfAttempts = 3
+    static let maxNumberOfAttempts = 3
 
     /// Returns what action should be executed when we retry a failed upload.
     ///
@@ -29,7 +29,7 @@ final class PostAutoUploadInteractor {
         guard post.isFailed,
             let status = post.status,
             PostAutoUploadInteractor.allowedStatuses.contains(status),
-            post.autoUploadAttemptsCount.intValue < maxNumberOfAttempts else {
+            post.autoUploadAttemptsCount.intValue < PostAutoUploadInteractor.maxNumberOfAttempts else {
                 return .nothing
         }
 

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -15,7 +15,7 @@ final class PostAutoUploadInteractor {
 
     private static let allowedStatuses: [BasePost.Status] = [.draft, .publish]
 
-    private let maxNumberOfAttempts = 3
+    let maxNumberOfAttempts = 3
 
     /// Returns what action should be executed when we retry a failed upload.
     ///

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -13,6 +13,12 @@ final class PostAutoUploadInteractor {
         case nothing
     }
 
+    enum AutoUploadAttemptState {
+        case attempted
+        case reachedLimit
+        case notAttempted
+    }
+
     private static let allowedStatuses: [BasePost.Status] = [.draft, .publish]
 
     static let maxNumberOfAttempts = 3
@@ -65,5 +71,18 @@ final class PostAutoUploadInteractor {
         }
 
         return !PostAutoUploadInteractor.allowedStatuses.contains(status)
+    }
+
+    /// Returns what is the auto upload attempt state for a given post
+    ///
+    func autoUploadAttemptState(of post: AbstractPost) -> AutoUploadAttemptState {
+        let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
+        if autoUploadAttemptsCount >= PostAutoUploadInteractor.maxNumberOfAttempts {
+            return .reachedLimit
+        } else if autoUploadAttemptsCount > 0 {
+            return .attempted
+        } else {
+            return .notAttempted
+        }
     }
 }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -83,7 +83,7 @@ class PostCoordinator: NSObject {
             post.deleteRevision()
         }
 
-        post.autoUploadFailureCount = NSNumber(value: automatedRetry ? post.autoUploadFailureCount.intValue + 1 : 1)
+        post.autoUploadAttemptsCount = NSNumber(value: automatedRetry ? post.autoUploadAttemptsCount.intValue + 1 : 1)
 
         guard uploadMedia(for: post, automatedRetry: automatedRetry) else {
             change(post: post, status: .failed)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -83,7 +83,7 @@ class PostCoordinator: NSObject {
             post.deleteRevision()
         }
 
-        post.autoUploadAttemptsCount = NSNumber(value: automatedRetry ? post.autoUploadAttemptsCount.intValue + 1 : 1)
+        post.autoUploadAttemptsCount = NSNumber(value: automatedRetry ? post.autoUploadAttemptsCount.intValue + 1 : 0)
 
         guard uploadMedia(for: post, automatedRetry: automatedRetry) else {
             change(post: post, status: .failed)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -83,6 +83,8 @@ class PostCoordinator: NSObject {
             post.deleteRevision()
         }
 
+        post.autoUploadFailureCount = NSNumber(value: automatedRetry ? post.autoUploadFailureCount.intValue + 1 : 1)
+
         guard uploadMedia(for: post, automatedRetry: automatedRetry) else {
             change(post: post, status: .failed)
             return

--- a/WordPress/Classes/ViewRelated/Post/AutoUploadMessages.swift
+++ b/WordPress/Classes/ViewRelated/Post/AutoUploadMessages.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum AutoUploadMessages {
+    static let postWillBePublished = NSLocalizedString("Post will be published next time your device is online",
+                                                       comment: "Text displayed in notice after a post if published while offline.")
+    static let draftWillBeUploaded = NSLocalizedString("Draft will be uploaded next time your device is online",
+                                                       comment: "Text displayed in notice after the app fails to upload a draft.")
+    static let pageFailedToUpload = NSLocalizedString("Page failed to upload",
+                                                      comment: "Title of notification displayed when a page has failed to upload.")
+    static let postFailedToUpload = NSLocalizedString("Post failed to upload",
+                                                      comment: "Title of notification displayed when a post has failed to upload.")
+    static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
+                                                         comment: "Text displayed in notice after the app fails to upload a post.")
+    static let willAttemptToPublishLater = NSLocalizedString("Post couldn't be published. We'll try again later",
+                                                       comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
+    static let willNotAttemptToPublishLater = NSLocalizedString("Couldn't perform operation. Post not published",
+                                                        comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
+    static let willAttemptToSubmitLater = NSLocalizedString("Post couldn't be submitted. We'll try again later",
+                                                       comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
+    static let willNotAttemptToSubmitLater = NSLocalizedString("Couldn't perform operation",
+                                                        comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
+
+    static func willAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
+        return postStatus == .publish ? AutoUploadMessages.willAttemptToPublishLater : AutoUploadMessages.willAttemptToSubmitLater
+    }
+
+    static func willNotAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
+        return postStatus == .publish ? AutoUploadMessages.willNotAttemptToPublishLater : AutoUploadMessages.willNotAttemptToSubmitLater
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostAutoUploadMessages.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostAutoUploadMessages.swift
@@ -27,4 +27,16 @@ enum PostAutoUploadMessages {
     static func willNotAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
         return postStatus == .publish ? PostAutoUploadMessages.willNotAttemptToPublishLater : PostAutoUploadMessages.willNotAttemptToSubmitLater
     }
+
+    static func attemptFailures(for post: AbstractPost,
+                                withState state: PostAutoUploadInteractor.AutoUploadAttemptState) -> String? {
+        switch state {
+        case .attempted:
+            return PostAutoUploadMessages.willAttemptToAutoUpload(for: post.status)
+        case .reachedLimit:
+            return PostAutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
+        default:
+            return nil
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostAutoUploadMessages.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostAutoUploadMessages.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum AutoUploadMessages {
+enum PostAutoUploadMessages {
     static let postWillBePublished = NSLocalizedString("Post will be published next time your device is online",
                                                        comment: "Text displayed in notice after a post if published while offline.")
     static let draftWillBeUploaded = NSLocalizedString("Draft will be uploaded next time your device is online",
@@ -21,10 +21,10 @@ enum AutoUploadMessages {
                                                         comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
 
     static func willAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
-        return postStatus == .publish ? AutoUploadMessages.willAttemptToPublishLater : AutoUploadMessages.willAttemptToSubmitLater
+        return postStatus == .publish ? PostAutoUploadMessages.willAttemptToPublishLater : PostAutoUploadMessages.willAttemptToSubmitLater
     }
 
     static func willNotAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
-        return postStatus == .publish ? AutoUploadMessages.willNotAttemptToPublishLater : AutoUploadMessages.willNotAttemptToSubmitLater
+        return postStatus == .publish ? PostAutoUploadMessages.willNotAttemptToPublishLater : PostAutoUploadMessages.willNotAttemptToSubmitLater
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -229,11 +229,8 @@ class PostCardStatusViewModel: NSObject {
             return StatusMessages.localChanges
         }
 
-        let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
-        if autoUploadAttemptsCount >= PostAutoUploadInteractor.maxNumberOfAttempts {
-            return PostAutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
-        } else if autoUploadAttemptsCount > 0 {
-            return PostAutoUploadMessages.willAttemptToAutoUpload(for: post.status)
+        if let autoUploadMessage = PostAutoUploadMessages.attemptFailures(for: post, withState: autoUploadInteractor.autoUploadAttemptState(of: post)) {
+            return autoUploadMessage
         }
 
         if autoUploadInteractor.autoUploadAction(for: post) != .upload {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -152,7 +152,9 @@ class PostCardStatusViewModel: NSObject {
 
             if autoUploadInteractor.autoUploadAttemptState(of: post) == .reachedLimit {
                 buttons.append(.retry)
-            } else if canPublish {
+            }
+
+            if canPublish {
                 buttons.append(.publish)
             }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -150,7 +150,7 @@ class PostCardStatusViewModel: NSObject {
                 buttons.append(.cancelAutoUpload)
             }
 
-            if post.autoUploadAttemptsCount.intValue >= autoUploadInteractor.maxNumberOfAttempts {
+            if post.autoUploadAttemptsCount.intValue >= PostAutoUploadInteractor.maxNumberOfAttempts {
                 buttons.append(.retry)
             } else if canPublish {
                 buttons.append(.publish)
@@ -230,7 +230,7 @@ class PostCardStatusViewModel: NSObject {
         }
 
         let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
-        if autoUploadAttemptsCount >= autoUploadInteractor.maxNumberOfAttempts {
+        if autoUploadAttemptsCount >= PostAutoUploadInteractor.maxNumberOfAttempts {
             return AutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
         } else if autoUploadAttemptsCount > 0 {
             return AutoUploadMessages.willAttemptToAutoUpload(for: post.status)

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -150,7 +150,7 @@ class PostCardStatusViewModel: NSObject {
                 buttons.append(.cancelAutoUpload)
             }
 
-            if post.autoUploadAttemptsCount.intValue >= PostAutoUploadInteractor.maxNumberOfAttempts {
+            if autoUploadInteractor.autoUploadAttemptState(of: post) == .reachedLimit {
                 buttons.append(.retry)
             } else if canPublish {
                 buttons.append(.publish)

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -146,7 +146,9 @@ class PostCardStatusViewModel: NSObject {
                 buttons.append(.cancelAutoUpload)
             }
 
-            if canPublish {
+            if post.autoUploadAttemptsCount.intValue >= autoUploadInteractor.maxNumberOfAttempts {
+                buttons.append(.retry)
+            } else if canPublish {
                 buttons.append(.publish)
             }
 
@@ -223,6 +225,13 @@ class PostCardStatusViewModel: NSObject {
             return StatusMessages.localChanges
         }
 
+        let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
+        if autoUploadAttemptsCount >= autoUploadInteractor.maxNumberOfAttempts {
+            return StatusMessages.postFailedToUploadWillNotAttempt
+        } else if autoUploadAttemptsCount > 0 {
+            return StatusMessages.postWillAtemptLater
+        }
+
         if autoUploadInteractor.autoUploadAction(for: post) != .upload {
             return defaultFailedMessage
         }
@@ -253,5 +262,9 @@ class PostCardStatusViewModel: NSObject {
                                                            comment: "Message shown in post list when a draft is scheduled to be automatically uploaded.")
         static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
                                                              comment: "Message shown in post list when a post's local changes will be automatically uploaded when the device is online.")
+        static let postWillAtemptLater = NSLocalizedString("Post couldn't be published. We'll try again later",
+                                                           comment: "Message shown in the posts list when a post failed to be auto uploaded but we'll try again later.")
+        static let postFailedToUploadWillNotAttempt = NSLocalizedString("Couldn't perform operation. Post not published",
+                                                            comment: "Message shown in the posts list when a post failed to be auto uploaded several times and we'll not try again.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -231,23 +231,23 @@ class PostCardStatusViewModel: NSObject {
 
         let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
         if autoUploadAttemptsCount >= PostAutoUploadInteractor.maxNumberOfAttempts {
-            return AutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
+            return PostAutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
         } else if autoUploadAttemptsCount > 0 {
-            return AutoUploadMessages.willAttemptToAutoUpload(for: post.status)
+            return PostAutoUploadMessages.willAttemptToAutoUpload(for: post.status)
         }
 
         if autoUploadInteractor.autoUploadAction(for: post) != .upload {
             return defaultFailedMessage
         }
         if post.hasRemote() {
-            return AutoUploadMessages.changesWillBeUploaded
+            return PostAutoUploadMessages.changesWillBeUploaded
         }
 
         switch postStatus {
         case .draft:
-            return AutoUploadMessages.draftWillBeUploaded
+            return PostAutoUploadMessages.draftWillBeUploaded
         case .publish:
-            return AutoUploadMessages.postWillBePublished
+            return PostAutoUploadMessages.postWillBePublished
         default:
             return defaultFailedMessage
         }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -266,17 +266,17 @@ class PostCardStatusViewModel: NSObject {
                                                            comment: "Message shown in the posts list when a post failed to be auto published but we'll try again later.")
         static let willNotAttemptToPublishLater = NSLocalizedString("Couldn't perform operation. Post not published",
                                                             comment: "Message shown in the posts list when a post failed to be auto published several times and we'll not try again.")
-        static let willAttemptToDraftLater = NSLocalizedString("Post couldn't be drafted. We'll try again later",
-                                                           comment: "Message shown in the posts list when a post failed to be auto drafted but we'll try again later.")
-        static let willNotAttemptToDraftLater = NSLocalizedString("Couldn't perform operation. Post not drafted",
-                                                            comment: "Message shown in the posts list when a post failed to be auto drafted several times and we'll not try again.")
+        static let willAttemptToSubmitLater = NSLocalizedString("Post couldn't be submitted. We'll try again later",
+                                                           comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
+        static let willNotAttemptToSubmitLater = NSLocalizedString("Couldn't perform operation",
+                                                            comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
 
         static func willAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
-            return postStatus == .publish ? StatusMessages.willAttemptToPublishLater : StatusMessages.willAttemptToDraftLater
+            return postStatus == .publish ? StatusMessages.willAttemptToPublishLater : StatusMessages.willAttemptToSubmitLater
         }
 
         static func willNotAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
-            return postStatus == .publish ? StatusMessages.willNotAttemptToPublishLater : StatusMessages.willNotAttemptToDraftLater
+            return postStatus == .publish ? StatusMessages.willNotAttemptToPublishLater : StatusMessages.willNotAttemptToSubmitLater
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -227,9 +227,9 @@ class PostCardStatusViewModel: NSObject {
 
         let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
         if autoUploadAttemptsCount >= autoUploadInteractor.maxNumberOfAttempts {
-            return StatusMessages.postFailedToUploadWillNotAttempt
+            return StatusMessages.willNotAttemptToAutoUpload(for: post.status)
         } else if autoUploadAttemptsCount > 0 {
-            return StatusMessages.postWillAtemptLater
+            return StatusMessages.willAttemptToAutoUpload(for: post.status)
         }
 
         if autoUploadInteractor.autoUploadAction(for: post) != .upload {
@@ -262,9 +262,21 @@ class PostCardStatusViewModel: NSObject {
                                                            comment: "Message shown in post list when a draft is scheduled to be automatically uploaded.")
         static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
                                                              comment: "Message shown in post list when a post's local changes will be automatically uploaded when the device is online.")
-        static let postWillAtemptLater = NSLocalizedString("Post couldn't be published. We'll try again later",
-                                                           comment: "Message shown in the posts list when a post failed to be auto uploaded but we'll try again later.")
-        static let postFailedToUploadWillNotAttempt = NSLocalizedString("Couldn't perform operation. Post not published",
-                                                            comment: "Message shown in the posts list when a post failed to be auto uploaded several times and we'll not try again.")
+        static let willAttemptToPublishLater = NSLocalizedString("Post couldn't be published. We'll try again later",
+                                                           comment: "Message shown in the posts list when a post failed to be auto published but we'll try again later.")
+        static let willNotAttemptToPublishLater = NSLocalizedString("Couldn't perform operation. Post not published",
+                                                            comment: "Message shown in the posts list when a post failed to be auto published several times and we'll not try again.")
+        static let willAttemptToDraftLater = NSLocalizedString("Post couldn't be drafted. We'll try again later",
+                                                           comment: "Message shown in the posts list when a post failed to be auto drafted but we'll try again later.")
+        static let willNotAttemptToDraftLater = NSLocalizedString("Couldn't perform operation. Post not drafted",
+                                                            comment: "Message shown in the posts list when a post failed to be auto drafted several times and we'll not try again.")
+
+        static func willAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
+            return postStatus == .publish ? StatusMessages.willAttemptToPublishLater : StatusMessages.willAttemptToDraftLater
+        }
+
+        static func willNotAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
+            return postStatus == .publish ? StatusMessages.willNotAttemptToPublishLater : StatusMessages.willNotAttemptToDraftLater
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -227,23 +227,23 @@ class PostCardStatusViewModel: NSObject {
 
         let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
         if autoUploadAttemptsCount >= autoUploadInteractor.maxNumberOfAttempts {
-            return StatusMessages.willNotAttemptToAutoUpload(for: post.status)
+            return AutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
         } else if autoUploadAttemptsCount > 0 {
-            return StatusMessages.willAttemptToAutoUpload(for: post.status)
+            return AutoUploadMessages.willAttemptToAutoUpload(for: post.status)
         }
 
         if autoUploadInteractor.autoUploadAction(for: post) != .upload {
             return defaultFailedMessage
         }
         if post.hasRemote() {
-            return StatusMessages.changesWillBeUploaded
+            return AutoUploadMessages.changesWillBeUploaded
         }
 
         switch postStatus {
         case .draft:
-            return StatusMessages.draftWillBeUploaded
+            return AutoUploadMessages.draftWillBeUploaded
         case .publish:
-            return StatusMessages.postWillBePublished
+            return AutoUploadMessages.postWillBePublished
         default:
             return defaultFailedMessage
         }
@@ -254,29 +254,9 @@ class PostCardStatusViewModel: NSObject {
     }
 
     enum StatusMessages {
-        static let uploadFailed = NSLocalizedString("Upload failed", comment: "Message displayed on a post's card when the post has failed to upload")
-        static let postWillBePublished = NSLocalizedString("Post will be published next time your device is online",
-                                                           comment: "Message shown in the posts list when a post is scheduled for publishing")
-        static let localChanges = NSLocalizedString("Local changes", comment: "A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog.")
-        static let draftWillBeUploaded = NSLocalizedString("Draft will be uploaded next time your device is online",
-                                                           comment: "Message shown in post list when a draft is scheduled to be automatically uploaded.")
-        static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
-                                                             comment: "Message shown in post list when a post's local changes will be automatically uploaded when the device is online.")
-        static let willAttemptToPublishLater = NSLocalizedString("Post couldn't be published. We'll try again later",
-                                                           comment: "Message shown in the posts list when a post failed to be auto published but we'll try again later.")
-        static let willNotAttemptToPublishLater = NSLocalizedString("Couldn't perform operation. Post not published",
-                                                            comment: "Message shown in the posts list when a post failed to be auto published several times and we'll not try again.")
-        static let willAttemptToSubmitLater = NSLocalizedString("Post couldn't be submitted. We'll try again later",
-                                                           comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
-        static let willNotAttemptToSubmitLater = NSLocalizedString("Couldn't perform operation",
-                                                            comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
-
-        static func willAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
-            return postStatus == .publish ? StatusMessages.willAttemptToPublishLater : StatusMessages.willAttemptToSubmitLater
-        }
-
-        static func willNotAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
-            return postStatus == .publish ? StatusMessages.willNotAttemptToPublishLater : StatusMessages.willNotAttemptToSubmitLater
-        }
+        static let uploadFailed = NSLocalizedString("Upload failed",
+                                                            comment: "Message displayed on a post's card when the post has failed to upload")
+        static let localChanges = NSLocalizedString("Local changes",
+                                                            comment: "A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -664,9 +664,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func retry(_ post: AbstractPost) {
-        ReachabilityUtils.onAvailableInternetConnectionDo {
-            PostCoordinator.shared.save(post)
-        }
+        PostCoordinator.shared.save(post)
     }
 
     func cancelAutoUpload(_ post: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -113,11 +113,8 @@ struct PostNoticeViewModel {
             }
         }
 
-        let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
-        if autoUploadAttemptsCount >= PostAutoUploadInteractor.maxNumberOfAttempts {
-            return PostAutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
-        } else if autoUploadAttemptsCount > 0 {
-            return PostAutoUploadMessages.willAttemptToAutoUpload(for: post.status)
+        if let autoUploadMessage = PostAutoUploadMessages.attemptFailures(for: post, withState: autoUploadInteractor.autoUploadAttemptState(of: post)) {
+            return autoUploadMessage
         }
 
         guard let postStatus = post.status,

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -113,6 +113,14 @@ struct PostNoticeViewModel {
             }
         }
 
+        if post.autoUploadAttemptsCount.intValue >= autoUploadInteractor.maxNumberOfAttempts {
+            return FailureTitles.postFailedToUploadWillNotAttempt
+        }
+
+        if post.autoUploadAttemptsCount.intValue > 0 {
+            return FailureTitles.postWillAtemptLater
+        }
+
         guard let postStatus = post.status,
             autoUploadInteractor.autoUploadAction(for: post) == .upload else {
             return defaultTitle
@@ -271,6 +279,10 @@ struct PostNoticeViewModel {
                                                           comment: "Title of notification displayed when a post has failed to upload.")
         static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
                                                              comment: "Text displayed in notice after the app fails to upload a post.")
+        static let postWillAtemptLater = NSLocalizedString("Post couldn't be published. We'll try again later",
+                                                           comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
+        static let postFailedToUploadWillNotAttempt = NSLocalizedString("Couldn't perform operation. Post not published",
+                                                            comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
     }
 
     enum FailureActionTitles {

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -114,7 +114,7 @@ struct PostNoticeViewModel {
         }
 
         let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
-        if autoUploadAttemptsCount >= autoUploadInteractor.maxNumberOfAttempts {
+        if autoUploadAttemptsCount >= PostAutoUploadInteractor.maxNumberOfAttempts {
             return AutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
         } else if autoUploadAttemptsCount > 0 {
             return AutoUploadMessages.willAttemptToAutoUpload(for: post.status)

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -282,17 +282,17 @@ struct PostNoticeViewModel {
                                                            comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
         static let willNotAttemptToPublishLater = NSLocalizedString("Couldn't perform operation. Post not published",
                                                             comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
-        static let willAttemptToDraftLater = NSLocalizedString("Post couldn't be drafted. We'll try again later",
+        static let willAttemptToSubmitLater = NSLocalizedString("Post couldn't be submitted. We'll try again later",
                                                            comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
-        static let willNotAttemptToDraftLater = NSLocalizedString("Couldn't perform operation. Post not drafted",
+        static let willNotAttemptToSubmitLater = NSLocalizedString("Couldn't perform operation",
                                                             comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
 
         static func willAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
-            return postStatus == .publish ? FailureTitles.willAttemptToPublishLater : FailureTitles.willAttemptToDraftLater
+            return postStatus == .publish ? FailureTitles.willAttemptToPublishLater : FailureTitles.willAttemptToSubmitLater
         }
 
         static func willNotAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
-            return postStatus == .publish ? FailureTitles.willNotAttemptToPublishLater : FailureTitles.willNotAttemptToDraftLater
+            return postStatus == .publish ? FailureTitles.willNotAttemptToPublishLater : FailureTitles.willNotAttemptToSubmitLater
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -115,9 +115,9 @@ struct PostNoticeViewModel {
 
         let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
         if autoUploadAttemptsCount >= autoUploadInteractor.maxNumberOfAttempts {
-            return FailureTitles.postFailedToUploadWillNotAttempt
+            return FailureTitles.willNotAttemptToAutoUpload(for: post.status)
         } else if autoUploadAttemptsCount > 0 {
-            return FailureTitles.postWillAtemptLater
+            return FailureTitles.willAttemptToAutoUpload(for: post.status)
         }
 
         guard let postStatus = post.status,
@@ -278,10 +278,22 @@ struct PostNoticeViewModel {
                                                           comment: "Title of notification displayed when a post has failed to upload.")
         static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
                                                              comment: "Text displayed in notice after the app fails to upload a post.")
-        static let postWillAtemptLater = NSLocalizedString("Post couldn't be published. We'll try again later",
+        static let willAttemptToPublishLater = NSLocalizedString("Post couldn't be published. We'll try again later",
                                                            comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
-        static let postFailedToUploadWillNotAttempt = NSLocalizedString("Couldn't perform operation. Post not published",
+        static let willNotAttemptToPublishLater = NSLocalizedString("Couldn't perform operation. Post not published",
                                                             comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
+        static let willAttemptToDraftLater = NSLocalizedString("Post couldn't be drafted. We'll try again later",
+                                                           comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
+        static let willNotAttemptToDraftLater = NSLocalizedString("Couldn't perform operation. Post not drafted",
+                                                            comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
+
+        static func willAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
+            return postStatus == .publish ? FailureTitles.willAttemptToPublishLater : FailureTitles.willAttemptToDraftLater
+        }
+
+        static func willNotAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
+            return postStatus == .publish ? FailureTitles.willNotAttemptToPublishLater : FailureTitles.willNotAttemptToDraftLater
+        }
     }
 
     enum FailureActionTitles {

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -113,11 +113,10 @@ struct PostNoticeViewModel {
             }
         }
 
-        if post.autoUploadAttemptsCount.intValue >= autoUploadInteractor.maxNumberOfAttempts {
+        let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
+        if autoUploadAttemptsCount >= autoUploadInteractor.maxNumberOfAttempts {
             return FailureTitles.postFailedToUploadWillNotAttempt
-        }
-
-        if post.autoUploadAttemptsCount.intValue > 0 {
+        } else if autoUploadAttemptsCount > 0 {
             return FailureTitles.postWillAtemptLater
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -107,17 +107,17 @@ struct PostNoticeViewModel {
     private var failureTitle: String {
         var defaultTitle: String {
             if post is Page {
-                return AutoUploadMessages.pageFailedToUpload
+                return PostAutoUploadMessages.pageFailedToUpload
             } else {
-                return AutoUploadMessages.postFailedToUpload
+                return PostAutoUploadMessages.postFailedToUpload
             }
         }
 
         let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
         if autoUploadAttemptsCount >= PostAutoUploadInteractor.maxNumberOfAttempts {
-            return AutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
+            return PostAutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
         } else if autoUploadAttemptsCount > 0 {
-            return AutoUploadMessages.willAttemptToAutoUpload(for: post.status)
+            return PostAutoUploadMessages.willAttemptToAutoUpload(for: post.status)
         }
 
         guard let postStatus = post.status,
@@ -126,14 +126,14 @@ struct PostNoticeViewModel {
         }
 
         if post.hasRemote() {
-            return AutoUploadMessages.changesWillBeUploaded
+            return PostAutoUploadMessages.changesWillBeUploaded
         }
 
         switch postStatus {
         case .draft:
-            return AutoUploadMessages.draftWillBeUploaded
+            return PostAutoUploadMessages.draftWillBeUploaded
         case .publish:
-            return AutoUploadMessages.postWillBePublished
+            return PostAutoUploadMessages.postWillBePublished
         default:
             return defaultTitle
         }

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -107,17 +107,17 @@ struct PostNoticeViewModel {
     private var failureTitle: String {
         var defaultTitle: String {
             if post is Page {
-                return FailureTitles.pageFailedToUpload
+                return AutoUploadMessages.pageFailedToUpload
             } else {
-                return FailureTitles.postFailedToUpload
+                return AutoUploadMessages.postFailedToUpload
             }
         }
 
         let autoUploadAttemptsCount = post.autoUploadAttemptsCount.intValue
         if autoUploadAttemptsCount >= autoUploadInteractor.maxNumberOfAttempts {
-            return FailureTitles.willNotAttemptToAutoUpload(for: post.status)
+            return AutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
         } else if autoUploadAttemptsCount > 0 {
-            return FailureTitles.willAttemptToAutoUpload(for: post.status)
+            return AutoUploadMessages.willAttemptToAutoUpload(for: post.status)
         }
 
         guard let postStatus = post.status,
@@ -126,14 +126,14 @@ struct PostNoticeViewModel {
         }
 
         if post.hasRemote() {
-            return FailureTitles.changesWillBeUploaded
+            return AutoUploadMessages.changesWillBeUploaded
         }
 
         switch postStatus {
         case .draft:
-            return FailureTitles.draftWillBeUploaded
+            return AutoUploadMessages.draftWillBeUploaded
         case .publish:
-            return FailureTitles.postWillBePublished
+            return AutoUploadMessages.postWillBePublished
         default:
             return defaultTitle
         }
@@ -265,35 +265,6 @@ struct PostNoticeViewModel {
         let postInContext = objectInContext as? AbstractPost
 
         return postInContext
-    }
-
-    enum FailureTitles {
-        static let postWillBePublished = NSLocalizedString("Post will be published the next time your device is online",
-                                                           comment: "Text displayed in notice after a post if published while offline.")
-        static let draftWillBeUploaded = NSLocalizedString("Draft will be uploaded next time your device is online",
-                                                           comment: "Text displayed in notice after the app fails to upload a draft.")
-        static let pageFailedToUpload = NSLocalizedString("Page failed to upload",
-                                                          comment: "Title of notification displayed when a page has failed to upload.")
-        static let postFailedToUpload = NSLocalizedString("Post failed to upload",
-                                                          comment: "Title of notification displayed when a post has failed to upload.")
-        static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
-                                                             comment: "Text displayed in notice after the app fails to upload a post.")
-        static let willAttemptToPublishLater = NSLocalizedString("Post couldn't be published. We'll try again later",
-                                                           comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
-        static let willNotAttemptToPublishLater = NSLocalizedString("Couldn't perform operation. Post not published",
-                                                            comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
-        static let willAttemptToSubmitLater = NSLocalizedString("Post couldn't be submitted. We'll try again later",
-                                                           comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
-        static let willNotAttemptToSubmitLater = NSLocalizedString("Couldn't perform operation",
-                                                            comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
-
-        static func willAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
-            return postStatus == .publish ? FailureTitles.willAttemptToPublishLater : FailureTitles.willAttemptToSubmitLater
-        }
-
-        static func willNotAttemptToAutoUpload(for postStatus: BasePost.Status?) -> String {
-            return postStatus == .publish ? FailureTitles.willNotAttemptToPublishLater : FailureTitles.willNotAttemptToSubmitLater
-        }
     }
 
     enum FailureActionTitles {

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 91.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 91.xcdatamodel/contents
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14903" systemVersion="18G95" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AbstractPost" representedClassName="AbstractPost" isAbstract="YES" parentEntity="BasePost">
-        <attribute name="autoUploadFailureCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="autoUploadAttemptsCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="confirmedChangesHash" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="confirmedChangesTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 91.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 91.xcdatamodel/contents
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14492.1" systemVersion="18G87" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14903" systemVersion="18G95" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AbstractPost" representedClassName="AbstractPost" isAbstract="YES" parentEntity="BasePost">
+        <attribute name="autoUploadFailureCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="confirmedChangesHash" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="confirmedChangesTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
@@ -67,132 +68,74 @@
         <attribute name="totalWordsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <entity name="BasePost" representedClassName="BasePost" isAbstract="YES">
-        <attribute name="author" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="author" optional="YES" attributeType="String"/>
         <attribute name="authorAvatarURL" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="authorID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
-        <attribute name="content" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="date_created_gmt" optional="YES" attributeType="Date" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="mt_excerpt" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="password" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="date_created_gmt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="mt_excerpt" optional="YES" attributeType="String"/>
+        <attribute name="password" optional="YES" attributeType="String"/>
         <attribute name="pathForDisplayImage" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="permaLink" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="postTitle" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="remoteStatusNumber" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="status" optional="YES" attributeType="String" defaultValueString="publish">
-            <userInfo/>
-        </attribute>
+        <attribute name="permaLink" optional="YES" attributeType="String"/>
+        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="NO"/>
+        <attribute name="postTitle" optional="YES" attributeType="String"/>
+        <attribute name="remoteStatusNumber" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="status" optional="YES" attributeType="String" defaultValueString="publish"/>
         <attribute name="suggested_slug" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="wp_slug" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="wp_slug" optional="YES" attributeType="String"/>
         <relationship name="comments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Comment" inverseName="post" inverseEntity="Comment" syncable="YES"/>
         <userInfo/>
     </entity>
     <entity name="Blog" representedClassName="Blog">
-        <attribute name="apiKey" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="blogID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
+        <attribute name="apiKey" optional="YES" attributeType="String"/>
+        <attribute name="blogID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
         <attribute name="capabilities" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="currentThemeId" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="hasDomainCredit" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="hasOlderPages" transient="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="hasOlderPosts" transient="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
+        <attribute name="hasOlderPages" transient="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO"/>
+        <attribute name="hasOlderPosts" transient="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO"/>
         <attribute name="hasPaidPlan" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="isActivated" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="isAdmin" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="isHostedAtWPcom" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="isMultiAuthor" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="lastCommentsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="lastPagesSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="lastPostsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="lastStatsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
+        <attribute name="lastCommentsSync" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastPagesSync" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastPostsSync" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="lastStatsSync" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lastUpdateWarning" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="mobileEditor" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="options" optional="YES" attributeType="Transformable">
-            <userInfo/>
-        </attribute>
+        <attribute name="options" optional="YES" attributeType="Transformable"/>
         <attribute name="planID" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="planTitle" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="postFormats" optional="YES" attributeType="Transformable">
-            <userInfo/>
-        </attribute>
+        <attribute name="postFormats" optional="YES" attributeType="Transformable"/>
         <attribute name="quotaSpaceAllowed" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="quotaSpaceUsed" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="url" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="url" attributeType="String"/>
         <attribute name="userID" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="username" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="username" optional="YES" attributeType="String"/>
         <attribute name="visible" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="webEditor" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="xmlrpc" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="xmlrpc" attributeType="String"/>
         <relationship name="account" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="blogs" inverseEntity="Account" indexed="YES" syncable="YES"/>
         <relationship name="accountForDefaultBlog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="defaultBlog" inverseEntity="Account" syncable="YES"/>
         <relationship name="authors" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="BlogAuthor" inverseName="blog" inverseEntity="BlogAuthor" syncable="YES"/>
-        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Category" inverseName="blog" inverseEntity="Category" indexed="YES">
-            <userInfo/>
-        </relationship>
-        <relationship name="comments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Comment" inverseName="blog" inverseEntity="Comment" indexed="YES">
-            <userInfo/>
-        </relationship>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Category" inverseName="blog" inverseEntity="Category" indexed="YES"/>
+        <relationship name="comments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Comment" inverseName="blog" inverseEntity="Comment" indexed="YES"/>
         <relationship name="connections" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PublicizeConnection" inverseName="blog" inverseEntity="PublicizeConnection" syncable="YES"/>
         <relationship name="domains" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Domain" inverseName="blog" inverseEntity="Domain" syncable="YES"/>
-        <relationship name="media" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Media" inverseName="blog" inverseEntity="Media" indexed="YES">
-            <userInfo/>
-        </relationship>
+        <relationship name="media" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Media" inverseName="blog" inverseEntity="Media" indexed="YES"/>
         <relationship name="menuLocations" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="MenuLocation" inverseName="blog" inverseEntity="MenuLocation" syncable="YES"/>
         <relationship name="menus" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Menu" inverseName="blog" inverseEntity="Menu" syncable="YES"/>
-        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="AbstractPost" inverseName="blog" inverseEntity="AbstractPost" indexed="YES">
-            <userInfo/>
-        </relationship>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="AbstractPost" inverseName="blog" inverseEntity="AbstractPost" indexed="YES"/>
         <relationship name="postTypes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PostType" inverseName="blog" inverseEntity="PostType" syncable="YES"/>
         <relationship name="quickStartTours" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="QuickStartTourState" inverseName="blog" inverseEntity="QuickStartTourState" syncable="YES"/>
         <relationship name="roles" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Role" inverseName="blog" inverseEntity="Role" syncable="YES"/>
         <relationship name="settings" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BlogSettings" inverseName="blog" inverseEntity="BlogSettings" syncable="YES"/>
         <relationship name="sharingButtons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SharingButton" inverseName="blog" inverseEntity="SharingButton" syncable="YES"/>
         <relationship name="statsRecords" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="StatsRecord" inverseName="blog" inverseEntity="StatsRecord" syncable="YES"/>
-        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PostTag" inverseName="blog" inverseEntity="PostTag">
-            <userInfo/>
-        </relationship>
+        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PostTag" inverseName="blog" inverseEntity="PostTag"/>
         <relationship name="themes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Theme" inverseName="blog" inverseEntity="Theme" syncable="YES"/>
         <userInfo/>
     </entity>
@@ -227,9 +170,7 @@
         <attribute name="dateFormat" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="defaultCategoryID" optional="YES" attributeType="Integer 32" defaultValueString="1" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="defaultPostFormat" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="geolocationEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
+        <attribute name="geolocationEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO"/>
         <attribute name="gmtOffset" optional="YES" attributeType="Decimal" defaultValueString="0.0" syncable="YES"/>
         <attribute name="iconMediaID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="jetpackBlockMaliciousLoginAttempts" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
@@ -265,21 +206,11 @@
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="settings" inverseEntity="Blog" syncable="YES"/>
     </entity>
     <entity name="Category" representedClassName="PostCategory">
-        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="categoryName" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="parentID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="categories" inverseEntity="Blog" indexed="YES">
-            <userInfo/>
-        </relationship>
-        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Post" inverseName="categories" inverseEntity="Post" indexed="YES">
-            <userInfo/>
-        </relationship>
+        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO"/>
+        <attribute name="categoryName" attributeType="String"/>
+        <attribute name="parentID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="categories" inverseEntity="Blog" indexed="YES"/>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Post" inverseName="categories" inverseEntity="Post" indexed="YES"/>
         <userInfo/>
     </entity>
     <entity name="ClicksStatsRecordValue" representedClassName=".ClicksStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
@@ -291,50 +222,24 @@
         <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ClicksStatsRecordValue" inverseName="children" inverseEntity="ClicksStatsRecordValue" syncable="YES"/>
     </entity>
     <entity name="Comment" representedClassName="Comment">
-        <attribute name="author" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="author_email" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="author_ip" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="author_url" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="author" optional="YES" attributeType="String"/>
+        <attribute name="author_email" optional="YES" attributeType="String"/>
+        <attribute name="author_ip" optional="YES" attributeType="String"/>
+        <attribute name="author_url" optional="YES" attributeType="String"/>
         <attribute name="authorAvatarURL" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="commentID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="content" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
+        <attribute name="commentID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO"/>
+        <attribute name="content" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="depth" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="hierarchy" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="isLiked" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="likeCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="link" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="parentID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="postID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="postTitle" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="status" optional="YES" attributeType="String" indexed="YES">
-            <userInfo/>
-        </attribute>
-        <attribute name="type" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="link" optional="YES" attributeType="String"/>
+        <attribute name="parentID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO"/>
+        <attribute name="postID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO"/>
+        <attribute name="postTitle" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="String" indexed="YES"/>
+        <attribute name="type" optional="YES" attributeType="String"/>
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="comments" inverseEntity="Blog" syncable="YES"/>
         <relationship name="post" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BasePost" inverseName="comments" inverseEntity="BasePost" syncable="YES"/>
         <userInfo/>
@@ -389,59 +294,29 @@
         <attribute name="alt" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="autoUploadFailureCount" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="caption" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="desc" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="error" optional="YES" attributeType="Transformable" syncable="YES"/>
-        <attribute name="filename" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="filesize" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="height" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="length" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
+        <attribute name="filename" optional="YES" attributeType="String"/>
+        <attribute name="filesize" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="height" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="length" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
         <attribute name="localThumbnailIdentifier" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="localThumbnailURL" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="localURL" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="mediaID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <attribute name="mediaTypeString" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="localURL" optional="YES" attributeType="String"/>
+        <attribute name="mediaID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO"/>
+        <attribute name="mediaTypeString" optional="YES" attributeType="String"/>
         <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="remoteStatusNumber" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
+        <attribute name="remoteStatusNumber" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO"/>
         <attribute name="remoteThumbnailURL" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="remoteURL" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="shortcode" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="title" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="remoteURL" optional="YES" attributeType="String"/>
+        <attribute name="shortcode" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="videopressGUID" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="width" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
-        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="media" inverseEntity="Blog" indexed="YES">
-            <userInfo/>
-        </relationship>
+        <attribute name="width" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="media" inverseEntity="Blog" indexed="YES"/>
         <relationship name="featuredOnPosts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="featuredImage" inverseEntity="AbstractPost" syncable="YES"/>
-        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="media" inverseEntity="AbstractPost" indexed="YES">
-            <userInfo/>
-        </relationship>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="media" inverseEntity="AbstractPost" indexed="YES"/>
         <userInfo/>
     </entity>
     <entity name="Menu" representedClassName="Menu" syncable="YES">
@@ -495,9 +370,7 @@
         <attribute name="totalCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <entity name="Page" representedClassName="Page" parentEntity="AbstractPost">
-        <attribute name="parentID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
+        <attribute name="parentID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
         <userInfo/>
     </entity>
     <entity name="Person" representedClassName=".ManagedPerson" syncable="YES">
@@ -537,49 +410,27 @@
     </entity>
     <entity name="Post" representedClassName="Post" parentEntity="AbstractPost">
         <attribute name="commentCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="disabledPublicizeConnections" optional="YES" attributeType="Transformable">
-            <userInfo/>
-        </attribute>
-        <attribute name="geolocation" optional="YES" attributeType="Transformable">
-            <userInfo/>
-        </attribute>
+        <attribute name="disabledPublicizeConnections" optional="YES" attributeType="Transformable"/>
+        <attribute name="geolocation" optional="YES" attributeType="Transformable"/>
         <attribute name="isStickyPost" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="latitudeID" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="latitudeID" optional="YES" attributeType="String"/>
         <attribute name="likeCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="longitudeID" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="postFormat" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="longitudeID" optional="YES" attributeType="String"/>
+        <attribute name="postFormat" optional="YES" attributeType="String"/>
         <attribute name="postType" attributeType="String" defaultValueString="post" syncable="YES"/>
-        <attribute name="publicID" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <attribute name="publicizeMessage" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="publicID" optional="YES" attributeType="String"/>
+        <attribute name="publicizeMessage" optional="YES" attributeType="String"/>
         <attribute name="publicizeMessageID" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="tags" optional="YES" attributeType="String">
-            <userInfo/>
-        </attribute>
-        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Category" inverseName="posts" inverseEntity="Category" indexed="YES">
-            <userInfo/>
-        </relationship>
+        <attribute name="tags" optional="YES" attributeType="String"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Category" inverseName="posts" inverseEntity="Category" indexed="YES"/>
         <userInfo/>
     </entity>
     <entity name="PostTag" representedClassName="PostTag">
-        <attribute name="name" attributeType="String">
-            <userInfo/>
-        </attribute>
+        <attribute name="name" attributeType="String"/>
         <attribute name="postCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="tagDescription" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="tagID" optional="YES" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO">
-            <userInfo/>
-        </attribute>
+        <attribute name="tagID" optional="YES" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO"/>
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="tags" inverseEntity="Blog" syncable="YES"/>
         <userInfo/>
     </entity>
@@ -909,7 +760,7 @@
         <attribute name="visitorsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <elements>
-        <element name="AbstractPost" positionX="0" positionY="0" width="128" height="180"/>
+        <element name="AbstractPost" positionX="0" positionY="0" width="128" height="223"/>
         <element name="Account" positionX="0" positionY="0" width="128" height="210"/>
         <element name="AccountSettings" positionX="18" positionY="153" width="128" height="255"/>
         <element name="AllTimeStatsRecordValue" positionX="27" positionY="162" width="128" height="120"/>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1010,6 +1010,7 @@
 		85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */ = {isa = PBXBuildFile; fileRef = 85DA8C4318F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m */; };
 		85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */; };
 		8B8C814D2318073300A0E620 /* BasePostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8C814C2318073300A0E620 /* BasePostTests.swift */; };
+		8B8FE8582343955500F9AD2E /* AutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* AutoUploadMessages.swift */; };
 		8B93856E22DC08060010BF02 /* PageListSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */; };
 		8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */; };
 		8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */; };
@@ -3162,6 +3163,7 @@
 		85ED98AA17DFB17200090D0B /* iTunesArtwork@2x */ = {isa = PBXFileReference; lastKnownFileType = file; path = "iTunesArtwork@2x"; sourceTree = "<group>"; };
 		85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationServiceTests.swift; sourceTree = "<group>"; };
 		8B8C814C2318073300A0E620 /* BasePostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePostTests.swift; sourceTree = "<group>"; };
+		8B8FE8562343952B00F9AD2E /* AutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoUploadMessages.swift; sourceTree = "<group>"; };
 		8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListSectionHeaderView.swift; sourceTree = "<group>"; };
 		8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorTests.swift; sourceTree = "<group>"; };
 		8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeeded.swift"; sourceTree = "<group>"; };
@@ -5718,6 +5720,7 @@
 				570BFD8A22823D7B007859A8 /* PostActionSheet.swift */,
 				570265142298921800F2214C /* PostListTableViewHandler.swift */,
 				57047A4E22A961BC00B461DF /* PostSearchHeader.swift */,
+				8B8FE8562343952B00F9AD2E /* AutoUploadMessages.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -10753,6 +10756,7 @@
 				740516892087B73400252FD0 /* SearchableActivityConvertable.swift in Sources */,
 				B5F641B31E37C36700B7819F /* AdaptiveNavigationController.swift in Sources */,
 				74BC35B820499EEB00AC1525 /* RemotePostCategory+Extensions.swift in Sources */,
+				8B8FE8582343955500F9AD2E /* AutoUploadMessages.swift in Sources */,
 				57D5812D2228526C002BAAD7 /* WPError+Swift.swift in Sources */,
 				988AC37922F10E2C00BC1433 /* FileDownloadsStatsRecordValue+CoreDataClass.swift in Sources */,
 				825327581FBF7CD600B8B7D2 /* ActivityUtils.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1010,7 +1010,7 @@
 		85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */ = {isa = PBXBuildFile; fileRef = 85DA8C4318F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m */; };
 		85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */; };
 		8B8C814D2318073300A0E620 /* BasePostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8C814C2318073300A0E620 /* BasePostTests.swift */; };
-		8B8FE8582343955500F9AD2E /* AutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* AutoUploadMessages.swift */; };
+		8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */; };
 		8B93856E22DC08060010BF02 /* PageListSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */; };
 		8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */; };
 		8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */; };
@@ -3163,7 +3163,7 @@
 		85ED98AA17DFB17200090D0B /* iTunesArtwork@2x */ = {isa = PBXFileReference; lastKnownFileType = file; path = "iTunesArtwork@2x"; sourceTree = "<group>"; };
 		85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationServiceTests.swift; sourceTree = "<group>"; };
 		8B8C814C2318073300A0E620 /* BasePostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePostTests.swift; sourceTree = "<group>"; };
-		8B8FE8562343952B00F9AD2E /* AutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoUploadMessages.swift; sourceTree = "<group>"; };
+		8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadMessages.swift; sourceTree = "<group>"; };
 		8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListSectionHeaderView.swift; sourceTree = "<group>"; };
 		8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorTests.swift; sourceTree = "<group>"; };
 		8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeeded.swift"; sourceTree = "<group>"; };
@@ -5720,7 +5720,7 @@
 				570BFD8A22823D7B007859A8 /* PostActionSheet.swift */,
 				570265142298921800F2214C /* PostListTableViewHandler.swift */,
 				57047A4E22A961BC00B461DF /* PostSearchHeader.swift */,
-				8B8FE8562343952B00F9AD2E /* AutoUploadMessages.swift */,
+				8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -10756,7 +10756,7 @@
 				740516892087B73400252FD0 /* SearchableActivityConvertable.swift in Sources */,
 				B5F641B31E37C36700B7819F /* AdaptiveNavigationController.swift in Sources */,
 				74BC35B820499EEB00AC1525 /* RemotePostCategory+Extensions.swift in Sources */,
-				8B8FE8582343955500F9AD2E /* AutoUploadMessages.swift in Sources */,
+				8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */,
 				57D5812D2228526C002BAAD7 /* WPError+Swift.swift in Sources */,
 				988AC37922F10E2C00BC1433 /* FileDownloadsStatsRecordValue+CoreDataClass.swift in Sources */,
 				825327581FBF7CD600B8B7D2 /* ActivityUtils.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1015,6 +1015,7 @@
 		8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */; };
 		8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */; };
 		8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */; };
+		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BFE36FD230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */; };
 		8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */; };
 		91138455228373EB00FB02B7 /* GutenbergVideoUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91138454228373EB00FB02B7 /* GutenbergVideoUploadProcessor.swift */; };
@@ -3169,6 +3170,7 @@
 		8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeeded.swift"; sourceTree = "<group>"; };
 		8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeededTests.swift"; sourceTree = "<group>"; };
 		8BE377832339416800082EFE /* WordPress 91.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 91.xcdatamodel"; sourceTree = "<group>"; };
+		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLs.swift"; sourceTree = "<group>"; };
 		8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLsTests.swift"; sourceTree = "<group>"; };
 		8CE5BBD00FF1470AC4B88247 /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -8751,6 +8753,7 @@
 				933D1F6B1EA7A3AB009FB462 /* TestingMode.storyboard */,
 				933D1F6D1EA7A402009FB462 /* TestAssets.xcassets */,
 				D81C2F5720F86CEA002AE1F1 /* NetworkStatus.swift */,
+				8BE7C84023466927006EDE70 /* I18n.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -11860,6 +11863,7 @@
 				572FB401223A806000933C76 /* NoticeStoreTests.swift in Sources */,
 				D816B8D12112D5960052CE4D /* DefaultNewsManagerTests.swift in Sources */,
 				748437EE1F1D4A7300E8DDAF /* RichContentFormatterTests.swift in Sources */,
+				8BE7C84123466927006EDE70 /* I18n.swift in Sources */,
 				D88A649E208D82D2008AE9BC /* XCTestCase+Wait.swift in Sources */,
 				E18549DB230FBFEF003C620E /* BlogServiceDeduplicationTests.swift in Sources */,
 				400A2C8F2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift in Sources */,

--- a/WordPress/WordPressTest/I18n.swift
+++ b/WordPress/WordPressTest/I18n.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+// Helper function that returns a localized string
+func i18n(_ content: String) -> String {
+    return NSLocalizedString(content, comment: "_")
+}

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -119,8 +119,8 @@ class PostBuilder {
         return self
     }
 
-    func with(autoUploadFailureCount: Int) -> PostBuilder {
-        post.autoUploadFailureCount = NSNumber(value: autoUploadFailureCount)
+    func with(autoUploadAttemptsCount: Int) -> PostBuilder {
+        post.autoUploadAttemptsCount = NSNumber(value: autoUploadAttemptsCount)
         
         return self
     }

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -121,7 +121,7 @@ class PostBuilder {
 
     func with(autoUploadAttemptsCount: Int) -> PostBuilder {
         post.autoUploadAttemptsCount = NSNumber(value: autoUploadAttemptsCount)
-        
+
         return self
     }
 

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -119,6 +119,12 @@ class PostBuilder {
         return self
     }
 
+    func with(autoUploadFailureCount: Int) -> PostBuilder {
+        post.autoUploadFailureCount = NSNumber(value: autoUploadFailureCount)
+        
+        return self
+    }
+
     func `is`(sticked: Bool) -> PostBuilder {
         post.isStickyPost = sticked
         return self

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -273,7 +273,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, AutoUploadMessages.changesWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.text, PostAutoUploadMessages.changesWillBeUploaded)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
@@ -285,7 +285,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, AutoUploadMessages.postWillBePublished)
+        XCTAssertEqual(postCell.statusLabel.text, PostAutoUploadMessages.postWillBePublished)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
@@ -348,7 +348,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, AutoUploadMessages.changesWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.text, PostAutoUploadMessages.changesWillBeUploaded)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
@@ -360,7 +360,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, AutoUploadMessages.draftWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.text, PostAutoUploadMessages.draftWillBeUploaded)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -1,5 +1,6 @@
 import UIKit
 import XCTest
+import Nimble
 
 @testable import WordPress
 
@@ -272,7 +273,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.changesWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.text, AutoUploadMessages.changesWillBeUploaded)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
@@ -284,7 +285,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.postWillBePublished)
+        XCTAssertEqual(postCell.statusLabel.text, AutoUploadMessages.postWillBePublished)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
@@ -347,7 +348,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.changesWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.text, AutoUploadMessages.changesWillBeUploaded)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
@@ -359,8 +360,26 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.draftWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.text, AutoUploadMessages.draftWillBeUploaded)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
+    }
+
+    func testShowsFailedMessageWhenAttemptToAutoUploadADraft() {
+        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).build()
+
+        postCell.configure(with: post)
+
+        expect(self.postCell.statusLabel.text).to(equal("Post couldn't be submitted. We'll try again later"))
+        expect(self.postCell.statusLabel.textColor).to(equal(UIColor.warning))
+    }
+
+    func testFailedMessageWhenMaxNumberOfAttemptsToAutoDraftIsReached() {
+        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
+
+        postCell.configure(with: post)
+
+        expect(self.postCell.statusLabel.text).to(equal("Couldn't perform operation"))
+        expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
     }
 
     private func postCellFromNib() -> PostCardCell {

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -411,4 +411,3 @@ class PostActionSheetDelegateMock: PostActionSheetDelegate {
         calledWithView = view
     }
 }
-

--- a/WordPress/WordPressTest/PostCompactCellTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellTests.swift
@@ -3,8 +3,6 @@ import XCTest
 
 @testable import WordPress
 
-private typealias StatusMessages = PostCardStatusViewModel.StatusMessages
-
 class PostCompactCellTests: XCTestCase {
 
     var postCell: PostCompactCell!
@@ -119,7 +117,7 @@ class PostCompactCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.badgesLabel.text, StatusMessages.postWillBePublished)
+        XCTAssertEqual(postCell.badgesLabel.text, AutoUploadMessages.postWillBePublished)
         XCTAssertEqual(postCell.badgesLabel.textColor, UIColor.warning)
     }
 

--- a/WordPress/WordPressTest/PostCompactCellTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellTests.swift
@@ -117,7 +117,7 @@ class PostCompactCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.badgesLabel.text, AutoUploadMessages.postWillBePublished)
+        XCTAssertEqual(postCell.badgesLabel.text, PostAutoUploadMessages.postWillBePublished)
         XCTAssertEqual(postCell.badgesLabel.textColor, UIColor.warning)
     }
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -56,6 +56,26 @@ class PostCoordinatorTests: XCTestCase {
 
         expect(post.remoteStatus).toEventually(equal(.pushing))
     }
+
+    func testFailureCountIsIncrementedAfterFailingToAutomaticallyUpload() {
+        let postServiceMock = PostServiceMock()
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let post = PostBuilder(context).build()
+
+        postCoordinator.save(post, automatedRetry: true)
+
+        expect(post.autoUploadFailureCount).to(equal(1))
+    }
+
+    func testFailureCountIsResetWhenNotAutomaticallyUpload() {
+        let postServiceMock = PostServiceMock()
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let post = PostBuilder(context).with(autoUploadFailureCount: 3).build()
+
+        postCoordinator.save(post, automatedRetry: false)
+
+        expect(post.autoUploadFailureCount).to(equal(1))
+    }
 }
 
 private class PostServiceMock: PostService {

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -74,7 +74,7 @@ class PostCoordinatorTests: XCTestCase {
 
         postCoordinator.save(post, automatedRetry: false)
 
-        expect(post.autoUploadAttemptsCount).to(equal(1))
+        expect(post.autoUploadAttemptsCount).to(equal(0))
     }
 }
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -57,24 +57,24 @@ class PostCoordinatorTests: XCTestCase {
         expect(post.remoteStatus).toEventually(equal(.pushing))
     }
 
-    func testFailureCountIsIncrementedAfterFailingToAutomaticallyUpload() {
+    func testAttemptCountIsIncrementedAfterFailingToAutomaticallyUpload() {
         let postServiceMock = PostServiceMock()
         let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
         let post = PostBuilder(context).build()
 
         postCoordinator.save(post, automatedRetry: true)
 
-        expect(post.autoUploadFailureCount).to(equal(1))
+        expect(post.autoUploadAttemptsCount).to(equal(1))
     }
 
-    func testFailureCountIsResetWhenNotAutomaticallyUpload() {
+    func testAttemptCountIsResetWhenNotAutomaticallyUpload() {
         let postServiceMock = PostServiceMock()
         let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
-        let post = PostBuilder(context).with(autoUploadFailureCount: 3).build()
+        let post = PostBuilder(context).with(autoUploadAttemptsCount: 3).build()
 
         postCoordinator.save(post, automatedRetry: false)
 
-        expect(post.autoUploadFailureCount).to(equal(1))
+        expect(post.autoUploadAttemptsCount).to(equal(1))
     }
 }
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -170,4 +170,3 @@ private class MediaCoordinatorMock: MediaCoordinator {
         // noop
     }
 }
-

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -103,7 +103,7 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
     }
 
     func testReturnNothingAsPostActionWhenAttemptLimitIsReached() {
-        let post = createPost(.publish, confirmedAutoUpload: true, autoUploadFailureCount: 3)
+        let post = createPost(.publish, confirmedAutoUpload: true, attemptsCount: 3)
 
         let action = interactor.autoUploadAction(for: post)
 
@@ -111,7 +111,7 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
     }
 
     func testReturnUploadAsPostActionWhenAttemptLimitIsNotReached() {
-        let post = createPost(.publish, confirmedAutoUpload: true, autoUploadFailureCount: 2)
+        let post = createPost(.publish, confirmedAutoUpload: true, attemptsCount: 2)
 
         let action = interactor.autoUploadAction(for: post)
 
@@ -124,11 +124,11 @@ private extension PostCoordinatorUploadActionUseCaseTests {
                     remoteStatus: AbstractPostRemoteStatus = .failed,
                     hasRemote: Bool = false,
                     confirmedAutoUpload: Bool = false,
-                    autoUploadFailureCount: Int = 1) -> Post {
+                    attemptsCount: Int = 1) -> Post {
         let post = Post(context: context)
         post.status = status
         post.remoteStatus = remoteStatus
-        post.autoUploadAttemptsCount = NSNumber(value: autoUploadFailureCount)
+        post.autoUploadAttemptsCount = NSNumber(value: attemptsCount)
 
         if hasRemote {
             post.postID = NSNumber(value: Int.random(in: 1...Int.max))

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -128,7 +128,7 @@ private extension PostCoordinatorUploadActionUseCaseTests {
         let post = Post(context: context)
         post.status = status
         post.remoteStatus = remoteStatus
-        post.autoUploadFailureCount = NSNumber(value: autoUploadFailureCount)
+        post.autoUploadAttemptsCount = NSNumber(value: autoUploadFailureCount)
 
         if hasRemote {
             post.postID = NSNumber(value: Int.random(in: 1...Int.max))

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -101,16 +101,34 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
             expect(actualResult).to(equal(expectedCancelableResult))
         }
     }
+
+    func testReturnNothingAsPostActionWhenAttemptLimitIsReached() {
+        let post = createPost(.publish, confirmedAutoUpload: true, autoUploadFailureCount: 3)
+
+        let action = interactor.autoUploadAction(for: post)
+
+        expect(action).to(equal(.nothing))
+    }
+
+    func testReturnUploadAsPostActionWhenAttemptLimitIsNotReached() {
+        let post = createPost(.publish, confirmedAutoUpload: true, autoUploadFailureCount: 2)
+
+        let action = interactor.autoUploadAction(for: post)
+
+        expect(action).to(equal(.upload))
+    }
 }
 
 private extension PostCoordinatorUploadActionUseCaseTests {
     func createPost(_ status: BasePost.Status,
                     remoteStatus: AbstractPostRemoteStatus = .failed,
                     hasRemote: Bool = false,
-                    confirmedAutoUpload: Bool = false) -> Post {
+                    confirmedAutoUpload: Bool = false,
+                    autoUploadFailureCount: Int = 1) -> Post {
         let post = Post(context: context)
         post.status = status
         post.remoteStatus = remoteStatus
+        post.autoUploadFailureCount = NSNumber(value: autoUploadFailureCount)
 
         if hasRemote {
             post.postID = NSNumber(value: Int.random(in: 1...Int.max))

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -72,15 +72,27 @@ class PostNoticeViewModelTests: XCTestCase {
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
-                scenario: "Post with at least 1 auto upload attempt",
+                scenario: "Post with at least 1 auto upload to publish attempt",
                 post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 2),
                 title: "Post couldn't be published. We'll try again later",
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
-                scenario: "Post with the maximum number of auto upload attempts",
+                scenario: "Post with the maximum number of auto upload to publish attempts",
                 post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 3),
                 title: "Couldn't perform operation. Post not published",
+                actionTitle: FailureActionTitles.retry
+            ),
+            Expectation(
+                scenario: "Post with at least 1 auto upload to draft attempt",
+                post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 2),
+                title: "Post couldn't be drafted. We'll try again later",
+                actionTitle: FailureActionTitles.cancel
+            ),
+            Expectation(
+                scenario: "Post with the maximum number of auto upload to draft attempts",
+                post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 3),
+                title: "Couldn't perform operation. Post not drafted",
                 actionTitle: FailureActionTitles.retry
             ),
         ]

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -71,6 +71,18 @@ class PostNoticeViewModelTests: XCTestCase {
                 title: FailureTitles.postFailedToUpload,
                 actionTitle: FailureActionTitles.retry
             ),
+            Expectation(
+                scenario: "Post with at least 1 auto upload attempt",
+                post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 2),
+                title: "Post couldn't be published. We'll try again later",
+                actionTitle: FailureActionTitles.cancel
+            ),
+            Expectation(
+                scenario: "Post with the maximum number of auto upload attempts",
+                post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 3),
+                title: "Couldn't perform operation. Post not published",
+                actionTitle: FailureActionTitles.retry
+            ),
         ]
 
         expectations.forEach { expectation in
@@ -136,7 +148,7 @@ class PostNoticeViewModelTests: XCTestCase {
     }
 
 
-    private func createPost(_ status: BasePost.Status, hasRemote: Bool = false) -> Post {
+    private func createPost(_ status: BasePost.Status, hasRemote: Bool = false, autoUploadAttemptsCount: Int = 0) -> Post {
         var builder = PostBuilder(context)
             .with(title: UUID().uuidString)
             .with(status: status)
@@ -145,6 +157,8 @@ class PostNoticeViewModelTests: XCTestCase {
         if hasRemote {
             builder = builder.withRemote()
         }
+
+        builder = builder.with(autoUploadAttemptsCount: autoUploadAttemptsCount)
 
         builder = builder.confirmedAutoUpload()
 

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -5,7 +5,6 @@ import Nimble
 @testable import WordPress
 
 private typealias FailureActionTitles = PostNoticeViewModel.FailureActionTitles
-private typealias FailureTitles = PostNoticeViewModel.FailureTitles
 
 class PostNoticeViewModelTests: XCTestCase {
     private var contextManager: TestContextManager!
@@ -38,37 +37,37 @@ class PostNoticeViewModelTests: XCTestCase {
             Expectation(
                 scenario: "Local draft",
                 post: createPost(.draft),
-                title: FailureTitles.draftWillBeUploaded,
+                title: AutoUploadMessages.draftWillBeUploaded,
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
                 scenario: "Draft with confirmed local changes",
                 post: createPost(.draft, hasRemote: true),
-                title: FailureTitles.changesWillBeUploaded,
+                title: AutoUploadMessages.changesWillBeUploaded,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Local published draft",
                 post: createPost(.publish),
-                title: FailureTitles.postWillBePublished,
+                title: AutoUploadMessages.postWillBePublished,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Published post with confirmed local changes",
                 post: createPost(.publish, hasRemote: true),
-                title: FailureTitles.changesWillBeUploaded,
+                title: AutoUploadMessages.changesWillBeUploaded,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Currently unsupported: Locally scheduled post",
                 post: createPost(.scheduled),
-                title: FailureTitles.postFailedToUpload,
+                title: AutoUploadMessages.postFailedToUpload,
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
                 scenario: "Currently unsupported: Scheduled post with confirmed local changes",
                 post: createPost(.scheduled, hasRemote: true),
-                title: FailureTitles.postFailedToUpload,
+                title: AutoUploadMessages.postFailedToUpload,
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -84,15 +84,15 @@ class PostNoticeViewModelTests: XCTestCase {
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
-                scenario: "Post with at least 1 auto upload to draft attempt",
+                scenario: "Draft with at least 1 auto upload attempt",
                 post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 2),
-                title: "Post couldn't be drafted. We'll try again later",
+                title: "Post couldn't be submitted. We'll try again later",
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
-                scenario: "Post with the maximum number of auto upload to draft attempts",
+                scenario: "Draft with the maximum number of auto upload attempts",
                 post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 3),
-                title: "Couldn't perform operation. Post not drafted",
+                title: "Couldn't perform operation",
                 actionTitle: FailureActionTitles.retry
             ),
         ]

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -73,25 +73,25 @@ class PostNoticeViewModelTests: XCTestCase {
             Expectation(
                 scenario: "Post with at least 1 auto upload to publish attempt",
                 post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 2),
-                title: NSLocalizedString("Post couldn't be published. We'll try again later", comment: ""),
+                title: i18n("Post couldn't be published. We'll try again later"),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Post with the maximum number of auto upload to publish attempts",
                 post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 3),
-                title: NSLocalizedString("Couldn't perform operation. Post not published", comment: ""),
+                title: i18n("Couldn't perform operation. Post not published"),
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
                 scenario: "Draft with at least 1 auto upload attempt",
                 post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 2),
-                title: NSLocalizedString("Post couldn't be submitted. We'll try again later", comment: ""),
+                title: i18n("Post couldn't be submitted. We'll try again later"),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Draft with the maximum number of auto upload attempts",
                 post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 3),
-                title: NSLocalizedString("Couldn't perform operation", comment: ""),
+                title: i18n("Couldn't perform operation"),
                 actionTitle: FailureActionTitles.retry
             ),
         ]

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -37,37 +37,37 @@ class PostNoticeViewModelTests: XCTestCase {
             Expectation(
                 scenario: "Local draft",
                 post: createPost(.draft),
-                title: AutoUploadMessages.draftWillBeUploaded,
+                title: PostAutoUploadMessages.draftWillBeUploaded,
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
                 scenario: "Draft with confirmed local changes",
                 post: createPost(.draft, hasRemote: true),
-                title: AutoUploadMessages.changesWillBeUploaded,
+                title: PostAutoUploadMessages.changesWillBeUploaded,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Local published draft",
                 post: createPost(.publish),
-                title: AutoUploadMessages.postWillBePublished,
+                title: PostAutoUploadMessages.postWillBePublished,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Published post with confirmed local changes",
                 post: createPost(.publish, hasRemote: true),
-                title: AutoUploadMessages.changesWillBeUploaded,
+                title: PostAutoUploadMessages.changesWillBeUploaded,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Currently unsupported: Locally scheduled post",
                 post: createPost(.scheduled),
-                title: AutoUploadMessages.postFailedToUpload,
+                title: PostAutoUploadMessages.postFailedToUpload,
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
                 scenario: "Currently unsupported: Scheduled post with confirmed local changes",
                 post: createPost(.scheduled, hasRemote: true),
-                title: AutoUploadMessages.postFailedToUpload,
+                title: PostAutoUploadMessages.postFailedToUpload,
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -73,25 +73,25 @@ class PostNoticeViewModelTests: XCTestCase {
             Expectation(
                 scenario: "Post with at least 1 auto upload to publish attempt",
                 post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 2),
-                title: "Post couldn't be published. We'll try again later",
+                title: NSLocalizedString("Post couldn't be published. We'll try again later", comment: ""),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Post with the maximum number of auto upload to publish attempts",
                 post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 3),
-                title: "Couldn't perform operation. Post not published",
+                title: NSLocalizedString("Couldn't perform operation. Post not published", comment: ""),
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
                 scenario: "Draft with at least 1 auto upload attempt",
                 post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 2),
-                title: "Post couldn't be submitted. We'll try again later",
+                title: NSLocalizedString("Post couldn't be submitted. We'll try again later", comment: ""),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Draft with the maximum number of auto upload attempts",
                 post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 3),
-                title: "Couldn't perform operation",
+                title: NSLocalizedString("Couldn't perform operation", comment: ""),
                 actionTitle: FailureActionTitles.retry
             ),
         ]

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -114,7 +114,7 @@ class PostCardStatusViewModelTests: XCTestCase {
 
         let message = viewModel.statusAndBadges(separatedBy: "")
 
-        expect(message).to(equal("Post couldn't be drafted. We'll try again later"))
+        expect(message).to(equal("Post couldn't be submitted. We'll try again later"))
     }
 
     func testFailedMessageWhenMaxNumberOfAttemptsToAutoDraftIsReached() {
@@ -123,7 +123,7 @@ class PostCardStatusViewModelTests: XCTestCase {
 
         let message = viewModel.statusAndBadges(separatedBy: "")
 
-        expect(message).to(equal("Couldn't perform operation. Post not drafted"))
+        expect(message).to(equal("Couldn't perform operation"))
     }
 }
 

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -90,7 +90,7 @@ class PostCardStatusViewModelTests: XCTestCase {
         }
     }
 
-    func testFailedMessageWhenAttemptToAutoUpload() {
+    func testFailedMessageWhenAttemptToAutoPublish() {
         let post = PostBuilder(context).with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).build()
         let viewModel = PostCardStatusViewModel(post: post)
 
@@ -99,13 +99,31 @@ class PostCardStatusViewModelTests: XCTestCase {
         expect(message).to(equal("Post couldn't be published. We'll try again later"))
     }
 
-    func testFailedMessageWhenMaxNumberOfAttemptsToAutoUploadIsReached() {
+    func testFailedMessageWhenMaxNumberOfAttemptsToAutoPublishIsReached() {
         let post = PostBuilder(context).with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
         let viewModel = PostCardStatusViewModel(post: post)
 
         let message = viewModel.statusAndBadges(separatedBy: "")
 
         expect(message).to(equal("Couldn't perform operation. Post not published"))
+    }
+
+    func testFailedMessageWhenAttemptToAutoDraft() {
+        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).build()
+        let viewModel = PostCardStatusViewModel(post: post)
+
+        let message = viewModel.statusAndBadges(separatedBy: "")
+
+        expect(message).to(equal("Post couldn't be drafted. We'll try again later"))
+    }
+
+    func testFailedMessageWhenMaxNumberOfAttemptsToAutoDraftIsReached() {
+        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
+        let viewModel = PostCardStatusViewModel(post: post)
+
+        let message = viewModel.statusAndBadges(separatedBy: "")
+
+        expect(message).to(equal("Couldn't perform operation. Post not drafted"))
     }
 }
 

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -65,9 +65,10 @@ class PostCardStatusViewModelTests: XCTestCase {
                 ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.stats, .moveToDraft, .trash])
             ),
             (
-                "Published post with canceled local changes",
-                PostBuilder(context).published().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build(),
-                ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.stats, .moveToDraft, .trash])
+                "Post with the max number of auto uploades retry reached",
+                PostBuilder(context).with(remoteStatus: .failed)
+                    .with(autoUploadAttemptsCount: 3).confirmedAutoUpload().build(),
+                ButtonGroups(primary: [.edit, .retry, .more], secondary: [.moveToDraft, .trash])
             ),
         ]
 
@@ -87,6 +88,24 @@ class PostCardStatusViewModelTests: XCTestCase {
                 return .succeeded
             }).to(succeed())
         }
+    }
+
+    func testFailedMessageWhenAttemptToAutoUpload() {
+        let post = PostBuilder(context).with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).build()
+        let viewModel = PostCardStatusViewModel(post: post)
+
+        let message = viewModel.statusAndBadges(separatedBy: "")
+
+        expect(message).to(equal("Post couldn't be published. We'll try again later"))
+    }
+
+    func testFailedMessageWhenMaxNumberOfAttemptsToAutoUploadIsReached() {
+        let post = PostBuilder(context).with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
+        let viewModel = PostCardStatusViewModel(post: post)
+
+        let message = viewModel.statusAndBadges(separatedBy: "")
+
+        expect(message).to(equal("Couldn't perform operation. Post not published"))
     }
 }
 

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -89,42 +89,6 @@ class PostCardStatusViewModelTests: XCTestCase {
             }).to(succeed())
         }
     }
-
-    func testFailedMessageWhenAttemptToAutoPublish() {
-        let post = PostBuilder(context).with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).build()
-        let viewModel = PostCardStatusViewModel(post: post)
-
-        let message = viewModel.statusAndBadges(separatedBy: "")
-
-        expect(message).to(equal("Post couldn't be published. We'll try again later"))
-    }
-
-    func testFailedMessageWhenMaxNumberOfAttemptsToAutoPublishIsReached() {
-        let post = PostBuilder(context).with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
-        let viewModel = PostCardStatusViewModel(post: post)
-
-        let message = viewModel.statusAndBadges(separatedBy: "")
-
-        expect(message).to(equal("Couldn't perform operation. Post not published"))
-    }
-
-    func testFailedMessageWhenAttemptToAutoDraft() {
-        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).build()
-        let viewModel = PostCardStatusViewModel(post: post)
-
-        let message = viewModel.statusAndBadges(separatedBy: "")
-
-        expect(message).to(equal("Post couldn't be submitted. We'll try again later"))
-    }
-
-    func testFailedMessageWhenMaxNumberOfAttemptsToAutoDraftIsReached() {
-        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
-        let viewModel = PostCardStatusViewModel(post: post)
-
-        let message = viewModel.statusAndBadges(separatedBy: "")
-
-        expect(message).to(equal("Couldn't perform operation"))
-    }
 }
 
 private extension ButtonGroups {

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -68,7 +68,7 @@ class PostCardStatusViewModelTests: XCTestCase {
                 "Post with the max number of auto uploades retry reached",
                 PostBuilder(context).with(remoteStatus: .failed)
                     .with(autoUploadAttemptsCount: 3).confirmedAutoUpload().build(),
-                ButtonGroups(primary: [.edit, .retry, .more], secondary: [.moveToDraft, .trash])
+                ButtonGroups(primary: [.edit, .retry, .more], secondary: [.publish, .moveToDraft, .trash])
             ),
         ]
 


### PR DESCRIPTION
Fixes #12369

# To test

## Scenario 1: offline publishing

While offline:
1. Create and publish a post
2. Check that both the toast and the post card says: "Post will be published next time..."
3. Restart the app
4. Check that both the toast and the post card says: "Post couldn't be published. We'll try again later"
5. Restart the app and check the same behavior as above
6. Restart again and check that the post failed and that the message "Couldn't perform operation. Post not published" is shown

## Scenario 2: offline drafting

While offline:
1. Create and publish a post
2. Check that both the toast and the post card says: "Draft will be uploaded next time..."
3. Restart the app
4. Check that both the toast and the post card says: "Post couldn't be drafted. We'll try again later"
5. Restart the app and check the same behavior as above
6. Restart again and check that the post failed and that the message "Couldn't perform operation. Post not drafted" is shown

## Scenario 3: restart after 3 failures

1. While offline, add a post and make sure to reach the message "Couldn't perform operation. Post not published" (you can do that by restarting the app at least 3 times)
2. Click retry.
3. While offline, this should mark the post to be auto-uploaded later
4. If online, the bost should be uploaded right away

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 