### PR TITLE
Issue/12796 Fix domain registration failure due to spaces

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * Better support for creating or editing posts while offline. Posts can be saved while offline and they will be automatically uploaded (or published) when the device is back online.
 * Me view: fix issue where view was blank when logging in with a self-hosted site.
 * Block Editor: Added support for image alignment options.
+* Fixed validation issues in the domain registration screen.
  
 13.5
 -----

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -13,10 +13,15 @@ import WordPressAuthenticator
 
 class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
 
-    enum Const {
+    fileprivate enum Const {
         enum Color {
             static let nameText = UIColor.text
             static let valueText = UIColor.textSubtle
+        }
+
+        enum Text {
+            static let nonBreakingSpace = "\u{00a0}"
+            static let space = " "
         }
     }
 
@@ -64,7 +69,7 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
     }
 
     @objc func textFieldDidChange(textField: UITextField) {
-        textField.text = textField.text?.replacingOccurrences(of: " ", with: "\u{00a0}")
+        textField.text = textField.text?.replacingOccurrences(of: Const.Text.space, with: Const.Text.nonBreakingSpace)
 
         let text = sanitizedText(for: textField)
         delegate?.inlineEditableNameValueCell?(self, valueTextFieldDidChange: text)
@@ -78,7 +83,7 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
     }
 
     private func sanitizedText(for textField: UITextField) -> String {
-        return textField.text?.replacingOccurrences(of: "\u{00a0}", with: " ") ?? ""
+        return textField.text?.replacingOccurrences(of: Const.Text.nonBreakingSpace, with: Const.Text.space) ?? ""
     }
 
     @objc func setValueTextFieldAsFirstResponder(_ gesture: UITapGestureRecognizer) {

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -3,9 +3,9 @@ import WordPressAuthenticator
 
 @objc protocol InlineEditableNameValueCellDelegate: class {
     @objc optional func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell,
-                                                    valueTextFieldDidChange valueTextField: UITextField)
+                                                    valueTextFieldDidChange value: String)
     @objc optional func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell,
-                                                    valueTextFieldEditingDidEnd valueTextField: UITextField)
+                                                    valueTextFieldEditingDidEnd text: String)
 }
 
 class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
@@ -61,12 +61,20 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
 
     @objc func textFieldDidChange(textField: UITextField) {
         textField.text = textField.text?.replacingOccurrences(of: " ", with: "\u{00a0}")
-        delegate?.inlineEditableNameValueCell?(self, valueTextFieldDidChange: textField)
+
+        let text = sanitizedText(for: textField)
+        delegate?.inlineEditableNameValueCell?(self, valueTextFieldDidChange: text)
     }
 
     @objc func textEditingDidEnd(textField: UITextField) {
-        textField.text = textField.text?.replacingOccurrences(of: "\u{00a0}", with: " ")
-        delegate?.inlineEditableNameValueCell?(self, valueTextFieldEditingDidEnd: textField)
+        let text = sanitizedText(for: textField)
+
+        textField.text = text
+        delegate?.inlineEditableNameValueCell?(self, valueTextFieldEditingDidEnd: text)
+    }
+
+    private func sanitizedText(for textField: UITextField) -> String {
+        return textField.text?.replacingOccurrences(of: "\u{00a0}", with: " ") ?? ""
     }
 
     @objc func setValueTextFieldAsFirstResponder(_ gesture: UITapGestureRecognizer) {

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -6,6 +6,9 @@ import WordPressAuthenticator
                                                     valueTextFieldDidChange value: String)
     @objc optional func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell,
                                                     valueTextFieldEditingDidEnd text: String)
+    @objc optional func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell,
+                                                    valueTextFieldShouldReturn textField: UITextField) -> Bool
+
 }
 
 class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
@@ -42,6 +45,7 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
         valueTextField.tintColor = .textPlaceholder
         valueTextField.font = WPStyleGuide.tableviewTextFont()
         valueTextField.borderStyle = .none
+        valueTextField.delegate = self
         valueTextField.addTarget(self,
                                  action: #selector(textFieldDidChange(textField:)),
                                  for: UIControl.Event.editingChanged)
@@ -79,6 +83,12 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
 
     @objc func setValueTextFieldAsFirstResponder(_ gesture: UITapGestureRecognizer) {
         valueTextField.becomeFirstResponder()
+    }
+}
+
+extension InlineEditableNameValueCell: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        return delegate?.inlineEditableNameValueCell?(self, valueTextFieldShouldReturn: textField) ?? true
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+Cells.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+Cells.swift
@@ -58,12 +58,16 @@ extension RegisterDomainDetailsViewController {
         guard let section = SectionIndex(rawValue: indexPath.section) else {
             return
         }
+
+        cell.valueTextField.returnKeyType = .next
+
         switch section {
         case .contactInformation:
             guard let index = RegisterDomainDetailsViewModel.CellIndex.ContactInformation(rawValue: indexPath.row) else {
                 return
             }
             cell.valueTextField.keyboardType = index.keyboardType
+            cell.valueTextField.autocapitalizationType = .words
         case .phone:
             cell.valueTextField.keyboardType = .numberPad
         case .address:
@@ -73,9 +77,11 @@ extension RegisterDomainDetailsViewController {
                 cell.valueTextField.keyboardType = .numbersAndPunctuation
             default:
                 cell.valueTextField.keyboardType = .default
+                cell.valueTextField.autocapitalizationType = .words
             }
         default:
             cell.valueTextField.keyboardType = .default
+            cell.valueTextField.autocapitalizationType = .none
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -228,6 +228,30 @@ extension RegisterDomainDetailsViewController: InlineEditableNameValueCellDelega
                 viewModel.enableAddAddressRow()
         }
     }
