### PR TITLE
[VoiceOver] Improvements for Stats Posting Activity 

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
@@ -157,6 +157,13 @@ private extension PostingActivityMonth {
 private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
 
     private var events = [PostingStreakEvent]()
+    private var selectedIndex: Int = 0
+
+    private lazy var monthDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM d"
+        return formatter
+    }()
 
     override var accessibilityFrameInContainerSpace: CGRect {
         get {
@@ -184,5 +191,44 @@ private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
         }
 
         self.events = (events ?? [PostingStreakEvent]()).filter { $0.postCount > 0 }
+
+        select(index: 0)
+    }
+
+    private func select(index: Int) {
+        self.selectedIndex = index
+
+        guard events.isEmpty == false else {
+            accessibilityValue = Strings.noPosts
+            return
+        }
+
+        guard let event = events[safe: index] else {
+            accessibilityValue = nil
+            return
+        }
+
+        if event.postCount == 1 {
+            accessibilityValue = String(format: Strings.dayAndPostsSingular,
+                                        monthDayFormatter.string(from: event.date))
+        } else {
+            accessibilityValue = String(format: Strings.dayAndPostsPlural,
+                                        monthDayFormatter.string(from: event.date),
+                                        event.postCount)
+        }
+    }
+
+    private enum Strings {
+        static let noPosts =
+            NSLocalizedString("No posts.",
+                              comment: "Accessibility value for a Stats' Posting Activity Month if there are no posts.")
+        static let dayAndPostsSingular =
+            NSLocalizedString("%@. 1 post.",
+                              comment: "Accessibility value for a Stats' Posting Activity Month if the user selected a day with posts."
+                                + " The first parameter is day (e.g. November 2019).")
+        static let dayAndPostsPlural =
+            NSLocalizedString("%@. %d posts.",
+                              comment: "Accessibility value for a Stats' Posting Activity Month if the user selected a day with posts."
+                                + " The first parameter is day (e.g. November 2019). The second parameter is the number of posts.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
@@ -156,6 +156,8 @@ private extension PostingActivityMonth {
 ///
 private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
 
+    private var events = [PostingStreakEvent]()
+
     override var accessibilityFrameInContainerSpace: CGRect {
         get {
             (accessibilityContainer as? UIView)?.bounds ?? CGRect.zero
@@ -180,5 +182,7 @@ private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
         } else {
             accessibilityLabel = nil
         }
+
+        self.events = (events ?? [PostingStreakEvent]()).filter { $0.postCount > 0 }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
@@ -157,7 +157,15 @@ private extension PostingActivityMonth {
 private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
 
     private var events = [PostingStreakEvent]()
-    private var selectedIndex: Int = 0
+
+    /// The currently selected index for `event`
+    ///
+    /// This starts at -1 so that when `rotatedIndex(forward:)` is called with `true`, it will
+    /// return with `0`, which is what we want.
+    ///
+    /// - SeeAlso: rotatedIndex(forward:)
+    ///
+    private var selectedIndex: Int = -1
 
     private lazy var monthDayFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -191,8 +199,6 @@ private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
         }
 
         self.events = (events ?? [PostingStreakEvent]()).filter { $0.postCount > 0 }
-
-        select(index: 0)
     }
 
     override func accessibilityDecrement() {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
@@ -16,6 +16,30 @@ class PostingActivityMonth: UIView, NibLoadable {
     // Used to adjust the view width when hiding the last stack view.
     private let lastStackViewWidth = CGFloat(14)
 
+    /// The only accessibility element for self.
+    ///
+    /// This is only loaded if accessibility features are turned on.
+    ///
+    /// - SeeAlso: accessibilityElements
+    ///
+    private var accessibilityElement: PostingActivityMonthAccessibilityElement?
+
+    override var accessibilityElements: [Any]? {
+        get {
+            if let elementForSelf = accessibilityElement {
+                return [elementForSelf]
+            }
+
+            let elementForSelf = PostingActivityMonthAccessibilityElement(accessibilityContainer: self)
+            elementForSelf.configure(month: month, events: monthData)
+
+            accessibilityElement = elementForSelf
+
+            return [elementForSelf]
+        }
+        set { }
+    }
+
     // MARK: - Configure
 
     func configure(monthData: [PostingStreakEvent], postingActivityDayDelegate: PostingActivityDayDelegate? = nil) {
@@ -23,12 +47,16 @@ class PostingActivityMonth: UIView, NibLoadable {
         self.postingActivityDayDelegate = postingActivityDayDelegate
         getMonth()
         addDays()
+
+        accessibilityElement?.configure(month: month, events: monthData)
     }
 
     func configureGhost(monthData: [PostingStreakEvent]) {
         self.monthData = monthData
         monthLabel.text = ""
         addDays()
+
+        accessibilityElement?.configure(month: month, events: monthData)
     }
 }
 
@@ -120,4 +148,34 @@ private extension PostingActivityMonth {
         viewWidthConstraint.constant -= viewWidthAdjustment
     }
 
+}
+
+// MARK: - Accessibility
+
+/// An accessibility element for the whole `PostingActivityMonth` UI tree.
+///
+private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
+
+    override var accessibilityFrameInContainerSpace: CGRect {
+        get {
+            (accessibilityContainer as? UIView)?.bounds ?? CGRect.zero
+        }
+        set { }
+    }
+
+    override init(accessibilityContainer container: Any) {
+        super.init(accessibilityContainer: container)
+
+        accessibilityTraits = .adjustable
+    }
+
+    func configure(month: Date?, events: [PostingStreakEvent]?) {
+        if let month = month {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "MMMM yyyy"
+            accessibilityLabel = formatter.string(from: month)
+        } else {
+            accessibilityLabel = nil
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
@@ -167,9 +167,12 @@ private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
         super.init(accessibilityContainer: container)
 
         accessibilityTraits = .adjustable
+        isAccessibilityElement = false
     }
 
     func configure(month: Date?, events: [PostingStreakEvent]?) {
+        isAccessibilityElement = month != nil
+
         if let month = month {
             let formatter = DateFormatter()
             formatter.dateFormat = "MMMM yyyy"

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
@@ -202,22 +202,22 @@ private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
     }
 
     override func accessibilityDecrement() {
-        select(index: rotatedIndex(forward: false))
+        rotateAccessibilityValue(forward: false)
     }
 
     override func accessibilityIncrement() {
-        select(index: rotatedIndex(forward: true))
+        rotateAccessibilityValue(forward: true)
     }
 
-    private func select(index: Int) {
-        self.selectedIndex = index
+    private func rotateAccessibilityValue(forward: Bool) {
+        selectedIndex = rotatedIndex(forward: forward)
 
         guard events.isEmpty == false else {
             accessibilityValue = Strings.noPosts
             return
         }
 
-        guard let event = events[safe: index] else {
+        guard let event = events[safe: selectedIndex] else {
             accessibilityValue = nil
             return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
@@ -195,6 +195,14 @@ private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
         select(index: 0)
     }
 
+    override func accessibilityDecrement() {
+        select(index: rotatedIndex(forward: false))
+    }
+
+    override func accessibilityIncrement() {
+        select(index: rotatedIndex(forward: true))
+    }
+
     private func select(index: Int) {
         self.selectedIndex = index
 
@@ -215,6 +223,24 @@ private class PostingActivityMonthAccessibilityElement: UIAccessibilityElement {
             accessibilityValue = String(format: Strings.dayAndPostsPlural,
                                         monthDayFormatter.string(from: event.date),
                                         event.postCount)
+        }
+    }
+
+    /// Returns the rotated index value of `selectedIndex`.
+    ///
+    private func rotatedIndex(forward: Bool) -> Int {
+        if forward {
+            var index = selectedIndex + 1
+            if index >= events.count {
+                index = 0
+            }
+            return index
+        } else {
+            var index = selectedIndex - 1
+            if index < 0 {
+                index = events.count - 1
+            }
+            return index
         }
     }
 


### PR DESCRIPTION
Refs #12971, #11995.

This improves the accessibility of the [`PostingActivityMonth`](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/Stats/Insights/Posting%20Activity/PostingActivityMonth.swift) component. 

Currently, VoiceOver users are able to access all the days within the component. This is a bit problematic if the user tries to navigate the page by swiping right. They would have to go through one hundred tiny UI elements before they can reach the bottom of the page. 

This is an attempt to make this better. 

Before | After 
--------|-------
 [before video (15s)](https://drive.google.com/file/d/12hC_VO-1BvJQikFvS4C3bXbZDBppuPF5/view?usp=sharing)       |       [after video (23s)](https://drive.google.com/file/d/12mFSze8u0pvlwhpkSsGw0Kc8WXFBMx-V/view?usp=sharing)
Everything inside is accessible | Only the container is accessible
_ | You can swipe up or down to access more data

I'm not sure about [preselecting the first day](https://github.com/wordpress-mobile/WordPress-iOS/blob/7ab48a2f01326bedb6e4d20012a91b109533b025/WordPress/Classes/ViewRelated/Stats/Insights/Posting%20Activity/PostingActivityMonth.swift#L195). But please let me know what you think. 🙂 

## Possible Enhancements

There are still more that can be done here. Some of my ideas are:

- The container's `accessibilityLabel` could describe what you can visually see. For example, “December 2019. High posting activity“. Or perhaps the total number of posts for the month? 
- Visual indicator of what date is currently being spoken. The **red** selection is not happening when you navigate using VoiceOver. 

## Testing

1. Turn VoiceOver on. 
2. Navigate to Stats → Insights.
3. Swipe right until you reach a month in the _Posting Activity_ section. 
4. When a month is selected, what do you think about what's being spoken by VoiceOver?
5. Swipe up or down to navigate through the dates with posts in them. 
6. What do you think about this navigation? 

Please do similar testing in Stats → Insights → Posting Activity.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] If it's feasible, I have added unit tests. 
- [ ] Add unit tests if the proposed changes are acceptable
