### PR TITLE
Removes check for `isAdmin` for mention suggestions

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -463,8 +463,9 @@ NSString * const OptionsKeyIsAutomatedTransfer = @"is_automated_transfer";
             return [self supportsSharing];
         case BlogFeatureOAuth2Login:
             return [self isHostedAtWPcom];
-        case BlogFeatureReblog:
         case BlogFeatureMentions:
+            return [self isHostedAtWPcom];
+        case BlogFeatureReblog:
         case BlogFeaturePlans:
             return [self isHostedAtWPcom] && [self isAdmin];
         case BlogFeaturePluginManagement:


### PR DESCRIPTION
When replying to a comment in Notifications, if you type the @ symbol you'll be presented with a list of users you can @-mention. This functionality had a check on it for if the current user `isAdmin`, however the suggestions service that powers it also seems to work if you're not an admin. I've removed this check so it should work in more situations.

**To test:**

* Build and run
* Find a notification for a reply or comment or mention for a site that you have admin access for.
* Start typing a reply and type the @ symbol. Check the autocomplete menu appears.
* Change your access to the site to something other than admin (or remove yourself entirely) – if you're unsure how, ask me! :)
* Log out and back into the app to force it to refresh the site details so it knows you're no longer an admin.
* Repeat the same test as above with the same notification – you should still see the mentions menu. Prior to this change, no suggestions would have appeared.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
