### PR TITLE
Disable UI tests that use a magic link

### DIFF
--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
@@ -69,6 +69,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BuildableName = "WordPress.app"
+            BlueprintName = "WordPress"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -83,20 +92,15 @@
                <Test
                   Identifier = "EditorTests/testPlayground()">
                </Test>
+               <Test
+                  Identifier = "LoginTests/testEmailMagicLinkLogin()">
+               </Test>
+               <Test
+                  Identifier = "SignupTests/testEmailSignup()">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
-            BuildableName = "WordPress.app"
-            BlueprintName = "WordPress"
-            ReferencedContainer = "container:WordPress.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -118,8 +122,6 @@
             ReferencedContainer = "container:WordPress.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
We have been seeing a lot of erroneous/flaky failures for the UI tests that use a magic link (magic link login and signup), due to the issue described in https://github.com/wordpress-mobile/WordPress-iOS/issues/12608. This PR disables those tests until we can make them reliable.

FYI @designsimply we'll want to make sure signup and magic link login are fully tested in beta while these tests are disabled.

To test:

* Confirm all tests pass on CircleCI and the tests `testEmailMagicLinkLogin` and `testEmailSignup` are skipped.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @frosty 