### PR TITLE
[Dark Mode] Fix Ghost animations colors in DWMY header

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -122,7 +122,7 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
         backButton.isEnabled = !animate
 
         if animate {
-            startGhostAnimation()
+            startGhostAnimation(style: GhostCellStyle.muriel)
             return
         }
         stopGhostAnimation()
@@ -132,7 +132,7 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
 private extension SiteStatsTableHeaderView {
 
     func applyStyles() {
-        contentView.backgroundColor = .basicBackground
+        contentView.backgroundColor = .listForeground
         Style.configureLabelAsCellRowTitle(dateLabel)
         Style.configureLabelAsChildRowTitle(timezoneLabel)
         Style.configureViewAsSeparator(bottomSeparatorLine)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -89,6 +89,6 @@ struct StatsGhostTitleRow: StatsRowGhostable {
     }()
 }
 
-private enum GhostCellStyle {
+enum GhostCellStyle {
     static let muriel = GhostStyle(beatStartColor: .placeholderElement, beatEndColor: .placeholderElementFaded)
 }


### PR DESCRIPTION
This PR fixes a bug in the colors used by the Ghost animations layer in the DWMY header.
It also fixes the header background color.
![stats-loading-blocks](https://user-images.githubusercontent.com/912252/68222054-4f525b80-ffe2-11e9-8a28-72ab938d271f.jpg)

## To test:
- Open Stats from a selected blog (like en.blog)
- Select one Period and check the header colors in light and dark mode

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
