### PR TITLE
[Offline Posting] Fix Page List → Retry regression

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -576,12 +576,6 @@
             || self.remoteStatus == AbstractPostRemoteStatusFailed);
 }
 
-- (void)markRemoteStatusFailed
-{
-    self.remoteStatus = AbstractPostRemoteStatusFailed;
-    [self save];
-}
-
 - (BOOL)shouldAttemptAutoUpload {
     if (!self.confirmedChangesTimestamp || !self.confirmedChangesHash) {
         return NO;

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -317,7 +317,11 @@ class PostCoordinator: NSObject {
             return
         }
         context.perform {
-            post.remoteStatus = status
+            if status == .failed {
+                self.mainService.markAsFailedAndDraftIfNeeded(post: post)
+            } else {
+                post.remoteStatus = status
+            }
 
             ContextManager.sharedInstance().saveContextAndWait(context)
         }

--- a/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
+++ b/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
@@ -1,0 +1,18 @@
+@objc extension PostService {
+
+    // MARK: - Updating the Remote Status
+    /// Updates the post after an upload failure.
+    ///
+    /// - Important: This logic could have been placed in the setter for `remoteStatus`, but it's my belief
+    ///     that our code will be much more resilient if we decouple the act of setting the `remoteStatus` value
+    ///     and the logic behind processing an upload failure.  In fact I think the `remoteStatus` setter should
+    ///     eventually be made private.
+    ///
+    func markAsFailedAndDraftIfNeeded(post: AbstractPost) {
+        guard post.remoteStatus != .failed else {
+            return
+        }
+
+        post.remoteStatus = .failed
+    }
+}

--- a/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
+++ b/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
@@ -1,12 +1,25 @@
 @objc extension PostService {
 
     // MARK: - Updating the Remote Status
+
     /// Updates the post after an upload failure.
+    ///
+    /// Local-only pages will be reverted back to `.draft` to avoid scenarios like this:
+    ///
+    /// 1. A locally published page upload failed
+    /// 2. The user presses the Page List's Retry button.
+    /// 3. The page upload is retried and the page is **published**.
+    ///
+    /// This is an unexpected behavior and can be surprising for the user. We'd want the user to
+    /// explicitly press on a “Publish” button instead.
+    ///
+    /// Posts' statuses are kept as is because we support automatic uploading of posts.
     ///
     /// - Important: This logic could have been placed in the setter for `remoteStatus`, but it's my belief
     ///     that our code will be much more resilient if we decouple the act of setting the `remoteStatus` value
     ///     and the logic behind processing an upload failure.  In fact I think the `remoteStatus` setter should
     ///     eventually be made private.
+    /// - SeeAlso: PostCoordinator.resume
     ///
     func markAsFailedAndDraftIfNeeded(post: AbstractPost) {
         guard post.remoteStatus != .failed else {
@@ -14,5 +27,10 @@
         }
 
         post.remoteStatus = .failed
+
+        if !post.hasRemote() && post is Page {
+            post.status = .draft
+            post.dateModified = Date()
+        }
     }
 }

--- a/WordPress/Classes/Services/PostService+RefreshStatus.swift
+++ b/WordPress/Classes/Services/PostService+RefreshStatus.swift
@@ -16,7 +16,7 @@ extension PostService {
             do {
                 let postsPushing = try self.managedObjectContext.fetch(fetch)
                 for post in postsPushing {
-                    post.remoteStatus = .failed
+                    self.markAsFailedAndDraftIfNeeded(post: post)
                 }
 
                 ContextManager.sharedInstance().save(self.managedObjectContext, withCompletionBlock: {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -301,7 +301,7 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
         [self.managedObjectContext performBlock:^{
             Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
-                postInContext.remoteStatus = AbstractPostRemoteStatusFailed;
+                [self markAsFailedAndDraftIfNeededWithPost:postInContext];
                 [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
             }
             if (failure) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1019,6 +1019,8 @@
 		8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */; };
 		8B93856E22DC08060010BF02 /* PageListSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */; };
 		8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */; };
+		8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */; };
+		8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BFE36FD230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */; };
 		8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */; };
@@ -3177,6 +3179,8 @@
 		8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadMessages.swift; sourceTree = "<group>"; };
 		8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListSectionHeaderView.swift; sourceTree = "<group>"; };
 		8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorTests.swift; sourceTree = "<group>"; };
