### PR TITLE
Today Widget: Correct value used for Visitors

### DIFF
--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -246,7 +246,7 @@ private extension TodayViewController {
 
             DispatchQueue.main.async {
                 self.statsValues = TodayWidgetStats(views: todayInsight?.viewsCount ?? 0,
-                                                    visitors: todayInsight?.viewsCount ?? 0,
+                                                    visitors: todayInsight?.visitorsCount ?? 0,
                                                     likes: todayInsight?.likesCount ?? 0,
                                                     comments: todayInsight?.commentsCount ?? 0)
                 self.tableView.reloadData()


### PR DESCRIPTION
Fixes #12990

To test:
- Go to Stats, and select a site to use for the Today widget.
- Go to the widget.
- Verify the Visitors value matches Visitors from the Insights > Today stat. 

<img width="400" alt="widget_stats" src="https://user-images.githubusercontent.com/1816888/69452034-027abe80-0d1e-11ea-9738-3454d12a1ce3.png">

<img width="400" alt="app_stats" src="https://user-images.githubusercontent.com/1816888/69452029-fee73780-0d1d-11ea-885a-24140c8ebf03.png"> 


PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
