### PR TITLE
[Stats Refresh] DWMY Async loading operations and feature flag

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -351,9 +351,13 @@ private extension StatsPeriodStore {
             return
         }
 
+        // Legacy overview fetching method
+        //
         fetchSyncData(date: date, period: period)
     }
 
+    // Fetch Chart data first using the async operation
+    //
     func fetchChartData(date: Date, period: StatsPeriodUnit) {
         guard let service = statsRemote() else {
             return
@@ -379,6 +383,8 @@ private extension StatsPeriodStore {
         operationQueue.addOperation(chartOperation)
     }
 
+    // Fetch the rest of the overview data using the async operations
+    //
     func fetchAsyncData(date: Date, period: StatsPeriodUnit) {
         guard let service = statsRemote() else {
             return

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1,6 +1,11 @@
 import Foundation
 import WordPressFlux
 
+enum PeriodType {
+    case summary
+    case topPostsAndPages
+}
+
 enum PeriodAction: Action {
 
     // Period overview

--- a/WordPress/Classes/Stores/StatsStore+Cache.swift
+++ b/WordPress/Classes/Stores/StatsStore+Cache.swift
@@ -48,3 +48,14 @@ extension StatsInsightsStore: StatsStoreCacheable {
         }
     }
 }
+
+extension StatsPeriodStore: StatsStoreCacheable {
+    func containsCachedData(for type: PeriodType) -> Bool {
+        switch type {
+        case .summary:
+            return state.summary != nil
+        case .topPostsAndPages:
+            return state.topPostsAndPages != nil
+        }
+    }
+}

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -9,6 +9,7 @@ enum FeatureFlag: Int {
     case domainCredit
     case signInWithApple
     case statsAsyncLoading
+    case statsAsyncLoadingDWMY
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -32,6 +33,8 @@ enum FeatureFlag: Int {
             return true
         case .statsAsyncLoading:
             return true
+        case .statsAsyncLoadingDWMY:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Operation/AsyncOperation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Operation/AsyncOperation.swift
@@ -1,0 +1,38 @@
+class AsyncOperation: Operation {
+    enum State: String {
+        case isReady, isExecuting, isFinished
+    }
+
+    override var isAsynchronous: Bool {
+        return true
+    }
+
+    var state = State.isReady {
+        willSet {
+            willChangeValue(forKey: state.rawValue)
+            willChangeValue(forKey: newValue.rawValue)
+        }
+        didSet {
+            didChangeValue(forKey: oldValue.rawValue)
+            didChangeValue(forKey: state.rawValue)
+        }
+    }
+
+    override var isExecuting: Bool {
+        return state == .isExecuting
+    }
+
+    override var isFinished: Bool {
+        return state == .isFinished
+    }
+
+    override func start() {
+        if isCancelled {
+            state = .isFinished
+            return
+        }
+
+        state = .isExecuting
+        main()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Operation/StatsPeriodAsyncOperation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Operation/StatsPeriodAsyncOperation.swift
@@ -1,0 +1,28 @@
+final class StatsPeriodAsyncOperation<TimeStatsType: StatsTimeIntervalData>: AsyncOperation {
+    typealias StatsPeriodCompletion = (TimeStatsType?, Error?) -> Void
+
+    private weak var service: StatsServiceRemoteV2?
+    private let period: StatsPeriodUnit
+    private let date: Date
+    private let limit: Int
+    private var completion: StatsPeriodCompletion
+
+    init(service: StatsServiceRemoteV2, for period: StatsPeriodUnit, date: Date, limit: Int = 10, completion: @escaping StatsPeriodCompletion) {
+        self.service = service
+        self.period = period
+        self.date = date
+        self.limit = limit
+        self.completion = completion
+    }
+
+    override func main() {
+        service?.getData(for: period, endingOn: date, limit: limit) { [unowned self] (type: TimeStatsType?, error: Error?) in
+            if self.isCancelled {
+                self.state = .isFinished
+                return
+            }
+
+            self.completion(type, error)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -194,8 +194,6 @@ private extension SiteStatsPeriodTableViewController {
             return
         }
 
-        DDLogInfo("--- Refresh Table View")
-
         tableHandler.viewModel = viewModel.tableViewModel()
 
         if asyncLoadingActivated {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -86,7 +86,9 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
         }
 
         cell.configure(date: selectedDate, period: selectedPeriod, delegate: self)
-        cell.animateGhostLayers(viewModel?.isFetchingChart() == true)
+        if asyncLoadingActivated {
+            cell.animateGhostLayers(viewModel?.isFetchingChart() == true)
+        }
         tableHeaderView = cell
         return cell
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -86,6 +86,7 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
         }
 
         cell.configure(date: selectedDate, period: selectedPeriod, delegate: self)
+        cell.animateGhostLayers(viewModel?.isFetchingChart() == true)
         tableHeaderView = cell
         return cell
     }
@@ -191,10 +192,16 @@ private extension SiteStatsPeriodTableViewController {
             return
         }
 
+        DDLogInfo("--- Refresh Table View")
+
         tableHandler.viewModel = viewModel.tableViewModel()
 
         if asyncLoadingActivated {
             refreshControl?.endRefreshing()
+
+            if viewModel.fetchingFailed() {
+                displayFailureViewIfNecessary()
+            }
         }
     }
 
@@ -205,7 +212,6 @@ private extension SiteStatsPeriodTableViewController {
     }
 
     func refreshData() {
-
         guard let selectedDate = selectedDate,
             let selectedPeriod = selectedPeriod,
             viewIsVisible() else {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -69,15 +69,30 @@ class SiteStatsPeriodViewModel: Observable {
                                                                                forceRefresh: true))
     }
 
+    func isFetchingChart() -> Bool {
+        return store.isFetchingSummary &&
+            !store.containsCachedData(for: .summary)
+    }
+
+    func fetchingFailed() -> Bool {
+        return store.fetchingOverviewHasFailed
+    }
+
     // MARK: - Table Model
 
     func tableViewModel() -> ImmuTable {
 
         var tableRows = [ImmuTableRow]()
 
-        if !store.containsCachedData &&
-            (store.fetchingOverviewHasFailed || store.isFetchingOverview) {
-            return ImmuTable.Empty
+        if Feature.enabled(.statsAsyncLoadingDWMY) {
+            if !store.containsCachedData && store.fetchingOverviewHasFailed {
+                return ImmuTable.Empty
+            }
+        } else {
+            if !store.containsCachedData &&
+                (store.fetchingOverviewHasFailed || store.isFetchingOverview) {
+                return ImmuTable.Empty
+            }
         }
 
         tableRows.append(contentsOf: overviewTableRows())
@@ -513,4 +528,9 @@ private extension SiteStatsPeriodViewModel {
             ?? []
     }
 
+}
+
+enum PeriodType {
+    case summary
+    case topPostsAndPages
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -529,8 +529,3 @@ private extension SiteStatsPeriodViewModel {
     }
 
 }
-
-enum PeriodType {
-    case summary
-    case topPostsAndPages
-}

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -18,8 +18,21 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
     @IBOutlet weak var forwardArrow: UIImageView!
     @IBOutlet weak var bottomSeparatorLine: UIView!
 
-    @IBOutlet weak var backButton: UIButton!
-    @IBOutlet weak var forwardButton: UIButton!
+    @IBOutlet weak var backButton: UIButton! {
+        didSet {
+            backButton.isGhostableDisabled = true
+        }
+    }
+    @IBOutlet weak var forwardButton: UIButton! {
+        didSet {
+            forwardButton.isGhostableDisabled = true
+        }
+    }
+    @IBOutlet private var containerView: UIView! {
+        didSet {
+            containerView.isGhostableDisabled = true
+        }
+    }
 
     private typealias Style = WPStyleGuide.Stats
     private weak var delegate: SiteStatsTableHeaderDelegate?
@@ -98,6 +111,17 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
 
         delegate?.dateChangedTo(self.date)
         reloadView()
+    }
+
+    func animateGhostLayers(_ animate: Bool) {
+        forwardButton.isEnabled = !animate
+        backButton.isEnabled = !animate
+
+        if animate {
+            startGhostAnimation()
+            return
+        }
+        stopGhostAnimation()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -129,6 +129,7 @@
                 <outlet property="backArrow" destination="Ssg-6U-5Ac" id="vC4-Hc-zMu"/>
                 <outlet property="backButton" destination="b3M-QS-Aux" id="d3f-cX-bL9"/>
                 <outlet property="bottomSeparatorLine" destination="82h-So-kdz" id="EKp-FJ-DKe"/>
+                <outlet property="containerView" destination="tc3-qS-cyd" id="x64-zO-RHZ"/>
                 <outlet property="dateLabel" destination="hDF-ds-FAU" id="DkU-jG-M41"/>
                 <outlet property="forwardArrow" destination="2dA-xk-MWI" id="Kz1-HD-bfG"/>
                 <outlet property="forwardButton" destination="U1z-fb-p7G" id="7OL-e9-0vu"/>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1229,6 +1229,7 @@
 		9A8ECE1D2254AE4E0043C8DA /* JetpackRemoteInstallStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8ECE1B2254AE4E0043C8DA /* JetpackRemoteInstallStateView.swift */; };
 		9A8ECE1E2254AE4E0043C8DA /* JetpackRemoteInstallStateView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A8ECE1C2254AE4E0043C8DA /* JetpackRemoteInstallStateView.xib */; };
 		9A9D34FD23607CCC00BC95A3 /* AsyncOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9D34FC23607CCC00BC95A3 /* AsyncOperationTests.swift */; };
+		9A9D34FF2360A4E200BC95A3 /* StatsPeriodAsyncOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9D34FE2360A4E200BC95A3 /* StatsPeriodAsyncOperationTests.swift */; };
 		9A9E3FA3230D5F0A00909BC4 /* StatsStackViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9E3FA2230D5F0A00909BC4 /* StatsStackViewCell.swift */; };
 		9A9E3FAD230E9DD000909BC4 /* StatsGhostCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9E3FAB230E9DD000909BC4 /* StatsGhostCells.swift */; };
 		9A9E3FAE230E9DD000909BC4 /* StatsGhostTwoColumnCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E3FAC230E9DD000909BC4 /* StatsGhostTwoColumnCell.xib */; };
@@ -3420,6 +3421,7 @@
 		9A8ECE1B2254AE4E0043C8DA /* JetpackRemoteInstallStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JetpackRemoteInstallStateView.swift; path = Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift; sourceTree = SOURCE_ROOT; };
 		9A8ECE1C2254AE4E0043C8DA /* JetpackRemoteInstallStateView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = JetpackRemoteInstallStateView.xib; path = Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.xib; sourceTree = SOURCE_ROOT; };
 		9A9D34FC23607CCC00BC95A3 /* AsyncOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperationTests.swift; sourceTree = "<group>"; };
+		9A9D34FE2360A4E200BC95A3 /* StatsPeriodAsyncOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodAsyncOperationTests.swift; sourceTree = "<group>"; };
 		9A9E3FA2230D5F0A00909BC4 /* StatsStackViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsStackViewCell.swift; sourceTree = "<group>"; };
 		9A9E3FAB230E9DD000909BC4 /* StatsGhostCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGhostCells.swift; sourceTree = "<group>"; };
 		9A9E3FAC230E9DD000909BC4 /* StatsGhostTwoColumnCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatsGhostTwoColumnCell.xib; sourceTree = "<group>"; };
@@ -7457,6 +7459,7 @@
 			isa = PBXGroup;
 			children = (
 				9A9D34FC23607CCC00BC95A3 /* AsyncOperationTests.swift */,
+				9A9D34FE2360A4E200BC95A3 /* StatsPeriodAsyncOperationTests.swift */,
 			);
 			name = Operations;
 			sourceTree = "<group>";
