### PR TITLE
Standardize Reader menu list icon colors

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -613,7 +613,8 @@ import WordPressShared
 
         cell.selectionStyle = .default
         cell.textLabel?.text = menuItem.title
-        cell.imageView?.image = menuItem.icon
+        cell.imageView?.tintColor = .listIcon
+        cell.imageView?.image = menuItem.icon?.withRenderingMode(.alwaysTemplate)
     }
 
 


### PR DESCRIPTION
Fixes #12795. This PR ensures all icons in the Reader menu use the same tint color.

![icons](https://user-images.githubusercontent.com/4780/70466589-5ece3400-1abb-11ea-8fc7-ff0ab3cdab9e.png)

To test:

* Build and run and navigate to the Reader menu. You'll best be able to see this change if you have the Automattic item in your Reader.
* Ensure the colors of the list icons are all the same.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
