### PR TITLE
Editing a pending/scheduled post keeps it status

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -303,7 +303,7 @@ extension PostEditor where Self: UIViewController {
     }
 
     private func editorAction() -> PostEditorAction {
-        guard post.status != .pending else {
+        guard post.status != .pending && post.status != .scheduled else {
             return .save
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -288,8 +288,7 @@ extension PostEditor where Self: UIViewController {
 
             // The post is a local or remote draft
             alertController.addDefaultActionWithTitle(title) { _ in
-                let action: PostEditorAction = (self.post.status == .draft) ? .saveAsDraft : .publish
-                self.publishPost(action: action, dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
+                self.publishPost(action: self.editorAction(), dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
             }
         }
 
@@ -301,6 +300,14 @@ extension PostEditor where Self: UIViewController {
 
         alertController.popoverPresentationController?.barButtonItem = navigationBarManager.closeBarButtonItem
         present(alertController, animated: true, completion: nil)
+    }
+
+    private func editorAction() -> PostEditorAction {
+        guard post.status != .pending else {
+            return .save
+        }
+
+        return post.status == .draft ? .saveAsDraft : .publish
     }
 }
 


### PR DESCRIPTION
Fixes #12662

To test:

1. Edit an existing pending for review post. 
2. Make some changes. 
3. Tap X → Update Post. Notice that after doing this, no dialog asking to _Publish_ the post appears.
4. The post still "Pending Review"

You can repeat the same process while offline and then ensure that the message "We'll submit your post for review when your device is back online." appears.

1. Edit an existing scheduled post. 
2. Make some changes. 
3. Tap X → Update Post. Notice that after doing this, no dialog asking to _Publish_ the post appears.
4. The post still Scheduled

You can repeat the same process while offline and then ensure that the message "We'll schedule your post for review when your device is back online." appears.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.