### PR TITLE
[Stats] Update ghost cell colors for Dark Mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostChartCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostChartCell.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,12 +14,12 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="302"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="huv-sR-fvD" id="zRs-Bm-Vgb">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="301.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="302"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xm7-B5-Mcg">
                         <rect key="frame" x="16" y="25" width="20" height="38"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="20" id="SPf-NH-nmg"/>
                             <constraint firstAttribute="height" constant="38" id="XHE-JB-GBM"/>
@@ -31,7 +28,7 @@
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TZ9-xg-9dO">
                         <rect key="frame" x="44" y="43" width="45" height="20"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="45" id="LIf-9c-4Qh"/>
                             <constraint firstAttribute="height" constant="20" id="ldd-tx-FTd"/>
@@ -43,103 +40,104 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yQA-M2-tNd">
                                 <rect key="frame" x="0.0" y="0.0" width="14" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="g4Q-hJ-UtO"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UD4-SU-tfr">
                                 <rect key="frame" x="21" y="0.0" width="13.5" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="Yz8-x6-eFl"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C5p-VK-ySB">
                                 <rect key="frame" x="41.5" y="0.0" width="14" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="2tQ-4C-OlU"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AzN-uE-Wv5">
                                 <rect key="frame" x="62.5" y="0.0" width="14" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="1Px-7z-P5p"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Saw-dX-Q2D">
                                 <rect key="frame" x="83.5" y="0.0" width="13.5" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="7wR-BU-WBe"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kt9-n6-ho2">
                                 <rect key="frame" x="104" y="0.0" width="14" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="dSz-Lu-9p1"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9ih-Sw-9oQ">
                                 <rect key="frame" x="125" y="0.0" width="14" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="AaG-DD-63M"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="it1-M2-S7D">
                                 <rect key="frame" x="146" y="0.0" width="14" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="Lyr-Mo-m5f"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rim-Gt-kKJ">
                                 <rect key="frame" x="167" y="0.0" width="13.5" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="2vW-VK-3e8"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="isq-A5-UjF">
                                 <rect key="frame" x="187.5" y="0.0" width="14" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="61l-bq-Zy0"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vb5-cd-Qhz">
                                 <rect key="frame" x="208.5" y="0.0" width="14" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="czv-bw-s6i"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wLA-zG-smV">
                                 <rect key="frame" x="229.5" y="0.0" width="13.5" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="kzc-ej-P2C"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ucu-WQ-AZ5">
                                 <rect key="frame" x="250" y="0.0" width="14" height="100"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="kXD-kP-JjV"/>
                                 </constraints>
                             </view>
                         </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="100" id="Mb2-1H-1nD"/>
                         </constraints>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0ZN-V8-rLc">
                         <rect key="frame" x="16" y="187" width="65" height="8"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="65" id="OGo-eH-tjD"/>
                             <constraint firstAttribute="height" constant="8" id="Ome-8h-o0J"/>
@@ -148,7 +146,7 @@
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GTG-fs-LIN">
                         <rect key="frame" x="239" y="187" width="65" height="8"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="8" id="9c7-1x-tar"/>
                             <constraint firstAttribute="width" constant="65" id="Dyx-uY-hQU"/>
@@ -160,7 +158,7 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mhq-o2-zW4">
                                 <rect key="frame" x="0.0" y="0.0" width="16" height="8"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="16" id="ng9-rr-ywc"/>
                                     <constraint firstAttribute="height" constant="8" id="qOO-oy-iym"/>
@@ -168,7 +166,7 @@
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L3W-sq-4sx">
                                 <rect key="frame" x="0.0" y="23" width="16" height="8"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="8" id="QlX-fm-CYC"/>
                                     <constraint firstAttribute="width" constant="16" id="cL9-wx-A5m"/>
@@ -176,7 +174,7 @@
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2kI-c7-MaI">
                                 <rect key="frame" x="0.0" y="46" width="16" height="8"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="16" id="9TP-Jt-Cd5"/>
                                     <constraint firstAttribute="height" constant="8" id="cXX-k6-B1h"/>
