### PR TITLE
Fix search bar color

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Search.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Search.swift
@@ -9,10 +9,12 @@ extension WPStyleGuide {
         searchBar.autocorrectionType = .no
         searchBar.isTranslucent = false
         searchBar.barTintColor = .neutral(.shade10)
-        searchBar.searchTextField.backgroundColor = .basicBackground
         searchBar.layer.borderColor = UIColor.neutral(.shade10).cgColor
         searchBar.layer.borderWidth = 1.0
         searchBar.returnKeyType = .done
+        if #available(iOS 13.0, *) {
+            searchBar.searchTextField.backgroundColor = .basicBackground
+        }
     }
 
     @objc public class func configureSearchBarAppearance() {

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Search.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Search.swift
@@ -9,7 +9,7 @@ extension WPStyleGuide {
         searchBar.autocorrectionType = .no
         searchBar.isTranslucent = false
         searchBar.barTintColor = .neutral(.shade10)
-        searchBar.searchTextField.backgroundColor = .neutral(.shade0)
+        searchBar.searchTextField.backgroundColor = .basicBackground
         searchBar.layer.borderColor = UIColor.neutral(.shade10).cgColor
         searchBar.layer.borderWidth = 1.0
         searchBar.returnKeyType = .done

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Search.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Search.swift
@@ -9,6 +9,7 @@ extension WPStyleGuide {
         searchBar.autocorrectionType = .no
         searchBar.isTranslucent = false
         searchBar.barTintColor = .neutral(.shade10)
+        searchBar.searchTextField.backgroundColor = .neutral(.shade0)
         searchBar.layer.borderColor = UIColor.neutral(.shade10).cgColor
         searchBar.layer.borderWidth = 1.0
         searchBar.returnKeyType = .done


### PR DESCRIPTION
Fixes #13037

| Light mode | Dark mode |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/7040243/70258699-6c0dba80-176b-11ea-969b-91fa95d965c9.png" width="300" >  | <img src="https://user-images.githubusercontent.com/7040243/70258705-70d26e80-176b-11ea-948d-b1ee33fcef73.png" width="300">  |

## To test

Use the app in both light and dark mode and check the search bar appearance.

## Additional info

It seems that, for some reason, Apple changed the default color for the `searchTextField`. This PR updates it with neutral with zero shade. This changes slightly the colors of the component, that's why I'm requesting a designer review.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
