### PR TITLE
[VoiceOver] Enhancements for Aztec editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -415,6 +415,13 @@ class AztecPostViewController: UIViewController, PostEditor {
         return insertItem
     }()
 
+    /// Indicates whether the `insertToolbarItem` is always shown in `FormatBarMode.media` mode.
+    ///
+    /// If true, the insertToolbarItem is enabled and disabled instead of shown and hidden.
+    private var alwaysDisplayInsertToolbarItem: Bool {
+        UIAccessibility.isVoiceOverRunning
+    }
+
     fileprivate var mediaPickerInputViewController: WPInputMediaPickerViewController?
 
     fileprivate var originalLeadingBarButtonGroup = [UIBarButtonItemGroup]()
@@ -2048,6 +2055,7 @@ extension AztecPostViewController {
         case .media:
             toolbar.setDefaultItems(mediaItemsForToolbar,
                                     overflowItems: [])
+            setupFormatBarAccessibilityForMediaMode(toolbar)
         }
     }
 
@@ -3206,8 +3214,15 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
         }
 
         if assetCount == 0 {
-            formatBar.trailingItem = nil
+            insertToolbarItem.isEnabled = false
+            insertToolbarItem.setTitle(Constants.mediaPickerInsertTextDefault, for: .normal)
+
+            if !alwaysDisplayInsertToolbarItem {
+                formatBar.trailingItem = nil
+            }
         } else {
+            insertToolbarItem.isEnabled = true
+
             insertToolbarItem.setTitle(String(format: Constants.mediaPickerInsertText, NSNumber(value: assetCount)), for: .normal)
             insertToolbarItem.accessibilityIdentifier = "insert_media_button"
 
@@ -3215,6 +3230,15 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
                 formatBar.trailingItem = insertToolbarItem
             }
         }
+    }
+
+    /// Called once whenever the `formatBar` is switched from text to media mode.
+    private func setupFormatBarAccessibilityForMediaMode(_ formatBar: Aztec.FormatBar) {
+        if alwaysDisplayInsertToolbarItem {
+            formatBar.trailingItem = insertToolbarItem
+        }
+        
+        updateFormatBarInsertAssetCount()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -270,6 +270,8 @@ class AztecPostViewController: UIViewController, PostEditor {
         titlePlaceholderLabel.translatesAutoresizingMaskIntoConstraints = false
         titlePlaceholderLabel.textAlignment = .natural
 
+        titlePlaceholderLabel.isAccessibilityElement = false
+
         return titlePlaceholderLabel
     }()
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -410,6 +410,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         insertItem.titleLabel?.font = Fonts.mediaPickerInsert
         insertItem.tintColor = .primary
         insertItem.setTitleColor(.primary, for: .normal)
+        insertItem.accessibilityLabel = Constants.mediaPickerInsertAccessibilityLabel
 
         return insertItem
     }()
