### PR TITLE
[Stats] Tracking Posting Activity 'View more' and day selection.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,13 +11,13 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.8'
+    # pod 'WordPressShared', '~> 1.8.9-beta.1'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/change-username-events'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'issue/stats_posting_activity_tracks'
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
 end
 

--- a/Podfile
+++ b/Podfile
@@ -11,13 +11,13 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    # pod 'WordPressShared', '~> 1.8.9-beta.1'
+    pod 'WordPressShared', '~> 1.8.9-beta.1'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'issue/stats_posting_activity_tracks'
+    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => ''
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -304,7 +304,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.2)
   - WordPressKit (~> 4.5.3)
   - WordPressMocks (~> 0.0.6)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared`, branch `issue/stats_posting_activity_tracks`)
+  - WordPressShared (~> 1.8.9-beta.1)
   - WordPressUI (~> 1.5.0)
   - WPMediaPicker (~> 1.6.0)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.17.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -348,6 +348,7 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -411,9 +412,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.17.0
-  WordPressShared:
-    :branch: issue/stats_posting_activity_tracks
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.17.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -430,9 +428,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.17.0
-  WordPressShared:
-    :commit: 8c3cf22900c9ed835cf0d67ccdb357934e5cfb04
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 3.0.2
@@ -508,6 +503,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 35b16898fae049f6ebffba96793f209b03a41495
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: aa2f5f5f3574633df7adc43a820fde71cdedad03
+PODFILE CHECKSUM: 73556342e116329ad7ed996bc873bfe35e4d9392
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -231,7 +231,7 @@ PODS:
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
   - WordPressMocks (0.0.6)
-  - WordPressShared (1.8.8):
+  - WordPressShared (1.8.9-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.5.0)
@@ -304,7 +304,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.2)
   - WordPressKit (~> 4.5.3)
   - WordPressMocks (~> 0.0.6)
-  - WordPressShared (~> 1.8.8)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared`, branch `issue/stats_posting_activity_tracks`)
   - WordPressUI (~> 1.5.0)
   - WPMediaPicker (~> 1.6.0)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.17.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -348,7 +348,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -412,6 +411,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.17.0
+  WordPressShared:
+    :branch: issue/stats_posting_activity_tracks
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.17.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -428,6 +430,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.17.0
+  WordPressShared:
+    :commit: 8c3cf22900c9ed835cf0d67ccdb357934e5cfb04
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 3.0.2
@@ -495,7 +500,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: af8a2b733b8a33d2ad04cdd30f5410bfe772f439
   WordPressKit: 023c6b1c2e1576c66c3044dc4ae8d28df7b2f1b5
   WordPressMocks: 5913bd04586a360212e07a8ccbcb36068d4425a3
-  WordPressShared: 64332b24b8a70b7796ee137847cd0d66bdb6b4c1
+  WordPressShared: 7eb57db01ccf3d6e250b5d6ad1e4e6f605fdd57a
   WordPressUI: 4a4adafd2b052e94e4846c0a0203761773dc4fd5
   WPMediaPicker: e5d28197da6b467d4e5975d64a49255977e39455
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -503,6 +508,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 35b16898fae049f6ebffba96793f209b03a41495
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: d275f12ae528d2374c73e683366d91ae8a9c4d7d
+PODFILE CHECKSUM: aa2f5f5f3574633df7adc43a820fde71cdedad03
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1715,6 +1715,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatStatsItemTappedPostsAndPages:
             eventName = @"stats_posts_and_pages_item_tapped";
             break;
+        case WPAnalyticsStatStatsItemTappedPostingActivityDay:
+            eventName = @"stats_posting_activity_day_tapped";
+            break;
         case WPAnalyticsStatStatsItemTappedSearchTerms:
             eventName = @"stats_search_terms_item_tapped";
             break;
@@ -1787,6 +1790,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
         case WPAnalyticsStatStatsViewMoreTappedPostsAndPages:
             eventName = @"stats_posts_and_pages_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedPostingActivity:
+            eventName = @"stats_posting_activity_view_more_tapped";
             break;
         case WPAnalyticsStatStatsViewMoreTappedPublicize:
             eventName = @"stats_publicize_view_more_tapped";

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
@@ -69,6 +69,7 @@ private extension PostingActivityCell {
     }
 
     @IBAction func didTapViewMoreButton(_ sender: UIButton) {
+        WPAppAnalytics.track(.statsViewMoreTappedPostingActivity)
         siteStatsInsightsDelegate?.showPostingActivityDetails?()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
@@ -50,6 +50,7 @@ private extension PostingActivityDay {
     }
 
     @IBAction func dayButtonPressed(_ sender: UIButton) {
+        WPAppAnalytics.track(.statsItemTappedPostingActivityDay)
         dayButton.backgroundColor = WPStyleGuide.Stats.PostingActivityColors.selectedDay
         delegate?.daySelected(self)
     }


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/issues/7163#issuecomment-555523582
WPShared PR: https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/226

To test:

- Go to Stats > Insights > Posting Activity.
- Select 'View more'.
  - Verify `🔵 Tracked: stats_posting_activity_view_more_tapped` appears in the console.
- Select a specific day.
  - Verify `🔵 Tracked: stats_posting_activity_day_tapped` appears in the console.


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
