### PR TITLE
[Dark Mode] Fix Picker background color

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/PickerTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/PickerTableViewCell.swift
@@ -69,7 +69,7 @@ open class PickerTableViewCell: WPTableViewCell, UIPickerViewDelegate, UIPickerV
         // Setup Picker
         picker.dataSource = self
         picker.delegate = self
-        picker.backgroundColor = UIColor.white
+        picker.backgroundColor = .listForeground
         contentView.addSubview(picker)
 
         // ContentView: Pin to Left + Right + Top + Bottom edges


### PR DESCRIPTION
Fixes #12600 

This PR fixes the Picker background used in these screens:

**Post per Page**
![dark-mode-picker-01](https://user-images.githubusercontent.com/912252/66146441-b2785900-e604-11e9-85cc-b369475486e9.jpg)

**Close commenting, Paging, Links in comments**
![dark-mode-picker-02](https://user-images.githubusercontent.com/912252/66146443-b2785900-e604-11e9-95f8-3fe2740ebe48.jpg)
![dark-mode-picker-03](https://user-images.githubusercontent.com/912252/66146444-b310ef80-e604-11e9-8a4c-f0146e25ef77.jpg)

## To test:
• Run this branch on iOS 13
• Go to the _Site Settings_
• Under _Writing_ open **Posts per Page** and check if the background color is correctly set. Switch also between light/dark mode.
• Go to _Discussion_
• Under _Comments_ open **Close Commenting, Paging, Links in comments** and check if the background color is correctly set. Switch also between light/dark mode.
• Test everything works correctly on iOS 12

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
