### PR TITLE
Add simple tests for MediaCoordinator.uploadMedia

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -34,8 +34,13 @@ class MediaCoordinator: NSObject {
     /// Tracks uploads of media for specific posts
     private var postMediaProgressCoordinators = [AbstractPost: MediaProgressCoordinator]()
 
-    override init() {
+    private let mediaServiceFactory: MediaService.Factory
+
+    init(_ mediaServiceFactory: MediaService.Factory = MediaService.Factory()) {
+        self.mediaServiceFactory = mediaServiceFactory
+
         super.init()
+
         addObserverForDeletedFiles()
     }
 
@@ -49,7 +54,7 @@ class MediaCoordinator: NSObject {
     /// - Returns: `true` if all media in the post is uploading or was uploaded, `false` otherwise.
     ///
     func uploadMedia(for post: AbstractPost, automatedRetry: Bool = false) -> Bool {
-        let mediaService = MediaService(managedObjectContext: backgroundContext)
+        let mediaService = mediaServiceFactory.create(backgroundContext)
         let failedMedia: [Media] = post.media.filter({ $0.remoteStatus == .failed })
         let mediasToUpload: [Media]
 
@@ -149,7 +154,7 @@ class MediaCoordinator: NSObject {
     @discardableResult
     private func addMedia(from asset: ExportableAsset, to objectID: NSManagedObjectID, coordinator: MediaProgressCoordinator, analyticsInfo: MediaAnalyticsInfo? = nil) -> Media {
         coordinator.track(numberOfItems: 1)
-        let service = MediaService(managedObjectContext: mainContext)
+        let service = mediaServiceFactory.create(mainContext)
         let totalProgress = Progress.discreteProgress(totalUnitCount: MediaExportProgressUnits.done)
         var creationProgress: Progress? = nil
         let media = service.createMedia(with: asset,
@@ -277,7 +282,7 @@ class MediaCoordinator: NSObject {
     func delete(media: [Media], onProgress: ((Progress?) -> Void)? = nil, success: (() -> Void)? = nil, failure: (() -> Void)? = nil) {
         media.forEach({ self.cancelUpload(of: $0) })
 
-        let service = MediaService(managedObjectContext: backgroundContext)
+        let service = mediaServiceFactory.create(backgroundContext)
         service.deleteMedia(media,
                             progress: { onProgress?($0) },
                             success: success,
@@ -286,7 +291,7 @@ class MediaCoordinator: NSObject {
 
     @discardableResult
     private func uploadMedia(_ media: Media, automatedRetry: Bool = false) -> Progress {
-        let service = MediaService(managedObjectContext: backgroundContext)
+        let service = mediaServiceFactory.create(backgroundContext)
 
         var progress: Progress? = nil
 
@@ -596,7 +601,7 @@ class MediaCoordinator: NSObject {
     /// - parameter blog: The blog from where to sync the media library from.
     ///
     @objc func syncMedia(for blog: Blog, success: (() -> Void)? = nil, failure: ((Error) ->Void)? = nil) {
-        let service = MediaService(managedObjectContext: backgroundContext)
+        let service = mediaServiceFactory.create(backgroundContext)
         service.syncMediaLibrary(for: blog, success: success, failure: failure)
     }
 
@@ -604,7 +609,7 @@ class MediaCoordinator: NSObject {
     /// The main cause of wrong status is the app being killed while uploads of media are happening.
     ///
     @objc func refreshMediaStatus() {
-        let service = MediaService(managedObjectContext: backgroundContext)
+        let service = mediaServiceFactory.create(backgroundContext)
         service.refreshMediaStatus()
     }
 }
@@ -653,7 +658,7 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
 
 extension MediaCoordinator: Uploader {
     func resume() {
-        let service = MediaService(managedObjectContext: backgroundContext)
+        let service = mediaServiceFactory.create(backgroundContext)
 
         service.failedMediaForUpload(automatedRetry: true).forEach() {
             retryMedia($0, automatedRetry: true)

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -44,8 +44,8 @@ class MediaCoordinator: NSObject {
         addObserverForDeletedFiles()
     }
 
-    /// Uploads all local media for the post, and returns `true` if it was possible to start uploads for all
-    /// of the existing media for the post.
+    /// Uploads all failed media for the post, and returns `true` if it was possible to start
+    /// uploads for all of the existing media for the post.
     ///
     /// - Parameters:
     ///     - post: the post to get the media to upload from.

--- a/WordPress/Classes/Services/MediaService.swift
+++ b/WordPress/Classes/Services/MediaService.swift
@@ -90,3 +90,13 @@ extension MediaService {
         }
     }
 }
+
+// MARK: - Factory
+
+extension MediaService {
+    class Factory {
+        func create(_ context: NSManagedObjectContext) -> MediaService {
+            return MediaService(managedObjectContext: context)
+        }
+    }
+}

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -46,36 +46,6 @@ class PostCoordinator: NSObject {
         self.failedPostsFetcher = failedPostsFetcher ?? FailedPostsFetcher(mainContext)
     }
 
-    // MARK: - Uploading Media
-
-    /// Uploads all local media for the post, and returns `true` if it was possible to start uploads for all
-    /// of the existing media for the post.
-    ///
-    /// - Parameters:
-    ///     - post: the post to get the media to upload from.
-    ///     - automatedRetry: true if this call is the result of an automated upload-retry attempt.
-    ///
-    /// - Returns: `true` if all media in the post is uploading or was uploaded, `false` otherwise.
-    ///
-    private func uploadMedia(for post: AbstractPost, automatedRetry: Bool = false) -> Bool {
-        let mediaService = MediaService(managedObjectContext: backgroundContext)
-        let failedMedia: [Media] = post.media.filter({ $0.remoteStatus == .failed })
-        let mediasToUpload: [Media]
-
-        if automatedRetry {
-            mediasToUpload = mediaService.failedMediaForUpload(in: post, automatedRetry: automatedRetry)
-        } else {
-            mediasToUpload = failedMedia
-        }
-
-        mediasToUpload.forEach { mediaObject in
-            mediaCoordinator.retryMedia(mediaObject, automatedRetry: automatedRetry)
-        }
-
-        let isPushingAllPendingMedia = mediasToUpload.count == failedMedia.count
-        return isPushingAllPendingMedia
-    }
-
     func save(_ postToSave: AbstractPost,
               automatedRetry: Bool = false,
               defaultFailureNotice: Notice? = nil,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -553,6 +553,7 @@
 		5749984722FA0F2E00CE86ED /* PostNoticeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5749984622FA0F2E00CE86ED /* PostNoticeViewModelTests.swift */; };
 		574A79D22347FAF2004D4191 /* WordPress-90-91.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 574A79D12347FAF2004D4191 /* WordPress-90-91.xcmappingmodel */; };
 		57569CF2230485680052EE14 /* PostAutoUploadInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57569CF1230485680052EE14 /* PostAutoUploadInteractorTests.swift */; };
+		575802132357C41200E4C63C /* MediaCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575802122357C41200E4C63C /* MediaCoordinatorTests.swift */; };
 		575E126322973EBB0041B3EB /* PostCompactCellGhostableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575E126222973EBB0041B3EB /* PostCompactCellGhostableTests.swift */; };
 		575E126F229779E70041B3EB /* RestorePostTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575E126E229779E70041B3EB /* RestorePostTableViewCell.swift */; };
 		577C2AAB22936DCB00AD1F03 /* PostCardCellGhostableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577C2AAA22936DCB00AD1F03 /* PostCardCellGhostableTests.swift */; };
@@ -2643,6 +2644,7 @@
 		5749984622FA0F2E00CE86ED /* PostNoticeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticeViewModelTests.swift; sourceTree = "<group>"; };
 		574A79D12347FAF2004D4191 /* WordPress-90-91.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-90-91.xcmappingmodel"; sourceTree = "<group>"; };
 		57569CF1230485680052EE14 /* PostAutoUploadInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAutoUploadInteractorTests.swift; path = Services/PostAutoUploadInteractorTests.swift; sourceTree = "<group>"; };
+		575802122357C41200E4C63C /* MediaCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MediaCoordinatorTests.swift; path = Services/MediaCoordinatorTests.swift; sourceTree = "<group>"; };
 		575E126222973EBB0041B3EB /* PostCompactCellGhostableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCompactCellGhostableTests.swift; sourceTree = "<group>"; };
 		575E126E229779E70041B3EB /* RestorePostTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorePostTableViewCell.swift; sourceTree = "<group>"; };
 		577C2AAA22936DCB00AD1F03 /* PostCardCellGhostableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardCellGhostableTests.swift; sourceTree = "<group>"; };
@@ -4380,7 +4382,7 @@
 		FFB3132E204D59F400C177E7 /* WordPress 73.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 73.xcdatamodel"; sourceTree = "<group>"; };
 		FFB7B81D1A0012E80032E723 /* ApiCredentials.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ApiCredentials.m; sourceTree = "<group>"; };
 		FFC02B82222687BF00E64FDE /* GutenbergImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergImageLoader.swift; sourceTree = "<group>"; };
-		FFC245D91D8C2033007F7518 /* wpcom_app_credentials-example */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = wpcom_app_credentials-example; sourceTree = "<group>"; };
+		FFC245D91D8C2033007F7518 /* wpcom_app_credentials-example */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "wpcom_app_credentials-example"; sourceTree = "<group>"; };
 		FFC6ADD21B56F295002F3C84 /* AboutViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutViewController.swift; sourceTree = "<group>"; };
 		FFC6ADD31B56F295002F3C84 /* AboutViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AboutViewController.xib; sourceTree = "<group>"; };
 		FFC6ADD91B56F366002F3C84 /* LocalCoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocalCoreDataService.m; sourceTree = "<group>"; };
@@ -8045,6 +8047,7 @@
 				57569CF1230485680052EE14 /* PostAutoUploadInteractorTests.swift */,
 				57D66B9C234BB78B005A2D74 /* PostServiceWPComTests.swift */,
 				57240223234E5BE200227067 /* PostServiceSelfHostedTests.swift */,
+				575802122357C41200E4C63C /* MediaCoordinatorTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -12073,6 +12076,7 @@
 				40F50B80221310D400CBBB73 /* FollowersStatsRecordValueTests.swift in Sources */,
 				0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */,
 				D848CBF920FEF82100A9038F /* NotificationsContentFactoryTests.swift in Sources */,
+				575802132357C41200E4C63C /* MediaCoordinatorTests.swift in Sources */,
 				F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */,
 				400A2C972217B883000A8A59 /* VisitsSummaryStatsRecordValueTests.swift in Sources */,
 				E180BD4E1FB4681E00D0D781 /* MockCookieJar.swift in Sources */,

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -3,10 +3,10 @@ import Foundation
 @testable import WordPress
 
 final class BlogBuilder {
-    private let blog: Blog!
+    private let blog: Blog
 
     init(_ context: NSManagedObjectContext) {
-        blog = Blog(context: context)
+        blog = NSEntityDescription.insertNewObject(forEntityName: Blog.entityName(), into: context) as! Blog
 
         // Non-null properties in Core Data
         blog.dotComID = NSNumber(value: arc4random_uniform(UInt32.max))

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -6,7 +6,7 @@ class PostBuilder {
     private let post: Post
 
     init(_ context: NSManagedObjectContext = PostBuilder.setUpInMemoryManagedObjectContext()) {
-        post = Post(context: context)
+        post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: context) as! Post
 
         // Non-null Core Data properties
         post.blog = BlogBuilder(context).build()
@@ -125,7 +125,7 @@ class PostBuilder {
             return self
         }
 
-        guard let media = NSEntityDescription.insertNewObject(forEntityName: Media.classNameWithoutNamespaces(), into: context) as? Media else {
+        guard let media = NSEntityDescription.insertNewObject(forEntityName: Media.entityName(), into: context) as? Media else {
             return self
         }
         media.localURL = image

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -120,7 +120,7 @@ class PostBuilder {
         return self
     }
 
-    func with(image: String, status: MediaRemoteStatus? = nil) -> PostBuilder {
+    func with(image: String, status: MediaRemoteStatus? = nil, autoUploadFailureCount: Int = 0) -> PostBuilder {
         guard let context = post.managedObjectContext else {
             return self
         }
@@ -131,6 +131,7 @@ class PostBuilder {
         media.localURL = image
         media.localThumbnailURL = "thumb-\(image)"
         media.blog = post.blog
+        media.autoUploadFailureCount = NSNumber(value: autoUploadFailureCount)
 
         if let status = status {
             media.remoteStatus = status

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -18,6 +18,7 @@ class PostCoordinatorTests: XCTestCase {
         super.tearDown()
         TestAnalyticsTracker.tearDown()
         context = nil
+        ContextManager.overrideSharedInstance(nil)
     }
 
     func testDoNotUploadAPostWithFailedMedia() {

--- a/WordPress/WordPressTest/Services/MediaCoordinatorTests.swift
+++ b/WordPress/WordPressTest/Services/MediaCoordinatorTests.swift
@@ -1,9 +1,66 @@
-//
-//  MediaCoordinatorTests.swift
-//  WordPressTest
-//
-//  Created by Shiki on 2019-10-16.
-//  Copyright © 2019 WordPress. All rights reserved.
-//
 
 import Foundation
+import Nimble
+@testable import WordPress
+
+class MediaCoordinatorTests: XCTestCase {
+    private var context: NSManagedObjectContext!
+
+    private var coordinator: MediaCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        context = TestContextManager().mainContext
+        coordinator = MediaCoordinator(MediaServiceFactoryMock())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        coordinator = nil
+        context = nil
+        ContextManager.overrideSharedInstance(nil)
+    }
+
+    func testUploadMediaReturnsTrueIfAllPendingMediaAreQueuedForUpload() {
+        let post = PostBuilder(context)
+            .with(image: "test.jpg", status: .failed)
+            .with(image: "test-002.jpg", status: .failed)
+            .with(image: "test-003.jpg", status: .local)
+            .build()
+        try! context.save()
+
+        let isPushingAllPendingMedia = coordinator.uploadMedia(for: post, automatedRetry: true)
+
+        expect(isPushingAllPendingMedia).to(beTrue())
+    }
+
+    func testUploadMediaReturnsFalseIfNotAllPendingMediaAreQueuedForUpload() {
+        let post = PostBuilder(context)
+            .with(image: "test.jpg", status: .failed)
+            // This media has exceeded the maximum failure count and will not be queued
+            .with(image: "test-002.jpg", status: .failed, autoUploadFailureCount: 10)
+            .build()
+        try! context.save()
+
+        let isPushingAllPendingMedia = coordinator.uploadMedia(for: post, automatedRetry: true)
+
+        expect(isPushingAllPendingMedia).to(beFalse())
+    }
+}
+
+private class MediaServiceFactoryMock: MediaService.Factory {
+    override func create(_ context: NSManagedObjectContext) -> MediaService {
+        return MediaServiceMock(managedObjectContext: context)
+    }
+}
+
+private class MediaServiceMock: MediaService {
+    override func uploadMedia(_ media: Media, automatedRetry: Bool,
+                              progress: AutoreleasingUnsafeMutablePointer<Progress?>?,
+                              success: (() -> Void)?,
+                              failure: ((Error?) -> Void)? = nil) {
+        DispatchQueue.global().async {
+            success?()
+        }
+    }
+}

--- a/WordPress/WordPressTest/Services/MediaCoordinatorTests.swift
+++ b/WordPress/WordPressTest/Services/MediaCoordinatorTests.swift
@@ -1,0 +1,9 @@
+//
+//  MediaCoordinatorTests.swift
+//  WordPressTest
+//
+//  Created by Shiki on 2019-10-16.
+//  Copyright © 2019 WordPress. All rights reserved.
+//
+
+import Foundation


### PR DESCRIPTION
As we've discovered in #12690 and fixed in 3e37abf1527dc0aa0426f704990026e111ef0a77, we had a bad merge when we recently merged `develop` into `issue/12240-master-branch` during #12664. 

This adds a simple test for `MediaCoordinator.uploadMedia` to avoid this from happening in upcoming merges. 

## Testing

1. Revert `MediaCoordinator.uploadMedia` to the previous buggy version as shown in 3e37abf1527dc0aa0426f704990026e111ef0a77. 
2. Run `MediaCoordinatorTests`. The test `testUploadMediaReturnsTrueIfAllPendingMediaAreQueuedForUpload` should fail. 
3. Clean all changes and run the test again. The test `testUploadMediaReturnsTrueIfAllPendingMediaAreQueuedForUpload` should pass. 

## Reviewing 

- Only 1 reviewer is needed but anyone can review. 
- Please merge it if you approve of the change and are not requesting any changes. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
