### PR TITLE
[Gutenberg] Fix guten-gallery image size.

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergImageLoader.swift
@@ -18,15 +18,24 @@ class GutenbergImageLoader: NSObject, RCTImageURLLoader {
     }
 
     func loadImage(for imageURL: URL!, size: CGSize, scale: CGFloat, resizeMode: RCTResizeMode, progressHandler: RCTImageLoaderProgressBlock!, partialLoadHandler: RCTImageLoaderPartialLoadBlock!, completionHandler: RCTImageLoaderCompletionBlock!) -> RCTImageLoaderCancellationBlock! {
-        if let image = AnimatedImageCache.shared.cachedStaticImage(url: imageURL) {
+        let cacheKey = getCacheKey(for: imageURL, size: size)
+
+        if let image = AnimatedImageCache.shared.cachedStaticImage(url: cacheKey) {
             completionHandler(nil, image)
             return {}
         }
-        let size = sizeWidthFromURLQueryItem(from: imageURL) ?? size
-        let screenScale = UIScreen.main.scale // The provided scale does not always correspond to the UIScreen scale.
-        let scaledSize = CGSize(width: size.width / screenScale, height: size.height / screenScale)
-        let task = mediaUtility.downloadImage(from: imageURL, size: scaledSize, scale: 1, post: post, success: { (image) in
-            AnimatedImageCache.shared.cacheStaticImage(url: imageURL, image: image)
+
+        var finalSize = size
+        var finalScale = scale
+
+        if let size = sizeWidthFromURLQueryItem(from: imageURL) {
+            finalScale = 1
+            let screenScale = UIScreen.main.scale // The provided scale does not always correspond to the UIScreen scale.
+            finalSize = CGSize(width: size.width / screenScale, height: size.height / screenScale)
+        }
+
+        let task = mediaUtility.downloadImage(from: imageURL, size: finalSize, scale: finalScale, post: post, success: { (image) in
+            AnimatedImageCache.shared.cacheStaticImage(url: cacheKey, image: image)
             completionHandler(nil, image)
         }, onFailure: { (error) in
             completionHandler(error, nil)
@@ -35,7 +44,7 @@ class GutenbergImageLoader: NSObject, RCTImageURLLoader {
         return { task.cancel() }
     }
 
-    func sizeWidthFromURLQueryItem(from url: URL) -> CGSize? {
+    private func sizeWidthFromURLQueryItem(from url: URL) -> CGSize? {
         let components = URLComponents(url: url, resolvingAgainstBaseURL: true)
         for item in components?.queryItems ?? [] {
             if item.name == "w",
@@ -44,6 +53,14 @@ class GutenbergImageLoader: NSObject, RCTImageURLLoader {
             }
         }
         return nil
+    }
+
+    private func getCacheKey(for url: URL, size: CGSize) -> URL? {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        let queryItems = components?.queryItems
+        let newQueryItems = (queryItems ?? []) + [URLQueryItem(name: "cachekey", value: "\(size)")]
+        components?.queryItems = newQueryItems
+        return components?.url
     }
 
     static func moduleName() -> String! {


### PR DESCRIPTION
This PR fixes an issue with gallery blocks, where the image downloaded is of a noticeable lower quality than the expected:

**Expected:**
![image](https://user-images.githubusercontent.com/9772967/70341249-d188a680-1852-11ea-9cc7-9b91c29a1512.png)

**Actual result:**
![image](https://user-images.githubusercontent.com/9772967/70341307-f3822900-1852-11ea-9f68-1970ed1f8630.png)

To test:
- Test the gallery block, adding 3 images.
- Check that the 3rd image has good quality.
- Add an image block with an image in a WPCom site.
- Set the image size to Thumb
- Check that the image size changes and looks smaller.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