@@ -12021,6 +12024,7 @@
 				57D6C83E22945A10003DDC7E /* PostCompactCellTests.swift in Sources */,
 				D81C2F5C20F872C2002AE1F1 /* ReplyToCommentActionTests.swift in Sources */,
 				D848CC1720FF38EA00A9038F /* FormattableCommentRangeTests.swift in Sources */,
+				9A9D34FF2360A4E200BC95A3 /* StatsPeriodAsyncOperationTests.swift in Sources */,
 				B5EFB1C91B333C5A007608A3 /* NotificationSettingsServiceTests.swift in Sources */,
 				4089C51422371EE30031CE78 /* TodayStatsTests.swift in Sources */,
 				7E53AB0A20FE83A9005796FE /* MockContentCoordinator.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1234,6 +1234,8 @@
 		9A9E3FB0230EA7A300909BC4 /* StatsGhostTopCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E3FAF230EA7A300909BC4 /* StatsGhostTopCell.xib */; };
 		9A9E3FB2230EB74300909BC4 /* StatsGhostTabbedCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E3FB1230EB74300909BC4 /* StatsGhostTabbedCell.xib */; };
 		9A9E3FB4230EC4F700909BC4 /* StatsGhostPostingActivityCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E3FB3230EC4F700909BC4 /* StatsGhostPostingActivityCell.xib */; };
