### PR TITLE
[VoiceOver] NoResultsView enhancements

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -328,7 +328,6 @@ private extension ReaderSavedPostsViewController {
     struct NoResultsText {
         static let noResultsTitle = NSLocalizedString("No Saved Posts", comment: "Message displayed in Reader Saved Posts view if a user hasn't yet saved any posts.")
         static let subtitleFormat = NSLocalizedString("Tap [bookmark-outline] to save a post to your list.", comment: "A hint displayed in the Saved Posts section of the Reader. The '[bookmark-outline]' placeholder will be replaced by an icon at runtime – please leave that string intact.")
-        static let accessibilityLabel = NSLocalizedString("No posts saved – yet! Tap the Save Post button to save a post to your list.", comment: "Alternative accessibility text displayed to Voiceover users on the Reader Saved Posts screen.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -323,7 +323,6 @@ private extension ReaderSavedPostsViewController {
         messageText.replace("[bookmark-outline]", with: icon)
 
         noResultsViewController.configure(title: NoResultsText.noResultsTitle, attributedSubtitle: messageText)
-        noResultsViewController.view.accessibilityLabel = NoResultsText.accessibilityLabel
     }
 
     struct NoResultsText {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -42,11 +42,6 @@ final class ReaderSavedPostsViewController: UITableViewController {
         WPStyleGuide.configureColors(view: view, tableView: tableView)
 
         updateAndPerformFetchRequest()
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
         refreshNoResultsView()
     }
 

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -17,13 +17,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ae-eX-ae9" userLabel="No Results View">
-                                <rect key="frame" x="7.5" y="0.0" width="360" height="667"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="30" y="106.5" width="300" height="454"/>
+                                        <rect key="frame" x="30" y="106.5" width="315" height="454"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
-                                                <rect key="frame" x="30.5" y="0.0" width="239" height="234"/>
+                                                <rect key="frame" x="38" y="0.0" width="239" height="234"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czl-5D-gem" userLabel="Accessory View">
                                                         <rect key="frame" x="69.5" y="0.0" width="100" height="100"/>
@@ -39,7 +39,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
-                                                <rect key="frame" x="30" y="254" width="240.5" height="200"/>
+                                                <rect key="frame" x="37.5" y="254" width="240.5" height="200"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
                                                         <rect key="frame" x="26.5" y="0.0" width="187.5" height="72"/>
@@ -83,12 +83,14 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="jt1-he-Hs1"/>
+                                        </constraints>
                                     </stackView>
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="leading" secondItem="0Ae-eX-ae9" secondAttribute="leading" constant="30" id="Gn9-QB-PCu"/>
-                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="Pgx-Fg-qo8"/>
                                     <constraint firstAttribute="trailing" secondItem="Mkl-mm-wtH" secondAttribute="trailing" constant="30" id="gZv-Ze-rOt"/>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerY" secondItem="0Ae-eX-ae9" secondAttribute="centerY" id="kju-zT-gzN"/>
                                 </constraints>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -92,6 +92,7 @@
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="top" secondItem="0Ae-eX-ae9" secondAttribute="top" id="Jts-ss-Poh"/>
                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="Pgx-Fg-qo8"/>
                                     <constraint firstAttribute="trailing" secondItem="Mkl-mm-wtH" secondAttribute="trailing" id="gZv-Ze-rOt"/>
+                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerY" secondItem="0Ae-eX-ae9" secondAttribute="centerY" id="kju-zT-gzN"/>
                                 </constraints>
                             </view>
                         </subviews>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,16 +17,16 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ae-eX-ae9" userLabel="No Results View">
-                                <rect key="frame" x="30" y="175.5" width="315" height="336"/>
+                                <rect key="frame" x="30" y="106.5" width="315" height="454"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="0.0" y="0.0" width="315" height="336"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="315" height="454"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
-                                                <rect key="frame" x="107.5" y="0.0" width="100" height="116"/>
+                                                <rect key="frame" x="38" y="0.0" width="239" height="234"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czl-5D-gem" userLabel="Accessory View">
-                                                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                                                        <rect key="frame" x="69.5" y="0.0" width="100" height="100"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="100" id="AYV-Gw-aKL"/>
@@ -36,12 +34,12 @@
                                                         </constraints>
                                                     </view>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="wp-illustration-empty-results" translatesAutoresizingMaskIntoConstraints="NO" id="Fwm-rl-dKS" userLabel="Image View">
-                                                        <rect key="frame" x="42" y="100" width="16" height="16"/>
+                                                        <rect key="frame" x="0.0" y="100" width="239.00000000000006" height="134"/>
                                                     </imageView>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
-                                                <rect key="frame" x="37.5" y="136" width="240.5" height="200"/>
+                                                <rect key="frame" x="37.5" y="254" width="240.5" height="200"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
                                                         <rect key="frame" x="26.5" y="0.0" width="187.5" height="72"/>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -20,10 +20,10 @@
                                 <rect key="frame" x="7.5" y="0.0" width="360" height="667"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="0.0" y="106.5" width="360" height="454"/>
+                                        <rect key="frame" x="30" y="106.5" width="300" height="454"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
-                                                <rect key="frame" x="60.5" y="0.0" width="239" height="234"/>
+                                                <rect key="frame" x="30.5" y="0.0" width="239" height="234"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czl-5D-gem" userLabel="Accessory View">
                                                         <rect key="frame" x="69.5" y="0.0" width="100" height="100"/>
@@ -39,7 +39,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
-                                                <rect key="frame" x="60" y="254" width="240.5" height="200"/>
+                                                <rect key="frame" x="30" y="254" width="240.5" height="200"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
                                                         <rect key="frame" x="26.5" y="0.0" width="187.5" height="72"/>
@@ -87,9 +87,9 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="leading" secondItem="0Ae-eX-ae9" secondAttribute="leading" id="Gn9-QB-PCu"/>
+                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="leading" secondItem="0Ae-eX-ae9" secondAttribute="leading" constant="30" id="Gn9-QB-PCu"/>
                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="Pgx-Fg-qo8"/>
-                                    <constraint firstAttribute="trailing" secondItem="Mkl-mm-wtH" secondAttribute="trailing" id="gZv-Ze-rOt"/>
+                                    <constraint firstAttribute="trailing" secondItem="Mkl-mm-wtH" secondAttribute="trailing" constant="30" id="gZv-Ze-rOt"/>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerY" secondItem="0Ae-eX-ae9" secondAttribute="centerY" id="kju-zT-gzN"/>
                                 </constraints>
                             </view>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -17,13 +17,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ae-eX-ae9" userLabel="No Results View">
-                                <rect key="frame" x="30" y="0.0" width="315" height="667"/>
+                                <rect key="frame" x="7.5" y="0.0" width="360" height="667"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="0.0" y="106.5" width="315" height="454"/>
+                                        <rect key="frame" x="0.0" y="106.5" width="360" height="454"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
-                                                <rect key="frame" x="38" y="0.0" width="239" height="234"/>
+                                                <rect key="frame" x="60.5" y="0.0" width="239" height="234"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czl-5D-gem" userLabel="Accessory View">
                                                         <rect key="frame" x="69.5" y="0.0" width="100" height="100"/>
@@ -39,7 +39,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
-                                                <rect key="frame" x="37.5" y="254" width="240.5" height="200"/>
+                                                <rect key="frame" x="60" y="254" width="240.5" height="200"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
                                                         <rect key="frame" x="26.5" y="0.0" width="187.5" height="72"/>
@@ -96,11 +96,11 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="x31-wL-G0k" firstAttribute="trailing" secondItem="0Ae-eX-ae9" secondAttribute="trailing" priority="999" constant="30" id="8y0-se-MDj"/>
+                            <constraint firstItem="x31-wL-G0k" firstAttribute="trailing" secondItem="0Ae-eX-ae9" secondAttribute="trailing" priority="999" id="8y0-se-MDj"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="top" secondItem="x31-wL-G0k" secondAttribute="top" id="DRS-cd-4At"/>
                             <constraint firstItem="x31-wL-G0k" firstAttribute="bottom" secondItem="0Ae-eX-ae9" secondAttribute="bottom" id="H2g-99-0jI"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="centerX" secondItem="x31-wL-G0k" secondAttribute="centerX" id="Qie-JB-M8x"/>
-                            <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" priority="999" constant="30" id="Yvc-NG-l0P"/>
+                            <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" priority="999" id="Yvc-NG-l0P"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="x31-wL-G0k"/>
                     </view>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -20,7 +20,7 @@
                                 <rect key="frame" x="30" y="0.0" width="315" height="667"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="0.0" y="0.0" width="315" height="667"/>
+                                        <rect key="frame" x="0.0" y="106.5" width="315" height="454"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
                                                 <rect key="frame" x="38" y="0.0" width="239" height="234"/>
@@ -39,10 +39,10 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
-                                                <rect key="frame" x="37.5" y="254" width="240.5" height="413"/>
+                                                <rect key="frame" x="37.5" y="254" width="240.5" height="200"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
-                                                        <rect key="frame" x="26.5" y="0.0" width="187.5" height="285"/>
+                                                        <rect key="frame" x="26.5" y="0.0" width="187.5" height="72"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is the title text." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8BN-gx-7TL">
                                                                 <rect key="frame" x="9.5" y="0.0" width="168" height="24"/>
@@ -51,7 +51,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="This is the subtitle text." textAlignment="center" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pAg-XC-9IM" userLabel="Subtitle Text View">
-                                                                <rect key="frame" x="0.0" y="34" width="187.5" height="251"/>
+                                                                <rect key="frame" x="0.0" y="34" width="187.5" height="38"/>
                                                                 <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -59,13 +59,13 @@
                                                         </subviews>
                                                     </stackView>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3N8-XV-xJk" userLabel="Subtitle Image View">
-                                                        <rect key="frame" x="0.0" y="305" width="240.5" height="44"/>
+                                                        <rect key="frame" x="0.0" y="92" width="240.5" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="GdA-7V-dg9"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CPl-cH-d7b" customClass="FancyButton" customModule="WordPressUI">
-                                                        <rect key="frame" x="78" y="369" width="84" height="44"/>
+                                                        <rect key="frame" x="78" y="156" width="84" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="ALu-HJ-Bk4"/>
                                                         </constraints>
@@ -87,9 +87,7 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="Mkl-mm-wtH" secondAttribute="bottom" id="33e-F1-6vD"/>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="leading" secondItem="0Ae-eX-ae9" secondAttribute="leading" id="Gn9-QB-PCu"/>
-                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="top" secondItem="0Ae-eX-ae9" secondAttribute="top" id="Jts-ss-Poh"/>
                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="360" id="Pgx-Fg-qo8"/>
                                     <constraint firstAttribute="trailing" secondItem="Mkl-mm-wtH" secondAttribute="trailing" id="gZv-Ze-rOt"/>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerY" secondItem="0Ae-eX-ae9" secondAttribute="centerY" id="kju-zT-gzN"/>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -101,7 +101,6 @@
                             <constraint firstItem="x31-wL-G0k" firstAttribute="trailing" secondItem="0Ae-eX-ae9" secondAttribute="trailing" priority="999" id="8y0-se-MDj"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="top" secondItem="x31-wL-G0k" secondAttribute="top" id="DRS-cd-4At"/>
                             <constraint firstItem="x31-wL-G0k" firstAttribute="bottom" secondItem="0Ae-eX-ae9" secondAttribute="bottom" id="H2g-99-0jI"/>
-                            <constraint firstItem="0Ae-eX-ae9" firstAttribute="centerX" secondItem="x31-wL-G0k" secondAttribute="centerX" id="Qie-JB-M8x"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" priority="999" id="Yvc-NG-l0P"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="x31-wL-G0k"/>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -98,10 +98,10 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="x31-wL-G0k" firstAttribute="trailing" secondItem="0Ae-eX-ae9" secondAttribute="trailing" priority="999" id="8y0-se-MDj"/>
+                            <constraint firstItem="x31-wL-G0k" firstAttribute="trailing" secondItem="0Ae-eX-ae9" secondAttribute="trailing" id="8y0-se-MDj"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="top" secondItem="x31-wL-G0k" secondAttribute="top" id="DRS-cd-4At"/>
                             <constraint firstItem="x31-wL-G0k" firstAttribute="bottom" secondItem="0Ae-eX-ae9" secondAttribute="bottom" id="H2g-99-0jI"/>
-                            <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" priority="999" id="Yvc-NG-l0P"/>
+                            <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" id="Yvc-NG-l0P"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="x31-wL-G0k"/>
                     </view>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -99,6 +99,7 @@
                         <constraints>
                             <constraint firstItem="x31-wL-G0k" firstAttribute="trailing" secondItem="0Ae-eX-ae9" secondAttribute="trailing" priority="999" constant="30" id="8y0-se-MDj"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="top" secondItem="x31-wL-G0k" secondAttribute="top" id="DRS-cd-4At"/>
+                            <constraint firstItem="x31-wL-G0k" firstAttribute="bottom" secondItem="0Ae-eX-ae9" secondAttribute="bottom" id="H2g-99-0jI"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="centerX" secondItem="x31-wL-G0k" secondAttribute="centerX" id="Qie-JB-M8x"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" priority="999" constant="30" id="Yvc-NG-l0P"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="centerY" secondItem="x31-wL-G0k" secondAttribute="centerY" id="bvr-5b-sAb"/>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -17,10 +17,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ae-eX-ae9" userLabel="No Results View">
-                                <rect key="frame" x="30" y="106.5" width="315" height="454"/>
+                                <rect key="frame" x="30" y="0.0" width="315" height="667"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="0.0" y="0.0" width="315" height="454"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="315" height="667"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
                                                 <rect key="frame" x="38" y="0.0" width="239" height="234"/>
@@ -39,10 +39,10 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
-                                                <rect key="frame" x="37.5" y="254" width="240.5" height="200"/>
+                                                <rect key="frame" x="37.5" y="254" width="240.5" height="413"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
-                                                        <rect key="frame" x="26.5" y="0.0" width="187.5" height="72"/>
+                                                        <rect key="frame" x="26.5" y="0.0" width="187.5" height="285"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is the title text." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8BN-gx-7TL">
                                                                 <rect key="frame" x="9.5" y="0.0" width="168" height="24"/>
@@ -51,7 +51,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="This is the subtitle text." textAlignment="center" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pAg-XC-9IM" userLabel="Subtitle Text View">
-                                                                <rect key="frame" x="0.0" y="34" width="187.5" height="38"/>
+                                                                <rect key="frame" x="0.0" y="34" width="187.5" height="251"/>
                                                                 <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -59,13 +59,13 @@
                                                         </subviews>
                                                     </stackView>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3N8-XV-xJk" userLabel="Subtitle Image View">
-                                                        <rect key="frame" x="0.0" y="92" width="240.5" height="44"/>
+                                                        <rect key="frame" x="0.0" y="305" width="240.5" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="GdA-7V-dg9"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CPl-cH-d7b" customClass="FancyButton" customModule="WordPressUI">
-                                                        <rect key="frame" x="78" y="156" width="84" height="44"/>
+                                                        <rect key="frame" x="78" y="369" width="84" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="ALu-HJ-Bk4"/>
                                                         </constraints>
@@ -98,6 +98,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="x31-wL-G0k" firstAttribute="trailing" secondItem="0Ae-eX-ae9" secondAttribute="trailing" priority="999" constant="30" id="8y0-se-MDj"/>
+                            <constraint firstItem="0Ae-eX-ae9" firstAttribute="top" secondItem="x31-wL-G0k" secondAttribute="top" id="DRS-cd-4At"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="centerX" secondItem="x31-wL-G0k" secondAttribute="centerX" id="Qie-JB-M8x"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" priority="999" constant="30" id="Yvc-NG-l0P"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="centerY" secondItem="x31-wL-G0k" secondAttribute="centerY" id="bvr-5b-sAb"/>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -102,7 +102,6 @@
                             <constraint firstItem="x31-wL-G0k" firstAttribute="bottom" secondItem="0Ae-eX-ae9" secondAttribute="bottom" id="H2g-99-0jI"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="centerX" secondItem="x31-wL-G0k" secondAttribute="centerX" id="Qie-JB-M8x"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" priority="999" constant="30" id="Yvc-NG-l0P"/>
-                            <constraint firstItem="0Ae-eX-ae9" firstAttribute="centerY" secondItem="x31-wL-G0k" secondAttribute="centerY" id="bvr-5b-sAb"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="x31-wL-G0k"/>
                     </view>

--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -514,6 +514,8 @@ private extension NoResultsViewController {
 
 private extension NoResultsViewController {
     func configureForAccessibility() {
+        view.accessibilityElements = [noResultsView, actionButton]
+
         noResultsView.isAccessibilityElement = true
         noResultsView.accessibilityLabel = [
             titleLabel.text,

--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -518,14 +518,17 @@ private extension NoResultsViewController {
         view.isAccessibilityElement = false
         view.accessibilityLabel = nil
         view.accessibilityElements = nil
+        view.accessibilityTraits = .none
 
         if displayTitleViewOnly {
             view.isAccessibilityElement = true
             view.accessibilityLabel = titleLabel.text
+            view.accessibilityTraits = .staticText
         } else {
             view.accessibilityElements = [noResultsView, actionButton]
 
             noResultsView.isAccessibilityElement = true
+            noResultsView.accessibilityTraits = .staticText
             noResultsView.accessibilityLabel = [
                 titleLabel.text,
                 subtitleTextView.isHidden ? nil : subtitleTextView.attributedText.string

--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -338,6 +338,8 @@ private extension NoResultsViewController {
         setAccessoryViewsVisibility()
         configureForTitleViewOnly()
 
+        configureForAccessibility()
+
         view.layoutIfNeeded()
     }
 
@@ -505,5 +507,17 @@ private extension NoResultsViewController {
         static let title: String = NSLocalizedString("Unable to load this page right now.", comment: "Title for No results full page screen displayed when there is no connection")
         static let subTitle: String = NSLocalizedString("Check your network connection and try again.", comment: "Subtitle for No results full page screen displayed when there is no connection")
         static let imageName = "cloud"
+    }
+}
+
+// MARK: - Accessibility
+
+private extension NoResultsViewController {
+    func configureForAccessibility() {
+        noResultsView.isAccessibilityElement = true
+        noResultsView.accessibilityLabel = [
+            titleLabel.text,
+            subtitleTextView.isHidden ? nil : subtitleTextView.attributedText.string
+        ].compactMap { $0 }.joined(separator: ". ")
     }
 }

--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -514,12 +514,22 @@ private extension NoResultsViewController {
 
 private extension NoResultsViewController {
     func configureForAccessibility() {
-        view.accessibilityElements = [noResultsView, actionButton]
+        // Reset
+        view.isAccessibilityElement = false
+        view.accessibilityLabel = nil
+        view.accessibilityElements = nil
 
-        noResultsView.isAccessibilityElement = true
-        noResultsView.accessibilityLabel = [
-            titleLabel.text,
-            subtitleTextView.isHidden ? nil : subtitleTextView.attributedText.string
-        ].compactMap { $0 }.joined(separator: ". ")
+        if displayTitleViewOnly {
+            view.isAccessibilityElement = true
+            view.accessibilityLabel = titleLabel.text
+        } else {
+            view.accessibilityElements = [noResultsView, actionButton]
+
+            noResultsView.isAccessibilityElement = true
+            noResultsView.accessibilityLabel = [
+                titleLabel.text,
+                subtitleTextView.isHidden ? nil : subtitleTextView.attributedText.string
+            ].compactMap { $0 }.joined(separator: ". ")
+        }
     }
 }


### PR DESCRIPTION
Refs #11487 and #12906. 

This changes the `NoResultsViewController` so that the full view is accessible instead of just the title and subtitle as suggested in #11487. This makes the “no results” message easily discoverable by VoiceOver users. They do not need to have their finger travel far to _find_ the message.

The title and subtitle are now also dictated together. 

Before | After 
--------|-------
![IMG_1041](https://user-images.githubusercontent.com/198826/68789827-6b1db900-0603-11ea-84a3-407a1a3c27ae.PNG)       |       ![IMG_1044](https://user-images.githubusercontent.com/198826/68789821-6b1db900-0603-11ea-857a-7c79b52cb0f3.PNG)
![IMG_1042](https://user-images.githubusercontent.com/198826/68789824-6b1db900-0603-11ea-9b7e-bbb9328d01db.PNG)  | ![IMG_1043](https://user-images.githubusercontent.com/198826/68789822-6b1db900-0603-11ea-993b-1ab8c5c2916a.PNG)

Some attempts at announcing the “no results” message were done to no great results. More information about that starting at https://github.com/wordpress-mobile/WordPress-iOS/issues/11487#issuecomment-551319114 if you're interested. 🙂 

## View Changes

To make this work, I had to modify `NoResults.storyboard`:

- Made `noResultsView` cover the whole Safe Area
- Moved the `noResultsView` alignment and margins to the main stack view

![image](https://user-images.githubusercontent.com/198826/68789689-2e51c200-0603-11ea-99ac-f48aed18e7f7.png)

I tried to create commits for every single constraint change. I hope that helps. 

## Reader → Saved Posts

The `ReaderSavedPostsViewController` usage of `NoResultsVC` was causing issues. Even before this change, it seems that everything under `NoResultsVC.view` was inaccessible. The effect is that VoiceOver would dictate “empty list” instead of the desired “No results” dictation. 

It took me a while but it turned out that the fix was to move the routine for making `NoResultsVC` a child of `ReaderSavedPostsVC` from `viewDidAppear` to `viewDidLoad` (8c452000d864acaf1a18cae17a8e788affcbc651). With this change, the `tableView` is no longer an accessible element and all the intended views underneath `NoResultsVC` are accessible. 

## Outstanding Issues

As described in #11487, VoiceOver ignores the _bookmark icon_ when dictating the subtitle in Reader → Saved Posts' no-results view. I'm not quite sure how to fix this yet. I'll fix it in a separate PR. 

## Testing

Testing involves using VoiceOver on the places where `NoResultsViewController` is used. The following steps is a suggestion: 

1. Turn VoiceOver on. 
2. Navigate to an empty tab in Notifications and validate that the changes described above work correctly. 
3. Navigate to Site → Post List. Enter a string in the search bar that will result in an empty result. Validate the changes described above. 
4. Turn the Internet connection off.
5. Navigate back to an empty tab in Notifications. The tab should show an “Unable to load this page right now.” message. Validate the changes described above. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
