### PR TITLE
[Offline Posting] Self-hosted: Upload unconfirmed published posts as drafts

### DIFF
--- a/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
@@ -16,8 +16,4 @@ extension AbstractPost: ImageSourceInformation {
     var isLocalDraft: Bool {
         return self.isDraft() && !self.hasRemote()
     }
-
-    var supportsWPComAPI: Bool {
-        return self.blog.supports(.wpComRESTAPI)
-    }
 }

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -90,6 +90,8 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
 /**
  Syncs local changes on a post back to the server.
 
+ If the post only exists on the device, it will be created.
+
  @param post The post or page to upload
  @param success A success block.  If the post object exists locally (in CoreData) when the upload
         succeeds, then this block will also return a pointer to the updated local AbstractPost
@@ -99,6 +101,22 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
  @param failure A failure block
  */
 - (void)uploadPost:(AbstractPost *)post
+           success:(nullable void (^)(AbstractPost *post))success
+           failure:(void (^)(NSError * _Nullable error))failure;
+
+/**
+ The same as `uploadPost:success:failure`
+
+ Setting `forceDraftIfCreating` to `YES` is useful if we want to create a post in the server
+ with the intention of making it available for preview. If we create the post as is, and the user
+ has set its `status` to `.published`, then we would publishing the post even if we just
+ wanted to preview it!
+
+ Another use case of `forceDraftIfCreating` is to create the post in the background so we can
+ periodically auto-save it. Again, we'd still want to create it as a `.draft` status.
+ */
+- (void)uploadPost:(AbstractPost *)post
+forceDraftIfCreating:(BOOL)forceDraftIfCreating
            success:(nullable void (^)(AbstractPost *post))success
            failure:(void (^)(NSError * _Nullable error))failure;
 

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -241,19 +241,6 @@ forceDraftIfCreating:NO
              failure:failure];
 }
 
-/**
- * Creates or updates a post to the server.
- *
- * If the post only exists on the device, it will be created.
- *
- * Setting `forceDraftIfCreating` to `YES` is useful if we want to create a post in the server
- * with the intention of making it available for preview. If we create the post as is, and the user
- * has set its `status` to `.published`, then we would publishing the post even if we just
- * wanted to preview it!
- *
- * Another use case of `forceDraftIfCreating` is to create the post in the background so we can
- * periodically auto-save it. Again, we'd still want to create it as a `.draft` status.
- */
 - (void)uploadPost:(AbstractPost *)post
 forceDraftIfCreating:(BOOL)forceDraftIfCreating
            success:(void (^)(AbstractPost *post))success

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -2,6 +2,9 @@ import Foundation
 
 @testable import WordPress
 
