### PR TITLE
Optionally provide installable build on Pull Requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,31 @@ jobs:
           command: test-without-building
           arguments: -xctestrun DerivedData/Build/Products/WordPressUITests_iphonesimulator13.0-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
       - ios/save-xcodebuild-artifacts
+  Installable Build:
+    executor:
+      name: ios/default
+      xcode-version: "11.0.0"
+    steps:
+      - git/shallow-checkout
+      - load-chruby
+      - ios/install-dependencies:
+            bundle-install: true
+            pod-install: true
+      - run:
+          name: Copy Secrets
+          command: bundle exec fastlane run configure_apply
+      - run:
+          name: Build
+          working_directory: Scripts
+          command: "bundle exec fastlane build_and_upload_installable_build build_number:$CIRCLE_BUILD_NUM"
+      - run:
+          name: Prepare Artifacts
+          command: |
+            mkdir -p Artifacts
+            mv "Scripts/fastlane/comment.json" "Artifacts/comment.json"
+      - store_artifacts:
+          path: Artifacts
+          destination: Artifacts
 
 workflows:
   wordpress_ios:
@@ -87,3 +112,15 @@ workflows:
           name: UI Tests (iPad Air 3rd generation)
           device: iPad Air \\(3rd generation\\)
           requires: [ "Build Tests" ]
+  Installable Build:
+    jobs:
+      - Hold:
+          type: approval
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/
+      - Installable Build:
+          requires: [Hold]  
+          filters:
+            branches:
+              ignore: /pull\/[0-9]+/

--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "WordPress-iOS",
   "branch": "master",
