### PR TITLE
posts of self-hosted sites are not auto- uploaded if canceled

### DIFF
--- a/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
@@ -16,7 +16,7 @@ extension AbstractPost: ImageSourceInformation {
     var isLocalDraft: Bool {
         return self.isDraft() && !self.hasRemote()
     }
-    
+
     var isHostedAtWPcom: Bool {
         return self.blog.isHostedAtWPcom
     }

--- a/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
@@ -16,4 +16,8 @@ extension AbstractPost: ImageSourceInformation {
     var isLocalDraft: Bool {
         return self.isDraft() && !self.hasRemote()
     }
+    
+    var isHostedAtWPcom: Bool {
+        return self.blog.isHostedAtWPcom
+    }
 }

--- a/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
@@ -17,7 +17,7 @@ extension AbstractPost: ImageSourceInformation {
         return self.isDraft() && !self.hasRemote()
     }
 
-    var isHostedAtWPcom: Bool {
-        return self.blog.isHostedAtWPcom
+    var supportsWPComAPI: Bool {
+        return self.blog.supports(.wpComRESTAPI)
     }
 }

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -44,7 +44,7 @@ final class PostAutoUploadInteractor {
             return .upload
         } else {
             // because autosave call will end up uplaoding a post on self hosted we don't autosave in this case
-            return post.isHostedAtWPcom ? .autoSave : .nothing
+            return post.supportsWPComAPI ? .autoSave : .nothing
         }
     }
 

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -43,7 +43,8 @@ final class PostAutoUploadInteractor {
         if post.isLocalDraft || post.shouldAttemptAutoUpload {
             return .upload
         } else {
-            return .autoSave
+            // because autosave call will end up uplaoding a post on self hosted we return nothing
+            return post.isHostedAtWPcom ? .autoSave : .nothing
         }
     }
 

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -43,7 +43,7 @@ final class PostAutoUploadInteractor {
         if post.isLocalDraft || post.shouldAttemptAutoUpload {
             return .upload
         } else {
-            // because autosave call will end up uplaoding a post on self hosted we return nothing
+            // because autosave call will end up uplaoding a post on self hosted we don't autosave in this case
             return post.isHostedAtWPcom ? .autoSave : .nothing
         }
     }

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -18,3 +18,15 @@ final class BlogBuilder {
         return blog
     }
 }
+
+extension Blog {
+    func supportsWPComAPI() {
+        guard let context = managedObjectContext else {
+            return
+        }
+
+        let account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: context) as! WPAccount
+        account.username = "foo"
+        account.addBlogsObject(self)
+    }
+}

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -163,8 +163,8 @@ class PostBuilder {
         return self
     }
 
