### PR TITLE
Show media error if a post has permanent failed media

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -136,4 +136,10 @@ extension AbstractPost {
     @objc override open func featuredImageURLForDisplay() -> URL? {
         return featuredImageURL
     }
+
+    /// Returns true if the post has any media that needs manual intervention to be uploaded
+    ///
+    func hasPermanentFailedMedia() -> Bool {
+        return media.first(where: { !$0.willAttemptToUploadLater() }) != nil
+    }
 }

--- a/WordPress/Classes/Models/Media.swift
+++ b/WordPress/Classes/Models/Media.swift
@@ -19,6 +19,12 @@ extension Media {
     func resetAutoUploadFailureCount() {
         autoUploadFailureCount = 0
     }
+    /// Returns true if a new attempt to upload the media will be done later.
+    /// Otherwise, false.
+    ///
+    func willAttemptToUploadLater() -> Bool {
+        return autoUploadFailureCount.intValue < Media.maxAutoUploadFailureCount
+    }
 
     /// Returns true if media has any associated post
     ///

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -90,7 +90,7 @@ class PostCardStatusViewModel: NSObject {
         }
 
         if post.isRevision() {
-            return .warning
+            return post.hasPermanentFailedMedia() ? .error : .warning
         }
 
         if post.isFailed {
@@ -228,7 +228,7 @@ class PostCardStatusViewModel: NSObject {
         }
 
         if post.wasAutoUploadCancelled {
-            return StatusMessages.localChanges
+            return post.hasPermanentFailedMedia() ? PostAutoUploadMessages.failedMedia : StatusMessages.localChanges
         }
 
         if let autoUploadMessage = PostAutoUploadMessages.attemptFailures(for: post, withState: autoUploadInteractor.autoUploadAttemptState(of: post)) {

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -472,6 +472,15 @@ class PostCardCellTests: XCTestCase {
         expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
     }
 
+    func testFailedMessageForCanceledPostWithFailedMedias() {
+        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).with(image: "test.png", status: .failed, autoUploadFailureCount: 3).cancelledAutoUpload().revision().build()
+
+        postCell.configure(with: post)
+
+        expect(self.postCell.statusLabel.text).to(equal(i18n("We couldn't upload this media.")))
+        expect(self.postCell.statusLabel.textColor).to(equal(UIColor.error))
+    }
+
     func testMessageWhenPostIsArevision() {
         let post = PostBuilder(context).revision().with(remoteStatus: .failed).with(remoteStatus: .local).build()
 


### PR DESCRIPTION
Fixes #12802

To test:

1. Use a self-hosted site (or WPCom, the output is the same for both)
2. Go offline
3. Edit an existing draft
4. Add an image to it
5. Tap X → Update Draft
6. Tap "Cancel"
7. Go online and immediately go back offline as soon as you see the media being uploaded
8. Do the above step 3 times
9. Check the "Retry" button is appearing with a _We couldn't upload this media._ message

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 