### PR TITLE
Handle link tap inside WPRichContentView instead of in shouldInteractWith URL

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * Block editor: Tapping on empty editor area now always inserts new block at end of post
 * Block editor: Fixed a performance issue that caused a freeze in the editor with long text content.
 * Dark Mode: Fixed colors in rich notifications
+* Reader: Fixed issue with links opening while scrolling in reader posts and comments. 
 
 13.2
 -----

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1095,7 +1095,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 - (BOOL)textView:(UITextView *)textView shouldInteractWithURL:(NSURL *)URL inRange:(NSRange)characterRange interaction:(UITextItemInteraction)interaction
 {
-    [self presentWebViewControllerWithURL:URL];
     return NO;
 }
 
@@ -1121,6 +1120,10 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
         [self presentViewController:controller animated:YES completion:nil];
     }
 }
+
+- (void)interactWithURL:(NSURL *) URL {
+      [self presentWebViewControllerWithURL:URL];
+  }
 
 - (BOOL)richContentViewShouldUpdateLayoutForAttachments:(WPRichContentView *)richContentView
 {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -412,6 +412,8 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     fileprivate func setupTextView() {
         // This method should be called exactly once.
         assert(textView.superview == nil)
+        
+        textView.delegate = self
 
         view.addSubview(textView)
         view.addConstraints([
@@ -420,8 +422,6 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             view.trailingAnchor.constraint(equalTo: textView.trailingAnchor),
             textView.bottomAnchor.constraint(equalTo: footerView.topAnchor),
             ])
-        
-        textView.richDelegate = self
     }
 
     /// Composes the views for the post header and Discover attribution.
@@ -1370,10 +1370,6 @@ extension ReaderDetailViewController: WPRichContentViewDelegate {
             let frame = textView.frameForTextInRange(characterRange)
             let shareController = PostSharingController()
             shareController.shareURL(url: URL as NSURL, fromRect: frame, inView: textView, inViewController: self)
-        } else if readerLinkRouter.canHandle(url: URL) {
-            readerLinkRouter.handle(url: URL, shouldTrack: false, source: self)
-        } else if URL.isWordPressDotComPost {
-            presentReaderDetailViewControllerWithURL(URL)
         }
         return false
     }
@@ -1396,7 +1392,13 @@ extension ReaderDetailViewController: WPRichContentViewDelegate {
     }
     
     func interactWith(URL: URL) {
-        presentWebViewControllerWithURL(URL)
+        if readerLinkRouter.canHandle(url: URL) {
+            readerLinkRouter.handle(url: URL, shouldTrack: false, source: self)
+        } else if URL.isWordPressDotComPost {
+            presentReaderDetailViewControllerWithURL(URL)
+        } else {
+            presentWebViewControllerWithURL(URL)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -413,8 +413,6 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         // This method should be called exactly once.
         assert(textView.superview == nil)
 
-        textView.delegate = self
-
         view.addSubview(textView)
         view.addConstraints([
             view.safeAreaLayoutGuide.topAnchor.constraint(equalTo: textView.topAnchor),
@@ -422,6 +420,8 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             view.trailingAnchor.constraint(equalTo: textView.trailingAnchor),
             textView.bottomAnchor.constraint(equalTo: footerView.topAnchor),
             ])
+        
+        textView.richDelegate = self
     }
 
     /// Composes the views for the post header and Discover attribution.
@@ -1374,8 +1374,6 @@ extension ReaderDetailViewController: WPRichContentViewDelegate {
             readerLinkRouter.handle(url: URL, shouldTrack: false, source: self)
         } else if URL.isWordPressDotComPost {
             presentReaderDetailViewControllerWithURL(URL)
-        } else {
-            presentWebViewControllerWithURL(URL)
         }
         return false
     }
@@ -1395,6 +1393,10 @@ extension ReaderDetailViewController: WPRichContentViewDelegate {
         } else if let staticImage = image.imageView.image {
             presentFullScreenImage(with: staticImage)
         }
