### PR TITLE
Post Scheduling: Disable internal testing

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -28,9 +28,7 @@ enum FeatureFlag: Int {
         case .statsAsyncLoadingDWMY:
             return true
         case .postScheduling:
-            return BuildConfiguration.current ~= [.localDeveloper,
-                                                  .a8cBranchTest,
-                                                  .a8cPrereleaseTesting]
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 }


### PR DESCRIPTION
Ref #12992

This disables internal testing for Post Scheduling date/time pickers due to the above issue.

To test:
This feature is still present in dev, so you'll still see it. So verify the Feature Flag setting is correct.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
