### PR TITLE
Enable Feature Flag for Post Scheduling Calendar Picker

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 14.0
 -----
 * Fixed a bug that displayed incorrect time stamps for scheduled posts.
+* Post Settings: Added a new Calendar picker to select a Post's publish date
  
 13.9
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -30,7 +30,7 @@ enum FeatureFlag: Int, CaseIterable {
             }
             return true
         case .postScheduling:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .debugMenu:
             return BuildConfiguration.current ~= [.localDeveloper,
                                                   .a8cBranchTest]


### PR DESCRIPTION
Enables #12686, the Post Scheduling flow with Calendar picker.

Refer to the [Post Scheduling Enhancements label](https://github.com/wordpress-mobile/WordPress-iOS/labels/Post%20Scheduling%20Enhancements) to see related work.

To test:

- Create a post
- Enter Post Settings
- Change the Publish date to another value

PR submission checklist:

- [x] **I have considered adding unit tests where possible.** Most unit tests were added in #13128. 

- [x] **I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.** Added:

> Post Settings: Added a new Calendar picker to select a Post's publish date
