### PR TITLE
Removing dark appearance for gray colors

### DIFF
--- a/WordPress/ColorPalette.xcassets/Gray0.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray0.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "247"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "16",
-          "alpha" : "1.000",
-          "blue" : "23",
-          "green" : "21"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "196"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "44",
-          "alpha" : "1.000",
-          "blue" : "56",
-          "green" : "51"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray100.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray100.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "21"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "246",
-          "alpha" : "1.000",
-          "blue" : "247",
-          "green" : "247"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray20.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray20.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "170"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "60",
-          "alpha" : "1.000",
-          "blue" : "74",
-          "green" : "67"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "145"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "80",
-          "alpha" : "1.000",
-          "blue" : "94",
-          "green" : "87"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray40.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray40.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "124"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "100",
-          "alpha" : "1.000",
-          "blue" : "112",
-          "green" : "105"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray5.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray5.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "220"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "29",
-          "alpha" : "1.000",
-          "blue" : "39",
-          "green" : "35"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray50.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray50.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "105"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "120",
-          "alpha" : "1.000",
-          "blue" : "130",
-          "green" : "124"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray60.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray60.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "87"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "142",
-          "alpha" : "1.000",
-          "blue" : "150",
-          "green" : "145"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray70.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray70.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "67"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "167",
-          "alpha" : "1.000",
-          "blue" : "173",
-          "green" : "170"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray80.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray80.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "51"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "195",
-          "alpha" : "1.000",
-          "blue" : "199",
-          "green" : "196"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray90.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray90.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "35"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "220",
-          "alpha" : "1.000",
-          "blue" : "222",
-          "green" : "220"
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
The addition of dark appearance for gray colors (#12915) caused weird appearance issues in navigation bar that was displayed white bright in dark mode and table separators that appeared brighter. 

In this PR the colors are still updated to the right values according to https://github.com/Automattic/color-studio/blob/2.2.0/dist/color-properties-rgb.css

But their dark counterparts are no longer defined in ColorPalette.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
