### PR TITLE
[VoiceOver] Make WPImageViewController dismissible 

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -152,6 +152,8 @@ static CGFloat const MinimumZoomScale = 0.1;
     [self setupActivityIndicator];
     [self layoutActivityIndicator];
 
+    [self setupAccessibility];
+
     [self loadImage];
 }
 
@@ -542,6 +544,14 @@ static CGFloat const MinimumZoomScale = 0.1;
 - (void)flingableViewHandlerWasCancelled:(FlingableViewHandler *)handler
 {
     self.scrollView.multipleTouchEnabled = YES;
+}
+
+#pragma mark - Accessibility
+
+- (void)setupAccessibility
+{
+    self.imageView.isAccessibilityElement = YES;
+    self.imageView.accessibilityTraits = UIAccessibilityTraitImage;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -554,4 +554,13 @@ static CGFloat const MinimumZoomScale = 0.1;
     self.imageView.accessibilityTraits = UIAccessibilityTraitImage;
 }
 
+- (BOOL)accessibilityPerformEscape
+{
+    // Dismiss when self receives the VoiceOver escape gesture (Z). This does not seem to happen
+    // automatically if self is presented modally by itself (i.e. not inside a
+    // UINavigationController).
+    [self dismissViewControllerAnimated:YES completion:nil];
+    return YES;
+}
+
 @end


### PR DESCRIPTION
Fixes #12867

## Findings

When `WPImageViewController` is presented by itself, not inside a `UINavigationController`, the VoiceOver escape gesture does not automatically handle the dismissal. 

## Solution

This adds 2 things:

- 93bbc6d Make the image accessible so the VoiceOver user can interact with it.
- 85458c3 React to the escape gesture and dismiss self

## Testing

1. Navigate to Reader and to a post with an image.
2. Turn on VoiceOver
3. Tap on the image. The `WPImageViewController` should be shown. 

Confirm that you can:

- Double-tap on the image to dismiss the view. 
- Use the escape gesture to dismiss the view (move two fingers back and forth three times quickly, making a “z”).

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
