### PR TITLE
Update fastlane and release-toolkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,9 @@ source 'https://rubygems.org' do
   gem 'cocoapods-repo-update', '~> 0.0.3'
   gem 'xcpretty-travis-formatter'
   gem 'octokit', "~> 4.0"
-  gem 'fastlane', "2.127.2"
+  gem 'fastlane', "2.133.0"
   gem 'dotenv'
-  gem 'rubyzip', "~> 1.2.2"
+  gem 'rubyzip', "~> 1.3"
   gem 'commonmarker'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,11 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 21400012da8c2ceafa8ea2ce23d8a88233a97838
-  tag: 0.7.2
+  revision: c8007b8c11c282ea3e9f97f722d1971271959770
+  tag: 0.8.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.7.2)
+    fastlane-plugin-wpmreleasetoolkit (0.8.0)
+      activesupport (~> 4)
+      chroma (= 0.2.0)
       diffy (~> 3.3)
       git (~> 1.3)
       jsonlint
@@ -26,7 +28,8 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     atomos (0.1.3)
-    babosa (1.0.2)
+    babosa (1.0.3)
+    chroma (0.2.0)
     claide (1.0.3)
     cocoapods (1.7.5)
       activesupport (>= 4.0.2, < 5)
@@ -79,7 +82,7 @@ GEM
     dotenv (2.7.5)
     emoji_regex (1.0.1)
     escape (0.0.4)
-    excon (0.66.0)
+    excon (0.67.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -87,8 +90,8 @@ GEM
       http-cookie (~> 1.0.0)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
-    fastimage (2.1.5)
-    fastlane (2.127.2)
+    fastimage (2.1.7)
+    fastlane (2.133.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -98,9 +101,9 @@ GEM
       dotenv (>= 2.1.1, < 3.0.0)
       emoji_regex (>= 0.1, < 2.0)
       excon (>= 0.45.0, < 1.0.0)
-      faraday (~> 0.9)
+      faraday (< 0.16.0)
       faraday-cookie_jar (~> 0.0.6)
-      faraday_middleware (~> 0.9)
+      faraday_middleware (< 0.16.0)
       fastimage (>= 2.1.0, < 3.0.0)
       gh_inspector (>= 1.1.2, < 2.0.0)
       google-api-client (>= 0.21.2, < 0.24.0)
@@ -113,7 +116,7 @@ GEM
       multipart-post (~> 2.0.0)
       plist (>= 3.1.0, < 4.0.0)
       public_suffix (~> 2.0.0)
-      rubyzip (>= 1.2.2, < 2.0.0)
+      rubyzip (>= 1.3.0, < 2.0.0)
       security (= 0.1.3)
       simctl (~> 1.6.3)
       slack-notifier (>= 2.0.0, < 3.0.0)
@@ -166,9 +169,9 @@ GEM
       optimist (~> 3)
     jwt (2.1.0)
     memoist (0.16.0)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.0904)
     mini_magick (4.9.5)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -188,7 +191,7 @@ GEM
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
-    parallel (1.17.0)
+    parallel (1.18.0)
     plist (3.5.0)
     progress_bar (1.3.0)
       highline (>= 1.6, < 3)
@@ -207,7 +210,7 @@ GEM
     ruby-enum (0.7.2)
       i18n
     ruby-macho (1.4.0)
-    rubyzip (1.2.3)
+    rubyzip (1.3.0)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
@@ -217,7 +220,7 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simctl (1.6.5)
+    simctl (1.6.6)
       CFPropertyList
       naturally
     slack-notifier (2.3.2)
@@ -256,13 +259,13 @@ DEPENDENCIES
   cocoapods-repo-update (~> 0.0.3)!
   commonmarker!
   dotenv!
-  fastlane (= 2.127.2)!
+  fastlane (= 2.133.0)!
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)!
   rake!
   rmagick (~> 3.2.0)
-  rubyzip (~> 1.2.2)!
+  rubyzip (~> 1.3)!
   xcpretty-travis-formatter!
 
 BUNDLED WITH

--- a/Scripts/fastlane/Pluginfile
+++ b/Scripts/fastlane/Pluginfile
@@ -6,5 +6,5 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.7.2'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.0'
 gem 'fastlane-plugin-sentry'


### PR DESCRIPTION
This PR updates `release-toolkit` to import some fixes in the release notes handling for iOS.
It also updates `fastlane` to get rid of the security warning about rubyzip.

To test:

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