@@ -3293,6 +3294,7 @@ extension AztecPostViewController {
         static let toolbarHeight            = CGFloat(44.0)
         static let mediaPickerInsertTextDefault = NSLocalizedString("Insert", comment: "Default button title used in media picker to insert media (photos / videos) into a post.")
         static let mediaPickerInsertText    = NSLocalizedString("Insert %@", comment: "Button title used in media picker to insert media (photos / videos) into a post. Placeholder will be the number of items that will be inserted.")
+        static let mediaPickerInsertAccessibilityLabel = NSLocalizedString("Insert selected", comment: "Default accessibility label for the media picker insert button.")
         static let mediaPickerKeyboardHeightRatioPortrait   = CGFloat(0.20)
         static let mediaPickerKeyboardHeightRatioLandscape  = CGFloat(0.30)
         static let mediaOverlayBorderWidth  = CGFloat(3.0)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3291,6 +3291,7 @@ extension AztecPostViewController {
         static let headers                  = [Header.HeaderType.none, .h1, .h2, .h3, .h4, .h5, .h6]
         static let lists                    = [TextList.Style.unordered, .ordered]
         static let toolbarHeight            = CGFloat(44.0)
+        static let mediaPickerInsertTextDefault = NSLocalizedString("Insert", comment: "Default button title used in media picker to insert media (photos / videos) into a post.")
         static let mediaPickerInsertText    = NSLocalizedString("Insert %@", comment: "Button title used in media picker to insert media (photos / videos) into a post. Placeholder will be the number of items that will be inserted.")
         static let mediaPickerKeyboardHeightRatioPortrait   = CGFloat(0.20)
         static let mediaPickerKeyboardHeightRatioLandscape  = CGFloat(0.30)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3215,6 +3215,8 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
 
         if assetCount == 0 {
             insertToolbarItem.isEnabled = false
+            insertToolbarItem.accessibilityValue = nil
+            
             insertToolbarItem.setTitle(Constants.mediaPickerInsertTextDefault, for: .normal)
 
             if !alwaysDisplayInsertToolbarItem {
@@ -3222,6 +3224,7 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
             }
         } else {
             insertToolbarItem.isEnabled = true
+            insertToolbarItem.accessibilityValue = "\(assetCount)"
 
             insertToolbarItem.setTitle(String(format: Constants.mediaPickerInsertText, NSNumber(value: assetCount)), for: .normal)
             insertToolbarItem.accessibilityIdentifier = "insert_media_button"
@@ -3237,7 +3240,7 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
         if alwaysDisplayInsertToolbarItem {
             formatBar.trailingItem = insertToolbarItem
         }
-        
+
         updateFormatBarInsertAssetCount()
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -411,6 +411,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         insertItem.tintColor = .primary
         insertItem.setTitleColor(.primary, for: .normal)
         insertItem.accessibilityLabel = Constants.mediaPickerInsertAccessibilityLabel
+        insertItem.accessibilityIdentifier = "insert_media_button"
 
         return insertItem
     }()
@@ -3216,7 +3217,7 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
         if assetCount == 0 {
             insertToolbarItem.isEnabled = false
             insertToolbarItem.accessibilityValue = nil
-            
+
             insertToolbarItem.setTitle(Constants.mediaPickerInsertTextDefault, for: .normal)
 
             if !alwaysDisplayInsertToolbarItem {
@@ -3227,7 +3228,6 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
             insertToolbarItem.accessibilityValue = "\(assetCount)"
 
             insertToolbarItem.setTitle(String(format: Constants.mediaPickerInsertText, NSNumber(value: assetCount)), for: .normal)
-            insertToolbarItem.accessibilityIdentifier = "insert_media_button"
 
             if formatBar.trailingItem != insertToolbarItem {
                 formatBar.trailingItem = insertToolbarItem


### PR DESCRIPTION
Refs #12953

## Changes

### Removed extra accessible “Title“

<img src="https://user-images.githubusercontent.com/198826/70333409-aa08ee00-1800-11ea-9f25-b1203f2d9e1b.png" width="240">

This accessible element is the title placeholder (`UILabel`) and can be confused with the title text field. 

### Made “Insert” button always visible when VoiceOver is turned on

Disabled if nothing is selected | Enabled when a media is selected
--------|-------
![image](https://user-images.githubusercontent.com/198826/70333471-cb69da00-1800-11ea-9efc-54bffe2887c3.png)        |       ![image](https://user-images.githubusercontent.com/198826/70333486-d3c21500-1800-11ea-9a0d-5ee40459a798.png)

Making it visible could make it more discoverable and makes it easier to understand how to use the UI. If VoiceOver is turned off, the app will use the original behavior of hiding or showing the button. 

I also changed the `accessibilityLabel` of the button to `“Insert selected”` to make it more obvious **when** it will be enabled. 

## Testing

### For: Removed extra accessible “Title“

1. Turn VoiceOver on.
2. Create a new post (Aztec)
3. Navigate by swiping right or left. Confirm that there is only one accessible “Title“ element and it can be activated

### For: Made “Insert” button always visible when VoiceOver is turned on

1. Turn VoiceOver on.
2. Create a new post (Aztec)
3. Navigate to the content text field so that the Insert Media button is enabled. 
4. Tap on the Insert Media button. 
5. Confirm that the Insert button (on the right) is shown but disabled. 
6. Select a media. 
7. Confirm that the Insert button is enabled and VoiceOver will speak “Insert selected, 1, button“. 

If possible, please do a regression test with VoiceOver turned off. The Insert button should still be hidden and shown if necessary. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
