### PR TITLE
Fix MARK formatting across several files

### DIFF
--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -5,11 +5,11 @@ import WordPressKit
 /// Service providing access to the People Management WordPress.com API.
 ///
 struct PeopleService {
-    /// MARK: - Public Properties
+    // MARK: - Public Properties
     ///
     let siteID: Int
 
-    /// MARK: - Private Properties
+    // MARK: - Private Properties
     ///
     fileprivate let context: NSManagedObjectContext
     fileprivate let remote: PeopleServiceRemote

--- a/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
@@ -8,7 +8,7 @@ import MobileCoreServices
 ///
 class SiteIconPickerPresenter: NSObject {
 
-    /// MARK: - Public Properties
+    // MARK: - Public Properties
 
     @objc var blog: Blog
     /// Will be invoked with a Media item from the user library or an error
@@ -16,7 +16,7 @@ class SiteIconPickerPresenter: NSObject {
     @objc var onIconSelection: (() -> Void)?
     @objc var originalMedia: Media?
 
-    /// MARK: - Private Properties
+    // MARK: - Private Properties
 
     fileprivate let noResultsView = NoResultsViewController.controller()
     fileprivate var mediaLibraryChangeObserverKey: NSObjectProtocol? = nil
@@ -47,7 +47,7 @@ class SiteIconPickerPresenter: NSObject {
         return pickerViewController
     }()
 
-    /// MARK: - Public methods
+    // MARK: - Public methods
 
     /// Designated Initializer
     ///
@@ -71,7 +71,7 @@ class SiteIconPickerPresenter: NSObject {
         registerChangeObserver(forPicker: mediaPickerViewController.mediaPicker)
     }
 
-    /// MARK: - Private Methods
+    // MARK: - Private Methods
 
     fileprivate func showLoadingMessage() {
         SVProgressHUD.setDefaultMaskType(.clear)

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyMedia.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyMedia.swift
@@ -93,7 +93,7 @@ extension GiphyMedia: ExportableAsset {
     }
 }
 
-//// MARK: - MediaExternalAsset conformance
+// MARK: - MediaExternalAsset conformance
 //
 extension GiphyMedia: MediaExternalAsset {
     var URL: URL {

--- a/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
+++ b/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
@@ -11,7 +11,7 @@ class AppFeedbackPromptView: UIView {
     private let buttonStack = UIStackView()
     private var onRequestingFeedback = false
 
-    /// MARK: - UIView's Methods
+    // MARK: - UIView's Methods
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -23,7 +23,7 @@ class AppFeedbackPromptView: UIView {
         setupSubviews()
     }
 
-    /// MARK: - Helpers
+    // MARK: - Helpers
 
     fileprivate func setupSubviews() {
         translatesAutoresizingMaskIntoConstraints = false
@@ -136,7 +136,7 @@ class AppFeedbackPromptView: UIView {
         }
     }
 
-    /// MARK: - Static Constants
+    // MARK: - Static Constants
 
     // these values based on Zeplin mockups
     private struct LayoutConstants {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1570,7 +1570,7 @@ extension ReaderDetailViewController: Accessible {
 }
 
 
-//// MARK: - UIViewControllerTransitioningDelegate
+// MARK: - UIViewControllerTransitioningDelegate
 ////
 extension ReaderDetailViewController: UIViewControllerTransitioningDelegate {
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
@@ -1582,7 +1582,7 @@ extension ReaderDetailViewController: UIViewControllerTransitioningDelegate {
     }
 }
 
-/// MARK: - NoResultsViewControllerDelegate
+// MARK: - NoResultsViewControllerDelegate
 ///
 extension ReaderDetailViewController: NoResultsViewControllerDelegate {
     func actionButtonPressed() {

--- a/WordPress/Classes/ViewRelated/Tools/PromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/PromptViewController.swift
@@ -16,7 +16,7 @@ public func PromptViewController<T: UIViewController>(_ viewController: T) -> UI
 /// the childrenViewController (which *must* implement the Confirmable protocol).
 ///
 private class PromptContainerViewController: UIViewController {
-    /// MARK: - Initializers / Deinitializers
+    // MARK: - Initializers / Deinitializers
 
     deinit {
         stopListeningToProperties(childViewController)


### PR DESCRIPTION
Autocorrecting with `swiftlint` was leading to these changes. I figure we might as well change them since the Source Editor doesn't properly display these with more than two forward slashes.

All comments so there's no functionality change.

PR submission checklist:

- [x] ~I have considered adding unit tests where possible.~ Just formatting changes to comments.

- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Just formatting changes to comments.
