### PR TITLE
Rakefile: Always use latest credentials when running 'rake dependencies'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ namespace :dependencies do
   namespace :credentials do
     task :apply do
       next unless Dir.exist?(File.join(Dir.home, '.mobile-secrets/.git')) || ENV.key?('CONFIGURE_ENCRYPTION_KEY')
-      sh('FASTLANE_SKIP_UPDATE_CHECK=1 FASTLANE_ENV_PRINTER=1 bundle exec fastlane run configure_apply')
+      sh('FASTLANE_SKIP_UPDATE_CHECK=1 FASTLANE_ENV_PRINTER=1 bundle exec fastlane run configure_apply force:true')
     end
   end
 


### PR DESCRIPTION
@ScoutHarris pointed out that running `rake dependencies` when there are changes to any of the credentials files will lead to prompts like this:

```
Would you like to make a backup of .configure-files/project.env? (y/n)
```

This is not useful since we always should use the latest version. Using `force:true` with configure_apply ensures the latest is always used.

To Test:

- Run `rake dependencies`
- Add some whitespace to the bottom of `.configure-files/project.env`.
- Run `rake dependencies` again. It should run successfully without prompting about overwriting.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
