### PR TITLE
Fix Compact Post List to show date

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -9,6 +9,7 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
     @IBOutlet weak var featuredImageView: CachedAnimatedImageView!
     @IBOutlet weak var headerStackView: UIStackView!
     @IBOutlet weak var innerView: UIView!
+    @IBOutlet weak var contentStackView: UIStackView!
     @IBOutlet weak var ghostView: UIView!
     @IBOutlet weak var progressView: UIProgressView!
     @IBOutlet weak var separator: UIView!
@@ -183,7 +184,7 @@ extension PostCompactCell: GhostableView {
         separator.isGhostableDisabled = true
         ghostView.isHidden = !visible
         ghostView.backgroundColor = .listForeground
-        featuredImageView.isHidden = true
+        contentStackView.isHidden = visible
     }
 
     private enum GhostConstants {

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -120,9 +120,9 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
         }
 
         let isUploadingOrFailed = viewModel.isUploadingOrFailed
-        timestampLabel.text = isUploadingOrFailed ? "" : post.latest().dateStringForDisplay()
+        timestampLabel.text = post.latest().dateStringForDisplay()
+        timestampLabel.isHidden = false
         timestampTrailing.constant = isUploadingOrFailed ? 0 : Constants.contentSpacing
-        timestampLabel.isHidden = isUploadingOrFailed
     }
 
     private func configureStatus() {

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -7,12 +7,10 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
     @IBOutlet weak var badgesLabel: UILabel!
     @IBOutlet weak var menuButton: UIButton!
     @IBOutlet weak var featuredImageView: CachedAnimatedImageView!
+    @IBOutlet weak var headerStackView: UIStackView!
     @IBOutlet weak var innerView: UIView!
     @IBOutlet weak var ghostView: UIView!
     @IBOutlet weak var progressView: UIProgressView!
-    @IBOutlet weak var labelsLeadingConstraint: NSLayoutConstraint!
-    @IBOutlet weak var timestampTrailing: NSLayoutConstraint!
-    @IBOutlet var labelsContainerTrailing: NSLayoutConstraint!
     @IBOutlet weak var separator: UIView!
 
     private weak var actionSheetDelegate: PostActionSheetDelegate?
@@ -95,18 +93,14 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
 
         innerView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor).isActive = true
         innerView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor).isActive = true
-
-        labelsLeadingConstraint.constant = -Constants.contentSpacing
     }
 
     private func configureFeaturedImage() {
         if let post = post, let url = post.featuredImageURL {
             featuredImageView.isHidden = false
-            labelsContainerTrailing.isActive = true
             imageLoader.loadImage(with: url, from: post, preferredSize: CGSize(width: featuredImageView.frame.width, height: featuredImageView.frame.height))
         } else {
             featuredImageView.isHidden = true
-            labelsContainerTrailing.isActive = false
         }
     }
 
@@ -130,7 +124,6 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
 
         badgesLabel.textColor = viewModel.statusColor
         badgesLabel.text = viewModel.statusAndBadges(separatedBy: Constants.separator)
