### PR TITLE
[Insights Management] Update when the Customize card is hidden

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
@@ -6,6 +6,7 @@ class AddInsightTableViewController: UITableViewController {
 
     private weak var insightsDelegate: SiteStatsInsightsDelegate?
     private var insightsShown = [StatSection]()
+    private var selectedStat: StatSection?
 
     private lazy var tableHandler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self)
@@ -38,6 +39,15 @@ class AddInsightTableViewController: UITableViewController {
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
         tableView.accessibilityIdentifier = "Add Insight Table"
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        if selectedStat == nil {
+            insightsDelegate?.addInsightDismissed?()
+        }
+
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -80,6 +90,7 @@ private extension AddInsightTableViewController {
 
     func rowActionFor(_ statSection: StatSection) -> ImmuTableAction {
         return { [unowned self] row in
+            self.selectedStat = statSection
             self.insightsDelegate?.addInsightSelected?(statSection)
             self.navigationController?.popViewController(animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
@@ -47,7 +47,6 @@ class AddInsightTableViewController: UITableViewController {
         if selectedStat == nil {
             insightsDelegate?.addInsightDismissed?()
         }
-
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -90,8 +90,8 @@ enum InsightType: Int {
     @objc optional func customizeTryButtonTapped()
     @objc optional func showAddInsight()
     @objc optional func addInsightSelected(_ insight: StatSection)
+    @objc optional func addInsightDismissed()
     @objc optional func manageInsightSelected(_ insight: StatSection, fromButton: UIButton)
-
 }
 
 class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoadable {
@@ -115,6 +115,7 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
     private var allSitesInsights = [SiteInsights]()
     private typealias SiteInsights = [String: [Int]]
 
+    private var viewNeedsUpdating = false
     private var displayingEmptyView = false
     private let asyncLoadingActivated = Feature.enabled(.statsAsyncLoading)
 
@@ -164,6 +165,7 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
         addViewModelListeners()
         viewModel?.refreshInsights()
     }
+
 }
 
 // MARK: - Private Extension
@@ -371,7 +373,14 @@ private extension SiteStatsInsightsTableViewController {
     // MARK: - Insights Management
 
     func showAddInsightView() {
-        dismissCustomizeCard()
+
+        if insightsToShow.contains(.customize) {
+            // The view needs to be updated to remove the Customize card.
+            // However, if it's done here, there is a weird animation before AddInsight is presented.
+            // Instead, set 'viewNeedsUpdating' so the view is updated when 'addInsightDismissed' is called.
+            viewNeedsUpdating = true
+            dismissCustomizeCard()
+        }
 
         let controller = AddInsightTableViewController(insightsDelegate: self,
                                                        insightsShown: insightsToShow.compactMap { $0.statSection })
@@ -549,6 +558,15 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 
         insightsToShow.append(insightType)
         updateView()
+    }
+
+    func addInsightDismissed() {
+        guard viewNeedsUpdating else {
+            return
+        }
+
+        updateView()
+        viewNeedsUpdating = false
     }
 
     func manageInsightSelected(_ insight: StatSection, fromButton: UIButton) {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -350,6 +350,13 @@ private extension SiteStatsInsightsTableViewController {
         UserDefaults.standard.set(hideCustomizeCard, forKey: userDefaultsHideCustomizeKey)
     }
 
+    // MARK: - Customize Card Management
+
+    func dismissCustomizeCard() {
+        hideCustomizeCard = true
+        removeCustomizeCard()
+    }
+
     func removeCustomizeCard() {
         insightsToShow = insightsToShow.filter { $0 != .customize }
     }
@@ -364,6 +371,8 @@ private extension SiteStatsInsightsTableViewController {
     // MARK: - Insights Management
 
     func showAddInsightView() {
+        dismissCustomizeCard()
+
         let controller = AddInsightTableViewController(insightsDelegate: self,
                                                        insightsShown: insightsToShow.compactMap { $0.statSection })
         navigationController?.pushViewController(controller, animated: true)
@@ -520,8 +529,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
     }
 
     func customizeDismissButtonTapped() {
-        hideCustomizeCard = true
-        removeCustomizeCard()
+        dismissCustomizeCard()
         updateView()
     }
 


### PR DESCRIPTION
Fixes #12685 

This hides the Customize card when 'Try it now' or 'Add stats card' is selected.

To test:

---
- Start with a fresh install (to clear User Defaults).
- Go to Stats > Insights.
- Select 'Try it now' on the Customize card.
- Return to Insights.
- Verify the Customize card is not displayed.

---
- Start with a fresh install (to clear User Defaults).
- Go to Stats > Insights.
- Select 'Add stats card'.
- Return to Insights.
- Verify the Customize card is not displayed.

---
- Start with a fresh install (to clear User Defaults).
- Go to Stats > Insights.
- Select 'Dismiss' on the Customize card.
- Verify the Customize card is not displayed.

---
- Start with a fresh install (to clear User Defaults).
- Go to Stats > Insights.
- Remove all stats.
- Select 'Try it now' or 'Add stats card'.
- Return to Insights.
- Verify the empty view is displayed.

---
- Switch sites.
- Verify the Customize card is not displayed.

---
Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
