### PR TITLE
Make PostCoordinator.autoSave create non-draft posts if necessary and handle failures

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -338,7 +338,9 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         };
         
         BOOL needsUploading = [post isDraft] && [post.postID longLongValue] <= 0;
-        
+
+        // The autoSave endpoint returns an exception on posts that do not exist on the server
+        // so we'll create the post instead.
         if (needsUploading) {
             [self uploadPost:post
                      success:^(AbstractPost * _Nonnull post) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -547,6 +547,7 @@
 		570BFD8B22823D7B007859A8 /* PostActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8A22823D7B007859A8 /* PostActionSheet.swift */; };
 		570BFD8D22823DE5007859A8 /* PostActionSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8C22823DE5007859A8 /* PostActionSheetTests.swift */; };
 		570BFD902282418A007859A8 /* PostBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8F2282418A007859A8 /* PostBuilder.swift */; };
+		57240224234E5BE200227067 /* PostServiceSelfHostedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57240223234E5BE200227067 /* PostServiceSelfHostedTests.swift */; };
 		5727EAF82284F5AC00822104 /* InteractivePostViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5727EAF72284F5AC00822104 /* InteractivePostViewDelegate.swift */; };
 		572FB401223A806000933C76 /* NoticeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572FB400223A806000933C76 /* NoticeStoreTests.swift */; };
 		5749984722FA0F2E00CE86ED /* PostNoticeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5749984622FA0F2E00CE86ED /* PostNoticeViewModelTests.swift */; };
@@ -2635,6 +2636,7 @@
 		570BFD8A22823D7B007859A8 /* PostActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostActionSheet.swift; sourceTree = "<group>"; };
 		570BFD8C22823DE5007859A8 /* PostActionSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostActionSheetTests.swift; sourceTree = "<group>"; };
 		570BFD8F2282418A007859A8 /* PostBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostBuilder.swift; sourceTree = "<group>"; };
+		57240223234E5BE200227067 /* PostServiceSelfHostedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostServiceSelfHostedTests.swift; path = Services/PostServiceSelfHostedTests.swift; sourceTree = "<group>"; };
 		5727EAF72284F5AC00822104 /* InteractivePostViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractivePostViewDelegate.swift; sourceTree = "<group>"; };
 		572FB400223A806000933C76 /* NoticeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStoreTests.swift; sourceTree = "<group>"; };
 		5749984622FA0F2E00CE86ED /* PostNoticeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticeViewModelTests.swift; sourceTree = "<group>"; };
@@ -8039,6 +8041,7 @@
 				570B037622F1FFF6009D8411 /* PostCoordinatorFailedPostsFetcherTests.swift */,
 				57569CF1230485680052EE14 /* PostAutoUploadInteractorTests.swift */,
 				57D66B9C234BB78B005A2D74 /* PostServiceWPComTests.swift */,
+				57240223234E5BE200227067 /* PostServiceSelfHostedTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -11930,6 +11933,7 @@
 				B532ACCF1DC3AB8E00FFFA57 /* NotificationSyncMediatorTests.swift in Sources */,
 				7E4A772F20F7FDF8001C706D /* ActivityLogTestData.swift in Sources */,
 				40E7FEC82211EEC00032834E /* LastPostStatsRecordValueTests.swift in Sources */,
+				57240224234E5BE200227067 /* PostServiceSelfHostedTests.swift in Sources */,
 				B59D40A61DB522DF003D2D79 /* NSAttributedStringTests.swift in Sources */,
 				93E9050719E6F3D8005513C9 /* TestContextManager.m in Sources */,
 				D816B8D72112D75C0052CE4D /* NewsCardTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -566,7 +566,7 @@
 		57C2331822FE0EC900A3863B /* PostAutoUploadInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C2331722FE0EC900A3863B /* PostAutoUploadInteractor.swift */; };
 		57D5812D2228526C002BAAD7 /* WPError+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D5812C2228526C002BAAD7 /* WPError+Swift.swift */; };
 		57D66B9A234BB206005A2D74 /* PostServiceRemoteFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D66B99234BB206005A2D74 /* PostServiceRemoteFactory.swift */; };
