### PR TITLE
Testing: Ensure screens are loaded before continuing

### DIFF
--- a/WordPress/WordPressUITests/Screens/BaseScreen.swift
+++ b/WordPress/WordPressUITests/Screens/BaseScreen.swift
@@ -54,8 +54,7 @@ class BaseScreen {
 
             // Select the URL bar when Safari opens
             let urlBar = safari.textFields["URL"]
-            waitFor(element: urlBar, predicate: "exists == true")
-            if !urlBar.exists {
+            if !urlBar.waitForExistence(timeout: 5) {
                 safari.buttons["URL"].tap()
             }
 

--- a/WordPress/WordPressUITests/Screens/FancyAlertComponent.swift
+++ b/WordPress/WordPressUITests/Screens/FancyAlertComponent.swift
@@ -21,6 +21,6 @@ class FancyAlertComponent: BaseScreen {
     }
 
     static func isLoaded() -> Bool {
-        return XCUIApplication().buttons["defaultAlertButton"].exists
+        return XCUIApplication().buttons["defaultAlertButton"].waitForExistence(timeout: 3)
     }
 }

--- a/WordPress/WordPressUITests/Screens/Media/MediaPickerAlbumListScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Media/MediaPickerAlbumListScreen.swift
@@ -11,7 +11,9 @@ class MediaPickerAlbumListScreen: BaseScreen {
     }
 
     func selectAlbum(atIndex index: Int) -> MediaPickerAlbumScreen {
-        albumList.cells.element(boundBy: index).tap()
+        let selectedAlbum = albumList.cells.element(boundBy: index)
+        XCTAssertTrue(selectedAlbum.waitForExistence(timeout: 5), "Selected album did not load")
+        selectedAlbum.tap()
 
         return MediaPickerAlbumScreen()
     }

--- a/WordPress/WordPressUITests/Screens/Media/MediaPickerAlbumScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Media/MediaPickerAlbumScreen.swift
@@ -13,7 +13,9 @@ class MediaPickerAlbumScreen: BaseScreen {
     }
 
     func selectImage(atIndex index: Int) {
-        mediaCollection.cells.element(boundBy: index).tap()
+        let selectedImage = mediaCollection.cells.element(boundBy: index)
+        XCTAssertTrue(selectedImage.waitForExistence(timeout: 5), "Selected image did not load")
+        selectedImage.tap()
     }
 
     func insertSelectedImage() {


### PR DESCRIPTION
This is similar to the fix in https://github.com/wordpress-mobile/WordPress-iOS/pull/12928, in that it ensures screens are fully loaded before continuing a test. This includes a fix for the flakiness that I believe @jkmassel saw in https://github.com/wordpress-mobile/WordPress-iOS/pull/12930#pullrequestreview-316542476.

To test:

* Ensure tests pass on both iPhone and iPad on CircleCI.
* Run tests locally (be sure to run `rake mocks` first to start the mocks server) and confirm you don't see any flaky test failures.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
