### PR TITLE
[VoiceOver] Site Creation → Domains enhancements

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
@@ -29,6 +29,8 @@ final class AddressCell: UITableViewCell, ModelSettableCell {
 
     private func commonInit() {
         selectedBackgroundView?.backgroundColor = .clear
+
+        accessibilityTraits = .button
     }
 
     override func awakeFromNib() {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
@@ -31,6 +31,8 @@ final class AddressCell: UITableViewCell, ModelSettableCell {
         selectedBackgroundView?.backgroundColor = .clear
 
         accessibilityTraits = .button
+        accessibilityHint = NSLocalizedString("Selects this domain to use for your site.",
+                                              comment: "Accessibility hint for a domain in the Site Creation domains list.")
     }
 
     override func awakeFromNib() {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -226,6 +226,11 @@ final class WebAddressWizardContent: UIViewController {
         } else {
             noResultsLabel.isHidden = true
         }
+
+        if !isShowingImplicitSuggestions && !data.isEmpty {
+            UIAccessibility.post(notification: .announcement,
+                                 argument: NSLocalizedString("Suggestions updated", comment: "Announced by VoiceOver when new domains suggestions are shown in Site Creation."))
+        }
     }
 
     private func handleError(_ error: Error) {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -271,7 +271,8 @@ final class WebAddressWizardContent: UIViewController {
         let buttonTitle = NSLocalizedString("Create Site", comment: "Button to progress to the next step")
         createSite.setTitle(buttonTitle, for: .normal)
         createSite.accessibilityLabel = buttonTitle
-        createSite.accessibilityHint = NSLocalizedString("Creates a new Site", comment: "Site creation. Navigates to the next step")
+        createSite.accessibilityHint = NSLocalizedString("Creates a new site with the given information.",
+                                                         comment: "Accessibility hint for the Create Site button in Site Creation.")
 
         createSite.isPrimary = true
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -465,6 +465,8 @@ final class WebAddressWizardContent: UIViewController {
     // MARK: - Toolbar
 
     private func toggleBottomToolbar(enabled: Bool) {
+        createSite.isEnabled = enabled
+
         if enabled {
             tableViewOffsetCoordinator?.showBottomToolbar()
         } else {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -62,6 +62,8 @@ final class WebAddressWizardContent: UIViewController {
     /// This message advises the user that
     private let noResultsLabel: UILabel
 
+    private let isBottomToolbarAlwaysVisible = UIAccessibility.isVoiceOverRunning
+
     // MARK: WebAddressWizardContent
 
     init(creator: SiteCreator, service: SiteAddressService, selection: @escaping (DomainSuggestion) -> Void) {
@@ -104,7 +106,7 @@ final class WebAddressWizardContent: UIViewController {
 
         self.tableViewOffsetCoordinator = TableViewOffsetCoordinator(coordinated: table, footerControlContainer: view, footerControl: buttonWrapper, toolbarBottomConstraint: bottomConstraint)
 
-        tableViewOffsetCoordinator?.hideBottomToolbar()
+        toggleBottomToolbar(enabled: false)
 
         applyTitle()
         setupBackground()
@@ -180,7 +182,7 @@ final class WebAddressWizardContent: UIViewController {
     private func clearContent() {
         throttle.cancel()
 
-        tableViewOffsetCoordinator?.hideBottomToolbar()
+        toggleBottomToolbar(enabled: false)
 
         guard let validDataProvider = tableViewProvider as? WebAddressTableViewProvider else {
             setupTableDataProvider(isShowingImplicitSuggestions: true)
@@ -410,7 +412,7 @@ final class WebAddressWizardContent: UIViewController {
             let domainSuggestion = provider.data[selectedIndexPath.row]
             self.selectedDomain = domainSuggestion
             self.resignTextFieldResponderIfNeeded()
-            self.tableViewOffsetCoordinator?.showBottomToolbar()
+            self.toggleBottomToolbar(enabled: true)
         }
 
         let provider = WebAddressTableViewProvider(tableView: table, data: data, selectionHandler: handler)
@@ -436,7 +438,7 @@ final class WebAddressWizardContent: UIViewController {
     private func clearSelectionAndCreateSiteButton() {
         selectedDomain = nil
         table.deselectSelectedRowWithAnimation(true)
-        tableViewOffsetCoordinator?.hideBottomToolbar()
+        toggleBottomToolbar(enabled: false)
     }
 
     private func trackDomainsSelection(_ domainSuggestion: DomainSuggestion) {
@@ -458,6 +460,18 @@ final class WebAddressWizardContent: UIViewController {
 
         performSearchIfNeeded(query: query)
         tableViewOffsetCoordinator?.adjustTableOffsetIfNeeded()
+    }
+
+    // MARK: - Toolbar
+
+    private func toggleBottomToolbar(enabled: Bool) {
+        if enabled {
+            tableViewOffsetCoordinator?.showBottomToolbar()
+        } else {
+            if !isBottomToolbarAlwaysVisible {
+                tableViewOffsetCoordinator?.hideBottomToolbar()
+            }
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -358,6 +358,8 @@ final class WebAddressWizardContent: UIViewController {
         let attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: attributes)
         header.textField.attributedPlaceholder = attributedPlaceholder
 
+        header.textField.accessibilityHint = NSLocalizedString("Searches for available domains to use for your site.", comment: "Accessibility hint for the domains search field in Site Creation.")
+
         table.tableHeaderView = header
 
         view.addSubview(noResultsLabel)

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -81,9 +81,7 @@ final class WebAddressWizardContent: UIViewController {
             label.font = WPStyleGuide.fontForTextStyle(.title2)
             label.textAlignment = .center
             label.textColor = .text
-
-            let noResultsMessage = NSLocalizedString("No available addresses matching your search", comment: "Advises the user that no Domain suggestions could be found for the search query.")
-            label.text = noResultsMessage
+            label.text = Strings.noResults
 
             label.sizeToFit()
 
@@ -230,8 +228,7 @@ final class WebAddressWizardContent: UIViewController {
         }
 
         if !isShowingImplicitSuggestions && !data.isEmpty {
-            UIAccessibility.post(notification: .announcement,
-                                 argument: NSLocalizedString("Suggestions updated", comment: "Announced by VoiceOver when new domains suggestions are shown in Site Creation."))
+            UIAccessibility.post(notification: .announcement, argument: Strings.suggestionsUpdated)
         }
     }
 
@@ -476,6 +473,15 @@ final class WebAddressWizardContent: UIViewController {
                 tableViewOffsetCoordinator?.hideBottomToolbar()
             }
         }
+    }
+
+    // MARK: - Others
+
+    private enum Strings {
+        static let suggestionsUpdated = NSLocalizedString("Suggestions updated",
+                                                          comment: "Announced by VoiceOver when new domains suggestions are shown in Site Creation.")
+        static let noResults = NSLocalizedString("No available addresses matching your search",
+                                                 comment: "Advises the user that no Domain suggestions could be found for the search query.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -227,8 +227,8 @@ final class WebAddressWizardContent: UIViewController {
             noResultsLabel.isHidden = true
         }
 
-        if !isShowingImplicitSuggestions && !data.isEmpty {
-            UIAccessibility.post(notification: .announcement, argument: Strings.suggestionsUpdated)
+        if !isShowingImplicitSuggestions {
+            postSuggestionsUpdateAnnouncementForVoiceOver(listIsEmpty: data.isEmpty)
         }
     }
 
@@ -525,5 +525,10 @@ extension WebAddressWizardContent {
 private extension WebAddressWizardContent {
     func postScreenChangedForVoiceOver() {
         UIAccessibility.post(notification: .screenChanged, argument: table.tableHeaderView)
+    }
+
+    func postSuggestionsUpdateAnnouncementForVoiceOver(listIsEmpty: Bool) {
+        let message: String = listIsEmpty ? Strings.noResults : Strings.suggestionsUpdated
+        UIAccessibility.post(notification: .announcement, argument: message)
     }
 }


### PR DESCRIPTION
Refs #12127. 

This doesn't completely _fix_ #12127. I feel like there is still more we can do with the Domains step. But I'm not quite sure what those are. This PR hopefully makes the UI a bit easier to understand by VoiceOver users. 

## Changes 

### Announcing Suggestions Update

To help guide what needs to be done after entering something in the search field, I added a “Suggestions updated” announcement for VoiceOver. This idea was taken from [Android's implementation](https://github.com/wordpress-mobile/WordPress-Android/commit/990f0de44ea1702f87bc28c81e8bf1ac810f0fcd) which does the same thing.

<img src="https://user-images.githubusercontent.com/198826/70640057-9989b680-1bf8-11ea-99e1-225ab8e8204f.png" width="320">

### Create Site Button Visibility

By default, the _Create Site_ button is only shown when the user has selected a domain. My theory related to this is UI elements that are hidden and shown after an action is not ideal for VoiceOver users. There is usually no indication that something has happened in the UI. And it is less easy to understand how the UI works if a critical button is not there. 

In cases like this, we could:

a. Announce and focus the button when it is visible like the Notices (https://github.com/wordpress-mobile/WordPress-iOS/pull/12873). 
b. Make the button visible but disabled like the Insert button in Aztec (https://github.com/wordpress-mobile/WordPress-iOS/pull/13050). 

I decided to proceed with (b) as changing the focus (a) can be a jarring experience if they're just moving around on the domains list. 

<img src="https://user-images.githubusercontent.com/198826/70641197-74964300-1bfa-11ea-9230-41a05ace52c0.png" width="320">

### Labels and Hints

I also added various labels and hints:

- The domain cell is now a button (154987b16cd0f76917321036e9272cce7d94f5bd) and has a hint (254011360de1b3604c0c4f123bf224e9aa47c7e0)
- Added a hint to the search (839e92ee8ededdc4a6dd71648b40e5935b676d8b). I wasn't sure about this one but I hope it helps. 

## Outstanding Issues

I noticed that the domain search field gets disabled after you pick a domain. I think this is a bug and may have been unintentionally caused by https://github.com/wordpress-mobile/WordPress-iOS/pull/11739. I'll create a separate issue for it. 

## Testing

1. Turn VoiceOver on *before* tapping on the Add site button.
2. Tap on My Sites → Add button
3. Go through the steps until Step 3 of 3 (Domains). 
4. Confirm that:
    a. The Create Site button is always visible. It is enabled and disabled instead. 
    b. A “Suggestions updated” is announced after you finish typing something in the search field and waited for a bit until the search results are there. 
    c. The labels and hints described above are announced. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
