### PR TITLE
[VoiceOver] Reader Detail: Hide “Attachment. PNG. File” dictation

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -15,6 +15,18 @@ class ReaderPlaceholderAttachment: NSTextAttachment {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
+
+    override var accessibilityLabel: String? {
+        get {
+            // Setting isAccessibilityElement to false does not seem to work for this
+            // `NSTextAttachment`. VoiceOver will still dictate “Attachment. PNG. File” which is
+            // really weird. Returning an empty label here so nothing will just be dictated at all.
+            return ""
+        }
+        set {
+            super.accessibilityLabel = newValue
+        }
+    }
 }
 
 open class ReaderDetailViewController: UIViewController, UIViewControllerRestoration {

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextImage.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextImage.swift
@@ -36,6 +36,8 @@ open class WPRichTextImage: UIControl, WPRichTextMediaAttachment {
         imageView = CachedAnimatedImageView(frame: CGRect(x: 0, y: 0, width: frame.width, height: frame.height))
         imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         imageView.contentMode = .scaleAspectFit
+        imageView.isAccessibilityElement = true
+
         super.init(frame: frame)
 
         addSubview(imageView)


### PR DESCRIPTION
Refs #12866. 

This hides the dictated “Attachment. PNG. File“ message.

## Findings

The dictation was caused by the `ReaderPlaceholderAttachment`. The message gets dictated even for images. 

## Solution

For the life of me, I could not hide it from VoiceOver using `isAccessibilityElement`. I ended up using an empty `accessibilityLabel` instead. 

In addition, I also made the `CachedAnimatedImageView` used in `WPRichTextImage` accessible so when a user hovers over it, VoiceOver would announce that it's an image rather than be silent. 

## Testing

1. Turn VoiceOver on.
1. In Reader, navigate to a post with an image.
2. Hover over the first paragraph. Confirm that VoiceOver doesn't say ”Attachment. PNG. File” anymore and just proceeds to dictate the paragraph's content. 
4. Hover over an image. Confirm that VoiceOver will announce that it's an image.

Please also watch for regressions, particularly the one fixed by #12351. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
