### PR TITLE
[Dark Mode] Remove white background from Site Settings Tags and TimeZone

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -111,6 +111,7 @@ final class SiteTagsViewController: UITableViewController {
     private func setupRefreshControl() {
         if refreshControl == nil {
             refreshControl = UIRefreshControl()
+            refreshControl?.backgroundColor = .basicBackground
             refreshControl?.addTarget(self, action: #selector(refreshTags), for: .valueChanged)
         }
     }

--- a/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
@@ -154,6 +154,7 @@ class TimeZoneSelectorViewController: UITableViewController, UISearchResultsUpda
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureSearchBar(searchController.searchBar)
         tableView.tableHeaderView = searchController.searchBar
+        tableView.backgroundView = UIView()
 
         let store = StoreContainer.shared.timezone
         storeReceipt = store.onChange { [weak self] in


### PR DESCRIPTION
Fixes #12599 

This PR removes the white background from the Site Settings->Tags and TimeZone
![dark-mode-site-settings-tags](https://user-images.githubusercontent.com/912252/66144723-447e6280-e601-11e9-9918-afdb10ec3dae.jpg)
![dark-mode-site-settings-timezone](https://user-images.githubusercontent.com/912252/66144724-447e6280-e601-11e9-9411-0d92b1262633.jpg)

## To test:
• Run this branch on iOS 13
• Go to the Site Settings
• Click on TimeZone and pull down the tableView. The white background shouldn't be there anymore. Switch also between light/dark mode.
• Click on Tags and pull down to refresh the tableView. The white background shouldn't be there anymore. Switch also between light/dark mode.
• Test everything works correctly on iOS 12

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
