### PR TITLE
Remove auto-switching of Post List tabs

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -920,7 +920,6 @@ class AbstractPostListViewController: UIViewController,
 
         apost.status = .draft
         uploadPost(apost)
-        updateFilterWithPostStatus(.draft)
     }
 
     fileprivate func uploadPost(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -910,7 +910,6 @@ class AbstractPostListViewController: UIViewController,
             apost.status = .publish
             apost.shouldAttemptAutoUpload = true
             self.uploadPost(apost)
-            self.updateFilterWithPostStatus(.publish)
         }
 
         present(alertController, animated: true)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -498,13 +498,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             return
         }
         let editor = EditPostViewController(post: post)
-        editor.onClose = { [weak self] changesSaved in
-            if changesSaved {
-                if let postStatus = editor.post?.status {
-                    self?.updateFilterWithPostStatus(postStatus)
-                }
-            }
-        }
         editor.modalPresentationStyle = .fullScreen
         present(editor, animated: false)
         WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: apost)


### PR DESCRIPTION
Closes #12584 

The remaining auto-switching that were removed in this PR are:

- When pressing _Move to Draft_
- When pressing _Publish Now_
- Exiting the editor after publishing an existing draft

I didn't remove `updateFilterWithPostStatus` because it is being used in `PageListViewController` for Quick Start. 

## Testing

Verify that the Post List tabs are no longer automatically selected when the scenarios described above happen. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
