### PR TITLE
CircleCI: Update Orb to fix pod install timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  ios: wordpress-mobile/ios@0.0.33
-  git: wordpress-mobile/git@0.0.33
+  ios: wordpress-mobile/ios@0.0.37
+  git: wordpress-mobile/git@0.0.37
 
 commands:
   load-chruby:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -312,7 +312,7 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/specs.git:
+  https://github.com/cocoapods/specs.git:
     - 1PasswordExtension
     - Alamofire
     - AlamofireNetworkActivityIndicator

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -312,7 +312,7 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/specs.git:
     - 1PasswordExtension
     - Alamofire
     - AlamofireNetworkActivityIndicator


### PR DESCRIPTION
@jkmassel found and fixes a CocoaPods issue in https://github.com/wordpress-mobile/circleci-orbs/pull/41 which could lead to `pod install` timing out on CircleCI. This just updates the Orb to use that.

To test:

- There is a `Podfile.lock` change on the PR, see that `pod install` runs successfully on CI.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
