### PR TITLE
Update Gray colors dark mode colors

### DIFF
--- a/WordPress/ColorPalette.xcassets/Gray0.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray0.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "247",
+          "red" : "246",
           "alpha" : "1.000",
-          "blue" : "245",
-          "green" : "244"
+          "blue" : "247",
+          "green" : "247"
         }
       }
     },

--- a/WordPress/ColorPalette.xcassets/Gray0.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray0.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "244"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "16",
+          "alpha" : "1.000",
+          "blue" : "23",
+          "green" : "21"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "205",
+          "red" : "195",
           "alpha" : "1.000",
-          "blue" : "205",
-          "green" : "201"
+          "blue" : "199",
+          "green" : "196"
         }
       }
     },

--- a/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "201"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "44",
+          "alpha" : "1.000",
+          "blue" : "56",
+          "green" : "51"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
@@ -9,7 +9,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "196",
+          "red" : "195",
           "alpha" : "1.000",
           "blue" : "199",
           "green" : "196"

--- a/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
@@ -9,7 +9,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "195",
+          "red" : "196",
           "alpha" : "1.000",
           "blue" : "199",
           "green" : "196"

--- a/WordPress/ColorPalette.xcassets/Gray100.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray100.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "21"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "247",
+          "alpha" : "1.000",
+          "blue" : "245",
+          "green" : "244"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray100.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray100.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "247",
+          "red" : "246",
           "alpha" : "1.000",
-          "blue" : "245",
-          "green" : "244"
+          "blue" : "247",
+          "green" : "247"
         }
       }
     }

--- a/WordPress/ColorPalette.xcassets/Gray20.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray20.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "180",
+          "red" : "167",
           "alpha" : "1.000",
-          "blue" : "184",
-          "green" : "177"
+          "blue" : "173",
+          "green" : "170"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "61",
+          "red" : "60",
           "alpha" : "1.000",
-          "blue" : "75",
-          "green" : "68"
+          "blue" : "74",
+          "green" : "67"
         }
       }
     }

--- a/WordPress/ColorPalette.xcassets/Gray20.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray20.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "177"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "61",
+          "alpha" : "1.000",
+          "blue" : "75",
+          "green" : "68"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "152"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "81",
+          "alpha" : "1.000",
+          "blue" : "95",
+          "green" : "86"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "154",
+          "red" : "142",
           "alpha" : "1.000",
-          "blue" : "161",
-          "green" : "152"
+          "blue" : "150",
+          "green" : "145"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "81",
+          "red" : "80",
           "alpha" : "1.000",
-          "blue" : "95",
-          "green" : "86"
+          "blue" : "94",
+          "green" : "87"
         }
       }
     }

--- a/WordPress/ColorPalette.xcassets/Gray40.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray40.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "127",
+          "red" : "120",
           "alpha" : "1.000",
-          "blue" : "138",
-          "green" : "128"
+          "blue" : "130",
+          "green" : "124"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "103",
+          "red" : "100",
           "alpha" : "1.000",
-          "blue" : "116",
-          "green" : "106"
+          "blue" : "112",
+          "green" : "105"
         }
       }
     }

--- a/WordPress/ColorPalette.xcassets/Gray40.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray40.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "128"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "103",
+          "alpha" : "1.000",
+          "blue" : "116",
+          "green" : "106"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray5.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray5.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "223"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "29",
+          "alpha" : "1.000",
+          "blue" : "39",
+          "green" : "35"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray5.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray5.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "227",
+          "red" : "220",
           "alpha" : "1.000",
-          "blue" : "226",
-          "green" : "223"
+          "blue" : "222",
+          "green" : "220"
         }
       }
     },

--- a/WordPress/ColorPalette.xcassets/Gray50.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray50.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "106"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "127",
+          "alpha" : "1.000",
+          "blue" : "138",
+          "green" : "128"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray50.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray50.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "103",
+          "red" : "100",
           "alpha" : "1.000",
-          "blue" : "116",
-          "green" : "106"
+          "blue" : "112",
+          "green" : "105"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "127",
+          "red" : "120",
           "alpha" : "1.000",
-          "blue" : "138",
-          "green" : "128"
+          "blue" : "130",
+          "green" : "124"
         }
       }
     }

--- a/WordPress/ColorPalette.xcassets/Gray60.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray60.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "81",
+          "red" : "80",
           "alpha" : "1.000",
-          "blue" : "95",
-          "green" : "86"
+          "blue" : "94",
+          "green" : "87"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "154",
+          "red" : "142",
           "alpha" : "1.000",
-          "blue" : "161",
-          "green" : "152"
+          "blue" : "150",
+          "green" : "145"
         }
       }
     }

--- a/WordPress/ColorPalette.xcassets/Gray60.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray60.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "86"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "154",
+          "alpha" : "1.000",
+          "blue" : "161",
+          "green" : "152"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray70.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray70.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "68"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "180",
+          "alpha" : "1.000",
+          "blue" : "184",
+          "green" : "177"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray70.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray70.colorset/Contents.json
@@ -9,10 +9,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "61",
+          "red" : "60",
           "alpha" : "1.000",
-          "blue" : "75",
-          "green" : "68"
+          "blue" : "74",
+          "green" : "67"
         }
       }
     },
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "180",
+          "red" : "167",
           "alpha" : "1.000",
-          "blue" : "184",
-          "green" : "177"
+          "blue" : "173",
+          "green" : "170"
         }
       }
     }

--- a/WordPress/ColorPalette.xcassets/Gray80.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray80.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "51"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "205",
+          "alpha" : "1.000",
+          "blue" : "205",
+          "green" : "201"
+        }
+      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray80.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray80.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "205",
+          "red" : "195",
           "alpha" : "1.000",
-          "blue" : "205",
-          "green" : "201"
+          "blue" : "199",
+          "green" : "196"
         }
       }
     }

--- a/WordPress/ColorPalette.xcassets/Gray90.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray90.colorset/Contents.json
@@ -27,10 +27,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "227",
+          "red" : "220",
           "alpha" : "1.000",
-          "blue" : "226",
-          "green" : "223"
+          "blue" : "222",
+          "green" : "220"
         }
       }
     }

--- a/WordPress/ColorPalette.xcassets/Gray90.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray90.colorset/Contents.json
@@ -15,6 +15,24 @@
           "green" : "35"
         }
       }
+    },
+    {
+      "idiom" : "universal",
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "227",
+          "alpha" : "1.000",
+          "blue" : "226",
+          "green" : "223"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Based on spreadsheet:
<img width="999" alt="Screen Shot 2019-11-09 at 8 28 29 PM" src="https://user-images.githubusercontent.com/1335657/68551361-0a9f3980-03c1-11ea-9749-c75f595f6341.png">

To test:
Compare colors in spreadsheet to represented in ColorsPalette.xcassets

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
