### PR TITLE
Replace GiphyCoreSDK with Giphy pod

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -148,7 +148,7 @@ target 'WordPress' do
     pod '1PasswordExtension', '1.8.5'
     pod 'Charts', '~> 3.2.2'
     pod 'Gifu', '3.2.0'
-    pod 'GiphyCoreSDK', '~> 1.4.0'
+    pod 'Giphy', '1.1.3'
     pod 'HockeySDK', '5.1.4', :configurations => ['Release-Internal', 'Release-Alpha']
     pod 'MRProgress', '0.8.3'
     pod 'Starscream', '3.0.6'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,6 +15,7 @@ PODS:
   - CocoaLumberjack (3.5.2):
     - CocoaLumberjack/Core (= 3.5.2)
   - CocoaLumberjack/Core (3.5.2)
+  - DeepDiff (2.2.0)
   - DoubleConversion (1.1.5)
   - Down (0.6.6)
   - Folly (2018.10.22.00):
@@ -31,7 +32,10 @@ PODS:
     - FormatterKit/Resources
   - FSInteractiveMap (0.1.0)
   - Gifu (3.2.0)
-  - GiphyCoreSDK (1.4.3)
+  - Giphy (1.1.3):
+    - DeepDiff (~> 2.2.0)
+    - libwebp
+    - PINCache
   - glog (0.3.5)
   - GoogleSignIn (4.4.0):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
@@ -55,6 +59,15 @@ PODS:
   - HockeySDK (5.1.4):
     - HockeySDK/DefaultLib (= 5.1.4)
   - HockeySDK/DefaultLib (5.1.4)
+  - libwebp (1.0.3):
+    - libwebp/demux (= 1.0.3)
+    - libwebp/mux (= 1.0.3)
+    - libwebp/webp (= 1.0.3)
+  - libwebp/demux (1.0.3):
+    - libwebp/webp
+  - libwebp/mux (1.0.3):
+    - libwebp/demux
+  - libwebp/webp (1.0.3)
   - lottie-ios (2.5.2)
   - MRProgress (0.8.3):
     - MRProgress/ActivityIndicator (= 0.8.3)
@@ -103,6 +116,7 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (6.1.0)
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
+  - PINCache (2.3)
   - Reachability (3.2)
   - React (0.60.0-patched):
     - React-Core (= 0.60.0-patched)
@@ -261,7 +275,7 @@ DEPENDENCIES:
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - GiphyCoreSDK (~> 1.4.0)
+  - Giphy (= 1.1.3)
   - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.15.1/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 0.16)
   - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.15.1`)
@@ -320,16 +334,18 @@ SPEC REPOS:
     - boost-for-react-native
     - Charts
     - CocoaLumberjack
+    - DeepDiff
     - DoubleConversion
     - Down
     - FormatterKit
     - Gifu
-    - GiphyCoreSDK
+    - Giphy
     - GoogleSignIn
     - GoogleToolboxForMac
     - Gridicons
     - GTMSessionFetcher
     - HockeySDK
+    - libwebp
     - lottie-ios
     - MRProgress
     - Nimble
@@ -337,6 +353,7 @@ SPEC REPOS:
     - "NSURL+IDN"
     - OCMock
     - OHHTTPStubs
+    - PINCache
     - Reachability
     - Sentry
     - SimulatorStatusMagic
@@ -440,13 +457,14 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
   CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
+  DeepDiff: e329bc46dd14ca788d8ec08d34420799ba1d77f2
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   Down: 71bf4af3c04fa093e65dffa25c4b64fa61287373
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 7bcb6427457d85e0b4dff5a84ec5947ac19a93ea
-  GiphyCoreSDK: 354d60d3e1ea11050fb4fed272e0e4dd7d1eb48d
+  Giphy: 7a99ace30d32d7d3bcc4eb93225f30e4a1b940d7
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
   GoogleToolboxForMac: b3553629623a3b1bff17f555e736cd5a6d95ad55
@@ -454,6 +472,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 61bb0f61a4cb560030f1222021178008a5727a23
   Gutenberg: 3b8866adbfda831ce0f28d5c638eb40c23baed7b
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
+  libwebp: 057912d6d0abfb6357d8bb05c0ea470301f5d61e
   lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
@@ -461,6 +480,7 @@ SPEC CHECKSUMS:
   "NSURL+IDN": 82355a0afd532fe1de08f6417c134b49b1a1c4b3
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
+  PINCache: ce36ed282031b92fc7733ffe831f474ff80fddc2
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   React: f208cb37831d73d3feafe90ff5c353ef67516cfb
   React-Core: c84e22ad089efdf344669e09c0036a8e68c87c54
@@ -503,6 +523,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 07977c9aa708ea64461a1b18b7b3cfec3f496785
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 8f787cc5b70792b69d60c91147b882260b6948b3
+PODFILE CHECKSUM: fe470a244fd0e97bbcca95e634e3cf509ada69fe
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
GiphyCoreSDK has been deprecated (and deleted 😱), so we need to implement the new `Giphy` pod instead.

Sadly this pod also installs the Giphy UI library that we don't use.

This error started to appear in some [CI checks](https://circleci.com/gh/wordpress-mobile/WordPress-iOS/15175?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) already.
It should be able to reproduce the error by deleting the local `Pods/` folder and running `rake dependencies`.

To test:
- `rm -rf Pods/`
- `rake dependency`
- Build and Run.
- Check that you can download/add gifs to the Media Library or (Aztec) posts.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
