### PR TITLE
This PR silences some auto-layout warnings.

### DIFF
--- a/WordPress/Classes/Extensions/UIView+ExistingConstraints.swift
+++ b/WordPress/Classes/Extensions/UIView+ExistingConstraints.swift
@@ -1,0 +1,36 @@
+extension UIView {
+
+    /// Call this method to get any existing constraint for the specified axis and the specified relation.
+    ///
+    /// - Parameters:
+    ///     - axis: the axis for the first element in the constraint.
+    ///     - relation: the relation for the constraint
+    ///
+    /// - Returns: the existing constraint or `nil` if no matching constraint exists.
+    ///
+    func constraint(for axis: NSLayoutConstraint.Attribute, withRelation relation: NSLayoutConstraint.Relation) -> NSLayoutConstraint? {
+
+        return constraints.first(where: { constraint -> Bool in
+            return constraint.firstAttribute == axis && constraint.relation == relation
+        })
+    }
+
+    /// Call this method to update a constraint for this view without duplicating it.  If the constraint
+    /// exists it will be updated, but if it doesn't it will be added.
+    ///
+    /// - Parameters:
+    ///     - axis: the axis for the first element in the constraint.  This is part of the matching criteria.
+    ///     - relation: the relation for the constraint.  This is part of the matching criteria.
+    ///     - constant: the new constant for the constraint.
+    ///     - active: whether the constraint must be activated or deactivated.
+    ///
+    func updateConstraint(for axis: NSLayoutConstraint.Attribute, withRelation relation: NSLayoutConstraint.Relation, setConstant constant: CGFloat, setActive active: Bool) {
+
+        if let existingConstraint = constraint(for: .height, withRelation: .equal) {
+            existingConstraint.constant = constant
+            existingConstraint.isActive = active
+        } else {
+            heightAnchor.constraint(equalToConstant: constant).isActive = active
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
@@ -61,7 +61,7 @@ extension WPStyleGuide {
     }
 
     class func applyBorderStyle(_ view: UIView) {
-        view.heightAnchor.constraint(equalToConstant: separatorHeight).isActive = true
+        view.updateConstraint(for: .height, withRelation: .equal, setConstant: separatorHeight, setActive: true)
         view.backgroundColor = postCardBorderColor
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1963,6 +1963,8 @@
 		F15A230420A3EBE300625EA2 /* ImgUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F126FDFE20A33BDB0010EB6E /* ImgUploadProcessor.swift */; };
 		F15A230520A3ECC500625EA2 /* ImgUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F126FDFE20A33BDB0010EB6E /* ImgUploadProcessor.swift */; };
 		F1655B4822A6C2FA00227BFB /* Routes+Mbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1655B4722A6C2FA00227BFB /* Routes+Mbar.swift */; };
+		F17A2A1E23BFBD72001E96AC /* UIView+ExistingConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A2A1D23BFBD72001E96AC /* UIView+ExistingConstraints.swift */; };
+		F17A2A2023BFBD84001E96AC /* UIView+ExistingConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A2A1F23BFBD84001E96AC /* UIView+ExistingConstraints.swift */; };
 		F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B43771F849F580089B817 /* PostAttachmentTests.swift */; };
 		F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
@@ -4425,6 +4427,8 @@
 		F14B5F75208E64F900439554 /* Version.internal.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.internal.xcconfig; sourceTree = "<group>"; };
 		F14E844C2317252200D0C63E /* WordPress 90.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 90.xcdatamodel"; sourceTree = "<group>"; };
 		F1655B4722A6C2FA00227BFB /* Routes+Mbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Mbar.swift"; sourceTree = "<group>"; };
+		F17A2A1D23BFBD72001E96AC /* UIView+ExistingConstraints.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+ExistingConstraints.swift"; sourceTree = "<group>"; };
+		F17A2A1F23BFBD84001E96AC /* UIView+ExistingConstraints.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+ExistingConstraints.swift"; sourceTree = "<group>"; };
 		F18B43771F849F580089B817 /* PostAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAttachmentTests.swift; path = Posts/PostAttachmentTests.swift; sourceTree = "<group>"; };
 		F1D690141F828FF000200E30 /* BuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfiguration.swift; sourceTree = "<group>"; };
 		F1D690151F828FF000200E30 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -8218,6 +8222,7 @@
 				177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */,
 				7326A4A7221C8F4100B4EB8C /* UIStackView+Subviews.swift */,
 				D829C33A21B12EFE00B09F12 /* UIView+Borders.swift */,
+				F17A2A1D23BFBD72001E96AC /* UIView+ExistingConstraints.swift */,
 				9A162F2421C26F5F00FDC035 /* UIViewController+ChildViewController.swift */,
 				9F3EFCA2208E308900268758 /* UIViewController+Notice.swift */,
 				9A4E939E2268D9B400E14823 /* UIViewController+NoResults.swift */,
@@ -9304,6 +9309,7 @@
 				0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */,
 				D88A649D208D82D2008AE9BC /* XCTestCase+Wait.swift */,
 				E11DF3E320C97F0A00C0B07C /* NotificationCenterObserveOnceTests.swift */,
