### PR TITLE
Track Core Data startup errors to Sentry

### DIFF
--- a/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
+++ b/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
@@ -1,8 +1,10 @@
 import Foundation
 import Sentry
 
-// - WARNING: This class was created to track events of failures during
-// startup time. This will block the thread. Do not use unless you're sure.
+/**
+WARNING: This class was created to track events of failures during
+startup time. This will block the thread. Do not use unless you're sure.
+*/
 @objc class SentryStartupEvent: NSObject {
     static let shared = SentryStartupEvent()
 
@@ -20,6 +22,7 @@ import Sentry
         var errors = errors
         let lastError = errors.removeLast()
 
+        // Turn each error into a breadcrumb, except the last one
         for error in errors {
             let breadcrumb = Breadcrumb(level: .debug, category: error.domain)
             breadcrumb.message = "\(error.localizedDescription) | userInfo: \(lastError.userInfo)"

--- a/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
+++ b/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
@@ -19,7 +19,8 @@ startup time. This will block the thread. Do not use unless you're sure.
 
     // Send the event and block the thread until it was actually sent
     @objc func send(title: String) {
-        guard let client = try? Client(dsn: ApiCredentials.sentryDSN()) else {
+        guard !WPAppAnalytics.userHasOptedOut(),
+            let client = try? Client(dsn: ApiCredentials.sentryDSN()) else {
             return
         }
         let semaphore = DispatchSemaphore(value: 0)

--- a/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
+++ b/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
@@ -16,8 +16,17 @@ import Sentry
         return shared
     }
 
-    @objc func send(title: String, error: NSError) {
-        send(message: "\(title): error: \(error.localizedDescription) | domain: \(error.domain) | userInfo: \(error.userInfo)")
+    @objc func send(title: String, errors: [NSError]) {
+        var errors = errors;
+        let lastError = errors.removeLast()
+
+        for error in errors {
+            let breadcrumb = Breadcrumb(level: .debug, category: error.domain)
+            breadcrumb.message = "\(error.localizedDescription) | userInfo: \(lastError.userInfo)"
+            client?.breadcrumbs.add(breadcrumb)
+        }
+
+        send(message: "\(title): error: \(lastError.localizedDescription) | domain: \(lastError.domain) | userInfo: \(lastError.userInfo)")
     }
 
     // Send the event and block the thread until it was actually sent

--- a/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
+++ b/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
@@ -6,39 +6,32 @@ WARNING: This class was created to track events of failures during
 startup time. This will block the thread. Do not use unless you're sure.
 */
 @objc class SentryStartupEvent: NSObject {
-    static let shared = SentryStartupEvent()
+    private var errors = [String]()
 
-    private var client: Client?
-
-    private override init() {
-        client = try? Client(dsn: ApiCredentials.sentryDSN())
+    func add(error: NSError, file: String = #file, function: String = #function, line: UInt = #line) {
+        errors.append("\(function) (\(file):\(line)) \(error.localizedDescription) | userInfo: \(error.userInfo)")
     }
 
-    @objc class func sharedInstance() -> SentryStartupEvent {
-        return shared
-    }
-
-    @objc func send(title: String, errors: [NSError]) {
-        var errors = errors
-        let lastError = errors.removeLast()
-
-        // Turn each error into a breadcrumb, except the last one
-        for error in errors {
-            let breadcrumb = Breadcrumb(level: .debug, category: error.domain)
-            breadcrumb.message = "\(error.localizedDescription) | userInfo: \(lastError.userInfo)"
-            client?.breadcrumbs.add(breadcrumb)
-        }
-
-        send(message: "\(title): error: \(lastError.localizedDescription) | domain: \(lastError.domain) | userInfo: \(lastError.userInfo)")
+    @objc(addError:file:function:line:)
+    func _objc_add(error: NSError, file: UnsafePointer<CChar>, function: UnsafePointer<CChar>, line: UInt) {
+        add(error: error, file: String(cString: file), function: String(cString: function), line: line)
     }
 
     // Send the event and block the thread until it was actually sent
-    @objc func send(message: String) {
+    @objc func send(title: String) {
+        guard let client = try? Client(dsn: ApiCredentials.sentryDSN()) else {
+            return
+        }
         let semaphore = DispatchSemaphore(value: 0)
-
         let event = Event(level: .debug)
-        event.message = message
-        client?.send(event: event, completion: { _ in
+        let lastError = errors.removeLast()
+        event.message = "\(title): \(lastError)"
+        for error in errors {
+            let breadcrumb = Breadcrumb(level: .debug, category: "Startup")
+            breadcrumb.message = error
+            client.breadcrumbs.add(breadcrumb)
+        }
+        client.send(event: event, completion: { _ in
             semaphore.signal()
         })
 

--- a/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
+++ b/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Sentry
+
+// - WARNING: This class was created to track events of failures during
+// startup time. This will block the thread. Do not use unless you're sure.
+@objc class SentryStartupEvent: NSObject {
+    static let shared = SentryStartupEvent()
+
+    private var client: Client?
+
+    private override init() {
+        client = try? Client(dsn: ApiCredentials.sentryDSN())
+    }
+
+    @objc class func sharedInstance() -> SentryStartupEvent {
+        return shared
+    }
+
+    @objc func send(title: String, error: NSError) {
+        send(message: "\(title): error: \(error.localizedDescription) | domain: \(error.domain) | userInfo: \(error.userInfo)")
+    }
+
+    // Send the event and block the thread until it was actually sent
+    @objc func send(message: String) {
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let event = Event(level: .debug)
+        event.message = message
+        client?.send(event: event, completion: { _ in
+            semaphore.signal()
+        })
+
+        semaphore.wait()
+    }
+}

--- a/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
+++ b/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
@@ -17,7 +17,7 @@ import Sentry
     }
 
     @objc func send(title: String, errors: [NSError]) {
-        var errors = errors;
+        var errors = errors
         let lastError = errors.removeLast()
 
         for error in errors {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1010,6 +1010,7 @@
 		85D239AE1AE5A5FC0074768D /* BlogSyncFacade.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D239A21AE5A5FC0074768D /* BlogSyncFacade.m */; };
 		85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */ = {isa = PBXBuildFile; fileRef = 85DA8C4318F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m */; };
 		85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */; };
+		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */; };
 		8B8C814D2318073300A0E620 /* BasePostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8C814C2318073300A0E620 /* BasePostTests.swift */; };
 		8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */; };
@@ -3202,6 +3203,7 @@
 		85DA8C4318F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAnalyticsTrackerWPCom.m; sourceTree = "<group>"; };
 		85ED98AA17DFB17200090D0B /* iTunesArtwork@2x */ = {isa = PBXFileReference; lastKnownFileType = file; path = "iTunesArtwork@2x"; sourceTree = "<group>"; };
 		85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationServiceTests.swift; sourceTree = "<group>"; };
+		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewControllerTests.swift; sourceTree = "<group>"; };
 		8B8C814C2318073300A0E620 /* BasePostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePostTests.swift; sourceTree = "<group>"; };
 		8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadMessages.swift; sourceTree = "<group>"; };
@@ -5721,6 +5723,7 @@
 				59DD94331AC479ED0032DD6B /* WPLogger.m */,
 				F93735F022D534FE00A3C312 /* LoggingURLRedactor.swift */,
 				986CC4D120E1B2F6004F300E /* CustomLogFormatter.swift */,
+				8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */,
 			);
 			path = Logging;
 			sourceTree = "<group>";
@@ -11431,6 +11434,7 @@
 				08216FD21CDBF96000304BA7 /* MenuItemSourceViewController.m in Sources */,
 				74558369201A1FD3007809BB /* WPReusableTableViewCells.swift in Sources */,
 				E6DAABDD1CF632EC0069D933 /* ReaderSearchSuggestionsViewController.swift in Sources */,
+				8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */,
 				D8C31CC62188490000A33B35 /* SiteSegmentsCell.swift in Sources */,
 				98921EFB21372E57004949AA /* NewsService.swift in Sources */,
 				E6431DE51C4E892900FD8D90 /* SharingConnectionsViewController.m in Sources */,


### PR DESCRIPTION
Refs #12338

In https://github.com/wordpress-mobile/WordPress-iOS/pull/12569 we changed the Core Data startup error to a proper exception. However, we still unable to have more details about this issue. Mainly because:

1. Xcode reports don't give much information. They just state that an objc exception was thrown but no details;
2. No data is being sent to Sentry

This aims to fix number 2.

## To test

Add those lines in `ContextManager.m` right before `return _persistentStoreCoordinator;` inside `(NSPersistentStoreCoordinator *)persistentStoreCoordinator`:

```swift
NSError *errMsg = nil;
errMsg = [NSError errorWithDomain:@"aaa" code:1001 userInfo:@{ NSLocalizedDescriptionKey:@"aaa" }];
[errors addObject:errMsg];
errMsg = [NSError errorWithDomain:@"bbb" code:1001 userInfo:@{ NSLocalizedDescriptionKey:@"bbb" }];
[errors addObject:errMsg];
errMsg = [NSError errorWithDomain:@"ccc" code:1001 userInfo:@{ NSLocalizedDescriptionKey:@"ccc" }];
[errors addObject:errMsg];
[SentryStartupEvent.sharedInstance sendWithTitle:@"Test, ignore" errors:errors];

abort();
```

Run the app. It will crash.

After that go to [this link](https://sentry.io/organizations/a8c/events/?project=1438083) and make sure you can see the event in the list of events.

All the errors that happen until Core Data will be tracked and sent as breadcrumbs to Sentry. This would give us more insights into what's happening.

## Additional information

As of today, our tracking code needs a `CrashLoggingDataProvider` and we provide a `WPCrashLoggingProvider`. However, for this code to be initialized, we need Core Data. [You can see here](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift#L18).

One would assume that by fixing that we'd be able to track startup exceptions and/or crashes. Unfortunately not.

Sentry is not able to submit a [crash report that occurs on launch](https://docs.sentry.io/clients/cocoa/#testing-a-crash). My aim with that PR is to do that manually.

PR submission checklist:

- [x] I have considered adding unit tests where possible — since those are temporary changes to gain more info on the issue, I haven't spent time writing tests. If you think this is highly required please let me know.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