+		8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeeded.swift"; sourceTree = "<group>"; };
+		8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeededTests.swift"; sourceTree = "<group>"; };
 		8BE377832339416800082EFE /* WordPress 91.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 91.xcdatamodel"; sourceTree = "<group>"; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLs.swift"; sourceTree = "<group>"; };
@@ -7052,6 +7056,7 @@
 				B543D2B420570B5A00D3D4CC /* WordPressComSyncService.swift */,
 				57C2331722FE0EC900A3863B /* PostAutoUploadInteractor.swift */,
 				57D66B99234BB206005A2D74 /* PostServiceRemoteFactory.swift */,
+				8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -8036,6 +8041,7 @@
 				B532ACCE1DC3AB8E00FFFA57 /* NotificationSyncMediatorTests.swift */,
 				08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */,
 				8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */,
+				8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */,
 				08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */,
 				5DE8A0401912D95B00B2FF59 /* ReaderPostServiceTest.m */,
 				E66969C71B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift */,
@@ -10900,6 +10906,7 @@
 				173BCE731CEB368A00AE8817 /* DomainsListViewController.swift in Sources */,
 				E1B912891BB01288003C25B9 /* PeopleViewController.swift in Sources */,
 				436D561F2117312700CEAA33 /* RegisterDomainSuggestionsViewController.swift in Sources */,
+				8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */,
 				405BFB21223B37A000CD5BEA /* FollowersCountStatsRecordValue+CoreDataProperties.swift in Sources */,
 				D8212CC720AA85C1008E8AE8 /* ReaderHeaderAction.swift in Sources */,
 				405B53FB1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift in Sources */,
@@ -11924,6 +11931,7 @@
 				732A473F21878EB10015DA74 /* WPRichContentViewTests.swift in Sources */,
 				82301B8F1E787420009C9C4E /* AppRatingUtilityTests.swift in Sources */,
 				D81C2F5420F85DB1002AE1F1 /* ApproveCommentActionTests.swift in Sources */,
+				8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */,
 				74B335EC1F06F9520053A184 /* MockWordPressComRestApi.swift in Sources */,
 				D848CBFF20FF010F00A9038F /* FormattableCommentContentTests.swift in Sources */,
 				9123471B221449E200BD9F97 /* GutenbergInformativeDialogTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -559,6 +559,7 @@
 		577C2AAB22936DCB00AD1F03 /* PostCardCellGhostableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577C2AAA22936DCB00AD1F03 /* PostCardCellGhostableTests.swift */; };
 		577C2AB422943FEC00AD1F03 /* PostCompactCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577C2AB322943FEC00AD1F03 /* PostCompactCell.swift */; };
 		577C2AB62294401800AD1F03 /* PostCompactCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 577C2AB52294401800AD1F03 /* PostCompactCell.xib */; };
+		57889AB823589DF100DAE56D /* PageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57889AB723589DF100DAE56D /* PageBuilder.swift */; };
 		5789E5C822D7D40800333698 /* AztecPostViewControllerAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5789E5C722D7D40800333698 /* AztecPostViewControllerAttachmentTests.swift */; };
 		57AA848F228715DA00D3C2A2 /* PostCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AA848E228715DA00D3C2A2 /* PostCardCell.swift */; };
 		57AA8491228715E700D3C2A2 /* PostCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57AA8490228715E700D3C2A2 /* PostCardCell.xib */; };
