### PR TITLE
Opening post settings after uploading a featured image from another client displays the image

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -95,5 +95,4 @@ extension AbstractPost {
             return nil
         }
     }
-    
 }

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -95,4 +95,9 @@ extension AbstractPost {
             return nil
         }
     }
+
+    @objc override open func featuredImageURLForDisplay() -> URL? {
+        return featuredImageURL
+    }
+
 }

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -95,9 +95,5 @@ extension AbstractPost {
             return nil
         }
     }
-
-    @objc override open func featuredImageURLForDisplay() -> URL? {
-        return featuredImageURL
-    }
-
+    
 }

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -115,6 +115,8 @@
     if (self.pathForDisplayImage) {
         return [NSURL URLWithString:self.pathForDisplayImage];
     }
+    
+    return nil;
 }
 
 @end

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -110,4 +110,11 @@
     return  self.content ? self.content.isEmpty : YES;
 }
 
+- (NSURL *)featuredImageURLForDisplay
+{
+    if (self.pathForDisplayImage) {
+        return [NSURL URLWithString:self.pathForDisplayImage];
+    }
+}
+
 @end

--- a/WordPress/WordPressTest/AbstractPostTest.swift
+++ b/WordPress/WordPressTest/AbstractPostTest.swift
@@ -30,4 +30,10 @@ class AbstractPostTest: XCTestCase {
         XCTAssertTrue(title == NSLocalizedString("Scheduled", comment: "Scheduled"), "Title did not match status")
     }
 
+    func testFeaturedImageURLForDisplay() {
+        let post = PostBuilder().with(pathForDisplayImage: "https://wp.me/awesome.png").build()
+
+        XCTAssertEqual(post.featuredImageURLForDisplay()?.absoluteString, "https://wp.me/awesome.png")
+    }
+
 }


### PR DESCRIPTION
Fixes #12750

To test:

1. Create a new post in the app and save it as a draft.
2. Open the same post in the web editor.
3. Upload a featured image to the post and save it.
4. In the app, make sure the remote changes are synced (e.g. pull to refresh the post list) and then open the post again.
5. Open the post settings. The image should be loaded.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. This will prevent a similar bug in the future.