-		57D66B9D234BB78B005A2D74 /* PostServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D66B9C234BB78B005A2D74 /* PostServiceTests.swift */; };
+		57D66B9D234BB78B005A2D74 /* PostServiceWPComTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D66B9C234BB78B005A2D74 /* PostServiceWPComTests.swift */; };
 		57D6C83E22945A10003DDC7E /* PostCompactCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D6C83D22945A10003DDC7E /* PostCompactCellTests.swift */; };
 		57D6C840229498C5003DDC7E /* InteractivePostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D6C83F229498C4003DDC7E /* InteractivePostView.swift */; };
 		57DF04C1231489A200CC93D6 /* PostCardStatusViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DF04C0231489A200CC93D6 /* PostCardStatusViewModelTests.swift */; };
@@ -2654,7 +2654,7 @@
 		57C2331722FE0EC900A3863B /* PostAutoUploadInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadInteractor.swift; sourceTree = "<group>"; };
 		57D5812C2228526C002BAAD7 /* WPError+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPError+Swift.swift"; sourceTree = "<group>"; };
 		57D66B99234BB206005A2D74 /* PostServiceRemoteFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceRemoteFactory.swift; sourceTree = "<group>"; };
-		57D66B9C234BB78B005A2D74 /* PostServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostServiceTests.swift; path = Services/PostServiceTests.swift; sourceTree = "<group>"; };
+		57D66B9C234BB78B005A2D74 /* PostServiceWPComTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostServiceWPComTests.swift; path = Services/PostServiceWPComTests.swift; sourceTree = "<group>"; };
 		57D6C83D22945A10003DDC7E /* PostCompactCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCompactCellTests.swift; sourceTree = "<group>"; };
 		57D6C83F229498C4003DDC7E /* InteractivePostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractivePostView.swift; sourceTree = "<group>"; };
 		57DF04C0231489A200CC93D6 /* PostCardStatusViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardStatusViewModelTests.swift; sourceTree = "<group>"; };
@@ -5030,7 +5030,7 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -8038,7 +8038,7 @@
 				7E8980B822E73F4000C567B0 /* EditorSettingsServiceTests.swift */,
 				570B037622F1FFF6009D8411 /* PostCoordinatorFailedPostsFetcherTests.swift */,
 				57569CF1230485680052EE14 /* PostAutoUploadInteractorTests.swift */,
-				57D66B9C234BB78B005A2D74 /* PostServiceTests.swift */,
+				57D66B9C234BB78B005A2D74 /* PostServiceWPComTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -9677,7 +9677,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -11984,7 +11984,7 @@
 				08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */,
 				027AC5212278983F0033E56E /* DomainCreditEligibilityTests.swift in Sources */,
 				E10F3DA11E5C2CE0008FAADA /* PostListFilterTests.swift in Sources */,
-				57D66B9D234BB78B005A2D74 /* PostServiceTests.swift in Sources */,
+				57D66B9D234BB78B005A2D74 /* PostServiceWPComTests.swift in Sources */,
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,
 				D800D87820999B6D00E7C7E5 /* LikedMenuItemCreatorTests.swift in Sources */,
 				D816B8CA2112D2FD0052CE4D /* LocalNewsServiceTests.swift in Sources */,

