### PR TITLE
[Gutenberg] Update new editor popup message.

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -5,7 +5,7 @@ extension GutenbergViewController {
 
     enum InfoDialog {
         static let message = NSLocalizedString(
-            "You're currently using the block editor to create new posts. Want to use the classic editor by default? Head to Site Settings.",
+            "You're currently using the block editor to create new posts. If you want a different default, you can change it in the Site Settings.",
             comment: "Popup content about why this post is being opened in block editor"
         )
         static let title = NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -4,8 +4,12 @@ import Foundation
 extension GutenbergViewController {
 
     enum InfoDialog {
-        static let message = NSLocalizedString(
+        static let postMessage = NSLocalizedString(
             "You’re now using the block editor for new posts — great! If you’d like to change to the classic editor, go to ‘My Site’ > ‘Site Settings’.",
+            comment: "Popup content about why this post is being opened in block editor"
+        )
+        static let pageMessage = NSLocalizedString(
+            "You’re now using the block editor for new pages — great! If you’d like to change to the classic editor, go to ‘My Site’ > ‘Site Settings’.",
             comment: "Popup content about why this post is being opened in block editor"
         )
         static let title = NSLocalizedString(
@@ -17,12 +21,14 @@ extension GutenbergViewController {
 
     func showInformativeDialogIfNecessary() {
         if shouldPresentInformativeDialog {
-            GutenbergViewController.showInformativeDialog(on: self)
+            let message = post is Page ? InfoDialog.pageMessage : InfoDialog.postMessage
+            GutenbergViewController.showInformativeDialog(on: self, message: message)
         }
     }
 
     static func showInformativeDialog(
         on viewController: UIViewControllerTransitioningDelegate & UIViewController,
+        message: String,
         animated: Bool = true
     ) {
         let okButton: (title: String, handler: FancyAlertViewController.FancyAlertButtonHandler?) =
@@ -35,7 +41,7 @@ extension GutenbergViewController {
 
         let config = FancyAlertViewController.Config(
             titleText: InfoDialog.title,
-            bodyText: InfoDialog.message,
+            bodyText: message,
             headerImage: nil,
             dividerPosition: .top,
             defaultButton: okButton,

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -5,7 +5,7 @@ extension GutenbergViewController {
 
     enum InfoDialog {
         static let message = NSLocalizedString(
-            "You're currently using the block editor to create new posts. If you want a different default, you can change it in the Site Settings.",
+            "You’re now using the block editor for new posts — great! If you’d like to change to the classic editor, go to ‘My Site’ > ‘Site Settings’.",
             comment: "Popup content about why this post is being opened in block editor"
         )
         static let title = NSLocalizedString(

--- a/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
+++ b/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
@@ -34,6 +34,7 @@ class GutenbergInformativeDialogTests: XCTestCase {
     private func showInformativeDialog() {
         GutenbergViewController.showInformativeDialog(
             on: viewController,
+            message: GutenbergViewController.InfoDialog.postMessage,
             animated: false
         )
     }


### PR DESCRIPTION
Simple PR to update the text displayed when the user opens the block editor for the first time.

Old text:
> You're currently using the block editor to create new posts. Want to use the classic editor by default? Head to Site Settings.

New text:
> You’re now using the block editor for new posts — great! If you’d like to change to the classic editor, go to ‘My Site’ > ‘Site Settings’.

cc @hypest 