### PR TITLE
[Insights Management] Remove feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,7 +4,6 @@
 enum FeatureFlag: Int {
     case exampleFeature
     case jetpackDisconnect
-    case statsInsightsManagement
     case domainCredit
     case signInWithApple
     case statsAsyncLoading
@@ -17,8 +16,6 @@ enum FeatureFlag: Int {
             return true
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
-        case .statsInsightsManagement:
-            return true
         case .domainCredit:
             return true
         case .signInWithApple:

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -20,19 +20,6 @@ enum InsightType: Int {
     case allTagsAndCategories
     case allAnnual
 
-    // TODO: remove when Manage Insights is enabled.
-    static let allValues = [InsightType.latestPostSummary,
-                            .todaysStats,
-                            .annualSiteStats,
-                            .allTimeStats,
-                            .mostPopularTime,
-                            .postingActivity,
-                            .comments,
-                            .tagsAndCategories,
-                            .followersTotals,
-                            .followers,
-                            .publicize]
-
     // These Insights will be displayed in this order if a site's Insights have not been customized.
     static let defaultInsights = [InsightType.postingActivity,
                                   .todaysStats,
@@ -285,15 +272,6 @@ private extension SiteStatsInsightsTableViewController {
 
     func loadInsightsFromUserDefaults() {
 
-        // TODO: remove when Manage Insights is enabled.
-        guard FeatureFlag.statsInsightsManagement.enabled else {
-            // Show all Insights in the default order.
-            let allTypesValues = InsightType.allValues.map { $0.rawValue }
-            let insightTypesValues = UserDefaults.standard.array(forKey: userDefaultsInsightTypesKey) as? [Int] ?? allTypesValues
-            insightsToShow = InsightType.typesForValues(insightTypesValues)
-            return
-        }
-
         guard let siteID = SiteStatsInformation.sharedInstance.siteID?.stringValue else {
             insightsToShow = InsightType.defaultInsights
             loadCustomizeCardSetting()
@@ -313,15 +291,6 @@ private extension SiteStatsInsightsTableViewController {
     }
 
     func writeInsightsToUserDefaults() {
-
-        // TODO: remove when Manage Insights is enabled.
-        guard FeatureFlag.statsInsightsManagement.enabled else {
-            removeCustomizeCard()
-            let insightTypesValues = InsightType.valuesForTypes(insightsToShow)
-            UserDefaults.standard.set(insightTypesValues, forKey: userDefaultsInsightTypesKey)
-            writeCustomizeCardSetting()
-            return
-        }
 
         writeCustomizeCardSetting()
 
@@ -682,10 +651,6 @@ extension SiteStatsInsightsTableViewController: NoResultsViewHost {
     }
 
     private func displayEmptyViewIfNecessary() {
-        guard FeatureFlag.statsInsightsManagement.enabled else {
-            return
-        }
-
         guard insightsToShow.isEmpty else {
             displayingEmptyView = false
             hideNoResults()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -62,9 +62,7 @@ class SiteStatsInsightsViewModel: Observable {
 
             switch insightType {
             case .customize:
-                if FeatureFlag.statsInsightsManagement.enabled {
-                    tableRows.append(CustomizeInsightsRow(siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-                }
+                tableRows.append(CustomizeInsightsRow(siteStatsInsightsDelegate: siteStatsInsightsDelegate))
             case .latestPostSummary:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsLatestPostSummary,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
@@ -209,11 +207,9 @@ class SiteStatsInsightsViewModel: Observable {
             }
         }
 
-        if FeatureFlag.statsInsightsManagement.enabled {
-            tableRows.append(TableFooterRow())
-            tableRows.append(AddInsightRow(dataRow: createAddInsightRow(), siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-        }
-
+        tableRows.append(TableFooterRow())
+        tableRows.append(AddInsightRow(dataRow: createAddInsightRow(), siteStatsInsightsDelegate: siteStatsInsightsDelegate))
+        
         tableRows.append(TableFooterRow())
 
         return ImmuTable(sections: [

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -209,7 +209,7 @@ class SiteStatsInsightsViewModel: Observable {
 
         tableRows.append(TableFooterRow())
         tableRows.append(AddInsightRow(dataRow: createAddInsightRow(), siteStatsInsightsDelegate: siteStatsInsightsDelegate))
-        
+
         tableRows.append(TableFooterRow())
 
         return ImmuTable(sections: [

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -71,8 +71,7 @@ private extension StatsCellHeader {
 
     func configureManageInsightButton() {
 
-        guard FeatureFlag.statsInsightsManagement.enabled,
-            let statSection = statSection,
+        guard let statSection = statSection,
             StatSection.allInsights.contains(statSection) else {
                 showManageInsightButton(false)
                 return


### PR DESCRIPTION
Ref #12243

To test:

---
Initial View:
- Start with a fresh install.
- Go to Stats > Insights.
- Verify these cards appear in this order:
  - Customize
  - Posting Activity
  - Today
  - All-Time
  - Most Popular Time
  - Comments
  - Add stats card

---
Customize card:
- Dismiss the Customize card.
- Verify it is not shown for any site.

---
Customize Insights:
- Customize Insights on a site (i.e. add, remove, reorder).
- Switch sites.
- Verify the customized Insights affects only the original site.

---
Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
