### PR TITLE
Fix media crash

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -135,7 +135,7 @@ class MediaCoordinator: NSObject {
     @discardableResult
     func addMedia(from asset: ExportableAsset, to blog: Blog, analyticsInfo: MediaAnalyticsInfo? = nil) -> Media? {
         let coordinator = mediaLibraryProgressCoordinator
-        return addMedia(from: asset, to: blog.objectID, coordinator: coordinator, analyticsInfo: analyticsInfo)
+        return addMedia(from: asset, blog: blog, post: nil, coordinator: coordinator, analyticsInfo: analyticsInfo)
     }
 
     /// Adds the specified media asset to the specified post. The upload process
@@ -148,17 +148,18 @@ class MediaCoordinator: NSObject {
     @discardableResult
     func addMedia(from asset: ExportableAsset, to post: AbstractPost, analyticsInfo: MediaAnalyticsInfo? = nil) -> Media? {
         let coordinator = self.coordinator(for: post)
-        return addMedia(from: asset, to: post.objectID, coordinator: coordinator, analyticsInfo: analyticsInfo)
+        return addMedia(from: asset, blog: post.blog, post: post, coordinator: coordinator, analyticsInfo: analyticsInfo)
     }
 
     @discardableResult
-    private func addMedia(from asset: ExportableAsset, to objectID: NSManagedObjectID, coordinator: MediaProgressCoordinator, analyticsInfo: MediaAnalyticsInfo? = nil) -> Media? {
+    private func addMedia(from asset: ExportableAsset, blog: Blog, post: AbstractPost?, coordinator: MediaProgressCoordinator, analyticsInfo: MediaAnalyticsInfo? = nil) -> Media? {
         coordinator.track(numberOfItems: 1)
         let service = mediaServiceFactory.create(mainContext)
         let totalProgress = Progress.discreteProgress(totalUnitCount: MediaExportProgressUnits.done)
         var creationProgress: Progress? = nil
         let mediaOptional = service.createMedia(with: asset,
-                            objectID: objectID,
+                            blog: blog,
+                            post: post,
                             progress: &creationProgress,
                             thumbnailCallback: { [weak self] media, url in
                                 self?.thumbnailReady(url: url, for: media)

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -6,6 +6,7 @@
 
 @class Media;
 @class Blog;
+@class AbstractPost;
 @protocol ExportableAsset;
 
 extern NSErrorDomain _Nonnull const MediaServiceErrorDomain;
@@ -27,13 +28,15 @@ typedef NS_ERROR_ENUM(MediaServiceErrorDomain, MediaServiceError) {
  Create a media object using the url provided as the source of media.
 
  @param exportable an object that implements the exportable interface
- @param objectID the post or blog object ID to associate to the media
+ @param blog the blog object to associate to the media
+ @param post the post object to associate to the media
  @param progress a NSProgress that tracks the progress of the export process.
  @param thumbnailCallback a block that will be invoked when the thumbail for the media object is ready
  @param completion a block that will be invoked when the media is created, on success it will return a valid Media object, on failure it will return a nil Media and an error object with the details.
  */
 - (nullable Media *)createMediaWith:(nonnull id<ExportableAsset>)exportable
-                          objectID:(nonnull NSManagedObjectID *)objectID
+                               blog:(nonnull Blog *)blog
+                               post:(nullable AbstractPost *)post
                           progress:(NSProgress * __nullable __autoreleasing * __nullable)progress
                  thumbnailCallback:(nullable void (^)(Media * __nonnull media, NSURL * __nonnull thumbnailURL))thumbnailCallback
                         completion:(nullable void (^)(Media * __nullable media, NSError * __nullable error))completion;

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -12,7 +12,8 @@ extern NSErrorDomain _Nonnull const MediaServiceErrorDomain;
 typedef NS_ERROR_ENUM(MediaServiceErrorDomain, MediaServiceError) {
     MediaServiceErrorFileDoesNotExist = 0,
     MediaServiceErrorFileLargerThanDiskQuotaAvailable = 1,
-    MediaServiceErrorFileLargerThanMaxFileSize = 2
+    MediaServiceErrorFileLargerThanMaxFileSize = 2,
+    MediaServiceErrorUnableToCreateMedia = 3
 };
 
 @interface MediaService : LocalCoreDataService
@@ -31,7 +32,7 @@ typedef NS_ERROR_ENUM(MediaServiceErrorDomain, MediaServiceError) {
  @param thumbnailCallback a block that will be invoked when the thumbail for the media object is ready
  @param completion a block that will be invoked when the media is created, on success it will return a valid Media object, on failure it will return a nil Media and an error object with the details.
  */
-- (nonnull Media *)createMediaWith:(nonnull id<ExportableAsset>)exportable
+- (nullable Media *)createMediaWith:(nonnull id<ExportableAsset>)exportable
                           objectID:(nonnull NSManagedObjectID *)objectID
                           progress:(NSProgress * __nullable __autoreleasing * __nullable)progress
                  thumbnailCallback:(nullable void (^)(Media * __nonnull media, NSURL * __nonnull thumbnailURL))thumbnailCallback

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -77,6 +77,9 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
         [self.managedObjectContext obtainPermanentIDsForObjects:@[media] error:nil];
         [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
     }];
+    if (media == nil) {
+        return nil;
+    }
     NSManagedObjectID *mediaObjectID = media.objectID;
     [self.managedObjectContext performBlock:^{
         // Setup completion handlers

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -36,7 +36,8 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 #pragma mark - Creating media
 
 - (Media *)createMediaWith:(id<ExportableAsset>)exportable
-                  objectID:(NSManagedObjectID *)objectID
+                      blog:(Blog *)blog
+                      post:(AbstractPost *)post
                   progress:(NSProgress **)progress
          thumbnailCallback:(void (^)(Media *media, NSURL *thumbnailURL))thumbnailCallback
                 completion:(void (^)(Media *media, NSError *error))completion
@@ -45,18 +46,9 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
     __block Media *media;
     __block NSSet<NSString *> *allowedFileTypes = [NSSet set];
     [self.managedObjectContext performBlockAndWait:^{
-        AbstractPost *post = nil;
-        Blog *blog = nil;
-        NSError *error = nil;
-        NSManagedObject *existingObject = [self.managedObjectContext existingObjectWithID:objectID error:&error];
-        if ([existingObject isKindOfClass:[AbstractPost class]]) {
-            post = (AbstractPost *)existingObject;
-            blog = post.blog;
-        } else if ([existingObject isKindOfClass:[Blog class]]) {
-            blog = (Blog *)existingObject;
-        }
-        if (!post && !blog) {
+        if ( blog == nil ) {
             if (completion) {
+                NSError *error = [NSError errorWithDomain: MediaServiceErrorDomain code: MediaServiceErrorUnableToCreateMedia userInfo: nil];
                 completion(nil, error);
             }
             return;

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -42,6 +42,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
          thumbnailCallback:(void (^)(Media *media, NSURL *thumbnailURL))thumbnailCallback
                 completion:(void (^)(Media *media, NSError *error))completion
 {
+    NSParameterAssert(post == nil || blog == post.blog);
     NSProgress *createProgress = [NSProgress discreteProgressWithTotalUnitCount:1];
     __block Media *media;
     __block NSSet<NSString *> *allowedFileTypes = [NSSet set];

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -43,6 +43,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
                 completion:(void (^)(Media *media, NSError *error))completion
 {
     NSParameterAssert(post == nil || blog == post.blog);
+    NSParameterAssert(blog.managedObjectContext == self.managedObjectContext);
     NSProgress *createProgress = [NSProgress discreteProgressWithTotalUnitCount:1];
     __block Media *media;
     __block NSSet<NSString *> *allowedFileTypes = [NSSet set];

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2357,7 +2357,9 @@ extension AztecPostViewController {
         }
 
         let info = MediaAnalyticsInfo(origin: .editor(source), selectionMethod: mediaSelectionMethod)
-        let media = mediaCoordinator.addMedia(from: exportableAsset, to: self.post, analyticsInfo: info)
+        guard let media = mediaCoordinator.addMedia(from: exportableAsset, to: self.post, analyticsInfo: info) else {
+            return
+        }
         attachment?.uploadID = media.uploadID
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -980,7 +980,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     __weak __typeof(self) weakSelf = self;
     MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:[ContextManager sharedInstance].mainContext];
     NSProgress *mediaCreateProgress;
-    [mediaService createMediaWith:image objectID:self.blog.objectID progress:&mediaCreateProgress thumbnailCallback:nil completion:^(Media *media, NSError *error) {
+    [mediaService createMediaWith:image blog:self.blog post:nil progress:&mediaCreateProgress thumbnailCallback:nil completion:^(Media *media, NSError *error) {
         if (media == nil || error != nil) {
             return;
         }

--- a/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
@@ -92,26 +92,26 @@ class SiteIconPickerPresenter: NSObject {
             let imageCropViewController = ImageCropViewController(image: image)
             imageCropViewController.maskShape = .square
             imageCropViewController.onCompletion = { [weak self] image, modified in
-                self?.onIconSelection?()
-                if !modified, let media = self?.originalMedia {
-                    self?.onCompletion?(media, nil)
+                guard let self = self else {
+                    return
+                }
+                self.onIconSelection?()
+                if !modified, let media = self.originalMedia {
+                    self.onCompletion?(media, nil)
                 } else {
                     let mediaService = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-                    guard let blogId = self?.blog.objectID else {
-                        self?.onCompletion?(nil, nil)
-                        return
-                    }
 
                     WPAnalytics.track(.siteSettingsSiteIconCropped)
 
                     mediaService.createMedia(with: image,
-                                             objectID: blogId,
+                                             blog: self.blog,
+                                             post: nil,
                                              progress: nil,
                                              thumbnailCallback: nil,
                                              completion: { (media, error) in
                         guard let media = media, error == nil else {
                             WPAnalytics.track(.siteSettingsSiteIconUploadFailed)
-                            self?.onCompletion?(nil, error)
+                            self.onCompletion?(nil, error)
                             return
                         }
                         var uploadProgress: Progress?
@@ -120,10 +120,10 @@ class SiteIconPickerPresenter: NSObject {
                                                  progress: &uploadProgress,
                                                  success: {
                             WPAnalytics.track(.siteSettingsSiteIconUploaded)
-                            self?.onCompletion?(media, nil)
+                            self.onCompletion?(media, nil)
                         }, failure: { (error) in
                             WPAnalytics.track(.siteSettingsSiteIconUploadFailed)
-                            self?.onCompletion?(nil, error)
+                            self.onCompletion?(nil, error)
                         })
                     })
                 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -55,7 +55,10 @@ class GutenbergMediaInserterHelper: NSObject {
     }
 
     func insertFromDevice(asset: PHAsset, callback: @escaping MediaPickerDidPickMediaCallback) {
-        let media = insert(exportableAsset: asset, source: .deviceLibrary)
+        guard let media = insert(exportableAsset: asset, source: .deviceLibrary) else {
+            callback([])
+            return
+        }
         let options = PHImageRequestOptions()
         options.deliveryMode = .fastFormat
         options.version = .current
@@ -80,7 +83,10 @@ class GutenbergMediaInserterHelper: NSObject {
     }
 
     func insertFromDevice(url: URL, callback: @escaping MediaPickerDidPickMediaCallback) {
-        let media = insert(exportableAsset: url as NSURL, source: .otherApps)
+        guard let media = insert(exportableAsset: url as NSURL, source: .otherApps) else {
+            callback([])
+            return
+        }
         let mediaUploadID = media.gutenbergUploadID
         callback([MediaInfo(id: mediaUploadID, url: url.absoluteString, type: media.mediaTypeString)])
     }
@@ -127,7 +133,7 @@ class GutenbergMediaInserterHelper: NSObject {
         return mediaCoordinator.hasFailedMedia(for: post)
     }
 
-    func insert(exportableAsset: ExportableAsset, source: MediaSource) -> Media {
+    func insert(exportableAsset: ExportableAsset, source: MediaSource) -> Media? {
         let info = MediaAnalyticsInfo(origin: .editor(source), selectionMethod: mediaSelectionMethod)
         return mediaCoordinator.addMedia(from: exportableAsset, to: self.post, analyticsInfo: info)
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergStockPhotos.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergStockPhotos.swift
@@ -49,7 +49,10 @@ extension GutenbergStockPhotos: StockPhotosPickerDelegate {
             return assertionFailure("Image picked without callback")
         }
 
-        let media = self.mediaInserter.insert(exportableAsset: asset, source: .giphy)
+        guard let media = self.mediaInserter.insert(exportableAsset: asset, source: .giphy) else {
+            callback([])
+            return
+        }
         let mediaUploadID = media.gutenbergUploadID
         callback([MediaInfo(id: mediaUploadID, url: asset.URL.absoluteString, type: media.mediaTypeString)])
     }
@@ -59,8 +62,9 @@ extension GutenbergStockPhotos: StockPhotosPickerDelegate {
     /// - Parameter assets: Stock Media objects to append.
     func appendOnNewBlocks(assets: ArraySlice<StockPhotosMedia>) {
         assets.forEach {
-            let media = self.mediaInserter.insert(exportableAsset: $0, source: .giphy)
-            self.gutenberg.appendMedia(id: media.gutenbergUploadID, url: $0.URL, type: .image)
+            if let media = self.mediaInserter.insert(exportableAsset: $0, source: .giphy) {
+                self.gutenberg.appendMedia(id: media.gutenbergUploadID, url: $0.URL, type: .image)
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -282,7 +282,7 @@
     PHFetchResult *result = [PHAsset fetchAssetsWithLocalIdentifiers:@[assetIdentifier] options:nil];
     PHAsset *asset = [result firstObject];
     MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:self.blog.managedObjectContext];
-    [mediaService createMediaWith:asset objectID:objectID progress:nil thumbnailCallback:nil completion:^(Media *media, NSError *error) {
+    [mediaService createMediaWith:asset blog:self.blog post: self.post progress:nil thumbnailCallback:nil completion:^(Media *media, NSError *error) {
         [self loadDataWithOptions:WPMediaLoadOptionsAssets success:^{
             completionBlock(media, error);
         } failure:^(NSError *error) {
@@ -296,13 +296,10 @@
 -(void)addMediaFromURL:(NSURL *)url
            completionBlock:(WPMediaAddedBlock)completionBlock
 {
-    NSManagedObjectID *objectID = [self.post objectID];
-    if (objectID == nil) {
-        objectID = [self.blog objectID];
-    }
     MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:self.blog.managedObjectContext];
     [mediaService createMediaWith:url
-                     objectID:objectID
+                     blog:self.blog
+                     post:self.post
                          progress:nil
                    thumbnailCallback:nil
                           completion:^(Media *media, NSError *error) {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
@@ -5,7 +5,9 @@ import WordPressFlux
 extension PostSettingsViewController {
 
     @objc func setFeaturedImage(asset: PHAsset) {
-        let media = MediaCoordinator.shared.addMedia(from: asset, to: self.apost)
+        guard let media = MediaCoordinator.shared.addMedia(from: asset, to: self.apost) else {
+            return
+        }
         apost.featuredImage = media
         setupObservingOf(media: media)
     }

--- a/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
+++ b/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
@@ -93,7 +93,7 @@ class MediaLibraryPickerDataSourceTests: XCTestCase {
 
         let mediaService = MediaService(managedObjectContext: context)
         let expect = self.expectation(description: "Media should be create with success")
-        mediaService.createMedia(with: url as NSURL, objectID: post.objectID, progress: nil, thumbnailCallback: { (media, url) in
+        mediaService.createMedia(with: url as NSURL, blog: blog, post: post, progress: nil, thumbnailCallback: { (media, url) in
         }, completion: { (media, error) in
             expect.fulfill()
             if let _ = error {


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/12629

While doing tests on others part of the media stack I run through this exception. After some investigation I found that media creation sometimes could fail if the blog or post (for me it only make sense post) objects provided to `createMediaWith` method in `MediaService` to be a temporary ID that then is update to a permanent ID and then not found on search later on.

I changed the code to actually pass the Blog or Post objects to make it harder for this to happen. I also change the media signature method to be ready signal that the Media returned can be nil and adopted the code that uses it to this scenario.

To test:
 - Test the following media flows:
 - Add media to posts (Aztec, Gutenberg)
 - Add media using the media library
 - Change the site icon of a site

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
