### PR TITLE
Removes the Done button from the EditCommentViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/EditCommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentViewController.m
@@ -102,14 +102,6 @@ static UIEdgeInsets EditCommentInsetsPhone = {5, 10, 5, 11};
                                                                             action:@selector(btnCancelPressed)];
 }
 
-- (void)showDoneBarButton
-{
-    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Done", @"")
-                                                                             style:[WPStyleGuide barButtonStyleForDone]
-                                                                            target:self
-                                                                            action:@selector(btnDonePressed)];
-}
-
 - (void)showSaveBarButton
 {
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Save", @"Save button label (saving content, ex: Post, Page, Comment).")
@@ -167,23 +159,9 @@ static UIEdgeInsets EditCommentInsetsPhone = {5, 10, 5, 11};
 
 #pragma mark - Text View Delegate Methods
 
-- (void)textViewDidBeginEditing:(UITextView *)aTextView
-{
-    if (IS_IPAD == NO) {
-        [self showDoneBarButton];
-    }
-}
-
 - (void)textViewDidChange:(UITextView *)textView
 {
     [self enableSaveIfNeeded];
-}
-
-- (void)textViewDidEndEditing:(UITextView *)aTextView
-{
-    if (IS_IPAD == NO) {
-        [self showCancelBarButton];
-    }
 }
 
 #pragma mark - Button Delegates
@@ -209,11 +187,6 @@ static UIEdgeInsets EditCommentInsetsPhone = {5, 10, 5, 11};
     alertController.popoverPresentationController.barButtonItem = self.navigationItem.leftBarButtonItem;
     [self presentViewController:alertController animated:YES completion:nil];
 
-}
-
-- (void)btnDonePressed
-{
-    [self.textView resignFirstResponder];
 }
 
 - (void)btnSavePressed


### PR DESCRIPTION
Fixes #13121

| Device | iOS Version | Video |
| --- | --- | --- |
| iPhone 5s | 11.4 | https://www.dropbox.com/s/37xv4le0k6hzwbd/iPhone%205s%20-%2011.4.mov?dl=0 |
| iPhone 8 | 12.4 | https://www.dropbox.com/s/go1481pxp4o0inu/iPhone%208%20-%2012.4.mov?dl=0 | 
| iPhone 11 Pro Max | 13.3 | https://www.dropbox.com/s/volcro0h2yjxvx7/iPhone%2011%20Pro%20Max%20-%2013.3.mov?dl=0 | 
| iPad Air 3rd Gen | 13.3 | https://www.dropbox.com/s/eavcgnnfx8xl43z/iPad%20Air%203rd%20Gen%20-%2013.3.mov?dl=0 |

**To test:**
1. Locate a comment to edit
2. Tap the Edit button
3. Tap the cancel button to close the overlay

**PR submission checklist:**

- [X] I have considered adding unit tests where possible.

- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
