### PR TITLE
[VoiceOver] Published Date Picker enhancements

### DIFF
--- a/WordPress/Classes/Extensions/NotificationCenter+ObserveMultiple.swift
+++ b/WordPress/Classes/Extensions/NotificationCenter+ObserveMultiple.swift
@@ -1,0 +1,13 @@
+
+import Foundation
+
+extension NotificationCenter {
+    /// Adds an observer for all the given `NSNotification.Name`
+    ///
+    func addObserver(_ observer: Any, selector aSelector: Selector,
+                     names: [NSNotification.Name], object anObject: Any?) {
+        names.forEach {
+            addObserver(observer, selector: aSelector, name: $0, object: anObject)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/ChosenValueRow.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/ChosenValueRow.swift
@@ -13,7 +13,7 @@ class ChosenValueRow: UIView {
         label.accessibilityTraits = .header
         return label
     }()
-    
+
     let detailLabel = UILabel()
 
     override init(frame: CGRect) {

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/ChosenValueRow.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/ChosenValueRow.swift
@@ -8,7 +8,12 @@ class ChosenValueRow: UIView {
         static let rowInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
     }
 
-    let titleLabel = UILabel()
+    let titleLabel: UILabel = {
+        let label = UILabel()
+        label.accessibilityTraits = .header
+        return label
+    }()
+    
     let detailLabel = UILabel()
 
     override init(frame: CGRect) {

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
@@ -45,7 +45,14 @@ class SchedulingCalendarViewController: UIViewController, DatePickerSheet, DateC
         return calendarMonthView
     }()
 
-    private lazy var closeButton = UIBarButtonItem(image: Gridicon.iconOfType(.cross), style: .plain, target: self, action: #selector(SchedulingCalendarViewController.closeButtonPressed))
+    private lazy var closeButton: UIBarButtonItem = {
+        let item = UIBarButtonItem(image: Gridicon.iconOfType(.cross),
+                                   style: .plain,
+                                   target: self,
+                                   action: #selector(closeButtonPressed))
+        item.accessibilityLabel = NSLocalizedString("Close", comment: "Accessibility label for the date picker's close button.")
+        return item
+    }()
     private lazy var publishButton = UIBarButtonItem(title: NSLocalizedString("Publish immediately", comment: "Immediately publish button title"), style: .plain, target: self, action: #selector(SchedulingCalendarViewController.publishImmediately))
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
@@ -113,7 +113,9 @@ class SchedulingCalendarViewController: UIViewController, DatePickerSheet, DateC
     }
 
     @objc private func resetNavigationButtons() {
-        let includeCloseButton = traitCollection.verticalSizeClass == .compact || isVoiceOverOrSwitchControlRunning
+        let includeCloseButton = traitCollection.verticalSizeClass == .compact ||
+            (isVoiceOverOrSwitchControlRunning && navigationController?.modalPresentationStyle != .popover)
+
         if includeCloseButton {
             navigationItem.leftBarButtonItems = [closeButton, publishButton]
         } else {

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
@@ -16,6 +16,8 @@ class DateCoordinator {
     }
 }
 
+// MARK: - Date Picker
+
 class SchedulingCalendarViewController: UIViewController, DatePickerSheet, DateCoordinatorHandler {
 
     var coordinator: DateCoordinator? = nil
@@ -59,6 +61,8 @@ class SchedulingCalendarViewController: UIViewController, DatePickerSheet, DateC
         calendarMonthView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         calendarMonthView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         calendarMonthView.setContentHuggingPriority(.defaultHigh, for: .vertical)
+
+        setupForAccessibility()
     }
 
     override func viewDidLayoutSubviews() {
@@ -78,12 +82,7 @@ class SchedulingCalendarViewController: UIViewController, DatePickerSheet, DateC
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.verticalSizeClass == .compact {
-            navigationItem.leftBarButtonItems = [closeButton, publishButton]
-        } else {
-            navigationItem.leftBarButtonItems = [publishButton]
-        }
+        resetNavigationButtons()
     }
 
     @objc func closeButtonPressed() {
@@ -100,7 +99,37 @@ class SchedulingCalendarViewController: UIViewController, DatePickerSheet, DateC
         vc.coordinator = coordinator
         navigationController?.pushViewController(vc, animated: true)
     }
+
+    @objc private func resetNavigationButtons() {
+        let includeCloseButton = traitCollection.verticalSizeClass == .compact || isVoiceOverOrSwitchControlRunning
+        if includeCloseButton {
+            navigationItem.leftBarButtonItems = [closeButton, publishButton]
+        } else {
+            navigationItem.leftBarButtonItems = [publishButton]
+        }
+    }
 }
+
+// MARK: Accessibility
+
+private extension SchedulingCalendarViewController {
+    func setupForAccessibility() {
+        let notificationNames = [
+            UIAccessibility.voiceOverStatusDidChangeNotification,
+            UIAccessibility.switchControlStatusDidChangeNotification
+        ]
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(resetNavigationButtons),
+                                               names: notificationNames,
+                                               object: nil)
+    }
+
+    var isVoiceOverOrSwitchControlRunning: Bool {
+        UIAccessibility.isVoiceOverRunning || UIAccessibility.isSwitchControlRunning
+    }
+}
+
+// MARK: - Time Picker
 
 class TimePickerViewController: UIViewController, DatePickerSheet, DateCoordinatorHandler {
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
@@ -89,6 +89,11 @@ class SchedulingCalendarViewController: UIViewController, DatePickerSheet, DateC
         dismiss(animated: true, completion: nil)
     }
 
+    override func accessibilityPerformEscape() -> Bool {
+        dismiss(animated: true, completion: nil)
+        return true
+    }
+
     @objc func publishImmediately() {
         coordinator?.updated(nil)
         navigationController?.dismiss(animated: true, completion: nil)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -555,6 +555,7 @@
 		570BFD8D22823DE5007859A8 /* PostActionSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8C22823DE5007859A8 /* PostActionSheetTests.swift */; };
 		570BFD902282418A007859A8 /* PostBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8F2282418A007859A8 /* PostBuilder.swift */; };
 		57240224234E5BE200227067 /* PostServiceSelfHostedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57240223234E5BE200227067 /* PostServiceSelfHostedTests.swift */; };
+		57276E71239BDFD200515BE2 /* NotificationCenter+ObserveMultiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57276E70239BDFD200515BE2 /* NotificationCenter+ObserveMultiple.swift */; };
 		5727EAF82284F5AC00822104 /* InteractivePostViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5727EAF72284F5AC00822104 /* InteractivePostViewDelegate.swift */; };
 		572FB401223A806000933C76 /* NoticeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572FB400223A806000933C76 /* NoticeStoreTests.swift */; };
 		5749984722FA0F2E00CE86ED /* PostNoticeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5749984622FA0F2E00CE86ED /* PostNoticeViewModelTests.swift */; };
