### PR TITLE
Support: Truncate the log text so it fits in the ticket field.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+13.8
+-----
+* Support: Fix issue that caused 'Message failed to send' error.
+
 13.7
 -----
 * Updated the mobile apps blog address to a non-retired blog. 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -233,6 +233,8 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         #if DEBUG
         KeychainTools.processKeychainDebugArguments()
+
+        // Zendesk Logging
         CoreLogger.enabled = true
         CoreLogger.logLevel = .debug
         #endif

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -591,8 +591,13 @@ private extension ZendeskUtils {
             let fileLogger = appDelegate.logger?.fileLogger,
             let logFileInformation = fileLogger.logFileManager.sortedLogFileInfos.first,
             let logData = try? Data(contentsOf: URL(fileURLWithPath: logFileInformation.filePath)),
-            let logText = String(data: logData, encoding: .utf8) else {
+            var logText = String(data: logData, encoding: .utf8) else {
                 return ""
+        }
+
+        // Truncate the log text so it fits in the ticket field.
+        if logText.count > Constants.logFieldCharacterLimit {
+            logText = String(logText.suffix(Constants.logFieldCharacterLimit))
         }
 
         return logText
@@ -932,6 +937,7 @@ private extension ZendeskUtils {
         static let profileNameKey = "name"
         static let userDefaultsZendeskUnreadNotifications = "wp_zendesk_unread_notifications"
         static let nameFieldCharacterLimit = 50
+        static let logFieldCharacterLimit = 50000
         static let sourcePlatform = "mobile_-_ios"
         static let gutenbergIsDefault = "mobile_gutenberg_is_default"
     }


### PR DESCRIPTION
Fixes #12297 

As noted on #12297 , the problem was:

When _any_ request is created, we automatically take the `Current` activity log and populate the `System Status Report` field with it. If the log is big enough, it will exceed the field limit. This will cause _any_ request to fail (even if you're not attaching anything). 

The limit on that field type isn't specified, and I got no response from Zendesk support. So I did some testing, and found that it'll handle about 50k characters. So that's the limit.

If the log text exceeds that limit, the text is truncated from the beginning so we get the last 50k characters (i.e. most recent).

To test:
On an account with a large `Current` activity log:
- Go to Me > Help & Support > Contact us.
- Attempt to send a message.
- Verify it sends.
- Bonus: 
  - Find your ticket in Zendesk
  - Verify the `System Status Report` field has content.
  - Verify the last log message is the most recent.

Update release notes:
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
