### PR TITLE
[Gutenberg] Handling mediaInserter now returning optional media object

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
@@ -48,7 +48,10 @@ extension GutenbergFilesAppMediaSource: UIDocumentPickerDelegate {
             return assertionFailure("Image picked without callback")
         }
 
-        let media = self.mediaInserter.insert(exportableAsset: url as NSURL, source: .otherApps)
+        guard let media = self.mediaInserter.insert(exportableAsset: url as NSURL, source: .otherApps) else {
+            return callback([])
+        }
+
         let mediaUploadID = media.gutenbergUploadID
         callback([MediaInfo(id: mediaUploadID, url: url.absoluteString, type: media.mediaTypeString)])
     }


### PR DESCRIPTION
This PR fixes a build error on `develop` branch that happened by a PR that made mediaInserter return an optional media object, in parallel to the PR that implemented Files App media source on Gutenberg.

cc @SergioEstevao 

To test:
- Make sure that the project Builds and run.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
