### PR TITLE
Aztec: `shouldInteractWithURL` will return always false to avoid crashes

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1350,18 +1350,6 @@ extension AztecPostViewController: UITextViewDelegate {
     }
 
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-
-        if #available(iOS 13.1, *) {
-            return false
-        } else if #available(iOS 13.0.0, *) {
-            // Sergio Estevao: This shouldn't happen in an editable textView, but it looks we have a system bug in iOS13 so we need this workaround
-            let position = characterRange.location
-            textView.selectedRange = NSRange(location: position, length: 0)
-            textView.typingAttributes = textView.attributedText.attributes(at: position, effectiveRange: nil)
-            textView.delegate?.textViewDidChangeSelection?(textView)
-            updateFormatBar()
-        }
-
         return false
     }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/12730

Following up from https://github.com/wordpress-mobile/WordPress-iOS/pull/12772.
I agree with @koke on https://github.com/wordpress-mobile/WordPress-iOS/pull/12772#issuecomment-547299425.

Since iOS 13.0 is so low on adoption, I believe is better to keep the simpler fix, regardless of the UX issue on 13.0, avoiding possible crashes.

I will do the gutenberg side changes next, but will probably go live on WPiOS 13.6.

To test:

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
