### PR TITLE
Fix build warnings in Xcode 11

### DIFF
--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -160,7 +160,7 @@
 
 - (void)setRemoteStatus:(MediaRemoteStatus)aStatus
 {
-    [self setRemoteStatusNumber:[NSNumber numberWithInt:aStatus]];
+    [self setRemoteStatusNumber:@(aStatus)];
 }
 
 - (NSString *)remoteStatusText

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -114,7 +114,7 @@ open class WP3DTouchShortcutCreator: NSObject {
             guard let strongSelf = self else {
                 return
             }
-            var entireShortcutArray = strongSelf.loggedInShortcutArray()
+            let entireShortcutArray = strongSelf.loggedInShortcutArray()
             var visibleShortcutArray = [UIApplicationShortcutItem]()
 
             if strongSelf.hasWordPressComAccount() {

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/Views/RegisterDomainDetailsErrorSectionFooter.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/Views/RegisterDomainDetailsErrorSectionFooter.swift
@@ -8,8 +8,11 @@ class RegisterDomainDetailsErrorSectionFooter: UITableViewHeaderFooterView, NibR
     func addErrorMessage(_ message: String?) {
         let label = errorLabel(message: message)
         stackView.addArrangedSubview(label)
-        label.leadingAnchor.constraint(equalTo: stackView.leadingAnchor)
-        label.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            label.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
+        ])
     }
 
     func setErrorMessages(_ messages: [String]) {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -57,7 +57,7 @@ class SignupEpilogueCell: UITableViewCell {
             return value
         }
         set {
-            super.accessibilityLabel = accessibilityLabel
+            super.accessibilityLabel = newValue
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryAccessoryItem.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryAccessoryItem.swift
@@ -149,8 +149,11 @@ struct PluginDirectoryAccessoryItem {
 
         let container = UIView(frame: .zero)
         container.translatesAutoresizingMaskIntoConstraints = false
-        container.heightAnchor.constraint(equalToConstant: size.height)
-        container.widthAnchor.constraint(equalToConstant: size.width)
+
+        NSLayoutConstraint.activate([
+            container.heightAnchor.constraint(equalToConstant: size.height),
+            container.widthAnchor.constraint(equalToConstant: size.width)
+        ])
 
         let leftHalf = UIImageView(image: Gridicon.iconOfType(.star, withSize: size))
         leftHalf.tintColor = color

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -475,7 +475,7 @@ private struct URLExtractor: TypeBasedExtensionContentExtractor {
         }
 
         // If the first line is formatted as a heading, use it as the title
-        var lines = md.components(separatedBy: .newlines)
+        let lines = md.components(separatedBy: .newlines)
         if lines.count > 1, lines[0].first == "#" {
             let mdTitle = lines[0].replacingOccurrences(of: "^#{1,6} ?", with: "", options: .regularExpression)
             let titleConverter = Down(markdownString: mdTitle)


### PR DESCRIPTION
In Xcode 11 we had 12 build warnings. This PR fixes 9 of them, just leaving us with Swift 5 conversion and project settings updates.

I've tagged a couple of you for review, as these warnings were in sections of code that you edited last – please could you take a quick peek and check my changes look okay?

**To test:**

* Build and run, check there are only 3 warnings
* If you want to step through part of the app that a change affects then go ahead – I did try as many things as I could (media upload, browsing plugin directory, triggering register domain errors) and I think everything should be fine.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
