### PR TITLE
Revert "support multiple prop in gutenberg editor"

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -142,7 +142,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => 'b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5'
+    gutenberg :commit => '640455e3203791f84b207974fa8c3e307f1fa586'
 
     ## Third party libraries
     ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -47,7 +47,7 @@ PODS:
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.1)"
   - Gridicons (0.19)
   - GTMSessionFetcher/Core (1.2.2)
-  - Gutenberg (1.13.1):
+  - Gutenberg (1.13.0):
     - React (= 0.60.0-patched)
     - React-RCTImage (= 0.60.0-patched)
     - RNTAztecView
@@ -198,7 +198,7 @@ PODS:
   - RNSVG (9.3.3-gb):
     - React-Core
     - React-RCTImage
-  - RNTAztecView (1.13.1):
+  - RNTAztecView (1.13.0):
     - React-Core
     - WordPress-Aztec-iOS
   - Sentry (4.4.0):
@@ -257,14 +257,14 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `640455e3203791f84b207974fa8c3e307f1fa586`)
   - HockeySDK (= 5.1.4)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
@@ -274,29 +274,29 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-DevSupport (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-DevSupport.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - React-RCTWebSocket (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTWebSocket.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-DevSupport (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-DevSupport.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - React-RCTWebSocket (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTWebSocket.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `640455e3203791f84b207974fa8c3e307f1fa586`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -307,7 +307,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.8.7)
   - WordPressUI (~> 1.3.5)
   - WPMediaPicker (~> 1.4.2)
-  - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
+  - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (from `https://github.com/zendesk/zendesk_sdk_ios`, tag `3.0.1-swift5.1-GM`)
   - ZIPFoundation (~> 0.9.8)
 
@@ -356,64 +356,64 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :commit: b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5
+    :commit: 640455e3203791f84b207974fa8c3e307f1fa586
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json
   React-DevSupport:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-DevSupport.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-DevSupport.podspec.json
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json
   React-RCTWebSocket:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/React-RCTWebSocket.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/React-RCTWebSocket.podspec.json
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :commit: b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5
+    :commit: 640455e3203791f84b207974fa8c3e307f1fa586
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/640455e3203791f84b207974fa8c3e307f1fa586/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 3.0.1-swift5.1-GM
@@ -423,10 +423,10 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :commit: b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5
+    :commit: 640455e3203791f84b207974fa8c3e307f1fa586
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNTAztecView:
-    :commit: b8e8fe1f6b438b5cfcc9a9bf86d23616969eeff5
+    :commit: 640455e3203791f84b207974fa8c3e307f1fa586
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
@@ -452,7 +452,7 @@ SPEC CHECKSUMS:
   GoogleToolboxForMac: b3553629623a3b1bff17f555e736cd5a6d95ad55
   Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
   GTMSessionFetcher: 61bb0f61a4cb560030f1222021178008a5727a23
-  Gutenberg: e9876cbb13cd1c1f553ea8b603e82cae376a02e5
+  Gutenberg: 6b40a7678121891fc21b12fb6334ad205a40409d
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
@@ -484,7 +484,7 @@ SPEC CHECKSUMS:
   React-RCTWebSocket: 47dfd49bb143d4847fae643816e02646b7bce1b9
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
   RNSVG: c820516df826221ce4969594bf3e822a464abd51
-  RNTAztecView: 83380670672cf8e7d903f8e1b7bbd44d21fcf421
+  RNTAztecView: d42fdf8b52979cf0b1844d1b439ac5574df29077
   Sentry: 26650184fe71eb7476dfd2737acb5ea6cc64b4b1
   SimulatorStatusMagic: 28d4a9d1a500ac7cea0b2b5a43c1c6ddb40ba56c
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
@@ -503,6 +503,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 787414f9240ee6ef8cfe4ea0f00e8b4d01d2d264
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 907e99f5995a14583d361a93abf6ec599be0caab
+PODFILE CHECKSUM: df539eec39cf650b1e2e2bb800a784bfdf029fb9
 
 COCOAPODS: 1.7.5

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -30,32 +30,8 @@ class GutenbergMediaInserterHelper: NSObject {
         self.unregisterMediaObserver()
     }
 
-    func insertFromSiteMediaLibrary(media: [Media], callback: @escaping MediaPickerDidPickMediaCallback) {
-        let foramttedMedia = media.map { item in
-            return (item.mediaID?.int32Value, item.remoteURL)
-        }
-        callback(foramttedMedia)
-    }
-
-    func insertFromDevice(assets: [PHAsset], callback: @escaping MediaPickerDidPickMediaCallback) {
-        var mediaCollection: [(Int32?, String?)] = []
-        let group = DispatchGroup()
-        assets.forEach { asset in
-            group.enter()
-            insertFromDevice(asset: asset, callback: { media in
-                guard let media = media,
-                let selectedMedia = media.first else {
-                    group.leave()
-                    return
-                }
-                mediaCollection.append(selectedMedia)
-                group.leave()
-            })
-        }
-
-        group.notify(queue: .main) {
-            callback(mediaCollection)
-        }
+    func insertFromSiteMediaLibrary(media: Media, callback: @escaping MediaPickerDidPickMediaCallback) {
+        callback(media.mediaID?.int32Value, media.remoteURL)
     }
 
     func insertFromDevice(asset: PHAsset, callback: @escaping MediaPickerDidPickMediaCallback) {
@@ -68,16 +44,16 @@ class GutenbergMediaInserterHelper: NSObject {
         // Getting a quick thumbnail of the asset to display while the image is being exported and uploaded.
         PHImageManager.default().requestImage(for: asset, targetSize: asset.pixelSize(), contentMode: .default, options: options) { (image, info) in
             guard let thumbImage = image, let resizedImage = thumbImage.resizedImage(asset.pixelSize(), interpolationQuality: CGInterpolationQuality.low) else {
-                callback([(mediaUploadID, nil)])
+                callback(mediaUploadID, nil)
                 return
             }
             let filePath = NSTemporaryDirectory() + "\(mediaUploadID).jpg"
             let url = URL(fileURLWithPath: filePath)
             do {
                 try resizedImage.writeJPEGToURL(url)
-                callback([(mediaUploadID, url.absoluteString)])
+                callback(mediaUploadID, url.absoluteString)
             } catch {
-                callback([(mediaUploadID, nil)])
+                callback(mediaUploadID, nil)
                 return
             }
         }
@@ -87,7 +63,7 @@ class GutenbergMediaInserterHelper: NSObject {
     func insertFromDevice(url: URL, callback: @escaping MediaPickerDidPickMediaCallback) {
         let media = insert(exportableAsset: url as NSURL, source: .otherApps)
         let mediaUploadID = media.gutenbergUploadID
-        callback([(mediaUploadID, url.absoluteString)])
+        callback(mediaUploadID, url.absoluteString)
     }
 
     func syncUploads() {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -3,7 +3,7 @@ import CoreServices
 import WPMediaPicker
 import Gutenberg
 
-public typealias GutenbergMediaPickerHelperCallback = ([WPMediaAsset]?) -> Void
+public typealias GutenbergMediaPickerHelperCallback = (WPMediaAsset?) -> Void
 
 class GutenbergMediaPickerHelper: NSObject {
 
@@ -49,7 +49,6 @@ class GutenbergMediaPickerHelper: NSObject {
     func presentMediaPickerFullScreen(animated: Bool,
                                       filter: WPMediaType,
                                       dataSourceType: MediaPickerDataSourceType = .device,
-                                      allowMultipleSelection: Bool,
                                       callback: @escaping GutenbergMediaPickerHelperCallback) {
 
         didPickMediaCallback = callback
@@ -67,7 +66,6 @@ class GutenbergMediaPickerHelper: NSObject {
 
         picker.selectionActionTitle = Constants.mediaPickerInsertText
         mediaPickerOptions.filter = filter
-        mediaPickerOptions.allowMultipleSelection = allowMultipleSelection
         picker.mediaPicker.options = mediaPickerOptions
         picker.delegate = self
         picker.modalPresentationStyle = .currentContext
@@ -104,7 +102,12 @@ class GutenbergMediaPickerHelper: NSObject {
 extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, didFinishPicking assets: [WPMediaAsset]) {
-        invokeMediaPickerCallback(asset: assets)
+
+        guard let assetSelected = assets.first else {
+            return
+        }
+
+        invokeMediaPickerCallback(asset: assetSelected)
         picker.dismiss(animated: true, completion: nil)
     }
 
@@ -112,7 +115,7 @@ extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
         context.dismiss(animated: true, completion: { self.invokeMediaPickerCallback(asset: nil) })
     }
 
-    fileprivate func invokeMediaPickerCallback(asset: [WPMediaAsset]?) {
+    fileprivate func invokeMediaPickerCallback(asset: WPMediaAsset?) {
         didPickMediaCallback?(asset)
         didPickMediaCallback = nil
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -102,16 +102,13 @@ class GutenbergViewController: UIViewController, PostEditor {
         mediaPickerHelper.presentMediaPickerFullScreen(animated: true,
                                                        filter: .image,
                                                        dataSourceType: .device,
-                                                       allowMultipleSelection: false,
                                                        callback: {(asset) in
-                                                        guard let phAsset = asset as? [PHAsset] else {
+                                                        guard let phAsset = asset as? PHAsset else {
                                                             return
                                                         }
-                                                        self.mediaInserterHelper.insertFromDevice(assets: phAsset, callback: { media in
-                                                            guard let media = media,
-                                                                let (id, url) = media.first,
-                                                                let mediaID = id,
-                                                                let mediaURLString = url,
+                                                        self.mediaInserterHelper.insertFromDevice(asset: phAsset, callback: { (mediaID, mediaURL) in
+                                                            guard let mediaID = mediaID,
+                                                                let mediaURLString = mediaURL,
                                                                 let mediaURL = URL(string: mediaURLString) else {
                                                                 return
                                                             }
@@ -340,13 +337,13 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         autosaver.contentDidChange()
     }
 
-    func gutenbergDidRequestMedia(from source: MediaPickerSource, filter: [MediaFilter]?, allowMultipleSelection: Bool, with callback: @escaping MediaPickerDidPickMediaCallback) {
+    func gutenbergDidRequestMedia(from source: MediaPickerSource, filter: [MediaFilter]?, with callback: @escaping MediaPickerDidPickMediaCallback) {
         let flags = mediaFilterFlags(using: filter)
         switch source {
         case .mediaLibrary:
-            gutenbergDidRequestMediaFromSiteMediaLibrary(filter: flags, allowMultipleSelection: allowMultipleSelection, with: callback)
+            gutenbergDidRequestMediaFromSiteMediaLibrary(filter: flags, with: callback)
         case .deviceLibrary:
-            gutenbergDidRequestMediaFromDevicePicker(filter: flags, allowMultipleSelection: allowMultipleSelection, with: callback)
+            gutenbergDidRequestMediaFromDevicePicker(filter: flags, with: callback)
         case .deviceCamera:
             gutenbergDidRequestMediaFromCameraPicker(filter: flags, with: callback)
         }
@@ -376,40 +373,38 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         return WPMediaType.all
     }
 
-    func gutenbergDidRequestMediaFromSiteMediaLibrary(filter: WPMediaType, allowMultipleSelection: Bool, with callback: @escaping MediaPickerDidPickMediaCallback) {
+    func gutenbergDidRequestMediaFromSiteMediaLibrary(filter: WPMediaType, with callback: @escaping MediaPickerDidPickMediaCallback) {
         mediaPickerHelper.presentMediaPickerFullScreen(animated: true,
                                                        filter: filter,
                                                        dataSourceType: .mediaLibrary,
-                                                       allowMultipleSelection: allowMultipleSelection,
-                                                       callback: {(assets) in
-                                                        guard let media = assets as? [Media] else {
-                                                            callback(nil)
+                                                       callback: {(asset) in
+                                                        guard let media = asset as? Media else {
+                                                            callback(nil, nil)
                                                             return
                                                         }
                                                         self.mediaInserterHelper.insertFromSiteMediaLibrary(media: media, callback: callback)
         })
     }
 
-    func gutenbergDidRequestMediaFromDevicePicker(filter: WPMediaType, allowMultipleSelection: Bool, with callback: @escaping MediaPickerDidPickMediaCallback) {
+    func gutenbergDidRequestMediaFromDevicePicker(filter: WPMediaType, with callback: @escaping MediaPickerDidPickMediaCallback) {
         mediaPickerHelper.presentMediaPickerFullScreen(animated: true,
                                                        filter: filter,
                                                        dataSourceType: .device,
-                                                       allowMultipleSelection: allowMultipleSelection,
-                                                       callback: {(assets) in
-                                                        guard let phAssets = assets as? [PHAsset] else {
-                                                            callback(nil)
+                                                       callback: {(asset) in
+                                                        guard let phAsset = asset as? PHAsset else {
+                                                            callback(nil, nil)
                                                             return
                                                         }
-                                                        self.mediaInserterHelper.insertFromDevice(assets: phAssets, callback: callback)
+                                                        self.mediaInserterHelper.insertFromDevice(asset: phAsset, callback: callback)
         })
     }
 
     func gutenbergDidRequestMediaFromCameraPicker(filter: WPMediaType, with callback: @escaping MediaPickerDidPickMediaCallback) {
         mediaPickerHelper.presentCameraCaptureFullScreen(animated: true,
                                                          filter: filter,
-                                                         callback: {(assets) in
-                                                            guard let phAsset = assets?.first as? PHAsset else {
-                                                                callback(nil)
+                                                         callback: {(asset) in
+                                                            guard let phAsset = asset as? PHAsset else {
+                                                                callback(nil, nil)
                                                                 return
                                                             }
                                                             self.mediaInserterHelper.insertFromDevice(asset: phAsset, callback: callback)


### PR DESCRIPTION
This reverts changes done by #10556 since we are in a code freeze on gutenberg mobile and this wasn't supposed to get merged during it.

I used `git diff bbad25cf34e3130eb4bbc733d6d217710119aaca fa459afd34cd652817ea0224030666eb25d4d121` to compare this branch with the previous commit in develop to make sure this is reverting everything.

This reverts commit a2a5e527d26acf343c82648c228b84ceb8dbc616.

Fixes #

To test:

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.