### PR TITLE
Update Fastlane to work with AppCenter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
       xcodeproj (>= 1.8.1, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-appcenter (1.6.0)
     fastlane-plugin-sentry (1.6.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -262,6 +263,7 @@ DEPENDENCIES
   commonmarker!
   dotenv!
   fastlane (= 2.133.0)!
+  fastlane-plugin-appcenter (= 1.6.0)
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)!

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -298,13 +298,15 @@ import "./ScreenshotFastfile"
 
     sh("mv ../../build/WordPress.ipa \"../../build/WordPress Internal.ipa\"")
 
-    hockey(
-        api_token: get_required_env("HOCKEY_API_TOKEN"),        
-        public_identifier: get_required_env("HOCKEY_PUBLIC_ID"),
-        notify: "0",
-        status: "1",
-        ipa: "../build/WordPress Internal.ipa",
-        dsym: "../build/WordPress.app.dSYM.zip",
+    # NOTE: "ipa" parameter is deprecated in appcenter_upload 1.6.0, but there's a bug in the action that
+    # makes the default gym output override the "file" parameter. 
+    appcenter_upload(
+      api_token: ENV["APPCENTER_API_TOKEN"],
+      owner_name: "Hogwarts-Organization",
+      owner_type: "organization", 
+      app_name: "WP-Internal",
+      ipa: "../build/WordPress Internal.ipa",
+      notify_testers: false 
     )
     
 

--- a/Scripts/fastlane/Pluginfile
+++ b/Scripts/fastlane/Pluginfile
@@ -8,3 +8,4 @@ end
 
 gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.0'
 gem 'fastlane-plugin-sentry'
+gem 'fastlane-plugin-appcenter', '1.6.0'

--- a/Scripts/fastlane/env/user.env-example
+++ b/Scripts/fastlane/env/user.env-example
@@ -2,5 +2,5 @@ FASTLANE_USER=<Your Apple ID for fastlane>
 DELIVER_USER=<Your Apple ID for fastlane>
 
 GHHELPER_ACCESS=<GitHub access token>
-HOCKEY_API_TOKEN=<HockeyApp Api Token>
+APPCENTER_API_TOKEN=<AppCenter Api Token>
 SENTRY_AUTH_TOKEN=<Sentry Auth Token>


### PR DESCRIPTION
This PR updates the Fastlane configuration to switch binary upload from HockeyApp to MSAppCenter because of HockeyApp sunsetting.

## To test:
1. Create a new [API Token in AppCenter](https://appcenter.ms/settings/apitokens).
2. Add a APPCENTER_API_TOKEN entry to your ~/.wopios-env.default with the token above.
3. Bump the internal version of the app.
4. `bundle install`.
5. Run `bundle exec fastlane build_and_upload_internal` and verify that the app is built and uploaded to App Center.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
