### PR TITLE
Show snackbar with "We'll publish the post" on failure to upload post with media

### DIFF
--- a/WordPress/Classes/Models/Media.swift
+++ b/WordPress/Classes/Models/Media.swift
@@ -19,4 +19,14 @@ extension Media {
     func resetAutoUploadFailureCount() {
         autoUploadFailureCount = 0
     }
+
+    /// Returns true if media has any associated post
+    ///
+    func hasAssociatedPost() -> Bool {
+        guard let posts = posts else {
+            return false
+        }
+
+        return !posts.isEmpty
+    }
 }

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -634,12 +634,15 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
 
     func mediaProgressCoordinatorDidFinishUpload(_ mediaProgressCoordinator: MediaProgressCoordinator) {
         // We only want to show an upload notice for uploads initiated within
-        // the media library, or if there's been a failure.
+        // the media library.
         // If the errors are causes by a missing file, we want to ignore that too.
 
         let mediaErrorsAreMissingFilesErrors = mediaProgressCoordinator.failedMedia.allSatisfy { $0.hasMissingFileError }
 
+        let allMediaHaveAssociatedPost = mediaProgressCoordinator.failedMedia.allSatisfy { $0.hasAssociatedPost() }
+
         if !mediaErrorsAreMissingFilesErrors,
+            !allMediaHaveAssociatedPost,
             mediaProgressCoordinator == mediaLibraryProgressCoordinator || mediaProgressCoordinator.hasFailedMedia {
 
             let model = MediaProgressCoordinatorNoticeViewModel(mediaProgressCoordinator: mediaProgressCoordinator)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -345,8 +345,10 @@ class PostCoordinator: NSObject {
     }
 
     private func dispatchNotice(for post: AbstractPost) {
-        let model = PostNoticeViewModel(post: post)
-        ActionDispatcher.dispatch(NoticeAction.post(model.notice))
+        DispatchQueue.main.async {
+            let model = PostNoticeViewModel(post: post)
+            ActionDispatcher.dispatch(NoticeAction.post(model.notice))
+        }
     }
 }
 

--- a/WordPress/WordPressTest/MediaTests.swift
+++ b/WordPress/WordPressTest/MediaTests.swift
@@ -67,6 +67,20 @@ class MediaTests: XCTestCase {
         }
     }
 
+    func testMediaHasAssociatedPost() {
+        let post = PostBuilder(context).build()
+        let media = newTestMedia()
+        media.addPostsObject(post)
+
+        XCTAssertTrue(media.hasAssociatedPost())
+    }
+
+    func testMediaHasntAssociatedPost() {
+        let media = newTestMedia()
+
+        XCTAssertFalse(media.hasAssociatedPost())
+    }
+
     // MARK: - AutoUpload Failure Count
 
     func testThatIncrementAutoUploadFailureCountWorks() {


### PR DESCRIPTION
Fixes #12678

## Testing

Please, use Gutenberg and Aztek for testing.

1. While offline, create a post and add an image
2. Tap Publish (or Save, or Schedule)
3. Check that the snack bar message says the post will be published later

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests.