### PR TITLE
Issues/12672 fix notification setup glitch

### DIFF
--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -161,6 +161,13 @@ extern NSNotificationName const WPAccountEmailAndDefaultBlogUpdatedNotification;
  */
 - (void)purgeAccountIfUnused:(WPAccount *)account;
 
+/**
+ Restores a disassociated default WordPress.com account if the current defaultWordPressCom account is nil
+ and another candidate account is found.  This method bypasses the normal setter to avoid triggering unintended
+ side-effects from dispatching account changed notifications.
+ */
+- (void)restoreDisassociatedAccountIfNecessary;
+
 ///--------------------
 /// @name Visible blogs
 ///--------------------

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -41,16 +41,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         }
     }
 
-    // Attempt to restore a default account that has somehow been disassociated.
-    WPAccount *account = [self findDefaultAccountCandidate];
-    if (account) {
-        // Assume we have a good candidate account and make it the default account in the app.
-        // Note that this should be the account with the most blogs.
-        // Update user defaults here vs the setter method to avoid potential side-effects from dispatched notifications.
-        [[NSUserDefaults standardUserDefaults] setObject:account.uuid forKey:DefaultDotcomAccountUUIDDefaultsKey];
-        return account;
-    }
-
     // No account, or no default account set. Clear the defaults key.
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:DefaultDotcomAccountUUIDDefaultsKey];
     return nil;
@@ -300,6 +290,22 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         return defaultAccount;
     }
     return nil;
+}
+
+- (void)restoreDisassociatedAccountIfNecessary
+{
+    if ([self defaultWordPressComAccount]) {
+        return;
+    }
+
+    // Attempt to restore a default account that has somehow been disassociated.
+    WPAccount *account = [self findDefaultAccountCandidate];
+    if (account) {
+        // Assume we have a good candidate account and make it the default account in the app.
+        // Note that this should be the account with the most blogs.
+        // Updates user defaults here vs the setter method to avoid potential side-effects from dispatched notifications.
+        [[NSUserDefaults standardUserDefaults] setObject:account.uuid forKey:DefaultDotcomAccountUUIDDefaultsKey];
+    }
 }
 
 - (WPAccount *)findDefaultAccountCandidate

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -69,6 +69,9 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         window?.makeKeyAndVisible()
 
