### PR TITLE
Add a step about unit tests to the PR submission checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@ Fixes #
 
 To test:
 
-Update release notes:
+PR submission checklist:
+
+- [ ] I have considered adding unit tests where possible.
 
 - [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


### PR DESCRIPTION
With https://github.com/wordpress-mobile/WordPress-Android/pull/10554 we added a new item to the PR submitter checklist that reminds about adding unit tests where possible.
This PR makes the same change on WPiOS. 


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
