### PR TITLE
Testing: Wait for block editor to be fully loaded before closing it

### DIFF
--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -65,6 +65,14 @@ class BlockEditorScreen: BaseScreen {
 
     // returns void since return screen depends on from which screen it loaded
     func closeEditor() {
+        // Wait for editor to fully load before trying to close it
+        // See https://github.com/wordpress-mobile/gutenberg-mobile/issues/1567
+        XCTContext.runActivity(named: "Confirm editor is fully loaded") { (activity) in
+            let editorTitleLoaded = titleView.waitForExistence(timeout: 2)
+            let blockButtonLoaded = addBlockButton.waitForExistence(timeout: 2)
+            XCTAssertTrue(editorTitleLoaded && blockButtonLoaded, "Editor is not fully loaded")
+        }
+
         XCTContext.runActivity(named: "Close the block editor") { (activity) in
             XCTContext.runActivity(named: "Close the More menu if needed") { (activity) in
                 if actionSheet.exists {

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -28,7 +28,8 @@ class BlockEditorScreen: BaseScreen {
     let keepEditingButton = XCUIApplication().sheets.buttons["Keep Editing"] // Uses a localized string
 
     init() {
-        super.init(element: editorNavBar)
+        // Check addBlockButton element to ensure block editor is fully loaded
+        super.init(element: addBlockButton)
     }
 
     /**
@@ -65,14 +66,6 @@ class BlockEditorScreen: BaseScreen {
 
     // returns void since return screen depends on from which screen it loaded
     func closeEditor() {
-        // Wait for editor to fully load before trying to close it
-        // See https://github.com/wordpress-mobile/gutenberg-mobile/issues/1567
-        XCTContext.runActivity(named: "Confirm editor is fully loaded") { (activity) in
-            let editorTitleLoaded = titleView.waitForExistence(timeout: 2)
-            let blockButtonLoaded = addBlockButton.waitForExistence(timeout: 2)
-            XCTAssertTrue(editorTitleLoaded && blockButtonLoaded, "Editor is not fully loaded")
-        }
-
         XCTContext.runActivity(named: "Close the block editor") { (activity) in
             XCTContext.runActivity(named: "Close the More menu if needed") { (activity) in
                 if actionSheet.exists {


### PR DESCRIPTION
Fixes #12921

This works around the issue reported in https://github.com/wordpress-mobile/gutenberg-mobile/issues/1567 to ensure the `testTabBarNavigation()` doesn't fail due to the editor not being fully loaded. It will also prevent other flaky test failures due to slow editor loading in editor tests.

To test:

* Check the UI test runs on CircleCI to confirm that all tests pass, especially `testTabBarNavigation()`.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