+/// Creates a Blog
+///
+/// Defaults to creating a self-hosted blog
 final class BlogBuilder {
     private let blog: Blog
 

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -2,6 +2,9 @@ import Foundation
 
 @testable import WordPress
 
+/// Builds a Post
+///
+/// Defaults to creating a post in a self-hosted site.
 class PostBuilder {
     private let post: Post
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -157,6 +157,29 @@ class PostCoordinatorTests: XCTestCase {
         expect(postServiceMock.didCallAutoSave).toEventually(beTrue())
     }
 
+    func testResumeWillUploadUnconfirmedPublishedPostsAsDraftsOnSelfHostedSites() {
+        // Arrange
+        let postServiceMock = PostServiceMock(managedObjectContext: context)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        _ = PostBuilder(context)
+            .with(status: .publish)
+            .with(remoteStatus: .failed)
+            .with(title: "Ipsam nihil")
+            .build()
+        try! context.save()
+
+        // Act
+        postCoordinator.resume()
+
+        // Assert
+        expect(postServiceMock.didCallUploadPost).toEventually(beTrue())
+        expect(postServiceMock.lastUploadPostInvocation).toEventuallyNot(beNil())
+
+        let invocation = postServiceMock.lastUploadPostInvocation!
+        expect(invocation.post.postTitle).to(equal("Ipsam nihil"))
+        expect(invocation.forceDraftIfCreating).to(beTrue())
+    }
+
     func testCancelAutoUploadOfAPost() {
         let post = PostBuilder(context).confirmedAutoUpload().build()
         let postServiceMock = PostServiceMock(managedObjectContext: context)
@@ -415,21 +438,29 @@ class PostCoordinatorTests: XCTestCase {
 }
 
 private class PostServiceMock: PostService {
-    private(set) var didCallUploadPost = false
+    struct UploadPostInvocation {
+        let post: AbstractPost
+        let forceDraftIfCreating: Bool
+    }
+
     private(set) var didCallMarkAsFailedAndDraftIfNeeded = false
     private(set) var didCallAutoSave = false
+
+    private(set) var lastUploadPostInvocation: UploadPostInvocation?
+    var didCallUploadPost: Bool {
+        return lastUploadPostInvocation != nil
+    }
 
     var returnPost: AbstractPost?
     var returnError: Error?
 
-    override func uploadPost(_ post: AbstractPost, success: ((AbstractPost) -> Void)?, failure: @escaping (Error?) -> Void) {
-        didCallUploadPost = true
+    override func uploadPost(_ post: AbstractPost, forceDraftIfCreating: Bool, success: ((AbstractPost) -> Void)?, failure: @escaping (Error?) -> Void) {
+        lastUploadPostInvocation = UploadPostInvocation(post: post, forceDraftIfCreating: forceDraftIfCreating)
 
         if let post = returnPost {
             post.remoteStatus = .sync
             success?(post)
         }
-
         if let error = returnError {
             post.remoteStatus = .failed
             failure(error)

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -131,6 +131,15 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
         expect(action).to(equal(.nothing))
     }
 
+    func testUnconfirmedLocallyPublishedPostsOfSelfHostedSitesAreUploadedAsDrafts() {
+        let blog = createBlog(supportsWPComAPI: false)
+        let post = createPost(.publish, confirmedAutoUpload: false, blog: blog)
+
+        let action = interactor.autoUploadAction(for: post)
+
+        expect(action).to(equal(.uploadAsDraft))
+    }
+
     func testPageNotAutoUploaded() {
         let page = createPage(.draft)
 

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -2,23 +2,21 @@
 @testable import WordPress
 import Nimble
 
-class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
-    private var contextManager: TestContextManager!
+class PostAutoUploadInteractorTests: XCTestCase {
     private var context: NSManagedObjectContext!
 
     private var interactor: PostAutoUploadInteractor!
 
     override func setUp() {
         super.setUp()
-        contextManager = TestContextManager()
-        context = contextManager.newDerivedContext()
+        context = TestContextManager().mainContext
         interactor = PostAutoUploadInteractor()
     }
 
     override func tearDown() {
         interactor = nil
         context = nil
-        contextManager = nil
+        ContextManager.overrideSharedInstance(nil)
         super.tearDown()
     }
 
@@ -149,7 +147,7 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
     }
 }
 
-private extension PostCoordinatorUploadActionUseCaseTests {
+private extension PostAutoUploadInteractorTests {
     func createPost(_ status: BasePost.Status,
                     remoteStatus: AbstractPostRemoteStatus = .failed,
                     hasRemote: Bool = false,

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -120,9 +120,12 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
         expect(action).to(equal(.upload))
     }
 
-    func testReturnNothingPostActionWhenSelfHostedShouldNotBeAutoUploaded() {
+    func testUnconfirmedExistingPostsOfSelfHostedSitesAreNotAutoSaved() {
+        // For WPCom, unconfirmed posts are auto-saved. However, self-hosted sites do not support
+        // auto-save. We just do nothing in this case.
         let blog = createBlog(supportsWPComAPI: false)
         let post = createPost(.draft, hasRemote: true, confirmedAutoUpload: false, blog: blog)
+
         let action = interactor.autoUploadAction(for: post)
 
         expect(action).to(equal(.nothing))

--- a/WordPress/WordPressTest/Services/PostServiceSelfHostedTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceSelfHostedTests.swift
@@ -84,6 +84,33 @@ class PostServiceSelfHostedTests: XCTestCase {
         expect(self.remoteMock.invocationsCountOfUpdate).to(equal(0))
     }
 
+    func testUploadWithForceDraftCreationWillUploadALocallyPublishedPostAsDraft() {
+        // This applies to scenarios where a published post that only exists locally previously
+        // failed to upload. If the user canceled the auto-upload confirmation
+        // (by pressing Cancel in the Post List), we will still upload the post as a draft.
+
+        // Arrange
+        let post = PostBuilder(context).with(status: .publish).with(remoteStatus: .local).with(title: "sequi").build()
+        try! context.save()
+
+        remoteMock.remotePostToReturnOnCreatePost = createRemotePost(.draft)
+
+        // Act
+        waitUntil(timeout: 2) { done in
+            self.service.uploadPost(post, forceDraftIfCreating: true, success: { _ in
+                done()
+            }, failure: self.impossibleFailureBlock)
+        }
+
+        // Assert
+        expect(self.remoteMock.invocationsCountOfCreatePost).to(equal(1))
+        expect(post.remoteStatus).to(equal(.sync))
+
+        let submittedRemotePost: RemotePost = remoteMock.remotePostSubmittedOnCreatePostInvocation!
+        expect(submittedRemotePost.title).to(equal("sequi"))
+        expect(submittedRemotePost.status).to(equal(BasePost.Status.draft.rawValue))
+    }
+
     private func createRemotePost(_ status: BasePost.Status = .draft) -> RemotePost {
         let remotePost = RemotePost(siteID: 1,
                                     status: status.rawValue,
@@ -108,6 +135,8 @@ private class PostServiceXMLRPCMock: PostServiceRemoteXMLRPC {
     private(set) var invocationsCountOfCreatePost = 0
     private(set) var invocationsCountOfUpdate = 0
 
+    private(set) var remotePostSubmittedOnCreatePostInvocation: RemotePost?
+
     override func update(_ post: RemotePost!, success: ((RemotePost?) -> Void)!, failure: ((Error?) -> Void)!) {
         DispatchQueue.global().async {
             self.invocationsCountOfUpdate += 1
@@ -117,6 +146,7 @@ private class PostServiceXMLRPCMock: PostServiceRemoteXMLRPC {
 
     override func createPost(_ post: RemotePost!, success: ((RemotePost?) -> Void)!, failure: ((Error?) -> Void)!) {
         DispatchQueue.global().async {
+            self.remotePostSubmittedOnCreatePostInvocation = post
             self.invocationsCountOfCreatePost += 1
             success(self.remotePostToReturnOnCreatePost)
         }

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -183,7 +183,7 @@ class PostNoticeViewModelTests: XCTestCase {
             cancelAutoUploadOfInvocations += 1
         }
 
-        override func save(_ postToSave: AbstractPost, automatedRetry: Bool = false, defaultFailureNotice: Notice? = nil, completion: ((Result<AbstractPost>) -> ())? = nil) {
+        override func save(_ postToSave: AbstractPost, automatedRetry: Bool = false, forceDraftIfCreating: Bool = false, defaultFailureNotice: Notice? = nil, completion: ((Result<AbstractPost>) -> ())? = nil) {
 
         }
     }


### PR DESCRIPTION
Fixes #12861. 

## Findings

After the changes in #12812, we no longer call `PostService.autoSave()` for self-hosted site posts. That seems to be the correct fix. It does cause the effect of not having unconfirmed published posts uploaded as drafts. This is one of the features of Offline Posting — avoiding data loss and always uploading the changes to the server. 

## Solution

This was a bit tricky, which is why I'm targeting `develop` instead of the frozen `release/13.6` branch. I thought of adding another logic in `PostService.autoSave()` to support this. However, that method is also used in post previews. Adding that logic in `autoSave` would cause previews to be confusing for users. Consider this scenario:

1. Create a post. Set its status as Published in Post Settings.
2. Preview — the post will be auto-uploaded as a draft. ✔️ 
3. Preview again — the post will no longer be auto-uploaded as a draft. We cannot upload it as `published` either because the user is still writing the post. So in this case, Preview will just show a “Cannot preview“ error. ❌ 

With this, I opted to have a new `AutoUploadAction`, `.uploadAsDraft`, and used `PostService.uploadPost(:forceDraftIfCreating:)`. This seems simpler and more direct. 

## Testing

1. While offline, create a post and publish it. 
2. Tap _Cancel_ 
3. Go back online. 

The post should be uploaded as a draft. 

## Reviewing 

- Only 1 reviewer is needed but anyone can review. 
- Please merge it if you approve of the change and are not requesting any changes. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
