### PR TITLE
[Insights Management] Add Accessibility support for Manage Insight

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -36,10 +36,17 @@ class StatsCellHeader: UITableViewCell, NibLoadable, Accessible {
     }
 
     func prepareForVoiceOver() {
-        isAccessibilityElement = !(headerLabel.text?.isEmpty ?? true)
-        accessibilityElementsHidden = (headerLabel.text?.isEmpty ?? true)
-        accessibilityLabel = headerLabel.text
-        accessibilityTraits = .staticText
+        headerLabel.isAccessibilityElement = !(headerLabel.text?.isEmpty ?? true)
+        headerLabel.accessibilityElementsHidden = (headerLabel.text?.isEmpty ?? true)
+        headerLabel.accessibilityLabel = headerLabel.text
+        headerLabel.accessibilityTraits = .staticText
+
+        manageInsightImageView.isAccessibilityElement = false
+        manageInsightButton.isAccessibilityElement = !manageInsightButton.isHidden
+        manageInsightButton.accessibilityElementsHidden = manageInsightButton.isHidden
+        manageInsightButton.accessibilityTraits = .button
+        manageInsightButton.accessibilityLabel = NSLocalizedString("Manage Insight", comment: "Accessibility label for button that displays Manage Insight options.")
+        manageInsightButton.accessibilityHint = NSLocalizedString("Select to manage this Insight.", comment: "Accessibility hint for Manage Insight button.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -7,6 +7,7 @@ class StatsCellHeader: UITableViewCell, NibLoadable, Accessible {
 
     @IBOutlet weak var headerLabel: UILabel!
     @IBOutlet weak var manageInsightButton: UIButton!
+    @IBOutlet weak var manageInsightImageView: UIImageView!
     @IBOutlet weak var stackViewTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var stackViewHeightConstraint: NSLayoutConstraint!
 
@@ -66,14 +67,12 @@ private extension StatsCellHeader {
         guard FeatureFlag.statsInsightsManagement.enabled,
             let statSection = statSection,
             StatSection.allInsights.contains(statSection) else {
-                manageInsightButton.isHidden = true
+                showManageInsightButton(false)
                 return
         }
 
-        manageInsightButton.isHidden = false
-        manageInsightButton.tintColor = Style.manageInsightsButtonTintColor
-        manageInsightButton.setImage(Style.imageForGridiconType(.ellipsis, withTint: .darkGrey), for: .normal)
-        manageInsightButton.accessibilityLabel = NSLocalizedString("Manage Insight", comment: "Action button to display manage insight options.")
+        showManageInsightButton()
+        manageInsightImageView.image = Style.imageForGridiconType(.ellipsis, withTint: .darkGrey)
     }
 
     // MARK: - Button Action
@@ -85,6 +84,11 @@ private extension StatsCellHeader {
         }
 
         siteStatsInsightsDelegate?.manageInsightSelected?(statSection, fromButton: sender)
+    }
+
+    func showManageInsightButton(_ show: Bool = true) {
+        manageInsightImageView.isHidden = !show
+        manageInsightButton.isHidden = !show
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -36,8 +36,8 @@ class StatsCellHeader: UITableViewCell, NibLoadable, Accessible {
     }
 
     func prepareForVoiceOver() {
-        headerLabel.isAccessibilityElement = !(headerLabel.text?.isEmpty ?? true)
-        headerLabel.accessibilityElementsHidden = (headerLabel.text?.isEmpty ?? true)
+        headerLabel.isAccessibilityElement = (headerLabel.text?.isEmpty == false)
+        headerLabel.accessibilityElementsHidden = (headerLabel.text?.isEmpty == true)
         headerLabel.accessibilityLabel = headerLabel.text
         headerLabel.accessibilityTraits = .staticText
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
@@ -16,35 +16,42 @@
                 <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="B45-HF-Mto">
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="B45-HF-Mto">
                         <rect key="frame" x="16" y="20" width="343" height="36"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CELL HEADER LABEL" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fZv-YC-hoV">
-                                <rect key="frame" x="0.0" y="10" width="319" height="16"/>
+                                <rect key="frame" x="0.0" y="10" width="309" height="16"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pmt-5q-3Mg">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Yfh-mh-D56" userLabel="Manage Insight Image View">
                                 <rect key="frame" x="319" y="6" width="24" height="24"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="24" id="71g-sj-afi"/>
-                                    <constraint firstAttribute="width" constant="24" id="kMN-0Q-A6x"/>
+                                    <constraint firstAttribute="width" constant="24" id="j0R-In-UqG"/>
+                                    <constraint firstAttribute="width" secondItem="Yfh-mh-D56" secondAttribute="height" multiplier="1:1" id="sjL-h5-j5a"/>
                                 </constraints>
-                                <connections>
-                                    <action selector="manageInsightButtonPressed:" destination="3fP-pA-Ovw" eventType="touchUpInside" id="3ln-6E-gCK"/>
-                                </connections>
-                            </button>
+                            </imageView>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="height" constant="36" id="zcu-iF-hUF"/>
                         </constraints>
                     </stackView>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pmt-5q-3Mg">
+                        <rect key="frame" x="325" y="20" width="45" height="36"/>
+                        <connections>
+                            <action selector="manageInsightButtonPressed:" destination="3fP-pA-Ovw" eventType="touchUpInside" id="3ln-6E-gCK"/>
+                        </connections>
+                    </button>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="Pmt-5q-3Mg" firstAttribute="leading" secondItem="fZv-YC-hoV" secondAttribute="trailing" id="1Tv-eQ-5Xv"/>
+                    <constraint firstItem="Pmt-5q-3Mg" firstAttribute="bottom" secondItem="B45-HF-Mto" secondAttribute="bottom" id="6RO-dJ-QwM"/>
                     <constraint firstItem="B45-HF-Mto" firstAttribute="leading" secondItem="fMA-Y8-HGb" secondAttribute="leading" constant="16" id="Bum-ye-yWk"/>
+                    <constraint firstItem="Pmt-5q-3Mg" firstAttribute="top" secondItem="B45-HF-Mto" secondAttribute="top" id="FC3-HX-6aQ"/>
                     <constraint firstAttribute="trailing" secondItem="B45-HF-Mto" secondAttribute="trailing" constant="16" id="OPB-sC-KWU"/>
                     <constraint firstItem="B45-HF-Mto" firstAttribute="top" secondItem="fMA-Y8-HGb" secondAttribute="top" constant="20" id="RWL-Fv-z9B"/>
+                    <constraint firstAttribute="trailing" secondItem="Pmt-5q-3Mg" secondAttribute="trailing" constant="5" id="eLs-eI-MGH"/>
                     <constraint firstAttribute="bottom" secondItem="B45-HF-Mto" secondAttribute="bottom" priority="999" id="zBu-as-SLm"/>
                 </constraints>
             </tableViewCellContentView>
@@ -52,6 +59,7 @@
             <connections>
                 <outlet property="headerLabel" destination="fZv-YC-hoV" id="iNM-se-RIs"/>
                 <outlet property="manageInsightButton" destination="Pmt-5q-3Mg" id="y2o-B3-h7B"/>
+                <outlet property="manageInsightImageView" destination="Yfh-mh-D56" id="Ddx-31-pPT"/>
                 <outlet property="stackViewHeightConstraint" destination="zcu-iF-hUF" id="Dj4-IG-tje"/>
                 <outlet property="stackViewTopConstraint" destination="RWL-Fv-z9B" id="ywF-XN-ZM2"/>
             </connections>


### PR DESCRIPTION
Fixes #12647 

To test:
- Enable VoiceOver.
- Go to Stats > Insights.
- Select these element types:
  - Stat card header > title.
  - Stat card header > Manage Insight button.
- Go to Stats > DWMY.
  - Verify Manage Insight button is not present.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
