### PR TITLE
Fix warnings in localize.py

### DIFF
--- a/Scripts/localize.py
+++ b/Scripts/localize.py
@@ -134,9 +134,9 @@ def localize(path, language, include_pods_and_frameworks):
 
     # TODO: This is super ugly, we have to come up with a better way of doing it
     if include_pods_and_frameworks:
-        find_cmd = 'find . ../Pods/WordPress* ../Pods/WPMediaPicker ../WordPressComStatsiOS/WordPressComStatsiOS ../WordPressShared/WordPressShared ../Pods/Gutenberg -name "*.m" -o -name "*.swift" | grep -v Vendor'
+        find_cmd = 'find . ../Pods/WordPress* ../Pods/WPMediaPicker ../WordPressShared/WordPressShared ../Pods/Gutenberg -name "*.m" -o -name "*.swift" | grep -v Vendor | grep -v ./WordPressTest/I18n.swift'
     else:
-        find_cmd = 'find . -name "*.m" -o -name "*.swift" | grep -v Vendor'
+        find_cmd = 'find . -name "*.m" -o -name "*.swift" | grep -v Vendor | grep -v ./WordPressTest/I18n.swift'
     filelist = os.popen(find_cmd).read().strip().split('\n')
     filelist = '"{0}"'.format('" "'.join(filelist))
 


### PR DESCRIPTION
This PR fixes two warnings issued by `Scritps/localize.py`:
1. https://github.com/wordpress-mobile/WordPress-iOS/pull/12794 removed `WordPressComStatsiOS`, so this PR removes it from the list of the source frameworks.
2. https://github.com/wordpress-mobile/WordPress-iOS/pull/12580 added this helper file https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/WordPressTest/I18n.swift that triggers an error in `genstrings` because it passes a not literal string as the argument. Since this is only used as a helper for some tests, this PR makes sure it's not analyzed by `genstrings`.

_Note_: this is an ugly fix for an ugly script that's overdue for an update to new technologies. Since we'll have to throw this one away in order to be able to make use of some of the new features with strings, I opted for the easiest (though horrible) fix.
 
### To test:
1. Checkout a test branch from `develop` on your local machine (don't push it).
2. Run `Scripts/localize.py`. This will update `localizable.strings`.
3. Commit the changes in your test branch.
4. Cherry pick the updated script from this branch to your test branch.
5. Run the new `Scripts/localize.py` and verify that the warnings are gone and that the branch is clean.
6. Delete the test branch.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
