### PR TITLE
Changes Gutenberg VC accordingly with changes in the post

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -145,6 +145,8 @@ class GutenbergViewController: UIViewController, PostEditor {
 
     var post: AbstractPost {
         didSet {
+            removeObservers(fromPost: oldValue)
+            addObservers(toPost: post)
             postEditorStateContext = PostEditorStateContext(post: post, delegate: self)
             attachmentDelegate = AztecAttachmentDelegate(post: post)
             mediaPickerHelper = GutenbergMediaPickerHelper(context: self, post: post)
@@ -220,6 +222,8 @@ class GutenbergViewController: UIViewController, PostEditor {
 
         super.init(nibName: nil, bundle: nil)
 
+        addObservers(toPost: post)
+
         PostCoordinator.shared.cancelAnyPendingSaveOf(post: post)
         navigationBarManager.delegate = self
     }
@@ -229,6 +233,7 @@ class GutenbergViewController: UIViewController, PostEditor {
     }
 
     deinit {
+        removeObservers(fromPost: post)
         gutenberg.invalidate()
         attachmentDelegate.cancelAllPendingMediaRequests()
     }
@@ -555,6 +560,23 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
 // MARK: - PostEditorStateContextDelegate
 
 extension GutenbergViewController: PostEditorStateContextDelegate {
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        guard let keyPath = keyPath else {
+            return
+        }
+
+        switch keyPath {
+        case BasePost.statusKeyPath:
+            if let status = post.status {
+                postEditorStateContext.updated(postStatus: status)
+            }
+        case #keyPath(AbstractPost.date_created_gmt):
+            let dateCreated = post.dateCreated ?? Date()
+            postEditorStateContext.updated(publishDate: dateCreated)
+        default:
+            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
+        }
+    }
 
     func context(_ context: PostEditorStateContext, didChangeAction: PostEditorAction) {
         reloadPublishButton()
@@ -568,6 +590,15 @@ extension GutenbergViewController: PostEditorStateContextDelegate {
         navigationBarManager.reloadPublishButton()
     }
 
+    internal func addObservers(toPost: AbstractPost) {
+        toPost.addObserver(self, forKeyPath: AbstractPost.statusKeyPath, options: [], context: nil)
+        toPost.addObserver(self, forKeyPath: #keyPath(AbstractPost.date_created_gmt), options: [], context: nil)
+    }
+
+    internal func removeObservers(fromPost: AbstractPost) {
+        fromPost.removeObserver(self, forKeyPath: AbstractPost.statusKeyPath)
+        fromPost.removeObserver(self, forKeyPath: #keyPath(AbstractPost.date_created_gmt))
+    }
 }
 
 // MARK: - PostEditorNavigationBarManagerDelegate


### PR DESCRIPTION
Fixes #12661

# What was happening?

The `GutenbergViewController` was not being updated accordingly with the changes in a post.

# To test

1. Start the creation of a new post
2. Post Settings -> Choose a future date to be scheduled
3. Go back, check that the upper-right button label is "Schedule"

1. Start the creation of a new post
2. Post Settings -> Set the status to "Pending review"
3. Go back, check that the upper-right button label is "Save"
4. Tap it, check that the post is "Pending review"

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. Unfortunately, I wasn't able to instantiate the `GutenbergViewController`. I'm open to ideas though. 💡 

Ps.: Initially this was meant to target the Offline Support master branch, but talking with @etoledom we've decided that it worths to be fixed in `develop`.