### PR TITLE
Store all credentials under .configure-files to prevent accidental commits

### DIFF
--- a/.configure
+++ b/.configure
@@ -5,22 +5,22 @@
   "files_to_copy": [
     {
       "file": "iOS/WPiOS/wpcom_app_credentials",
-      "destination": "WordPress/Credentials/wpcom_app_credentials",
+      "destination": ".configure-files/wpcom_app_credentials",
       "encrypt": true
     },
     {
       "file": "iOS/WPiOS/wpcom_alpha_app_credentials",
-      "destination": "WordPress/Credentials/wpcom_alpha_app_credentials",
+      "destination": ".configure-files/wpcom_alpha_app_credentials",
       "encrypt": true
     },
     {
       "file": "iOS/WPiOS/wpcom_internal_app_credentials",
-      "destination": "WordPress/Credentials/wpcom_internal_app_credentials",
+      "destination": ".configure-files/wpcom_internal_app_credentials",
       "encrypt": true
     },
     {
       "file": "shared/google_cloud_keys.json",
-      "destination": "Scripts/fastlane/google_cloud_keys.json",
+      "destination": ".configure-files/google_cloud_keys.json",
       "encrypt": true
     }
   ],

--- a/.gitignore
+++ b/.gitignore
@@ -81,7 +81,12 @@ Scripts/fastlane/google_cloud_keys.json
 /WordPress/Resources/AppImages.xcassets/AppIcon-Internal.appiconset
 /WordPress/Resources/Icons-Internal
 
-# Credentials
+# All secrets should be stored under .configure-files
+# Everything without a .enc extension is ignored
+.configure-files/*
+!.configure-files/*.enc
+
+# Ignoring old locations to be sure they aren't commited accidentally
 WordPress/Credentials/wpcom_app_credentials
 WordPress/Credentials/wpcom_alpha_app_credentials
 WordPress/Credentials/wpcom_internal_app_credentials

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ In order to login to WordPress.com using the app:
 1. Create an application at https://developer.wordpress.com/apps/.
 1. Set "Redirect URLs"= `https://localhost` and "Type" = `Native` and click "Create" then "Update".
 1. Copy the `Client ID` and `Client Secret` from the OAuth Information. 
-1. `cp WordPress/Credentials/wpcom_app_credentials-example WordPress/Credentials/wpcom_app_credentials` to copy the sample credentials file to your home folder.
-1. Paste `Client ID` and `Client Secret` from the app you created into `WPCOM_APP_ID` and `WPCOM_APP_SECRET` in `WordPress/Credentials/wpcom_app_credentials`.
+1. `cp WordPress/Credentials/wpcom_app_credentials-example .configure-files/wpcom_app_credentials` to copy the sample credentials file to your home folder.
+1. Paste `Client ID` and `Client Secret` from the app you created into `WPCOM_APP_ID` and `WPCOM_APP_SECRET` in `.configure-files/wpcom_app_credentials`.
 1. Recompile and run the app on a device or an simulator.
 
 You can only log in with the WordPress.com account that you used to create the WordPress application.
@@ -79,7 +79,7 @@ After you created an application you will have an associated a client ID and a c
 
 In order to use these details, you'll need to create a credential file in your build machine. Start by copying the sample credentials file in your local repo by doing this:
 
-`cp WordPress/Credentials/wpcom_app_credentials-example WordPress/Credentials/wpcom_app_credentials`
+`cp WordPress/Credentials/wpcom_app_credentials-example .configure-files/wpcom_app_credentials`
 
 Then edit the `WordPress/Credentials/wpcom_app_credentials-example` file and change the `WPCOM_APP_ID` and `WPCOM_APP_SECRET` fields to the values you got for your app.
 

--- a/Scripts/fastlane/Matchfile
+++ b/Scripts/fastlane/Matchfile
@@ -3,4 +3,4 @@
 # Store certs/profiles encrypted in Google Cloud
 storage_mode("google_cloud")
 google_cloud_bucket_name("a8c-fastlane-match")
-google_cloud_keys_file("fastlane/google_cloud_keys.json")
+google_cloud_keys_file("../.configure-files/google_cloud_keys.json")

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -13259,7 +13259,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$(SRCROOT)/Credentials/wpcom_alpha_app_credentials";
+				WPCOM_CONFIG = "$(SRCROOT)/../.configure-files/wpcom_alpha_app_credentials";
 			};
 			name = "Release-Alpha";
 		};
@@ -13735,7 +13735,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$(SRCROOT)/Credentials/wpcom_internal_app_credentials";
+				WPCOM_CONFIG = "$(SRCROOT)/../.configure-files/wpcom_internal_app_credentials";
 			};
 			name = "Release-Internal";
 		};
@@ -14084,7 +14084,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0;
-				WPCOM_CONFIG = "$(SRCROOT)/Credentials/wpcom_app_credentials";
+				WPCOM_CONFIG = "$(SRCROOT)/../.configure-files/wpcom_app_credentials";
 			};
 			name = Debug;
 		};
@@ -14137,7 +14137,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$(SRCROOT)/Credentials/wpcom_app_credentials";
+				WPCOM_CONFIG = "$(SRCROOT)/../.configure-files/wpcom_app_credentials";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
@loremattei raised a very good point in https://github.com/wordpress-mobile/WordPress-iOS/pull/12653#discussion_r333399836 that we need to be careful about copying sensitive files to the project, even if they are ignored by git.

We discussed this and agreed that a good compromise to mitigate this is to store all files under one directory, and add it to `.gitignore`. This means when new files are added, there is no need for a new entry in `.gitignore` and the risk of committing the files should not be there.

To test:

Since the files are moved, we should test they are still working:

1. Run `rake dependencies`, it should succeed and the new files under `.gitignore` should be ignored.
- Run fastlane match to see it still succeeds: `bundle exec fastlane match enterprise --app_identifier org.wordpress.internal --readonly`.
- Build and run the app. Check that you can still login with a WP.com account.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
