### PR TITLE
Enables direction lock on the post scheduling calendar view

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -25,6 +25,7 @@ class CalendarCollectionView: JTACMonthView {
         scrollDirection = .horizontal
         scrollingMode = .stopAtEachCalendarFrame
         showsHorizontalScrollIndicator = false
+        isDirectionalLockEnabled = true
 
         calendarDataSource = calDataSource
         calendarDelegate = calDataSource


### PR DESCRIPTION
Fixes #13113

Demo Video: https://www.dropbox.com/s/489k5s2tpy00omi/iPhone%208%20-%2013.3%20-%20Calendar%20Paging%20-%20Fix.mov?dl=0

**To test:**
1. Launch WPiOS
2. Tap the + button to create a post
3. Tap the `...` tab bar item to show more controls
4. Tap Post Settings
5. Tap the Publish row
6. Tap Date & Time
7. Swipe the calendar to change months
   7.a While swiping move your finger/cursor up and down

**PR submission checklist:**

- [X] I have considered adding unit tests where possible.

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
