### PR TITLE
Fix empty Me screen due to network conditions

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * Block editor: Images from Image Block can now be previewed full screen by tapping on them.
 * Support: Fix issue that caused 'Message failed to send' error.
+* Fixed an issue where the Me screen would sometimes be blank.
 
 13.7
 -----

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -57,6 +57,8 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         tableView.accessibilityIdentifier = "Me Table"
+
+        reloadViewModel()
     }
 
     override func viewDidLayoutSubviews() {


### PR DESCRIPTION
Fixes #13000.

The Me screen currently shows empty until a network request to refresh the current account details is complete. This PR moves the call to load the view model so that it's displayed instantly.

**To test:**

* Build and run
* Log in and check you can view the Me screen without seeing it blank at all
* Quit the app and relaunch, and check the Me screen isn't blank
* Quit the app, turn on airplane mode, relaunch the app and check the Me screen isn't blank

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
