### PR TITLE
Implementing NSBatchUpdateRequest in PostService+RefreshStatus

### DIFF
--- a/WordPress/Classes/Services/PostService+RefreshStatus.swift
+++ b/WordPress/Classes/Services/PostService+RefreshStatus.swift
@@ -14,12 +14,14 @@ extension PostService {
             let processingPredicate = NSPredicate(format: "remoteStatusNumber = %@", NSNumber(value: AbstractPostRemoteStatus.pushingMedia.rawValue))
             let pushingOrProcessingPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [pushingPredicate, processingPredicate])
             let notFailedPredicate = NSPredicate(format: "remoteStatusNumber != %@ AND NOT (postID != nil AND postID > 0)", NSNumber(value: AbstractPostRemoteStatus.failed.rawValue))
-        
+            
             request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [pushingOrProcessingPredicate, notFailedPredicate])
-            request.propertiesToUpdate = ["remoteStatusNumber": NSNumber(value: AbstractPostRemoteStatus.failed.rawValue),
+            request.propertiesToUpdate = [
+                "remoteStatusNumber": NSNumber(value: AbstractPostRemoteStatus.failed.rawValue),
                 "status": NSString(string: BasePost.Status.draft.rawValue),
-                "dateModified": NSDate()]
-
+                "dateModified": NSDate()
+            ]
+            
             do {
                 try self.managedObjectContext.execute(request)
 

--- a/WordPress/Classes/Services/PostService+RefreshStatus.swift
+++ b/WordPress/Classes/Services/PostService+RefreshStatus.swift
@@ -14,17 +14,14 @@ extension PostService {
             let processingPredicate = NSPredicate(format: "remoteStatusNumber = %@", NSNumber(value: AbstractPostRemoteStatus.pushingMedia.rawValue))
             let pushingOrProcessingPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [pushingPredicate, processingPredicate])
             let notFailedPredicate = NSPredicate(format: "remoteStatusNumber != %@ AND NOT (postID != nil AND postID > 0)", NSNumber(value: AbstractPostRemoteStatus.failed.rawValue))
-            
             request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [pushingOrProcessingPredicate, notFailedPredicate])
             request.propertiesToUpdate = [
                 "remoteStatusNumber": NSNumber(value: AbstractPostRemoteStatus.failed.rawValue),
                 "status": NSString(string: BasePost.Status.draft.rawValue),
                 "dateModified": NSDate()
             ]
-            
             do {
                 try self.managedObjectContext.execute(request)
-
                 ContextManager.sharedInstance().save(self.managedObjectContext, withCompletionBlock: {
                     DispatchQueue.main.async {
                         onCompletion?()


### PR DESCRIPTION
Fixes #12573 

Updated the referenced method to use `NSBatchUpdateRequest` instead of `NSFetchRequest`. Since there isn't an option to use any logic during the update and the posts were being previously updated using logic in the `markAsFailedAndDraftIfNeeded` method, I've decided to implement this logic using predicates, which could be done pretty simply and neatly (`notFailedPredicate`).

To test:
(Taken from https://github.com/wordpress-mobile/WordPress-iOS/pull/12567)
1. Be offline
2. Create a post
3. Publish post
4. See the message: "Post will be published..."
5. Quit the app
6. return to the app turn online
7. See that the post is being auto uploaded


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