@@ -2652,6 +2653,7 @@
 		577C2AAA22936DCB00AD1F03 /* PostCardCellGhostableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardCellGhostableTests.swift; sourceTree = "<group>"; };
 		577C2AB322943FEC00AD1F03 /* PostCompactCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCompactCell.swift; sourceTree = "<group>"; };
 		577C2AB52294401800AD1F03 /* PostCompactCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostCompactCell.xib; sourceTree = "<group>"; };
+		57889AB723589DF100DAE56D /* PageBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PageBuilder.swift; path = TestUtilities/PageBuilder.swift; sourceTree = "<group>"; };
 		5789E5C722D7D40800333698 /* AztecPostViewControllerAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AztecPostViewControllerAttachmentTests.swift; path = Aztec/AztecPostViewControllerAttachmentTests.swift; sourceTree = "<group>"; };
 		57AA848E228715DA00D3C2A2 /* PostCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardCell.swift; sourceTree = "<group>"; };
 		57AA8490228715E700D3C2A2 /* PostCardCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostCardCell.xib; sourceTree = "<group>"; };
@@ -5652,6 +5654,7 @@
 				570BFD8F2282418A007859A8 /* PostBuilder.swift */,
 				57B71D4D230DB5F200789A68 /* BlogBuilder.swift */,
 				F11023A223186BCA00C4E84A /* MediaBuilder.swift */,
+				57889AB723589DF100DAE56D /* PageBuilder.swift */,
 			);
 			name = TestUtilities;
 			sourceTree = "<group>";
@@ -11932,6 +11935,7 @@
 				82301B8F1E787420009C9C4E /* AppRatingUtilityTests.swift in Sources */,
 				D81C2F5420F85DB1002AE1F1 /* ApproveCommentActionTests.swift in Sources */,
 				8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */,
+				57889AB823589DF100DAE56D /* PageBuilder.swift in Sources */,
 				74B335EC1F06F9520053A184 /* MockWordPressComRestApi.swift in Sources */,
 				D848CBFF20FF010F00A9038F /* FormattableCommentContentTests.swift in Sources */,
 				9123471B221449E200BD9F97 /* GutenbergInformativeDialogTests.swift in Sources */,

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -32,7 +32,7 @@ class PostCoordinatorTests: XCTestCase {
 
         postCoordinator.save(post)
 
-        expect(post.remoteStatus).toEventually(equal(.failed))
+        expect(postServiceMock.didCallMarkAsFailedAndDraftIfNeeded).toEventually(beTrue())
         expect(postServiceMock.didCallUploadPost).to(beFalse())
     }
 
