### PR TITLE
[Dark Mode] Re-enable screenshots when app is in background

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -342,3 +342,12 @@ extension UIColor {
         self.init(red: r, green: g, blue: b, alpha: a)
     }
 }
+
+extension UIColor {
+    func color(for trait: UITraitCollection?) -> UIColor {
+        if #available(iOS 13, *), let trait = trait {
+            return resolvedColor(with: trait)
+        }
+        return self
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -769,6 +769,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         guard let post = post else {
             return
         }
+
         textView.isPrivate = post.isPrivate()
         textView.content = post.contentForDisplay()
 
@@ -780,6 +781,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         guard let post = post else {
             return
         }
+
         if #available(iOS 13, *) {
             let isDark = traitCollection.userInterfaceStyle == .dark
             textView.attributedText = isDark ? darkTextViewAttributedString : lightTextViewAttributedString

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -102,6 +102,9 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     private let bottomMarginAttachment = ReaderPlaceholderAttachment()
 
+    private var lightTextViewAttributedString: NSAttributedString?
+    private var darkTextViewAttributedString: NSAttributedString?
+
     @objc var currentPreferredStatusBarStyle = UIStatusBarStyle.lightContent {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
@@ -301,9 +304,9 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         view.layoutIfNeeded()
 
         if #available(iOS 13.0, *) {
-            if previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) == true, UIApplication.shared.applicationState != .background {
+            if previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) == true {
                 reloadGradientColors()
-                configureRichText()
+                updateRichText()
             }
         }
     }
@@ -561,6 +564,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         configureFeaturedImage()
         configureTitle()
         configureByLine()
+        configureAttributedString()
         configureRichText()
         configureDiscoverAttribution()
         configureTag()
@@ -768,19 +772,41 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         textView.isPrivate = post.isPrivate()
         textView.content = post.contentForDisplay()
 
