### PR TITLE
Fixes crash when the App is launched by certain notifications after being inactive.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Post Settings: Added a new Calendar picker to select a Post's publish date
 * Fixed bugs with the "Save as Draft" action extension's navigation bar colors and iPad sizing in iOS 13.
 * Fixes appearance issues with navigation bar colors when logged out of the app.
+* Fixed a bug that was causing the App to crash when the user tapped on certain notifications.
 
 13.9
 -----

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -654,7 +654,7 @@ extension NotificationsViewController {
         // Before trying to show the details of a notification, we need to make sure the view is loaded.
         //
         // Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/12669#issuecomment-561579415
-        // Ref: https://sentry.io/organizations/a8c/issues/1329631657/?query=is%3Aunresolved
+        // Ref: https://sentry.io/organizations/a8c/issues/1329631657/
         //
         loadViewIfNeeded()
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -651,6 +651,13 @@ extension NotificationsViewController {
     private func showDetails(for note: Notification) {
         DDLogInfo("Pushing Notification Details for: [\(note.notificationId)]")
 
+        // Before trying to show the details of a notification, we need to make sure the view is loaded.
+        //
+        // Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/12669#issuecomment-561579415
+        // Ref: https://sentry.io/organizations/a8c/issues/1329631657/?query=is%3Aunresolved
+        //
+        loadViewIfNeeded()
+
         /// Note: markAsRead should be the *first* thing we do. This triggers a context save, and may have many side effects that
         /// could affect the OP's that go below!!!.
         ///


### PR DESCRIPTION
## Description:

Fixes crash when the App is launched by certain notifications after being inactive.

Fixes #12669 

## Before Testing:

You'll need to enable push notifications for our development environment.  This can be done by logging into your WordPress Sandbox, and running these commands:

```bash
cd /home/wpcom/public_html/bin/mobile-push-notification
svn up
php push-notifications-server.php -type=push -qi=10 -app_id=5
```

## Reproducing the original issue:

Just run the testing steps below in our `develop` branch and you should see an exception being raised.

## Testing:

1. Make sure push notifications are running for our dev environment (see "Before Testing").
2. Run the App.
3. Immediately send it to brackground.
4. Comment with another user in one of your test blogs so that a notification is sent to your device.
5. Tap on the notification.

The notification should be opened correctly, and the App should not crash.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
