### PR TITLE
Update WordPressKit pod

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -45,7 +45,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.5.1'
+    pod 'WordPressKit', '~> 4.5.2-beta.1'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -223,7 +223,7 @@ PODS:
     - WordPressKit (~> 4.5.1)
     - WordPressShared (~> 1.8)
     - WordPressUI (~> 1.4-beta.1)
-  - WordPressKit (4.5.1):
+  - WordPressKit (4.5.2-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -302,7 +302,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.10.1)
   - WordPressAuthenticator (~> 1.10.1-beta.1)
-  - WordPressKit (~> 4.5.1)
+  - WordPressKit (~> 4.5.2-beta.1)
   - WordPressMocks (~> 0.0.6)
   - WordPressShared (~> 1.8.7)
   - WordPressUI (~> 1.4-beta.1)
@@ -493,7 +493,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 419ebf7a333fe147da33e4754978f20a5fd08a86
   WordPress-Editor-iOS: b3ec2b9484c76ad30918ed5dfe87bbbf9fa9de7d
   WordPressAuthenticator: f88358bd25edacfff23d78bb2aef5c3d5d176cbd
-  WordPressKit: c35230114bbd380d63250b6d9a43337c29266c9b
+  WordPressKit: 096fb17b8bd4a97d25f2fd7417ec52eab0b7d4ac
   WordPressMocks: 5913bd04586a360212e07a8ccbcb36068d4425a3
   WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
   WordPressUI: 35b144885c8e5817ba6874b68accc200bda61ee1
@@ -503,6 +503,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 787414f9240ee6ef8cfe4ea0f00e8b4d01d2d264
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: aec59cf36181558dd2c93ed2ce32843db11ce74c
+PODFILE CHECKSUM: e3ae9a52654b75650fbaf8a87ad41b5df7449fcc
 
 COCOAPODS: 1.7.5


### PR DESCRIPTION
Now includes a new signup param.

Fixes #12724 

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
