### PR TITLE
[Stats] Enable internal testing for Insights async loading.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -31,7 +31,7 @@ enum FeatureFlag: Int {
             }
             return true
         case .statsAsyncLoading:
-            return BuildConfiguration.current == .localDeveloper
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cPrereleaseTesting]
         }
     }
 }


### PR DESCRIPTION
Ref #12405 

To test:
- On a slow network, go to Stats > Insights.
- Verify the Ghost Animations appear on the Insights card until the stats are loaded.

![loading](https://user-images.githubusercontent.com/1816888/66505177-06ad8e00-ea88-11e9-9d50-b1eaa4f77d0f.png)


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
