### PR TITLE
[VoiceOver] Announce Notices when they are shown

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -249,6 +249,8 @@ class NoticePresenter: NSObject {
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Animations.dismissDelay, execute: dismiss)
         })
 
+        UIAccessibility.post(notification: .layoutChanged, argument: noticeContainerView)
+
         return NoticePresentation(notice: notice, containerView: noticeContainerView)
     }
 

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -279,7 +279,7 @@ class NoticePresenter: NSObject {
             // being shown. Hiding the window would cause that new Notice to be invisible.
             if self?.currentNoticePresentation == nil {
                 UIAccessibility.post(notification: .layoutChanged, argument: nil)
-                
+
                 self?.window.isHidden = true
             }
         })

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -278,6 +278,8 @@ class NoticePresenter: NSObject {
             // It is possible that when the dismiss animation finished, another Notice was already
             // being shown. Hiding the window would cause that new Notice to be invisible.
             if self?.currentNoticePresentation == nil {
+                UIAccessibility.post(notification: .layoutChanged, argument: nil)
+                
                 self?.window.isHidden = true
             }
         })

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -52,7 +52,7 @@ class NoticeView: UIView {
             configureDismissRecognizer()
         }
 
-        configureForVoiceOver()
+        configureForAccessibility()
     }
 
     private func configureBackgroundViews() {
@@ -353,11 +353,12 @@ fileprivate extension UIView {
 // MARK: - VoiceOver
 
 private extension NoticeView {
-    func configureForVoiceOver() {
+    func configureForAccessibility() {
         labelStackView.accessibilityLabel = [titleLabel, messageLabel].compactMap {
             return $0.isHidden ? "" : $0.text
         }.joined(separator: ". ")
 
         labelStackView.isAccessibilityElement = true
+        labelStackView.accessibilityIdentifier = "notice_title_and_message"
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -2,14 +2,18 @@ import UIKit
 
 class NoticeView: UIView {
     internal let contentStackView = UIStackView()
+
     internal let backgroundContainerView = UIView()
     internal let backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: .extraLight))
     internal let actionBackgroundView = UIView()
     private let shadowLayer = CAShapeLayer()
     private let shadowMaskLayer = CAShapeLayer()
 
+    /// Container for the title and content labels
+    private let labelStackView = UIStackView()
     internal let titleLabel = UILabel()
     internal let messageLabel = UILabel()
+
     private let actionButton = UIButton(type: .system)
     private let cancelButton = UIButton(type: .system)
 
@@ -47,6 +51,8 @@ class NoticeView: UIView {
         if notice.style.isDismissable {
             configureDismissRecognizer()
         }
+
+        configureForVoiceOver()
     }
 
     private func configureBackgroundViews() {
@@ -109,7 +115,6 @@ class NoticeView: UIView {
     }
 
     private func configureLabels() {
-        let labelStackView = UIStackView()
         labelStackView.translatesAutoresizingMaskIntoConstraints = false
         labelStackView.alignment = .leading
         labelStackView.axis = .vertical
@@ -342,5 +347,17 @@ fileprivate extension UIView {
 
     struct Constants {
         static let borderColor = UIColor.white.withAlphaComponent(0.25)
+    }
+}
+
+// MARK: - VoiceOver
+
+private extension NoticeView {
+    func configureForVoiceOver() {
+        labelStackView.accessibilityLabel = [titleLabel, messageLabel].compactMap {
+            return $0.isHidden ? "" : $0.text
+        }.joined(separator: ". ")
+
+        labelStackView.isAccessibilityElement = true
     }
 }

--- a/WordPress/WordPressUITests/Screens/Editor/EditorNoticeComponent.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/EditorNoticeComponent.swift
@@ -4,15 +4,25 @@ import XCTest
 class EditorNoticeComponent: BaseScreen {
     let noticeAction: XCUIElement
 
-    init(withNotice noticeText: String, andAction buttonText: String) {
-        let notice = XCUIApplication().staticTexts[noticeText]
+    private let expectedNoticeTitle: String
+
+    init(withNotice noticeTitle: String, andAction buttonText: String) {
+        let notice = XCUIApplication().otherElements["notice_title_and_message"]
+
         noticeAction = XCUIApplication().buttons[buttonText]
+
+        expectedNoticeTitle = noticeTitle
 
         super.init(element: notice)
     }
 
-    func viewPublishedPost(withTitle title: String) -> EditorPublishEpilogueScreen {
-        XCTAssert(XCUIApplication().staticTexts[title].exists, "Post title not visible on published post notice")
+    func viewPublishedPost(withTitle postTitle: String) -> EditorPublishEpilogueScreen {
+        // The publish notice has a joined accessibility label equal to: title + message
+        // (the postTitle). It does not seem possible to target the specific postTitle label
+        // only because of this.
+        let expectedLabel = String(format: "%@. %@", expectedNoticeTitle, postTitle)
+        XCTAssertEqual(expectedElement.label, expectedLabel, "Post title not visible on published post notice")
+
         noticeAction.tap()
 
         return EditorPublishEpilogueScreen()


### PR DESCRIPTION
Fixes part of #11496.

This adds 2 things: 

- d34c7af Announcement of Notices when they are shown
- d04b6f1 Grouping the title and message together so they are dictated once by VoiceOver

## Testing

### Option A

Run through Quick Start and validate that whenever a Notice is shown, VoiceOver will announce the title and message. 

I noticed that VoiceOver will sometimes not dictate the Notice when you go navigate back to the Site page from a different page (e.g. Themes). VoiceOver will either: 

- Select the previously selected element
- Select the announced Notice

Not sure if it's worth it to chase the fix for that. It seems to be out of our control. 🤷‍♂ 

### Option B

1. Replace [`showNoInternetConnectionNotice`](https://github.com/wordpress-mobile/WordPress-iOS/blob/b96410ddc5700b50fcba763ddad6da17bcb78b00/WordPress/Classes/Utility/ReachabilityUtils%2BOnlineActions.swift#L46-L50) with this:
    ```swift
            let notice = Notice(title: "This is a title", message: message, actionTitle: "Run", cancelTitle: "Slide", tag: DefaultNoConnectionMessage.tag)
        ActionDispatcher.dispatch(NoticeAction.post(notice))
    ```
1. Navigate to Posts List 
2. Go offline
3. Pull to refresh (swipe down with three fingers in VoiceOver)

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 

---

@frosty Can I bother you with this one? 🙂 