### PR TITLE
Fixes suggestions service endpoint path

### DIFF
--- a/WordPress/Classes/Services/SuggestionService.m
+++ b/WordPress/Classes/Services/SuggestionService.m
@@ -59,7 +59,7 @@ NSString * const SuggestionListUpdatedNotification = @"SuggestionListUpdatedNoti
     // add this siteID to currently being requested list
     [self.siteIDsCurrentlyBeingRequested addObject:siteID];
     
-    NSString *suggestPath = @"v1.1/users/suggest";
+    NSString *suggestPath = @"rest/v1.1/users/suggest";
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
     WPAccount *defaultAccount = [accountService defaultWordPressComAccount];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -517,8 +517,7 @@ private extension NotificationDetailsViewController {
             return false
         }
 
-        let suggestionsService = SuggestionService()
-        return shouldAttachReplyView && suggestionsService.shouldShowSuggestions(forSiteID: siteID)
+        return shouldAttachReplyView && SuggestionService.sharedInstance().shouldShowSuggestions(forSiteID: siteID)
     }
 }
 


### PR DESCRIPTION
While testing another PR I noticed that the suggestions service (used in CommentViewController in Notifications) has a broken endpoint path, which results in a lot of 404 requests when you type a comment:

```
2019-11-19 19:25:13:862 WordPress[31045:3833400] [Rest API] ! The specified path was not found. Please visit https://developer.wordpress.com/docs/ for valid paths.
2019-11-19 19:25:14:106 WordPress[31045:3833400] [Rest API] ! The specified path was not found. Please visit https://developer.wordpress.com/docs/ for valid paths.
2019-11-19 19:25:14:545 WordPress[31045:3833400] [Rest API] ! The specified path was not found. Please visit https://developer.wordpress.com/docs/ for valid paths.
```

Ideally, we should write a remote for this service which uses the remote methods for constructive a v1.1 endpoint path, but as a quick fix I just updated it in place for now.

**To test:**

* Open a comment in Notifications
* Type an @ symbol and see the suggestions UI appear

<img width="361" alt="Screenshot 2019-11-19 at 19 52 08" src="https://user-images.githubusercontent.com/4780/69180938-1b108c00-0b06-11ea-89dd-ac195d2dc0ac.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
