### PR TITLE
Update media status when opening post in Gutenberg.

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -132,6 +132,29 @@ class GutenbergMediaInserterHelper: NSObject {
         return mediaCoordinator.addMedia(from: exportableAsset, to: self.post, analyticsInfo: info)
     }
 
+    /// Method to be used to refresh the status of all media associated with the post.
+    /// this method should be called when opening a post to make sure every media block has the correct visual status.
+    func refreshMediaStatus() {
+        for media in post.media {
+            switch media.remoteStatus {
+            case .processing:
+                mediaObserver(media: media, state: .processing)
+            case .pushing:
+                var progressValue = 0.5
+                if let progress = mediaCoordinator.progress(for: media) {
+                    progressValue = progress.fractionCompleted
+                }
+                mediaObserver(media: media, state: .progress(value: progressValue))
+            case .failed:
+                if let error = media.error as NSError? {
+                    mediaObserver(media: media, state: .failed(error: error))
+                }
+            default:
+                break
+            }
+        }
+    }
+
     private func registerMediaObserver() {
         mediaObserverReceipt =  mediaCoordinator.addObserver({ [weak self](media, state) in
             self?.mediaObserver(media: media, state: state)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -515,6 +515,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
                 showMediaSelectionOnStart()
             }
             focusTitleIfNeeded()
+            mediaInserterHelper.refreshMediaStatus()
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1525

This PR make sure that after the content of a post is set, the status of the media objects is refreshed to show the more recent state

To test:
 - Start a new post using Gutenberg
 - Add some image blocks to the post
 - Save the post while media is still uploading
 - Exit the editor
 - Renter the editor
 - Check that the media progress is refresh for all the media objects in the post as soon as the post is opened.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
