### PR TITLE
Improve media processors for gutenberg

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -308,7 +308,7 @@ class PostCoordinator: NSObject {
         } else if media.mediaType == .video {
             let videoPostUploadProcessor = VideoUploadProcessor(mediaUploadID: mediaUploadID, remoteURLString: remoteURLStr, videoPressID: media.videopressGUID)
             postContent = videoPostUploadProcessor.process(postContent)
-            let gutenbergVideoPostUploadProcessor = GutenbergVideoUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr, localURLString: media.absoluteThumbnailLocalURL?.absoluteString)
+            let gutenbergVideoPostUploadProcessor = GutenbergVideoUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
             postContent = gutenbergVideoPostUploadProcessor.process(postContent)
         } else if let remoteURL = URL(string: remoteURLStr) {
             let documentTitle = remoteURL.lastPathComponent

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
@@ -9,11 +9,11 @@ public struct GutenbergBlock {
     public let content: String
 }
 
-/// A class that processes a string and replace the designated shortcode for the replacement provided strings
+/// A class that processes a gutenberg post content and replaces the designated gutenberg block for the replacement provided strings.
 ///
 public class GutenbergBlockProcessor: Processor {
 
-    /// Whenever an HTML is found by the processor, this closure will be executed so that elements can be customized.
+    /// Whenever an Guntenberg block  is found by the processor, this closure will be executed so that elements can be customized.
     ///
     public typealias Replacer = (GutenbergBlock) -> String?
 
@@ -37,6 +37,7 @@ public class GutenbergBlockProcessor: Processor {
     ///
     /// 1. The block id
     /// 2. The block attributes
+    /// 3. Block content
     ///
     private lazy var gutenbergBlockRegexProcessor: RegexProcessor = { [weak self]() in
         let pattern = "\\<!--[ ]?(\(name))([\\s\\S]*?)-->([\\s\\S]*?)<!-- \\/\(name) -->"
@@ -67,7 +68,7 @@ public class GutenbergBlockProcessor: Processor {
 // MARK: - Regex Match Processing Logic
 
 private extension GutenbergBlockProcessor {
-    /// Processes an HTML Element regex match.
+    /// Processes an Gutenberg block  regex match.
     ///
     func process(match: NSTextCheckingResult, text: String) -> String? {
 
@@ -97,7 +98,7 @@ private extension GutenbergBlockProcessor {
         return jsonDictionary
     }
 
-    /// Obtains the attributes from an block match.
+    /// Obtains the block content from an block match.
     ///
     private func readContent(from match: NSTextCheckingResult, in text: String) -> String {
         guard let content = match.captureGroup(in: CaptureGroups.content.rawValue, text: text) else {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Aztec
 
-/// Struct to represent a Gutenberg element
+/// Struct to represent a Gutenberg block element
 ///
 public struct GutenbergBlock {
     public let name: String
@@ -9,11 +9,11 @@ public struct GutenbergBlock {
     public let content: String
 }
 
-/// A class that processes a gutenberg post content and replaces the designated gutenberg block for the replacement provided strings.
+/// A class that processes a Gutenberg post content and replaces the designated Gutenberg block for the replacement provided strings.
 ///
 public class GutenbergBlockProcessor: Processor {
 
-    /// Whenever an Guntenberg block  is found by the processor, this closure will be executed so that elements can be customized.
+    /// Whenever a Guntenberg block  is found by the processor, this closure will be executed so that elements can be customized.
     ///
     public typealias Replacer = (GutenbergBlock) -> String?
 
@@ -85,7 +85,7 @@ private extension GutenbergBlockProcessor {
 
     // MARK: - Regex Match Processing Logic
 
-    /// Obtains the attributes from an block match.
+    /// Obtains the attributes from a block match.
     ///
     private func readAttributes(from match: NSTextCheckingResult, in text: String) -> [String: Any] {
         guard let attributesText = match.captureGroup(in: CaptureGroups.attributes.rawValue, text: text),
@@ -98,7 +98,7 @@ private extension GutenbergBlockProcessor {
         return jsonDictionary
     }
 
-    /// Obtains the block content from an block match.
+    /// Obtains the block content from a block match.
     ///
     private func readContent(from match: NSTextCheckingResult, in text: String) -> String {
         guard let content = match.captureGroup(in: CaptureGroups.content.rawValue, text: text) else {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Aztec
+
+/// Struct to represent a Gutenberg element
+///
+public struct GutenbergBlock {
+    public let name: String
+    public let attributes: [String: Any]
+    public let content: String
+}
+
+/// A class that processes a string and replace the designated shortcode for the replacement provided strings
+///
+public class GutenbergBlockProcessor: Processor {
+
+    /// Whenever an HTML is found by the processor, this closure will be executed so that elements can be customized.
+    ///
+    public typealias Replacer = (GutenbergBlock) -> String?
+
+    // MARK: - Basic Info
+
+    let name: String
+
+    // MARK: - Regex
+
+    private enum CaptureGroups: Int {
+        case all = 0
+        case name
+        case attributes
+        case content
+
+        static let allValues: [CaptureGroups] = [.all, .name, .attributes, .content]
+    }
+
+    /// Regular expression to detect attributes
+    /// Capture groups:
+    ///
+    /// 1. The block id
+    /// 2. The block attributes
+    ///
+    private lazy var gutenbergBlockRegexProcessor: RegexProcessor = { [weak self]() in
+        let pattern = "\\<!--[ ]?(\(name))([\\s\\S]*?)-->([\\s\\S]*?)<!-- \\/\(name) -->"
+        let regex = try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+
+        return RegexProcessor(regex: regex) { (match: NSTextCheckingResult, text: String) -> String? in
+            return self?.process(match: match, text: text)
+        }
+    }()
+
+    // MARK: - Parsing & processing properties
+    private let replacer: Replacer
+
+    // MARK: - Initializers
+
+    public init(for blockName: String, replacer: @escaping Replacer) {
+        self.name = blockName
+        self.replacer = replacer
+    }
+
+    // MARK: - Processing
+
+    public func process(_ text: String) -> String {
+        return gutenbergBlockRegexProcessor.process(text)
+    }
+}
+
+// MARK: - Regex Match Processing Logic
+
+private extension GutenbergBlockProcessor {
+    /// Processes an HTML Element regex match.
+    ///
+    func process(match: NSTextCheckingResult, text: String) -> String? {
+
+        guard match.numberOfRanges == CaptureGroups.allValues.count else {
+            return nil
+        }
+
+        let attributes = readAttributes(from: match, in: text)
+        let content = readContent(from: match, in: text)
+        let block = GutenbergBlock(name: name, attributes: attributes, content: content)
+
+        return replacer(block)
+    }
+
+    // MARK: - Regex Match Processing Logic
+
+    /// Obtains the attributes from an block match.
+    ///
+    private func readAttributes(from match: NSTextCheckingResult, in text: String) -> [String: Any] {
+        guard let attributesText = match.captureGroup(in: CaptureGroups.attributes.rawValue, text: text),
+            let data = attributesText.data(using: .utf8 ),
+            let json = try? JSONSerialization.jsonObject(with: data , options: .allowFragments),
+            let jsonDictionary = json as? [String: Any] else {
+                return [:]
+        }
+
+        return jsonDictionary
+    }
+
+    /// Obtains the attributes from an block match.
+    ///
+    private func readContent(from match: NSTextCheckingResult, in text: String) -> String {
+        guard let content = match.captureGroup(in: CaptureGroups.content.rawValue, text: text) else {
+            return ""
+        }
+
+        return content
+    }
+}

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergBlockProcessor.swift
@@ -90,7 +90,7 @@ private extension GutenbergBlockProcessor {
     private func readAttributes(from match: NSTextCheckingResult, in text: String) -> [String: Any] {
         guard let attributesText = match.captureGroup(in: CaptureGroups.attributes.rawValue, text: text),
             let data = attributesText.data(using: .utf8 ),
-            let json = try? JSONSerialization.jsonObject(with: data , options: .allowFragments),
+            let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments),
             let jsonDictionary = json as? [String: Any] else {
                 return [:]
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoUploadProcessor.swift
@@ -14,7 +14,7 @@ class GutenbergVideoUploadProcessor: Processor {
     }
 
     lazy var videoHtmlProcessor = HTMLProcessor(for: "video", replacer: { (video) in
-        var attributes = video.attributes        
+        var attributes = video.attributes
 
         attributes.set(.string(self.remoteURLString), forKey: "src")
 
@@ -73,7 +73,7 @@ class GutenbergVideoUploadProcessor: Processor {
 
 
     func process(_ text: String) -> String {
-        var result = videoBlockProcessor.process(text)    
+        var result = videoBlockProcessor.process(text)
         result = mediaTextVideoBlockProcessor.process(result)
         return result
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoUploadProcessor.swift
@@ -6,24 +6,15 @@ class GutenbergVideoUploadProcessor: Processor {
     let mediaUploadID: Int32
     let remoteURLString: String
     let serverMediaID: Int
-    let localURLString: String?
 
-    init(mediaUploadID: Int32, serverMediaID: Int, remoteURLString: String, localURLString: String?) {
+    init(mediaUploadID: Int32, serverMediaID: Int, remoteURLString: String) {
         self.mediaUploadID = mediaUploadID
         self.serverMediaID = serverMediaID
         self.remoteURLString = remoteURLString
-        self.localURLString = localURLString
     }
 
     lazy var videoHtmlProcessor = HTMLProcessor(for: "video", replacer: { (video) in
-        var attributes = video.attributes
-        guard let originalSrcValue = attributes["src"]?.value,
-            case let .string(originalSrc) = originalSrcValue,
-            let srcURL = URL(string: originalSrc),
-            let mediaUploadID = srcURL.lastPathComponent.split(separator: ".").first,
-            mediaUploadID == "\(self.mediaUploadID)" else {
-            return nil
-        }
+        var attributes = video.attributes        
 
         attributes.set(.string(self.remoteURLString), forKey: "src")
 
@@ -34,11 +25,56 @@ class GutenbergVideoUploadProcessor: Processor {
         return html
     })
 
+    private struct VideoBlockKeys {
+        static var name = "wp:video"
+        static var id = "id"
+    }
+
+    lazy var videoBlockProcessor = GutenbergBlockProcessor(for: VideoBlockKeys.name, replacer: { videoBlock in
+        guard let mediaID = videoBlock.attributes[VideoBlockKeys.id] as? Int,
+            mediaID == self.mediaUploadID else {
+                return nil
+        }
+        var block = "<!-- \(VideoBlockKeys.name) "
+        var attributes = videoBlock.attributes
+        attributes[VideoBlockKeys.id] = self.serverMediaID
+        if let jsonData = try? JSONSerialization.data(withJSONObject: attributes, options: .sortedKeys),
+            let jsonString = String(data: jsonData, encoding: .utf8) {
+            block += jsonString
+        }
+        block += " -->"
+        block += self.videoHtmlProcessor.process(videoBlock.content)
+        block += "<!-- /\(VideoBlockKeys.name) -->"
+        return block
+    })
+
+    private struct MediaTextBlockKeys {
+        static var name = "wp:media-text"
+        static var id = "mediaId"
+    }
+
+    lazy var mediaTextVideoBlockProcessor = GutenbergBlockProcessor(for: MediaTextBlockKeys.name, replacer: { videoBlock in
+        guard let mediaID = videoBlock.attributes[MediaTextBlockKeys.id] as? Int,
+            mediaID == self.mediaUploadID else {
+                return nil
+        }
+        var block = "<!-- \(MediaTextBlockKeys.name) "
+        var attributes = videoBlock.attributes
+        attributes[MediaTextBlockKeys.id] = self.serverMediaID
+        if let jsonData = try? JSONSerialization.data(withJSONObject: attributes, options: .sortedKeys),
+            let jsonString = String(data: jsonData, encoding: .utf8) {
+            block += jsonString
+        }
+        block += " -->"
+        block += self.videoHtmlProcessor.process(videoBlock.content)
+        block += "<!-- /\(MediaTextBlockKeys.name) -->"
+        return block
+    })
+
 
     func process(_ text: String) -> String {
-        var result = videoHtmlProcessor.process(text)
-        result = result.replacingOccurrences(of: "wp:video {\"id\":\(String(mediaUploadID))", with: "wp:video {\"id\":\(String(serverMediaID))")
-        result = result.replacingOccurrences(of: "wp:media-text {\"mediaId\":\(String(mediaUploadID))", with: "wp:media-text {\"mediaId\":\(String(serverMediaID))")
+        var result = videoBlockProcessor.process(text)    
+        result = mediaTextVideoBlockProcessor.process(result)
         return result
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1951,6 +1951,7 @@
 		FF00889F204E01AE007CCE66 /* MediaQuotaCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00889E204E01AE007CCE66 /* MediaQuotaCell.swift */; };
 		FF0148E51DFABBC9001AD265 /* NSFileManager+FolderSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0148E41DFABBC9001AD265 /* NSFileManager+FolderSize.swift */; };
 		FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0AAE091A150A560089841D /* WPProgressTableViewCell.m */; };
+		FF0B2567237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0B2566237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift */; };
 		FF0D8146205809C8000EE505 /* PostCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0D8145205809C8000EE505 /* PostCoordinator.swift */; };
 		FF0F722C206E5345000DAAB5 /* PostService+RefreshStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */; };
 		FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */; };
@@ -4367,6 +4368,7 @@
 		FF0AAE081A1509C50089841D /* WPProgressTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPProgressTableViewCell.h; sourceTree = "<group>"; };
 		FF0AAE091A150A560089841D /* WPProgressTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPProgressTableViewCell.m; sourceTree = "<group>"; };
 		FF0AAE0B1A16550D0089841D /* WPMediaProgressTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPMediaProgressTableViewController.h; sourceTree = "<group>"; };
+		FF0B2566237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergVideoUploadProcessorTests.swift; sourceTree = "<group>"; };
 		FF0D8145205809C8000EE505 /* PostCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostCoordinator.swift; sourceTree = "<group>"; };
 		FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+RefreshStatus.swift"; sourceTree = "<group>"; };
 		FF1933FD1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RelatedPostsPreviewTableViewCell.h; sourceTree = "<group>"; };
@@ -9415,6 +9417,7 @@
 				FF9A6E7021F9361700D36D14 /* MediaUploadHashTests.swift */,
 				FF2EC3C12209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift */,
 				9123471A221449E200BD9F97 /* GutenbergInformativeDialogTests.swift */,
+				FF0B2566237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift */,
 			);
 			name = Gutenberg;
 			sourceTree = "<group>";
@@ -12104,6 +12107,7 @@
 				400A2C952217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift in Sources */,
 				D81C2F6620F8ACCD002AE1F1 /* FormattableContentFormatterTests.swift in Sources */,
 				F93735F822D53C3B00A3C312 /* LoggingURLRedactorTests.swift in Sources */,
+				FF0B2567237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift in Sources */,
 				8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */,
 				D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */,
 				E135965D1E7152D1006C6606 /* RecentSitesServiceTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1982,6 +1982,7 @@
 		FF8DDCDF1B5DB1C10098826F /* SettingTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF8DDCDE1B5DB1C10098826F /* SettingTableViewCell.m */; };
 		FF945F701B28242300FB8AC4 /* MediaLibraryPickerDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FF945F6F1B28242300FB8AC4 /* MediaLibraryPickerDataSource.m */; };
 		FF9A6E7121F9361700D36D14 /* MediaUploadHashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9A6E7021F9361700D36D14 /* MediaUploadHashTests.swift */; };
+		FF9C81C42375BA8100DC4B2F /* GutenbergBlockProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9C81C32375BA8100DC4B2F /* GutenbergBlockProcessor.swift */; };
 		FFA0B7D71CAC1F9F00533B9D /* MainNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA0B7D61CAC1F9F00533B9D /* MainNavigationTests.swift */; };
 		FFA162311CB7031A00E2E110 /* AppSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA162301CB7031A00E2E110 /* AppSettingsViewController.swift */; };
 		FFABD800213423F1003C65B6 /* LinkSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFABD7FF213423F1003C65B6 /* LinkSettingsViewController.swift */; };
@@ -4407,6 +4408,7 @@
 		FF945F6F1B28242300FB8AC4 /* MediaLibraryPickerDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MediaLibraryPickerDataSource.m; sourceTree = "<group>"; };
 		FF947A8C1BBE89A100B27B6A /* WordPress 39.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 39.xcdatamodel"; sourceTree = "<group>"; };
 		FF9A6E7021F9361700D36D14 /* MediaUploadHashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MediaUploadHashTests.swift; path = Gutenberg/MediaUploadHashTests.swift; sourceTree = "<group>"; };
+		FF9C81C32375BA8100DC4B2F /* GutenbergBlockProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergBlockProcessor.swift; sourceTree = "<group>"; };
 		FFA0B7D61CAC1F9F00533B9D /* MainNavigationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainNavigationTests.swift; sourceTree = "<group>"; };
 		FFA162301CB7031A00E2E110 /* AppSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsViewController.swift; sourceTree = "<group>"; };
 		FFA40D4D1CB3EDD5001CB1FB /* WordPress 48.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 48.xcdatamodel"; sourceTree = "<group>"; };
@@ -5061,7 +5063,7 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -9375,6 +9377,7 @@
 			children = (
 				FF2EC3BF2209A144006176E1 /* GutenbergImgUploadProcessor.swift */,
 				91138454228373EB00FB02B7 /* GutenbergVideoUploadProcessor.swift */,
+				FF9C81C32375BA8100DC4B2F /* GutenbergBlockProcessor.swift */,
 			);
 			path = Processors;
 			sourceTree = "<group>";
@@ -9773,7 +9776,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -10800,6 +10803,7 @@
 				433432521E9ED18900915988 /* LoginEpilogueViewController.swift in Sources */,
 				4395A1592106389800844E8E /* QuickStartTours.swift in Sources */,
 				9A2B28EE2191B50500458F2A /* RevisionsTableViewFooter.swift in Sources */,
+				FF9C81C42375BA8100DC4B2F /* GutenbergBlockProcessor.swift in Sources */,
 				17F52DB72315233300164966 /* WPStyleGuide+FilterTabBar.swift in Sources */,
 				E1DD4CCB1CAE41B800C3863E /* PagedViewController.swift in Sources */,
 				B549BA681CF7447E0086C608 /* InvitePersonViewController.swift in Sources */,

--- a/WordPress/WordPressTest/Gutenberg/GutenbergImgUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/Gutenberg/GutenbergImgUploadProcessorTests.swift
@@ -11,11 +11,11 @@ class GutenbergImgUploadProcessorTests: XCTestCase {
 
     let postResultContent = """
 <!-- wp:image {"id":100} -->
-<figure class="wp-block-image"><img src="http://www.wordpress.com/logo.jpg" alt="" class="wp-image-100"></figure>
+<figure class="wp-block-image"><img src="http://www.wordpress.com/logo.jpg" alt="" class="wp-image-100"/></figure>
 <!-- /wp:image -->
 """
 
-    func testProcessor() {
+    func testImgBlockProcessor() {
         let gutenbergMediaUploadID = Int32(-181231834)
         let mediaID = 100
         let remoteURLStr = "http://www.wordpress.com/logo.jpg"
@@ -24,6 +24,33 @@ class GutenbergImgUploadProcessorTests: XCTestCase {
         let resultContent = gutenbergImgPostUploadProcessor.process(postContent)
 
         XCTAssertEqual(resultContent, postResultContent, "Post content should be updated correctly")
+    }
+
+    let postMediaBlockContent = """
+    <!-- wp:media-text {"mediaId":-181231834,"mediaType":"image"} -->
+    <div class="wp-block-media-text alignwide"><figure class="wp-block-media-text__media"><img src="file://tmp/EC856C66-7B79-4631-9503-2FB9FF0E6C66.jpg" alt="" class="wp-image--181231834"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+    <p class="has-large-font-size"></p>
+    <!-- /wp:paragraph --></div></div>
+    <!-- /wp:media-text -->
+    """
+
+    let postMediaBlockResultContent = """
+    <!-- wp:media-text {"mediaId":100,"mediaType":"image"} -->
+    <div class="wp-block-media-text alignwide"><figure class="wp-block-media-text__media"><img src="http://www.wordpress.com/logo.jpg" alt="" class="wp-image-100"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+    <p class="has-large-font-size"></p>
+    <!-- /wp:paragraph --></div></div>
+    <!-- /wp:media-text -->
+    """
+
+    func testMediaTextBlockProcessor() {
+        let gutenbergMediaUploadID = Int32(-181231834)
+        let mediaID = 100
+        let remoteURLStr = "http://www.wordpress.com/logo.jpg"
+
+        let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
+        let resultContent = gutenbergImgPostUploadProcessor.process(postMediaBlockContent)
+
+        XCTAssertEqual(resultContent, postMediaBlockResultContent, "Post content should be updated correctly")
     }
 
 }

--- a/WordPress/WordPressTest/GutenbergVideoUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/GutenbergVideoUploadProcessorTests.swift
@@ -54,4 +54,31 @@ class GutenbergVideoUploadProcessorTests: XCTestCase {
         XCTAssertEqual(resultContent, postMediaBlockResultContent, "Post content should be updated correctly")
     }
 
+    let postMediaBlockReversedAttributesContent = """
+    <!-- wp:media-text {"mediaType":"video", "mediaId":-181231834} -->
+    <div class="wp-block-media-text alignwide"><figure class="wp-block-media-text__media"><video controls src="file://tmp.mp4"></video></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+    <p class="has-large-font-size"></p>
+    <!-- /wp:paragraph --></div></div>
+    <!-- /wp:media-text -->
+    """
+
+    let postMediaBlockReversedAttributesResultContent = """
+    <!-- wp:media-text {"mediaId":100,"mediaType":"video"} -->
+    <div class="wp-block-media-text alignwide"><figure class="wp-block-media-text__media"><video controls src="http://www.wordpress.com/video.mp4"></video></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+    <p class="has-large-font-size"></p>
+    <!-- /wp:paragraph --></div></div>
+    <!-- /wp:media-text -->
+    """
+
+    func testMediaTextBlockReversedAttributesProcessor() {
+        let gutenbergMediaUploadID = Int32(-181231834)
+        let mediaID = 100
+        let remoteURLStr = "http://www.wordpress.com/video.mp4"
+
+        let gutenbergVideoUploadProcessor = GutenbergVideoUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
+        let resultContent = gutenbergVideoUploadProcessor.process(postMediaBlockReversedAttributesContent)
+
+        XCTAssertEqual(resultContent, postMediaBlockReversedAttributesResultContent, "Post content should be updated correctly")
+    }
+
 }

--- a/WordPress/WordPressTest/GutenbergVideoUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/GutenbergVideoUploadProcessorTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import XCTest
+@testable import WordPress
+
+class GutenbergVideoUploadProcessorTests: XCTestCase {
+
+    let postContent = """
+<!-- wp:video {"id":-181231834} -->
+<figure class="wp-block-video"><video controls src="file://tmp.mp4"></video></figure>
+<!-- /wp:video -->
+"""
+
+    let postResultContent = """
+<!-- wp:video {"id":100} -->
+<figure class="wp-block-video"><video controls src="http://www.wordpress.com/video.mp4"></video></figure>
+<!-- /wp:video -->
+"""
+
+    func testVideoBlockProcessor() {
+        let gutenbergMediaUploadID = Int32(-181231834)
+        let mediaID = 100
+        let remoteURLStr = "http://www.wordpress.com/video.mp4"
+
+        let gutenbergVideoUploadProcessor = GutenbergVideoUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
+        let resultContent = gutenbergVideoUploadProcessor.process(postContent)
+
+        XCTAssertEqual(resultContent, postResultContent, "Post content should be updated correctly")
+    }
+
+    let postMediaBlockContent = """
+    <!-- wp:media-text {"mediaId":-181231834,"mediaType":"video"} -->
+    <div class="wp-block-media-text alignwide"><figure class="wp-block-media-text__media"><video controls src="file://tmp.mp4"></video></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+    <p class="has-large-font-size"></p>
+    <!-- /wp:paragraph --></div></div>
+    <!-- /wp:media-text -->
+    """
+
+    let postMediaBlockResultContent = """
+    <!-- wp:media-text {"mediaId":100,"mediaType":"video"} -->
+    <div class="wp-block-media-text alignwide"><figure class="wp-block-media-text__media"><video controls src="http://www.wordpress.com/video.mp4"></video></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
+    <p class="has-large-font-size"></p>
+    <!-- /wp:paragraph --></div></div>
+    <!-- /wp:media-text -->
+    """
+
+    func testMediaTextBlockProcessor() {
+        let gutenbergMediaUploadID = Int32(-181231834)
+        let mediaID = 100
+        let remoteURLStr = "http://www.wordpress.com/video.mp4"
+
+        let gutenbergVideoUploadProcessor = GutenbergVideoUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
+        let resultContent = gutenbergVideoUploadProcessor.process(postMediaBlockContent)
+
+        XCTAssertEqual(resultContent, postMediaBlockResultContent, "Post content should be updated correctly")
+    }
+
+}

--- a/WordPress/WordPressTest/MediaAssetExporterTests.swift
+++ b/WordPress/WordPressTest/MediaAssetExporterTests.swift
@@ -164,7 +164,7 @@ class MediaAssetExporterTests: XCTestCase {
         exporter.mediaDirectoryType = .temporary
         exporter.export(onCompletion: { (imageExport) in
             // If not resising the image the orientation stays the same has the original
-            MediaImageExporterTests.validateImageExportedWithExpectedOrientation(export: imageExport, expected: .leftMirrored)
+            MediaImageExporterTests.validateImageExportedWithExpectedOrientation(export: imageExport, expected: .up)
             MediaExporterTests.cleanUpExportedMedia(atURL: imageExport.url)
             expect.fulfill()
         }) { (error) in


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1512

This PR improves the media processors used in Gutenberg media upload to check for blocks and don't relay on the id of media to be the first attributed.

To test:
 - Start a new post
 - Create a video or img block
 - Choose a video or img from the device
 - Publish the post while the upload is still going
 - Wait for the upload to finish while seeing the list
 - When all the uploads are finished
 - Open the post again
 - Check that content is correct and pointing to remote videos
 - Repeat using the media-text blocks.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
