### PR TITLE
Change WP Internal’s name to be “WordPress β”

### DIFF
--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>WP Internal</string>
+	<string>WordPress β</string>
 	<key>CFBundleIcons</key>
 	<dict>
 		<key>CFBundlePrimaryIcon</key>


### PR DESCRIPTION
Addresses a comment mentioning that WP Internal isn't searchable as "WordPress".

To test:
- Run the app using the "WordPress Internal" scheme in the "Release-Internal" build configuration (or view the attached screenshots)

![Simulator Screen Shot - iPhone 11 Pro Max - 2019-11-04 at 14 30 25](https://user-images.githubusercontent.com/1123407/68160952-177be300-ff12-11e9-9c16-10d6d32f7c98.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2019-11-04 at 14 30 27](https://user-images.githubusercontent.com/1123407/68160955-177be300-ff12-11e9-9302-dd808ade7505.png)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
