### PR TITLE
Try/appcenter installable builds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
       xcodeproj (>= 1.8.1, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-appcenter (1.6.0)
     fastlane-plugin-sentry (1.6.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -262,6 +263,7 @@ DEPENDENCIES
   commonmarker!
   dotenv!
   fastlane (= 2.133.0)!
+  fastlane-plugin-appcenter (= 1.6.0)
   fastlane-plugin-sentry
   fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)!

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -244,26 +244,24 @@ import "./ScreenshotFastfile"
 
     sh("mv ../../build/WordPress.ipa \"../../build/WordPress Alpha.ipa\"")
       
-    hockey(
-      api_token: get_required_env("HOCKEY_API_TOKEN"),        
-      public_identifier: get_required_env("HOCKEY_INSTALLABLE_BUILDS_PUBLIC_ID"),
-      notify: "0",
-      status: "2",
+    # NOTE: "ipa" parameter is deprecated in appcenter_upload 1.6.0, but there's a bug in the action that
+    # makes the default gym output override the "file" parameter. 
+    appcenter_upload(
+      api_token: get_required_env("APPCENTER_API_TOKEN"),
+      owner_name: "Hogwarts-Organization",
+      owner_type: "organization", 
+      app_name: "WPiOS-One-Offs",
       ipa: "../build/WordPress Alpha.ipa",
-      dsym: "../build/WordPress.app.dSYM.zip",
+      destinations: "All-users-of-WPiOS-One-Offs",
+      notify_testers: false 
     )
 
-    # Getting the download link from the HockeyApp Api, since `hockey(..)` only gives us the app link
-    # See documentation here: https://support.hockeyapp.net/kb/api/api-versions
-    url = "https://rink.hockeyapp.net/api/2/apps/#{get_required_env("HOCKEY_INSTALLABLE_BUILDS_PUBLIC_ID")}/app_versions"
-    result = open(url, {"X-HockeyAppToken" => get_required_env("HOCKEY_API_TOKEN")}).read
-    versions = JSON.parse(result)
-
-    download_url = versions["app_versions"].find {|v| v["version"] == build_number}["download_url"]
+    download_url = Actions.lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]
     UI.message("Successfully built and uploaded installable build here: #{download_url}")
+    install_url = "https://install.appcenter.ms/orgs/Hogwarts-Organization/apps/WPiOS-One-Offs/"
 
     # Create a comment.json file so that Peril to comment with the build details, if this is running on CI
-    comment_body = "You can test the changes on this Pull Request by downloading it from HockeyApp [here](#{download_url}). If you need access to this, you can ask a maintainer to add you."
+    comment_body = "You can test the changes on this Pull Request by downloading it from AppCenter [here](#{install_url}) with build number: #{build_number}. IPA is available [here](#{download_url}). If you need access to this, you can ask a maintainer to add you."
     File.write("comment.json", { body: comment_body }.to_json)
   end
 

--- a/Scripts/fastlane/Pluginfile
+++ b/Scripts/fastlane/Pluginfile
@@ -8,3 +8,4 @@ end
 
 gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.0'
 gem 'fastlane-plugin-sentry'
+gem 'fastlane-plugin-appcenter', '1.6.0'


### PR DESCRIPTION
This PR updates the Installable builds lane in order to make it work with AppCenter.

Currently AppCenter doesn't support release URLs (related issue and discussion here: microsoft/fastlane-plugin-appcenter#49), so it's not possible to link to the version to download, but only to the general download page.

I updated the message to make it show a link to the general download page and the build number (which is unique because it's the CircleCI build number) related to this PR. Users have to look for the right build on the page.

I also added the direct link to the .ipa file, but it's only useful if you have XCode to install it.

I'll monitor the AppCenter issue and update our tooling as soon as it's solved and, in the meantime, I'll post an update on the relevant blogs to make users aware of this.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
