### PR TITLE
Do not delete revision outside from the editors

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -116,16 +116,8 @@ class PostCoordinator: NSObject {
     /// - Parameter automatedRetry: if this is an automated retry, without user intervenction
     /// - Parameter then: a block to perform after post is ready to be saved
     ///
-    private func prepareToSave(_ postToSave: AbstractPost, automatedRetry: Bool = false,
+    private func prepareToSave(_ post: AbstractPost, automatedRetry: Bool = false,
                                then completion: @escaping (Result<AbstractPost, Error>) -> ()) {
-        var post = postToSave
-
-        if postToSave.isRevision() && !postToSave.hasRemote(), let originalPost = postToSave.original {
-            post = originalPost
-            post.applyRevision()
-            post.deleteRevision()
-        }
-
         post.autoUploadAttemptsCount = NSNumber(value: automatedRetry ? post.autoUploadAttemptsCount.intValue + 1 : 0)
 
         guard mediaCoordinator.uploadMedia(for: post, automatedRetry: automatedRetry) else {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -330,6 +330,8 @@ extension PostEditor where Self: UIViewController {
 
         mapUIContentToPostAndSave(immediate: true)
 
+        consolidateChangesIfPostIsNew()
+
         PostCoordinator.shared.save(post,
                                     defaultFailureNotice: uploadFailureNotice(action: action)) { [weak self] result in
             guard let self = self else {
@@ -373,6 +375,18 @@ extension PostEditor where Self: UIViewController {
         dismissOrPopView()
 
         self.postEditorStateContext.updated(isBeingPublished: false)
+    }
+
+    /// If the post is fresh new and doesn't has remote we apply the current changes to the original post
+    ///
+    fileprivate func consolidateChangesIfPostIsNew() {
+        guard post.isRevision() && !post.hasRemote(), let originalPost = post.original else {
+            return
+        }
+
+        originalPost.applyRevision()
+        originalPost.deleteRevision()
+        post = originalPost
     }
 
     func dismissOrPopView(didSave: Bool = true) {


### PR DESCRIPTION
Fixes #12282

### To test

1. While offline, run the app
2. Create a new post and an image
3. Tap "..." > "Save as Draft"
4. Add another image
5. Go back online, everything should work :)

(If you follow these steps in `develop` the app will crash)

### Additional information

As @etoledom [mentioned](https://github.com/wordpress-mobile/WordPress-iOS/issues/12282#issuecomment-566471145) the problem is not only related to Media. What was happening is that `PostCoordinator` was deleting a revision being used by the Editor. This caused a lot of trouble.

The idea of this PR is to remove this deletion from `PostCoordinator` so this problem will not happen anymore. This logic is now in the Editors.

However, you can see the content in the editor blinking when the content is updated. I wonder if this is a bad experience, if it is, I'd suggest closing the Editor when the user tap "Save as Draft". I'm open to suggestions too. :)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