--- a/WordPress/WordPressTest/Services/PostServiceSelfHostedTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceSelfHostedTests.swift
@@ -1,0 +1,124 @@
+
+import Foundation
+import Nimble
+@testable import WordPress
+
+/// Tests unique behaviors of self-hosted sites.
+///
+/// Most the time, self-hosted, WPCom, and Jetpack sites behave the same. So, these common tests
+/// are currently in `PostServiceWPComTests`.
+///
+/// - SeeAlso: PostServiceWPComTests
+///
+class PostServiceSelfHostedTests: XCTestCase {
+
+    private var remoteMock: PostServiceXMLRPCMock!
+    private var service: PostService!
+    private var context: NSManagedObjectContext!
+
+    private let impossibleFailureBlock: (Error?) -> Void = { _ in
+        assertionFailure("This shouldn't happen.")
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        context = TestContextManager().mainContext
+
+        remoteMock = PostServiceXMLRPCMock()
+
+        let remoteFactory = PostServiceRemoteFactoryMock()
+        remoteFactory.remoteToReturn = remoteMock
+        service = PostService(managedObjectContext: context, postServiceRemoteFactory: remoteFactory)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        service = nil
+        remoteMock = nil
+        context = nil
+        ContextManager.overrideSharedInstance(nil)
+    }
+
+    func testAutoSavingALocalDraftWillCallTheCreateEndpointInstead() {
+        // Arrange
+        let post = PostBuilder(context).drafted().with(remoteStatus: .local).build()
+        try! context.save()
+
+        remoteMock.remotePostToReturnOnCreatePost = createRemotePost(.draft)
+
+        // Act
+        waitUntil(timeout: 3) { done in
+            self.service.autoSave(post, success: { _, _ in
+                done()
+            }, failure: self.impossibleFailureBlock)
+        }
+
+        // Assert
+        expect(self.remoteMock.invocationsCountOfCreatePost).to(equal(1))
+        expect(post.remoteStatus).to(equal(.sync))
+    }
+
+    /// Local drafts with `.published` status will be ignored.
+    func testAutoSavingALocallyPublishedDraftWillFail() {
+        // Arrange
+        let post = PostBuilder(context).published().with(remoteStatus: .local).build()
+        try! context.save()
+
+        // Act
+        var failureBlockCalled = false
+        waitUntil(timeout: 3) { done in
+            self.service.autoSave(post, success: { _, _ in
+                done()
+            }, failure: { _ in
+                failureBlockCalled = true
+                done()
+            })
+        }
+
+        // Assert
+        expect(failureBlockCalled).to(beTrue())
+        expect(post.remoteStatus).to(equal(.failed))
+        expect(self.remoteMock.invocationsCountOfCreatePost).to(equal(0))
+        expect(self.remoteMock.invocationsCountOfUpdate).to(equal(0))
+    }
+
+    private func createRemotePost(_ status: BasePost.Status = .draft) -> RemotePost {
+        let remotePost = RemotePost(siteID: 1,
+                                    status: status.rawValue,
+                                    title: "Tenetur im",
+                                    content: "Velit tempore rerum")!
+        remotePost.type = "qui"
+        return remotePost
+    }
+}
+
+private class PostServiceRemoteFactoryMock: PostServiceRemoteFactory {
+    var remoteToReturn: PostServiceRemote?
+
+    override func forBlog(_ blog: Blog) -> PostServiceRemote? {
+        return remoteToReturn
+    }
+}
+
+private class PostServiceXMLRPCMock: PostServiceRemoteXMLRPC {
+    var remotePostToReturnOnCreatePost: RemotePost?
+
+    private(set) var invocationsCountOfCreatePost = 0
+    private(set) var invocationsCountOfUpdate = 0
+
+    override func update(_ post: RemotePost!, success: ((RemotePost?) -> Void)!, failure: ((Error?) -> Void)!) {
+        DispatchQueue.global().async {
+            self.invocationsCountOfUpdate += 1
+            success(nil)
+        }
+    }
+
+    override func createPost(_ post: RemotePost!, success: ((RemotePost?) -> Void)!, failure: ((Error?) -> Void)!) {
+        DispatchQueue.global().async {
+            self.invocationsCountOfCreatePost += 1
+            success(self.remotePostToReturnOnCreatePost)
+        }
+    }
+}

--- a/WordPress/WordPressTest/Services/PostServiceTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceTests.swift
@@ -145,6 +145,27 @@ class PostServiceTests: XCTestCase {
         expect(post.remoteStatus).to(equal(.sync))
     }
 