@@ -184,7 +182,7 @@
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eVO-oE-ucr">
                                 <rect key="frame" x="0.0" y="69" width="16" height="8"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="8" id="8nX-MB-ruX"/>
                                     <constraint firstAttribute="width" constant="16" id="tzU-o3-on4"/>
@@ -192,19 +190,21 @@
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lIa-22-ptW">
                                 <rect key="frame" x="0.0" y="92" width="16" height="8"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="8" id="175-Nn-ke0"/>
                                     <constraint firstAttribute="width" constant="16" id="I1h-PE-6Sz"/>
                                 </constraints>
                             </view>
                         </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="16" id="Qqr-r2-XQb"/>
                             <constraint firstAttribute="height" constant="100" id="gJQ-7t-yjh"/>
                         </constraints>
                     </stackView>
                 </subviews>
+                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="ew5-IW-6Hi" firstAttribute="leading" secondItem="zRs-Bm-Vgb" secondAttribute="leading" constant="16" id="6BP-v4-ZjT"/>
                     <constraint firstItem="TZ9-xg-9dO" firstAttribute="leading" secondItem="xm7-B5-Mcg" secondAttribute="trailing" constant="8" id="96r-j7-Ant"/>
@@ -222,12 +222,8 @@
                     <constraint firstItem="ew5-IW-6Hi" firstAttribute="top" secondItem="xm7-B5-Mcg" secondAttribute="bottom" constant="16" id="xbs-cN-eIQ"/>
                 </constraints>
             </tableViewCellContentView>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <point key="canvasLocation" x="339.13043478260875" y="186.16071428571428"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <namedColor name="Gray0">
-            <color red="0.96862745098039216" green="0.95686274509803926" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostPostingActivityCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostPostingActivityCell.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="391" height="198"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mup-p4-lY9" id="gKB-vs-9LT">
-                <rect key="frame" x="0.0" y="0.0" width="391" height="197.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="391" height="198"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="qz9-Fi-Yby">
@@ -27,12 +24,13 @@
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G6z-rs-9uG">
                         <rect key="frame" x="16" y="159" width="140.5" height="16"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="16" id="UKT-Wk-QIc"/>
                         </constraints>
                     </view>
                 </subviews>
+                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="G6z-rs-9uG" secondAttribute="trailing" multiplier="2.5" id="3Ei-m3-7Zv"/>
                     <constraint firstAttribute="trailing" secondItem="qz9-Fi-Yby" secondAttribute="trailing" constant="16" id="ApT-1q-Jf9"/>
@@ -43,15 +41,11 @@
                     <constraint firstItem="G6z-rs-9uG" firstAttribute="leading" secondItem="gKB-vs-9LT" secondAttribute="leading" constant="16" id="w5Q-Ug-Gvj"/>
                 </constraints>
             </tableViewCellContentView>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <connections>
                 <outlet property="stackView" destination="qz9-Fi-Yby" id="k0s-X9-NiX"/>
             </connections>
             <point key="canvasLocation" x="67.391304347826093" y="152.67857142857142"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <namedColor name="Gray0">
-            <color red="0.96862745098039216" green="0.95686274509803926" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTabbedCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTabbedCell.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="471" height="243"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7af-GX-k7V" id="n4F-of-kmC">
-                <rect key="frame" x="0.0" y="0.0" width="471" height="242.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="471" height="243"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="80" translatesAutoresizingMaskIntoConstraints="NO" id="DYP-pZ-QEw">
@@ -24,19 +21,20 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YLr-zu-ulz">
                                 <rect key="frame" x="40" y="13" width="155.5" height="18"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="18" id="PHj-jf-Z4C"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="CVE-Pi-WFV">
                                 <rect key="frame" x="275.5" y="13" width="155.5" height="18"/>
-                                <color key="backgroundColor" name="Gray0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="18" id="lZe-Cd-gQ2"/>
                                 </constraints>
                             </view>
                         </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="44" id="Cxw-GA-ifc"/>
                         </constraints>
