### PR TITLE
[All Time Widget] Add data handling

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -52,7 +52,11 @@ struct InsightStoreState {
 
     // Other Blocks
 
-    var allTimeStats: StatsAllTimesInsight?
+    var allTimeStats: StatsAllTimesInsight? {
+        didSet {
+            storeAllTimeWidgetData()
+        }
+    }
     var allTimeStatus: StoreFetchingStatus = .idle
 
     var annualAndMostPopularTime: StatsAnnualAndMostPopularTimeInsight?
@@ -938,13 +942,13 @@ extension StatsInsightsStore {
     }
 }
 
+// MARK: - Widget Data
+
 private extension InsightStoreState {
+
     func storeTodayWidgetData() {
-        // Only store data if the widget is using the current site
-        guard let sharedDefaults = UserDefaults(suiteName: WPAppGroupName),
-            let widgetSiteID = sharedDefaults.object(forKey: WPStatsTodayWidgetUserDefaultsSiteIdKey) as? NSNumber,
-            widgetSiteID == SiteStatsInformation.sharedInstance.siteID  else {
-                return
+        guard widgetUsingCurrentSite() else {
+            return
         }
 
         let data = TodayWidgetStats(views: todaysStats?.viewsCount ?? 0,
@@ -953,4 +957,27 @@ private extension InsightStoreState {
                                     comments: todaysStats?.commentsCount ?? 0)
         data.saveData()
     }
+
+    func storeAllTimeWidgetData() {
+        guard widgetUsingCurrentSite() else {
+            return
+        }
+
+        let data = AllTimeWidgetStats(views: allTimeStats?.viewsCount ?? 0,
+                                    visitors: allTimeStats?.visitorsCount ?? 0,
+                                    posts: allTimeStats?.postsCount ?? 0,
+                                    bestViews: allTimeStats?.bestViewsPerDayCount ?? 0)
+        data.saveData()
+    }
+
+    func widgetUsingCurrentSite() -> Bool {
+        // Only store data if the widget is using the current site
+        guard let sharedDefaults = UserDefaults(suiteName: WPAppGroupName),
+            let widgetSiteID = sharedDefaults.object(forKey: WPStatsTodayWidgetUserDefaultsSiteIdKey) as? NSNumber,
+            widgetSiteID == SiteStatsInformation.sharedInstance.siteID  else {
+                return false
+        }
+        return true
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -74,7 +74,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 - (void)addStatsViewControllerToView
 {
     if (self.presentingViewController == nil) {
-        UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Today", @"") style:UIBarButtonItemStylePlain target:self action:@selector(makeSiteTodayWidgetSite:)];
+        UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Widgets", @"Nav bar title to set the site used for Stats widgets.") style:UIBarButtonItemStylePlain target:self action:@selector(makeSiteTodayWidgetSite:)];
         self.navigationItem.rightBarButtonItem = settingsButton;
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// This struct contains data for the Insights All Time stats to be displayed in the corresponding widget.
+/// The data is stored in a plist for the widget to access.
+/// This file is shared with WordPressAllTimeWidget, which accesses the data when it is viewed.
+///
+
+struct AllTimeWidgetStats: Codable {
+    let views: Int
+    let visitors: Int
+    let posts: Int
+    let bestViews: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case views
+        case visitors
+        case posts
+        case bestViews
+    }
+
+    init(views: Int, visitors: Int, posts: Int, bestViews: Int) {
+        self.views = views
+        self.visitors = visitors
+        self.posts = posts
+        self.bestViews = bestViews
+    }
+}
+
+extension AllTimeWidgetStats {
+
+    static func loadSavedData() -> AllTimeWidgetStats {
+        guard let sharedDataFileURL = dataFileURL,
+            FileManager.default.fileExists(atPath: sharedDataFileURL.path) == true else {
+                DDLogError("AllTimeWidgetStats: data file '\(dataFileName)' does not exist.")
+                return AllTimeWidgetStats(views: 0, visitors: 0, posts: 0, bestViews: 0)
+        }
+
+        let decoder = PropertyListDecoder()
+        do {
+            let data = try Data(contentsOf: sharedDataFileURL)
+            return try decoder.decode(AllTimeWidgetStats.self, from: data)
+        } catch {
+            DDLogError("Failed loading AllTimeWidgetStats data: \(error.localizedDescription)")
+            return AllTimeWidgetStats(views: 0, visitors: 0, posts: 0, bestViews: 0)
+        }
+    }
+
+    func saveData() {
+        guard let dataFileURL = AllTimeWidgetStats.dataFileURL else {
+                return
+        }
+
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
+
+        do {
+            let data = try encoder.encode(self)
+            try data.write(to: dataFileURL)
+        } catch {
+            DDLogError("Failed saving AllTimeWidgetStats data: \(error.localizedDescription)")
+        }
+    }
+
+    private static var dataFileName = "AllTimeData.plist"
+
+    private static var dataFileURL: URL? {
+        guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName) else {
+            return nil
+        }
+        return url.appendingPathComponent(dataFileName)
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
@@ -18,11 +18,11 @@ struct AllTimeWidgetStats: Codable {
         case bestViews
     }
 
-    init(views: Int, visitors: Int, posts: Int, bestViews: Int) {
-        self.views = views
-        self.visitors = visitors
-        self.posts = posts
-        self.bestViews = bestViews
+    init(views: Int? = 0, visitors: Int? = 0, posts: Int? = 0, bestViews: Int? = 0) {
+        self.views = views ?? 0
+        self.visitors = visitors ?? 0
+        self.posts = posts ?? 0
+        self.bestViews = bestViews ?? 0
     }
 }
 
@@ -32,7 +32,7 @@ extension AllTimeWidgetStats {
         guard let sharedDataFileURL = dataFileURL,
             FileManager.default.fileExists(atPath: sharedDataFileURL.path) == true else {
                 DDLogError("AllTimeWidgetStats: data file '\(dataFileName)' does not exist.")
-                return AllTimeWidgetStats(views: 0, visitors: 0, posts: 0, bestViews: 0)
+                return AllTimeWidgetStats()
         }
 
         let decoder = PropertyListDecoder()
@@ -41,7 +41,7 @@ extension AllTimeWidgetStats {
             return try decoder.decode(AllTimeWidgetStats.self, from: data)
         } catch {
             DDLogError("Failed loading AllTimeWidgetStats data: \(error.localizedDescription)")
-            return AllTimeWidgetStats(views: 0, visitors: 0, posts: 0, bestViews: 0)
+            return AllTimeWidgetStats()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
@@ -31,6 +31,7 @@ extension TodayWidgetStats {
     static func loadSavedData() -> TodayWidgetStats {
         guard let sharedDataFileURL = dataFileURL,
             FileManager.default.fileExists(atPath: sharedDataFileURL.path) == true else {
+                DDLogError("TodayWidgetStats: data file '\(dataFileName)' does not exist.")
                 return TodayWidgetStats(views: 0, visitors: 0, likes: 0, comments: 0)
         }
 
@@ -60,11 +61,13 @@ extension TodayWidgetStats {
         }
     }
 
+    private static var dataFileName = "TodayData.plist"
+
     private static var dataFileURL: URL? {
         guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName) else {
             return nil
         }
-        return url.appendingPathComponent("TodayData.plist")
+        return url.appendingPathComponent(dataFileName)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
@@ -18,11 +18,11 @@ struct TodayWidgetStats: Codable {
         case comments
     }
 
-    init(views: Int, visitors: Int, likes: Int, comments: Int) {
-        self.views = views
-        self.visitors = visitors
-        self.likes = likes
-        self.comments = comments
+    init(views: Int? = 0, visitors: Int? = 0, likes: Int? = 0, comments: Int? = 0) {
+        self.views = views ?? 0
+        self.visitors = visitors ?? 0
+        self.likes = likes ?? 0
+        self.comments = comments ?? 0
     }
 }
 
@@ -32,7 +32,7 @@ extension TodayWidgetStats {
         guard let sharedDataFileURL = dataFileURL,
             FileManager.default.fileExists(atPath: sharedDataFileURL.path) == true else {
                 DDLogError("TodayWidgetStats: data file '\(dataFileName)' does not exist.")
-                return TodayWidgetStats(views: 0, visitors: 0, likes: 0, comments: 0)
+                return TodayWidgetStats()
         }
 
         let decoder = PropertyListDecoder()
@@ -41,7 +41,7 @@ extension TodayWidgetStats {
             return try decoder.decode(TodayWidgetStats.self, from: data)
         } catch {
             DDLogError("Failed loading TodayWidgetStats data: \(error.localizedDescription)")
-            return TodayWidgetStats(views: 0, visitors: 0, likes: 0, comments: 0)
+            return TodayWidgetStats()
         }
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1202,6 +1202,9 @@
 		98B3FA8621C05BF000148DD4 /* ViewMoreRow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98B3FA8521C05BF000148DD4 /* ViewMoreRow.xib */; };
 		98B52AE121F7AF4A006FF6B4 /* StatsDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */; };
 		98BDFF6B20D0732900C72C58 /* SupportTableViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BDFF6A20D0732900C72C58 /* SupportTableViewController+Activity.swift */; };
+		98BFF57C2398406A008A1DCB /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CF3DB1EF1BE6800AF838E /* CocoaLumberjack.swift */; };
+		98BFF57E23984345008A1DCB /* AllTimeWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */; };
+		98BFF57F23984345008A1DCB /* AllTimeWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */; };
 		98CAD296221B4ED2003E8F45 /* StatSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CAD295221B4ED1003E8F45 /* StatSection.swift */; };
 		98D31B8F2396ED7F009CFF43 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E5283B19A7741A003A1A9C /* NotificationCenter.framework */; };
 		98D31B992396ED7F009CFF43 /* WordPressAllTimeWidget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 98D31B8E2396ED7E009CFF43 /* WordPressAllTimeWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -3453,6 +3456,7 @@
 		98B3FA8521C05BF000148DD4 /* ViewMoreRow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ViewMoreRow.xib; sourceTree = "<group>"; };
 		98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsDataHelper.swift; sourceTree = "<group>"; };
 		98BDFF6A20D0732900C72C58 /* SupportTableViewController+Activity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SupportTableViewController+Activity.swift"; sourceTree = "<group>"; };
+		98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllTimeWidgetStats.swift; sourceTree = "<group>"; };
 		98CAD295221B4ED1003E8F45 /* StatSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatSection.swift; sourceTree = "<group>"; };
 		98D31B8E2396ED7E009CFF43 /* WordPressAllTimeWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WordPressAllTimeWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D31B962396ED7F009CFF43 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -7385,6 +7389,7 @@
 		989064F9237CC1A300218CD2 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */,
 				98E58A2E2360D23400E5534B /* TodayWidgetStats.swift */,
 			);
 			path = Data;
@@ -11146,6 +11151,7 @@
 				08216FD51CDBF96000304BA7 /* MenuItemTypeViewController.m in Sources */,
 				B526DC291B1E47FC002A8C5F /* WPStyleGuide+WebView.m in Sources */,
 				82FC61271FA8ADAD00A1757E /* WPStyleGuide+Activity.swift in Sources */,
+				98BFF57E23984345008A1DCB /* AllTimeWidgetStats.swift in Sources */,
 				7E40713A2372AD54003627FA /* GutenbergFilesAppMediaSource.swift in Sources */,
 				B532D4EC199D4357006E4DF6 /* NoteBlockTextTableViewCell.swift in Sources */,
 				B52F8CD81B43260C00D36025 /* NotificationSettingStreamsViewController.swift in Sources */,
@@ -12323,6 +12329,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				98D31BAD2397015C009CFF43 /* Tracks.swift in Sources */,
+				98BFF57C2398406A008A1DCB /* CocoaLumberjack.swift in Sources */,
+				98BFF57F23984345008A1DCB /* AllTimeWidgetStats.swift in Sources */,
 				98D31BAC23970078009CFF43 /* Tracks+AllTimeWidget.swift in Sources */,
 				98D31BA72396F7E2009CFF43 /* AllTimeViewController.swift in Sources */,
 				98D31BC223972A79009CFF43 /* SFHFKeychainUtils.m in Sources */,

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -73,7 +73,7 @@ extension AllTimeViewController: NCWidgetProviding {
         }
 
         tracks.trackExtensionAccessed()
-        fetchData()
+        fetchData(completionHandler: completionHandler)
     }
 
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize) {
@@ -122,7 +122,7 @@ private extension AllTimeViewController {
         statsValues?.saveData()
     }
 
-    func fetchData() {
+    func fetchData(completionHandler: (@escaping (NCUpdateResult) -> Void)) {
         guard let statsRemote = statsRemote() else {
             return
         }
@@ -130,6 +130,7 @@ private extension AllTimeViewController {
         statsRemote.getInsight { (allTimesStats: StatsAllTimesInsight?, error) in
             if error != nil {
                 DDLogError("All Time Widget: Error fetching StatsAllTimesInsight: \(String(describing: error?.localizedDescription))")
+                completionHandler(NCUpdateResult.failed)
                 return
             }
 
@@ -143,6 +144,7 @@ private extension AllTimeViewController {
 
                 // TODO: reload table here
             }
+            completionHandler(NCUpdateResult.newData)
         }
     }
 

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -1,9 +1,16 @@
 import UIKit
 import NotificationCenter
+import WordPressKit
 
 class AllTimeViewController: UIViewController {
 
     // MARK: - Properties
+
+    private var statsValues: AllTimeWidgetStats?
+
+    private var siteID: NSNumber?
+    private var timeZone: TimeZone?
+    private var oauthToken: String?
 
     private let tracks = Tracks(appGroupName: WPAppGroupName)
 
@@ -12,6 +19,17 @@ class AllTimeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
     }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        loadSavedData()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        saveData()
+    }
+
 }
 
 // MARK: - Widget Updating
@@ -25,6 +43,60 @@ extension AllTimeViewController: NCWidgetProviding {
 
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize) {
         tracks.trackDisplayModeChanged(properties: ["expanded": activeDisplayMode == .expanded])
+    }
+
+}
+
+// MARK: - Private Extension
+
+private extension AllTimeViewController {
+
+    // MARK: - Data Management
+
+    func loadSavedData() {
+        statsValues = AllTimeWidgetStats.loadSavedData()
+    }
+
+    func saveData() {
+        statsValues?.saveData()
+    }
+
+    func fetchData() {
+        guard let statsRemote = statsRemote() else {
+            return
+        }
+
+        statsRemote.getInsight { (allTimesStats: StatsAllTimesInsight?, error) in
+            if error != nil {
+                DDLogError("All Time Widget: Error fetching StatsAllTimesInsight: \(String(describing: error?.localizedDescription))")
+                return
+            }
+
+            DDLogDebug("All Time Widget: Fetched StatsAllTimesInsight data.")
+
+            DispatchQueue.main.async {
+                self.statsValues = AllTimeWidgetStats(views: allTimesStats?.viewsCount ?? 0,
+                                            visitors: allTimesStats?.visitorsCount ?? 0,
+                                            posts: allTimesStats?.postsCount ?? 0,
+                                            bestViews: allTimesStats?.bestViewsPerDayCount ?? 0)
+
+                // TODO: - reload table here
+            }
+        }
+    }
+
+    func statsRemote() -> StatsServiceRemoteV2? {
+        guard
+            let siteID = siteID,
+            let timeZone = timeZone,
+            let oauthToken = oauthToken
+            else {
+                DDLogError("All Time Widget: Missing site ID, timeZone or oauth2Token")
+                return nil
+        }
+
+        let wpApi = WordPressComRestApi(oAuthToken: oauthToken)
+        return StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: siteID.intValue, siteTimezone: timeZone)
     }
 
 }

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -6,7 +6,19 @@ class AllTimeViewController: UIViewController {
 
     // MARK: - Properties
 
-    private var statsValues: AllTimeWidgetStats?
+    // TODO: For testing only. Remove when table added.
+    @IBOutlet private var visitors: UILabel!
+    @IBOutlet private var views: UILabel!
+    @IBOutlet private var posts: UILabel!
+    @IBOutlet private var best: UILabel!
+    @IBOutlet private var url: UILabel!
+    ////
+
+    private var statsValues: AllTimeWidgetStats? {
+        didSet {
+            updateStatsLabels()
+        }
+    }
 
     private var siteUrl: String = Constants.noDataLabel
 
@@ -14,6 +26,12 @@ class AllTimeViewController: UIViewController {
     private var timeZone: TimeZone?
     private var oauthToken: String?
     private var isConfigured = false
+
+    private let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
 
     private let tracks = Tracks(appGroupName: WPAppGroupName)
 
@@ -140,6 +158,20 @@ private extension AllTimeViewController {
 
         let wpApi = WordPressComRestApi(oAuthToken: oauthToken)
         return StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: siteID.intValue, siteTimezone: timeZone)
+    }
+
+    // MARK: - Helpers
+
+    func displayString(for value: Int) -> String {
+        return numberFormatter.string(from: NSNumber(value: value)) ?? "0"
+    }
+
+    func updateStatsLabels() {
+        views.text = displayString(for: statsValues?.views ?? 0)
+        visitors.text = displayString(for: statsValues?.visitors ?? 0)
+        posts.text = displayString(for: statsValues?.posts ?? 0)
+        best.text = displayString(for: statsValues?.bestViews ?? 0)
+        url.text = siteUrl
     }
 
     // MARK: - Constants

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -165,7 +165,7 @@ private extension AllTimeViewController {
     // MARK: - Helpers
 
     func displayString(for value: Int) -> String {
-        return numberFormatter.string(from: NSNumber(value: value)) ?? "0"
+        return numberFormatter.string(from: NSNumber(value: value)) ?? String(value)
     }
 
     func updateStatsLabels() {

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -137,10 +137,10 @@ private extension AllTimeViewController {
             DDLogDebug("All Time Widget: Fetched StatsAllTimesInsight data.")
 
             DispatchQueue.main.async {
-                self.statsValues = AllTimeWidgetStats(views: allTimesStats?.viewsCount ?? 0,
-                                            visitors: allTimesStats?.visitorsCount ?? 0,
-                                            posts: allTimesStats?.postsCount ?? 0,
-                                            bestViews: allTimesStats?.bestViewsPerDayCount ?? 0)
+                self.statsValues = AllTimeWidgetStats(views: allTimesStats?.viewsCount,
+                                            visitors: allTimesStats?.visitorsCount,
+                                            posts: allTimesStats?.postsCount,
+                                            bestViews: allTimesStats?.bestViewsPerDayCount)
 
                 // TODO: reload table here
             }

--- a/WordPress/WordPressAllTimeWidget/MainInterface.storyboard
+++ b/WordPress/WordPressAllTimeWidget/MainInterface.storyboard
@@ -12,27 +12,106 @@
         <scene sceneID="cwh-vc-ff4">
             <objects>
                 <viewController id="M4Y-Lb-cyx" customClass="AllTimeViewController" customModule="WordPressAllTimeWidget" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" ambiguous="YES" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="37"/>
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="200"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
-                                <rect key="frame" x="0.0" y="44" width="320" height="20.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2GW-KZ-aqA">
+                                <rect key="frame" x="10" y="5" width="50" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Visitors:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l6g-g7-trg">
+                                <rect key="frame" x="211" y="5" width="62" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Posts:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OMG-pU-riJ">
+                                <rect key="frame" x="10" y="31" width="48" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Best:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Drq-vl-HH5">
+                                <rect key="frame" x="234" y="31" width="39" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0SE-Ih-LrX">
+                                <rect key="frame" x="65" y="5" width="32" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kMt-ET-XWG">
+                                <rect key="frame" x="278" y="5" width="32" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TGZ-Y5-k5j">
+                                <rect key="frame" x="63" y="31" width="32" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nv6-Lv-t4V">
+                                <rect key="frame" x="278" y="31" width="32" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="URL:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cd9-3W-xHe">
+                                <rect key="frame" x="10" y="57" width="37" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="xyz.com" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eRP-Fd-wxu">
+                                <rect key="frame" x="52" y="57" width="64" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="bottom" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="20" symbolic="YES" id="0Q0-KW-PJ6"/>
-                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="20" symbolic="YES" id="6Vq-gs-PHe"/>
-                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU"/>
-                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="ssy-KU-ocm" secondAttribute="top" constant="20" symbolic="YES" id="mYS-Cv-VNx"/>
+                            <constraint firstItem="Cd9-3W-xHe" firstAttribute="top" secondItem="OMG-pU-riJ" secondAttribute="bottom" constant="5" id="0KG-zS-S5I"/>
+                            <constraint firstItem="ssy-KU-ocm" firstAttribute="trailing" secondItem="Nv6-Lv-t4V" secondAttribute="trailing" constant="10" id="0MW-sw-e3C"/>
+                            <constraint firstItem="TGZ-Y5-k5j" firstAttribute="leading" secondItem="OMG-pU-riJ" secondAttribute="trailing" constant="5" id="0N5-E8-Ag8"/>
+                            <constraint firstItem="kMt-ET-XWG" firstAttribute="top" secondItem="S3S-Oj-5AN" secondAttribute="top" constant="5" id="1JL-z6-3Mj"/>
+                            <constraint firstItem="0SE-Ih-LrX" firstAttribute="top" secondItem="S3S-Oj-5AN" secondAttribute="top" constant="5" id="2kK-Ai-S3a"/>
+                            <constraint firstItem="Cd9-3W-xHe" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="10" id="HrP-yi-ac4"/>
+                            <constraint firstItem="l6g-g7-trg" firstAttribute="top" secondItem="S3S-Oj-5AN" secondAttribute="top" constant="5" id="Jmv-el-HYt"/>
+                            <constraint firstItem="Drq-vl-HH5" firstAttribute="top" secondItem="l6g-g7-trg" secondAttribute="bottom" constant="5" id="QTa-qQ-aHI"/>
+                            <constraint firstItem="Nv6-Lv-t4V" firstAttribute="top" secondItem="kMt-ET-XWG" secondAttribute="bottom" constant="5" id="RAh-dc-Y9y"/>
+                            <constraint firstItem="Nv6-Lv-t4V" firstAttribute="leading" secondItem="Drq-vl-HH5" secondAttribute="trailing" constant="5" id="ROh-bn-e8P"/>
+                            <constraint firstItem="kMt-ET-XWG" firstAttribute="leading" secondItem="l6g-g7-trg" secondAttribute="trailing" constant="5" id="U9L-Xd-FRM"/>
+                            <constraint firstItem="eRP-Fd-wxu" firstAttribute="top" secondItem="OMG-pU-riJ" secondAttribute="bottom" constant="5" id="Uv8-5j-RT3"/>
+                            <constraint firstItem="OMG-pU-riJ" firstAttribute="top" secondItem="2GW-KZ-aqA" secondAttribute="bottom" constant="5" id="X2j-nr-0j9"/>
+                            <constraint firstItem="2GW-KZ-aqA" firstAttribute="top" secondItem="S3S-Oj-5AN" secondAttribute="top" constant="5" id="aKf-PD-7Nj"/>
+                            <constraint firstItem="2GW-KZ-aqA" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" constant="10" id="alB-l4-zU0"/>
+                            <constraint firstItem="eRP-Fd-wxu" firstAttribute="leading" secondItem="Cd9-3W-xHe" secondAttribute="trailing" constant="5" id="eNS-qP-2S2"/>
+                            <constraint firstItem="0SE-Ih-LrX" firstAttribute="leading" secondItem="2GW-KZ-aqA" secondAttribute="trailing" constant="5" id="g1D-I8-7ve"/>
+                            <constraint firstItem="OMG-pU-riJ" firstAttribute="leading" secondItem="ssy-KU-ocm" secondAttribute="leading" constant="10" id="pSo-lY-4gg"/>
+                            <constraint firstAttribute="trailing" secondItem="kMt-ET-XWG" secondAttribute="trailing" constant="10" id="ykV-Fg-k9r"/>
+                            <constraint firstItem="TGZ-Y5-k5j" firstAttribute="top" secondItem="0SE-Ih-LrX" secondAttribute="bottom" constant="5" id="ynU-u5-Nft"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ssy-KU-ocm"/>
                     </view>
-                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <nil key="simulatedTopBarMetrics"/>
+                    <nil key="simulatedBottomBarMetrics"/>
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <size key="freeformSize" width="320" height="37"/>
+                    <size key="freeformSize" width="320" height="200"/>
+                    <connections>
+                        <outlet property="best" destination="Nv6-Lv-t4V" id="7h4-XZ-axg"/>
+                        <outlet property="posts" destination="TGZ-Y5-k5j" id="5v7-DT-y1I"/>
+                        <outlet property="url" destination="eRP-Fd-wxu" id="ryP-6T-PBh"/>
+                        <outlet property="views" destination="0SE-Ih-LrX" id="uPu-bX-lq9"/>
+                        <outlet property="visitors" destination="kMt-ET-XWG" id="y5p-J6-FxK"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -246,10 +246,10 @@ private extension TodayViewController {
             DDLogDebug("Today Widget: Fetched StatsTodayInsight data.")
 
             DispatchQueue.main.async {
-                self.statsValues = TodayWidgetStats(views: todayInsight?.viewsCount ?? 0,
-                                                    visitors: todayInsight?.visitorsCount ?? 0,
-                                                    likes: todayInsight?.likesCount ?? 0,
-                                                    comments: todayInsight?.commentsCount ?? 0)
+                self.statsValues = TodayWidgetStats(views: todayInsight?.viewsCount,
+                                                    visitors: todayInsight?.visitorsCount,
+                                                    likes: todayInsight?.likesCount,
+                                                    comments: todayInsight?.commentsCount)
                 self.tableView.reloadData()
             }
             completionHandler(NCUpdateResult.newData)

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -345,7 +345,7 @@ private extension TodayViewController {
     // MARK: - Helpers
 
     func displayString(for value: Int) -> String {
-        return numberFormatter.string(from: NSNumber(value: value)) ?? "0"
+        return numberFormatter.string(from: NSNumber(value: value)) ?? String(value)
     }
 
     func updateStatsLabels() {

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -105,7 +105,7 @@ extension TodayViewController: NCWidgetProviding {
         }
 
         tracks.trackExtensionAccessed()
-        fetchData()
+        fetchData(completionHandler: completionHandler)
     }
 
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize) {
@@ -231,7 +231,7 @@ private extension TodayViewController {
         statsValues?.saveData()
     }
 
-    func fetchData() {
+    func fetchData(completionHandler: (@escaping (NCUpdateResult) -> Void)) {
         guard let statsRemote = statsRemote() else {
             return
         }
@@ -239,6 +239,7 @@ private extension TodayViewController {
         statsRemote.getInsight { (todayInsight: StatsTodayInsight?, error) in
             if error != nil {
                 DDLogError("Today Widget: Error fetching StatsTodayInsight: \(String(describing: error?.localizedDescription))")
+                completionHandler(NCUpdateResult.failed)
                 return
             }
 
@@ -251,6 +252,7 @@ private extension TodayViewController {
                                                     comments: todayInsight?.commentsCount ?? 0)
                 self.tableView.reloadData()
             }
+            completionHandler(NCUpdateResult.newData)
         }
     }
 


### PR DESCRIPTION
Ref #13030 

This implements data handling for the 'All Time' widget.
- When Insights are accessed in the WP app, 'All Time' data is stored in `AllTimeData.plist`.
- The widget loads and saves data from/to the plist.
- The widget loads site information from `UserDefaults`, and uses it to fetch stat data.

The data is displayed in plain labels in the widget to facilitate testing this. The real UI will be implemented in a future PR.

To test:

---
- Go to Stats > Insights.
- Select `Widgets` in the nav bar, and then `Use this site`.
- Add the `WordPress All-Time` widget to your Today view.
- Verify the data displayed matches Insights > All-Time in the app.

<img width="400" alt="insights" src="https://user-images.githubusercontent.com/1816888/70186188-934f8380-16a8-11ea-966e-787e0b634fa1.png">

<img width="400" alt="widget" src="https://user-images.githubusercontent.com/1816888/70186229-b11ce880-16a8-11ea-8268-9cc2fcb4bdd0.png">

---
- In the app, switch sites and `Use this site` again to change the site used for widgets.
- Verify the All Time widget updates accordingly.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
