### PR TITLE
Ignore derived-data folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ Scripts/fastlane/README.md
 Scripts/Preview.html
 Scripts/fastlane/test_output/
 Scripts/fastlane/google_cloud_keys.json
+derived-data/
 
 # Generated Internal Icons
 /WordPress/Resources/AppImages.xcassets/AppIcon-Internal.appiconset


### PR DESCRIPTION
Derived data path for Fastlane driven builds have been changed in [PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/12654). This PR updates `.gitignore` to ignore that folder.  
 
To test:
1. Run a fastlane build lane (for example: `bundle exec fastlane build_and_upload_itc`) and verify that git status is clean after the build.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