-        badgesLabel.numberOfLines = viewModel.isUploadingOrFailed ? 0 : 1
     }
 
     private func configureProgressView() {

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -124,6 +124,11 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
 
         badgesLabel.textColor = viewModel.statusColor
         badgesLabel.text = viewModel.statusAndBadges(separatedBy: Constants.separator)
+        if badgesLabel.text?.isEmpty ?? true {
+            badgesLabel.isHidden = true
+        } else {
+            badgesLabel.isHidden = false
+        }
     }
 
     private func configureProgressView() {

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -115,11 +115,10 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
     }
 
     private func configureDate() {
-        guard let post = post, let viewModel = viewModel else {
+        guard let post = post else {
             return
         }
 
-        let isUploadingOrFailed = viewModel.isUploadingOrFailed
         timestampLabel.text = post.latest().dateStringForDisplay()
         timestampLabel.isHidden = false
     }

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -122,7 +122,6 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
         let isUploadingOrFailed = viewModel.isUploadingOrFailed
         timestampLabel.text = post.latest().dateStringForDisplay()
         timestampLabel.isHidden = false
-        timestampTrailing.constant = isUploadingOrFailed ? 0 : Constants.contentSpacing
     }
 
     private func configureStatus() {

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
@@ -14,140 +14,134 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="186" id="Bfq-Ne-g8g" customClass="PostCompactCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="186"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="110" id="Bfq-Ne-g8g" customClass="PostCompactCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Bfq-Ne-g8g" id="9ZV-7I-syI">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="186"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HJK-1N-bmY">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="186"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UrU-r4-hAL" userLabel="Labels">
-                                <rect key="frame" x="16" y="6" width="192" height="170"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTi-We-ou2" userLabel="Header">
+                                <rect key="frame" x="8" y="16" width="304" height="40"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
-                                        <rect key="frame" x="0.0" y="0.0" width="192" height="23.5"/>
-                                        <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="17"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
-                                        <rect key="frame" x="0.0" y="25.5" width="74.5" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" text="Private • Local changes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
-                                        <rect key="frame" x="0.0" y="154" width="192" height="16"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="nQW-3W-m3b" userLabel="Title and Timestamp">
+                                        <rect key="frame" x="8" y="0.0" width="208" height="40"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
+                                                <rect key="frame" x="0.0" y="0.0" width="208" height="18"/>
+                                                <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="17"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
+                                                <rect key="frame" x="0.0" y="22" width="208" height="18"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTx-r8-hUF">
+                                                <rect key="frame" x="0.0" y="40" width="208" height="0.0"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
+                                                        <rect key="frame" x="0.0" y="-18" width="208" height="36"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6QQ-XY-q2l">
+                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="14.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yxn-r2-waJ">
+                                                                <rect key="frame" x="0.0" y="22.5" width="88" height="13.5"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="trailing" secondItem="6QQ-XY-q2l" secondAttribute="trailing" constant="40" id="Bc6-rp-y5l"/>
+                                                            <constraint firstAttribute="bottom" secondItem="yxn-r2-waJ" secondAttribute="bottom" id="E5o-DB-eDv"/>
+                                                            <constraint firstItem="yxn-r2-waJ" firstAttribute="top" secondItem="6QQ-XY-q2l" secondAttribute="bottom" constant="8" id="KZV-Rp-kev"/>
+                                                            <constraint firstItem="yxn-r2-waJ" firstAttribute="leading" secondItem="6QQ-XY-q2l" secondAttribute="leading" id="KvI-HE-g92"/>
+                                                            <constraint firstItem="6QQ-XY-q2l" firstAttribute="leading" secondItem="ESK-bT-Bix" secondAttribute="leading" id="Vlw-EV-qw7"/>
+                                                            <constraint firstItem="6QQ-XY-q2l" firstAttribute="top" secondItem="ESK-bT-Bix" secondAttribute="top" id="hxM-IR-oZP"/>
+                                                            <constraint firstAttribute="trailing" secondItem="yxn-r2-waJ" secondAttribute="trailing" constant="120" id="j1w-ks-jni"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="trailing" secondItem="ESK-bT-Bix" secondAttribute="trailing" id="h96-7a-N0h"/>
+                                                    <constraint firstItem="ESK-bT-Bix" firstAttribute="leading" secondItem="XTx-r8-hUF" secondAttribute="leading" id="mJJ-sj-Om2"/>
+                                                    <constraint firstItem="ESK-bT-Bix" firstAttribute="centerY" secondItem="XTx-r8-hUF" secondAttribute="centerY" id="yNO-gY-vZq"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="fEo-hS-PK1" firstAttribute="top" secondItem="ZUq-Dg-elW" secondAttribute="bottom" constant="4" id="0qk-zM-VRi"/>
+                                        </constraints>
+                                    </stackView>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tne-qn-oAS" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
+                                        <rect key="frame" x="216" y="0.0" width="40" height="40"/>
+                                        <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="40" id="WGx-7Y-oMs"/>
+                                            <constraint firstAttribute="width" constant="40" id="eg9-Kp-Xfc"/>
+                                        </constraints>
+                                    </imageView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh4-Mc-AK7">
+                                        <rect key="frame" x="256" y="-7" width="56" height="47"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="47" id="SNG-8G-08p"/>
+                                            <constraint firstAttribute="width" constant="56" id="ciz-Vj-1BT"/>
+                                        </constraints>
+                                        <state key="normal" image="icon-post-actionbar-more">
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="more:" destination="Bfq-Ne-g8g" eventType="touchUpInside" id="t3f-ip-IBh"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="leading" id="8de-H8-BGJ"/>
-                                    <constraint firstItem="fEo-hS-PK1" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="leading" id="Ar0-bF-oL3"/>
-                                    <constraint firstAttribute="trailing" secondItem="ZUq-Dg-elW" secondAttribute="trailing" id="K78-Nm-WTO"/>
-                                    <constraint firstItem="ZUq-Dg-elW" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="leading" id="LcB-FM-8SQ"/>
-                                    <constraint firstItem="fEo-hS-PK1" firstAttribute="top" secondItem="ZUq-Dg-elW" secondAttribute="bottom" constant="2" id="Na7-iX-HyI"/>
-                                    <constraint firstAttribute="trailing" secondItem="ZNQ-Pm-fi0" secondAttribute="trailing" id="ULF-V1-s1k"/>
-                                    <constraint firstItem="ZUq-Dg-elW" firstAttribute="top" secondItem="UrU-r4-hAL" secondAttribute="top" id="d30-IF-aiG"/>
-                                    <constraint firstAttribute="bottom" secondItem="ZNQ-Pm-fi0" secondAttribute="bottom" id="k2R-gp-BRa"/>
-                                    <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="top" secondItem="fEo-hS-PK1" secondAttribute="bottom" constant="5" id="kcM-tR-3L1"/>
+                                    <constraint firstAttribute="trailing" secondItem="Zh4-Mc-AK7" secondAttribute="trailing" constant="-8" id="04Q-1Y-r44"/>
+                                    <constraint firstItem="tne-qn-oAS" firstAttribute="centerY" secondItem="XTi-We-ou2" secondAttribute="centerY" id="GFk-cc-soI"/>
+                                    <constraint firstItem="nQW-3W-m3b" firstAttribute="leading" secondItem="XTi-We-ou2" secondAttribute="leading" constant="8" id="qqs-SD-gXL"/>
                                 </constraints>
-                            </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh4-Mc-AK7">
-                                <rect key="frame" x="264" y="8" width="56" height="47"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="47" id="SNG-8G-08p"/>
-                                    <constraint firstAttribute="width" constant="56" id="ciz-Vj-1BT"/>
-                                </constraints>
-                                <state key="normal" image="icon-post-actionbar-more">
-                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="more:" destination="Bfq-Ne-g8g" eventType="touchUpInside" id="t3f-ip-IBh"/>
-                                </connections>
-                            </button>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tne-qn-oAS" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="224" y="16" width="40" height="40"/>
-                                <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="WGx-7Y-oMs"/>
-                                    <constraint firstAttribute="width" constant="40" id="eg9-Kp-Xfc"/>
-                                </constraints>
-                            </imageView>
+                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" text="Private • Local changes | More text to test wrapping" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
+                                <rect key="frame" x="16" y="64" width="288" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="06O-B0-y3k">
-                                <rect key="frame" x="0.0" y="182" width="320" height="4"/>
+                                <rect key="frame" x="0.0" y="106" width="320" height="4"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="4" id="j1t-t8-KFy"/>
                                 </constraints>
                             </progressView>
-                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTx-r8-hUF">
-                                <rect key="frame" x="16" y="0.0" width="248" height="186"/>
-                                <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
-                                        <rect key="frame" x="0.0" y="74.5" width="248" height="37"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6QQ-XY-q2l">
-                                                <rect key="frame" x="0.0" y="0.0" width="208" height="15"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yxn-r2-waJ">
-                                                <rect key="frame" x="0.0" y="23" width="128" height="14"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="6QQ-XY-q2l" secondAttribute="trailing" constant="40" id="Bc6-rp-y5l"/>
-                                            <constraint firstAttribute="bottom" secondItem="yxn-r2-waJ" secondAttribute="bottom" id="E5o-DB-eDv"/>
-                                            <constraint firstItem="yxn-r2-waJ" firstAttribute="top" secondItem="6QQ-XY-q2l" secondAttribute="bottom" constant="8" id="KZV-Rp-kev"/>
-                                            <constraint firstItem="yxn-r2-waJ" firstAttribute="leading" secondItem="6QQ-XY-q2l" secondAttribute="leading" id="KvI-HE-g92"/>
-                                            <constraint firstItem="6QQ-XY-q2l" firstAttribute="leading" secondItem="ESK-bT-Bix" secondAttribute="leading" id="Vlw-EV-qw7"/>
-                                            <constraint firstItem="6QQ-XY-q2l" firstAttribute="top" secondItem="ESK-bT-Bix" secondAttribute="top" id="hxM-IR-oZP"/>
-                                            <constraint firstAttribute="trailing" secondItem="yxn-r2-waJ" secondAttribute="trailing" constant="120" id="j1w-ks-jni"/>
-                                        </constraints>
-                                    </view>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="ESK-bT-Bix" secondAttribute="trailing" id="h96-7a-N0h"/>
-                                    <constraint firstItem="ESK-bT-Bix" firstAttribute="leading" secondItem="XTx-r8-hUF" secondAttribute="leading" id="mJJ-sj-Om2"/>
-                                    <constraint firstItem="ESK-bT-Bix" firstAttribute="centerY" secondItem="XTx-r8-hUF" secondAttribute="centerY" id="yNO-gY-vZq"/>
-                                </constraints>
-                            </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="Zh4-Mc-AK7" firstAttribute="leading" secondItem="tne-qn-oAS" secondAttribute="trailing" id="3s0-QP-5YT"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="Zh4-Mc-AK7" secondAttribute="trailing" constant="-8" id="6OK-8s-Dxs"/>
+                            <constraint firstAttribute="trailing" secondItem="XTi-We-ou2" secondAttribute="trailing" constant="8" id="1I3-l4-XU9"/>
+                            <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="top" secondItem="XTi-We-ou2" secondAttribute="bottom" constant="8" id="4Km-sC-0kq"/>
+                            <constraint firstItem="XTi-We-ou2" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" constant="8" id="4ks-94-4HJ"/>
                             <constraint firstAttribute="trailing" secondItem="06O-B0-y3k" secondAttribute="trailing" id="8ib-ER-7zy"/>
-                            <constraint firstItem="Zh4-Mc-AK7" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="8" id="9Ro-zJ-VZh"/>
-                            <constraint firstItem="XTx-r8-hUF" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" id="DSl-Iw-NhL"/>
-                            <constraint firstItem="UrU-r4-hAL" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="6" id="JL4-zc-5bz"/>
-                            <constraint firstItem="tne-qn-oAS" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="16" id="P2g-Rs-kzJ"/>
-                            <constraint firstAttribute="bottom" secondItem="XTx-r8-hUF" secondAttribute="bottom" id="Psp-EO-ZSL"/>
-                            <constraint firstAttribute="bottom" secondItem="UrU-r4-hAL" secondAttribute="bottom" constant="10" id="QLd-8e-C0k"/>
-                            <constraint firstItem="XTx-r8-hUF" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="leading" id="Sn7-OG-k7S"/>
-                            <constraint firstItem="UrU-r4-hAL" firstAttribute="trailing" secondItem="Zh4-Mc-AK7" secondAttribute="leading" priority="750" id="VgY-3y-Xq1"/>
+                            <constraint firstAttribute="trailing" secondItem="ZNQ-Pm-fi0" secondAttribute="trailing" constant="16" id="B7u-g4-75M"/>
+                            <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" constant="16" id="JHe-IL-nWK"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="60" id="XwZ-7a-9Cd"/>
-                            <constraint firstItem="tne-qn-oAS" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="trailing" constant="16" id="YXw-VS-KHH"/>
-                            <constraint firstItem="Zh4-Mc-AK7" firstAttribute="leading" secondItem="XTx-r8-hUF" secondAttribute="trailing" id="ex5-gp-3zr"/>
                             <constraint firstItem="06O-B0-y3k" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" id="g6x-y3-fZX"/>
-                            <constraint firstItem="UrU-r4-hAL" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leadingMargin" constant="8" id="mXG-L5-nGo"/>
-                            <constraint firstItem="UrU-r4-hAL" firstAttribute="centerY" secondItem="HJK-1N-bmY" secondAttribute="centerY" constant="-2" id="pMu-QZ-JtL"/>
+                            <constraint firstItem="XTi-We-ou2" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="16" id="okC-fb-NZl"/>
+                            <constraint firstItem="06O-B0-y3k" firstAttribute="top" secondItem="ZNQ-Pm-fi0" secondAttribute="bottom" constant="8" id="vSg-EK-ooo"/>
                             <constraint firstAttribute="bottom" secondItem="06O-B0-y3k" secondAttribute="bottom" id="wZI-eS-fxp"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y9d-AS-bhE">
-                        <rect key="frame" x="0.0" y="185" width="320" height="1"/>
+                        <rect key="frame" x="0.0" y="109" width="320" height="1"/>
                         <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" placeholder="YES" id="Yov-Gm-bZ6"/>
@@ -171,16 +165,15 @@
                 <outlet property="badgesLabel" destination="ZNQ-Pm-fi0" id="XSV-yJ-XKT"/>
                 <outlet property="featuredImageView" destination="tne-qn-oAS" id="cE0-O7-RC0"/>
                 <outlet property="ghostView" destination="XTx-r8-hUF" id="MIr-fB-1Hp"/>
+                <outlet property="headerStackView" destination="XTi-We-ou2" id="1A3-p8-lCa"/>
                 <outlet property="innerView" destination="HJK-1N-bmY" id="V61-8s-DZ1"/>
-                <outlet property="labelsContainerTrailing" destination="YXw-VS-KHH" id="mMj-WE-nCF"/>
-                <outlet property="labelsLeadingConstraint" destination="mXG-L5-nGo" id="X0d-iX-rY3"/>
                 <outlet property="menuButton" destination="Zh4-Mc-AK7" id="D6v-4Q-OPG"/>
                 <outlet property="progressView" destination="06O-B0-y3k" id="kXa-eP-uHE"/>
                 <outlet property="separator" destination="y9d-AS-bhE" id="jTZ-52-pNX"/>
                 <outlet property="timestampLabel" destination="fEo-hS-PK1" id="Ih0-91-vRW"/>
                 <outlet property="titleLabel" destination="ZUq-Dg-elW" id="Dzt-PV-spZ"/>
             </connections>
-            <point key="canvasLocation" x="136.23188405797103" y="209.59821428571428"/>
+            <point key="canvasLocation" x="136.23188405797103" y="184.15178571428569"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
@@ -14,32 +14,32 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="83" id="Bfq-Ne-g8g" customClass="PostCompactCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="83"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="186" id="Bfq-Ne-g8g" customClass="PostCompactCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="186"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Bfq-Ne-g8g" id="9ZV-7I-syI">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="83"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="186"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HJK-1N-bmY">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="83"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="186"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UrU-r4-hAL" userLabel="Labels">
-                                <rect key="frame" x="16" y="6" width="192" height="67"/>
+                                <rect key="frame" x="16" y="6" width="192" height="170"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="248" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
-                                        <rect key="frame" x="0.0" y="0.0" width="192" height="26"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
+                                        <rect key="frame" x="0.0" y="0.0" width="192" height="23.5"/>
                                         <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
-                                        <rect key="frame" x="0.0" y="28" width="74.5" height="18"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
+                                        <rect key="frame" x="0.0" y="25.5" width="74.5" height="18"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Private • Local changes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
-                                        <rect key="frame" x="0.0" y="51" width="192" height="16"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" text="Private • Local changes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
+                                        <rect key="frame" x="0.0" y="154" width="192" height="16"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -59,7 +59,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh4-Mc-AK7">
-                                <rect key="frame" x="264" y="18" width="56" height="47"/>
+                                <rect key="frame" x="264" y="8" width="56" height="47"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="47" id="SNG-8G-08p"/>
                                     <constraint firstAttribute="width" constant="56" id="ciz-Vj-1BT"/>
@@ -72,7 +72,7 @@
                                 </connections>
                             </button>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tne-qn-oAS" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="224" y="21.5" width="40" height="40"/>
+                                <rect key="frame" x="224" y="16" width="40" height="40"/>
                                 <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="WGx-7Y-oMs"/>
@@ -80,16 +80,16 @@
                                 </constraints>
                             </imageView>
                             <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="06O-B0-y3k">
-                                <rect key="frame" x="0.0" y="79" width="320" height="4"/>
+                                <rect key="frame" x="0.0" y="182" width="320" height="4"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="4" id="j1t-t8-KFy"/>
                                 </constraints>
                             </progressView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTx-r8-hUF">
-                                <rect key="frame" x="16" y="0.0" width="248" height="83"/>
+                                <rect key="frame" x="16" y="0.0" width="248" height="186"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
-                                        <rect key="frame" x="0.0" y="23" width="248" height="37"/>
+                                        <rect key="frame" x="0.0" y="74.5" width="248" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6QQ-XY-q2l">
                                                 <rect key="frame" x="0.0" y="0.0" width="208" height="15"/>
@@ -126,16 +126,16 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="Zh4-Mc-AK7" firstAttribute="centerY" secondItem="HJK-1N-bmY" secondAttribute="centerY" id="2iv-Yl-BvI"/>
                             <constraint firstItem="Zh4-Mc-AK7" firstAttribute="leading" secondItem="tne-qn-oAS" secondAttribute="trailing" id="3s0-QP-5YT"/>
                             <constraint firstAttribute="trailingMargin" secondItem="Zh4-Mc-AK7" secondAttribute="trailing" constant="-8" id="6OK-8s-Dxs"/>
                             <constraint firstAttribute="trailing" secondItem="06O-B0-y3k" secondAttribute="trailing" id="8ib-ER-7zy"/>
+                            <constraint firstItem="Zh4-Mc-AK7" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="8" id="9Ro-zJ-VZh"/>
                             <constraint firstItem="XTx-r8-hUF" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" id="DSl-Iw-NhL"/>
                             <constraint firstItem="UrU-r4-hAL" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="6" id="JL4-zc-5bz"/>
+                            <constraint firstItem="tne-qn-oAS" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="16" id="P2g-Rs-kzJ"/>
                             <constraint firstAttribute="bottom" secondItem="XTx-r8-hUF" secondAttribute="bottom" id="Psp-EO-ZSL"/>
                             <constraint firstAttribute="bottom" secondItem="UrU-r4-hAL" secondAttribute="bottom" constant="10" id="QLd-8e-C0k"/>
                             <constraint firstItem="XTx-r8-hUF" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="leading" id="Sn7-OG-k7S"/>
-                            <constraint firstItem="tne-qn-oAS" firstAttribute="centerY" secondItem="HJK-1N-bmY" secondAttribute="centerY" id="UEo-T2-kHC"/>
                             <constraint firstItem="UrU-r4-hAL" firstAttribute="trailing" secondItem="Zh4-Mc-AK7" secondAttribute="leading" priority="750" id="VgY-3y-Xq1"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="60" id="XwZ-7a-9Cd"/>
                             <constraint firstItem="tne-qn-oAS" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="trailing" constant="16" id="YXw-VS-KHH"/>
@@ -147,7 +147,7 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y9d-AS-bhE">
-                        <rect key="frame" x="0.0" y="82" width="320" height="1"/>
+                        <rect key="frame" x="0.0" y="185" width="320" height="1"/>
                         <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" placeholder="YES" id="Yov-Gm-bZ6"/>
@@ -180,7 +180,7 @@
                 <outlet property="timestampLabel" destination="fEo-hS-PK1" id="Ih0-91-vRW"/>
                 <outlet property="titleLabel" destination="ZUq-Dg-elW" id="Dzt-PV-spZ"/>
             </connections>
-            <point key="canvasLocation" x="136.23188405797103" y="175.78125"/>
+            <point key="canvasLocation" x="136.23188405797103" y="209.59821428571428"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
@@ -17,9 +18,11 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="99"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Bfq-Ne-g8g" id="9ZV-7I-syI">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="99"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HJK-1N-bmY">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="99"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ca1-WK-dzn">
                                 <rect key="frame" x="16" y="8" width="304" height="83"/>
@@ -90,7 +93,7 @@
                                                 </constraints>
                                             </imageView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh4-Mc-AK7">
-                                                <rect key="frame" x="248" y="0.3333333333333357" width="56" height="47"/>
+                                                <rect key="frame" x="248" y="0.5" width="56" height="47"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="47" id="SNG-8G-08p"/>
                                                     <constraint firstAttribute="width" constant="56" id="ciz-Vj-1BT"/>
@@ -103,13 +106,10 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <constraints>
-                                            <constraint firstItem="tne-qn-oAS" firstAttribute="centerY" secondItem="XTi-We-ou2" secondAttribute="centerY" id="GFk-cc-soI"/>
-                                        </constraints>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" text="Private • Local changes | More text to test wrapping" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
-                                        <rect key="frame" x="0.0" y="51.666666666666664" width="304" height="31.333333333333336"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <rect key="frame" x="0.0" y="50" width="304" height="36"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
@@ -125,9 +125,9 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="06O-B0-y3k" secondAttribute="trailing" id="8ib-ER-7zy"/>
-                            <constraint firstAttribute="bottom" secondItem="ca1-WK-dzn" secondAttribute="bottom" constant="8" id="CaL-ph-mNW"/>
+                            <constraint firstAttribute="bottom" secondItem="ca1-WK-dzn" secondAttribute="bottom" constant="7" id="CaL-ph-mNW"/>
                             <constraint firstItem="ca1-WK-dzn" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" constant="16" id="Dj8-MK-kGj"/>
-                            <constraint firstItem="ca1-WK-dzn" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="8" id="XOO-Xi-dht"/>
+                            <constraint firstItem="ca1-WK-dzn" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="6" id="XOO-Xi-dht"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="60" id="XwZ-7a-9Cd"/>
                             <constraint firstItem="06O-B0-y3k" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" id="g6x-y3-fZX"/>
                             <constraint firstAttribute="bottom" secondItem="06O-B0-y3k" secondAttribute="bottom" id="wZI-eS-fxp"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
@@ -14,109 +13,110 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="103" id="Bfq-Ne-g8g" customClass="PostCompactCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="103"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="99" id="Bfq-Ne-g8g" customClass="PostCompactCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="99"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Bfq-Ne-g8g" id="9ZV-7I-syI">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="103"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HJK-1N-bmY">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="103"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="XTi-We-ou2" userLabel="Header">
-                                <rect key="frame" x="8" y="8" width="304" height="47.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ca1-WK-dzn">
+                                <rect key="frame" x="16" y="8" width="304" height="83"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="nQW-3W-m3b" userLabel="Title and Timestamp">
-                                        <rect key="frame" x="8" y="0.5" width="208" height="47"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="XTi-We-ou2" userLabel="Header">
+                                        <rect key="frame" x="0.0" y="0.0" width="304" height="47.666666666666664"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Title ygpj" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
-                                                <rect key="frame" x="0.0" y="0.0" width="208" height="23.5"/>
-                                                <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="17"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
-                                                <rect key="frame" x="0.0" y="23.5" width="208" height="23.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTx-r8-hUF">
-                                                <rect key="frame" x="0.0" y="47" width="208" height="0.0"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="nQW-3W-m3b" userLabel="Title and Timestamp">
+                                                <rect key="frame" x="0.0" y="0.0" width="208" height="47.666666666666664"/>
                                                 <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
-                                                        <rect key="frame" x="0.0" y="-18" width="208" height="36"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title ygpj" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
+                                                        <rect key="frame" x="0.0" y="0.0" width="80.333333333333329" height="23.333333333333332"/>
+                                                        <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="17"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
+                                                        <rect key="frame" x="0.0" y="24.333333333333336" width="74.666666666666671" height="23.333333333333336"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTx-r8-hUF">
+                                                        <rect key="frame" x="0.0" y="47.666666666666664" width="208" height="0.0"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6QQ-XY-q2l">
-                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="14.5"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yxn-r2-waJ">
-                                                                <rect key="frame" x="0.0" y="22.5" width="88" height="13.5"/>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
+                                                                <rect key="frame" x="0.0" y="-17.666666666666664" width="208" height="35.666666666666664"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6QQ-XY-q2l">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="168" height="14.333333333333334"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yxn-r2-waJ">
+                                                                        <rect key="frame" x="0.0" y="22.333333333333336" width="88" height="13.333333333333336"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="trailing" secondItem="6QQ-XY-q2l" secondAttribute="trailing" constant="40" id="Bc6-rp-y5l"/>
+                                                                    <constraint firstAttribute="bottom" secondItem="yxn-r2-waJ" secondAttribute="bottom" id="E5o-DB-eDv"/>
+                                                                    <constraint firstItem="yxn-r2-waJ" firstAttribute="top" secondItem="6QQ-XY-q2l" secondAttribute="bottom" constant="8" id="KZV-Rp-kev"/>
+                                                                    <constraint firstItem="yxn-r2-waJ" firstAttribute="leading" secondItem="6QQ-XY-q2l" secondAttribute="leading" id="KvI-HE-g92"/>
+                                                                    <constraint firstItem="6QQ-XY-q2l" firstAttribute="leading" secondItem="ESK-bT-Bix" secondAttribute="leading" id="Vlw-EV-qw7"/>
+                                                                    <constraint firstItem="6QQ-XY-q2l" firstAttribute="top" secondItem="ESK-bT-Bix" secondAttribute="top" id="hxM-IR-oZP"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="yxn-r2-waJ" secondAttribute="trailing" constant="120" id="j1w-ks-jni"/>
+                                                                </constraints>
+                                                            </view>
                                                         </subviews>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="trailing" secondItem="6QQ-XY-q2l" secondAttribute="trailing" constant="40" id="Bc6-rp-y5l"/>
-                                                            <constraint firstAttribute="bottom" secondItem="yxn-r2-waJ" secondAttribute="bottom" id="E5o-DB-eDv"/>
-                                                            <constraint firstItem="yxn-r2-waJ" firstAttribute="top" secondItem="6QQ-XY-q2l" secondAttribute="bottom" constant="8" id="KZV-Rp-kev"/>
-                                                            <constraint firstItem="yxn-r2-waJ" firstAttribute="leading" secondItem="6QQ-XY-q2l" secondAttribute="leading" id="KvI-HE-g92"/>
-                                                            <constraint firstItem="6QQ-XY-q2l" firstAttribute="leading" secondItem="ESK-bT-Bix" secondAttribute="leading" id="Vlw-EV-qw7"/>
-                                                            <constraint firstItem="6QQ-XY-q2l" firstAttribute="top" secondItem="ESK-bT-Bix" secondAttribute="top" id="hxM-IR-oZP"/>
-                                                            <constraint firstAttribute="trailing" secondItem="yxn-r2-waJ" secondAttribute="trailing" constant="120" id="j1w-ks-jni"/>
+                                                            <constraint firstAttribute="trailing" secondItem="ESK-bT-Bix" secondAttribute="trailing" id="h96-7a-N0h"/>
+                                                            <constraint firstItem="ESK-bT-Bix" firstAttribute="leading" secondItem="XTx-r8-hUF" secondAttribute="leading" id="mJJ-sj-Om2"/>
+                                                            <constraint firstItem="ESK-bT-Bix" firstAttribute="centerY" secondItem="XTx-r8-hUF" secondAttribute="centerY" id="yNO-gY-vZq"/>
                                                         </constraints>
                                                     </view>
                                                 </subviews>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </stackView>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tne-qn-oAS" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="208" y="4" width="40" height="40"/>
+                                                <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="trailing" secondItem="ESK-bT-Bix" secondAttribute="trailing" id="h96-7a-N0h"/>
-                                                    <constraint firstItem="ESK-bT-Bix" firstAttribute="leading" secondItem="XTx-r8-hUF" secondAttribute="leading" id="mJJ-sj-Om2"/>
-                                                    <constraint firstItem="ESK-bT-Bix" firstAttribute="centerY" secondItem="XTx-r8-hUF" secondAttribute="centerY" id="yNO-gY-vZq"/>
+                                                    <constraint firstAttribute="height" constant="40" id="WGx-7Y-oMs"/>
+                                                    <constraint firstAttribute="width" constant="40" id="eg9-Kp-Xfc"/>
                                                 </constraints>
-                                            </view>
+                                            </imageView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh4-Mc-AK7">
+                                                <rect key="frame" x="248" y="0.3333333333333357" width="56" height="47"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="47" id="SNG-8G-08p"/>
+                                                    <constraint firstAttribute="width" constant="56" id="ciz-Vj-1BT"/>
+                                                </constraints>
+                                                <state key="normal" image="icon-post-actionbar-more">
+                                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="more:" destination="Bfq-Ne-g8g" eventType="touchUpInside" id="t3f-ip-IBh"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstItem="tne-qn-oAS" firstAttribute="centerY" secondItem="XTi-We-ou2" secondAttribute="centerY" id="GFk-cc-soI"/>
+                                        </constraints>
                                     </stackView>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tne-qn-oAS" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="216" y="4" width="40" height="40"/>
-                                        <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="40" id="WGx-7Y-oMs"/>
-                                            <constraint firstAttribute="width" constant="40" id="eg9-Kp-Xfc"/>
-                                        </constraints>
-                                    </imageView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh4-Mc-AK7">
-                                        <rect key="frame" x="256" y="0.5" width="56" height="47"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="47" id="SNG-8G-08p"/>
-                                            <constraint firstAttribute="width" constant="56" id="ciz-Vj-1BT"/>
-                                        </constraints>
-                                        <state key="normal" image="icon-post-actionbar-more">
-                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="more:" destination="Bfq-Ne-g8g" eventType="touchUpInside" id="t3f-ip-IBh"/>
-                                        </connections>
-                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" text="Private • Local changes | More text to test wrapping" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
+                                        <rect key="frame" x="0.0" y="51.666666666666664" width="304" height="31.333333333333336"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="Zh4-Mc-AK7" secondAttribute="trailing" constant="-8" id="04Q-1Y-r44"/>
-                                    <constraint firstItem="tne-qn-oAS" firstAttribute="centerY" secondItem="XTi-We-ou2" secondAttribute="centerY" id="GFk-cc-soI"/>
-                                    <constraint firstItem="nQW-3W-m3b" firstAttribute="leading" secondItem="XTi-We-ou2" secondAttribute="leading" constant="8" id="qqs-SD-gXL"/>
-                                </constraints>
                             </stackView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" text="Private • Local changes | More text to test wrapping" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
-                                <rect key="frame" x="16" y="59.5" width="288" height="31.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="06O-B0-y3k">
-                                <rect key="frame" x="0.0" y="99" width="320" height="4"/>
+                                <rect key="frame" x="0.0" y="95" width="320" height="4"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="4" id="j1t-t8-KFy"/>
                                 </constraints>
@@ -124,21 +124,18 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="XTi-We-ou2" secondAttribute="trailing" constant="8" id="1I3-l4-XU9"/>
-                            <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="top" secondItem="XTi-We-ou2" secondAttribute="bottom" constant="4" id="4Km-sC-0kq"/>
-                            <constraint firstItem="XTi-We-ou2" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" constant="8" id="4ks-94-4HJ"/>
                             <constraint firstAttribute="trailing" secondItem="06O-B0-y3k" secondAttribute="trailing" id="8ib-ER-7zy"/>
-                            <constraint firstAttribute="trailing" secondItem="ZNQ-Pm-fi0" secondAttribute="trailing" constant="16" id="B7u-g4-75M"/>
-                            <constraint firstAttribute="bottom" secondItem="ZNQ-Pm-fi0" secondAttribute="bottom" constant="12" id="CNa-6D-VNk"/>
-                            <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" constant="16" id="JHe-IL-nWK"/>
+                            <constraint firstAttribute="bottom" secondItem="ca1-WK-dzn" secondAttribute="bottom" constant="8" id="CaL-ph-mNW"/>
+                            <constraint firstItem="ca1-WK-dzn" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" constant="16" id="Dj8-MK-kGj"/>
+                            <constraint firstItem="ca1-WK-dzn" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="8" id="XOO-Xi-dht"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="60" id="XwZ-7a-9Cd"/>
                             <constraint firstItem="06O-B0-y3k" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" id="g6x-y3-fZX"/>
-                            <constraint firstItem="XTi-We-ou2" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="8" id="okC-fb-NZl"/>
                             <constraint firstAttribute="bottom" secondItem="06O-B0-y3k" secondAttribute="bottom" id="wZI-eS-fxp"/>
+                            <constraint firstAttribute="trailing" secondItem="ca1-WK-dzn" secondAttribute="trailing" id="xQh-q4-r4A"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y9d-AS-bhE">
-                        <rect key="frame" x="0.0" y="102" width="320" height="1"/>
+                        <rect key="frame" x="0.0" y="98" width="320" height="1"/>
                         <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" placeholder="YES" id="Yov-Gm-bZ6"/>
@@ -170,7 +167,7 @@
                 <outlet property="timestampLabel" destination="fEo-hS-PK1" id="Ih0-91-vRW"/>
                 <outlet property="titleLabel" destination="ZUq-Dg-elW" id="Dzt-PV-spZ"/>
             </connections>
-            <point key="canvasLocation" x="136.23188405797103" y="181.80803571428569"/>
+            <point key="canvasLocation" x="135" y="179.72222222222223"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
@@ -14,35 +14,35 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="110" id="Bfq-Ne-g8g" customClass="PostCompactCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="103" id="Bfq-Ne-g8g" customClass="PostCompactCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="103"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Bfq-Ne-g8g" id="9ZV-7I-syI">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="103"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HJK-1N-bmY">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="110"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="103"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTi-We-ou2" userLabel="Header">
-                                <rect key="frame" x="8" y="16" width="304" height="40"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="XTi-We-ou2" userLabel="Header">
+                                <rect key="frame" x="8" y="8" width="304" height="47.5"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="nQW-3W-m3b" userLabel="Title and Timestamp">
-                                        <rect key="frame" x="8" y="0.0" width="208" height="40"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="nQW-3W-m3b" userLabel="Title and Timestamp">
+                                        <rect key="frame" x="8" y="0.5" width="208" height="47"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
-                                                <rect key="frame" x="0.0" y="0.0" width="208" height="18"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Title ygpj" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
+                                                <rect key="frame" x="0.0" y="0.0" width="208" height="23.5"/>
                                                 <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="17"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
-                                                <rect key="frame" x="0.0" y="22" width="208" height="18"/>
+                                                <rect key="frame" x="0.0" y="23.5" width="208" height="23.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTx-r8-hUF">
-                                                <rect key="frame" x="0.0" y="40" width="208" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="47" width="208" height="0.0"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
                                                         <rect key="frame" x="0.0" y="-18" width="208" height="36"/>
@@ -80,12 +80,9 @@
                                                 </constraints>
                                             </view>
                                         </subviews>
-                                        <constraints>
-                                            <constraint firstItem="fEo-hS-PK1" firstAttribute="top" secondItem="ZUq-Dg-elW" secondAttribute="bottom" constant="4" id="0qk-zM-VRi"/>
-                                        </constraints>
                                     </stackView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tne-qn-oAS" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="216" y="0.0" width="40" height="40"/>
+                                        <rect key="frame" x="216" y="4" width="40" height="40"/>
                                         <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="WGx-7Y-oMs"/>
@@ -93,7 +90,7 @@
                                         </constraints>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh4-Mc-AK7">
-                                        <rect key="frame" x="256" y="-7" width="56" height="47"/>
+                                        <rect key="frame" x="256" y="0.5" width="56" height="47"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="47" id="SNG-8G-08p"/>
                                             <constraint firstAttribute="width" constant="56" id="ciz-Vj-1BT"/>
@@ -113,13 +110,13 @@
                                 </constraints>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" text="Private • Local changes | More text to test wrapping" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
-                                <rect key="frame" x="16" y="64" width="288" height="34"/>
+                                <rect key="frame" x="16" y="59.5" width="288" height="31.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="06O-B0-y3k">
-                                <rect key="frame" x="0.0" y="106" width="320" height="4"/>
+                                <rect key="frame" x="0.0" y="99" width="320" height="4"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="4" id="j1t-t8-KFy"/>
                                 </constraints>
@@ -128,20 +125,20 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="XTi-We-ou2" secondAttribute="trailing" constant="8" id="1I3-l4-XU9"/>
-                            <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="top" secondItem="XTi-We-ou2" secondAttribute="bottom" constant="8" id="4Km-sC-0kq"/>
+                            <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="top" secondItem="XTi-We-ou2" secondAttribute="bottom" constant="4" id="4Km-sC-0kq"/>
                             <constraint firstItem="XTi-We-ou2" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" constant="8" id="4ks-94-4HJ"/>
                             <constraint firstAttribute="trailing" secondItem="06O-B0-y3k" secondAttribute="trailing" id="8ib-ER-7zy"/>
                             <constraint firstAttribute="trailing" secondItem="ZNQ-Pm-fi0" secondAttribute="trailing" constant="16" id="B7u-g4-75M"/>
+                            <constraint firstAttribute="bottom" secondItem="ZNQ-Pm-fi0" secondAttribute="bottom" constant="12" id="CNa-6D-VNk"/>
                             <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" constant="16" id="JHe-IL-nWK"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="60" id="XwZ-7a-9Cd"/>
                             <constraint firstItem="06O-B0-y3k" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" id="g6x-y3-fZX"/>
-                            <constraint firstItem="XTi-We-ou2" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="16" id="okC-fb-NZl"/>
-                            <constraint firstItem="06O-B0-y3k" firstAttribute="top" secondItem="ZNQ-Pm-fi0" secondAttribute="bottom" constant="8" id="vSg-EK-ooo"/>
+                            <constraint firstItem="XTi-We-ou2" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="8" id="okC-fb-NZl"/>
                             <constraint firstAttribute="bottom" secondItem="06O-B0-y3k" secondAttribute="bottom" id="wZI-eS-fxp"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y9d-AS-bhE">
-                        <rect key="frame" x="0.0" y="109" width="320" height="1"/>
+                        <rect key="frame" x="0.0" y="102" width="320" height="1"/>
                         <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" placeholder="YES" id="Yov-Gm-bZ6"/>
@@ -173,7 +170,7 @@
                 <outlet property="timestampLabel" destination="fEo-hS-PK1" id="Ih0-91-vRW"/>
                 <outlet property="titleLabel" destination="ZUq-Dg-elW" id="Dzt-PV-spZ"/>
             </connections>
-            <point key="canvasLocation" x="136.23188405797103" y="184.15178571428569"/>
+            <point key="canvasLocation" x="136.23188405797103" y="181.80803571428569"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
@@ -24,95 +24,100 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HJK-1N-bmY">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="99"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ca1-WK-dzn">
-                                <rect key="frame" x="16" y="8" width="304" height="83"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="g4N-kF-vRX" userLabel="Inner Stack View">
+                                <rect key="frame" x="16" y="8" width="312" height="83"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="XTi-We-ou2" userLabel="Header">
-                                        <rect key="frame" x="0.0" y="0.0" width="304" height="47.666666666666664"/>
+                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTx-r8-hUF">
+                                        <rect key="frame" x="0.0" y="0.0" width="312" height="0.0"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="nQW-3W-m3b" userLabel="Title and Timestamp">
-                                                <rect key="frame" x="0.0" y="0.0" width="208" height="47.666666666666664"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
+                                                <rect key="frame" x="0.0" y="-18" width="312" height="36"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title ygpj" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
-                                                        <rect key="frame" x="0.0" y="0.0" width="80.333333333333329" height="23.333333333333332"/>
-                                                        <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="17"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
-                                                        <rect key="frame" x="0.0" y="24.333333333333336" width="74.666666666666671" height="23.333333333333336"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6QQ-XY-q2l">
+                                                        <rect key="frame" x="0.0" y="0.0" width="272" height="14.666666666666666"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTx-r8-hUF">
-                                                        <rect key="frame" x="0.0" y="47.666666666666664" width="208" height="0.0"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yxn-r2-waJ">
+                                                        <rect key="frame" x="0.0" y="22.666666666666664" width="192" height="13.333333333333336"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="trailing" secondItem="6QQ-XY-q2l" secondAttribute="trailing" constant="40" id="Bc6-rp-y5l"/>
+                                                    <constraint firstAttribute="bottom" secondItem="yxn-r2-waJ" secondAttribute="bottom" id="E5o-DB-eDv"/>
+                                                    <constraint firstItem="yxn-r2-waJ" firstAttribute="top" secondItem="6QQ-XY-q2l" secondAttribute="bottom" constant="8" id="KZV-Rp-kev"/>
+                                                    <constraint firstItem="yxn-r2-waJ" firstAttribute="leading" secondItem="6QQ-XY-q2l" secondAttribute="leading" id="KvI-HE-g92"/>
+                                                    <constraint firstItem="6QQ-XY-q2l" firstAttribute="leading" secondItem="ESK-bT-Bix" secondAttribute="leading" id="Vlw-EV-qw7"/>
+                                                    <constraint firstItem="6QQ-XY-q2l" firstAttribute="top" secondItem="ESK-bT-Bix" secondAttribute="top" id="hxM-IR-oZP"/>
+                                                    <constraint firstAttribute="trailing" secondItem="yxn-r2-waJ" secondAttribute="trailing" constant="120" id="j1w-ks-jni"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="ESK-bT-Bix" secondAttribute="trailing" id="h96-7a-N0h"/>
+                                            <constraint firstItem="ESK-bT-Bix" firstAttribute="leading" secondItem="XTx-r8-hUF" secondAttribute="leading" id="mJJ-sj-Om2"/>
+                                            <constraint firstItem="ESK-bT-Bix" firstAttribute="centerY" secondItem="XTx-r8-hUF" secondAttribute="centerY" id="yNO-gY-vZq"/>
+                                        </constraints>
+                                    </view>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ca1-WK-dzn" userLabel="Content Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="312" height="83"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="XTi-We-ou2" userLabel="Header">
+                                                <rect key="frame" x="0.0" y="0.0" width="312" height="47"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="nQW-3W-m3b" userLabel="Title and Timestamp">
+                                                        <rect key="frame" x="0.0" y="0.0" width="216" height="47"/>
                                                         <subviews>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
-                                                                <rect key="frame" x="0.0" y="-17.666666666666664" width="208" height="35.666666666666664"/>
-                                                                <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6QQ-XY-q2l">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="168" height="14.333333333333334"/>
-                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                                        <nil key="textColor"/>
-                                                                        <nil key="highlightedColor"/>
-                                                                    </label>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yxn-r2-waJ">
-                                                                        <rect key="frame" x="0.0" y="22.333333333333336" width="88" height="13.333333333333336"/>
-                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
-                                                                        <nil key="textColor"/>
-                                                                        <nil key="highlightedColor"/>
-                                                                    </label>
-                                                                </subviews>
-                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="trailing" secondItem="6QQ-XY-q2l" secondAttribute="trailing" constant="40" id="Bc6-rp-y5l"/>
-                                                                    <constraint firstAttribute="bottom" secondItem="yxn-r2-waJ" secondAttribute="bottom" id="E5o-DB-eDv"/>
-                                                                    <constraint firstItem="yxn-r2-waJ" firstAttribute="top" secondItem="6QQ-XY-q2l" secondAttribute="bottom" constant="8" id="KZV-Rp-kev"/>
-                                                                    <constraint firstItem="yxn-r2-waJ" firstAttribute="leading" secondItem="6QQ-XY-q2l" secondAttribute="leading" id="KvI-HE-g92"/>
-                                                                    <constraint firstItem="6QQ-XY-q2l" firstAttribute="leading" secondItem="ESK-bT-Bix" secondAttribute="leading" id="Vlw-EV-qw7"/>
-                                                                    <constraint firstItem="6QQ-XY-q2l" firstAttribute="top" secondItem="ESK-bT-Bix" secondAttribute="top" id="hxM-IR-oZP"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="yxn-r2-waJ" secondAttribute="trailing" constant="120" id="j1w-ks-jni"/>
-                                                                </constraints>
-                                                            </view>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title ygpj" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
+                                                                <rect key="frame" x="0.0" y="0.0" width="80.333333333333329" height="23"/>
+                                                                <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="17"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
+                                                                <rect key="frame" x="0.0" y="24" width="74.666666666666671" height="23"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
                                                         </subviews>
-                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </stackView>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tne-qn-oAS" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="216" y="3.6666666666666643" width="40" height="40"/>
+                                                        <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="trailing" secondItem="ESK-bT-Bix" secondAttribute="trailing" id="h96-7a-N0h"/>
-                                                            <constraint firstItem="ESK-bT-Bix" firstAttribute="leading" secondItem="XTx-r8-hUF" secondAttribute="leading" id="mJJ-sj-Om2"/>
-                                                            <constraint firstItem="ESK-bT-Bix" firstAttribute="centerY" secondItem="XTx-r8-hUF" secondAttribute="centerY" id="yNO-gY-vZq"/>
+                                                            <constraint firstAttribute="height" constant="40" id="WGx-7Y-oMs"/>
+                                                            <constraint firstAttribute="width" constant="40" id="eg9-Kp-Xfc"/>
                                                         </constraints>
-                                                    </view>
+                                                    </imageView>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh4-Mc-AK7">
+                                                        <rect key="frame" x="256" y="0.0" width="56" height="47"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="47" id="SNG-8G-08p"/>
+                                                            <constraint firstAttribute="width" constant="56" id="ciz-Vj-1BT"/>
+                                                        </constraints>
+                                                        <state key="normal" image="icon-post-actionbar-more">
+                                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        </state>
+                                                        <connections>
+                                                            <action selector="more:" destination="Bfq-Ne-g8g" eventType="touchUpInside" id="t3f-ip-IBh"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                             </stackView>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tne-qn-oAS" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="208" y="4" width="40" height="40"/>
-                                                <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="WGx-7Y-oMs"/>
-                                                    <constraint firstAttribute="width" constant="40" id="eg9-Kp-Xfc"/>
-                                                </constraints>
-                                            </imageView>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh4-Mc-AK7">
-                                                <rect key="frame" x="248" y="0.5" width="56" height="47"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="47" id="SNG-8G-08p"/>
-                                                    <constraint firstAttribute="width" constant="56" id="ciz-Vj-1BT"/>
-                                                </constraints>
-                                                <state key="normal" image="icon-post-actionbar-more">
-                                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </state>
-                                                <connections>
-                                                    <action selector="more:" destination="Bfq-Ne-g8g" eventType="touchUpInside" id="t3f-ip-IBh"/>
-                                                </connections>
-                                            </button>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" text="Private • Local changes | More text to test wrapping" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
+                                                <rect key="frame" x="0.0" y="51" width="312" height="32"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
                                     </stackView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="252" horizontalCompressionResistancePriority="749" text="Private • Local changes | More text to test wrapping" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
-                                        <rect key="frame" x="0.0" y="50" width="304" height="36"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                 </subviews>
                             </stackView>
                             <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="06O-B0-y3k">
@@ -125,13 +130,13 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="06O-B0-y3k" secondAttribute="trailing" id="8ib-ER-7zy"/>
-                            <constraint firstAttribute="bottom" secondItem="ca1-WK-dzn" secondAttribute="bottom" constant="7" id="CaL-ph-mNW"/>
-                            <constraint firstItem="ca1-WK-dzn" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" constant="16" id="Dj8-MK-kGj"/>
-                            <constraint firstItem="ca1-WK-dzn" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="6" id="XOO-Xi-dht"/>
+                            <constraint firstItem="g4N-kF-vRX" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="8" id="DEB-xv-5NP"/>
+                            <constraint firstItem="g4N-kF-vRX" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" constant="16" id="Fev-WW-c6b"/>
+                            <constraint firstItem="06O-B0-y3k" firstAttribute="top" secondItem="g4N-kF-vRX" secondAttribute="bottom" constant="4" id="THK-RN-Wte"/>
+                            <constraint firstAttribute="trailing" secondItem="g4N-kF-vRX" secondAttribute="trailing" constant="-8" id="U3Z-UB-o0I"/>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="60" id="XwZ-7a-9Cd"/>
                             <constraint firstItem="06O-B0-y3k" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" id="g6x-y3-fZX"/>
                             <constraint firstAttribute="bottom" secondItem="06O-B0-y3k" secondAttribute="bottom" id="wZI-eS-fxp"/>
-                            <constraint firstAttribute="trailing" secondItem="ca1-WK-dzn" secondAttribute="trailing" id="xQh-q4-r4A"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y9d-AS-bhE">
@@ -157,6 +162,7 @@
             <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
                 <outlet property="badgesLabel" destination="ZNQ-Pm-fi0" id="XSV-yJ-XKT"/>
+                <outlet property="contentStackView" destination="ca1-WK-dzn" id="GhH-aN-qnX"/>
                 <outlet property="featuredImageView" destination="tne-qn-oAS" id="cE0-O7-RC0"/>
                 <outlet property="ghostView" destination="XTx-r8-hUF" id="MIr-fB-1Hp"/>
                 <outlet property="headerStackView" destination="XTi-We-ou2" id="1A3-p8-lCa"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -14,53 +14,52 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="Bfq-Ne-g8g" customClass="PostCompactCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="83" id="Bfq-Ne-g8g" customClass="PostCompactCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="83"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Bfq-Ne-g8g" id="9ZV-7I-syI">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="83"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HJK-1N-bmY">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="83"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UrU-r4-hAL" userLabel="Labels">
-                                <rect key="frame" x="16" y="6.5" width="192" height="43.5"/>
+                                <rect key="frame" x="16" y="6" width="192" height="67"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
-                                        <rect key="frame" x="0.0" y="0.0" width="192" height="23.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="248" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
+                                        <rect key="frame" x="0.0" y="0.0" width="192" height="26"/>
                                         <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
-                                        <rect key="frame" x="0.0" y="25.5" width="75" height="18"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="249" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fEo-hS-PK1">
+                                        <rect key="frame" x="0.0" y="28" width="74.5" height="18"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Private • Local changes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZNQ-Pm-fi0">
-                                        <rect key="frame" x="83" y="25.5" width="109" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <rect key="frame" x="0.0" y="51" width="192" height="16"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
+                                    <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="leading" id="8de-H8-BGJ"/>
                                     <constraint firstItem="fEo-hS-PK1" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="leading" id="Ar0-bF-oL3"/>
                                     <constraint firstAttribute="trailing" secondItem="ZUq-Dg-elW" secondAttribute="trailing" id="K78-Nm-WTO"/>
                                     <constraint firstItem="ZUq-Dg-elW" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="leading" id="LcB-FM-8SQ"/>
                                     <constraint firstItem="fEo-hS-PK1" firstAttribute="top" secondItem="ZUq-Dg-elW" secondAttribute="bottom" constant="2" id="Na7-iX-HyI"/>
                                     <constraint firstAttribute="trailing" secondItem="ZNQ-Pm-fi0" secondAttribute="trailing" id="ULF-V1-s1k"/>
-                                    <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="leading" secondItem="fEo-hS-PK1" secondAttribute="trailing" constant="8" id="cRx-5q-JF6"/>
                                     <constraint firstItem="ZUq-Dg-elW" firstAttribute="top" secondItem="UrU-r4-hAL" secondAttribute="top" id="d30-IF-aiG"/>
-                                    <constraint firstAttribute="bottom" secondItem="fEo-hS-PK1" secondAttribute="bottom" id="f3q-Uz-O9K"/>
                                     <constraint firstAttribute="bottom" secondItem="ZNQ-Pm-fi0" secondAttribute="bottom" id="k2R-gp-BRa"/>
-                                    <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="top" secondItem="ZUq-Dg-elW" secondAttribute="bottom" constant="2" id="rip-wh-JUn"/>
+                                    <constraint firstItem="ZNQ-Pm-fi0" firstAttribute="top" secondItem="fEo-hS-PK1" secondAttribute="bottom" constant="5" id="kcM-tR-3L1"/>
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zh4-Mc-AK7">
-                                <rect key="frame" x="264" y="6.5" width="56" height="47"/>
+                                <rect key="frame" x="264" y="18" width="56" height="47"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="47" id="SNG-8G-08p"/>
                                     <constraint firstAttribute="width" constant="56" id="ciz-Vj-1BT"/>
@@ -73,7 +72,7 @@
                                 </connections>
                             </button>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tne-qn-oAS" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="224" y="10" width="40" height="40"/>
+                                <rect key="frame" x="224" y="21.5" width="40" height="40"/>
                                 <color key="backgroundColor" red="0.84705882349999995" green="0.84705882349999995" blue="0.84705882349999995" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="WGx-7Y-oMs"/>
@@ -81,16 +80,16 @@
                                 </constraints>
                             </imageView>
                             <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="06O-B0-y3k">
-                                <rect key="frame" x="0.0" y="56" width="320" height="4"/>
+                                <rect key="frame" x="0.0" y="79" width="320" height="4"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="4" id="j1t-t8-KFy"/>
                                 </constraints>
                             </progressView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTx-r8-hUF">
-                                <rect key="frame" x="16" y="0.0" width="248" height="60"/>
+                                <rect key="frame" x="16" y="0.0" width="248" height="83"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
-                                        <rect key="frame" x="0.0" y="11.5" width="248" height="37"/>
+                                        <rect key="frame" x="0.0" y="23" width="248" height="37"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6QQ-XY-q2l">
                                                 <rect key="frame" x="0.0" y="0.0" width="208" height="15"/>
@@ -148,7 +147,7 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y9d-AS-bhE">
-                        <rect key="frame" x="0.0" y="59" width="320" height="1"/>
+                        <rect key="frame" x="0.0" y="82" width="320" height="1"/>
                         <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" placeholder="YES" id="Yov-Gm-bZ6"/>
@@ -179,10 +178,9 @@
                 <outlet property="progressView" destination="06O-B0-y3k" id="kXa-eP-uHE"/>
                 <outlet property="separator" destination="y9d-AS-bhE" id="jTZ-52-pNX"/>
                 <outlet property="timestampLabel" destination="fEo-hS-PK1" id="Ih0-91-vRW"/>
-                <outlet property="timestampTrailing" destination="cRx-5q-JF6" id="M5z-Fm-qZs"/>
                 <outlet property="titleLabel" destination="ZUq-Dg-elW" id="Dzt-PV-spZ"/>
             </connections>
-            <point key="canvasLocation" x="137.59999999999999" y="153.82308845577214"/>
+            <point key="canvasLocation" x="136.23188405797103" y="175.78125"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -47,7 +47,7 @@ class NotificationUtility {
     func mockCommentContent() -> FormattableCommentContent {
         let dictionary = contextManager.object(withContentOfFile: "notifications-replied-comment.json") as! [String: AnyObject]
         let body = dictionary["body"]
-        let blocks = NotificationContentFactory.content(from: body as! [[String : AnyObject]], actionsParser: NotificationActionParser(), parent: WordPress.Notification(context: contextManager.mainContext))
+        let blocks = NotificationContentFactory.content(from: body as! [[String: AnyObject]], actionsParser: NotificationActionParser(), parent: WordPress.Notification(context: contextManager.mainContext))
         return blocks.filter { $0.kind == .comment }.first! as! FormattableCommentContent
     }
 

--- a/WordPress/WordPressTest/PostCompactCellGhostableTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellGhostableTests.swift
@@ -18,10 +18,7 @@ class PostCompactCellGhostableTests: XCTestCase {
 
     func testShowGhost() {
         XCTAssertFalse(postCell.ghostView.isHidden)
-    }
-
-    func testHideFeaturedImage() {
-        XCTAssertTrue(postCell.featuredImageView.isHidden)
+        XCTAssertTrue(postCell.contentStackView.isHidden)
     }
 
     func testMenuButtonIsNotGhostable() {
@@ -54,6 +51,7 @@ class PostCompactCellGhostableTests: XCTestCase {
         postCell.configure(with: post)
 
         XCTAssertTrue(postCell.ghostView.isHidden)
+        XCTAssertFalse(postCell.contentStackView.isHidden)
     }
 
     func testMenuButtonOpacityAfterConfigure() {

--- a/WordPress/WordPressTest/PostCompactCellTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellTests.swift
@@ -17,7 +17,6 @@ class PostCompactCellTests: XCTestCase {
         postCell.configure(with: post)
 
         XCTAssertFalse(postCell.featuredImageView.isHidden)
-        XCTAssertTrue(postCell.labelsContainerTrailing.isActive)
     }
 
     func testHideImageWhenNotAvailable() {
@@ -26,7 +25,6 @@ class PostCompactCellTests: XCTestCase {
         postCell.configure(with: post)
 
         XCTAssertTrue(postCell.featuredImageView.isHidden)
-        XCTAssertFalse(postCell.labelsContainerTrailing.isActive)
     }
 
     func testShowPostTitle() {

--- a/WordPress/WordPressTest/PostCompactCellTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellTests.swift
@@ -65,6 +65,26 @@ class PostCompactCellTests: XCTestCase {
         XCTAssertEqual(postCell.badgesLabel.text, "Sticky")
     }
 
+    func testHideBadgesWhenEmpty() {
+        let post = PostBuilder().build()
+
+        postCell.configure(with: post)
+
+        XCTAssertEqual(postCell.badgesLabel.text, "Uploading post...")
+        XCTAssertFalse(postCell.badgesLabel.isHidden)
+    }
+
+    func testShowBadgesWhenNotEmpty() {
+        let post = PostBuilder()
+            .with(remoteStatus: .sync)
+            .build()
+
+        postCell.configure(with: post)
+
+        XCTAssertEqual(postCell.badgesLabel.text, "")
+        XCTAssertTrue(postCell.badgesLabel.isHidden)
+    }
+
     func testShowProgressView() {
         let post = PostBuilder()
             .with(remoteStatus: .pushing)

--- a/WordPress/WordPressTest/PostCompactCellTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellTests.swift
@@ -67,28 +67,6 @@ class PostCompactCellTests: XCTestCase {
         XCTAssertEqual(postCell.badgesLabel.text, "Sticky")
     }
 
-    func testHideTimestampWhenUploading() {
-        let post = PostBuilder().build()
-
-        postCell.configure(with: post)
-
-        XCTAssertEqual(postCell.badgesLabel.text, "Uploading post...")
-        XCTAssertTrue(postCell.timestampLabel.isHidden)
-        XCTAssertEqual(postCell.timestampLabel.text, "")
-        XCTAssertEqual(postCell.timestampTrailing.constant, 0)
-    }
-
-    func testShowTimestampWhenNotUploading() {
-        let post = PostBuilder().with(remoteStatus: .sync)
-            .with(dateCreated: Date()).build()
-
-        postCell.configure(with: post)
-
-        XCTAssertEqual(postCell.badgesLabel.text, "")
-        XCTAssertFalse(postCell.timestampLabel.isHidden)
-        XCTAssertEqual(postCell.timestampTrailing.constant, 8)
-    }
-
     func testShowProgressView() {
         let post = PostBuilder()
             .with(remoteStatus: .pushing)


### PR DESCRIPTION
Fixes #12675 

# Changes

Following wordpress-mobile/WordPress-Android#10559's model.

| Before | After |
|---|:---|
| ![alt before](https://user-images.githubusercontent.com/198826/66603404-5d3ec900-eb69-11e9-83cb-83a6a89ad261.png)| ![alt after](https://i.imgur.com/PENsVNT.png) |

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
