### PR TITLE
Adds tracks for post reblogging

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,13 +11,13 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    # pod 'WordPressShared', '1.8.10'
+    pod 'WordPressShared', '1.8.11-beta.1'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/Gio2018/WordPress-iOS-Shared.git', :branch => 'develop'
+    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
 end
 

--- a/Podfile
+++ b/Podfile
@@ -11,14 +11,14 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '1.8.10'
+    # pod 'WordPressShared', '1.8.10'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => ''
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
+    pod 'WordPressShared', :git => 'https://github.com/Gio2018/WordPress-iOS-Shared.git', :branch => 'develop'
+    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
 end
 
 def aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -240,7 +240,7 @@ PODS:
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
   - WordPressMocks (0.0.6)
-  - WordPressShared (1.8.10):
+  - WordPressShared (1.8.11-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.5.0)
@@ -315,7 +315,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.6-beta.1)
   - WordPressKit (~> 4.5.5)
   - WordPressMocks (~> 0.0.6)
-  - WordPressShared (= 1.8.10)
+  - WordPressShared (from `https://github.com/Gio2018/WordPress-iOS-Shared.git`, branch `develop`)
   - WordPressUI (~> 1.5.0)
   - WPMediaPicker (~> 1.6.0)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.19.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -359,7 +359,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -425,6 +424,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.19.0
+  WordPressShared:
+    :branch: develop
+    :git: https://github.com/Gio2018/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.19.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -441,6 +443,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.19.0
+  WordPressShared:
+    :commit: 5aa8e8dfd359eeca9734c13037bb668663aec0b8
+    :git: https://github.com/Gio2018/WordPress-iOS-Shared.git
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 4.0.0
@@ -509,7 +514,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 67901f1b519cf65ccec8a755c3e7044af5039345
   WordPressKit: 8029cb93a89de79442254c346523da11c2706d7b
   WordPressMocks: 5913bd04586a360212e07a8ccbcb36068d4425a3
-  WordPressShared: 5561910e9b6635874abeb10e450b7d2a29f23838
+  WordPressShared: db94f749f546fdb5fcb48d38cd49fa8dff9596a4
   WordPressUI: 4a4adafd2b052e94e4846c0a0203761773dc4fd5
   WPMediaPicker: e5d28197da6b467d4e5975d64a49255977e39455
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -517,6 +522,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 99679d8420a6d862773e2ddef0ebcc51b282317d
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 663359a34f140f35e31f03cd6cdc09a4ac4d7dc5
+PODFILE CHECKSUM: 34fd62c8b363381b7cacd790e370730dd57e3968
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -315,7 +315,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.6-beta.1)
   - WordPressKit (~> 4.5.5)
   - WordPressMocks (~> 0.0.6)
-  - WordPressShared (from `https://github.com/Gio2018/WordPress-iOS-Shared.git`, branch `develop`)
+  - WordPressShared (= 1.8.11-beta.1)
   - WordPressUI (~> 1.5.0)
   - WPMediaPicker (~> 1.6.0)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.19.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -359,6 +359,7 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -424,9 +425,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.19.0
-  WordPressShared:
-    :branch: develop
-    :git: https://github.com/Gio2018/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.19.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -443,9 +441,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.19.0
-  WordPressShared:
-    :commit: 5aa8e8dfd359eeca9734c13037bb668663aec0b8
-    :git: https://github.com/Gio2018/WordPress-iOS-Shared.git
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 4.0.0
@@ -522,6 +517,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 99679d8420a6d862773e2ddef0ebcc51b282317d
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 34fd62c8b363381b7cacd790e370730dd57e3968
+PODFILE CHECKSUM: a14166eca8401c6a591064eb1c46789e62d07991
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1364,6 +1364,8 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatReaderArticleReblogged:
             eventName = @"reader_article_reblogged";
             break;
+        case WPAnalyticsStatReaderArticleDetailReblogged:
+            eventName = @"reader_article_detail_reblogged";
         case WPAnalyticsStatReaderArticleOpened:
             eventName = @"reader_article_opened";
             break;


### PR DESCRIPTION
adds WPAnalyticsStatReaderArticleDetailReblogged for Post Reblogging tracks

Ref: #12960

WPShared PR: wordpress-mobile/WordPress-iOS-Shared/pull/236

It will be possible to test once the feature is merged

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
