### PR TITLE
[Dark Mode] Fix Post Undo cell background and divider

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.swift
@@ -2,7 +2,11 @@ import UIKit
 import Gridicons
 
 class RestorePostTableViewCell: UITableViewCell, ConfigurablePostView, InteractivePostView {
-    @IBOutlet var postContentView: UIView!
+    @IBOutlet var postContentView: UIView! {
+        didSet {
+            postContentView.backgroundColor = .listForeground
+        }
+    }
     @IBOutlet var restoreLabel: UILabel!
     @IBOutlet var restoreButton: UIButton!
     @IBOutlet var topMargin: NSLayoutConstraint!

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
@@ -15,7 +15,7 @@ extension WPStyleGuide {
     }
 
     // MARK: - Card View Styles
-    static let postCardBorderColor: UIColor = .neutral(.shade10)
+    static let postCardBorderColor: UIColor = .divider
 
     static let separatorHeight: CGFloat = .hairlineBorderWidth
 


### PR DESCRIPTION
Fixes #12598 

This PR fixes the white background (and divider color) in the Post Undo cell
![dark-mode-post-undo](https://user-images.githubusercontent.com/912252/66135119-55bf7300-e5f1-11e9-95df-7983d8b224ed.jpg)

## To test:
• Run this branch on iOS 13
• Go to the Post list and delete one so the Undo cell will appear
• Check the colors are correctly set. Switch also between light/dark mode.
* Test everything works correctly on iOS 12

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