+        // Restore a disassociated account prior to fixing tokens.
+        AccountService(managedObjectContext: ContextManager.shared.mainContext).restoreDisassociatedAccountIfNecessary()
+
         let solver = WPAuthTokenIssueSolver()
         let isFixingAuthTokenIssue = solver.fixAuthTokenIssueAndDo { [weak self] in
             self?.runStartupSequence(with: launchOptions ?? [:])

--- a/WordPress/WordPressTest/AccountServiceTests.swift
+++ b/WordPress/WordPressTest/AccountServiceTests.swift
@@ -113,6 +113,7 @@ class AccountServiceTests: XCTestCase {
 
         UserDefaults.standard.removeObject(forKey: "AccountDefaultDotcomUUID")
 
+        accountService.restoreDisassociatedAccountIfNecessary()
         XCTAssertEqual(accountService.defaultWordPressComAccount(), account)
     }
 
@@ -133,6 +134,7 @@ class AccountServiceTests: XCTestCase {
         contextManager.save(context)
 
         UserDefaults.standard.removeObject(forKey: "AccountDefaultDotcomUUID")
+        accountService.restoreDisassociatedAccountIfNecessary()
         XCTAssertEqual(accountService.defaultWordPressComAccount(), account)
 
         accountService.removeDefaultWordPressComAccount()

--- a/WordPress/WordPressTest/AccountServiceTests.swift
+++ b/WordPress/WordPressTest/AccountServiceTests.swift
@@ -10,16 +10,27 @@ class AccountServiceTests: XCTestCase {
         super.setUp()
 
         contextManager = TestContextManager()
+        contextManager.requiresTestExpectation = false
         accountService = AccountService(managedObjectContext: contextManager.mainContext)
     }
 
     override func tearDown() {
         super.tearDown()
 
+        deleteTestAccounts()
+
         ContextManager.overrideSharedInstance(nil)
         contextManager.mainContext.reset()
         contextManager = nil
         accountService = nil
+    }
+
+    func deleteTestAccounts() {
+        let context = contextManager.mainContext
+        for account in accountService.allAccounts() {
+            context.delete(account)
+        }
+        contextManager.save(context)
     }
 
     func testCreateWordPressComAccountUUID() {
@@ -142,29 +153,32 @@ class AccountServiceTests: XCTestCase {
     }
 
     func testMergeMultipleDuplicateAccounts() {
-        let account1 = WPAccount(context: contextManager.mainContext)
+        let context = contextManager.mainContext
+        let account1 = WPAccount(context: context)
         account1.userID = 1
         account1.username = "username"
         account1.authToken = "authToken"
         account1.uuid = UUID().uuidString
 
-        let account2 = WPAccount(context: contextManager.mainContext)
+        let account2 = WPAccount(context: context)
         account2.userID = 1
         account2.username = "username"
         account2.authToken = "authToken"
         account2.uuid = UUID().uuidString
 
-        let account3 = WPAccount(context: contextManager.mainContext)
+        let account3 = WPAccount(context: context)
         account3.userID = 1
         account3.username = "username"
         account3.authToken = "authToken"
         account3.uuid = UUID().uuidString
 
-        let context = contextManager.mainContext
+
         account1.addBlogs(createMockBlogs(withIDs: [1, 2, 3, 4, 5, 6], in: context))
         account2.addBlogs(createMockBlogs(withIDs: [1, 2, 3], in: context))
         account3.addBlogs(createMockBlogs(withIDs: [4, 5, 6], in: context))
         contextManager.save(context)
+
+        accountService.setDefaultWordPressComAccount(account1)
 
         accountService.mergeDuplicatesIfNecessary()
         contextManager.save(context)
@@ -180,29 +194,30 @@ class AccountServiceTests: XCTestCase {
     }
 
     func testMergeDuplicateAccountsKeepingNonDups() {
-        let account1 = WPAccount(context: contextManager.mainContext)
+        let context = contextManager.mainContext
+        let account1 = WPAccount(context: context)
         account1.userID = 1
         account1.username = "username"
         account1.authToken = "authToken"
         account1.uuid = UUID().uuidString
 
-        let account2 = WPAccount(context: contextManager.mainContext)
+        let account2 = WPAccount(context: context)
         account2.userID = 1
         account2.username = "username"
         account2.authToken = "authToken"
         account2.uuid = UUID().uuidString
 
-        let account3 = WPAccount(context: contextManager.mainContext)
+        let account3 = WPAccount(context: context)
         account3.userID = 3
         account3.username = "username3"
         account3.authToken = "authToken3"
         account3.uuid = UUID().uuidString
 
-        let context = contextManager.mainContext
         account1.addBlogs(createMockBlogs(withIDs: [1, 2, 3, 4, 5, 6], in: context))
         account2.addBlogs(createMockBlogs(withIDs: [1, 2, 3], in: context))
         account3.addBlogs(createMockBlogs(withIDs: [4, 5, 6], in: context))
         contextManager.save(context)
+        accountService.setDefaultWordPressComAccount(account1)
 
         accountService.mergeDuplicatesIfNecessary()
         contextManager.save(context)


### PR DESCRIPTION
Refs #12672 

H/T @frosty who troubleshooted this one. 
An earlier patch to fix a disassociated default account was a bit too aggressive in its approach. As a consequence, setting a default account during login never executed code to setup notifications.  This patch moves the disassociation fix out of the getter into a separate method and calls it during application launch.  This should be sufficient to restore an account that was disassociated during an upgrade/restore. 

@koke, if you have a free moment I'd appreciate your 👀 on this one too. 

To test:
Run unit tests. Confirm they pass. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
