### PR TITLE
Revert "[Insights Management] Add Analytics tracking"

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,13 +13,13 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.8-beta.2'
+    pod 'WordPressShared', '~> 1.8.7'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => ''
+    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/change-username-events'
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -231,7 +231,7 @@ PODS:
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
   - WordPressMocks (0.0.6)
-  - WordPressShared (1.8.8-beta.2):
+  - WordPressShared (1.8.7):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.4-beta.1)
@@ -304,7 +304,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.1-beta.1)
   - WordPressKit (~> 4.5.1)
   - WordPressMocks (~> 0.0.6)
-  - WordPressShared (~> 1.8.8-beta.2)
+  - WordPressShared (~> 1.8.7)
   - WordPressUI (~> 1.4-beta.1)
   - WPMediaPicker (~> 1.4.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/9c1cfb830bdb3411fe8964539bec812b099589f1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -495,7 +495,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: f88358bd25edacfff23d78bb2aef5c3d5d176cbd
   WordPressKit: c35230114bbd380d63250b6d9a43337c29266c9b
   WordPressMocks: 5913bd04586a360212e07a8ccbcb36068d4425a3
-  WordPressShared: 257c40790d3c7cb2ab979bc891fa8b1f8127facb
+  WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
   WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -503,6 +503,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 787414f9240ee6ef8cfe4ea0f00e8b4d01d2d264
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 34660e5dd0f4200c413b82c523991223d8dcee0a
+PODFILE CHECKSUM: aec59cf36181558dd2c93ed2ce32843db11ce74c
 
 COCOAPODS: 1.7.5

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1667,23 +1667,11 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatStatsInsightsAccessed:
             eventName = @"stats_insights_accessed";
             break;
-        case WPAnalyticsStatStatsItemSelectedAddInsight:
-            eventName = @"stats_add_insight_item_selected";
-            break;
         case WPAnalyticsStatStatsItemTappedAuthors:
             eventName = @"stats_authors_view_post_tapped";
             break;
         case WPAnalyticsStatStatsItemTappedClicks:
             eventName = @"stats_clicks_item_tapped";
-            break;
-        case WPAnalyticsStatStatsItemTappedInsightMoveDown:
-            eventName = @"stats_insight_move_down_tapped";
-            break;
-        case WPAnalyticsStatStatsItemTappedInsightMoveUp:
-            eventName = @"stats_insight_move_up_tapped";
-            break;
-        case WPAnalyticsStatStatsItemTappedInsightRemove:
-            eventName = @"stats_insight_remove_tapped";
             break;
         case WPAnalyticsStatStatsItemTappedInsightsAddStat:
             eventName = @"stats_add_insight_item_tapped";
@@ -1705,9 +1693,6 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
         case WPAnalyticsStatStatsItemTappedLatestPostSummaryViewPostDetails:
             eventName = @"stats_latest_post_summary_view_post_details_tapped";
-            break;
-        case WPAnalyticsStatStatsItemTappedManageInsight:
-            eventName = @"stats_manage_insight_tapped";
             break;
         case WPAnalyticsStatStatsItemTappedPostsAndPages:
             eventName = @"stats_posts_and_pages_item_tapped";

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -392,7 +392,6 @@ private extension SiteStatsInsightsTableViewController {
             return
         }
 
-        WPAnalytics.track(.statsItemTappedInsightMoveUp)
         moveInsight(insight, by: -1)
     }
 
@@ -401,12 +400,10 @@ private extension SiteStatsInsightsTableViewController {
             return
         }
 
-        WPAnalytics.track(.statsItemTappedInsightMoveDown)
         moveInsight(insight, by: 1)
     }
 
     func removeInsight(_ insight: InsightType) {
-        WPAnalytics.track(.statsItemTappedInsightRemove)
         insightsToShow = insightsToShow.filter { $0 != insight }
         updateView()
     }
@@ -559,7 +556,6 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
                 return
         }
 
-        WPAnalytics.track(.statsItemSelectedAddInsight, withProperties: ["insight": insight.title])
         insightsToShow.append(insightType)
         updateView()
     }
@@ -579,8 +575,6 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             DDLogDebug("manageInsightSelected: unknown insightType for statSection: \(insight.title).")
             return
         }
-
-        WPAnalytics.track(.statsItemTappedManageInsight)
 
         let alert = UIAlertController(title: insight.title,
                                       message: nil,
@@ -616,7 +610,6 @@ extension SiteStatsInsightsTableViewController: NoResultsViewControllerDelegate 
     func actionButtonPressed() {
 
         guard !displayingEmptyView else {
-            WPAnalytics.track(.statsItemTappedInsightsAddStat)
             showAddInsightView()
             return
         }


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-iOS#12695 as tests are failing since this was merged.