### PR TITLE
Load appearance proxy earlier in launch

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * Fixed a bug that displayed incorrect time stamps for scheduled posts.
 * Post Settings: Added a new Calendar picker to select a Post's publish date
 * Fixed bugs with the "Save as Draft" action extension's navigation bar colors and iPad sizing in iOS 13.
+* Fixes appearance issues with navigation bar colors when logged out of the app.
 
 13.9
 -----

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -80,6 +80,8 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         // Restore a disassociated account prior to fixing tokens.
         AccountService(managedObjectContext: ContextManager.shared.mainContext).restoreDisassociatedAccountIfNecessary()
 
+        customizeAppearance()
+
         let solver = WPAuthTokenIssueSolver()
         let isFixingAuthTokenIssue = solver.fixAuthTokenIssueAndDo { [weak self] in
             self?.runStartupSequence(with: launchOptions ?? [:])
@@ -252,14 +254,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         setupNetworkActivityIndicator()
         WPUserAgent.useWordPressInUIWebViews()
-
-        // WORKAROUND: Preload the Noto regular font to ensure it is not overridden
-        // by any of the Noto varients.  Size is arbitrary.
-        // See: https://github.com/wordpress-mobile/WordPress-Shared-iOS/issues/79
-        // Remove this when #79 is resolved.
-        WPFontManager.notoRegularFont(ofSize: 16.0)
-
-        customizeAppearance()
 
         // Push notifications
         // This is silent (the user isn't prompted) so we can do it on launch.


### PR DESCRIPTION
Fixes #11250 
Fixes #11377

- Moves the appearance proxy up earlier during the launch cycle
- Removes preloading of the noto regular font. This code was a workaround from 4 years ago and I was unable to notice a difference in the places which used the font.

<div style="float: left">
<img width="300px" src="https://user-images.githubusercontent.com/3250/71274835-7c986600-2311-11ea-9361-c13be33275d5.png">
<img width="300px" src="https://user-images.githubusercontent.com/3250/71274926-828e4700-2311-11ea-9780-162bb5cfc987.png">
</div>

## Testing

### Navigation Bar Appearance

- Log in to the app
- Go to https://wordpress.com/me/security/connected-applications and disconnect WordPress for iOS
- Navigate somewhere in the app, any network request should trigger the login screen

### Noto Font Loading

- Navigate to the Notifications view and view a Comment notification cell

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
