### PR TITLE
[Dark Mode] Fix Reader comment background color

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 13.5
 -----
+* Dark Mode: General improvements
  
 13.4
 -----

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -35,6 +35,7 @@ class ReaderCommentCell: UITableViewCell {
         newTextView.isScrollEnabled = false
         newTextView.isEditable = false
         newTextView.translatesAutoresizingMaskIntoConstraints = false
+        newTextView.backgroundColor = .clear
 
         return newTextView
     }()
@@ -97,7 +98,7 @@ class ReaderCommentCell: UITableViewCell {
         textView.textContainerInset = Constants.textViewInsets
 
         let backgroundView = UIView()
-        backgroundView.backgroundColor = .primary(.shade0)
+        backgroundView.backgroundColor = .listForegroundUnread
         selectedBackgroundView = backgroundView
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -126,7 +126,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    self.view.backgroundColor = [UIColor murielListBackground];
+    self.view.backgroundColor = [UIColor murielBasicBackground];
 
     [self checkIfLoggedIn];
 
@@ -313,7 +313,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
     self.tableView.cellLayoutMarginsFollowReadableWidth = YES;
     self.tableView.preservesSuperviewLayoutMargins = YES;
-    self.tableView.backgroundColor = [UIColor murielListBackground];
+    self.tableView.backgroundColor = [UIColor murielBasicBackground];
     [self.view addSubview:self.tableView];
 
     UINib *commentNib = [UINib nibWithNibName:@"ReaderCommentCell" bundle:nil];


### PR DESCRIPTION
Fixes #12601 

This PR fixes the background color when a Reader comment cell is selected
![dark-mode-reader-comment-selected](https://user-images.githubusercontent.com/912252/66649066-1f9f7600-ec25-11e9-812f-573aebcef31c.jpg)

The background is using the `listForegroundUnread` as color. This color has `.primary(.shade0)` for **old iOS versions** and `tertiarySystemGroupedBackground` for **iOS 13**

## To test:
- Build this PR on **iOS 13**
- Go to _Reader -> Discover_ and tap the comment icon on the top post
- Tap the _Reply_ button underneath one of the comments and check the cell background color
- Test everything works with **iOS 12**

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