@@ -260,6 +260,7 @@ class PostCoordinatorTests: XCTestCase {
 
 private class PostServiceMock: PostService {
     private(set) var didCallUploadPost = false
+    private(set) var didCallMarkAsFailedAndDraftIfNeeded = false
     private(set) var didCallAutoSave = false
 
     var returnPost: AbstractPost?
@@ -279,6 +280,10 @@ private class PostServiceMock: PostService {
 
     override func autoSave(_ post: AbstractPost, success: ((AbstractPost, String) -> Void)?, failure: @escaping (Error?) -> Void) {
         didCallAutoSave = true
+    }
+
+    override func markAsFailedAndDraftIfNeeded(post: AbstractPost) {
+        didCallMarkAsFailedAndDraftIfNeeded = true
     }
 }
 

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -6,8 +6,22 @@ import Nimble
 
 /// Test cases for PostService.markAsFailedAndDraftIfNeeded()
 class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
+
+    private var context: NSManagedObjectContext!
+    
+    override func setUp() {
+        super.setUp()
+        context = TestContextManager().mainContext
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        context = nil
+        ContextManager.overrideSharedInstance(nil)
+    }
+
     func testMarkAPostAsFailedAndKeepItsStatus() {
-        let post = PostBuilder()
+        let post = PostBuilder(context)
             .with(status: .pending)
             .withRemote()
             .build()
@@ -17,5 +31,34 @@ class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
 
         expect(post.remoteStatus).to(equal(.failed))
         expect(post.status).to(equal(.pending))
+    }
+
+    func testMarksALocalPageAsFailedAndResetsItToDraft() {
+        let page = PageBuilder(context)
+            .with(status: .publish)
+            .with(remoteStatus: .pushing)
+            .with(dateModified: Date(timeIntervalSince1970: 0))
+            .build()
+        let postService = PostService()
+
+        postService.markAsFailedAndDraftIfNeeded(post: page)
+
+        expect(page.remoteStatus).to(equal(.failed))
+        expect(page.status).to(equal(.draft))
+        expect(page.dateModified).to(beCloseTo(Date(), within: 3))
+    }
+
+    func testMarkingExistingPagesAsFailedWillNotRevertTheStatusToDraft() {
+        let page = PageBuilder(context)
+            .with(status: .scheduled)
+            .with(remoteStatus: .pushing)
+            .withRemote()
+            .build()
+        let postService = PostService()
+
+        postService.markAsFailedAndDraftIfNeeded(post: page)
+
+        expect(page.status).to(equal(.scheduled))
+        expect(page.remoteStatus).to(equal(.failed))
     }
 }

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -1,0 +1,21 @@
+import UIKit
+import XCTest
+import Nimble
+
+@testable import WordPress
+
+/// Test cases for PostService.markAsFailedAndDraftIfNeeded()
+class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
+    func testMarkAPostAsFailedAndKeepItsStatus() {
+        let post = PostBuilder()
+            .with(status: .pending)
+            .withRemote()
+            .build()
+        let postService = PostService()
+
+        postService.markAsFailedAndDraftIfNeeded(post: post)
+
+        expect(post.remoteStatus).to(equal(.failed))
+        expect(post.status).to(equal(.pending))
+    }
+}

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -8,7 +8,7 @@ import Nimble
 class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
 
     private var context: NSManagedObjectContext!
-    
+
     override func setUp() {
         super.setUp()
         context = TestContextManager().mainContext

--- a/WordPress/WordPressTest/TestUtilities/PageBuilder.swift
+++ b/WordPress/WordPressTest/TestUtilities/PageBuilder.swift
@@ -1,0 +1,40 @@
+
+import Foundation
+
+@testable import WordPress
+
+class PageBuilder {
+    private let page: Page
+
+    init(_ context: NSManagedObjectContext) {
+        page = NSEntityDescription.insertNewObject(forEntityName: Page.entityName(), into: context) as! Page
+
+        // Non-null Core Data properties
+        page.blog = BlogBuilder(context).build()
+    }
+
+    func with(status: BasePost.Status) -> Self {
+        page.status = status
+        return self
+    }
+
+    func with(remoteStatus: AbstractPostRemoteStatus) -> Self {
+        page.remoteStatus = remoteStatus
+        return self
+    }
+
+    func with(dateModified: Date) -> Self {
+        page.dateModified = dateModified
+        return self
+    }
+
+    /// Sets a random postID to emulate that self exists in the server.
+    func withRemote() -> Self {
+        page.postID = NSNumber(value: arc4random_uniform(UINT32_MAX))
+        return self
+    }
+
+    func build() -> Page {
+        return page
+    }
+}


### PR DESCRIPTION
Closes #12713

## Findings

This definitely happened when I suggested to remove `markAsFailedAndDraftIfNeeded` in #12613. Because of that, we forgot to update that part to revert Pages to `.draft.`

## Solution

This reverts the `markAsFailedAndDraftIfNeeded` removal and adds additional logic which reverts the `status` to `.draft` if the post is a `Page. 

## Testing

1. Go offline.
2. Create a page and publish it.
3. Go online.
4. Tap on More → Retry

The page should be uploaded as a draft. 

## Reviewing 

- Only 1 reviewer is needed but anyone can review. 
- Please merge it if you approve of the change and are not requesting any changes. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 