+
+    func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell, valueTextFieldShouldReturn textField: UITextField) -> Bool {
+        guard let indexPath = tableView.indexPath(for: cell) else {
+                return false
+        }
+        
+        let nextSection = indexPath.section + 1
+        let nextRow = indexPath.row + 1
+
+        // If there's an enabled editable row next in this section then select it, otherwise check the next section
+        if tableView.numberOfRows(inSection: indexPath.section) > nextRow,
+            let nextCell = tableView.cellForRow(at: IndexPath(row: nextRow, section: indexPath.section)) as? InlineEditableNameValueCell,
+            nextCell.valueTextField.isEnabled {
+            nextCell.valueTextField.becomeFirstResponder()
+        } else if tableView.numberOfSections > nextSection,
+            let nextCell = tableView.cellForRow(at: IndexPath(row: indexPath.row, section: nextSection)) as? InlineEditableNameValueCell,
+            nextCell.valueTextField.isEnabled {
+            nextCell.valueTextField.becomeFirstResponder()
+        } else {
+            textField.resignFirstResponder()
+        }
+
+        return true
+    }
 }
 
 // MARK: - UITableViewDelegate

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -63,26 +63,11 @@ class RegisterDomainDetailsViewController: NUXTableViewController {
 
         viewModel.prefill()
 
-        changeBottomSafeAreaInset()
         setupEditingEndingTapGestureRecognizer()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         configureTableFooterView(width: size.width)
-
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        changeBottomSafeAreaInset()
-    }
-
-    private func changeBottomSafeAreaInset() {
-        // Footer in this case is the submit button. We want the background to extend under the home indicator.
-        let safeAreaInsets = tableView.safeAreaInsets.bottom
-
-        var newInsets = tableView.contentInset
-        newInsets.bottom = -safeAreaInsets
-        tableView.contentInset = newInsets
     }
 
     private func configureTableView() {

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -213,18 +213,18 @@ extension RegisterDomainDetailsViewController {
 extension RegisterDomainDetailsViewController: InlineEditableNameValueCellDelegate {
 
     func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell,
-                                     valueTextFieldDidChange valueTextField: UITextField) {
+                                     valueTextFieldDidChange text: String) {
         guard let indexPath = tableView.indexPath(for: cell),
             let sectionType = SectionIndex(rawValue: indexPath.section) else {
                 return
         }
 
-        viewModel.updateValue(valueTextField.text, at: indexPath)
+        viewModel.updateValue(text, at: indexPath)
 
         if sectionType == .address,
             viewModel.addressSectionIndexHelper.addressField(for: indexPath.row) == .addressLine,
             indexPath.row == viewModel.addressSectionIndexHelper.extraAddressLineCount,
-            valueTextField.text?.isEmpty == false {
+            text.isEmpty == false {
                 viewModel.enableAddAddressRow()
         }
     }

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -233,7 +233,7 @@ extension RegisterDomainDetailsViewController: InlineEditableNameValueCellDelega
         guard let indexPath = tableView.indexPath(for: cell) else {
                 return false
         }
-        
+
         let nextSection = indexPath.section + 1
         let nextRow = indexPath.row + 1
 

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
@@ -314,7 +314,7 @@ extension SiteInformationWizardContent: UITableViewDataSource {
 
 extension SiteInformationWizardContent: InlineEditableNameValueCellDelegate {
     func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell,
-                                      valueTextFieldDidChange valueTextField: UITextField) {
+                                      valueTextFieldDidChange  text: String) {
         updateButton()
     }
 


### PR DESCRIPTION
Fixes #12796. A previous PR, #12564, introduced some changes to the way spaces were handled in the domain registration form. Unfortunately, this wasn't entirely successful and has resulted in form validation failures due to fields containing unicode non-breaking spaces instead of actual space characters.

This PR fixes that by ensuring text field values are sanitised before being passed back to the delegate. See the first commit for this change.

I also took the liberty to improve the UX of the domain registration form while I was in there. The second two commits enable auto capitalization on fields in the form and allows the Next button to tab to the next available editable field.

**To test:**

* Access domain registration for one of your sites. I did this by commenting out code at the start of `configureTableViewData` in `BlogDetailsViewController` so that the domains row is visible.
* Select a domain to get to the registration form.
* Enter the address `1200 Getty Center Dr, Los Angeles, CA 90049`, and ensure that no validation errors occur (without this patch, you'll get an error for address and city).
* While you're doing that, check you can use Next to move between fields, and your words are capitalised.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
