### PR TITLE
Fix copy/paste in dark mode for Aztec.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -25,11 +25,11 @@ def aztec
     ## When using a tagged version, feel free to comment out the WordPress-Aztec-iOS line below.
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
-    ## pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '81e1e1bb1cb209004d66bba75338595cc9aab147'
-    ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '81e1e1bb1cb209004d66bba75338595cc9aab147'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ba8524aba1332550efb05cad583a85ed3511beb5'
+    pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ba8524aba1332550efb05cad583a85ed3511beb5'
     ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag => '1.5.0.beta.1'
     ## pod 'WordPress-Editor-iOS', :path => '../AztecEditor-iOS'
-    pod 'WordPress-Editor-iOS', '~> 1.12.0'
+    ## pod 'WordPress-Editor-iOS', '~> 1.12.0'
 end
 
 def wordpress_ui

--- a/Podfile
+++ b/Podfile
@@ -25,11 +25,11 @@ def aztec
     ## When using a tagged version, feel free to comment out the WordPress-Aztec-iOS line below.
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ba8524aba1332550efb05cad583a85ed3511beb5'
-    pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ba8524aba1332550efb05cad583a85ed3511beb5'
+    ## pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ba8524aba1332550efb05cad583a85ed3511beb5'
+    ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ba8524aba1332550efb05cad583a85ed3511beb5'
     ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag => '1.5.0.beta.1'
     ## pod 'WordPress-Editor-iOS', :path => '../AztecEditor-iOS'
-    ## pod 'WordPress-Editor-iOS', '~> 1.12.0'
+    pod 'WordPress-Editor-iOS', '~> 1.13.0'
 end
 
 def wordpress_ui

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -300,7 +300,8 @@ DEPENDENCIES:
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
-  - WordPress-Editor-iOS (~> 1.12.0)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ba8524aba1332550efb05cad583a85ed3511beb5`)
+  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ba8524aba1332550efb05cad583a85ed3511beb5`)
   - WordPressAuthenticator (~> 1.10.2)
   - WordPressKit (~> 4.5.3)
   - WordPressMocks (~> 0.0.6)
@@ -343,8 +344,6 @@ SPEC REPOS:
     - Starscream
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPress-Aztec-iOS
-    - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
@@ -412,6 +411,12 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.17.0
+  WordPress-Aztec-iOS:
+    :commit: ba8524aba1332550efb05cad583a85ed3511beb5
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPress-Editor-iOS:
+    :commit: ba8524aba1332550efb05cad583a85ed3511beb5
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.17.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -428,6 +433,12 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.17.0
+  WordPress-Aztec-iOS:
+    :commit: ba8524aba1332550efb05cad583a85ed3511beb5
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPress-Editor-iOS:
+    :commit: ba8524aba1332550efb05cad583a85ed3511beb5
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 3.0.2
@@ -503,6 +514,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 35b16898fae049f6ebffba96793f209b03a41495
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: d275f12ae528d2374c73e683366d91ae8a9c4d7d
+PODFILE CHECKSUM: f47e229f788ebdd474369c4f99f9a5eb30ca8f79
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -208,9 +208,9 @@ PODS:
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPress-Aztec-iOS (1.12.0)
-  - WordPress-Editor-iOS (1.12.0):
-    - WordPress-Aztec-iOS (= 1.12.0)
+  - WordPress-Aztec-iOS (1.13.0)
+  - WordPress-Editor-iOS (1.13.0):
+    - WordPress-Aztec-iOS (= 1.13.0)
   - WordPressAuthenticator (1.10.2):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
@@ -300,8 +300,7 @@ DEPENDENCIES:
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ba8524aba1332550efb05cad583a85ed3511beb5`)
-  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ba8524aba1332550efb05cad583a85ed3511beb5`)
+  - WordPress-Editor-iOS (~> 1.13.0)
   - WordPressAuthenticator (~> 1.10.2)
   - WordPressKit (~> 4.5.3)
   - WordPressMocks (~> 0.0.6)
@@ -344,6 +343,8 @@ SPEC REPOS:
     - Starscream
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPress-Aztec-iOS
+    - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
@@ -411,12 +412,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.17.0
-  WordPress-Aztec-iOS:
-    :commit: ba8524aba1332550efb05cad583a85ed3511beb5
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPress-Editor-iOS:
-    :commit: ba8524aba1332550efb05cad583a85ed3511beb5
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.17.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -433,12 +428,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.17.0
-  WordPress-Aztec-iOS:
-    :commit: ba8524aba1332550efb05cad583a85ed3511beb5
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPress-Editor-iOS:
-    :commit: ba8524aba1332550efb05cad583a85ed3511beb5
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 3.0.2
@@ -501,8 +490,8 @@ SPEC CHECKSUMS:
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPress-Aztec-iOS: 316a3897753731847c3ed3337dbd4bb1d664b92b
-  WordPress-Editor-iOS: c070068608056079ac7d2e020204016a7159cbb8
+  WordPress-Aztec-iOS: 450cb7095c6852c9c933d2062c318c4d7fa4d9a6
+  WordPress-Editor-iOS: c3373b246efe59adf7b6ac476c8e562964724bf9
   WordPressAuthenticator: af8a2b733b8a33d2ad04cdd30f5410bfe772f439
   WordPressKit: 023c6b1c2e1576c66c3044dc4ae8d28df7b2f1b5
   WordPressMocks: 5913bd04586a360212e07a8ccbcb36068d4425a3
@@ -514,6 +503,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 35b16898fae049f6ebffba96793f209b03a41495
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: f47e229f788ebdd474369c4f99f9a5eb30ca8f79
+PODFILE CHECKSUM: 6ccf76b6cf9ee203ef996f5ce7c15ae93db634b9
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Fixes #12688 

Updates Aztec version to bring fixes for copy/paste in dark mode.

After the fix is confirmed I will need to release a new version of Aztec and update the reference here.

To test:
 - Set your device to dark mode
 - Using the Aztec editor, copy text from other apps that don't support dark mode and/or have black text on white background
 - Check that text is show correctly
 - Double check the same thing on the Gutenberg editor

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
