### PR TITLE
Resolve scheduled post status

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -63,6 +63,17 @@ struct PublishSettingsViewModel {
             state = .immediately
         }
 
+        /// Set the post's status to scheduled or published depending on our date value
+        switch state {
+        case .scheduled:
+            post.status = .scheduled
+        case .immediately:
+            post.publishImmediately()
+        case .published:
+            /// Don't need to do anything for published states (based on previous logic in PostSettingsViewController)
+            break
+        }
+
         post.dateCreated = date
     }
 }


### PR DESCRIPTION
Need to manually set the post status after setting the data. Functionality was copied from `PostSettingsViewController` implementation.