@@ -2682,6 +2683,7 @@
 		570BFD8C22823DE5007859A8 /* PostActionSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostActionSheetTests.swift; sourceTree = "<group>"; };
 		570BFD8F2282418A007859A8 /* PostBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostBuilder.swift; sourceTree = "<group>"; };
 		57240223234E5BE200227067 /* PostServiceSelfHostedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostServiceSelfHostedTests.swift; path = Services/PostServiceSelfHostedTests.swift; sourceTree = "<group>"; };
+		57276E70239BDFD200515BE2 /* NotificationCenter+ObserveMultiple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationCenter+ObserveMultiple.swift"; sourceTree = "<group>"; };
 		5727EAF72284F5AC00822104 /* InteractivePostViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractivePostViewDelegate.swift; sourceTree = "<group>"; };
 		572FB400223A806000933C76 /* NoticeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStoreTests.swift; sourceTree = "<group>"; };
 		5749984622FA0F2E00CE86ED /* PostNoticeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticeViewModelTests.swift; sourceTree = "<group>"; };
@@ -5101,7 +5103,7 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -8086,6 +8088,7 @@
 				9A4E939E2268D9B400E14823 /* UIViewController+NoResults.swift */,
 				0845B8C51E833C56001BA771 /* URL+Helpers.swift */,
 				17E60E08220DBD6E00848F89 /* WKWebView+Preview.swift */,
+				57276E70239BDFD200515BE2 /* NotificationCenter+ObserveMultiple.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -9860,7 +9863,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -11536,6 +11539,7 @@
 				7E729C28209A087300F76599 /* ImageLoader.swift in Sources */,
 				73C8F06821BF1A5E00DDDF7E /* SiteAssemblyContentView.swift in Sources */,
 				5D146EBB189857ED0068FDC6 /* FeaturedImageViewController.m in Sources */,
+				57276E71239BDFD200515BE2 /* NotificationCenter+ObserveMultiple.swift in Sources */,
 				D817799020ABF26800330998 /* ReaderCellConfiguration.swift in Sources */,
 				D88106FC20C0D4A4001D2F00 /* ReaderSavedPostCellActions.swift in Sources */,
 				31EC15081A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m in Sources */,


### PR DESCRIPTION
Refs #12959.  

This fixes only a few things in #12959 but it felt like a good stopping point. 🙂 

## Changes

### Allow Dismissal

Currently, you cannot dismiss the picker by using the global escape (Z). The Close button is also hidden when in portrait mode. With VoiceOver turned on, you basically have to continue and pick a date and time to dismiss the picker. 

- The Close button is now always shown in iPhone portrait mode if VoiceOver (or Switch Control) is turned on
- You can dismiss the picker using VoiceOver by using the global escape (making a Z with 2 fingers)

### Labels and Traits

Heading | Close Button
--------|-------
![image](https://user-images.githubusercontent.com/198826/70376501-c8392180-18c6-11ea-89d3-213c5e1010ca.png)        |       ![image](https://user-images.githubusercontent.com/198826/70376506-cf602f80-18c6-11ea-97ac-baf4c5898fcb.png)

I made the “Choose a date” a heading to (possibly) better clarify what the user is currently interacting with. The Close button was also missing an accessibility label. 

## Testing

1. Turn VoiceOver on
1. Navigate to Post Settings → Publish → Date and Time
3. Confirm that you can dismiss using the methods described above. 
4. Confirm that the “Choose a date” is declared as a heading by VoiceOver. 
5. Confirm that the Close button is no longer described by VoiceOver as “Possibly, Close”. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
