### PR TITLE
Remove warning in AbstractPost

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -32,6 +32,7 @@
 @dynamic revisions;
 @dynamic confirmedChangesHash;
 @dynamic confirmedChangesTimestamp;
+@dynamic autoUploadAttemptsCount;
 
 @synthesize restorableStatus;
 


### PR DESCRIPTION
To test:

1. Build the project
2. Make sure no warnings are shown in `AbstractPost`

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