+				F17A2A1F23BFBD84001E96AC /* UIView+ExistingConstraints.swift */,
 				F9941D1722A805F600788F33 /* UIImage+XCAssetTests.swift */,
 				8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */,
 			);
@@ -11930,6 +11936,7 @@
 				FFB1FAA01BF0EC4E0090C761 /* PHAsset+Exporters.swift in Sources */,
 				D816B8D92112D85F0052CE4D /* News.swift in Sources */,
 				8298F38F1EEF2B15008EB7F0 /* AppFeedbackPromptView.swift in Sources */,
+				F17A2A1E23BFBD72001E96AC /* UIView+ExistingConstraints.swift in Sources */,
 				400A2C892217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift in Sources */,
 				9881296E219CF1310075FF33 /* StatsCellHeader.swift in Sources */,
 				E1823E6C1E42231C00C19F53 /* UIEdgeInsets.swift in Sources */,
@@ -12553,6 +12560,7 @@
 				D800D87820999B6D00E7C7E5 /* LikedMenuItemCreatorTests.swift in Sources */,
 				D816B8CA2112D2FD0052CE4D /* LocalNewsServiceTests.swift in Sources */,
 				D800D87A20999C0500E7C7E5 /* OtherMenuItemCreatorTests.swift in Sources */,
+				F17A2A2023BFBD84001E96AC /* UIView+ExistingConstraints.swift in Sources */,
 				9A9D34FD23607CCC00BC95A3 /* AsyncOperationTests.swift in Sources */,
 				B5552D821CD1061F00B26DF6 /* StringExtensionsTests.swift in Sources */,
 				73178C3521BEE9AC00E37C9A /* TitleSubtitleHeaderTests.swift in Sources */,

--- a/WordPress/WordPressTest/Extensions/UIView+ExistingConstraints.swift
+++ b/WordPress/WordPressTest/Extensions/UIView+ExistingConstraints.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import WordPress
+
+class UIView_ExistingConstraints: XCTestCase {
+
+    /// Tests that constraint(for:withRelation:) returns an existing constraint if there's one.
+    ///
+    func testConstraintReturnsExistingConstraint() {
+        let parentView = UIView()
+        let childView = UIView()
+
+        parentView.addSubview(childView)
+
+        let expectedConstraint = childView.heightAnchor.constraint(equalToConstant: 10)
+        expectedConstraint.isActive = true
+
+        XCTAssertEqual(childView.constraint(for: .height, withRelation: .equal), expectedConstraint)
+    }
+
+    /// Tests that constraint(for:withRelation:) returns `nil` when there's no existing constraint.
+    ///
+    func testConstraintReturnsNilWhenNoConstraintExists() {
+        let parentView = UIView()
+        let childView = UIView()
+
+        parentView.addSubview(childView)
+
+        XCTAssertNil(childView.constraint(for: .height, withRelation: .equal))
+    }
+
+    /// Tests that updateConstraint(for:withRelation:constant:active) works.
+    ///
+    func testUpdateConstraintWorks() {
+        let parentView = UIView()
+        let childView = UIView()
+
+        parentView.addSubview(childView)
+
+        let expectedConstraint = childView.heightAnchor.constraint(equalToConstant: 10)
+        expectedConstraint.isActive = true
+
+        XCTAssertEqual(expectedConstraint.constant, 10)
+
+        childView.updateConstraint(for: .height, withRelation: .equal, setConstant: 20, setActive: true)
+
+        XCTAssertEqual(childView.constraint(for: .height, withRelation: .equal)!.constant, 20)
+    }
+
+    /// Tests that updateConstraint(for:withRelation:constant:active) works even if no previous constraint exists.
+    ///
+    func testUpdateConstraintWorksEvenIfNoPreviousConstraintExists() {
+        let parentView = UIView()
+        let childView = UIView()
+
+        parentView.addSubview(childView)
+
+        XCTAssertNil(childView.constraint(for: .height, withRelation: .equal))
+
+        childView.updateConstraint(for: .height, withRelation: .equal, setConstant: 20, setActive: true)
+
+        XCTAssertEqual(childView.constraint(for: .height, withRelation: .equal)!.constant, 20)
+    }
+}


### PR DESCRIPTION
This PR silences some auto-layout warnings.

This is NOT high priority - but it's something I found a quick solution for while researching other issues.

## Reproduce the original warnings:

1. Run the App in `develop`.
2. Place a breakpoint here:

https://github.com/wordpress-mobile/WordPress-iOS/blob/5e9aa81f67082e17b4f6b15d608f79f7898c074b/WordPress/Classes/ViewRelated/Post/WPStyleGuide%2BPosts.swift#L64

3. Run the app and open the posts list for one of your sites.

Check that when that breakpoint hits, stepping over it will show up a warning.

## PR submission checklist:

Repeat the reproduction steps in this branch and notice the warning is gone.

## Testing:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
