### PR TITLE
Add All Time Widget signing configuration

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -376,7 +376,8 @@ import "./ScreenshotFastfile"
                        "org.wordpress.alpha.WordPressDraftAction",
                        "org.wordpress.alpha.WordPressTodayWidget",
                        "org.wordpress.alpha.WordPressNotificationServiceExtension",
-                       "org.wordpress.alpha.WordPressNotificationContentExtension"])
+                       "org.wordpress.alpha.WordPressNotificationContentExtension", 
+                       "org.wordpress.alpha.WordPressAllTimeWidget"])
   end
 
   private_lane :internal_code_signing do |options|
@@ -389,7 +390,8 @@ import "./ScreenshotFastfile"
                        "org.wordpress.internal.WordPressDraftAction",
                        "org.wordpress.internal.WordPressTodayWidget",
                        "org.wordpress.internal.WordPressNotificationServiceExtension",
-                       "org.wordpress.internal.WordPressNotificationContentExtension"])
+                       "org.wordpress.internal.WordPressNotificationContentExtension",
+                       "org.wordpress.internal.WordPressAllTimeWidget"])
   end
 
   private_lane :appstore_code_signing do |options|
@@ -402,7 +404,8 @@ import "./ScreenshotFastfile"
                        "org.wordpress.WordPressDraftAction",
                        "org.wordpress.WordPressTodayWidget",
                        "org.wordpress.WordPressNotificationServiceExtension",
-                       "org.wordpress.WordPressNotificationContentExtension"])
+                       "org.wordpress.WordPressNotificationContentExtension",
+                       "org.wordpress.WordPressAllTimeWidget"])
   end
 
 ########################################################################

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -14678,7 +14678,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressAllTimeWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "WordPress All Time Widget App Store Distribution";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore org.wordpress.WordPressAllTimeWidget";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressAllTimeWidget/WordPressAllTimeWidget-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -14707,7 +14707,7 @@
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = PZYM8XX95Q;
+				DEVELOPMENT_TEAM = 99KV9Z6BKV;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -14726,7 +14726,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.internal.WordPressAllTimeWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "WordPress All Time Widget Adhoc Distribution";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.internal.WordPressAllTimeWidget";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressAllTimeWidget/WordPressAllTimeWidget-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -14755,7 +14755,7 @@
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = PZYM8XX95Q;
+				DEVELOPMENT_TEAM = 99KV9Z6BKV;
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -14774,7 +14774,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.alpha.WordPressAllTimeWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "WordPress All Time Widget Adhoc Distribution";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha.WordPressAllTimeWidget";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressAllTimeWidget/WordPressAllTimeWidget-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
https://github.com/wordpress-mobile/WordPress-iOS/pull/13053 added a new All Time Widget, but it didn't include the configuration of the profiles for all the schemes. 
This PR just adds the new profiles and the related configuration. 

### To test:
- Check that CI is green. 
- Check that an Installable build has been successfully generated. 
- Check that a local build on your machine is successful. 

@cameronvoell you'll need to rebase your branch after this is merged into `develop` in order to fix Installable Builds. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
