### PR TITLE
Improves the nullability info in TextBundleWrapper.h (potential Crasher).

### DIFF
--- a/WordPress/WordPressShareExtension/TextBundleWrapper.h
+++ b/WordPress/WordPressShareExtension/TextBundleWrapper.h
@@ -30,7 +30,7 @@ typedef NS_ENUM(NSInteger, TextBundleError)
 /**
  File wrapper represeting the whole TextBundle.
  */
-@property (readonly, nonatomic) NSFileWrapper *fileWrapper;
+@property (readonly, nullable, nonatomic) NSFileWrapper *fileWrapper;
 
 /**
  File wrapper containing all asset files referenced from the plain text file.


### PR DESCRIPTION
While testing a high-impact Sentry issue (https://sentry.io/organizations/a8c/issues/1340948093/?project=1438083) I came across several warnings from the static analyzer.  This PR fixes a nullability issue we have.

## Details:

The static analyzer is rightfully complaining about this method returning `nil`:

https://github.com/wordpress-mobile/WordPress-iOS/blob/726379543f13492d52841532846a60ed2e5a1931/WordPress/WordPressShareExtension/TextBundleWrapper.m#L81-L85

While it's declared as not being able to return `nil` (due to `NS_ASSUME_NONNULL_BEGIN` on top):

https://github.com/wordpress-mobile/WordPress-iOS/blob/726379543f13492d52841532846a60ed2e5a1931/WordPress/WordPressShareExtension/TextBundleWrapper.h#L10-L33

## Importance:

While this may look like a minor fix at first, this bug is (theoretically) quite capable of crashing the App if the calling end is written in Swift (as a non-nullable result would be non-optional by default).

## Testing:

Just run the static analyzer in `develop` and notice the warning.

Then run the static analyzer in this branch and notice the alert is gone.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