@@ -44,14 +42,14 @@
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="71l-fT-BHP">
                         <rect key="frame" x="0.0" y="44" width="235.5" height="2"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="2" id="FDi-oo-Pvr"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="foQ-eG-3TO">
                         <rect key="frame" x="405" y="53" width="50" height="16"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="16" id="6Os-19-kuy"/>
                             <constraint firstAttribute="width" constant="50" id="cN9-a7-P6f"/>
@@ -59,7 +57,7 @@
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m5L-pq-qz6">
                         <rect key="frame" x="16" y="53" width="50" height="16"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="50" id="0GP-L4-jyC"/>
                             <constraint firstAttribute="height" constant="16" id="gRe-cR-VSR"/>
@@ -67,7 +65,7 @@
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rRL-o4-Lsv">
                         <rect key="frame" x="16" y="85" width="28" height="28"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="28" id="J5T-Gw-eBT"/>
                             <constraint firstAttribute="width" constant="28" id="opR-HG-clN"/>
@@ -75,12 +73,13 @@
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rZ8-tB-uMd">
                         <rect key="frame" x="60" y="91" width="395" height="16"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="16" id="bgk-9f-KIx"/>
                         </constraints>
                     </view>
                 </subviews>
+                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="DYP-pZ-QEw" firstAttribute="top" secondItem="n4F-of-kmC" secondAttribute="top" id="2r7-pi-m3Q"/>
                     <constraint firstItem="rRL-o4-Lsv" firstAttribute="top" secondItem="m5L-pq-qz6" secondAttribute="bottom" constant="16" id="7kM-MS-6LJ"/>
@@ -100,12 +99,8 @@
                     <constraint firstAttribute="trailing" secondItem="foQ-eG-3TO" secondAttribute="trailing" constant="16" id="zTj-Co-Koz"/>
                 </constraints>
             </tableViewCellContentView>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <point key="canvasLocation" x="36.956521739130437" y="169.75446428571428"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <namedColor name="Gray0">
