### PR TITLE
[Insights Management] Enable feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * Dark Mode: General improvements
 * Stats: each Insight stat now loads independently.
+* Stats: added ability to customize Insights.
  
 13.4
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -20,7 +20,7 @@ enum FeatureFlag: Int {
         case .statsRefresh:
             return true
         case .statsInsightsManagement:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .domainCredit:
             return true
         case .signInWithApple:


### PR DESCRIPTION
Ref #12243 

To test:
- Start with a fresh install (or an account you've not used to test Insights Management).
- Go to Stats > Insights.
- Verify these cards appear, in this order:
  - Customize
  - Posting Activity
  - Today
  - All Time
  - Most Popular Time
  - Comments
  - Add Stats

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
