### PR TITLE
[Insights Management] Add Accessibility support for Add Insight view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -265,6 +265,9 @@ struct AddInsightStatRow: ImmuTableRow {
     let enabled: Bool
     let action: ImmuTableAction?
 
+    let enabledHint = NSLocalizedString("Select to add this stat to Insights.", comment: "Accessibility hint for stat available to add to Insights.")
+    let disabledHint = NSLocalizedString("Stat is already displayed in Insights.", comment: "Accessibility hint for stat not available to add to Insights.")
+
     func configureCell(_ cell: UITableViewCell) {
         WPStyleGuide.configureTableViewCell(cell)
 
@@ -273,6 +276,11 @@ struct AddInsightStatRow: ImmuTableRow {
         cell.textLabel?.adjustsFontForContentSizeCategory = true
         cell.textLabel?.textColor = enabled ? .text : .textPlaceholder
         cell.selectionStyle = .none
+
+        cell.accessibilityLabel = title
+        cell.isAccessibilityElement = true
+        cell.accessibilityTraits = enabled ? .button : .notEnabled
+        cell.accessibilityHint = enabled ? enabledHint : disabledHint
     }
 }
 


### PR DESCRIPTION
Fixes #12651 

To test:
- Enable VoiceOver.
- Access 'Add New Stats Card' via either:
  - Customize card > Try it now.
  - 'Add stats card' row.
- Select these element types:
  - Section header
  - Enabled row
  - Disabled row

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