+		9AA0ADB1235F11700027AB5D /* AsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0ADB0235F116F0027AB5D /* AsyncOperation.swift */; };
+		9AA0ADB3235F11DC0027AB5D /* StatsPeriodAsyncOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0ADB2235F11DC0027AB5D /* StatsPeriodAsyncOperation.swift */; };
 		9AC3C69B231543C2007933CD /* StatsGhostChartCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9AC3C69A231543C2007933CD /* StatsGhostChartCell.xib */; };
 		9AF724EF2146813C00F63A61 /* ParentPageSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF724EE2146813C00F63A61 /* ParentPageSettingsViewController.swift */; };
 		9AF9551821A1D7970057827C /* DiffAbstractValue+Attributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF9551721A1D7970057827C /* DiffAbstractValue+Attributes.swift */; };
@@ -3422,6 +3424,8 @@
 		9A9E3FAF230EA7A300909BC4 /* StatsGhostTopCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatsGhostTopCell.xib; sourceTree = "<group>"; };
 		9A9E3FB1230EB74300909BC4 /* StatsGhostTabbedCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatsGhostTabbedCell.xib; sourceTree = "<group>"; };
 		9A9E3FB3230EC4F700909BC4 /* StatsGhostPostingActivityCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatsGhostPostingActivityCell.xib; sourceTree = "<group>"; };
+		9AA0ADB0235F116F0027AB5D /* AsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperation.swift; sourceTree = "<group>"; };
+		9AA0ADB2235F11DC0027AB5D /* StatsPeriodAsyncOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodAsyncOperation.swift; sourceTree = "<group>"; };
 		9AC3C69A231543C2007933CD /* StatsGhostChartCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatsGhostChartCell.xib; sourceTree = "<group>"; };
 		9AE21A3D2181ED8C002D4FE2 /* WordPress 82.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 82.xcdatamodel"; sourceTree = "<group>"; };
 		9AF724EE2146813C00F63A61 /* ParentPageSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentPageSettingsViewController.swift; sourceTree = "<group>"; };
@@ -5291,6 +5295,7 @@
 		3792259E12F6DBCC00F2176A /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				9AA0ADAF235F11500027AB5D /* Operation */,
 				73FF702D221F43BB00541798 /* Charts */,
 				98747670219638990080967F /* Extensions */,
 				98747674219644E40080967F /* Helpers */,