+    /// Local drafts with `.trash` status will not be automatically created on the server.
+    func testAutoSavingALocallyTrashedPostWillFail() {
+        // Arrange
+        let post = PostBuilder(context).trashed().with(remoteStatus: .local).build()
+        try! context.save()
+
+        // Act
+        var failureBlockCalled = false
+        waitUntil(timeout: 2) { done in
+            self.service.autoSave(post, success: { _, _ in
+                done()
+            }, failure: { _ in
+                failureBlockCalled = true
+                done()
+            })
+        }
+
+        // Assert
+        expect(failureBlockCalled).to(beTrue())
+    }
+
     func testAutoSavingAnExistingPostWillCallTheAutoSaveEndpoint() {
         // Arrange
         let post = PostBuilder(context).published().withRemote().with(remoteStatus: .sync).build()

--- a/WordPress/WordPressTest/Services/PostServiceTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceTests.swift
@@ -206,11 +206,17 @@ private class PostServiceRemoteFactoryMock: PostServiceRemoteFactory {
 }
 
 private class PostServiceRemoteMock: PostServiceRemoteREST {
+    enum StubbedBehavior {
+        case success(RemotePost?)
+        case fail
+    }
+
     var remotePostToReturnOnGetPostWithID: RemotePost?
     var remotePostsToReturnOnSyncPostsOfType = [RemotePost]()
     var remotePostToReturnOnUpdatePost: RemotePost?
     var remotePostToReturnOnCreatePost: RemotePost?
-    var remotePostToReturnOnAutoSave: RemotePost?
+
+    var autoSaveStubbedBehavior = StubbedBehavior.success(nil)
 
     private(set) var invocationsCountOfCreatePost = 0
     private(set) var invocationsCountOfAutoSave = 0
@@ -243,7 +249,12 @@ private class PostServiceRemoteMock: PostServiceRemoteREST {
     override func autoSave(_ post: RemotePost!, success: ((RemotePost?, String?) -> Void)!, failure: ((Error?) -> Void)!) {
         DispatchQueue.global().async {
             self.invocationsCountOfAutoSave += 1
-            success(self.remotePostToReturnOnAutoSave, nil)
+            switch self.autoSaveStubbedBehavior {
+            case .fail:
+                failure(nil)
+            case .success(let remotePost):
+                success(remotePost, nil)
+            }
         }
     }
 }

--- a/WordPress/WordPressTest/Services/PostServiceTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceTests.swift
@@ -9,6 +9,10 @@ class PostServiceTests: XCTestCase {
     private var service: PostService!
     private var context: NSManagedObjectContext!
 
+    private let impossibleFailureBlock: (Error?) -> Void = { _ in
+        assertionFailure("This shouldn't happen.")
+    }
+
     override func setUp() {
         super.setUp()
 
@@ -41,9 +45,7 @@ class PostServiceTests: XCTestCase {
             self.service.getPostWithID(123, for: blog, success: { postFromAPI in
                 post = postFromAPI
                 done()
-            }) { _ in
-                assertionFailure("This shouldn't happen.")
-            }
+            }, failure: self.impossibleFailureBlock)
         }
 
         // Assert
@@ -65,9 +67,7 @@ class PostServiceTests: XCTestCase {
             self.service.syncPosts(ofType: .any, for: blog, success: { postsFromAPI in
                 posts = postsFromAPI
                 done()
-            }) { _ in
-                assertionFailure("This shouldn't happen.")
-            }
+            }, failure: self.impossibleFailureBlock)
         }
 
         // Assert
@@ -95,9 +95,7 @@ class PostServiceTests: XCTestCase {
             self.service.uploadPost(post, success: { aPost in
                 postFromAPI = aPost
                 done()
-            }) { _ in
-                assertionFailure("This shouldn't happen.")
-            }
+            }, failure: self.impossibleFailureBlock)
         }
 
         // Assert

