### PR TITLE
*Temporarily* not allowing auto upload for pages

### DIFF
--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -35,6 +35,7 @@ final class PostAutoUploadInteractor {
         guard post.isFailed,
             let status = post.status,
             !PostAutoUploadInteractor.disallowedStatuses.contains(status),
+            !(post is Page),
             post.autoUploadAttemptsCount.intValue < PostAutoUploadInteractor.maxNumberOfAttempts else {
                 return .nothing
         }

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -122,7 +122,9 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
 
     func testPageNotAutoUploaded() {
         let page = createPage(.draft)
+
         let action = interactor.autoUploadAction(for: page)
+
         expect(action).to(equal(.nothing))
     }
 }

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -119,6 +119,12 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
 
         expect(action).to(equal(.upload))
     }
+    
+    func testPageNotAutoUploaded() {
+        let page = createPage(.draft)
+        let action = interactor.autoUploadAction(for: page)
+        expect(action).to(equal(.nothing))
+    }
 }
 
 private extension PostCoordinatorUploadActionUseCaseTests {
@@ -141,5 +147,18 @@ private extension PostCoordinatorUploadActionUseCaseTests {
         }
 
         return post
+    }
+
+    func createPage(_ status: BasePost.Status,
+                    remoteStatus: AbstractPostRemoteStatus = .failed,
+                    hasRemote: Bool = false) -> Page {
+        let page = NSEntityDescription.insertNewObject(forEntityName: Page.entityName(), into: context) as! Page
+        page.remoteStatus = remoteStatus
+
+        if hasRemote {
+            page.postID = NSNumber(value: Int.random(in: 1...Int.max))
+        }
+        
+        return page
     }
 }

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -119,7 +119,7 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
 
         expect(action).to(equal(.upload))
     }
-    
+
     func testPageNotAutoUploaded() {
         let page = createPage(.draft)
         let action = interactor.autoUploadAction(for: page)
@@ -158,7 +158,7 @@ private extension PostCoordinatorUploadActionUseCaseTests {
         if hasRemote {
             page.postID = NSNumber(value: Int.random(in: 1...Int.max))
         }
-        
+
         return page
     }
 }


### PR DESCRIPTION
Fixes #12586 

To test:
1. Be offline
2. Publish a page
3. Make sure you get notice "Page upload failed" and not "Post will be published"
3. Come back online 
4. Make sure page is not auto-uploaded 


This PR and its test will be reversed in a following Pages Improvement project.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
