### PR TITLE
Issue/fix rotation of photos hotfix

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -170,7 +170,7 @@ target 'WordPress' do
 
     pod 'NSURL+IDN', '0.3'
 
-    pod 'WPMediaPicker', '~> 1.4.2'
+    pod 'WPMediaPicker', '~> 1.6.0'
     ## while PR is in review:
     ## pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '7c3cb8f00400b9316a803640b42bb88a66bbc648'
     

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -235,7 +235,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.3.5)
-  - WPMediaPicker (1.4.2)
+  - WPMediaPicker (1.6.0)
   - wpxmlrpc (0.8.4)
   - yoga (0.60.0-patched.React)
   - ZendeskSDK (3.0.1):
@@ -306,7 +306,7 @@ DEPENDENCIES:
   - WordPressMocks (~> 0.0.6)
   - WordPressShared (~> 1.8.7)
   - WordPressUI (~> 1.3.5)
-  - WPMediaPicker (~> 1.4.2)
+  - WPMediaPicker (~> 1.6.0)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.14.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (from `https://github.com/zendesk/zendesk_sdk_ios`, tag `3.0.1-swift5.1-GM`)
   - ZIPFoundation (~> 0.9.8)
@@ -497,12 +497,12 @@ SPEC CHECKSUMS:
   WordPressMocks: 5913bd04586a360212e07a8ccbcb36068d4425a3
   WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
   WordPressUI: 1b006c7440e85e724b9773c7ebe3a2e783f70941
-  WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
+  WPMediaPicker: e5d28197da6b467d4e5975d64a49255977e39455
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   yoga: 4e71c9a33abf45ba55af55ae9cbc86f4234bb2a9
-  ZendeskSDK: 787414f9240ee6ef8cfe4ea0f00e8b4d01d2d264
+  ZendeskSDK: ce880e75f12ae5dacaa3658f49e545f3c8471030
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: ef6f0218db46220a51220f0226d83d27180cc9f3
+PODFILE CHECKSUM: ac23b9908e4e31edb4f08a29604af59ec7a0ed5f
 
 COCOAPODS: 1.7.5

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -249,7 +249,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.3.5)
-  - WPMediaPicker (1.4.2)
+  - WPMediaPicker (1.6.0)
   - wpxmlrpc (0.8.4)
   - yoga (0.60.0-patched.React)
   - ZendeskSDK (3.0.1):
@@ -320,7 +320,7 @@ DEPENDENCIES:
   - WordPressMocks (~> 0.0.6)
   - WordPressShared (~> 1.8.7)
   - WordPressUI (~> 1.3.5)
-  - WPMediaPicker (~> 1.4.2)
+  - WPMediaPicker (~> 1.6.0)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.14.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (from `https://github.com/zendesk/zendesk_sdk_ios`, tag `3.0.1-swift5.1-GM`)
   - ZIPFoundation (~> 0.9.8)
@@ -517,12 +517,12 @@ SPEC CHECKSUMS:
   WordPressMocks: 5913bd04586a360212e07a8ccbcb36068d4425a3
   WordPressShared: 09cf184caa614835f5811e8609227165201e6d3e
   WordPressUI: 1b006c7440e85e724b9773c7ebe3a2e783f70941
-  WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
+  WPMediaPicker: e5d28197da6b467d4e5975d64a49255977e39455
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   yoga: 4e71c9a33abf45ba55af55ae9cbc86f4234bb2a9
-  ZendeskSDK: 07977c9aa708ea64461a1b18b7b3cfec3f496785
+  ZendeskSDK: 787414f9240ee6ef8cfe4ea0f00e8b4d01d2d264
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 1a0c699d3c7aa85090801a935c3ca2fc49b94ee8
+PODFILE CHECKSUM: e0685a5046f08946444c4aae4f5f1cf56939d24c
 
 COCOAPODS: 1.7.5

--- a/WordPress/Classes/Utility/Media/MediaImageExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaImageExporter.swift
@@ -313,7 +313,7 @@ class MediaImageExporter: MediaExporter {
                 throw ImageExportError.imageSourceThumbnailGenerationFailed
             }
 
-            if nullifyGPSData == true {
+            if nullifyGPSData {
                 // When removing GPS data for a thumbnail, we have to remove the dictionary
                 // itself for the CGImageDestinationAddImage method.
                 imageProperties.removeValue(forKey: kCGImagePropertyGPSDictionary)

--- a/WordPress/WordPressTest/MediaImageExporterTests.swift
+++ b/WordPress/WordPressTest/MediaImageExporterTests.swift
@@ -164,7 +164,7 @@ class MediaImageExporterTests: XCTestCase {
 
     // MARK: - Image export orientation testing
 
-    func testExportingAPortraitImageWithoutResizeKeepsTheOrientationWorks() {
+    func testExportingAPortraitImageWithoutResizeRotatesToUpOrientationWorks() {
         let image = MediaImageExporterTests.imageForFileNamed(testImageNameInPortrait)
         if image.imageOrientation != .leftMirrored {
             XCTFail("Error: the test portrait image was not in the expected orientation, expected: " +
@@ -177,7 +177,7 @@ class MediaImageExporterTests: XCTestCase {
         exporter.mediaDirectoryType = .temporary
         exporter.export(onCompletion: { (imageExport) in
             // If not resising the image the orientation stays the same has the original
-            MediaImageExporterTests.validateImageExportedWithExpectedOrientation(export: imageExport, expected: .leftMirrored)
+            MediaImageExporterTests.validateImageExportedWithExpectedOrientation(export: imageExport, expected: .up)
             MediaExporterTests.cleanUpExportedMedia(atURL: imageExport.url)
             expect.fulfill()
         }) { (error) in


### PR DESCRIPTION
Fixes #12703 

This PR bings fixes for two issues:

 - Images that were captured inside the app using a non-standard orientation of the device (ex: upside down) were being saved incorrectly in the camera roll
- Images that have a non-standard orientation, capture inside the app or in the camera app, when updated to a WP.org site that was is bellow version 5.3 will be show incorrectly on the web.

For the first issue we are updating the WPMediaPicker version that has a fix to save the images correctly when taken inside the app

For the second issue we are now applying a transform on all images uploaded from the app to make sure that they all have orientation up independently of the size setting. 

To test:
 - Capture a photo inside the app with the device upside down
 - Make sure the image is recorded with the correct orientation and display properly inside the media library
 - Use that photo on a post and upload it to a WP.org site that is bellow version 5.3 ( it cannot be connected with Jetpack or else the Photon will fix/hide the issue)
- Upload/Publish the Post
- See the post on the web, using Safari, to see if photo shows with the correct orientation.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.