### PR TITLE
Update NoticeComponent to accommodate VoiceOver changes

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -52,7 +52,7 @@ class NoticeView: UIView {
             configureDismissRecognizer()
         }
 
-        configureForVoiceOver()
+        configureForAccessibility()
     }
 
     private func configureBackgroundViews() {
@@ -353,11 +353,12 @@ fileprivate extension UIView {
 // MARK: - VoiceOver
 
 private extension NoticeView {
-    func configureForVoiceOver() {
+    func configureForAccessibility() {
         labelStackView.accessibilityLabel = [titleLabel, messageLabel].compactMap {
             return $0.isHidden ? "" : $0.text
         }.joined(separator: ". ")
 
         labelStackView.isAccessibilityElement = true
+        labelStackView.accessibilityIdentifier = "notice_title_and_message"
     }
 }

--- a/WordPress/WordPressUITests/Screens/Editor/EditorNoticeComponent.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/EditorNoticeComponent.swift
@@ -4,9 +4,14 @@ import XCTest
 class EditorNoticeComponent: BaseScreen {
     let noticeAction: XCUIElement
 
-    init(withNotice noticeText: String, andAction buttonText: String) {
-        let notice = XCUIApplication().staticTexts[noticeText]
+    private let expectedNoticeTitle: String
+
+    init(withNotice noticeTitle: String, andAction buttonText: String) {
+        let notice = XCUIApplication().otherElements["notice_title_and_message"]
+
         noticeAction = XCUIApplication().buttons[buttonText]
+
+        expectedNoticeTitle = noticeTitle
 
         super.init(element: notice)
     }

--- a/WordPress/WordPressUITests/Screens/Editor/EditorNoticeComponent.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/EditorNoticeComponent.swift
@@ -17,7 +17,12 @@ class EditorNoticeComponent: BaseScreen {
     }
 
     func viewPublishedPost(withTitle postTitle: String) -> EditorPublishEpilogueScreen {
-        XCTAssert(XCUIApplication().staticTexts[postTitle].exists, "Post title not visible on published post notice")
+        // The publish notice has a joined accessibility label equal to: title + message
+        // (the postTitle). It does not seem possible to target the specific postTitle label
+        // only because of this.
+        let expectedLabel = String(format: "%@. %@", expectedNoticeTitle, postTitle)
+        XCTAssertEqual(expectedElement.label, expectedLabel, "Post title not visible on published post notice")
+
         noticeAction.tap()
 
         return EditorPublishEpilogueScreen()

--- a/WordPress/WordPressUITests/Screens/Editor/EditorNoticeComponent.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/EditorNoticeComponent.swift
@@ -16,8 +16,8 @@ class EditorNoticeComponent: BaseScreen {
         super.init(element: notice)
     }
 
-    func viewPublishedPost(withTitle title: String) -> EditorPublishEpilogueScreen {
-        XCTAssert(XCUIApplication().staticTexts[title].exists, "Post title not visible on published post notice")
+    func viewPublishedPost(withTitle postTitle: String) -> EditorPublishEpilogueScreen {
+        XCTAssert(XCUIApplication().staticTexts[postTitle].exists, "Post title not visible on published post notice")
         noticeAction.tap()
 
         return EditorPublishEpilogueScreen()


### PR DESCRIPTION
Fixes the failing UI tests caused by #12873. 

## Findings

In #12873, I changed the accessibility of `NoticeView` so that both the title and message are dictated as a single unit (d04b6f12abe9154a7bea0e7e64d817133d605cfb). This broke the editor UI tests. 

## Solution

This PR changes `EditorNoticeComponent` so that:

- 881a6c2 It will wait for the container of the Notice's title and message 
- ac4a04f It will validate based on the expected title and message

I'd love to have your opinion on the changes as I wasn't sure of how the UI test architecture connects all the classes together. 

## Testing

I believe testing that `EditorAztecTests` and `EditorGutenbergTests` pass should be good enough. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
