### PR TITLE
[Dark Mode] Removed white background in Reader Manage button

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
@@ -63,14 +63,14 @@ import WordPressShared.WPStyleGuide
 
 
     @IBAction func didTouchUpInside(_ sender: UIButton) {
-        borderedView.backgroundColor = UIColor.white
+        borderedView.backgroundColor = .listForeground
 
         delegate?.handleFollowActionForHeader(self)
     }
 
 
     @IBAction func didTouchUpOutside(_ sender: UIButton) {
-        borderedView.backgroundColor = UIColor.white
+        borderedView.backgroundColor = .listForeground
     }
 }
 


### PR DESCRIPTION
Fixes #12602 

This PR removes the white background in `ReaderFollowedSitesStreamHeader`.

## To test:
• Run this branch on iOS 13
• Go to the _Reader_ and tap the _Manage_ button.
• Navigate back and check if the button still has the white background. Switch also between light/dark mode.
• Test everything works correctly on iOS 12

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