@@ -7444,6 +7449,15 @@
 				9A8ECE0B2254A3260043C8DA /* JetpackInstallError+Blocking.swift */,
 			);
 			path = Error;
+			sourceTree = "<group>";
+		};
+		9AA0ADAF235F11500027AB5D /* Operation */ = {
+			isa = PBXGroup;
+			children = (
+				9AA0ADB0235F116F0027AB5D /* AsyncOperation.swift */,
+				9AA0ADB2235F11DC0027AB5D /* StatsPeriodAsyncOperation.swift */,
+			);
+			path = Operation;
 			sourceTree = "<group>";
 		};
 		AC3439790E11434600E5D79B /* Post */ = {
@@ -10778,6 +10792,7 @@
 				17BD4A192101D31B00975AC3 /* NavigationActionHelpers.swift in Sources */,
 				B55FFCFA1F034F1A0070812C /* String+Ranges.swift in Sources */,
 				7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */,
+				9AA0ADB1235F11700027AB5D /* AsyncOperation.swift in Sources */,
 				FF8791BB1FBAF4B500AD86E6 /* MediaService+Swift.swift in Sources */,
 				D8212CB920AA77AD008E8AE8 /* ReaderActionHelpers.swift in Sources */,
 				B52C4C7D199D4CD3009FD823 /* NoteBlockUserTableViewCell.swift in Sources */,
@@ -11271,6 +11286,7 @@
 				FF0D8146205809C8000EE505 /* PostCoordinator.swift in Sources */,
 				7EA30DB621ADA20F0092F894 /* AztecAttachmentDelegate.swift in Sources */,
 				82B67B361FC726CD006FB593 /* Memoize.swift in Sources */,
+				9AA0ADB3235F11DC0027AB5D /* StatsPeriodAsyncOperation.swift in Sources */,
 				B5DBE4FE1D21A700002E81D3 /* NotificationsViewController.swift in Sources */,
 				E1B84F001E02E94D00BF6434 /* PingHubManager.swift in Sources */,
 				E1CECE051E6F01CE009C6695 /* PostPreviewGenerator.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1228,6 +1228,7 @@
 		9A8ECE132254A3260043C8DA /* JetpackInstallError+Blocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8ECE0B2254A3260043C8DA /* JetpackInstallError+Blocking.swift */; };
 		9A8ECE1D2254AE4E0043C8DA /* JetpackRemoteInstallStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8ECE1B2254AE4E0043C8DA /* JetpackRemoteInstallStateView.swift */; };
 		9A8ECE1E2254AE4E0043C8DA /* JetpackRemoteInstallStateView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A8ECE1C2254AE4E0043C8DA /* JetpackRemoteInstallStateView.xib */; };