-        // TODO: Get attributed string
-        // Modify the attributed string. Add top and bottom embeds
-        // Ensure formatting for embeds.
-        // Assign attributed string to textView.
-        // Besure that embed bounds are updated.
-        let attrStr = WPRichContentView.formattedAttributedStringForString(post.contentForDisplay())
-        let mAttrStr = NSMutableAttributedString(attributedString: attrStr)
+        updateRichText()
+        updateTextViewMargins()
+    }
+
+    private func updateRichText() {
+        guard let post = post else {
+            return
+        }
+        if #available(iOS 13, *) {
+            let isDark = traitCollection.userInterfaceStyle == .dark
+            textView.attributedText = isDark ? darkTextViewAttributedString : lightTextViewAttributedString
+        } else {
+            let attrStr = WPRichContentView.formattedAttributedStringForString(post.contentForDisplay())
+            textView.attributedText = attributedString(with: attrStr)
+        }
+    }
+
+    private func configureAttributedString() {
+        if #available(iOS 13, *), let post = post {
+            let string: String = post.contentForDisplay()
+            let light = WPRichContentView.formattedAttributedStringForString(string, style: .light)
+            let dark = WPRichContentView.formattedAttributedStringForString(string, style: .dark)
+            lightTextViewAttributedString = attributedString(with: light)
+            darkTextViewAttributedString = attributedString(with: dark)
+        }
+    }
+
+    private func attributedString(with attributedString: NSAttributedString) -> NSAttributedString {
+        let mAttrStr = NSMutableAttributedString(attributedString: attributedString)
 
         // Ensure the starting paragraph style is applied to the topMarginAttachment else the
         // first paragraph might not have the correct line height.
         var paraStyle = NSParagraphStyle.default
-        if attrStr.length > 0 {
-            if let pstyle = attrStr.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle {
+        if attributedString.length > 0 {
+            if let pstyle = attributedString.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle {
                 paraStyle = pstyle
             }
         }
@@ -789,11 +815,8 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         mAttrStr.addAttributes([.paragraphStyle: paraStyle], range: NSRange(location: 0, length: 1))
         mAttrStr.append(NSAttributedString(attachment: bottomMarginAttachment))
 
-        textView.attributedText = mAttrStr
-
-        updateTextViewMargins()
+        return mAttrStr
     }
-
 
     fileprivate func configureDiscoverAttribution() {
         if post?.sourceAttributionStyle() == SourceAttributionStyle.none {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -791,9 +791,8 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     private func configureAttributedString() {
         if #available(iOS 13, *), let post = post {
-            let string: String = post.contentForDisplay()
-            let light = WPRichContentView.formattedAttributedStringForString(string, style: .light)
-            let dark = WPRichContentView.formattedAttributedStringForString(string, style: .dark)
+            let light = WPRichContentView.formattedAttributedString(for: post.contentForDisplay(), style: .light)
+            let dark = WPRichContentView.formattedAttributedString(for: post.contentForDisplay(), style: .dark)
             lightTextViewAttributedString = attributedString(with: light)
             darkTextViewAttributedString = attributedString(with: dark)
         }

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -66,17 +66,17 @@ class WPRichContentView: UITextView {
                                           blockQuoteColorHex: UIColor.textSubtle.hexString() ?? fallbackTextColorHex,
                                           linkColorHex: UIColor.primary.hexString() ?? fallbackTextColorHex,
                                           linkColorActiveHex: UIColor.primaryDark.hexString() ?? fallbackTextColorHex)
-        return formattedAttributedStringForString(string, style: style)
+        return formattedAttributedString(for: string, style: style)
     }
 
     @available(iOS 13, *)
-    class func formattedAttributedStringForString(_ string: String, style: UIUserInterfaceStyle) -> NSAttributedString {
+    class func formattedAttributedString(for string: String, style: UIUserInterfaceStyle) -> NSAttributedString {
         let trait = UITraitCollection(userInterfaceStyle: style)
         let style = AttributedStringStyle(textColorHex: UIColor.text.color(for: trait).hexString() ?? fallbackTextColorHex,
                                           blockQuoteColorHex: UIColor.textSubtle.color(for: trait).hexString() ?? fallbackTextColorHex,
                                           linkColorHex: UIColor.primary.color(for: trait).hexString() ?? fallbackTextColorHex,
                                           linkColorActiveHex: UIColor.primaryDark.color(for: trait).hexString() ?? fallbackTextColorHex)
-        return formattedAttributedStringForString(string, style: style)
+        return formattedAttributedString(for: string, style: style)
     }
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
@@ -153,7 +153,7 @@ class WPRichContentView: UITextView {
 }
 
 private extension WPRichContentView {
-    class func formattedAttributedStringForString(_ string: String, style: AttributedStringStyle) -> NSAttributedString {
+    class func formattedAttributedString(for string: String, style: AttributedStringStyle) -> NSAttributedString {
         let styleString = "<style>" +
             "body { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6; color: #\(style.textColorHex); }" +
             "blockquote { color:#\(style.blockQuoteColorHex); } " +

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -53,6 +53,8 @@ class WPRichContentView: UITextView {
         }
     }
 
+    private static let fallbackTextColorHex = "000"
+
     override var attributedText: NSAttributedString! {
         didSet {
             attachmentManager.enumerateAttachments()
@@ -60,34 +62,21 @@ class WPRichContentView: UITextView {
     }
 
     @objc class func formattedAttributedStringForString(_ string: String) -> NSAttributedString {
-        let fallbackTextColorHex = "000"
-        let textColorHex = UIColor.text.hexString() ?? fallbackTextColorHex
-        let blockQuoteColorHex = UIColor.textSubtle.hexString() ?? fallbackTextColorHex
-        let linkColorHex = UIColor.primary.hexString() ?? fallbackTextColorHex
-        let linkColorActiveHex = UIColor.primaryDark.hexString() ?? fallbackTextColorHex
+        let style = AttributedStringStyle(textColorHex: UIColor.text.hexString() ?? fallbackTextColorHex,
+                                          blockQuoteColorHex: UIColor.textSubtle.hexString() ?? fallbackTextColorHex,
+                                          linkColorHex: UIColor.primary.hexString() ?? fallbackTextColorHex,
+                                          linkColorActiveHex: UIColor.primaryDark.hexString() ?? fallbackTextColorHex)
+        return formattedAttributedStringForString(string, style: style)
+    }
 
-        let style = "<style>" +
-            "body { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6; color: #\(textColorHex); }" +
-            "blockquote { color:#\(blockQuoteColorHex); } " +
-            "em, i { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; font-style: italic; line-height:1.6; } " +
-            "a { color: #\(linkColorHex); text-decoration: none; } " +
-            "a:active { color: #\(linkColorActiveHex); } " +
-        "</style>"
-        let html = style + string
-
-        // Request the font to ensure it's loaded. Otherwise NSAttributedString
-        // falls back to Times New Roman :o
-        // https://github.com/wordpress-mobile/WordPress-iOS/issues/6564
-        _ = WPFontManager.notoItalicFont(ofSize: 16)
-        do {
-            if let attrTxt = try NSAttributedString.attributedStringFromHTMLString(html, defaultAttributes: nil) {
-                return attrTxt
-            }
-        } catch let error {
-            DDLogError("Error converting post content to attributed string: \(error)")
-        }
-        let text = NSLocalizedString("There was a problem displaying this post.", comment: "A short error message letting the user know about a problem displaying a post.")
-        return NSAttributedString(string: text)
+    @available(iOS 13, *)
+    class func formattedAttributedStringForString(_ string: String, style: UIUserInterfaceStyle) -> NSAttributedString {
+        let trait = UITraitCollection(userInterfaceStyle: style)
+        let style = AttributedStringStyle(textColorHex: UIColor.text.color(for: trait).hexString() ?? fallbackTextColorHex,
+                                          blockQuoteColorHex: UIColor.textSubtle.color(for: trait).hexString() ?? fallbackTextColorHex,
+                                          linkColorHex: UIColor.primary.color(for: trait).hexString() ?? fallbackTextColorHex,
+                                          linkColorActiveHex: UIColor.primaryDark.color(for: trait).hexString() ?? fallbackTextColorHex)
+        return formattedAttributedStringForString(string, style: style)
     }
 
     override init(frame: CGRect, textContainer: NSTextContainer?) {
@@ -155,8 +144,41 @@ class WPRichContentView: UITextView {
         }
     }
 
+    struct AttributedStringStyle {
+        let textColorHex: String
+        let blockQuoteColorHex: String
+        let linkColorHex: String
+        let linkColorActiveHex: String
+    }
+}
 
-    private func ensureLayoutForAttachment(_ attachment: NSTextAttachment, at range: NSRange) {
+private extension WPRichContentView {
+    class func formattedAttributedStringForString(_ string: String, style: AttributedStringStyle) -> NSAttributedString {
+        let styleString = "<style>" +
+            "body { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6; color: #\(style.textColorHex); }" +
+            "blockquote { color:#\(style.blockQuoteColorHex); } " +
+            "em, i { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; font-style: italic; line-height:1.6; } " +
+            "a { color: #\(style.linkColorHex); text-decoration: none; } " +
+            "a:active { color: #\(style.linkColorActiveHex); } " +
+        "</style>"
+        let html = styleString + string
+
+        // Request the font to ensure it's loaded. Otherwise NSAttributedString
+        // falls back to Times New Roman :o
+        // https://github.com/wordpress-mobile/WordPress-iOS/issues/6564
+        _ = WPFontManager.notoItalicFont(ofSize: 16)
+        do {
+            if let attrTxt = try NSAttributedString.attributedStringFromHTMLString(html, defaultAttributes: nil) {
+                return attrTxt
+            }
+        } catch let error {
+            DDLogError("Error converting post content to attributed string: \(error)")
+        }
+        let text = NSLocalizedString("There was a problem displaying this post.", comment: "A short error message letting the user know about a problem displaying a post.")
+        return NSAttributedString(string: text)
+    }
+
+    func ensureLayoutForAttachment(_ attachment: NSTextAttachment, at range: NSRange) {
         layoutManager.invalidateLayout(forCharacterRange: range, actualCharacterRange: nil)
         layoutManager.ensureLayout(forCharacterRange: range)
         attachmentManager.layoutAttachmentViews()


### PR DESCRIPTION
Fixes #12554 

This PR fix the problem introduced fixing [#12540](https://github.com/wordpress-mobile/WordPress-iOS/pull/12540) where the app wasn't able to keep the screenshot in background. Using @koke suggestion and the new _UIColor_ API `resolvedColor(with:)` I'm able to generate an attributed string for the dark and light user interface and assign it.

## To test:
• Run this branch on iOS 13 and go to the Reader
• Open a post and check everything works normally
• Switch user interface style (light to dark or vice versa)
• Put the app in background and check it doesn't crash
• On the App switch screen, change user interface style (light to dark or vice versa) and see if the app screenshot change
• Test on iOS 12 to check everything works fine

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
