### PR TITLE
Stats: Lighten selected highlight color on bar charts

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -19,7 +19,7 @@ class StatsBarChartView: BarChartView {
         static let intrinsicHeight          = CGFloat(150)
         static let highlightAlpha           = CGFloat(1)
         static let horizontalAxisLabelCount = 2
-        static let markerAlpha              = CGFloat(0.2)
+        static let markerAlpha              = CGFloat(0.1)
         static let presentationDelay        = TimeInterval(0.01)
         static let primaryDataSetIndex      = 0
         static let rotationDelay            = TimeInterval(0.35)


### PR DESCRIPTION
Fixes #12283. This PR just slightly adjusts the alpha component of the stats chart highlight background to make the bar itself stand out more.

![bar-highlight](https://user-images.githubusercontent.com/4780/70521637-73e8a880-1b37-11ea-8fcf-bf0e2168c3ca.png)

**To test:**

* Build and run, select a bar in stats and check it looks like the above

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
