### PR TITLE
[Insights Management] Add Analytics tracking

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,13 +13,13 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.7'
+    # pod 'WordPressShared', '~> 1.8.7'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/change-username-events'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/12641-insight_management_tracks'
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
 end
 

--- a/Podfile
+++ b/Podfile
@@ -13,13 +13,13 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-    # pod 'WordPressShared', '~> 1.8.7'
+    pod 'WordPressShared', '~> 1.8.8-beta.2'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/12641-insight_management_tracks'
+    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => ''
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -304,7 +304,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.1-beta.1)
   - WordPressKit (~> 4.5.1)
   - WordPressMocks (~> 0.0.6)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared`, branch `feature/12641-insight_management_tracks`)
+  - WordPressShared (~> 1.8.8-beta.2)
   - WordPressUI (~> 1.4-beta.1)
   - WPMediaPicker (~> 1.4.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -348,6 +348,7 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -411,9 +412,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 9c1cfb830bdb3411fe8964539bec812b099589f1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressShared:
-    :branch: feature/12641-insight_management_tracks
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -430,9 +428,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 9c1cfb830bdb3411fe8964539bec812b099589f1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressShared:
-    :commit: ab4eb78fd295e74fed854fc51837dd4056d90e2d
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 3.0.1-swift5.1-GM
@@ -500,7 +495,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: f88358bd25edacfff23d78bb2aef5c3d5d176cbd
   WordPressKit: c35230114bbd380d63250b6d9a43337c29266c9b
   WordPressMocks: 5913bd04586a360212e07a8ccbcb36068d4425a3
-  WordPressShared: 0e2dfcb3ab993492d970f9650049d72eb053102a
+  WordPressShared: 257c40790d3c7cb2ab979bc891fa8b1f8127facb
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -508,6 +503,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 787414f9240ee6ef8cfe4ea0f00e8b4d01d2d264
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: a3170a15efcd1dc0bf8923d6985d5c63b12a2bd2
+PODFILE CHECKSUM: 34660e5dd0f4200c413b82c523991223d8dcee0a
 
 COCOAPODS: 1.7.5

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -231,7 +231,7 @@ PODS:
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
   - WordPressMocks (0.0.6)
-  - WordPressShared (1.8.7):
+  - WordPressShared (1.8.8-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.4-beta.1)
@@ -304,7 +304,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.1-beta.1)
   - WordPressKit (~> 4.5.1)
   - WordPressMocks (~> 0.0.6)
-  - WordPressShared (~> 1.8.7)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared`, branch `feature/12641-insight_management_tracks`)
   - WordPressUI (~> 1.4-beta.1)
   - WPMediaPicker (~> 1.4.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -348,7 +348,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -412,6 +411,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 9c1cfb830bdb3411fe8964539bec812b099589f1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressShared:
+    :branch: feature/12641-insight_management_tracks
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -428,6 +430,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 9c1cfb830bdb3411fe8964539bec812b099589f1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressShared:
+    :commit: ab4eb78fd295e74fed854fc51837dd4056d90e2d
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 3.0.1-swift5.1-GM
@@ -495,7 +500,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: f88358bd25edacfff23d78bb2aef5c3d5d176cbd
   WordPressKit: c35230114bbd380d63250b6d9a43337c29266c9b
   WordPressMocks: 5913bd04586a360212e07a8ccbcb36068d4425a3
-  WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
+  WordPressShared: 0e2dfcb3ab993492d970f9650049d72eb053102a
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -503,6 +508,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 787414f9240ee6ef8cfe4ea0f00e8b4d01d2d264
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: aec59cf36181558dd2c93ed2ce32843db11ce74c
+PODFILE CHECKSUM: a3170a15efcd1dc0bf8923d6985d5c63b12a2bd2
 
 COCOAPODS: 1.7.5

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1667,11 +1667,23 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatStatsInsightsAccessed:
             eventName = @"stats_insights_accessed";
             break;
+        case WPAnalyticsStatStatsItemSelectedAddInsight:
+            eventName = @"stats_add_insight_item_selected";
+            break;
         case WPAnalyticsStatStatsItemTappedAuthors:
             eventName = @"stats_authors_view_post_tapped";
             break;
         case WPAnalyticsStatStatsItemTappedClicks:
             eventName = @"stats_clicks_item_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedInsightMoveDown:
+            eventName = @"stats_insight_move_down_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedInsightMoveUp:
+            eventName = @"stats_insight_move_up_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedInsightRemove:
+            eventName = @"stats_insight_remove_tapped";
             break;
         case WPAnalyticsStatStatsItemTappedInsightsAddStat:
             eventName = @"stats_add_insight_item_tapped";
@@ -1693,6 +1705,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
         case WPAnalyticsStatStatsItemTappedLatestPostSummaryViewPostDetails:
             eventName = @"stats_latest_post_summary_view_post_details_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedManageInsight:
+            eventName = @"stats_manage_insight_tapped";
             break;
         case WPAnalyticsStatStatsItemTappedPostsAndPages:
             eventName = @"stats_posts_and_pages_item_tapped";

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -374,6 +374,7 @@ private extension SiteStatsInsightsTableViewController {
             return
         }
 
+        WPAnalytics.track(.statsItemTappedInsightMoveUp)
         moveInsight(insight, by: -1)
     }
 
@@ -382,10 +383,12 @@ private extension SiteStatsInsightsTableViewController {
             return
         }
 
+        WPAnalytics.track(.statsItemTappedInsightMoveDown)
         moveInsight(insight, by: 1)
     }
 
     func removeInsight(_ insight: InsightType) {
+        WPAnalytics.track(.statsItemTappedInsightRemove)
         insightsToShow = insightsToShow.filter { $0 != insight }
         updateView()
     }
@@ -539,6 +542,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
                 return
         }
 
+        WPAnalytics.track(.statsItemSelectedAddInsight, withProperties: ["insight": insight.title])
         insightsToShow.append(insightType)
         updateView()
     }
@@ -549,6 +553,8 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             DDLogDebug("manageInsightSelected: unknown insightType for statSection: \(insight.title).")
             return
         }
+
+        WPAnalytics.track(.statsItemTappedManageInsight)
 
         let alert = UIAlertController(title: insight.title,
                                       message: nil,
@@ -584,6 +590,7 @@ extension SiteStatsInsightsTableViewController: NoResultsViewControllerDelegate 
     func actionButtonPressed() {
 
         guard !displayingEmptyView else {
+            WPAnalytics.track(.statsItemTappedInsightsAddStat)
             showAddInsightView()
             return
         }


### PR DESCRIPTION
Fixes #12641 
Shared PR: https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/221

To test:

---
- On the 'Add New Stats Card' view, select a stat.
- Verify `stats_add_insight_item_selected <insight: Insight Title>` is logged.

---
- On a stat header, tap the Manage Insights button.
  - Verify `stats_manage_insight_tapped` is logged.
- Select 'Move up'.
  - Verify `stats_insight_move_up_tapped` is logged.
- Select 'Move down'.
  - Verify `stats_insight_move_down_tapped` is logged.
- Select 'Remove from Insights'
  - Verify `stats_insight_remove_tapped` is logged.

---
- Remove all stats from Insights.
- Tap the 'Add stats card' button.
- Verify `stats_add_insight_item_tapped` is logged.

---
Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
