### PR TITLE
Add push notification logging

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -910,6 +910,7 @@ private extension NotificationsViewController {
         selectedNotification = notification
 
         if let indexPath = tableViewHandler.resultsController.indexPath(forObject: notification), indexPath != tableView.indexPathForSelectedRow {
+            DDLogInfo("\(self) \(#function) Selecting row at \(indexPath) for Notification: \(notification.notificationId) (\(notification.type ?? "Unknown type")) - \(notification.title ?? "No title")")
             tableView.selectRow(at: indexPath, animated: animated, scrollPosition: scrollPosition)
         }
     }

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -39,8 +39,8 @@ class NotificationService: UNNotificationServiceExtension {
             let notificationType = notificationContent.type,
             let notificationKind = NotificationKind(rawValue: notificationType),
             token != nil else {
-
-            tracks.trackNotificationMalformed()
+            tracks.trackNotificationMalformed(properties: ["have_token": (token != nil) as AnyObject,
+                                                           "content": request.content])
             contentHandler(request.content)
 
             return

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -60,8 +60,8 @@ extension Tracks {
     }
 
     /// Tracks the unsuccessful unwrapping of push notification payload data.
-    func trackNotificationMalformed() {
-        trackEvent(ServiceExtensionEvents.malformed)
+    func trackNotificationMalformed(properties: [String: AnyObject]? = nil) {
+        trackEvent(ServiceExtensionEvents.malformed, properties: properties)
     }
 
     /// Tracks the timeout of service extension processing.


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/issues/12669#issuecomment-545375106

This adds some logging to help identify crashes with malformed push notifications.
- `NotificationsViewController.selectRow` now logs more information before calling `tableView.selectRow`. 
- The `request.content` is now added to the `wpios_notification_service_extension_malformed_payload` track properties.

To test:
- Go to Notifications and select a row. Note something like this in the logs:
`<WordPress.NotificationsViewController: 0x1088f9a00> selectRow(for:animated:scrollPosition:) Selecting row at [1, 8] for Notification: <note_id> (<notif_type>) - <notif_title>`

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
