### PR TITLE
Deleted post with local changes appears only under Trashed tab

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -487,6 +487,8 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
                 [self.managedObjectContext deleteObject:post];
             } else {
                 [self updatePost:postInContext withRemotePost:remotePost];
+                postInContext.latest.statusAfterSync = postInContext.statusAfterSync;
+                postInContext.latest.status = postInContext.status;
             }
             [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
         }

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -129,6 +129,8 @@ class PostServiceWPComTests: XCTestCase {
         }
 
         // Assert
+        expect(post.statusAfterSync).to(equal(.trash))
+        expect(post.status).to(equal(.trash))
         expect(revision.statusAfterSync).to(equal(.trash))
         expect(revision.status).to(equal(.trash))
      }


### PR DESCRIPTION
Fixes #12763

To test:

1. Publish a post
2. While offline, edit the post and tap "Update"
3. Tap "Cancel" in the post list
4. Go back online, wait for the post to be autosaved
5. Tap More -> "Move to Trash"
6. Refresh the list, the post will appear only under "Trashed"

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 