### PR TITLE
Automatically upload published and draft posts with existing remote

### DIFF
--- a/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
+++ b/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
@@ -12,7 +12,7 @@
         guard post.remoteStatus != .failed else {
             return
         }
-        
+
         post.remoteStatus = .failed
 
         // If the post was not created on the server yet we convert the post to a local draft

--- a/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
+++ b/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
@@ -9,10 +9,6 @@
     ///     eventually be made private.
     ///
     func markAsFailedAndDraftIfNeeded(post: AbstractPost) {
-        guard post.remoteStatus != .failed, !post.hasRemote() else {
-            return
-        }
-
         post.remoteStatus = .failed
 
         // If the post was not created on the server yet we convert the post to a local draft

--- a/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
+++ b/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
@@ -9,6 +9,10 @@
     ///     eventually be made private.
     ///
     func markAsFailedAndDraftIfNeeded(post: AbstractPost) {
+        guard post.remoteStatus != .failed else {
+            return
+        }
+        
         post.remoteStatus = .failed
 
         // If the post was not created on the server yet we convert the post to a local draft

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -258,7 +258,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         [self.managedObjectContext performBlock:^{
             Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
-                [self markAsFailedAndDraftIfNeededWithPost:postInContext];
+                [self markAsFailedAndDraftIfNeededWithPost:post];
                 [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
             }
             if (failure) {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -258,7 +258,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         [self.managedObjectContext performBlock:^{
             Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
-                [self markAsFailedAndDraftIfNeededWithPost:post];
+                [self markAsFailedAndDraftIfNeededWithPost:postInContext];
                 [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
             }
             if (failure) {

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -4,7 +4,7 @@ import Nimble
 
 @testable import WordPress
 
-class PostServiceMarkAsFailedAndDraftTests: XCTestCase {
+class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
     func testMarkAPostAsFailedAndDraftIt() {
         let post = PostBuilder()
             .with(status: .pending)

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -4,6 +4,7 @@ import Nimble
 
 @testable import WordPress
 
+/// Test cases for PostService.markAsFailedAndDraftIfNeeded()
 class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
     func testMarkAPostAsFailedAndDraftIt() {
         let post = PostBuilder()
@@ -15,6 +16,16 @@ class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
 
         expect(post.remoteStatus).to(equal(.failed))
         expect(post.status).to(equal(.draft))
+    }
+
+    func testItWillMarkLocallyPublishedPostsAsFailedButKeepTheStatus() {
+        let post = PostBuilder().published().with(remoteStatus: .local).build()
+        let postService = PostService()
+
+        postService.markAsFailedAndDraftIfNeeded(post: post)
+
+        expect(post.remoteStatus).to(equal(.failed))
+        expect(post.status).to(equal(.publish))
     }
 
     func testMarkAPostAsFailedAndKeepItsStatus() {

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -6,12 +6,27 @@ import Nimble
 
 class PostServiceMarkAsFailedAndDraftTests: XCTestCase {
     func testMarkAPostAsFailedAndDraftIt() {
-        let post = PostBuilder().with(status: .pending).build()
+        let post = PostBuilder()
+            .with(status: .pending)
+            .build()
         let postService = PostService()
 
         postService.markAsFailedAndDraftIfNeeded(post: post)
 
         expect(post.remoteStatus).to(equal(.failed))
         expect(post.status).to(equal(.draft))
+    }
+
+    func testMarkAPostAsFailedAndKeepItsStatus() {
+        let post = PostBuilder()
+            .with(status: .pending)
+            .withRemote()
+            .build()
+        let postService = PostService()
+
+        postService.markAsFailedAndDraftIfNeeded(post: post)
+
+        expect(post.remoteStatus).to(equal(.failed))
+        expect(post.status).to(equal(.pending))
     }
 }


### PR DESCRIPTION
Fixes a regression in #12324 

For tests instructions, please take a look in #12466 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests.