### PR TITLE
[Stats Refresh] DWMY Async loading and Ghost views

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1,9 +1,12 @@
 import Foundation
 import WordPressFlux
 
-enum PeriodType {
+enum PeriodType: CaseIterable {
     case summary
     case topPostsAndPages
+    case topReferrers
+    case topPublished
+    case topClicks
 }
 
 enum PeriodAction: Action {
@@ -131,14 +134,17 @@ struct PeriodStoreState {
     var fetchingPostsAndPagesHasFailed = false
 
     var topReferrers: StatsTopReferrersTimeIntervalData?
+    var topReferrersStatus: StoreFetchingStatus = .idle
     var fetchingReferrers = false
     var fetchingReferrersHasFailed = false
 
     var topClicks: StatsTopClicksTimeIntervalData?
+    var topClicksStatus: StoreFetchingStatus = .idle
     var fetchingClicks = false
     var fetchingClicksHasFailed = false
 
     var topPublished: StatsPublishedPostsTimeIntervalData?
+    var topPublishedStatus: StoreFetchingStatus = .idle
     var fetchingPublished = false
     var fetchingPublishedHasFailed = false
 
@@ -171,6 +177,7 @@ struct PeriodStoreState {
 
 class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
     private typealias PeriodOperation = StatsPeriodAsyncOperation
+    private typealias PublishedPostOperation = StatsPublishedPostsAsyncOperation
 
     var fetchingOverviewListener: ((_ fetching: Bool, _ success: Bool) -> Void)?
     var cachedDataListener: ((_ hasCachedData: Bool) -> Void)?
@@ -178,6 +185,7 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
     private var statsServiceRemote: StatsServiceRemoteV2?
     private var operationQueue = OperationQueue()
     private let scheduler = Scheduler(seconds: 0.3)
+    private let asyncLoadingActivated = Feature.enabled(.statsAsyncLoadingDWMY)
 
     init() {
         super.init(initialState: PeriodStoreState())
@@ -336,14 +344,14 @@ private extension StatsPeriodStore {
         loadFromCache(date: date, period: period)
 
         guard shouldFetchOverview() else {
-            if !Feature.enabled(.statsAsyncLoadingDWMY) {
+            if !asyncLoadingActivated {
                 fetchingOverviewListener?(true, false)
             }
             DDLogInfo("Stats Period Overview refresh triggered while one was in progress.")
             return
         }
 
-        if Feature.enabled(.statsAsyncLoadingDWMY) {
+        if asyncLoadingActivated {
             setAllFetchingStatus(.loading)
             scheduler.debounce { [weak self] in
                 self?.fetchChartData(date: date, period: period)
@@ -395,7 +403,7 @@ private extension StatsPeriodStore {
                 DDLogError("Stats Period: Error fetching likes summary: \(String(describing: error?.localizedDescription))")
             }
 
-            DDLogInfo("Stats Period:  Finished fetching likes summary.")
+            DDLogInfo("Stats Period: Finished fetching likes summary.")
             DispatchQueue.main.async {
                 self?.receivedLikesSummary(likes, error)
             }
@@ -413,8 +421,47 @@ private extension StatsPeriodStore {
             }
         }
 
+        let topReferrers = PeriodOperation(service: service, for: period, date: date) { [weak self] (referrers: StatsTopReferrersTimeIntervalData?, error: Error?) in
+            if error != nil {
+                DDLogError("Stats Period: Error fetching referrers: \(String(describing: error?.localizedDescription))")
+            }
+
+            DDLogInfo("Stats Period: Finished fetching referrers.")
+
+            DispatchQueue.main.async {
+                self?.receivedReferrers(referrers, error)
+            }
+        }
+
+        let topPublished = PublishedPostOperation(service: service, for: period, date: date) { [weak self] (published: StatsPublishedPostsTimeIntervalData?, error: Error?) in
+            if error != nil {
+                DDLogError("Stats Period: Error fetching published: \(String(describing: error?.localizedDescription))")
+            }
+
+            DDLogInfo("Stats Period: Finished fetching published.")
+
+            DispatchQueue.main.async {
+                self?.receivedPublished(published, error)
+            }
+        }
+
+        let topClicks = PeriodOperation(service: service, for: period, date: date) { [weak self] (clicks: StatsTopClicksTimeIntervalData?, error: Error?) in
+            if error != nil {
+                DDLogError("Stats Period: Error fetching clicks: \(String(describing: error?.localizedDescription))")
+            }
+
+            DDLogInfo("Stats Period: Finished fetching clicks.")
+
+            DispatchQueue.main.async {
+                self?.receivedClicks(clicks, error)
+            }
+        }
+
         operationQueue.addOperations([likesOperation,
-                                      topPostsOperation],
+                                      topPostsOperation,
+                                      topReferrers,
+                                      topPublished,
+                                      topClicks],
                                      waitUntilFinished: false)
     }
 
@@ -593,7 +640,7 @@ private extension StatsPeriodStore {
         // when user has left the screen/app, we would possibly lose on storing A LOT of data.
         persistToCoreData()
 
-        if forceRefresh && !Feature.enabled(.statsAsyncLoadingDWMY) {
+        if forceRefresh && !asyncLoadingActivated {
             setAllAsFetchingOverview(fetching: false)
             cancelQueries()
         }
@@ -940,6 +987,7 @@ private extension StatsPeriodStore {
         transaction { state in
             state.fetchingReferrers = false
             state.fetchingReferrersHasFailed = error != nil
+            state.topReferrersStatus = error != nil ? .error : .success
 
             if referrers != nil {
                 state.topReferrers = referrers
@@ -951,6 +999,7 @@ private extension StatsPeriodStore {
         transaction { state in
             state.fetchingClicks = false
             state.fetchingClicksHasFailed = error != nil
+            state.topClicksStatus = error != nil ? .error : .success
 
             if clicks != nil {
                 state.topClicks = clicks
@@ -973,6 +1022,7 @@ private extension StatsPeriodStore {
         transaction { state in
             state.fetchingPublished = false
             state.fetchingPublishedHasFailed = error != nil
+            state.topPublishedStatus = error != nil ? .error : .success
 
             if published != nil {
                 state.topPublished = published
@@ -1083,6 +1133,9 @@ private extension StatsPeriodStore {
     func setAllFetchingStatus(_ status: StoreFetchingStatus) {
         state.summaryStatus = status
         state.topPostsAndPagesStatus = status
+        state.topReferrersStatus = status
+        state.topPublishedStatus = status
+        state.topClicksStatus = status
     }
 
     func shouldFetchPostsAndPages() -> Bool {
@@ -1212,12 +1265,24 @@ extension StatsPeriodStore {
         return state.topPostsAndPagesStatus
     }
 
+    var topReferrersStatus: StoreFetchingStatus {
+        return state.topReferrersStatus
+    }
+
+    var topPublishedStatus: StoreFetchingStatus {
+        return state.topPublishedStatus
+    }
+
+    var topClicksStatus: StoreFetchingStatus {
+        return state.topClicksStatus
+    }
+
     var isFetchingSummaryLikes: Bool {
         return state.fetchingSummaryLikes
     }
 
     var isFetchingPostsAndPages: Bool {
-        if Feature.enabled(.statsAsyncLoadingDWMY) {
+        if asyncLoadingActivated {
             return topPostsAndPagesStatus == .loading
         }
         return state.fetchingPostsAndPages
@@ -1232,6 +1297,9 @@ extension StatsPeriodStore {
     }
 
     var isFetchingClicks: Bool {
+        if asyncLoadingActivated {
+            return topClicksStatus == .loading
+        }
         return state.fetchingClicks
     }
 
@@ -1240,6 +1308,9 @@ extension StatsPeriodStore {
     }
 
     var isFetchingReferrers: Bool {
+        if asyncLoadingActivated {
+            return topReferrersStatus == .loading
+        }
         return state.fetchingReferrers
     }
 
@@ -1248,6 +1319,9 @@ extension StatsPeriodStore {
     }
 
     var isFetchingPublished: Bool {
+        if asyncLoadingActivated {
+            return topPublishedStatus == .loading
+        }
         return state.fetchingPublished
     }
 
@@ -1256,9 +1330,11 @@ extension StatsPeriodStore {
     }
 
     var fetchingOverviewHasFailed: Bool {
-        if Feature.enabled(.statsAsyncLoadingDWMY) {
-            return state.summaryStatus == .error &&
-                state.topPostsAndPagesStatus == .error
+        if asyncLoadingActivated {
+            return [state.summaryStatus,
+                    state.topPostsAndPagesStatus,
+                    state.topReferrersStatus,
+                    state.topPublishedStatus].first { $0 != .error } == nil
         }
 
         return state.fetchingSummaryHasFailed &&
@@ -1301,9 +1377,8 @@ extension StatsPeriodStore {
     }
 
     var containsCachedData: Bool {
-        if Feature.enabled(.statsAsyncLoadingDWMY) {
-            return containsCachedData(for: [.summary,
-                                            .topPostsAndPages])
+        if asyncLoadingActivated {
+            return containsCachedData(for: PeriodType.allCases)
         }
 
         if state.summary != nil ||

--- a/WordPress/Classes/Stores/StatsStore+Cache.swift
+++ b/WordPress/Classes/Stores/StatsStore+Cache.swift
@@ -56,6 +56,12 @@ extension StatsPeriodStore: StatsStoreCacheable {
             return state.summary != nil
         case .topPostsAndPages:
             return state.topPostsAndPages != nil
+        case .topReferrers:
+            return state.topReferrers != nil
+        case .topPublished:
+            return state.topPublished != nil
+        case .topClicks:
+            return state.topClicks != nil
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -56,6 +56,10 @@ class SiteStatsInsightsViewModel: Observable {
         }
 
         insightsToShow.forEach { insightType in
+            let errorBlock = {
+                return StatsErrorRow(rowStatus: .error, statType: .insights)
+            }
+
             switch insightType {
             case .customize:
                 if FeatureFlag.statsInsightsManagement.enabled {
@@ -64,131 +68,142 @@ class SiteStatsInsightsViewModel: Observable {
             case .latestPostSummary:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsLatestPostSummary,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .latestPostSummary,
-                                     rowStatus: insightsStore.lastPostSummaryStatus,
-                                     rowBlock: {
-                                        return LatestPostSummaryRow(summaryData: insightsStore.getLastPostInsight(),
-                                                                    chartData: insightsStore.getPostStats(),
-                                                                    siteStatsInsightsDelegate: siteStatsInsightsDelegate)
-                }, loadingRow: {
+                tableRows.append(blocks(for: .latestPostSummary,
+                                        type: .insights,
+                                        status: insightsStore.lastPostSummaryStatus,
+                                        block: {
+                                            return LatestPostSummaryRow(summaryData: insightsStore.getLastPostInsight(),
+                                                                        chartData: insightsStore.getPostStats(),
+                                                                        siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+                }, loading: {
                     return StatsGhostChartImmutableRow()
-                }))
+                }, error: errorBlock))
             case .allTimeStats:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsAllTime,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .allTimeStats,
-                                     rowStatus: insightsStore.allTimeStatus,
-                                     rowBlock: {
-                                        return TwoColumnStatsRow(dataRows: createAllTimeStatsRows(),
-                                                                 statSection: .insightsAllTime,
-                                                                 siteStatsInsightsDelegate: nil)
-                }, loadingRow: {
+                tableRows.append(blocks(for: .allTimeStats,
+                                        type: .insights,
+                                        status: insightsStore.allTimeStatus,
+                                        block: {
+                                            return TwoColumnStatsRow(dataRows: createAllTimeStatsRows(),
+                                                                     statSection: .insightsAllTime,
+                                                                     siteStatsInsightsDelegate: nil)
+                }, loading: {
                     return StatsGhostTwoColumnImmutableRow()
-                }))
+                }, error: errorBlock))
             case .followersTotals:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsFollowerTotals,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .followersTotals,
-                                     rowStatus: insightsStore.followersTotalsStatus,
-                                     rowBlock: {
-                                        return TwoColumnStatsRow(dataRows: createTotalFollowersRows(),
-                                                                 statSection: .insightsFollowerTotals,
-                                                                 siteStatsInsightsDelegate: nil)
-                }, loadingRow: {
+                tableRows.append(blocks(for: .followersTotals,
+                                        type: .insights,
+                                        status: insightsStore.followersTotalsStatus,
+                                        block: {
+                                            return TwoColumnStatsRow(dataRows: createTotalFollowersRows(),
+                                                                     statSection: .insightsFollowerTotals,
+                                                                     siteStatsInsightsDelegate: nil)
+                }, loading: {
                     return StatsGhostTwoColumnImmutableRow()
-                }))
+                }, error: errorBlock))
             case .mostPopularTime:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsMostPopularTime,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .mostPopularTime,
-                                     rowStatus: insightsStore.annualAndMostPopularTimeStatus,
-                                     rowBlock: {
-                                        return TwoColumnStatsRow(dataRows: createMostPopularStatsRows(),
-                                                                 statSection: .insightsMostPopularTime,
-                                                                 siteStatsInsightsDelegate: nil)
-                }, loadingRow: {
+                tableRows.append(blocks(for: .mostPopularTime,
+                                        type: .insights,
+                                        status: insightsStore.annualAndMostPopularTimeStatus,
+                                        block: {
+                                            return TwoColumnStatsRow(dataRows: createMostPopularStatsRows(),
+                                                                     statSection: .insightsMostPopularTime,
+                                                                     siteStatsInsightsDelegate: nil)
+                }, loading: {
                     return StatsGhostTwoColumnImmutableRow()
-                }))
+                }, error: errorBlock))
             case .tagsAndCategories:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsTagsAndCategories,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .tagsAndCategories,
-                                     rowStatus: insightsStore.tagsAndCategoriesStatus,
-                                     rowBlock: {
-                                        return TopTotalsInsightStatsRow(itemSubtitle: StatSection.insightsTagsAndCategories.itemSubtitle,
-                                                                        dataSubtitle: StatSection.insightsTagsAndCategories.dataSubtitle,
-                                                                        dataRows: createTagsAndCategoriesRows(),
-                                                                        siteStatsInsightsDelegate: siteStatsInsightsDelegate)
-                }, loadingRow: {
+                tableRows.append(blocks(for: .tagsAndCategories,
+                                        type: .insights,
+                                        status: insightsStore.tagsAndCategoriesStatus,
+                                        block: {
+                                            return TopTotalsInsightStatsRow(itemSubtitle: StatSection.insightsTagsAndCategories.itemSubtitle,
+                                                                            dataSubtitle: StatSection.insightsTagsAndCategories.dataSubtitle,
+                                                                            dataRows: createTagsAndCategoriesRows(),
+                                                                            siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+                }, loading: {
                     return StatsGhostTopImmutableRow()
-                }))
+                }, error: errorBlock))
             case .annualSiteStats:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsAnnualSiteStats,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .annualSiteStats,
-                                     rowStatus: insightsStore.annualAndMostPopularTimeStatus,
-                                     rowBlock: {
-                                        return TwoColumnStatsRow(dataRows: createAnnualRows(),
-                                                                 statSection: .insightsAnnualSiteStats,
-                                                                 siteStatsInsightsDelegate: siteStatsInsightsDelegate)
-                }, loadingRow: {
+                tableRows.append(blocks(for: .annualSiteStats,
+                                        type: .insights,
+                                        status: insightsStore.annualAndMostPopularTimeStatus,
+                                        block: {
+                                            return TwoColumnStatsRow(dataRows: createAnnualRows(),
+                                                                     statSection: .insightsAnnualSiteStats,
+                                                                     siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+                }, loading: {
                     return StatsGhostTwoColumnImmutableRow()
-                }))
+                }, error: errorBlock))
             case .comments:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsCommentsPosts,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .comments,
-                                     rowStatus: insightsStore.commentsInsightStatus,
-                                     rowBlock: {
-                                        return createCommentsRow()
-                }, loadingRow: {
+                tableRows.append(blocks(for: .comments,
+                                        type: .insights,
+                                        status: insightsStore.commentsInsightStatus,
+                                        block: {
+                                            return createCommentsRow()
+                }, loading: {
                     return StatsGhostTabbedImmutableRow()
-                }))
+                }, error: errorBlock))
             case .followers:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsFollowersWordPress,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .followers,
-                                     rowStatus: insightsStore.followersTotalsStatus,
-                                     rowBlock: {
-                                        return createFollowersRow()
-                }, loadingRow: {
+                tableRows.append(blocks(for: .followers,
+                                        type: .insights,
+                                        status: insightsStore.followersTotalsStatus,
+                                        block: {
+                                            return createFollowersRow()
+                }, loading: {
                     return StatsGhostTabbedImmutableRow()
-                }))
+                }, error: errorBlock))
             case .todaysStats:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsTodaysStats,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .todaysStats,
-                                     rowStatus: insightsStore.todaysStatsStatus,
-                                     rowBlock: {
-                                        return TwoColumnStatsRow(dataRows: createTodaysStatsRows(),
-                                                                 statSection: .insightsTodaysStats,
-                                                                 siteStatsInsightsDelegate: nil)
-                }, loadingRow: {
+                tableRows.append(blocks(for: .todaysStats,
+                                        type: .insights,
+                                        status: insightsStore.todaysStatsStatus,
+                                        block: {
+                                            return TwoColumnStatsRow(dataRows: createTodaysStatsRows(),
+                                                                     statSection: .insightsTodaysStats,
+                                                                     siteStatsInsightsDelegate: nil)
+                }, loading: {
                     return StatsGhostTwoColumnImmutableRow()
-                }))
+                }, error: errorBlock))
             case .postingActivity:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsPostingActivity,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .postingActivity,
-                                     rowStatus: insightsStore.postingActivityStatus,
-                                     rowBlock: {
-                                        return createPostingActivityRow()
-                }, loadingRow: {
+                tableRows.append(blocks(for: .postingActivity,
+                                        type: .insights,
+                                        status: insightsStore.postingActivityStatus,
+                                        block: {
+                                            return createPostingActivityRow()
+                }, loading: {
                     return StatsGhostPostingActivitiesImmutableRow()
-                }))
+                }, error: errorBlock))
             case .publicize:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsPublicize,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                tableRows.append(row(for: .publicize,
-                                     rowStatus: insightsStore.publicizeFollowersStatus,
-                                     rowBlock: {
-                                        return TopTotalsInsightStatsRow(itemSubtitle: StatSection.insightsPublicize.itemSubtitle,
-                                                                        dataSubtitle: StatSection.insightsPublicize.dataSubtitle,
-                                                                        dataRows: createPublicizeRows(),
-                                                                        siteStatsInsightsDelegate: nil)
-                }, loadingRow: {
+                tableRows.append(blocks(for: .publicize,
+                                        type: .insights,
+                                        status: insightsStore.publicizeFollowersStatus,
+                                        block: {
+                                            return TopTotalsInsightStatsRow(itemSubtitle: StatSection.insightsPublicize.itemSubtitle,
+                                                                            dataSubtitle: StatSection.insightsPublicize.dataSubtitle,
+                                                                            dataRows: createPublicizeRows(),
+                                                                            siteStatsInsightsDelegate: nil)
+                }, loading: {
                     return StatsGhostTopImmutableRow()
-                }))
+                }, error: errorBlock))
             default:
                 break
             }
@@ -554,19 +569,12 @@ private extension SiteStatsInsightsViewModel {
                                  icon: Style.imageForGridiconType(.plus, withTint: .darkGrey),
                                  statSection: .insightsAddInsight)
     }
+}
 
-    func row(for insight: InsightType, rowStatus: StoreFetchingStatus, rowBlock: () -> ImmuTableRow, loadingRow: () -> ImmuTableRow) -> ImmuTableRow {
-        if insightsStore.containsCachedData(for: insight) || !Feature.enabled(.statsAsyncLoading) {
-            return rowBlock()
-        }
+extension SiteStatsInsightsViewModel: AsyncBlocksLoadable {
+    typealias RowType = InsightType
 
-        switch rowStatus {
-        case .loading, .idle:
-            return loadingRow()
-        case .success:
-            return rowBlock()
-        case .error:
-            return StatsErrorRow(rowStatus: rowStatus, statType: .insights)
-        }
+    var currentStore: StatsInsightsStore {
+        return insightsStore
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Operation/StatsPeriodAsyncOperation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Operation/StatsPeriodAsyncOperation.swift
@@ -26,3 +26,32 @@ final class StatsPeriodAsyncOperation<TimeStatsType: StatsTimeIntervalData>: Asy
         }
     }
 }
+
+final class StatsPublishedPostsAsyncOperation: AsyncOperation {
+    typealias StatsPeriodCompletion = (StatsPublishedPostsTimeIntervalData?, Error?) -> Void
+
+    private weak var service: StatsServiceRemoteV2?
+    private let period: StatsPeriodUnit
+    private let date: Date
+    private let limit: Int
+    private var completion: StatsPeriodCompletion
+
+    init(service: StatsServiceRemoteV2, for period: StatsPeriodUnit, date: Date, limit: Int = 10, completion: @escaping StatsPeriodCompletion) {
+        self.service = service
+        self.period = period
+        self.date = date
+        self.limit = limit
+        self.completion = completion
+    }
+
+    override func main() {
+        service?.getData(for: period, endingOn: date, limit: limit) { [unowned self] (published: StatsPublishedPostsTimeIntervalData?, error: Error?) in
+            if self.isCancelled {
+                self.state = .isFinished
+                return
+            }
+
+            self.completion(published, error)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -175,26 +175,34 @@ private extension SiteStatsPeriodTableViewController {
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
-        return [PeriodEmptyCellHeaderRow.self,
-                CellHeaderRow.self,
-                TopTotalsPeriodStatsRow.self,
-                TopTotalsNoSubtitlesPeriodStatsRow.self,
-                CountriesStatsRow.self,
-                CountriesMapRow.self,
-                OverviewRow.self,
-                TableFooterRow.self]
+        var rows: [ImmuTableRow.Type] = [PeriodEmptyCellHeaderRow.self,
+                                         CellHeaderRow.self,
+                                         TopTotalsPeriodStatsRow.self,
+                                         TopTotalsNoSubtitlesPeriodStatsRow.self,
+                                         CountriesStatsRow.self,
+                                         CountriesMapRow.self,
+                                         OverviewRow.self,
+                                         TableFooterRow.self]
+        if asyncLoadingActivated {
+            rows.append(contentsOf: [StatsErrorRow.self,
+                                     StatsGhostChartImmutableRow.self,
+                                     StatsGhostTopImmutableRow.self])
+        }
+        return rows
     }
 
     // MARK: - Table Refreshing
 
     func refreshTableView() {
-        guard let viewModel = viewModel,
-            viewIsVisible(),
-            !store.isFetchingOverview else {
+        guard let viewModel = viewModel else {
             return
         }
 
-        DDLogInfo("--- Refresh Table View")
+        if !viewIsVisible(),
+            store.isFetchingOverview,
+            !asyncLoadingActivated {
+            return
+        }
 
         tableHandler.viewModel = viewModel.tableViewModel()
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -95,8 +95,26 @@ class SiteStatsPeriodViewModel: Observable {
             }
         }
 
-        tableRows.append(contentsOf: overviewTableRows())
-        tableRows.append(contentsOf: postsAndPagesTableRows())
+        let errorBlock = {
+            return [StatsErrorRow(rowStatus: .error, statType: .period)]
+        }
+
+        tableRows.append(contentsOf: blocks(for: .summary,
+                                            type: .period,
+                                            status: store.summaryStatus,
+                                            block: { [weak self] in
+                                                return self?.overviewTableRows() ?? []
+            }, loading: {
+                return [StatsGhostChartImmutableRow()]
+        }, error: errorBlock))
+        tableRows.append(contentsOf: blocks(for: .topPostsAndPages,
+                                            type: .period,
+                                            status: store.topPostsAndPagesStatus,
+                                            block: { [weak self] in
+                                                return self?.postsAndPagesTableRows() ?? []
+            }, loading: {
+                return [StatsGhostChartImmutableRow()]
+        }, error: errorBlock))
         tableRows.append(contentsOf: referrersTableRows())
         tableRows.append(contentsOf: clicksTableRows())
         tableRows.append(contentsOf: authorsTableRows())
@@ -528,4 +546,12 @@ private extension SiteStatsPeriodViewModel {
             ?? []
     }
 
+}
+
+extension SiteStatsPeriodViewModel: AsyncBlocksLoadable {
+    typealias RowType = PeriodType
+
+    var currentStore: StatsPeriodStore {
+        return store
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -71,7 +71,7 @@ class SiteStatsPeriodViewModel: Observable {
 
     func isFetchingChart() -> Bool {
         return store.isFetchingSummary &&
-            !store.containsCachedData(for: .summary)
+            mostRecentChartData == nil
     }
 
     func fetchingFailed() -> Bool {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -113,7 +113,7 @@ class SiteStatsPeriodViewModel: Observable {
                                             status: store.summaryStatus,
                                             checkingCache: { [weak self] in
                                                 return self?.mostRecentChartData != nil
-                                            },
+            },
                                             block: { [weak self] in
                                                 return self?.overviewTableRows() ?? summaryErrorBlock()
             }, loading: {
@@ -130,34 +130,34 @@ class SiteStatsPeriodViewModel: Observable {
                 return errorBlock(.periodPostsAndPages)
         }))
         tableRows.append(contentsOf: blocks(for: .topReferrers,
-                                        type: .period,
-                                        status: store.topReferrersStatus,
-                                        block: { [weak self] in
-                                            return self?.referrersTableRows() ?? errorBlock(.periodReferrers)
-        }, loading: loadingBlock,
-           error: {
-            return errorBlock(.periodReferrers)
+                                            type: .period,
+                                            status: store.topReferrersStatus,
+                                            block: { [weak self] in
+                                                return self?.referrersTableRows() ?? errorBlock(.periodReferrers)
+            }, loading: loadingBlock,
+               error: {
+                return errorBlock(.periodReferrers)
         }))
         tableRows.append(contentsOf: blocks(for: .topClicks,
-                                        type: .period,
-                                        status: store.topClicksStatus,
-                                        block: { [weak self] in
-                                            return self?.clicksTableRows() ?? errorBlock(.periodClicks)
-        }, loading: loadingBlock,
-           error: {
-            return errorBlock(.periodClicks)
+                                            type: .period,
+                                            status: store.topClicksStatus,
+                                            block: { [weak self] in
+                                                return self?.clicksTableRows() ?? errorBlock(.periodClicks)
+            }, loading: loadingBlock,
+               error: {
+                return errorBlock(.periodClicks)
         }))
         tableRows.append(contentsOf: authorsTableRows())
         tableRows.append(contentsOf: countriesTableRows())
         tableRows.append(contentsOf: searchTermsTableRows())
         tableRows.append(contentsOf: blocks(for: .topPublished,
-                                        type: .period,
-                                        status: store.topPublishedStatus,
-                                        block: { [weak self] in
-                                            return self?.publishedTableRows() ?? errorBlock(.periodPublished)
-        }, loading: loadingBlock,
-           error: {
-            return errorBlock(.periodPublished)
+                                            type: .period,
+                                            status: store.topPublishedStatus,
+                                            block: { [weak self] in
+                                                return self?.publishedTableRows() ?? errorBlock(.periodPublished)
+            }, loading: loadingBlock,
+               error: {
+                return errorBlock(.periodPublished)
         }))
         tableRows.append(contentsOf: videosTableRows())
         tableRows.append(contentsOf: fileDownloadsTableRows())

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsViewModel+AsyncBlock.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsViewModel+AsyncBlock.swift
@@ -35,7 +35,7 @@ extension AsyncBlocksLoadable where CurrentStore: StatsStoreCacheable, RowType =
                        error: AsyncBlock<Value>) -> Value {
         let featureFlag: FeatureFlag = type == .insights ? .statsAsyncLoading : .statsAsyncLoadingDWMY
         let isFeatureEnabled = Feature.enabled(featureFlag)
-        let containsCachedData = checkingCache != nil ? checkingCache!() : currentStore.containsCachedData(for: blockType)
+        let containsCachedData = checkingCache?() ?? currentStore.containsCachedData(for: blockType)
 
         if containsCachedData || !isFeatureEnabled {
             return block()

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsViewModel+AsyncBlock.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsViewModel+AsyncBlock.swift
@@ -1,28 +1,43 @@
 protocol AsyncBlocksLoadable {
-    typealias CompletionBlock<Value> = () -> Value
+    typealias AsyncBlock<Value> = () -> Value
+    typealias CacheBlock = () -> Bool
 
     associatedtype CurrentStore
     associatedtype RowType
 
+    /// The current Store used
     var currentStore: CurrentStore { get }
 
+    /// This function returns the blocks to display during the Stats loading event
+    /// - Parameter blockType: The block type
+    /// - Parameter type: The Stats type
+    /// - Parameter status: The block status
+    /// - Parameter checkingCache: The block used to check if the data is cached and needs to be checked in a different way from the default implementation
+    /// - Parameter block: The main block to display
+    /// - Parameter loading: The loading block to display
+    /// - Parameter error: The error block to display
     func blocks<Value>(for blockType: RowType,
                        type: StatType,
                        status: StoreFetchingStatus,
-                       block: CompletionBlock<Value>,
-                       loading: CompletionBlock<Value>,
-                       error: CompletionBlock<Value>) -> Value
+                       checkingCache: CacheBlock?,
+                       block: AsyncBlock<Value>,
+                       loading: AsyncBlock<Value>,
+                       error: AsyncBlock<Value>) -> Value
 }
 
 extension AsyncBlocksLoadable where CurrentStore: StatsStoreCacheable, RowType == CurrentStore.StatsStoreType {
     func blocks<Value>(for blockType: RowType,
                        type: StatType,
                        status: StoreFetchingStatus,
-                       block: CompletionBlock<Value>,
-                       loading: CompletionBlock<Value>,
-                       error: CompletionBlock<Value>) -> Value {
+                       checkingCache: CacheBlock? = nil,
+                       block: AsyncBlock<Value>,
+                       loading: AsyncBlock<Value>,
+                       error: AsyncBlock<Value>) -> Value {
         let featureFlag: FeatureFlag = type == .insights ? .statsAsyncLoading : .statsAsyncLoadingDWMY
-        if currentStore.containsCachedData(for: blockType) || !Feature.enabled(featureFlag) {
+        let isFeatureEnabled = Feature.enabled(featureFlag)
+        let containsCachedData = checkingCache != nil ? checkingCache!() : currentStore.containsCachedData(for: blockType)
+
+        if containsCachedData || !isFeatureEnabled {
             return block()
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsViewModel+AsyncBlock.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsViewModel+AsyncBlock.swift
@@ -1,0 +1,38 @@
+protocol AsyncBlocksLoadable {
+    typealias CompletionBlock<Value> = () -> Value
+
+    associatedtype CurrentStore
+    associatedtype RowType
+
+    var currentStore: CurrentStore { get }
+
+    func blocks<Value>(for blockType: RowType,
+                       type: StatType,
+                       status: StoreFetchingStatus,
+                       block: CompletionBlock<Value>,
+                       loading: CompletionBlock<Value>,
+                       error: CompletionBlock<Value>) -> Value
+}
+
+extension AsyncBlocksLoadable where CurrentStore: StatsStoreCacheable, RowType == CurrentStore.StatsStoreType {
+    func blocks<Value>(for blockType: RowType,
+                       type: StatType,
+                       status: StoreFetchingStatus,
+                       block: CompletionBlock<Value>,
+                       loading: CompletionBlock<Value>,
+                       error: CompletionBlock<Value>) -> Value {
+        let featureFlag: FeatureFlag = type == .insights ? .statsAsyncLoading : .statsAsyncLoadingDWMY
+        if currentStore.containsCachedData(for: blockType) || !Feature.enabled(featureFlag) {
+            return block()
+        }
+
+        switch status {
+        case .loading, .idle:
+            return loading()
+        case .success:
+            return block()
+        case .error:
+            return error()
+        }
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1217,6 +1217,7 @@
 		9A51DA1522E9E8C7005CC335 /* ChangeUsernameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A51DA1322E9E8C7005CC335 /* ChangeUsernameViewController.swift */; };
 		9A5C854822B3E42800BEE7A3 /* CountriesMapCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5C854622B3E42800BEE7A3 /* CountriesMapCell.swift */; };
 		9A5C854922B3E42800BEE7A3 /* CountriesMapCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A5C854722B3E42800BEE7A3 /* CountriesMapCell.xib */; };
+		9A73B7152362FBAE004624A8 /* SiteStatsViewModel+AsyncBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A73B7142362FBAE004624A8 /* SiteStatsViewModel+AsyncBlock.swift */; };
 		9A73CB082350DE4C002EF20C /* StatsGhostSingleRowCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9A73CB072350DE4C002EF20C /* StatsGhostSingleRowCell.xib */; };
 		9A76C32F22AFDA2100F5D819 /* world-map.svg in Resources */ = {isa = PBXBuildFile; fileRef = 9A76C32E22AFDA2100F5D819 /* world-map.svg */; };
 		9A8ECE0C2254A3260043C8DA /* JetpackLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A8ECE012254A3250043C8DA /* JetpackLoginViewController.swift */; };
@@ -3409,6 +3410,7 @@
 		9A51DA1322E9E8C7005CC335 /* ChangeUsernameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeUsernameViewController.swift; sourceTree = "<group>"; };
 		9A5C854622B3E42800BEE7A3 /* CountriesMapCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountriesMapCell.swift; sourceTree = "<group>"; };
 		9A5C854722B3E42800BEE7A3 /* CountriesMapCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CountriesMapCell.xib; sourceTree = "<group>"; };
+		9A73B7142362FBAE004624A8 /* SiteStatsViewModel+AsyncBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SiteStatsViewModel+AsyncBlock.swift"; sourceTree = "<group>"; };
 		9A73CB072350DE4C002EF20C /* StatsGhostSingleRowCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatsGhostSingleRowCell.xib; sourceTree = "<group>"; };
 		9A76C32E22AFDA2100F5D819 /* world-map.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "world-map.svg"; sourceTree = "<group>"; };
 		9A8ECE012254A3250043C8DA /* JetpackLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackLoginViewController.swift; sourceTree = "<group>"; };
@@ -5309,6 +5311,7 @@
 				981C348F2183871100FC2683 /* SiteStatsDashboard.storyboard */,
 				981C3493218388CA00FC2683 /* SiteStatsDashboardViewController.swift */,
 				9874766E219630240080967F /* SiteStatsTableViewCells.swift */,
+				9A73B7142362FBAE004624A8 /* SiteStatsViewModel+AsyncBlock.swift */,
 				C56636E61868D0CE00226AAB /* StatsViewController.h */,
 				C56636E71868D0CE00226AAB /* StatsViewController.m */,
 			);
@@ -10530,6 +10533,7 @@
 				7462BFD02028C49800B552D8 /* ShareNoticeViewModel.swift in Sources */,
 				17A4A36920EE51870071C2CA /* Routes+Reader.swift in Sources */,
 				0807CB721CE670A800CDBDAC /* WPContentSearchHelper.swift in Sources */,
+				9A73B7152362FBAE004624A8 /* SiteStatsViewModel+AsyncBlock.swift in Sources */,
 				74AF4D7C1FE417D200E3EBFE /* PostUploadOperation.swift in Sources */,
 				37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */,
 				59DCA5211CC68AF3000F245F /* PageListViewController.swift in Sources */,


### PR DESCRIPTION
Refs. #12147 

This PR continues the Load Blocks Independently started [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/12764), implementing a new operation, new operations in the queue and ghost views. It also refactored the method used to handling the blocks in Insights.

To keep the PR easy to review and because of this refactor, I implemented the operations and the ghost views for these blocks only:
• _summary_
• _topPostsAndPages_
• _topReferrers_
• _topPublished_
• _topClicks_

_topPublished_ uses a different API. For this reason there's a specific operation for that case: `StatsPublishedPostsAsyncOperation`

### Refactor
The method implemented by the Insights and Period view models is now a protocol called `AsyncBlocksLoadable`. It uses a Generic Value as return type, which means it can be anything (in our case a single or a collection of ImmutableRow).

## To test:
- Open Stats -> DWMY from a Site you never opened before (or from a fresh install)
- Yous shouldn't see the NRV
- You should be able to load the chart and Top Posts card
- Disable the feature flag and make sure everything works as before

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
