### PR TITLE
Fix comment moderation on self-hosted sites

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,8 +43,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.5.3-beta.2'
-    #pod 'WordPressKit', :git => 'https://github.com/guarani/WordPressKit-iOS.git', :branch => 'issue/12141-restore-revision-dialog'
+    #pod 'WordPressKit', '~> 4.5.3-beta.2'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/xmlrpc-comment-moderation'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -43,8 +43,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 4.5.3-beta.2'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/xmlrpc-comment-moderation'
+    pod 'WordPressKit', '~> 4.5.3-beta.3'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -223,7 +223,7 @@ PODS:
     - WordPressKit (~> 4.5.1)
     - WordPressShared (~> 1.8)
     - WordPressUI (~> 1.4-beta.1)
-  - WordPressKit (4.5.3-beta.2):
+  - WordPressKit (4.5.3-beta.3):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -302,7 +302,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 1.10.2)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `fix/xmlrpc-comment-moderation`)
+  - WordPressKit (~> 4.5.3-beta.3)
   - WordPressMocks (~> 0.0.6)
   - WordPressShared (~> 1.8.8)
   - WordPressUI (~> 1.5.0)
@@ -346,6 +346,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -411,9 +412,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: bdbe882b1071cbfdd67fc3a5314e5d1de37cb04b
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressKit:
-    :branch: fix/xmlrpc-comment-moderation
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdbe882b1071cbfdd67fc3a5314e5d1de37cb04b/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -430,9 +428,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: bdbe882b1071cbfdd67fc3a5314e5d1de37cb04b
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressKit:
-    :commit: 6c8a7b96a06e690fa5eb6a4962ddcd76dd9a4d20
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 3.0.2
@@ -498,7 +493,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 050b34d4c3adfb7c60363849049b13d60683b348
   WordPress-Editor-iOS: 304098424f1051cb271546c99f906aac296b1b81
   WordPressAuthenticator: af8a2b733b8a33d2ad04cdd30f5410bfe772f439
-  WordPressKit: 620bff49011b1e888a6132410c700a25dd059f2d
+  WordPressKit: 839cf499576b6ebaf5793a466c3ced622b6fe44e
   WordPressMocks: 5913bd04586a360212e07a8ccbcb36068d4425a3
   WordPressShared: 64332b24b8a70b7796ee137847cd0d66bdb6b4c1
   WordPressUI: 4a4adafd2b052e94e4846c0a0203761773dc4fd5
@@ -508,6 +503,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 35b16898fae049f6ebffba96793f209b03a41495
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: c9d596e05f7681f989d3380485696648f2257347
+PODFILE CHECKSUM: 23d28718b172f521491bcdfe18430b7d9be6ee4c
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -302,7 +302,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.11.0)
   - WordPressAuthenticator (~> 1.10.2)
-  - WordPressKit (~> 4.5.3-beta.2)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `fix/xmlrpc-comment-moderation`)
   - WordPressMocks (~> 0.0.6)
   - WordPressShared (~> 1.8.8)
   - WordPressUI (~> 1.5.0)
@@ -346,7 +346,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -412,6 +411,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: bdbe882b1071cbfdd67fc3a5314e5d1de37cb04b
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressKit:
+    :branch: fix/xmlrpc-comment-moderation
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdbe882b1071cbfdd67fc3a5314e5d1de37cb04b/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -428,6 +430,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: bdbe882b1071cbfdd67fc3a5314e5d1de37cb04b
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressKit:
+    :commit: 6c8a7b96a06e690fa5eb6a4962ddcd76dd9a4d20
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 3.0.2
@@ -503,6 +508,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 35b16898fae049f6ebffba96793f209b03a41495
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 7b2c35272bb7a64f9e114582b6cec1a00391547d
+PODFILE CHECKSUM: c9d596e05f7681f989d3380485696648f2257347
 
 COCOAPODS: 1.8.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * Updated the mobile apps blog address to a non-retired blog. 
 * Block editor: Added option to insert images from "Free Photo Library".
+* Fixed a bug that made comment moderation fail on the first attempt for self-hosted sites.
 
 13.6
 -----


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/12909

Related WordPressKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/197

To test:

1. Log in to a self-hosted site (without Jetpack).
2. Open the My Sites tab.
3. Open the Comments section.
4. Select a pending comment.
5. Tap "Approve" and confirm the comment is approved (doesn't revert to pending state).
6. Tap "Unapprove" and confirm the comment is unapproved (doesn't revert to approved state).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