--- a/WordPress/WordPressTest/Services/PostServiceTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceTests.swift
@@ -113,8 +113,9 @@ class PostServiceTests: XCTestCase {
         let post = PostBuilder(context).drafted().with(remoteStatus: .local).build()
         try! context.save()
 
-        // Act
         remoteMock.remotePostToReturnOnCreatePost = createRemotePost(.draft)
+
+        // Act
         waitUntil(timeout: 3) { done in
             self.service.autoSave(post, success: { _, _ in
                 done()
@@ -132,8 +133,9 @@ class PostServiceTests: XCTestCase {
         let post = PostBuilder(context).published().with(remoteStatus: .local).build()
         try! context.save()
 
-        // Act
         remoteMock.remotePostToReturnOnCreatePost = createRemotePost(.draft)
+
+        // Act
         waitUntil(timeout: 3) { done in
             self.service.autoSave(post, success: { _, _ in
                 done()
@@ -171,8 +173,9 @@ class PostServiceTests: XCTestCase {
         let post = PostBuilder(context).published().withRemote().with(remoteStatus: .sync).build()
         try! context.save()
 
+        remoteMock.autoSaveStubbedBehavior = .success(createRemotePost(.publish))
+
         // Act
-        remoteMock.remotePostToReturnOnAutoSave = createRemotePost(.publish)
         waitUntil(timeout: 3) { done in
             self.service.autoSave(post, success: { _, _ in
                 done()

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -3,6 +3,10 @@ import Foundation
 import Nimble
 @testable import WordPress
 
+/// Tests common and WPCom-only PostService behavior.
+///
+/// - SeeAlso: PostServiceSelfHostedTests
+///
 class PostServiceWPComTests: XCTestCase {
 
     private var remoteMock: PostServiceRESTMock!

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -5,7 +5,7 @@ import Nimble
 
 class PostServiceWPComTests: XCTestCase {
 
-    private var remoteMock: PostServiceRemoteMock!
+    private var remoteMock: PostServiceRESTMock!
     private var service: PostService!
     private var context: NSManagedObjectContext!
 
@@ -18,7 +18,7 @@ class PostServiceWPComTests: XCTestCase {
 
         context = TestContextManager().mainContext
 
-        remoteMock = PostServiceRemoteMock()
+        remoteMock = PostServiceRESTMock()
 
         let remoteFactory = PostServiceRemoteFactoryMock()
         remoteFactory.remoteToReturn = remoteMock
@@ -226,7 +226,7 @@ private class PostServiceRemoteFactoryMock: PostServiceRemoteFactory {
     }
 }
 
-private class PostServiceRemoteMock: PostServiceRemoteREST {
+private class PostServiceRESTMock: PostServiceRemoteREST {
     enum StubbedBehavior {
         case success(RemotePost?)
         case fail

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Nimble
 @testable import WordPress
 
-class PostServiceTests: XCTestCase {
+class PostServiceWPComTests: XCTestCase {
 
     private var remoteMock: PostServiceRemoteMock!
     private var service: PostService!


### PR DESCRIPTION
Fixes #12630 

## Findings

Whenever a **new published post** is auto-saved, it gets stuck at “Uploading post...”. The cause was `PostCoordinator.autoSave` thinks that the post should be auto-saved instead of created in the server. 

https://github.com/wordpress-mobile/WordPress-iOS/blob/db3444be48d52294f83fc0024badeb0b19a7a114/WordPress/Classes/Services/PostService.m#L340

And because the post is _new_, the call to `[restRemote autoSave]` will fail and the `failureBlock` is called:

https://github.com/wordpress-mobile/WordPress-iOS/blob/db3444be48d52294f83fc0024badeb0b19a7a114/WordPress/Classes/Services/PostService.m#L336-L338

But the `failureBlock` never resets the `Post.remoteStatus` to `.failed`, so the post gets stuck at `.pushing`. Hence, the cause of the infinite “Uploading post...” message. 

## Solution

I opted not to create a variation of `PostService.autoSave()` and refactor it instead. This will benefit (hopefully positively) previewing too so that users who set their new posts to `.published` can still preview them. 

There are 2 main changes:

- Local posts, regardless of the status, will be automatically created
- If an auto-save fails, the post's `remoteStatus` will be changed to `.failed`. 

## Testing

### Creating

1. While offline, create a post and publish it. 
2. In the Post List, cancel the auto-upload. 
3. Go online. The post should be automatically uploaded as a draft. 

### Editing 

1. While offline, edit an existing published post. 
2. Exit the editor → Update Post
3. In the Post List, cancel the auto-upload. 
4. Go online. The post should be auto-saved. Please verify that when editing the post in Calypso, you will be able to a message that there is an available auto-save of the post.

### Failures

1. While offline, edit an existing published post. 
2. Exit the editor → Update Post
3. In the Post List, cancel the auto-upload. 
4. Go online. While the _uploading UI_ is happening, immediately go back offline. The _uploading UI_ should disappear and the post should say “Local changes”. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] I have added unit tests. 
