### PR TITLE
Make placeholder images tinted with text color.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3108,7 +3108,7 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
     }
 
     func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
-        return mediaUtility.placeholderImage(for: attachment, size: Constants.mediaPlaceholderImageSize)
+        return mediaUtility.placeholderImage(for: attachment, size: Constants.mediaPlaceholderImageSize, tintColor: textView.textColor)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/AztecAttachmentDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/AztecAttachmentDelegate.swift
@@ -37,7 +37,7 @@ class AztecAttachmentDelegate: TextViewAttachmentDelegate {
     }
 
     func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
-        return mediaUtility.placeholderImage(for: attachment, size: Constants.mediaPlaceholderImageSize)
+        return mediaUtility.placeholderImage(for: attachment, size: Constants.mediaPlaceholderImageSize, tintColor: textView.textColor)
     }
 
     func textView(_ textView: TextView, deletedAttachment attachment: MediaAttachment) {

--- a/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
@@ -21,11 +21,8 @@ class EditorMediaUtility {
         default:
             icon = Gridicon.iconOfType(.attachment, withSize: size)
         }
-        if #available(iOS 13.0, *) {
-            if let color = tintColor {
-
-                icon = icon.withTintColor(color)
-            }
+        if #available(iOS 13.0, *), let color = tintColor {
+            icon = icon.withTintColor(color)
         }
         icon.addAccessibilityForAttachment(attachment)
         return icon

--- a/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
@@ -7,8 +7,8 @@ class EditorMediaUtility {
         static let placeholderDocumentLink = URL(string: "documentUploading://")!
     }
 
-    func placeholderImage(for attachment: NSTextAttachment, size: CGSize) -> UIImage {
-        let icon: UIImage
+    func placeholderImage(for attachment: NSTextAttachment, size: CGSize, tintColor: UIColor?) -> UIImage {
+        var icon: UIImage
         switch attachment {
         case let imageAttachment as ImageAttachment:
             if imageAttachment.url == Constants.placeholderDocumentLink {
@@ -21,7 +21,12 @@ class EditorMediaUtility {
         default:
             icon = Gridicon.iconOfType(.attachment, withSize: size)
         }
+        if #available(iOS 13.0, *) {
+            if let color = tintColor {
 
+                icon = icon.withTintColor(color)
+            }
+        }
         icon.addAccessibilityForAttachment(attachment)
         return icon
     }

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewTextViewManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewTextViewManager.swift
@@ -38,7 +38,7 @@ extension RevisionPreviewTextViewManager: TextViewAttachmentDelegate {
     }
 
     func textView(_ textView: TextView, placeholderFor attachment: NSTextAttachment) -> UIImage {
-        return mediaUtility.placeholderImage(for: attachment, size: Constants.mediaPlaceholderImageSize)
+        return mediaUtility.placeholderImage(for: attachment, size: Constants.mediaPlaceholderImageSize, tintColor: textView.textColor)
     }
 
     /* These 3 functions are mandatory implemented but not needed


### PR DESCRIPTION
This way the placeholder images will adapt to the current interface
mode on the device.

Fixes #https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1236

**Note**: At this PR I'm not fixing the placeholders when the user switches from dark mode to light mode, while the editor is open. This will need a fix in the Aztec lib to force a refresh of the media attachments.

To test:
 - Start the app using dark mode

Scenario 1:

 - Open a new post
 - Insert a new media from device
 - Check that the placeholder image show properly while the final image is not ready

Scenario 2

 - Open a post with several images
 - Check that the placeholder images show properly while the final images are loading.

Run the same tests with image/video/files
Run the same tests with light mode to make sure all is ok

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
