### PR TITLE
Do full link selection fix only on 13.0

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1350,14 +1350,18 @@ extension AztecPostViewController: UITextViewDelegate {
     }
 
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        // Sergio Estevao: This shouldn't happen in an editable textView, but it looks we have a system bug in iOS13 so we need this workaround
-        if !textView.isFirstResponder {
-            textView.becomeFirstResponder()
+
+        if #available(iOS 13.1, *) {
+            return false
+        } else if #available(iOS 13.0.0, *) {
+            // Sergio Estevao: This shouldn't happen in an editable textView, but it looks we have a system bug in iOS13 so we need this workaround
+            let position = characterRange.location
+            textView.selectedRange = NSRange(location: position, length: 0)
+            textView.typingAttributes = textView.attributedText.attributes(at: position, effectiveRange: nil)
+            textView.delegate?.textViewDidChangeSelection?(textView)
+            updateFormatBar()
         }
-        let position = characterRange.location
-        textView.selectedRange = NSRange(location: position, length: 0)
-        textView.typingAttributes = textView.attributedText.attributes(at: position, effectiveRange: nil)
-        updateFormatBar()
+
         return false
     }
 


### PR DESCRIPTION
Fixes #12626

To test:
 - Check the scenario referred in the ticket to see if the bug still happens

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
