### PR TITLE
Use the correct const for the service name.

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -926,7 +926,7 @@ extension WordPressAppDelegate {
     func removeAppleIDFromKeychain() {
         do {
             try SFHFKeychainUtils.deleteItem(forUsername: WPAppleIDKeychainUsernameKey,
-                                             andServiceName: WPAppleIDKeychainUsernameKey)
+                                             andServiceName: WPAppleIDKeychainServiceName)
         } catch let error as NSError {
             if error.code != errSecItemNotFound {
                 DDLogError("Error while removing Apple User ID from keychain: \(error.localizedDescription)")


### PR DESCRIPTION
After testing the SIWA, and subsequently removing the Apple 2fa from my test account, I notice I was being logged out of the app after every launch (sometimes with a crash).  I traced the cause back to `WPAppleIDKeychainUsernameKey` being used as a service name rather than `WPAppleIDKeychainServiceName`. This was interfering with the delete call to the keychain so the apple ID was always checked at launch and assumed revoked. 

To test:
For a full test, create an Apple id to use for testing, setup 2fa then create a wpcom account via SIWA.   Then find the email from apple that will let you roll back 2fa and disable SIWA from Apple's side.  You can confirm the glitch from a `develop` branch by logging in to the app with a normal WPCom flow.  Finally, switch to this branch and log in to the app and confirm you are not logged off the next time you launch the app.

Alternatively, confirm the correct service name is consistently used when saving the apple id to the keychain, and again when removing it. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
