### PR TITLE
Fix tap link bug in Aztec editor.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -169,7 +169,7 @@ class AztecPostViewController: UIViewController, PostEditor {
             textView.autocorrectionType = .no
         }
 
-        removeTapGestureRecognizer(from: textView)
+        disableLinkTapRecognizer(from: textView)
     }
 
     /**

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -168,8 +168,22 @@ class AztecPostViewController: UIViewController, PostEditor {
         if UIApplication.shared.isCreatingScreenshots() {
             textView.autocorrectionType = .no
         }
+
+        removeTapGestureRecognizer(from: textView)
     }
 
+    /**
+    This handles a bug introduced by iOS 13.0 (tested up to 13.2) where link interactions don't respect what the documentation says.
+    The documenatation for textView(_:shouldInteractWith:in:interaction:) says:
+    > Links in text views are interactive only if the text view is selectable but noneditable.
+    Our Aztec Text views are selectable and editable, and yet iOS was opening links on Safari when tapped.
+    */
+    fileprivate func disableLinkTapRecognizer(from textView: UITextView) {
+        guard let recognizer = textView.gestureRecognizers?.first(where: { $0.name == "UITextInteractionNameLinkTap" }) else {
+            return
+        }
+        recognizer.isEnabled = false
+    }
 
     /// Aztec's Text Placeholder
     ///
@@ -1347,10 +1361,6 @@ extension AztecPostViewController: UITextViewDelegate {
         }
 
         return true
-    }
-
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        return false
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {


### PR DESCRIPTION
Related #https://github.com/wordpress-mobile/gutenberg-mobile/issues/1373

Fix the tap in links bug in Aztec editor.

To test:
 - Start the app
 - Open a post using Aztec
 - Try to tap in a link and see that you can interact correctly with and no Safari browser is open.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
