### PR TITLE
Stats: force refresh when Period changes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 * Block editor: Images from Image Block can now be previewed full screen by tapping on them.
 * Fixed an issue that caused logging in with a 2FA Google account to fail.
 * Sign in with Apple: now supports logging in with 2FA enabled on linked WordPress accounts.
+* Stats: Fixed issue that caused incorrect data to be displayed.
 
 13.7
 -----

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1058,6 +1058,8 @@ private extension StatsPeriodStore {
         operationQueue.cancelAllOperations()
 
         statsServiceRemote?.wordPressComRestApi.invalidateAndCancelTasks()
+        setAllFetchingStatus(.idle)
+
         // `invalidateAndCancelTasks` invalidates the SessionManager,
         // so we need to recreate it to run queries.
         initializeStatsRemote()

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -56,7 +56,7 @@ class SiteStatsPeriodViewModel: Observable {
         periodReceipt = store.query(.periods(date: lastRequestedDate, period: lastRequestedPeriod))
         store.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: lastRequestedDate,
                                                                                period: lastRequestedPeriod,
-                                                                               forceRefresh: false))
+                                                                               forceRefresh: true))
     }
 
     func isFetchingChart() -> Bool {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -56,7 +56,7 @@ class SiteStatsPeriodViewModel: Observable {
         periodReceipt = store.query(.periods(date: lastRequestedDate, period: lastRequestedPeriod))
         store.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: lastRequestedDate,
                                                                                period: lastRequestedPeriod,
-                                                                               forceRefresh: true))
+                                                                               forceRefresh: false))
     }
 
     func isFetchingChart() -> Bool {
@@ -211,7 +211,7 @@ class SiteStatsPeriodViewModel: Observable {
 
         lastRequestedDate = date
         lastRequestedPeriod = period
-        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date, period: period, forceRefresh: false))
+        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date, period: period, forceRefresh: true))
     }
 
     // MARK: - State


### PR DESCRIPTION
Fixes #13138 

This change forces the period queries to be cancelled and restarted when period data is refreshed. 

I referred to the PR that fixed this problem initially (https://github.com/wordpress-mobile/WordPress-iOS/pull/11495), and it appears somewhere along the way the `forceRefresh` flags got swapped. I simply swapped them back.


To test:
- Got to Stats > Periods.
- Quickly switch between period tabs.
- Verify the tab you end up on displays the correct data.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
    