### PR TITLE
[VoiceOver] Enhancements for main Notifications page

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1075,6 +1075,8 @@ extension NotificationsViewController: WPTableViewHandlerDelegate {
             self?.cancelDeletionRequestForNoteWithID(note.objectID)
         }
 
+        cell.accessibilityHint = Self.accessibilityHint(for: note)
+
         cell.downloadIconWithURL(note.iconURL)
     }
 
@@ -1110,8 +1112,26 @@ extension NotificationsViewController: WPTableViewHandlerDelegate {
             selectFirstNotificationIfAppropriate()
         }
     }
-}
 
+    private static func accessibilityHint(for note: Notification) -> String? {
+        switch note.kind {
+        case .comment:
+            return NSLocalizedString("Shows details and moderation actions.",
+                                     comment: "Accessibility hint for a comment notification.")
+        case .commentLike, .like:
+            return NSLocalizedString("Shows all likes.",
+                                     comment: "Accessibility hint for a post or comment “like” notification.")
+        case .follow:
+            return NSLocalizedString("Shows all followers",
+                                     comment: "Accessibility hint for a follow notification.")
+        case .matcher, .newPost:
+            return NSLocalizedString("Shows the post",
+                                     comment: "Accessibility hint for a match/mention on a post notification.")
+        default:
+            return nil
+        }
+    }
+}
 
 // MARK: - Filter Helpers
 //

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
@@ -12,6 +12,8 @@ class NoteTableHeaderView: UIView {
             let unwrappedTitle = newValue?.localizedUppercase ?? String()
             let attributes = Style.sectionHeaderRegularStyle
             titleLabel.attributedText = NSAttributedString(string: unwrappedTitle, attributes: attributes)
+
+            contentView.accessibilityLabel = unwrappedTitle
         }
         get {
             return titleLabel.text

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -32,6 +32,9 @@
                             <size key="shadowOffset" width="0.0" height="0.0"/>
                         </label>
                     </subviews>
+                    <accessibility key="accessibilityConfiguration">
+                        <bool key="isElement" value="YES"/>
+                    </accessibility>
                     <constraints>
                         <constraint firstItem="zK2-Ta-Z1W" firstAttribute="leading" secondItem="imt-VI-wdh" secondAttribute="trailing" constant="4" id="5gJ-xQ-IIv"/>
                         <constraint firstItem="imt-VI-wdh" firstAttribute="centerY" secondItem="AjL-Ni-9e0" secondAttribute="centerY" id="7ht-6A-0hZ"/>

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
@@ -33,6 +33,7 @@
                         </label>
                     </subviews>
                     <accessibility key="accessibilityConfiguration">
+                        <accessibilityTraits key="traits" header="YES"/>
                         <bool key="isElement" value="YES"/>
                     </accessibility>
                     <constraints>

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="87"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="9ZS-co-ZCe" id="9Ex-yA-LkS">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="86.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="87"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="JUi-EY-Obv" userLabel="IconImageView" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -99,6 +96,9 @@
                     <constraint firstAttribute="trailingMargin" secondItem="WuB-h0-mSd" secondAttribute="trailing" id="tuw-OS-5Gn"/>
                 </constraints>
             </tableViewCellContentView>
+            <accessibility key="accessibilityConfiguration">
+                <accessibilityTraits key="traits" button="YES"/>
+            </accessibility>
             <inset key="separatorInset" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
                 <outlet property="iconImageView" destination="JUi-EY-Obv" id="TRa-w4-qvm"/>


### PR DESCRIPTION
Refs #12906 

This enhances VoiceOver support for the Notifications page. 

## Changes

### Cells as buttons

<img src="https://user-images.githubusercontent.com/198826/68708139-53d1c380-0550-11ea-8eb9-f943556b180b.png" width="320">

The cells now have the `.button` trait so that it's more obvious that they can be tapped. I also added hints (66a9c26) for the notification kinds that I know of. I couldn't find information on how to _create sample notifications_ the following:

- `.post`
- `.user`

### Headers 

Before | After 
--------|-------
![IMG_1034](https://user-images.githubusercontent.com/198826/68708441-eeca9d80-0550-11ea-90c4-7d1f2fbbea58.PNG)        |       ![IMG_1033](https://user-images.githubusercontent.com/198826/68708444-eeca9d80-0550-11ea-814a-b0232d1eab85.PNG)

I increased the accessible width of the table headers and added `.heading` traits on them. This makes them navigatable via Headings using [the rotor](https://support.apple.com/en-ca/guide/iphone/iph3e2e3a6d/ios) and also just simply give out more useful information than a normal label. 

## Testing

1. Turn VoiceOver on
2. Navigate to Notifications
3. Verify the changes have been implemented as described above. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
