### PR TITLE
[Gutenberg] Image size improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
@@ -51,7 +51,7 @@ class EditorMediaUtility {
         return downloadImage(from: url, size: size, scale: scale, post: post, success: success, onFailure: failure)
     }
 
-    func downloadImage(from url: URL, size requestSize: CGSize, scale: CGFloat, post: AbstractPost, success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Error) -> Void) -> ImageDownloader.Task {
+    func downloadImage(from url: URL, size requestSize: CGSize, scale: CGFloat, post: AbstractPost, allowPhotonAPI: Bool = true, success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Error) -> Void) -> ImageDownloader.Task {
         var requestURL = url
         let imageMaxDimension = max(requestSize.width, requestSize.height)
         //use height zero to maintain the aspect ratio when fetching
@@ -70,9 +70,15 @@ class EditorMediaUtility {
             size.width = size.width * scale
             requestURL = WPImageURLHelper.imageURLWithSize(size, forImageURL: requestURL)
             request = URLRequest(url: requestURL)
-        } else {
+        } else if allowPhotonAPI {
             // the size that PhotonImageURLHelper expects is points size
             requestURL = PhotonImageURLHelper.photonURL(with: size, forImageURL: requestURL)
+            request = URLRequest(url: requestURL)
+        } else {
+            if size != CGSize.zero {
+                size.width = size.width * scale
+                requestURL = WPImageURLHelper.imageURLWithSize(size, forImageURL: requestURL)
+            }
             request = URLRequest(url: requestURL)
         }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
@@ -51,7 +51,7 @@ class EditorMediaUtility {
         return downloadImage(from: url, size: size, scale: scale, post: post, success: success, onFailure: failure)
     }
 
-    func downloadImage(from url: URL, size requestSize: CGSize, scale: CGFloat, post: AbstractPost, allowPhotonAPI: Bool = true, success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Error) -> Void) -> ImageDownloader.Task {
+    func downloadImage(from url: URL, size requestSize: CGSize, scale: CGFloat, post: AbstractPost, success: @escaping (UIImage) -> Void, onFailure failure: @escaping (Error) -> Void) -> ImageDownloader.Task {
         var requestURL = url
         let imageMaxDimension = max(requestSize.width, requestSize.height)
         //use height zero to maintain the aspect ratio when fetching
@@ -70,15 +70,9 @@ class EditorMediaUtility {
             size.width = size.width * scale
             requestURL = WPImageURLHelper.imageURLWithSize(size, forImageURL: requestURL)
             request = URLRequest(url: requestURL)
-        } else if allowPhotonAPI {
+        } else {
             // the size that PhotonImageURLHelper expects is points size
             requestURL = PhotonImageURLHelper.photonURL(with: size, forImageURL: requestURL)
-            request = URLRequest(url: requestURL)
-        } else {
-            if size != CGSize.zero {
-                size.width = size.width * scale
-                requestURL = WPImageURLHelper.imageURLWithSize(size, forImageURL: requestURL)
-            }
             request = URLRequest(url: requestURL)
         }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift
@@ -18,9 +18,14 @@ class GutenbergImageLoader: NSObject, RCTImageURLLoader {
     }
 
     func loadImage(for imageURL: URL!, size: CGSize, scale: CGFloat, resizeMode: RCTResizeMode, progressHandler: RCTImageLoaderProgressBlock!, partialLoadHandler: RCTImageLoaderPartialLoadBlock!, completionHandler: RCTImageLoaderCompletionBlock!) -> RCTImageLoaderCancellationBlock! {
+        if let image = AnimatedImageCache.shared.cachedStaticImage(url: imageURL) {
+            completionHandler(nil, image)
+            return {}
+        }
+
         let size = sizeWidthFromURLQueryItem(from: imageURL) ?? size
-        let scaledSize = CGSize(width: size.width / scale, height: size.height / scale)
-        let task = mediaUtility.downloadImage(from: imageURL, size: scaledSize, scale: scale, post: post, allowPhotonAPI: false, success: { (image) in
+        let task = mediaUtility.downloadImage(from: imageURL, size: size, scale: scale, post: post, allowPhotonAPI: false, success: { (image) in
+            AnimatedImageCache.shared.cacheStaticImage(url: imageURL, image: image)
             completionHandler(nil, image)
         }, onFailure: { (error) in
             completionHandler(error, nil)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift
@@ -22,9 +22,8 @@ class GutenbergImageLoader: NSObject, RCTImageURLLoader {
             completionHandler(nil, image)
             return {}
         }
-
         let size = sizeWidthFromURLQueryItem(from: imageURL) ?? size
-        let task = mediaUtility.downloadImage(from: imageURL, size: size, scale: scale, post: post, allowPhotonAPI: false, success: { (image) in
+        let task = mediaUtility.downloadImage(from: imageURL, size: size, scale: 1, post: post, allowPhotonAPI: false, success: { (image) in
             AnimatedImageCache.shared.cacheStaticImage(url: imageURL, image: image)
             completionHandler(nil, image)
         }, onFailure: { (error) in

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift
@@ -18,13 +18,26 @@ class GutenbergImageLoader: NSObject, RCTImageURLLoader {
     }
 
     func loadImage(for imageURL: URL!, size: CGSize, scale: CGFloat, resizeMode: RCTResizeMode, progressHandler: RCTImageLoaderProgressBlock!, partialLoadHandler: RCTImageLoaderPartialLoadBlock!, completionHandler: RCTImageLoaderCompletionBlock!) -> RCTImageLoaderCancellationBlock! {
-        let task = mediaUtility.downloadImage(from: imageURL, size: size, scale: scale, post: post, success: { (image) in
+        let size = sizeWidthFromURLQueryItem(from: imageURL) ?? size
+        let scaledSize = CGSize(width: size.width / scale, height: size.height / scale)
+        let task = mediaUtility.downloadImage(from: imageURL, size: scaledSize, scale: scale, post: post, allowPhotonAPI: false, success: { (image) in
             completionHandler(nil, image)
         }, onFailure: { (error) in
             completionHandler(error, nil)
         })
 
         return { task.cancel() }
+    }
+
+    func sizeWidthFromURLQueryItem(from url: URL) -> CGSize? {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        for item in components?.queryItems ?? [] {
+            if item.name == "w",
+                let width = Int(item.value ?? "") {
+                return CGSize(width: width, height: 0)
+            }
+        }
+        return nil
     }
 
     static func moduleName() -> String! {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift
@@ -23,7 +23,9 @@ class GutenbergImageLoader: NSObject, RCTImageURLLoader {
             return {}
         }
         let size = sizeWidthFromURLQueryItem(from: imageURL) ?? size
-        let task = mediaUtility.downloadImage(from: imageURL, size: size, scale: 1, post: post, allowPhotonAPI: false, success: { (image) in
+        let screenScale = UIScreen.main.scale // The provided scale does not always correspond to the UIScreen scale.
+        let scaledSize = CGSize(width: size.width / screenScale, height: size.height / screenScale)
+        let task = mediaUtility.downloadImage(from: imageURL, size: scaledSize, scale: 1, post: post, success: { (image) in
             AnimatedImageCache.shared.cacheStaticImage(url: imageURL, image: image)
             completionHandler(nil, image)
         }, onFailure: { (error) in


### PR DESCRIPTION
Fixes n1 from https://github.com/wordpress-mobile/gutenberg-mobile/issues/1593

In this PR, we avoid using the PhotonAPI helper, which was aggressively stripping the image size properties from the URL.

The `downloadImage` method of `RCTImageURLLoader` is used by the JS function `Image.getSize()` to retrieve the original image and calculate its size.

I also took this opportunity to add a simple in-memory image cache to avoid fetching the same image multiple times.

To test:
- On a WPCom site:
- Add an image block.
- Add an image from any source.
- Change the image size to thumbnail.
- Check that the size of the image visually changes.

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
