### PR TITLE
Bug/12996 menu editor issue

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingHeaderView.m
@@ -47,8 +47,8 @@
 
     [NSLayoutConstraint activateConstraints:@[
                                               bottomConstraint,
-                                              [stackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:margins.left],
-                                              [stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-margins.right]
+                                              [stackView.leadingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.leadingAnchor constant:margins.left],
+                                              [stackView.trailingAnchor constraintEqualToAnchor:self.safeAreaLayoutGuide.trailingAnchor constant:-margins.right]
                                               ]];
 
     _stackView = stackView;
@@ -89,6 +89,7 @@
     margins.right = MenusDesignDefaultContentSpacing / 4.0;
     margins.bottom = margins.top;
     textFieldContainerView.layoutMargins = margins;
+    textFieldContainerView.insetsLayoutMarginsFromSafeArea = YES;
 
     UILayoutGuide *marginGuide = textFieldContainerView.layoutMarginsGuide;
 

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingHeaderView.m
@@ -43,15 +43,10 @@
 
     [self addSubview:stackView];
 
-    NSLayoutConstraint *topConstraint = [stackView.topAnchor constraintEqualToAnchor:self.topAnchor constant:margins.top];
-    topConstraint.priority = UILayoutPriorityDefaultHigh;
-    _stackViewTopConstraint  = topConstraint;
-
     NSLayoutConstraint *bottomConstraint = [stackView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor constant:-margins.bottom];
     bottomConstraint.priority = UILayoutPriorityDefaultHigh;
 
     [NSLayoutConstraint activateConstraints:@[
-                                              topConstraint,
                                               bottomConstraint,
                                               [stackView.leadingAnchor constraintEqualToAnchor:self.leadingAnchor constant:margins.left],
                                               [stackView.trailingAnchor constraintEqualToAnchor:self.trailingAnchor constant:-margins.right]

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingHeaderView.m
@@ -8,7 +8,6 @@
 
 @property (nonatomic, strong, readonly) UIStackView *stackView;
 @property (nonatomic, strong, readonly) NSLayoutConstraint *stackViewTopConstraint;
-@property (nonatomic, strong, readonly) UIView *textFieldContainerView;
 @property (nonatomic, strong, readonly) UIImageView *iconView;
 
 @end
@@ -79,8 +78,6 @@
 
     NSAssert(_stackView != nil, @"stackView is nil");
     [_stackView addArrangedSubview:textFieldContainerView];
-
-    _textFieldContainerView = textFieldContainerView;
 
     UIEdgeInsets margins = UIEdgeInsetsZero;
     margins.top = [self defaultStackDesignMargin];


### PR DESCRIPTION
Fixes #12996 

To test:
* Open *Menus* from a site page
* Tap on any added menu option

Current state: text field looks shrank, link icon doesn't respect the safe area
<img width="375" alt="image" src="https://user-images.githubusercontent.com/13601748/70331367-fd525f00-1847-11ea-81ef-b94495ef97aa.png">
<img width="399" alt="image" src="https://user-images.githubusercontent.com/13601748/70331376-03484000-1848-11ea-91f9-3e3fb90792e0.png">

After applied changes:
<img width="442" alt="image" src="https://user-images.githubusercontent.com/13601748/70331441-2246d200-1848-11ea-9630-fa7b4505b633.png">
<img width="409" alt="image" src="https://user-images.githubusercontent.com/13601748/70331457-270b8600-1848-11ea-8c03-b1c0e8228ed3.png">


PR submission checklist:

- [x ] I have considered adding unit tests where possible.

- [x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
