### PR TITLE
[Dark Mode] Fix Reader Detail Like star animation background color

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -929,7 +929,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         if likeButton.isSelected {
             // Prep a mask to hide the likeButton's image, since changes to visiblility and alpha are ignored
             let mask = UIView(frame: frame)
-            mask.backgroundColor = view.backgroundColor
+            mask.backgroundColor = footerView.backgroundColor
             likeButton.addSubview(mask)
             likeButton.bringSubviewToFront(imageView)
 


### PR DESCRIPTION
Fixes #12603.

This PR updates the background color of the Like star animation in Reader detail to fix an issue where it was appearing as black.

Before:

![like-before](https://user-images.githubusercontent.com/912252/65985037-ed4d8600-e478-11e9-8f3a-18f9061457c2.gif)

After:

![like-dark-mode](https://user-images.githubusercontent.com/4780/66307283-ee106d00-e8fb-11e9-9989-fc729c683cdc.gif)

To test:

* Build and run on iOS 13 and turn on dark mode
* Navigate to a post in the reader
* Tap the Like button and check the animation looks good
* Double check it still looks okay in light mode

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
