### PR TITLE
Stats: Remove statsAsyncLoading feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -6,7 +6,6 @@ enum FeatureFlag: Int {
     case jetpackDisconnect
     case domainCredit
     case signInWithApple
-    case statsAsyncLoading
     case statsAsyncLoadingDWMY
 
     /// Returns a boolean indicating if the feature is enabled
@@ -24,8 +23,6 @@ enum FeatureFlag: Int {
             if BuildConfiguration.current == .a8cBranchTest || BuildConfiguration.current == .a8cPrereleaseTesting {
                 return false
             }
-            return true
-        case .statsAsyncLoading:
             return true
         case .statsAsyncLoadingDWMY:
             return BuildConfiguration.current == .localDeveloper

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -211,9 +211,6 @@ private extension SiteStatsInsightsTableViewController {
         if viewModel.fetchingFailed() {
             displayFailureViewIfNecessary()
         }
-        else {
-            hideNoResults()
-        }
 
         refreshControl?.endRefreshing()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -565,12 +565,9 @@ extension SiteStatsInsightsTableViewController: NoResultsViewControllerDelegate 
             return
         }
 
-        defer {
-            addViewModelListeners()
-            refreshInsights()
-        }
-
         hideNoResults()
+        addViewModelListeners()
+        refreshInsights()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -109,7 +109,6 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
 
     private var viewNeedsUpdating = false
     private var displayingEmptyView = false
-    private let asyncLoadingActivated = Feature.enabled(.statsAsyncLoading)
 
     private lazy var mainContext: NSManagedObjectContext = {
         return ContextManager.sharedInstance().mainContext
@@ -145,7 +144,6 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
         tableView.estimatedRowHeight = 500
 
         displayEmptyViewIfNecessary()
-        displayLoadingViewIfNecessary()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -176,13 +174,6 @@ private extension SiteStatsInsightsTableViewController {
         }
 
         insightsChangeReceipt = viewModel?.onChange { [weak self] in
-            let asyncLoadingActivated = self?.asyncLoadingActivated ?? false
-            if !asyncLoadingActivated {
-                if let viewModel = self?.viewModel,
-                    viewModel.isFetchingOverview() {
-                        return
-                }
-            }
             self?.refreshTableView()
         }
     }
@@ -192,23 +183,20 @@ private extension SiteStatsInsightsTableViewController {
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
-        var rows: [ImmuTableRow.Type] = [InsightCellHeaderRow.self,
-                                         CustomizeInsightsRow.self,
-                                         LatestPostSummaryRow.self,
-                                         TwoColumnStatsRow.self,
-                                         PostingActivityRow.self,
-                                         TabbedTotalsStatsRow.self,
-                                         TopTotalsInsightStatsRow.self,
-                                         TableFooterRow.self]
-        if asyncLoadingActivated {
-            rows.append(contentsOf: [StatsErrorRow.self,
-                                     StatsGhostChartImmutableRow.self,
-                                     StatsGhostTwoColumnImmutableRow.self,
-                                     StatsGhostTopImmutableRow.self,
-                                     StatsGhostTabbedImmutableRow.self,
-                                     StatsGhostPostingActivitiesImmutableRow.self])
-        }
-        return rows
+        return [InsightCellHeaderRow.self,
+                CustomizeInsightsRow.self,
+                LatestPostSummaryRow.self,
+                TwoColumnStatsRow.self,
+                PostingActivityRow.self,
+                TabbedTotalsStatsRow.self,
+                TopTotalsInsightStatsRow.self,
+                TableFooterRow.self,
+                StatsErrorRow.self,
+                StatsGhostChartImmutableRow.self,
+                StatsGhostTwoColumnImmutableRow.self,
+                StatsGhostTopImmutableRow.self,
+                StatsGhostTabbedImmutableRow.self,
+                StatsGhostPostingActivitiesImmutableRow.self]
     }
 
     // MARK: - Table Refreshing
@@ -218,25 +206,13 @@ private extension SiteStatsInsightsTableViewController {
                 return
         }
 
-        if !asyncLoadingActivated {
-            guard viewIsVisible() else {
-                    return
-            }
-        }
-
         tableHandler.viewModel = viewModel.tableViewModel()
 
-        if asyncLoadingActivated {
-            if viewModel.fetchingFailed() {
-                displayFailureViewIfNecessary()
-            }
-        } else {
-            if viewModel.fetchingFailed() &&
-                !viewModel.containsCachedData() {
-                displayFailureViewIfNecessary()
-            } else {
-                hideNoResults()
-            }
+        if viewModel.fetchingFailed() {
+            displayFailureViewIfNecessary()
+        }
+        else {
+            hideNoResults()
         }
 
         refreshControl?.endRefreshing()
@@ -597,56 +573,25 @@ extension SiteStatsInsightsTableViewController: NoResultsViewControllerDelegate 
             refreshInsights()
         }
 
-        if asyncLoadingActivated {
-            hideNoResults()
-            return
-        }
-
-        updateNoResults(title: NoResultConstants.loadingTitle,
-                        accessoryView: NoResultsViewController.loadingAccessoryView()) { noResults in
-                            noResults.hideImageView(false)
-        }
+        hideNoResults()
     }
 }
 
 extension SiteStatsInsightsTableViewController: NoResultsViewHost {
-    private func displayLoadingViewIfNecessary() {
-        guard !displayingEmptyView,
-            !asyncLoadingActivated,
-            tableHandler.viewModel.sections.isEmpty else {
-                return
-        }
-
-        configureAndDisplayNoResults(on: tableView,
-                                     title: NoResultConstants.loadingTitle,
-                                     accessoryView: NoResultsViewController.loadingAccessoryView()) { [weak self] noResults in
-                                        noResults.delegate = self
-                                        noResults.hideImageView(false)
-        }
-    }
 
     private func displayFailureViewIfNecessary() {
         guard tableHandler.viewModel.sections.isEmpty else {
             return
         }
 
-        if asyncLoadingActivated {
-            configureAndDisplayNoResults(on: tableView,
-                                         title: NoResultConstants.errorTitle,
-                                         subtitle: NoResultConstants.errorSubtitle,
-                                         buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
-                                            noResults.delegate = self
-                                            if !noResults.isReachable {
-                                                noResults.resetButtonText()
-                                            }
-            }
-        } else {
-            updateNoResults(title: NoResultConstants.errorTitle,
-                            subtitle: NoResultConstants.errorSubtitle,
-                            buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
-                                noResults.delegate = self
-                                noResults.hideImageView()
-            }
+        configureAndDisplayNoResults(on: tableView,
+                                     title: NoResultConstants.errorTitle,
+                                     subtitle: NoResultConstants.errorSubtitle,
+                                     buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
+                                        noResults.delegate = self
+                                        if !noResults.isReachable {
+                                            noResults.resetButtonText()
+                                        }
         }
     }
 
@@ -668,7 +613,6 @@ extension SiteStatsInsightsTableViewController: NoResultsViewHost {
     }
 
     private enum NoResultConstants {
-        static let loadingTitle = NSLocalizedString("Loading Stats...", comment: "The loading view title displayed while the service is loading")
         static let errorTitle = NSLocalizedString("Stats not loaded", comment: "The loading view title displayed when an error occurred")
         static let errorSubtitle = NSLocalizedString("There was a problem loading your data, refresh your page to try again.", comment: "The loading view subtitle displayed when an error occurred")
         static let refreshButtonTitle = NSLocalizedString("Refresh", comment: "The loading view button title displayed when an error occurred")

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -32,8 +32,6 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
     private let periodStore = StoreContainer.shared.statsPeriod
     private var periodChangeReceipt: Receipt?
 
-    private let asyncLoadingActivated = Feature.enabled(.statsAsyncLoading)
-
     private lazy var tableHandler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self)
     }()
@@ -76,9 +74,6 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         statType = StatSection.allInsights.contains(statSection) ? .insights : .period
         title = statSection.detailsTitle
         initViewModel()
-        if !asyncLoadingActivated {
-            displayLoadingViewIfNecessary()
-        }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -143,26 +138,8 @@ private extension SiteStatsDetailTableViewController {
             return
         }
 
-        if asyncLoadingActivated {
-            receipt = viewModel?.onChange { [weak self] in
-                self?.refreshTableView()
-            }
-        } else {
-            if statType == .insights {
-                insightsChangeReceipt = viewModel?.onChange { [weak self] in
-                    guard self?.viewModel?.storeIsFetching(statSection: statSection) == false else {
-                        return
-                    }
-                    self?.refreshTableView()
-                }
-            } else {
-                periodChangeReceipt = viewModel?.onChange { [weak self] in
-                    guard self?.viewModel?.storeIsFetching(statSection: statSection) == false else {
-                        return
-                    }
-                    self?.refreshTableView()
-                }
-            }
+        receipt = viewModel?.onChange { [weak self] in
+            self?.refreshTableView()
         }
 
         viewModel?.fetchDataFor(statSection: statSection,
@@ -172,19 +149,16 @@ private extension SiteStatsDetailTableViewController {
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
-        var rows: [ImmuTableRow.Type] = [DetailDataRow.self,
-                                         DetailExpandableRow.self,
-                                         DetailExpandableChildRow.self,
-                                         DetailSubtitlesHeaderRow.self,
-                                         DetailSubtitlesTabbedHeaderRow.self,
-                                         DetailSubtitlesCountriesHeaderRow.self,
-                                         CountriesMapRow.self]
-        if asyncLoadingActivated {
-            rows.append(contentsOf: [StatsErrorRow.self,
-                                     StatsGhostTopImmutableRow.self,
-                                     StatsGhostDetailRow.self])
-        }
-        return rows
+        return [DetailDataRow.self,
+                DetailExpandableRow.self,
+                DetailExpandableChildRow.self,
+                DetailSubtitlesHeaderRow.self,
+                DetailSubtitlesTabbedHeaderRow.self,
+                DetailSubtitlesCountriesHeaderRow.self,
+                CountriesMapRow.self,
+                StatsErrorRow.self,
+                StatsGhostTopImmutableRow.self,
+                StatsGhostDetailRow.self]
     }
 
     // MARK: - Table Refreshing
@@ -326,51 +300,24 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
 // MARK: - NoResultsViewHost
 
 extension SiteStatsDetailTableViewController: NoResultsViewHost {
-    private func displayLoadingViewIfNecessary() {
-        guard tableHandler.viewModel.sections.isEmpty else {
-            return
-        }
-
-        if noResultsViewController.view.superview != nil {
-            return
-        }
-
-        configureAndDisplayNoResults(on: tableView,
-                                     title: NoResultConstants.successTitle,
-                                     accessoryView: NoResultsViewController.loadingAccessoryView()) { [weak self] noResults in
-                                        noResults.delegate = self
-                                        noResults.hideImageView(false)
-        }
-    }
 
     private func displayFailureViewIfNecessary() {
         guard tableHandler.viewModel.sections.isEmpty else {
             return
         }
 
-        if asyncLoadingActivated {
-            configureAndDisplayNoResults(on: tableView,
-                                         title: NoResultConstants.errorTitle,
-                                         subtitle: NoResultConstants.errorSubtitle,
-                                         buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
-                                            noResults.delegate = self
-                                            if !noResults.isReachable {
-                                                noResults.resetButtonText()
-                                            }
-            }
-            return
-        }
-
-        updateNoResults(title: NoResultConstants.errorTitle,
-                        subtitle: NoResultConstants.errorSubtitle,
-                        buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
-                            noResults.delegate = self
-                            noResults.hideImageView()
+        configureAndDisplayNoResults(on: tableView,
+                                     title: NoResultConstants.errorTitle,
+                                     subtitle: NoResultConstants.errorSubtitle,
+                                     buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
+                                        noResults.delegate = self
+                                        if !noResults.isReachable {
+                                            noResults.resetButtonText()
+                                        }
         }
     }
 
     private enum NoResultConstants {
-        static let successTitle = NSLocalizedString("Loading Stats...", comment: "The loading view title displayed while the service is loading")
         static let errorTitle = NSLocalizedString("Stats not loaded", comment: "The loading view title displayed when an error occurred")
         static let errorSubtitle = NSLocalizedString("There was a problem loading your data, refresh your page to try again.", comment: "The loading view subtitle displayed when an error occurred")
         static let refreshButtonTitle = NSLocalizedString("Refresh", comment: "The loading view button title displayed when an error occurred")
@@ -385,15 +332,7 @@ extension SiteStatsDetailTableViewController: NoResultsViewControllerDelegate {
             refreshData()
         }
 
-        if asyncLoadingActivated {
-            hideNoResults()
-            return
-        }
-
-        updateNoResults(title: NoResultConstants.successTitle,
-                        accessoryView: NoResultsViewController.loadingAccessoryView()) { noResults in
-                            noResults.hideImageView(false)
-        }
+        hideNoResults()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -940,7 +940,7 @@ private extension SiteStatsDetailsViewModel {
     }
 
     func immuTable(for row: (type: InsightType, status: StoreFetchingStatus), rowsBlock: () -> [ImmuTableRow]) -> ImmuTable {
-        if insightsStore.containsCachedData(for: row.type) || !Feature.enabled(.statsAsyncLoading) {
+        if insightsStore.containsCachedData(for: row.type) {
             return ImmuTable(sections: [
                 ImmuTableSection(
                     rows: rowsBlock())


### PR DESCRIPTION
Ref #11852 

To test:
- Go to Stats > Insights.
  - Verify ghost views appear when loading.
- On an Insight card, select 'View more'.
  - Verify ghost views appear when loading.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
