### PR TITLE
Increase the timeout of DomainServiceTests

### DIFF
--- a/WordPress/WordPressTest/DomainsServiceTests.swift
+++ b/WordPress/WordPressTest/DomainsServiceTests.swift
@@ -73,7 +73,7 @@ class DomainsServiceTests: XCTestCase {
             expect.fulfill()
         })
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 2, handler: nil)
     }
 
     func testDomainServiceHandlesTwoNewDomains() {


### PR DESCRIPTION
## Findings

Every so often, I get unit test failures in CircleCI because of `DomainServiceTests`. I looked at [one of the successful builds](https://circleci.com/gh/wordpress-mobile/WordPress-iOS/16348) and found that one of the tests is pretty close to 1 sec.

```
DomainsServiceTests
    ✓ testDomainServiceHandlesTwoNewDomains (0.868 seconds)
    ✓ testDomainServiceParsesAllDomainTypes (0.048 seconds)
    ✓ testDomainServiceParsesPrimaryDomain (0.044 seconds)
    ✓ testDomainServiceRemovesOldDomains (0.051 seconds)
    ✓ testDomainServiceUpdatesExistingDomains (0.044 seconds)
```

Locally, it takes about 0.2 seconds. Something might have changed somewhere that resulted in this test to be not as fast as we thought it was.

## Solution

This just increases the timeout to 2 seconds. This is not the most ideal solution but it's probably good enough to decrease the flakiness. 

## Testing

The test passing should be good enough I think? 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
