### PR TITLE
Commenting: Refreshes the ReplyTextView UI colors and font

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -256,7 +256,7 @@ import WordPressShared.WPStyleGuide
         bezierContainerView.outerColor = WPStyleGuide.Reply.backgroundColor
 
         // Bezier
-        bezierContainerView.bezierColor = WPStyleGuide.Reply.separatorColor
+        bezierContainerView.bezierColor = WPStyleGuide.Reply.backgroundColor
         bezierContainerView.bezierFillColor = WPStyleGuide.Reply.textViewBackground
         bezierContainerView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Reply.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Reply.swift
@@ -9,15 +9,15 @@ extension WPStyleGuide {
             return WPStyleGuide.fontForTextStyle(.footnote, symbolicTraits: .traitBold)
         }
         public static var textFont: UIFont {
-            return WPStyleGuide.notoFontForTextStyle(.subheadline)
+            return WPStyleGuide.regularTextFont()
         }
 
         public static let enabledColor       = UIColor.primary
-        public static let disabledColor      = UIColor.neutral(.shade20)
+        public static let disabledColor      = UIColor.listSmallIcon
         public static let placeholderColor   = UIColor.textPlaceholder
         public static let textColor          = UIColor.text
-        public static let separatorColor     = UIColor.neutral(.shade20)
-        public static let textViewBackground = UIColor.listForeground
-        public static let backgroundColor    = UIColor.listBackground
+        public static let separatorColor     = UIColor.divider
+        public static let textViewBackground = UIColor.basicBackground
+        public static let backgroundColor    = UIColor.basicBackground
     }
 }


### PR DESCRIPTION
Fixes #12918 subtask: Update the UI for the existing `ReplyTextView`

**To test:**

1. Enter any comment flow (reader, notification, comments)

**Screenshots**

| Device | Mode | Placeholder | Text |
|---|---|---|---|
| iPad Air 12.4 | Light | <img src="https://user-images.githubusercontent.com/793774/70844948-b6430b80-1dfd-11ea-9421-06621635d38a.png" width="50%"/> | <img src="https://user-images.githubusercontent.com/793774/70844949-b6430b80-1dfd-11ea-960d-2def4dca464e.png" width="50%"/> |
| iPhone 11 Pro Max 13.3 | Light | <img src="https://user-images.githubusercontent.com/793774/70844950-b6430b80-1dfd-11ea-8d6a-1934ba50f0a5.png" width="50%"/> | <img src="https://user-images.githubusercontent.com/793774/70844953-b6430b80-1dfd-11ea-83b3-b460ce775b30.png" width="50%"/> |
| iPhone 11 Pro Max 13.3 | Dark | <img src="https://user-images.githubusercontent.com/793774/70844951-b6430b80-1dfd-11ea-8177-3393aacb43d2.png" width="50%"/>  | <img src="https://user-images.githubusercontent.com/793774/70844952-b6430b80-1dfd-11ea-8e92-75c8984f7477.png" width="50%"/> |

**PR submission checklist:**

- [X] I have considered adding unit tests where possible.

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
