### PR TITLE
Update strings for Offline Support

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostAutoUploadMessages.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostAutoUploadMessages.swift
@@ -41,6 +41,16 @@ enum PostAutoUploadMessages {
                                                          comment: "Title for notice displayed on canceling auto-upload of a scheduled post")
     static let changesWillNotBeSaved = NSLocalizedString("We won't save the latest changes to your draft.",
                                                          comment: "Title for notice displayed on canceling auto-upload of a draft post")
+    static let failedMedia = NSLocalizedString("Couldn't upload media.",
+                                                         comment: "Text displayed if a media couldnt be uploaded.")
+    static let failedMediaForPublish = NSLocalizedString("Couldn't upload media. Post not published",
+                                                         comment: "Text displayed if a media couldn't be uploaded for a published post.")
+    static let failedMediaForPrivate = NSLocalizedString("Couldn't upload media. Private post not published",
+                                                         comment: "Text displayed if a media couldn't be uploaded for a private post.")
+    static let failedMediaForScheduled = NSLocalizedString("Couldn't upload media. Post not scheduled",
+                                                         comment: "Text displayed if a media couldn't be uploaded for a scheduled post.")
+    static let failedMediaForPending = NSLocalizedString("Couldn't upload media. Post not submitted",
+                                                         comment: "Text displayed if a media couldn't be uploaded for a pending post.")
 
     static func cancelMessage(for postStatus: BasePost.Status?) -> String {
         switch postStatus {
@@ -63,9 +73,24 @@ enum PostAutoUploadMessages {
         case .attempted:
             return PostAutoUploadMessages.willAttemptToAutoUpload(for: post.status)
         case .reachedLimit:
-            return PostAutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
+            return post.hasFailedMedia ? PostAutoUploadMessages.failedMedia(for: post.status) : PostAutoUploadMessages.willNotAttemptToAutoUpload(for: post.status)
         default:
             return nil
+        }
+    }
+
+    static func failedMedia(for postStatus: BasePost.Status?) -> String {
+        switch postStatus {
+        case .publish:
+            return PostAutoUploadMessages.failedMediaForPublish
+        case .publishPrivate:
+            return PostAutoUploadMessages.failedMediaForPrivate
+        case .scheduled:
+            return PostAutoUploadMessages.failedMediaForScheduled
+        case .pending:
+            return PostAutoUploadMessages.failedMediaForPending
+        default:
+            return PostAutoUploadMessages.failedMedia
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostAutoUploadMessages.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostAutoUploadMessages.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 enum PostAutoUploadMessages {
-    static let postWillBePublished = NSLocalizedString("Post will be published next time your device is online",
+    static let postWillBePublished = NSLocalizedString("We'll publish the post when your device is back online.",
                                                        comment: "Text displayed in notice after a post if published while offline.")
-    static let draftWillBeUploaded = NSLocalizedString("Draft will be uploaded next time your device is online",
+    static let draftWillBeUploaded = NSLocalizedString("We'll save your draft when your device is back online.",
                                                        comment: "Text displayed in notice after the app fails to upload a draft.")
     static let pageFailedToUpload = NSLocalizedString("Page failed to upload",
                                                       comment: "Title of notification displayed when a page has failed to upload.")
@@ -11,45 +11,49 @@ enum PostAutoUploadMessages {
                                                       comment: "Title of notification displayed when a post has failed to upload.")
     static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
                                                          comment: "Text displayed in notice after the app fails to upload a post.")
-    static let willAttemptToPublishLater = NSLocalizedString("Post couldn't be published. We'll try again later",
+    static let willAttemptToPublishLater = NSLocalizedString("We couldn't publish this post, but we'll try again later.",
                                                        comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
-    static let willNotAttemptToPublishLater = NSLocalizedString("Couldn't perform operation. Post not published",
+    static let willNotAttemptToPublishLater = NSLocalizedString("We couldn't complete this action, and didn't publish this post.",
                                                         comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
-    static let willSubmitLater = NSLocalizedString("Post will be submitted for review when your device is back online",
+    static let willSubmitLater = NSLocalizedString("We'll submit your post for review when your device is back online.",
                                                         comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
-    static let willAttemptToSubmitLater = NSLocalizedString("Post couldn't be submitted. We'll try again later",
+    static let willAttemptToSubmitLater = NSLocalizedString("We couldn't submit this post for review, but we'll try again later.",
                                                        comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
-    static let willNotAttemptToSubmitLater = NSLocalizedString("Couldn't perform operation. Post not submitted",
+    static let willAttemptLater = NSLocalizedString("We couldn't complete this action, but we'll try again later.",
+                                                        comment: "Text displayed after the app fails to upload a post, it will attempt to upload it later.")
+    static let willNotAttemptToSubmitLater = NSLocalizedString("We couldn't complete this action, and didn't submit this post for review.",
                                                         comment: "Text displayed in notice after the app fails to upload a post, not new attempt will be made.")
-    static let privateWillBeUploaded = NSLocalizedString("Private post will be published when your device is back online",
+    static let privateWillBeUploaded = NSLocalizedString("We'll publish your private post when your device is back online.",
                                                        comment: "Text displayed in notice after the app fails to upload a draft.")
-    static let willAttemptToPublishPrivateLater = NSLocalizedString("Private post couldn't be published. We'll try again later",
+    static let willAttemptToPublishPrivateLater = NSLocalizedString("We couldn't publish this private post, but we'll try again later.",
                                                         comment: "Text displayed after the app fails to upload a private post, it will attempt to upload it later.")
-    static let willNotAttemptToPublishPrivateLater = NSLocalizedString("Couldn't perform operation. Private post not published",
+    static let willNotAttemptToPublishPrivateLater = NSLocalizedString("We couldn't complete this action, and didn't publish this private post.",
                                                         comment: "Text displayed after the app fails to upload a private post, no new attempt will be made.")
-    static let scheduledWillBeUploaded = NSLocalizedString("Post will be scheduled when your device is back online",
+    static let scheduledWillBeUploaded = NSLocalizedString("We'll schedule your post when your device is back online.",
                                                        comment: "Text displayed after the app fails to upload a scheduled post.")
-    static let willAttemptToScheduleLater = NSLocalizedString("Post couldn't be scheduled. We'll try again later",
+    static let willAttemptToScheduleLater = NSLocalizedString("We couldn't schedule this post, but we'll try again later.",
                                                         comment: "Text displayed after the app fails to upload a scheduled post, it will attempt to upload it later.")
-    static let willNotAttemptToScheduleLater = NSLocalizedString("Couldn't perform operation. Post not scheduled",
+    static let willNotAttemptToScheduleLater = NSLocalizedString("We couldn't complete this action, and didn't schedule this post.",
                                                         comment: "Text displayed after the app fails to upload a scheduled post, no new attempt will be made.")
-    static let changesWillNotBePublished = NSLocalizedString("Changes will not be published",
+    static let willNotAttemptLater = NSLocalizedString("We couldn't complete this action.",
+                                                        comment: "Text displayed after the app fails to upload a post, no new attempt will be made.")
+    static let changesWillNotBePublished = NSLocalizedString("We won't publish these changes.",
                                                         comment: "Title for notice displayed on canceling auto-upload published post")
-    static let changesWillNotBeSubmitted = NSLocalizedString("Changes will not be submitted",
+    static let changesWillNotBeSubmitted = NSLocalizedString("We won't submit these changes for review.",
                                                          comment: "Title for notice displayed on canceling auto-upload pending post")
-    static let changesWillNotBeScheduled = NSLocalizedString("Changes will not be scheduled",
+    static let changesWillNotBeScheduled = NSLocalizedString("We won't schedule these changes.",
                                                          comment: "Title for notice displayed on canceling auto-upload of a scheduled post")
     static let changesWillNotBeSaved = NSLocalizedString("We won't save the latest changes to your draft.",
                                                          comment: "Title for notice displayed on canceling auto-upload of a draft post")
-    static let failedMedia = NSLocalizedString("Couldn't upload media.",
+    static let failedMedia = NSLocalizedString("We couldn't upload this media.",
                                                          comment: "Text displayed if a media couldnt be uploaded.")
-    static let failedMediaForPublish = NSLocalizedString("Couldn't upload media. Post not published",
+    static let failedMediaForPublish = NSLocalizedString("We couldn't upload this media, and didn't publish the post.",
                                                          comment: "Text displayed if a media couldn't be uploaded for a published post.")
-    static let failedMediaForPrivate = NSLocalizedString("Couldn't upload media. Private post not published",
+    static let failedMediaForPrivate = NSLocalizedString("We couldn't upload this media, and didn't publish this private post.",
                                                          comment: "Text displayed if a media couldn't be uploaded for a private post.")
-    static let failedMediaForScheduled = NSLocalizedString("Couldn't upload media. Post not scheduled",
+    static let failedMediaForScheduled = NSLocalizedString("We couldn't upload this media, and didn't schedule this post.",
                                                          comment: "Text displayed if a media couldn't be uploaded for a scheduled post.")
-    static let failedMediaForPending = NSLocalizedString("Couldn't upload media. Post not submitted",
+    static let failedMediaForPending = NSLocalizedString("We couldn't upload this media, and didn't submit this post for review.",
                                                          comment: "Text displayed if a media couldn't be uploaded for a pending post.")
 
     static func cancelMessage(for postStatus: BasePost.Status?) -> String {
@@ -102,8 +106,10 @@ enum PostAutoUploadMessages {
             return PostAutoUploadMessages.willAttemptToPublishPrivateLater
         case .scheduled:
             return PostAutoUploadMessages.willAttemptToScheduleLater
-        default:
+        case .pending:
             return PostAutoUploadMessages.willAttemptToSubmitLater
+        default:
+            return PostAutoUploadMessages.willAttemptLater
         }
     }
 
@@ -115,8 +121,10 @@ enum PostAutoUploadMessages {
             return PostAutoUploadMessages.willNotAttemptToPublishPrivateLater
         case .scheduled:
             return PostAutoUploadMessages.willNotAttemptToScheduleLater
-        default:
+        case .pending:
             return PostAutoUploadMessages.willNotAttemptToSubmitLater
+        default:
+            return PostAutoUploadMessages.willNotAttemptLater
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostAutoUploadMessages.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostAutoUploadMessages.swift
@@ -9,8 +9,6 @@ enum PostAutoUploadMessages {
                                                       comment: "Title of notification displayed when a page has failed to upload.")
     static let postFailedToUpload = NSLocalizedString("Post failed to upload",
                                                       comment: "Title of notification displayed when a post has failed to upload.")
-    static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
-                                                         comment: "Text displayed in notice after the app fails to upload a post.")
     static let willAttemptToPublishLater = NSLocalizedString("We couldn't publish this post, but we'll try again later.",
                                                        comment: "Text displayed in notice after the app fails to upload a post, it will attempt to upload it later.")
     static let willNotAttemptToPublishLater = NSLocalizedString("We couldn't complete this action, and didn't publish this post.",

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -239,10 +239,6 @@ class PostCardStatusViewModel: NSObject {
             return defaultFailedMessage
         }
 
-        if post.hasRemote() {
-            return PostAutoUploadMessages.changesWillBeUploaded
-        }
-
         switch postStatus {
         case .draft:
             return PostAutoUploadMessages.draftWillBeUploaded

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -238,6 +238,7 @@ class PostCardStatusViewModel: NSObject {
         if autoUploadInteractor.autoUploadAction(for: post) != .upload {
             return defaultFailedMessage
         }
+
         if post.hasRemote() {
             return PostAutoUploadMessages.changesWillBeUploaded
         }

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -122,10 +122,6 @@ struct PostNoticeViewModel {
             return defaultTitle
         }
 
-        if post.hasRemote() {
-            return PostAutoUploadMessages.changesWillBeUploaded
-        }
-
         switch postStatus {
         case .draft:
             return PostAutoUploadMessages.draftWillBeUploaded

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -369,7 +369,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Post couldn't be submitted. We'll try again later")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We couldn't complete this action, but we'll try again later.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.warning))
     }
 
@@ -378,7 +378,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Couldn't perform operation. Post not submitted")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We couldn't complete this action.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
     }
 
@@ -387,7 +387,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Couldn't upload media. Post not published")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We couldn't upload this media, and didn't publish the post.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
     }
 
@@ -396,7 +396,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Private post couldn't be published. We'll try again later")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We couldn't publish this private post, but we'll try again later.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.warning))
     }
 
@@ -405,7 +405,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Couldn't perform operation. Private post not published")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We couldn't complete this action, and didn't publish this private post.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
     }
 
@@ -414,7 +414,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Private post will be published when your device is back online")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We'll publish your private post when your device is back online.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.warning))
     }
 
@@ -423,7 +423,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Post couldn't be scheduled. We'll try again later")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We couldn't schedule this post, but we'll try again later.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.warning))
     }
 
@@ -432,7 +432,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Couldn't perform operation. Post not scheduled")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We couldn't complete this action, and didn't schedule this post.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
     }
 
@@ -441,7 +441,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Post will be scheduled when your device is back online")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We'll schedule your post when your device is back online.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.warning))
     }
 
@@ -450,7 +450,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Post will be submitted for review when your device is back online")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We'll submit your post for review when your device is back online.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.warning))
     }
 
@@ -459,7 +459,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Post couldn't be submitted. We'll try again later")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We couldn't submit this post for review, but we'll try again later.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.warning))
     }
 
@@ -468,7 +468,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        expect(self.postCell.statusLabel.text).to(equal(i18n("Couldn't perform operation. Post not submitted")))
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We couldn't complete this action, and didn't submit this post for review.")))
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
     }
 

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -265,7 +265,7 @@ class PostCardCellTests: XCTestCase {
         XCTAssertFalse(postCell.separatorLabel.isHidden)
     }
 
-    func testShowsChangesWillBeUploadedWarningForFailedPublishedPostsWithRemote() {
+    func testShowsPostWillBePublishedWarningForFailedPublishedPostsWithRemote() {
         // Given
         let post = PostBuilder(context).published().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
@@ -273,7 +273,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, PostAutoUploadMessages.postWillBePublished)
+        XCTAssertEqual(postCell.statusLabel.text, i18n("We'll publish the post when your device is back online."))
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
@@ -340,7 +340,7 @@ class PostCardCellTests: XCTestCase {
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
-    func testShowsChangesWillBeUploadedMessageForDraftsWithRemote() {
+    func testShowsDraftWillBeUploadedMessageForDraftsWithRemote() {
         // Given
         let post = PostBuilder(context).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
@@ -348,7 +348,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, PostAutoUploadMessages.draftWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.text, i18n("We'll save your draft when your device is back online."))
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
@@ -409,7 +409,7 @@ class PostCardCellTests: XCTestCase {
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
     }
 
-    func testShowsChangesWillBeUploadedMessageForPrivate() {
+    func testShowsPrivatePostWillBeUploadedMessageForPrivatePosts() {
         let post = PostBuilder(context).private().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         postCell.configure(with: post)
@@ -436,7 +436,7 @@ class PostCardCellTests: XCTestCase {
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
     }
 
-    func testShowsChangesWillBeUploadedMessageForScheduled() {
+    func testShowsScheduledPostWillBeUploadedMessageForScheduledPosts() {
         let post = PostBuilder(context).scheduled().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         postCell.configure(with: post)
@@ -445,7 +445,7 @@ class PostCardCellTests: XCTestCase {
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.warning))
     }
 
-    func testShowsChangesWillBeUploadedMessageForPendingPost() {
+    func testShowsPostWillBeSubmittedMessageForPendingPost() {
         let post = PostBuilder(context).pending().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         postCell.configure(with: post)

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -273,7 +273,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, PostAutoUploadMessages.changesWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.text, PostAutoUploadMessages.postWillBePublished)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
@@ -348,7 +348,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, PostAutoUploadMessages.changesWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.text, PostAutoUploadMessages.draftWillBeUploaded)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -382,6 +382,15 @@ class PostCardCellTests: XCTestCase {
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
     }
 
+    func testFailedMessageWhenMaxNumberOfAttemptsToAutoDraftIsReachedAndPostHasFailedMedia() {
+        let post = PostBuilder(context).with(image: "", status: .failed).with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
+
+        postCell.configure(with: post)
+
+        expect(self.postCell.statusLabel.text).to(equal(i18n("Couldn't upload media. Post not published")))
+        expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
+    }
+
     func testShowsFailedMessageWhenAttemptToAutoUploadAPrivatePost() {
         let post = PostBuilder(context).private().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).confirmedAutoUpload().build()
 

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -43,7 +43,7 @@ class PostNoticeViewModelTests: XCTestCase {
             Expectation(
                 scenario: "Draft with confirmed local changes",
                 post: createPost(.draft, hasRemote: true),
-                title: PostAutoUploadMessages.changesWillBeUploaded,
+                title: PostAutoUploadMessages.draftWillBeUploaded,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
@@ -55,7 +55,7 @@ class PostNoticeViewModelTests: XCTestCase {
             Expectation(
                 scenario: "Published post with confirmed local changes",
                 post: createPost(.publish, hasRemote: true),
-                title: PostAutoUploadMessages.changesWillBeUploaded,
+                title: PostAutoUploadMessages.postWillBePublished,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
@@ -67,7 +67,7 @@ class PostNoticeViewModelTests: XCTestCase {
             Expectation(
                 scenario: "Scheduled post with confirmed local changes",
                 post: createPost(.scheduled, hasRemote: true),
-                title: i18n("Changes will be uploaded next time your device is online"),
+                title: i18n("We'll schedule your post when your device is back online."),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -61,7 +61,7 @@ class PostNoticeViewModelTests: XCTestCase {
             Expectation(
                 scenario: "Locally scheduled post",
                 post: createPost(.scheduled),
-                title: i18n("Post will be scheduled when your device is back online"),
+                title: i18n("We'll schedule your post when your device is back online."),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
@@ -73,25 +73,25 @@ class PostNoticeViewModelTests: XCTestCase {
             Expectation(
                 scenario: "Post with at least 1 auto upload to publish attempt",
                 post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 2),
-                title: i18n("Post couldn't be published. We'll try again later"),
+                title: i18n("We couldn't publish this post, but we'll try again later."),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Post with the maximum number of auto upload to publish attempts",
                 post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 3),
-                title: i18n("Couldn't perform operation. Post not published"),
+                title: i18n("We couldn't complete this action, and didn't publish this post."),
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
                 scenario: "Draft with at least 1 auto upload attempt",
                 post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 2),
-                title: i18n("Post couldn't be submitted. We'll try again later"),
+                title: i18n("We couldn't complete this action, but we'll try again later."),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Draft with the maximum number of auto upload attempts",
                 post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 3),
-                title: i18n("Couldn't perform operation. Post not submitted"),
+                title: i18n("We couldn't complete this action."),
                 actionTitle: FailureActionTitles.retry
             ),
         ]


### PR DESCRIPTION
This PR updates the strings related to the Offline Support accordingly to the [Android Editorial Review](https://github.com/wordpress-mobile/WordPress-Android/pull/10542). It also:

* Removes the message that was shown when a post with remote was edited;
* Adds media-related fail messages

To test:

Review thoroughly the strings changed.

And:

# Failed Medias Test Cases

### Publishing with failed media

1. While offline, create a new post, add an image and tap publish
2. Restart the app 3 times
3. Check the message that says "We couldn't upload this media, and didn't publish the post."

### Draft with failed media

1. While offline, create a new post, add an image and save as draft
2. Restart the app 3 times
3. Check the message that says "We couldn't upload this media."

### Schedule with failed media

1. While offline, create a new scheduled post, add an image and tap publish
2. Restart the app 3 times
3. Check the message that says "We couldn't upload this media, and didn't schedule this post."

### Private with failed media

1. While offline, create a new private post, add an image and tap publish
2. Restart the app 3 times
3. Check the message that says "We couldn't upload this media, and didn't publish this private post."

### Pending with failed media

1. While offline, create a new pending post, add an image and submit it
2. Restart the app 3 times
3. Check the message that says "We couldn't upload this media, and didn't submit this post for review."

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 