### PR TITLE
Draft: Update Gutenberg to use React Native to 0.61.x

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -93,7 +93,6 @@ def gutenberg_dependencies(options)
     dependencies = [
         'React',
         'React-Core',
-        'React-DevSupport',
         'React-RCTActionSheet',
         'React-RCTAnimation',
         'React-RCTBlob',
@@ -103,12 +102,17 @@ def gutenberg_dependencies(options)
         'React-RCTSettings',
         'React-RCTText',
         'React-RCTVibration',
-        'React-RCTWebSocket',
         'React-cxxreact',
         'React-jsinspector',
         'React-jsi',
         'React-jsiexecutor',
-        'yoga',
+        'React-CoreModules',
+        'FBReactNativeSpec',
+        'FBLazyVector',
+        'RCTRequired',
+        'RCTTypeSafety',
+        'ReactCommon',
+        'Yoga',
         'Folly',
         'glog',
         'react-native-keyboard-aware-scroll-view',
@@ -142,7 +146,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => '9c1cfb830bdb3411fe8964539bec812b099589f1'
+    gutenberg :commit => '37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941'
 
     ## Third party libraries
     ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -17,6 +17,14 @@ PODS:
   - CocoaLumberjack/Core (3.5.2)
   - DoubleConversion (1.1.5)
   - Down (0.6.6)
+  - FBLazyVector (0.61.2)
+  - FBReactNativeSpec (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - RCTRequired (= 0.61.2)
+    - RCTTypeSafety (= 0.61.2)
+    - React-Core (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - ReactCommon/turbomodule/core (= 0.61.2)
   - Folly (2018.10.22.00):
     - boost-for-react-native
     - DoubleConversion
@@ -48,8 +56,9 @@ PODS:
   - Gridicons (0.19)
   - GTMSessionFetcher/Core (1.2.2)
   - Gutenberg (1.14.0):
-    - React (= 0.60.0-patched)
-    - React-RCTImage (= 0.60.0-patched)
+    - React (= 0.61.2)
+    - React-CoreModules (= 0.61.2)
+    - React-RCTImage (= 0.61.2)
     - RNTAztecView
     - WordPress-Aztec-iOS
   - HockeySDK (5.1.4):
@@ -103,63 +112,170 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (6.1.0)
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
+  - RCTRequired (0.61.2)
+  - RCTTypeSafety (0.61.2):
+    - FBLazyVector (= 0.61.2)
+    - Folly (= 2018.10.22.00)
+    - RCTRequired (= 0.61.2)
+    - React-Core (= 0.61.2)
   - Reachability (3.2)
-  - React (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-    - React-DevSupport (= 0.60.0-patched)
-    - React-RCTActionSheet (= 0.60.0-patched)
-    - React-RCTAnimation (= 0.60.0-patched)
-    - React-RCTBlob (= 0.60.0-patched)
-    - React-RCTImage (= 0.60.0-patched)
-    - React-RCTLinking (= 0.60.0-patched)
-    - React-RCTNetwork (= 0.60.0-patched)
-    - React-RCTSettings (= 0.60.0-patched)
-    - React-RCTText (= 0.60.0-patched)
-    - React-RCTVibration (= 0.60.0-patched)
-    - React-RCTWebSocket (= 0.60.0-patched)
-  - React-Core (0.60.0-patched):
+  - React (0.61.2):
+    - React-Core (= 0.61.2)
+    - React-Core/DevSupport (= 0.61.2)
+    - React-Core/RCTWebSocket (= 0.61.2)
+    - React-RCTActionSheet (= 0.61.2)
+    - React-RCTAnimation (= 0.61.2)
+    - React-RCTBlob (= 0.61.2)
+    - React-RCTImage (= 0.61.2)
+    - React-RCTLinking (= 0.61.2)
+    - React-RCTNetwork (= 0.61.2)
+    - React-RCTSettings (= 0.61.2)
+    - React-RCTText (= 0.61.2)
+    - React-RCTVibration (= 0.61.2)
+  - React-Core (0.61.2):
     - Folly (= 2018.10.22.00)
     - glog
-    - React-Core/Default (= 0.60.0-patched)
-    - React-cxxreact (= 0.60.0-patched)
-    - React-jsi (= 0.60.0-patched)
-    - React-jsiexecutor (= 0.60.0-patched)
-    - yoga (= 0.60.0-patched.React)
-  - React-Core/Default (0.60.0-patched):
+    - React-Core/Default (= 0.61.2)
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/CoreModulesHeaders (0.61.2):
     - Folly (= 2018.10.22.00)
     - glog
-    - React-cxxreact (= 0.60.0-patched)
-    - React-jsi (= 0.60.0-patched)
-    - React-jsiexecutor (= 0.60.0-patched)
-    - yoga (= 0.60.0-patched.React)
-  - React-cxxreact (0.60.0-patched):
+    - React-Core/Default
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/Default (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/DevSupport (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default (= 0.61.2)
+    - React-Core/RCTWebSocket (= 0.61.2)
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - React-jsinspector (= 0.61.2)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/RCTAnimationHeaders (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/RCTBlobHeaders (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/RCTImageHeaders (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/RCTLinkingHeaders (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/RCTNetworkHeaders (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/RCTSettingsHeaders (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/RCTTextHeaders (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/RCTVibrationHeaders (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-Core/RCTWebSocket (0.61.2):
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core/Default (= 0.61.2)
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-jsiexecutor (= 0.61.2)
+    - Yoga
+  - React-CoreModules (0.61.2):
+    - FBReactNativeSpec (= 0.61.2)
+    - Folly (= 2018.10.22.00)
+    - RCTTypeSafety (= 0.61.2)
+    - React-Core/CoreModulesHeaders (= 0.61.2)
+    - React-RCTImage (= 0.61.2)
+    - ReactCommon/turbomodule/core (= 0.61.2)
+  - React-cxxreact (0.61.2):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-jsinspector (= 0.60.0-patched)
-  - React-DevSupport (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-    - React-jsinspector (= 0.60.0-patched)
-    - React-RCTWebSocket (= 0.60.0-patched)
-  - React-jsi (0.60.0-patched):
+    - React-jsinspector (= 0.61.2)
+  - React-jsi (0.61.2):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-jsi/Default (= 0.60.0-patched)
-  - React-jsi/Default (0.60.0-patched):
+    - React-jsi/Default (= 0.61.2)
+  - React-jsi/Default (0.61.2):
     - boost-for-react-native (= 1.63.0)
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-  - React-jsiexecutor (0.60.0-patched):
+  - React-jsiexecutor (0.61.2):
     - DoubleConversion
     - Folly (= 2018.10.22.00)
     - glog
-    - React-cxxreact (= 0.60.0-patched)
-    - React-jsi (= 0.60.0-patched)
-  - React-jsinspector (0.60.0-patched)
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+  - React-jsinspector (0.61.2)
   - react-native-keyboard-aware-scroll-view (0.8.7):
     - React
   - react-native-safe-area (0.5.1):
@@ -169,30 +285,63 @@ PODS:
     - react-native-video/Video (= 4.4.1)
   - react-native-video/Video (4.4.1):
     - React-Core
-  - React-RCTActionSheet (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-  - React-RCTAnimation (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-  - React-RCTBlob (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-    - React-jsi (= 0.60.0-patched)
-    - React-RCTNetwork (= 0.60.0-patched)
-    - React-RCTWebSocket (= 0.60.0-patched)
-  - React-RCTImage (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-    - React-RCTNetwork (= 0.60.0-patched)
-  - React-RCTLinking (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-  - React-RCTNetwork (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-  - React-RCTSettings (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-  - React-RCTText (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-  - React-RCTVibration (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
-  - React-RCTWebSocket (0.60.0-patched):
-    - React-Core (= 0.60.0-patched)
+  - React-RCTActionSheet (0.61.2):
+    - React-Core/RCTActionSheetHeaders (= 0.61.2)
+  - React-RCTAnimation (0.61.2):
+    - React-Core/RCTAnimationHeaders (= 0.61.2)
+  - React-RCTBlob (0.61.2):
+    - React-Core/RCTBlobHeaders (= 0.61.2)
+    - React-Core/RCTWebSocket (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - React-RCTNetwork (= 0.61.2)
+  - React-RCTImage (0.61.2):
+    - React-Core/RCTImageHeaders (= 0.61.2)
+    - React-RCTNetwork (= 0.61.2)
+  - React-RCTLinking (0.61.2):
+    - React-Core/RCTLinkingHeaders (= 0.61.2)
+  - React-RCTNetwork (0.61.2):
+    - React-Core/RCTNetworkHeaders (= 0.61.2)
+  - React-RCTSettings (0.61.2):
+    - React-Core/RCTSettingsHeaders (= 0.61.2)
+  - React-RCTText (0.61.2):
+    - React-Core/RCTTextHeaders (= 0.61.2)
+  - React-RCTVibration (0.61.2):
+    - React-Core/RCTVibrationHeaders (= 0.61.2)
+  - ReactCommon (0.61.2):
+    - ReactCommon/jscallinvoker (= 0.61.2)
+    - ReactCommon/turbomodule (= 0.61.2)
+  - ReactCommon/jscallinvoker (0.61.2):
+    - DoubleConversion
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-cxxreact (= 0.61.2)
+  - ReactCommon/turbomodule (0.61.2):
+    - DoubleConversion
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core (= 0.61.2)
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - ReactCommon/jscallinvoker (= 0.61.2)
+    - ReactCommon/turbomodule/core (= 0.61.2)
+    - ReactCommon/turbomodule/samples (= 0.61.2)
+  - ReactCommon/turbomodule/core (0.61.2):
+    - DoubleConversion
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core (= 0.61.2)
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - ReactCommon/jscallinvoker (= 0.61.2)
+  - ReactCommon/turbomodule/samples (0.61.2):
+    - DoubleConversion
+    - Folly (= 2018.10.22.00)
+    - glog
+    - React-Core (= 0.61.2)
+    - React-cxxreact (= 0.61.2)
+    - React-jsi (= 0.61.2)
+    - ReactCommon/jscallinvoker (= 0.61.2)
+    - ReactCommon/turbomodule/core (= 0.61.2)
   - ReactNativeDarkMode (0.0.10):
     - React
   - RNSVG (9.3.3-gb):
@@ -237,7 +386,7 @@ PODS:
   - WordPressUI (1.4-beta.1)
   - WPMediaPicker (1.4.2)
   - wpxmlrpc (0.8.4)
-  - yoga (0.60.0-patched.React)
+  - Yoga (1.14.0)
   - ZendeskSDK (3.0.1):
     - ZendeskSDK/Providers (= 3.0.1)
     - ZendeskSDK/UI (= 3.0.1)
@@ -257,14 +406,16 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `9c1cfb830bdb3411fe8964539bec812b099589f1`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941`)
   - HockeySDK (= 5.1.4)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
@@ -273,30 +424,32 @@ DEPENDENCIES:
   - OCMock (~> 3.4)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
+  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-DevSupport (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-DevSupport.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - React-RCTWebSocket (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTWebSocket.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `9c1cfb830bdb3411fe8964539bec812b099589f1`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -307,12 +460,12 @@ DEPENDENCIES:
   - WordPressShared (~> 1.8.7)
   - WordPressUI (~> 1.4-beta.1)
   - WPMediaPicker (~> 1.4.2)
-  - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
+  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSDK (from `https://github.com/zendesk/zendesk_sdk_ios`, tag `3.0.1-swift5.1-GM`)
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/specs.git:
     - 1PasswordExtension
     - Alamofire
     - AlamofireNetworkActivityIndicator
@@ -355,65 +508,73 @@ SPEC REPOS:
     - ZIPFoundation
 
 EXTERNAL SOURCES:
+  FBLazyVector:
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json
+  FBReactNativeSpec:
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :commit: 9c1cfb830bdb3411fe8964539bec812b099589f1
+    :commit: 37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  RCTRequired:
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json
+  RCTTypeSafety:
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json
+  React-CoreModules:
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json
-  React-DevSupport:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-DevSupport.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json
-  React-RCTWebSocket:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTWebSocket.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json
+  ReactCommon:
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :commit: 9c1cfb830bdb3411fe8964539bec812b099589f1
+    :commit: 37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
+  Yoga:
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 3.0.1-swift5.1-GM
@@ -423,10 +584,10 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :commit: 9c1cfb830bdb3411fe8964539bec812b099589f1
+    :commit: 37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNTAztecView:
-    :commit: 9c1cfb830bdb3411fe8964539bec812b099589f1
+    :commit: 37dc0452e5e1ea62c65a224dbcddbbbf8d5a5941
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
@@ -442,6 +603,8 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   Down: 71bf4af3c04fa093e65dffa25c4b64fa61287373
+  FBLazyVector: a3875b28587e7d1fd017ccbe13903a821f7ab4dd
+  FBReactNativeSpec: 5342b9ed2b333e616283b682f9f99b1a060ef0bc
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
@@ -452,7 +615,7 @@ SPEC CHECKSUMS:
   GoogleToolboxForMac: b3553629623a3b1bff17f555e736cd5a6d95ad55
   Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
   GTMSessionFetcher: 61bb0f61a4cb560030f1222021178008a5727a23
-  Gutenberg: d715411700883ce98fd09f90d256b18e2079cd2a
+  Gutenberg: 8884b3b87471ad1603dd1a1d3f1bfa205360493b
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
@@ -461,27 +624,29 @@ SPEC CHECKSUMS:
   "NSURL+IDN": 82355a0afd532fe1de08f6417c134b49b1a1c4b3
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
+  RCTRequired: 82f59ab52a3c1313bedc8ff0fa247e9a88409795
+  RCTTypeSafety: dab0161cb659dfc089302ebd7857e07370792b00
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  React: f208cb37831d73d3feafe90ff5c353ef67516cfb
-  React-Core: c84e22ad089efdf344669e09c0036a8e68c87c54
-  React-cxxreact: 83e0eeaaf0bdcb32196c1d1b45741375e988e766
-  React-DevSupport: 3415f47b173bd12db823ef0c3792cf476007a4b3
-  React-jsi: 1ac67673d6a1151f8252af77caf2171098377d1d
-  React-jsiexecutor: 59a89ffa9ab4c0d8d4ac98cda564038be4951b3f
-  React-jsinspector: fd89d0a2012fb6d4e452c1caa87f4ed85902e128
+  React: 6dec165c1b0b3948ff6d8de63a96eec8aecb0978
+  React-Core: 12c11012cfb1ca7f87822c26d7ea7d9bb628f0d6
+  React-CoreModules: 4a6b2d8324312217e3850329d8f8b99c3b63a6dd
+  React-cxxreact: 6b6321c6241dddd38dede05fbf523e80df5e468a
+  React-jsi: b3f0acede193a2acd20db2bb53be7f2f4e36df38
+  React-jsiexecutor: c8a5245951265c3af9761d98764a3be2ab3fc426
+  React-jsinspector: 0fc105b20125670dac2d7561217892cacf7fd3c1
   react-native-keyboard-aware-scroll-view: 01c4b2303c4ef1c49c4d239c9c5856f0393104df
   react-native-safe-area: e8230b0017d76c00de6b01e2412dcf86b127c6a3
   react-native-video: 9de661e89386bb7ab78cc68e61a146cbdf5ad4ad
-  React-RCTActionSheet: f6f84ea3818164bba944c67ba6e681d9c4bb4d2e
-  React-RCTAnimation: cf0b6eda1308a7b49acf8efa424fe7bfbf8f7854
-  React-RCTBlob: 3811d8208edd395946cff234d43cf616d7cbb0c3
-  React-RCTImage: da8d433e4e0746ae78917378edcbb24b5ab58846
-  React-RCTLinking: 223b1a5500c89ad56baafea9b949d82a47a5874a
-  React-RCTNetwork: 7aa744dd0b169df268e68010326f3036e7aa2588
-  React-RCTSettings: 7edbd802e9fa868dde68f0cbfab67c28412e32d5
-  React-RCTText: d09f0d5aaf3ce225cf33ba4bdc067537b689acab
-  React-RCTVibration: 4e773d837c5608294b80c6f0b90e8f217731660a
-  React-RCTWebSocket: 47dfd49bb143d4847fae643816e02646b7bce1b9
+  React-RCTActionSheet: f703183a14a6e75478ab2cfa5f59128657c0ff2f
+  React-RCTAnimation: 35ca7e59b18b4883b653a933cb919885dd3fac12
+  React-RCTBlob: 093645e1b6370ecd005231374091a598953b8169
+  React-RCTImage: 9b3710eb41f3ed99886c6ec986b41a0f8fc7524d
+  React-RCTLinking: 1f22d88159c606826a4407bc3d9063e443914bfb
+  React-RCTNetwork: 85575a1ca9cfb1c3d0089bb90b35c4e784946bc1
+  React-RCTSettings: 6c193e77b1372c23f3a6c027fea6149667c620f1
+  React-RCTText: e4605a54f421fb632fc3778de38f6ee6e043ff13
+  React-RCTVibration: ce685c740dae335c7b25a1b33503f752927c7c81
+  ReactCommon: cacd4c0aedd8efecf5db14906987ee335e79a6d8
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
   RNSVG: c820516df826221ce4969594bf3e822a464abd51
   RNTAztecView: 87f5794256e2dc044582f87942f39ca9e2577d90
@@ -499,10 +664,10 @@ SPEC CHECKSUMS:
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
-  yoga: 4e71c9a33abf45ba55af55ae9cbc86f4234bb2a9
+  Yoga: 140bec14c12b361a7111ca3c9bb8adf95cfe3a65
   ZendeskSDK: 787414f9240ee6ef8cfe4ea0f00e8b4d01d2d264
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: aec59cf36181558dd2c93ed2ce32843db11ce74c
+PODFILE CHECKSUM: 5dcb86cb0866b315d21982744c6cb97ec38b5f75
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
This is the corresponding PR for https://github.com/wordpress-mobile/gutenberg-mobile/pull/1450. It integrates the updated Gutenberg and uses RN 0.61.2.

As you can see, it builds successfully.

To test:

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
