### PR TITLE
Update button works while offline

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -87,7 +87,7 @@ class PostCoordinator: NSObject {
             switch result {
             case .success(let post):
                 self.mainService.autoSave(post, success: { uploadedPost, _ in }, failure: { _ in })
-            case .error(_):
+            case .error:
                 break
             }
         }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -76,12 +76,19 @@ class PostCoordinator: NSObject {
         return isPushingAllPendingMedia
     }
 
-    func save(_ postToSave: AbstractPost, automatedRetry: Bool = false, completion: ((Result<AbstractPost>) -> ())? = nil) {
+    func save(_ postToSave: AbstractPost,
+              automatedRetry: Bool = false,
+              defaultFailureNotice: Notice? = nil,
+              completion: ((Result<AbstractPost>) -> ())? = nil) {
+
         prepareToSave(postToSave, automatedRetry: automatedRetry) { result in
             switch result {
             case .success(let post):
                 self.upload(post: post, completion: completion)
             case .error(let error):
+                if let notice = defaultFailureNotice {
+                    ActionDispatcher.dispatch(NoticeAction.post(notice))
+                }
                 completion?(.error(error))
             }
         }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -132,6 +132,7 @@ class PostCoordinator: NSObject {
 
         guard mediaCoordinator.uploadMedia(for: post, automatedRetry: automatedRetry) else {
             change(post: post, status: .failed)
+            completion(.error(SavingError.mediaFailure))
             return
         }
 
@@ -164,6 +165,7 @@ class PostCoordinator: NSObject {
                             switch result {
                             case .error:
                                 self?.change(post: post, status: .failed)
+                                completion(.error(SavingError.mediaFailure))
                             case .success(let value):
                                 media.remoteURL = value.videoURL.absoluteString
                                 successHandler()
@@ -174,6 +176,7 @@ class PostCoordinator: NSObject {
                     }
                 case .failed:
                     self.change(post: post, status: .failed)
+                    completion(.error(SavingError.mediaFailure))
                 default:
                     DDLogInfo("Post Coordinator -> Media state: \(state)")
                 }
@@ -410,5 +413,11 @@ extension PostCoordinator {
                 result(postsAndActions)
             }
         }
+    }
+}
+
+extension PostCoordinator {
+    enum SavingError: Error {
+        case mediaFailure
     }
 }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -4,6 +4,11 @@ import WordPressFlux
 
 class PostCoordinator: NSObject {
 
+    enum SavingError: Error {
+        case mediaFailure
+        case unknown
+    }
+
     @objc static let shared = PostCoordinator()
 
     private let backgroundContext: NSManagedObjectContext
@@ -417,12 +422,5 @@ extension PostCoordinator {
                 result(postsAndActions)
             }
         }
-    }
-}
-
-extension PostCoordinator {
-    enum SavingError: Error {
-        case mediaFailure
-        case unknown
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -337,11 +337,13 @@ extension PostEditor where Self: UIViewController {
 
                 generator.notificationOccurred(.success)
             case .error(let error):
-                if !self.post.shouldAttemptAutoUpload {
-                    DDLogError("Error publishing post: \(error.localizedDescription)")
-                    ActionDispatcher.dispatch(NoticeAction.post(self.uploadFailureNotice(action: action)))
-                    generator.notificationOccurred(.error)
+                guard !self.post.shouldAttemptAutoUpload else {
+                    break
                 }
+
+                DDLogError("Error publishing post: \(error.localizedDescription)")
+                ActionDispatcher.dispatch(NoticeAction.post(self.uploadFailureNotice(action: action)))
+                generator.notificationOccurred(.error)
             }
 
             if dismissWhenDone {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -34,21 +34,10 @@ extension PostEditor where Self: UIViewController {
         analyticsStat: WPAnalyticsStat?) {
 
         mapUIContentToPostAndSave(immediate: true)
-        MediaCoordinator.shared.uploadMedia(for: post)
 
         // Cancel publishing if media is currently being uploaded
         if !action.isAsync && !dismissWhenDone && isUploadingMedia {
             displayMediaIsUploadingAlert()
-            return
-        }
-
-        // If there is any failed media allow it to be removed or cancel publishing
-        if hasFailedMedia {
-            displayHasFailedMediaAlert(then: {
-                // Failed media is removed, try again.
-                // Note: Intentionally not tracking another analytics stat here (no appropriate one exists yet)
-                self.publishPost(action: action, dismissWhenDone: dismissWhenDone, analyticsStat: analyticsStat)
-            })
             return
         }
 
@@ -197,7 +186,13 @@ extension PostEditor where Self: UIViewController {
         ActionDispatcher.dispatch(NoticeAction.clearWithTag(uploadFailureNoticeTag))
         stopEditing()
 
-        if post.canSave() {
+        /// If a post is marked to be auto uploaded, it means that the changes had been already
+        /// confirmed by the user. In this case, we just close the editor.
+        /// Otherwise, we'll show an Action Sheet with options.
+        if post.shouldAttemptAutoUpload {
+            editorSession.end(outcome: .cancel)
+            dismissOrPopView(didSave: false)
+        } else if post.canSave() {
             showPostHasChangesAlert()
         } else {
             editorSession.end(outcome: .cancel)
@@ -326,7 +321,7 @@ extension PostEditor where Self: UIViewController {
         SVProgressHUD.show(withStatus: action.publishingActionLabel)
         postEditorStateContext.updated(isBeingPublished: true)
 
-        uploadPost() { [weak self] uploadedPost, error in
+        PostCoordinator.shared.save(post) { [weak self] result in
             guard let self = self else {
                 return
             }
@@ -336,14 +331,17 @@ extension PostEditor where Self: UIViewController {
             let generator = UINotificationFeedbackGenerator()
             generator.prepare()
 
-            if let error = error {
-                DDLogError("Error publishing post: \(error.localizedDescription)")
-                ActionDispatcher.dispatch(NoticeAction.post(self.uploadFailureNotice(action: action)))
-                generator.notificationOccurred(.error)
-            } else if let uploadedPost = uploadedPost {
+            switch result {
+            case .success(let uploadedPost):
                 self.post = uploadedPost
 
                 generator.notificationOccurred(.success)
+            case .error(let error):
+                if !self.post.shouldAttemptAutoUpload {
+                    DDLogError("Error publishing post: \(error.localizedDescription)")
+                    ActionDispatcher.dispatch(NoticeAction.post(self.uploadFailureNotice(action: action)))
+                    generator.notificationOccurred(.error)
+                }
             }
 
             if dismissWhenDone {
@@ -368,23 +366,6 @@ extension PostEditor where Self: UIViewController {
         dismissOrPopView()
 
         self.postEditorStateContext.updated(isBeingPublished: false)
-    }
-
-    /// Uploads the post
-    ///
-    /// - Parameters:
-    ///     - completion: the closure to execute when the publish operation completes.
-    ///
-    private func uploadPost(completion: ((_ post: AbstractPost?, _ error: Error?) -> Void)?) {
-        mapUIContentToPostAndSave(immediate: true)
-
-        let managedObjectContext = ContextManager.sharedInstance().mainContext
-        let postService = PostService(managedObjectContext: managedObjectContext)
-        postService.uploadPost(post, success: { uploadedPost in
-            completion?(uploadedPost, nil)
-        }) { error in
-            completion?(nil, error)
-        }
     }
 
     func dismissOrPopView(didSave: Bool = true) {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -321,6 +321,8 @@ extension PostEditor where Self: UIViewController {
         SVProgressHUD.show(withStatus: action.publishingActionLabel)
         postEditorStateContext.updated(isBeingPublished: true)
 
+        mapUIContentToPostAndSave(immediate: true)
+
         PostCoordinator.shared.save(post) { [weak self] result in
             guard let self = self else {
                 return

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -186,10 +186,10 @@ extension PostEditor where Self: UIViewController {
         ActionDispatcher.dispatch(NoticeAction.clearWithTag(uploadFailureNoticeTag))
         stopEditing()
 
-        /// If a post is marked to be auto uploaded, it means that the changes had been already
-        /// confirmed by the user. In this case, we just close the editor.
+        /// If a post is marked to be auto uploaded and can be saved, it means that the changes
+        /// had been already confirmed by the user. In this case, we just close the editor.
         /// Otherwise, we'll show an Action Sheet with options.
-        if post.shouldAttemptAutoUpload {
+        if post.shouldAttemptAutoUpload && post.canSave() {
             editorSession.end(outcome: .cancel)
             dismissOrPopView(didSave: false)
         } else if post.canSave() {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -323,7 +323,8 @@ extension PostEditor where Self: UIViewController {
 
         mapUIContentToPostAndSave(immediate: true)
 
-        PostCoordinator.shared.save(post) { [weak self] result in
+        PostCoordinator.shared.save(post,
+                                    defaultFailureNotice: uploadFailureNotice(action: action)) { [weak self] result in
             guard let self = self else {
                 return
             }
@@ -339,12 +340,7 @@ extension PostEditor where Self: UIViewController {
 
                 generator.notificationOccurred(.success)
             case .error(let error):
-                guard !self.post.shouldAttemptAutoUpload else {
-                    break
-                }
-
                 DDLogError("Error publishing post: \(error.localizedDescription)")
-                ActionDispatcher.dispatch(NoticeAction.post(self.uploadFailureNotice(action: action)))
                 generator.notificationOccurred(.error)
             }
 

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -183,7 +183,7 @@ class PostNoticeViewModelTests: XCTestCase {
             cancelAutoUploadOfInvocations += 1
         }
 
-        override func save(_ postToSave: AbstractPost, automatedRetry: Bool = false) {
+        override func save(_ postToSave: AbstractPost, automatedRetry: Bool = false, completion: ((Result<AbstractPost>) -> ())? = nil) {
 
         }
     }

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -183,7 +183,7 @@ class PostNoticeViewModelTests: XCTestCase {
             cancelAutoUploadOfInvocations += 1
         }
 
-        override func save(_ postToSave: AbstractPost, automatedRetry: Bool = false, completion: ((Result<AbstractPost>) -> ())? = nil) {
+        override func save(_ postToSave: AbstractPost, automatedRetry: Bool = false, defaultFailureNotice: Notice? = nil, completion: ((Result<AbstractPost>) -> ())? = nil) {
 
         }
     }


### PR DESCRIPTION
Fixes #12589

## To test:

1. Create and publish a post
2. While offline, edit the post
3. Tap "Update"
4. Tap X: note that no dialog should *not* appear if you already confirmed the changes
5. A snackbar message should appear
6. Check that the post will be updated when back online

Please, try different combinations:

* Add images
* Edit different type of posts: scheduled, drafts, pending
* Use Aztec and Gutenberg

## Additional info

Note that the original issue had 2 more tasks:

* A key difference is the button should not close the editor
* The blocking progress dialog should be removed

I decided to leave those to another task since it's not directly related to the Offline Support (and these behaviors are currently in `develop`).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. (`PostEditor` stills hard to test)