### PR TITLE
Me: Remove Notification Settings hint text

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -188,8 +188,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
                         myProfile,
                         accountSettings,
                         appSettingsRow
-                        ],
-                         footerText: NSLocalizedString("Notification settings can now be found in the Notifications tab", comment: "Instruction informing the user where notification settings can be found.")),
+                        ]),
                     ImmuTableSection(rows: [helpAndSupportIndicator]),
                     ImmuTableSection(
                         headerText: wordPressComAccount,


### PR DESCRIPTION
This PR removes the "Notification settings can now be found in the Notifications tab" hint that was present in the Me screen, now that the settings have been moved for a couple of releases.

Android equivalent PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10840

**To test**

* Build and run
* Access the Me tab
* Check you don't see the above text underneath the App Settings row in the table

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