+		9A9D34FD23607CCC00BC95A3 /* AsyncOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9D34FC23607CCC00BC95A3 /* AsyncOperationTests.swift */; };
 		9A9E3FA3230D5F0A00909BC4 /* StatsStackViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9E3FA2230D5F0A00909BC4 /* StatsStackViewCell.swift */; };
 		9A9E3FAD230E9DD000909BC4 /* StatsGhostCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9E3FAB230E9DD000909BC4 /* StatsGhostCells.swift */; };
 		9A9E3FAE230E9DD000909BC4 /* StatsGhostTwoColumnCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A9E3FAC230E9DD000909BC4 /* StatsGhostTwoColumnCell.xib */; };
@@ -3418,6 +3419,7 @@
 		9A8ECE0B2254A3260043C8DA /* JetpackInstallError+Blocking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "JetpackInstallError+Blocking.swift"; sourceTree = "<group>"; };
 		9A8ECE1B2254AE4E0043C8DA /* JetpackRemoteInstallStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JetpackRemoteInstallStateView.swift; path = Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift; sourceTree = SOURCE_ROOT; };
 		9A8ECE1C2254AE4E0043C8DA /* JetpackRemoteInstallStateView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = JetpackRemoteInstallStateView.xib; path = Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.xib; sourceTree = SOURCE_ROOT; };
+		9A9D34FC23607CCC00BC95A3 /* AsyncOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncOperationTests.swift; sourceTree = "<group>"; };
 		9A9E3FA2230D5F0A00909BC4 /* StatsStackViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsStackViewCell.swift; sourceTree = "<group>"; };
 		9A9E3FAB230E9DD000909BC4 /* StatsGhostCells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsGhostCells.swift; sourceTree = "<group>"; };
 		9A9E3FAC230E9DD000909BC4 /* StatsGhostTwoColumnCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatsGhostTwoColumnCell.xib; sourceTree = "<group>"; };
@@ -7451,6 +7453,14 @@
 			path = Error;
 			sourceTree = "<group>";
 		};
+		9A9D34FB23607C8400BC95A3 /* Operations */ = {
+			isa = PBXGroup;
+			children = (
+				9A9D34FC23607CCC00BC95A3 /* AsyncOperationTests.swift */,
+			);
+			name = Operations;
+			sourceTree = "<group>";
+		};
 		9AA0ADAF235F11500027AB5D /* Operation */ = {
 			isa = PBXGroup;
 			children = (
@@ -8685,6 +8695,7 @@
 				5D7A577D1AFBFD7C0097C028 /* Models */,
 				85F8E1991B017A8E000859BB /* Networking */,
 				B5416CF81C17542900006DD8 /* Notifications */,
+				9A9D34FB23607C8400BC95A3 /* Operations */,
 				59ECF8791CB705EB00E68F25 /* Posts */,
 				436D55EE2115CB3D00CEAA33 /* RegisterDomain */,
 				E6B9B8AB1B94EA710001B92F /* Reader */,
@@ -11977,6 +11988,7 @@
 				D800D87820999B6D00E7C7E5 /* LikedMenuItemCreatorTests.swift in Sources */,
 				D816B8CA2112D2FD0052CE4D /* LocalNewsServiceTests.swift in Sources */,
 				D800D87A20999C0500E7C7E5 /* OtherMenuItemCreatorTests.swift in Sources */,
+				9A9D34FD23607CCC00BC95A3 /* AsyncOperationTests.swift in Sources */,
 				B5552D821CD1061F00B26DF6 /* StringExtensionsTests.swift in Sources */,
 				73178C3521BEE9AC00E37C9A /* TitleSubtitleHeaderTests.swift in Sources */,
 				08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */,

--- a/WordPress/WordPressTest/AsyncOperationTests.swift
+++ b/WordPress/WordPressTest/AsyncOperationTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import WordPress
+
+class AsyncOperationTests: XCTestCase {
+    let operation = AsyncOperation()
+
+    func testIsAsynchronous() {
+        XCTAssertTrue(operation.isAsynchronous)
+    }
+
+    func testDefaultState() {
+        XCTAssertTrue(operation.state == AsyncOperation.State.isReady)
+    }
+
+    func testIsExecutingState() {
+        operation.start()
+        XCTAssertTrue(operation.isExecuting)
+    }
+
+    func testIsFinishedState() {
+        operation.cancel()
+        operation.start()
+        XCTAssertTrue(operation.isFinished)
+    }
+}

--- a/WordPress/WordPressTest/StatsPeriodAsyncOperationTests.swift
+++ b/WordPress/WordPressTest/StatsPeriodAsyncOperationTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import WordPress
+@testable import WordPressKit
+
+class StatsPeriodAsyncOperationTests: XCTestCase {
+    private let date = Date()
+    private let operationQueue = OperationQueue()
+    private lazy var mockRemoteService: MockStatsServiceRemoteV2 = {
+        return MockStatsServiceRemoteV2(wordPressComRestApi: MockWordPressComRestApi(),
+                                        siteID: 0,
+                                        siteTimezone: TimeZone.current)
+    }()
+
+    func testStatsPeriodOperation() {
+        let expect = expectation(description: "Add Stats Period Operation")
+        let operation = StatsPeriodAsyncOperation(service: mockRemoteService, for: .day, date: date) { [unowned self] (item: MockStatsType?, error: Error?) in
+            XCTAssertNotNil(item)
+            XCTAssertTrue(item?.period == .day)
+            XCTAssertTrue(item?.periodEndDate == self.date)
+            expect.fulfill()
+        }
+
+        operationQueue.addOperation(operation)
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+}
+
+private extension StatsPeriodAsyncOperationTests {
+    class MockStatsServiceRemoteV2: StatsServiceRemoteV2 {
+        override func getData<TimeStatsType: StatsTimeIntervalData>(for period: StatsPeriodUnit,
+                                                                    endingOn: Date,
+                                                                    limit: Int = 10,
+                                                                    completion: @escaping ((TimeStatsType?, Error?) -> Void)) {
+            let mockType = TimeStatsType(date: endingOn,
+                                         period: period,
+                                         jsonDictionary: [:])
+            completion(mockType, nil)
+        }
+    }
+
+    struct MockStatsType: StatsTimeIntervalData {
+        static var pathComponent: String {
+            return "test/path"
+        }
+
+        var period: StatsPeriodUnit
+        var periodEndDate: Date
+        var jsonDictionary: [String: AnyObject]
+
+        init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
+            self.periodEndDate = date
+            self.period = period
+            self.jsonDictionary = jsonDictionary
+        }
+    }
+}


### PR DESCRIPTION
Refs. #12147 
Refs. #11852

This is the first step to allow DWMY to load the blocks independently adding a new feature flag `statsAsyncLoadingDWMY` and the `AsyncOperation` class.

## To test:
- [ ] Run `AsyncOperationTests`
- [ ] Run `StatsPeriodAsyncOperationTests`
- [ ] Run the branch:
1. Open Stats -> DWMY from a Site you never opened before (or from a fresh install)
2. Yous shouldn't see the NRV
3. You should be able to load the chart and Top Posts card
4. Disable the feature flag and make sure everything works as before

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