+    }
+    
+    func interactWith(URL: URL) {
+        presentWebViewControllerWithURL(URL)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -412,7 +412,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     fileprivate func setupTextView() {
         // This method should be called exactly once.
         assert(textView.superview == nil)
-        
+
         textView.delegate = self
 
         view.addSubview(textView)
@@ -1390,7 +1390,7 @@ extension ReaderDetailViewController: WPRichContentViewDelegate {
             presentFullScreenImage(with: staticImage)
         }
     }
-    
+
     func interactWith(URL: URL) {
         if readerLinkRouter.canHandle(url: URL) {
             readerLinkRouter.handle(url: URL, shouldTrack: false, source: self)

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -177,6 +177,10 @@ class WPRichContentView: UITextView {
               let url = linkAttribute as? URL,
               let richDelegate = delegate as? WPRichContentViewDelegate {
               richDelegate.interactWith?(URL: url)
+          // handle tap on attachement
+          } else if let attachmentAttribute = self.attributedText?.attribute(.attachment, at: characterIndex, effectiveRange: nil),
+              let attachment = attachmentAttribute as? WPTextAttachment {
+              handleImageTapped(imageForAttachment(attachment))
           }
       }
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -177,11 +177,7 @@ class WPRichContentView: UITextView {
               let url = linkAttribute as? URL,
               let richDelegate = delegate as? WPRichContentViewDelegate {
               richDelegate.interactWith?(URL: url)
-          // handle tap on attachement
-          } else if let attachmentAttribute = self.attributedText?.attribute(.attachment, at: characterIndex, effectiveRange: nil),
-              let attachment = attachmentAttribute as? WPTextAttachment {
-              handleImageTapped(imageForAttachment(attachment))
-          }
+        }
       }
 
     private func ensureLayoutForAttachment(_ attachment: NSTextAttachment, at range: NSRange) {
@@ -591,9 +587,8 @@ extension WPRichContentView: UIGestureRecognizerDelegate {
         // handle tap on link
         if let linkAttribute = self.attributedText?.attribute(.link, at: characterIndex, effectiveRange: nil) {
             return linkAttribute is URL
-        } else if let attachmentAttribute = self.attributedText?.attribute(.attachment, at: characterIndex, effectiveRange: nil) {
-            return attachmentAttribute is WPTextAttachment
         }
+
         return false
     }
 }

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -177,10 +177,6 @@ class WPRichContentView: UITextView {
               let url = linkAttribute as? URL,
               let richDelegate = delegate as? WPRichContentViewDelegate {
               richDelegate.interactWith?(URL: url)
-          // handle tap on attachement
-          } else if let attachmentAttribute = self.attributedText?.attribute(.attachment, at: characterIndex, effectiveRange: nil),
-              let attachment = attachmentAttribute as? WPTextAttachment {
-              handleImageTapped(imageForAttachment(attachment))
           }
       }
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -165,7 +165,7 @@ class WPRichContentView: UITextView, UIGestureRecognizerDelegate {
             }
         }
     }
-    
+
     private func setupTouchDetection() {
           for gesture in gestureRecognizers ?? [] {
               gesture.require(toFail: linkTapGestureRecognizer)

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -33,7 +33,7 @@ class WPRichContentView: UITextView {
         let side = max(bounds.size.width, bounds.size.height)
         return CGSize(width: side, height: side)
     }()
-    
+
     private func setupTouchDetection() {
         addGestureRecognizer(linkTapGestureRecognizer)
     }


### PR DESCRIPTION
Fixes #12568 

Since iOS 13, the delegate method ```textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction)```
gets called not only when tapping on a link but also when scrolling.

As a result of this and the way we handle things inside that delegate method, links would open on scroll which feels especially buggy in link heavy posts like the ones in this blog: https://5blogs.wordpress.com

This PR adds a gesture recognizer to `WPRichContentView` where we now handle taps on links and attachments.

It also introduces a new WPRichContentViewDelegate method `interactWith(URL: URL)` to preform customization of the link presentation in the controller if needed. 

[Reported issues on SO](https://stackoverflow.com/questions/58189447/ios-13-uitextview-delegate-method-shouldinteract-called-when-scrolling-on-attach)

To test:

In reader post:
1. Open a post in reader (preferably with a lot of links)
2. Make sure that scrolling through doesn't open links
3. Make sure that tapping on a link opens the links as expected
4. Make sure that tapping on media is handled as expected

In reader post comments 
1. Open a post in reader with comments that have links 
2. Make sure that scrolling through the comment content doesn't open links
3. Make sure that tapping on a link in comment opens the links as expected
4. Make sure that tapping on media in comment is handled as expected

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
