### PR TITLE
Update PostPost navigation bar to use iOS 13 appearance methods

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -55,13 +55,21 @@ class PostPostViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        navBar.isTranslucent = true
-        navBar.barTintColor = UIColor.clear
         view.backgroundColor = .primary
-        navBar.tintColor = UIColor.white
-        let clearImage = UIImage(color: UIColor.clear, havingSize: CGSize(width: 1, height: 1))
-        navBar.shadowImage = clearImage
-        navBar.setBackgroundImage(clearImage, for: .default)
+
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithTransparentBackground()
+            navBar.standardAppearance = appearance
+        } else {
+            navBar.isTranslucent = true
+            navBar.barTintColor = UIColor.clear
+            navBar.tintColor = UIColor.white
+            let clearImage = UIImage(color: UIColor.clear, havingSize: CGSize(width: 1, height: 1))
+            navBar.shadowImage = clearImage
+            navBar.setBackgroundImage(clearImage, for: .default)
+        }
+
         navBar.topItem?.rightBarButtonItem?.title = NSLocalizedString("Done", comment: "Label on button to dismiss view presented after publishing a post")
         navBar.topItem?.rightBarButtonItem?.accessibilityIdentifier = "doneButton"
 


### PR DESCRIPTION
Fixes #13040. The methods for changing the appearance of a `UINavigationBar` changed in iOS 13. This PR updates `PostPostViewController` to use the new way of creating a transparent nav bar.

![Simulator Screen Shot - iPhone 11 - 2019-12-06 at 14 14 43](https://user-images.githubusercontent.com/4780/70329233-d0e01800-1832-11ea-9f97-3460c1d34eb1.png)

**To test:**

* Build and run
* Publish a new post
* Tap "View" when the published notice appears at the bottom of the screen
* Check the navigation bar isn't visible in the post-post screen

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
