### PR TITLE
Fixes a memory leak.

### DIFF
--- a/WordPress/WordPressShareExtension/TextBundleWrapper.m
+++ b/WordPress/WordPressShareExtension/TextBundleWrapper.m
@@ -193,7 +193,7 @@ NSString * const TextBundleErrorDomain = @"TextBundleErrorDomain";
 
 - (NSString *)textFilenameForType:(NSString *)type
 {
-    NSString *ext = (__bridge NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassFilenameExtension);
+    NSString *ext = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)type, kUTTagClassFilenameExtension);
     return [@"text" stringByAppendingPathExtension:ext];
 }
 


### PR DESCRIPTION
While testing a high-impact Sentry issue (https://sentry.io/organizations/a8c/issues/1340948093/?project=1438083) I came across several warnings from the static analyzer.  One of them was a memory leak that's fixed by this PR.

## Details:

The reason for the memory leak is that `UTTypeCopyPreferredTagWithClass()` returns a new `CFStringRef` which needs to be manually released after we're done working with it (using `CFRelease(stringRef)`).

By replacing the `__bridge` cast with a `__bridge_transfer` cast, we're just letting the compiler know that it's fine for ARC to take that string reference over, and release it when we're done.

## Testing:

Just run the static analyzer in `develop` and notice it points to a memory leak in the line that's modified by this PR.

Then run the static analyzer in this branch and notice the memory leak alert is gone.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