-            <color red="0.96862745098039216" green="0.95686274509803926" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -42,7 +42,7 @@ struct StatsGhostChartImmutableRow: StatsRowGhostable {
 }
 
 private enum GhostCellStyle {
-    static let muriel = GhostStyle(beatDuration: TimeInterval(0.75),
-                                   beatStartColor: .neutral(.shade0),
-                                   beatEndColor: .neutral(.shade5))
+    static let muriel = GhostStyle(beatDuration: GhostStyle.Defaults.beatDuration,
+                           beatStartColor: .placeholderElement,
+                           beatEndColor: .placeholderElementFaded)
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTopCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTopCell.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,48 +13,49 @@
             <rect key="frame" x="0.0" y="0.0" width="385" height="88"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nvH-i5-fa2" id="z3U-Dz-KW3">
-                <rect key="frame" x="0.0" y="0.0" width="385" height="87.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="385" height="88"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aIz-HO-onk">
-                        <rect key="frame" x="16" y="7.5" width="50" height="16"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <rect key="frame" x="16" y="7" width="50" height="16"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="16" id="THd-y7-PIC"/>
                             <constraint firstAttribute="width" constant="50" id="uhQ-AY-YaT"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DmG-JX-3gY">
-                        <rect key="frame" x="319" y="7.5" width="50" height="16"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <rect key="frame" x="319" y="7" width="50" height="16"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="16" id="0Vd-eQ-9pC"/>
                             <constraint firstAttribute="width" constant="50" id="csa-Wh-xgf"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="K4M-bQ-piX">
-                        <rect key="frame" x="16" y="45.5" width="28" height="28"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <rect key="frame" x="16" y="45" width="28" height="28"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="28" id="Ts8-dz-WPq"/>
                             <constraint firstAttribute="width" constant="28" id="n8Q-7w-nqb"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cpf-Oy-Tmi">
-                        <rect key="frame" x="60" y="39.5" width="309" height="20"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <rect key="frame" x="60" y="39" width="309" height="20"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="20" id="TqM-kO-gWN"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAb-Vl-aXI">
-                        <rect key="frame" x="60" y="64.5" width="309" height="15"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <rect key="frame" x="60" y="64" width="309" height="15"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="15" id="3n8-eE-jLQ"/>
                         </constraints>
                     </view>
                 </subviews>
+                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="K4M-bQ-piX" firstAttribute="leading" secondItem="z3U-Dz-KW3" secondAttribute="leading" constant="16" id="08B-Ng-CS2"/>
                     <constraint firstItem="DmG-JX-3gY" firstAttribute="top" secondItem="z3U-Dz-KW3" secondAttribute="top" constant="7" id="6Wf-Xv-zCd"/>
@@ -73,15 +71,11 @@
                     <constraint firstItem="KAb-Vl-aXI" firstAttribute="leading" secondItem="K4M-bQ-piX" secondAttribute="trailing" constant="16" id="vQS-Df-VPO"/>
                 </constraints>
             </tableViewCellContentView>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="cpf-Oy-Tmi" secondAttribute="trailing" constant="16" id="AHP-3y-Wu8"/>
             </constraints>
             <point key="canvasLocation" x="113.768115942029" y="153.34821428571428"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <namedColor name="Gray0">
-            <color red="0.96862745098039216" green="0.95686274509803926" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTwoColumnCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTwoColumnCell.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,45 +14,42 @@
             <rect key="frame" x="0.0" y="0.0" width="477" height="79"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="477" height="78.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="477" height="79"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LwP-eE-0z6" userLabel="Separator Line">
-                        <rect key="frame" x="238" y="13.5" width="1" height="53"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <rect key="frame" x="238" y="13" width="1" height="53"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="1" id="rsi-i7-TjJ"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TDF-ES-9nV">
-                        <rect key="frame" x="16" y="13.5" width="206" height="17"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <rect key="frame" x="16" y="13" width="206" height="17"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="17" id="ZSp-4o-CVc"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IJy-7r-tHx">
-                        <rect key="frame" x="16" y="35.5" width="206" height="31"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <rect key="frame" x="16" y="35" width="206" height="31"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="31" id="TcX-fh-zW5"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6sw-Jb-0Q7">
-                        <rect key="frame" x="255" y="13.5" width="206" height="17"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <rect key="frame" x="255" y="13" width="206" height="17"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="17" id="bxv-Qp-sCo"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="M28-bO-s3H">
-                        <rect key="frame" x="255" y="35.5" width="206" height="31"/>
-                        <color key="backgroundColor" name="Gray0"/>
+                        <rect key="frame" x="255" y="35" width="206" height="31"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="31" id="yHt-Fo-t8E"/>
                         </constraints>
                     </view>
                 </subviews>
+                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="M28-bO-s3H" secondAttribute="bottom" constant="13" id="G2L-M2-F9V"/>
                     <constraint firstAttribute="trailing" secondItem="6sw-Jb-0Q7" secondAttribute="trailing" constant="16" id="GAF-O6-Yhp"/>
@@ -76,13 +70,9 @@
                     <constraint firstItem="LwP-eE-0z6" firstAttribute="centerX" secondItem="H2p-sc-9uM" secondAttribute="centerX" id="zWq-TM-Zdo"/>
                 </constraints>
             </tableViewCellContentView>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <point key="canvasLocation" x="251.44927536231887" y="239.39732142857142"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <namedColor name="Gray0">
-            <color red="0.96862745098039216" green="0.95686274509803926" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-    </resources>
 </document>


### PR DESCRIPTION
Ref #12405 

This updates the colors used in the Stats ghost cells.

To test:
- On a slow network, go to Stats > Insights.
- Verify the ghost colors are correct in dark mode.

![ghost_colors](https://user-images.githubusercontent.com/1816888/66523878-2f487e80-eaae-11e9-94e9-2228dd1fbc14.gif)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
