### PR TITLE
Reader: Merge site name and URL for VoiceOver

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -59,6 +59,9 @@
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="www.blogname.com" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RfN-yk-yXb">
                                                 <rect key="frame" x="58" y="32" width="281" height="14.5"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1509,7 +1509,8 @@ extension ReaderDetailViewController: Accessible {
             return
         }
         blogNameButton.isAccessibilityElement = true
-        blogNameButton.accessibilityTraits = UIAccessibilityTraits.staticText
+        blogNameButton.accessibilityTraits = [.staticText, .button]
+        blogNameButton.accessibilityHint = NSLocalizedString("Shows the site's posts.", comment: "Accessibility hint for the site name and URL button on Reader's Post Details.")
         if let label = blogNameLabel(post) {
             blogNameButton.accessibilityLabel = label
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1517,17 +1517,18 @@ extension ReaderDetailViewController: Accessible {
 
     private func blogNameLabel(_ post: ReaderPost) -> String? {
         guard let postedIn = post.blogNameForDisplay(),
-            let postedBy = post.authorDisplayName else {
+            let postedBy = post.authorDisplayName,
+            let postedAtURL = post.siteURLForDisplay()?.components(separatedBy: "//").last else {
                 return nil
         }
 
         guard let postedOn = post.dateCreated?.mediumString() else {
-            let format = NSLocalizedString("Posted in %@, by %@.", comment: "Accessibility label for the blog name in the Reader's post details, without date. Placeholders are blog title, author name")
-            return String(format: format, postedIn, postedBy)
+            let format = NSLocalizedString("Posted in %@, at %@, by %@.", comment: "Accessibility label for the blog name in the Reader's post details, without date. Placeholders are blog title, blog URL, author name")
+            return String(format: format, postedIn, postedAtURL, postedBy)
         }
 
-        let format = NSLocalizedString("Posted in %@, by %@, %@", comment: "Accessibility label for the blog name in the Reader's post details. Placeholders are blog title, author name, published date")
-        return String(format: format, postedIn, postedBy, postedOn)
+        let format = NSLocalizedString("Posted in %@, at %@, by %@, %@", comment: "Accessibility label for the blog name in the Reader's post details. Placeholders are blog title, blog URL, author name, published date")
+        return String(format: format, postedIn, postedAtURL, postedBy, postedOn)
     }
 
     private func prepareContentForVoiceOver() {


### PR DESCRIPTION
Refs #12866.  

This is just a minor improvement on the Reader Detail's header.

I removed the site URL from the accessible elements. It was too small as a touch target and the site name (plus URL) being dictated together should be good enough. 

Removed | Improved
--------|-------
![IMG_0993](https://user-images.githubusercontent.com/198826/68397828-08bf4700-0131-11ea-8ae1-fd7dd77f38dd.PNG)        |       ![IMG_0992](https://user-images.githubusercontent.com/198826/68397829-08bf4700-0131-11ea-9ac4-0d5be75ddc94.PNG)

## Testing

1. Turn VoiceOver on.
2. Navigate to a Reader post 
3. Validate that you can no longer navigate to the site URL using VoiceOver. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 