-  "pinned_hash": "a12d06ac723ad3a8148d4b284c72c19fcfa69402",
+  "pinned_hash": "ca7d3b12061f49e446d1d28c3b6db8d1385bee14",
   "files_to_copy": [
     {
       "file": "iOS/WPiOS/wpcom_app_credentials",

--- a/.configure-files/project.env.enc
+++ b/.configure-files/project.env.enc
@@ -1,2 +1,2 @@
 òoÃÃ‚è_+¿1ŸRÛˆìäÏiÎ0¥ý£3eß3§*ö®/UkpãnQúi‘—]bÂ¢¥vöå–­9ÕËòÉhñÔ©tKã:ÞlxMÙ€E²
-!m+è¼O+f¾Dÿ¿]gÉ–läþezŸÐ›<€¾ƒäòÅÎ‹´ RöæžGY®PwÝÀóÙøý§nA%­‹÷xÿbï=œæ¢IÁg‹9¼TúèüágUH<f‚ãºlÜí÷§­|¸&A|´°‡¤j_#·R
+!m+è¼OàrÞ<0sÊÞùÍo·çOÐÓ\|[êJPq,ÿ*¼h	2ÝÄÕ­Òè êå°[É=4âÅI'yš§˜Ð>v—1l2€œTHÉÙèÃ=a´Û[¬¹FÛP$ž¯TèÛ€ßî}no¥ äèÑìÁt~À½ê.‚±gw gÄßg3‡å7¹àOÓ]ûD“H78‚Ò±Šé©Š/BB]¨§Îká!£dÄ	(ŸÁV

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -1,5 +1,7 @@
 default_platform(:ios)
+fastlane_require 'xcodeproj'
 fastlane_require 'dotenv'
+fastlane_require 'open-uri'
 
 USER_ENV_FILE_PATH = File.join(Dir.home, '.wpios-env.default')
 PROJECT_ENV_FILE_PATH = File.expand_path(File.join(Dir.pwd, '../../.configure-files/project.env'))
@@ -15,8 +17,17 @@ end
 
 before_all do
   # Check that the env files exist
-  UI.user_error!("~/.wpios-env.default not found: Please copy env/user.env-example to #{USER_ENV_FILE_PATH} and fill in the values") unless File.file?(USER_ENV_FILE_PATH)
-  UI.user_error!("project.env not found: Make sure your configuration is up to date with `rake dependencies`") unless File.file?(PROJECT_ENV_FILE_PATH)
+  unless is_ci || File.file?(USER_ENV_FILE_PATH)
+    UI.user_error!("~/.wpios-env.default not found: Please copy env/user.env-example to #{USER_ENV_FILE_PATH} and fill in the values")
+  end
+  unless File.file?(PROJECT_ENV_FILE_PATH)
+    UI.user_error!("project.env not found: Make sure your configuration is up to date with `rake dependencies`")
+  end
+
+  # This allows code signing to work on CircleCI
+  # It is skipped if this isn't running on CI
+  # See https://circleci.com/docs/2.0/ios-codesigning/
+  setup_circle_ci
 end
 
 platform :ios do
@@ -188,6 +199,72 @@ import "./ScreenshotFastfile"
     ios_build_preflight()
     build_and_upload_internal(skip_prechecks: true, skip_confirm: options[:skip_confirm])
     build_and_upload_itc(skip_prechecks: true, skip_confirm: options[:skip_confirm])
+  end
+
+  #####################################################################################
+  # build_and_upload_installable_build
+  # -----------------------------------------------------------------------------------
+  # This lane builds the app and upload it for adhoc testing 
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_and_upload_installable_build [version_long:<version_long>]
+  #
+  # Example:
+  # bundle exec fastlane build_and_upload_installable_build 
+  # bundle exec fastlane build_and_upload_installable_build build_number:123 
+  #####################################################################################
+  desc "Builds and uploads an installable build"
+  lane :build_and_upload_installable_build do | options |
+    alpha_code_signing
+
+    # Get the current build version, and update it if needed
+    version_config_path = "../../config/Version.internal.xcconfig"
+    versions = Xcodeproj::Config.new(File.new(version_config_path)).to_hash
+    build_number = versions["VERSION_LONG"]
+
+    if options.key?(:build_number)
+      build_number = options[:build_number]
+
+      UI.message("Updating build version to #{build_number}")
+
+      versions["VERSION_LONG"] = build_number
+      new_config = Xcodeproj::Config.new(versions)
+      new_config.save_as(Pathname.new(version_config_path))
+    end
+
+    gym(
+      scheme: "WordPress Alpha",
+      workspace: "../WordPress.xcworkspace",
+      export_method: "enterprise",
+      clean: true,
+      output_directory: "../build/",
+      derived_data_path: "../derived-data/alpha/",
+      export_team_id: ENV["INT_EXPORT_TEAM_ID"],
+      export_options: { method: "enterprise" })
+
+    sh("mv ../../build/WordPress.ipa \"../../build/WordPress Alpha.ipa\"")
+      
+    hockey(
+      api_token: get_required_env("HOCKEY_API_TOKEN"),        
+      public_identifier: get_required_env("HOCKEY_INSTALLABLE_BUILDS_PUBLIC_ID"),
+      notify: "0",
+      status: "2",
+      ipa: "../build/WordPress Alpha.ipa",
+      dsym: "../build/WordPress.app.dSYM.zip",
+    )
+
+    # Getting the download link from the HockeyApp Api, since `hockey(..)` only gives us the app link
+    # See documentation here: https://support.hockeyapp.net/kb/api/api-versions
+    url = "https://rink.hockeyapp.net/api/2/apps/#{get_required_env("HOCKEY_INSTALLABLE_BUILDS_PUBLIC_ID")}/app_versions"
+    result = open(url, {"X-HockeyAppToken" => get_required_env("HOCKEY_API_TOKEN")}).read
+    versions = JSON.parse(result)
+
+    download_url = versions["app_versions"].find {|v| v["version"] == build_number}["download_url"]
+    UI.message("Successfully built and uploaded installable build here: #{download_url}")
+
+    # Create a comment.json file so that Peril to comment with the build details, if this is running on CI
+    comment_body = "You can test the changes on this Pull Request by downloading it from HockeyApp [here](#{download_url}). If you need access to this, you can ask a maintainer to add you."
+    File.write("comment.json", { body: comment_body }.to_json)
   end
 
   #####################################################################################

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -289,6 +289,19 @@ import "./ScreenshotFastfile"
   ########################################################################
   # Fastlane match code signing
   ########################################################################  
+  private_lane :alpha_code_signing do |options|
+    match(
+      type: "enterprise",
+      team_id: get_required_env("INT_EXPORT_TEAM_ID"),
+      readonly: options[:readonly] || is_ci,
+      app_identifier: ["org.wordpress.alpha",
+                       "org.wordpress.alpha.WordPressShare",
+                       "org.wordpress.alpha.WordPressDraftAction",
+                       "org.wordpress.alpha.WordPressTodayWidget",
+                       "org.wordpress.alpha.WordPressNotificationServiceExtension",
+                       "org.wordpress.alpha.WordPressNotificationContentExtension"])
+  end
+
   private_lane :internal_code_signing do |options|
     match(
       type: "enterprise",

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -12625,6 +12625,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 99KV9Z6BKV;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -12640,7 +12641,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.wordpress.alpha.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "WordPress Alpha Notification Content Distribution";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha.WordPressNotificationContentExtension";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressNotificationContentExtension/Sources/WordPressNotificationContentExtension-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
@@ -12802,6 +12803,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 99KV9Z6BKV;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -12817,7 +12819,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.wordpress.alpha.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "WordPress Alpha Notification Service Distribution";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha.WordPressNotificationServiceExtension";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressNotificationServiceExtension/Sources/WordPressNotificationServiceExtension-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
@@ -13022,7 +13024,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.alpha.WordPressDraftAction;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "81837878-384c-45d9-909a-8c2c56a2ce58";
-				PROVISIONING_PROFILE_SPECIFIER = "WordPress Alpha Draft Action Distribution";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha.WordPressDraftAction";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressDraftActionExtension/WordPressDraftActionExtension-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
@@ -13277,6 +13279,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 99KV9Z6BKV;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
@@ -13316,7 +13319,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD -D INTERNAL_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.alpha;
 				PRODUCT_NAME = WordPress;
-				PROVISIONING_PROFILE_SPECIFIER = "WordPress Alpha Enterprise";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha";
 				SWIFT_INCLUDE_PATHS = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
@@ -13390,6 +13393,7 @@
 				CODE_SIGN_ENTITLEMENTS = "WordPressTodayWidget/WordPressTodayWidget-Alpha.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = 99KV9Z6BKV;
 				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -13414,7 +13418,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.wordpress.alpha.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "WordPress Alpha Today Widget Enterprise";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha.WordPressTodayWidget";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressTodayWidget/WordPressTodayWidget-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
@@ -13647,6 +13651,7 @@
 				CODE_SIGN_ENTITLEMENTS = "WordPressShareExtension/WordPressShare-Alpha.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = 99KV9Z6BKV;
 				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -13678,7 +13683,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.alpha.WordPressShare;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "WordPress Alpha Share Distribution";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha.WordPressShare";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressShareExtension/WordPressShare-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;


### PR DESCRIPTION
This adds installable builds for WPiOS. When triggered, a build with the current changes will be made and a comment with a HockeyApp link will be posted on the PR.

The changes can be broken down as follows:

- Fastlane Match support for the "WordPress Alpha" scheme. This mirrors what is already done for the AppStore and Internal schemes.
- Added a new lane, `build_and_upload_installable_build` which builds and uploads the "WordPress Alpha" scheme to HockeyApp.
- New CircleCI job, `Installable Build` which requires [manual approval](https://circleci.com/blog/manual-job-approval-and-scheduled-workflow-runs/) to run. It does not run automatically as it would use ~15 minutes of CI resources on every push. See the test instructions for how to trigger it.

It builds on these PRs:

- https://github.com/Automattic/peril-settings/pull/22
- https://github.com/Automattic/peril-settings/pull/21
- https://github.com/wordpress-mobile/WordPress-iOS/pull/12668
- https://github.com/wordpress-mobile/WordPress-iOS/pull/12653
- https://github.com/wordpress-mobile/WordPress-iOS/pull/12609

## To test:

### Fastlane

You can test this locally with these steps:

- Run `bundle exec fastlane run configure_apply` from the root of the project.
- Run `bundle exec fastlane build_and_upload_installable_build version_long:14523` (or some other build number).
- It should successfully build and upload the app. In the log output you will see a URL to download the app.

### On Github / CircleCI

Below, there is a comment from Peril that looks like this (if someone has triggered the build already, this will not be there):

![image](https://user-images.githubusercontent.com/1773641/66901118-f5b7cc00-eff5-11e9-8028-b1a2cde476f5.png)

Follow the link and approve the job, by clicking on "Hold" in CircleCI. Now you will see a new, in progress "Installable Build" check on the PR.

When it completes (around 15m), there should be a new comment with a link to HockeyApp. Visit the link on an iOS device and download the app. You should be able to login with WP.com credentials.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
