### PR TITLE
Silences several static analyzer warnings.

### DIFF
--- a/WordPress/WordPressShareExtension/TextBundleWrapper.m
+++ b/WordPress/WordPressShareExtension/TextBundleWrapper.m
@@ -254,10 +254,10 @@ NSString * const TextBundleErrorDomain = @"TextBundleErrorDomain";
     NSMutableDictionary *allMetadata = [NSMutableDictionary dictionary];
     [allMetadata addEntriesFromDictionary:metadata];
     
-    if (self.version)           { allMetadata[kTextBundleVersion] = self.version;                     }
-    if (self.type)              { allMetadata[kTextBundleType] = self.type;                           }
-    if (self.transient)         { allMetadata[kTextBundleTransient] = self.transient;                 }
-    if (self.creatorIdentifier) { allMetadata[kTextBundleCreatorIdentifier] = self.creatorIdentifier; }
+    if (self.version != nil)           { allMetadata[kTextBundleVersion] = self.version;                     }
+    if (self.type != nil)              { allMetadata[kTextBundleType] = self.type;                           }
+    if (self.transient != nil)         { allMetadata[kTextBundleTransient] = self.transient;                 }
+    if (self.creatorIdentifier != nil) { allMetadata[kTextBundleCreatorIdentifier] = self.creatorIdentifier; }
     
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:allMetadata
                                                        options:NSJSONWritingPrettyPrinted


### PR DESCRIPTION
While testing a high-impact Sentry issue (https://sentry.io/organizations/a8c/issues/1340948093/?project=1438083) I came across several warnings from the static analyzer.  This PR just silences some of those warnings.

## Details:

The warnings silenced in this PR are fairly harmless, but I took the opportunity to clean them up, in order to reduce the noise we get from the static analyzer.

## Testing:

Just run the static analyzer in `develop` and notice the warnings for the modified lines.

Then run the static analyzer in this branch and notice the alerts are gone.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