-    func `is`(hostedAtWPcom: Bool) -> PostBuilder {
-        post.blog.isHostedAtWPcom = hostedAtWPcom
+    func supportsWPComAPI() -> PostBuilder {
+        post.blog.supportsWPComAPI()
         return self
     }
 

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -162,7 +162,7 @@ class PostBuilder {
         post.isStickyPost = sticked
         return self
     }
-    
+
     func `is`(hostedAtWPcom: Bool) -> PostBuilder {
         post.blog.isHostedAtWPcom = hostedAtWPcom
         return self

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -162,6 +162,11 @@ class PostBuilder {
         post.isStickyPost = sticked
         return self
     }
+    
+    func `is`(hostedAtWPcom: Bool) -> PostBuilder {
+        post.blog.isHostedAtWPcom = hostedAtWPcom
+        return self
+    }
 
     func confirmedAutoUpload() -> PostBuilder {
         post.shouldAttemptAutoUpload = true

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -148,7 +148,7 @@ class PostCoordinatorTests: XCTestCase {
             .withRemote()
             .with(status: .draft)
             .with(remoteStatus: .failed)
-            .is(hostedAtWPcom: true)
+            .supportsWPComAPI()
             .build()
         try! context.save()
 
@@ -240,7 +240,7 @@ class PostCoordinatorTests: XCTestCase {
             .withRemote()
             .with(status: .draft)
             .with(remoteStatus: .failed)
-            .is(hostedAtWPcom: true)
+            .supportsWPComAPI()
             .build()
         try! context.save()
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -148,6 +148,7 @@ class PostCoordinatorTests: XCTestCase {
             .withRemote()
             .with(status: .draft)
             .with(remoteStatus: .failed)
+            .is(hostedAtWPcom: true)
             .build()
         try! context.save()
 
@@ -239,6 +240,7 @@ class PostCoordinatorTests: XCTestCase {
             .withRemote()
             .with(status: .draft)
             .with(remoteStatus: .failed)
+            .is(hostedAtWPcom: true)
             .build()
         try! context.save()
 

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -121,7 +121,7 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
     }
 
     func testReturnNothingPostActionWhenSelfHostedShouldNotBeAutoUploaded() {
-        let blog = createBlog(isHostedAtWPcom: false)
+        let blog = createBlog(supportsWPComAPI: false)
         let post = createPost(.draft, hasRemote: true, confirmedAutoUpload: false, blog: blog)
         let action = interactor.autoUploadAction(for: post)
 
@@ -160,7 +160,7 @@ private extension PostCoordinatorUploadActionUseCaseTests {
         if let blog = blog {
             post.blog = blog
         } else {
-            post.blog = createBlog(isHostedAtWPcom: true)
+            post.blog = createBlog(supportsWPComAPI: true)
         }
 
         return post
@@ -179,9 +179,13 @@ private extension PostCoordinatorUploadActionUseCaseTests {
         return page
     }
 
-    func createBlog(isHostedAtWPcom: Bool) -> Blog {
+    func createBlog(supportsWPComAPI: Bool) -> Blog {
         let blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as! Blog
-        blog.isHostedAtWPcom = isHostedAtWPcom
+
+        if supportsWPComAPI {
+            blog.supportsWPComAPI()
+        }
+
         return blog
     }
 }

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -148,7 +148,7 @@ private extension PostCoordinatorUploadActionUseCaseTests {
         post.status = status
         post.remoteStatus = remoteStatus
         post.autoUploadAttemptsCount = NSNumber(value: attemptsCount)
-        
+
         if hasRemote {
             post.postID = NSNumber(value: Int.random(in: 1...Int.max))
         }
@@ -156,7 +156,7 @@ private extension PostCoordinatorUploadActionUseCaseTests {
         if confirmedAutoUpload {
             post.shouldAttemptAutoUpload = true
         }
-        
+
         if let blog = blog {
             post.blog = blog
         } else {

--- a/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
+++ b/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
@@ -72,15 +72,19 @@ private extension PostCoordinatorFailedPostsFetcherTests {
         if let blog = blog {
             post.blog = blog
         } else {
-            post.blog = createBlog(isHostedAtWPcom: true)
+            post.blog = createBlog(supportsWPComAPI: true)
         }
 
         return post
     }
 
-    func createBlog(isHostedAtWPcom: Bool) -> Blog {
+    func createBlog(supportsWPComAPI: Bool) -> Blog {
         let blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as! Blog
-        blog.isHostedAtWPcom = isHostedAtWPcom
+
+        if supportsWPComAPI {
+            blog.supportsWPComAPI()
+        }
+
         return blog
     }
 }

--- a/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
+++ b/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
@@ -78,7 +78,7 @@ private extension PostCoordinatorFailedPostsFetcherTests {
         return post
     }
 
-    func createBlog(/*id: Int, url: String, account: WPAccount*/ isHostedAtWPcom: Bool) -> Blog {
+    func createBlog(isHostedAtWPcom: Bool) -> Blog {
         let blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as! Blog
         blog.isHostedAtWPcom = isHostedAtWPcom
         return blog

--- a/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
+++ b/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
@@ -59,7 +59,8 @@ class PostCoordinatorFailedPostsFetcherTests: XCTestCase {
 private extension PostCoordinatorFailedPostsFetcherTests {
     func createPost(status: BasePost.Status,
                     remoteStatus: AbstractPostRemoteStatus = .failed,
-                    hasRemote: Bool = false) -> Post {
+                    hasRemote: Bool = false,
+                    blog: Blog? = nil) -> Post {
         let post = Post(context: context)
         post.status = status
         post.remoteStatus = remoteStatus
@@ -67,8 +68,20 @@ private extension PostCoordinatorFailedPostsFetcherTests {
         if hasRemote {
             post.postID = NSNumber(value: Int.random(in: 1...Int.max))
         }
+        
+        if let blog = blog {
+            post.blog = blog
+        } else {
+            post.blog = createBlog(isHostedAtWPcom: true)
+        }
 
         return post
+    }
+    
+    func createBlog(/*id: Int, url: String, account: WPAccount*/ isHostedAtWPcom: Bool) -> Blog {
+        let blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as! Blog
+        blog.isHostedAtWPcom = isHostedAtWPcom
+        return blog
     }
 }
 

--- a/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
+++ b/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
@@ -68,7 +68,7 @@ private extension PostCoordinatorFailedPostsFetcherTests {
         if hasRemote {
             post.postID = NSNumber(value: Int.random(in: 1...Int.max))
         }
-        
+
         if let blog = blog {
             post.blog = blog
         } else {
@@ -77,7 +77,7 @@ private extension PostCoordinatorFailedPostsFetcherTests {
 
         return post
     }
-    
+
     func createBlog(/*id: Int, url: String, account: WPAccount*/ isHostedAtWPcom: Bool) -> Blog {
         let blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as! Blog
         blog.isHostedAtWPcom = isHostedAtWPcom


### PR DESCRIPTION
Fixes #12801 

To test:

1. While offline, edit an existing draft post.
2. Tap on X → Update Draft
3. In the Post List, tap Cancel.
4. Go online.
5. See that the post is *not* auto-uploaded  
Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests.