### PR TITLE
Analytics tracks for Post Reblogging

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1366,6 +1366,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
         case WPAnalyticsStatReaderArticleDetailReblogged:
             eventName = @"reader_article_detail_reblogged";
+            break;
         case WPAnalyticsStatReaderArticleOpened:
             eventName = @"reader_article_opened";
             break;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1291,7 +1291,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         guard let post = self.post else {
             return
         }
-        ReaderReblogAction().execute(readerPost: post, origin: self)
+        ReaderReblogAction().execute(readerPost: post, origin: self, originType: .detail)
     }
 
     @objc func didTapHeaderAvatar(_ gesture: UITapGestureRecognizer) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1291,7 +1291,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         guard let post = self.post else {
             return
         }
-        ReaderReblogAction().execute(readerPost: post, origin: self, originType: .detail)
+        ReaderReblogAction().execute(readerPost: post, origin: self, reblogSource: .detail)
     }
 
     @objc func didTapHeaderAvatar(_ gesture: UITapGestureRecognizer) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -84,7 +84,7 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         guard let post = provider as? ReaderPost, let origin = origin else {
             return
         }
-        ReaderReblogAction().execute(readerPost: post, origin: origin)
+        ReaderReblogAction().execute(readerPost: post, origin: origin, originType: .list)
     }
 
     func readerCellImageRequestAuthToken(_ cell: ReaderPostCardCell) -> String? {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -84,7 +84,7 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         guard let post = provider as? ReaderPost, let origin = origin else {
             return
         }
-        ReaderReblogAction().execute(readerPost: post, origin: origin, originType: .list)
+        ReaderReblogAction().execute(readerPost: post, origin: origin, reblogSource: .list)
     }
 
     func readerCellImageRequestAuthToken(_ cell: ReaderPostCardCell) -> String? {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogAction.swift
@@ -1,5 +1,9 @@
 /// Encapsulates a command to reblog a post
 class ReaderReblogAction {
+    // tells if the origin is the reader list or detail, for analytics purposes
+    enum OriginType {
+        case list, detail
+    }
 
     private let blogService: BlogService
     private let presenter: ReaderReblogPresenter
@@ -17,9 +21,27 @@ class ReaderReblogAction {
     }
 
     /// Executes the reblog action on the origin UIViewController
-    func execute(readerPost: ReaderPost, origin: UIViewController) {
+    func execute(readerPost: ReaderPost, origin: UIViewController, originType: OriginType) {
+        trackReblog(readerPost: readerPost, originType: originType)
+
         presenter.presentReblog(blogService: blogService,
                                 readerPost: readerPost,
                                 origin: origin)
+    }
+}
+
+// MARK: - Analytics
+extension ReaderReblogAction {
+    fileprivate func trackReblog(readerPost: ReaderPost, originType: OriginType) {
+
+
+        let properties = [WPAppAnalyticsKeyBlogID: readerPost.siteID,
+                          WPAppAnalyticsKeyPostID: readerPost.postID]
+
+        let stat: WPAnalyticsStat = originType == .detail ?
+            .readerArticleDetailReblogged :
+            .readerArticleReblogged
+
+        WPAnalytics.track(stat, withProperties: properties as [AnyHashable: Any])
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogAction.swift
@@ -1,8 +1,9 @@
 /// Encapsulates a command to reblog a post
 class ReaderReblogAction {
     // tells if the origin is the reader list or detail, for analytics purposes
-    enum OriginType {
-        case list, detail
+    enum ReblogSource {
+        case list
+        case detail
     }
 
     private let blogService: BlogService
@@ -21,8 +22,8 @@ class ReaderReblogAction {
     }
 
     /// Executes the reblog action on the origin UIViewController
-    func execute(readerPost: ReaderPost, origin: UIViewController, originType: OriginType) {
-        trackReblog(readerPost: readerPost, originType: originType)
+    func execute(readerPost: ReaderPost, origin: UIViewController, reblogSource: ReblogSource) {
+        trackReblog(readerPost: readerPost, reblogSource: reblogSource)
 
         presenter.presentReblog(blogService: blogService,
                                 readerPost: readerPost,
@@ -32,13 +33,12 @@ class ReaderReblogAction {
 
 // MARK: - Analytics
 extension ReaderReblogAction {
-    fileprivate func trackReblog(readerPost: ReaderPost, originType: OriginType) {
-
+    private func trackReblog(readerPost: ReaderPost, reblogSource: ReblogSource) {
 
         let properties = [WPAppAnalyticsKeyBlogID: readerPost.siteID,
                           WPAppAnalyticsKeyPostID: readerPost.postID]
 
-        let stat: WPAnalyticsStat = originType == .detail ?
+        let stat: WPAnalyticsStat = reblogSource == .detail ?
             .readerArticleDetailReblogged :
             .readerArticleReblogged
 

--- a/WordPress/WordPressTest/ReaderReblogActionTests.swift
+++ b/WordPress/WordPressTest/ReaderReblogActionTests.swift
@@ -88,7 +88,7 @@ class ReaderReblogActionTests: ReblogTestCase {
         let action = ReaderReblogAction(blogService: blogService!, presenter: presenter)
         let controller = UIViewController()
         // When
-        action.execute(readerPost: readerPost!, origin: controller)
+        action.execute(readerPost: readerPost!, origin: controller, originType: .list)
         // Then
         waitForExpectations(timeout: 4) { error in
             if let error = error {

--- a/WordPress/WordPressTest/ReaderReblogActionTests.swift
+++ b/WordPress/WordPressTest/ReaderReblogActionTests.swift
@@ -88,7 +88,7 @@ class ReaderReblogActionTests: ReblogTestCase {
         let action = ReaderReblogAction(blogService: blogService!, presenter: presenter)
         let controller = UIViewController()
         // When
-        action.execute(readerPost: readerPost!, origin: controller, originType: .list)
+        action.execute(readerPost: readerPost!, origin: controller, reblogSource: .list)
         // Then
         waitForExpectations(timeout: 4) { error in
             if let error = error {


### PR DESCRIPTION
### This PR adds analytics tracks to the Post Reblogging feature

Ref #12960

### To test:
- Build and run the app
- Go to the reader
- Tap on the `reblog` button in the post list
- check that the console contains the following log:
  - `🔵 Tracked: reader_article_reblogged <blog_id: [some_id], post_id: [some_id]>`
- Go back to the post list
- Tap on a post to enter the post detail
- Tap on the `reblog` button
- Check that the console contains the following log:
  - `🔵 Tracked: reader_article_detail_reblogged <blog_id: [some_id], post_id: [some_id]>`

### change log
- added an `OriginType` enum in `ReaderReblogAction` to distinguish between detail and list
- added an extension to `ReaderReblogAction` containing a `trackReblog(_ :, _ : )` method that will execute the track
- `changed the `execute( )` method to take `OriginType` as an additional parameter
### Note: 
there was a missing `break` in the case of the newly added value `WPAnalyticsStatReaderArticleDetailReblogged`, and since it's Objective-C, was falling through to the next value. This PR fixes that as well.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
