### PR TITLE
Show multiple images

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -446,14 +446,13 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 
         let mediaEditor = WPMediaEditor(image)
         mediaEditor.edit(from: self,
-                              onFinishEditing: { image, actions in
+                              onFinishEditing: { [weak self] image, actions in
                                 guard !actions.isEmpty else {
                                     // If the image wasn't edited, do nothing
                                     return
                                 }
 
-                                self.mediaInserterHelper.insertFromImage(image: image, callback: callback)
-                                mediaEditor.dismiss(animated: true)
+                                self?.mediaInserterHelper.insertFromImage(image: image, callback: callback)
         })
     }
 

--- a/WordPress/MediaEditor/Enums/MediaEditorStyle.swift
+++ b/WordPress/MediaEditor/Enums/MediaEditorStyle.swift
@@ -12,4 +12,5 @@ public enum MediaEditorStyle {
     case rotateClockwiseIcon
     case rotateCounterclockwiseButtonHidden
     case loadingLabel
+    case selectedColor
 }

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -45,6 +45,12 @@ public class MediaEditor: UINavigationController {
         setup()
     }
 
+    init(_ asyncImages: [AsyncImage]) {
+        self.asyncImages = asyncImages
+        super.init(rootViewController: hub)
+        setup()
+    }
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
@@ -75,9 +81,15 @@ public class MediaEditor: UINavigationController {
 
         hub.apply(styles: styles)
 
+        isMultipleImages() ? hub.showThumbsToolbar() : hub.hideThumbsToolbar()
+
         setupForAsync()
 
         presentIfSingleImageAndCapability()
+    }
+
+    private func isMultipleImages() -> Bool {
+        return asyncImages.count > 1 || images.count > 1
     }
 
     private func setupForAsync() {

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -93,7 +93,7 @@ public class MediaEditor: UINavigationController {
 
         hub.apply(styles: styles)
 
-        hub.availableThumbs = images
+        hub.availableThumbs = images.enumerated().reduce(into: [:]) { $0[$1.offset] = $1.element }
 
         hub.numberOfThumbs = max(images.count, asyncImages.count)
 

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -39,6 +39,12 @@ public class MediaEditor: UINavigationController {
         setup()
     }
 
+    init(_ images: [UIImage]) {
+        self.images = images
+        super.init(rootViewController: hub)
+        setup()
+    }
+
     init(_ asyncImage: AsyncImage) {
         self.asyncImages.append(asyncImage)
         super.init(rootViewController: hub)
@@ -81,7 +87,7 @@ public class MediaEditor: UINavigationController {
 
         hub.apply(styles: styles)
 
-        isMultipleImages() ? hub.showThumbsToolbar() : hub.hideThumbsToolbar()
+        hub.numberOfThumbs = max(images.count, asyncImages.count)
 
         setupForAsync()
 

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -30,7 +30,9 @@ public class MediaEditor: UINavigationController {
 
     private(set) var currentCapability: MediaEditorCapability?
 
-    private(set) var selectedImageIndex = 0
+    var selectedImageIndex: Int {
+        return hub.selectedThumbIndex
+    }
 
     public var styles: MediaEditorStyles = [:] {
         didSet {
@@ -116,7 +118,8 @@ public class MediaEditor: UINavigationController {
         if isSingleImageAndCapability {
             showActivityIndicator()
             asyncImages.first?.full(finishedRetrievingFullImage: { [weak self] image in
-                self?.fullImageAvailable(image, offset: 0)
+                let offset = self?.selectedImageIndex ?? 0
+                self?.fullImageAvailable(image, offset: offset)
             })
         }
     }
@@ -167,10 +170,6 @@ public class MediaEditor: UINavigationController {
         }
 
         DispatchQueue.main.async {
-            if offset == self.selectedImageIndex, !self.images.indices.contains(offset) {
-                self.hub.show(image: thumb)
-            }
-
             self.hub.show(thumb: thumb, at: offset)
         }
     }
@@ -187,7 +186,7 @@ public class MediaEditor: UINavigationController {
 
             self.presentIfSingleImageAndCapability()
 
-            self.hub.show(image: image)
+            self.hub.show(image: image, at: offset)
         }
     }
 

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -14,9 +14,9 @@ public class MediaEditor: UINavigationController {
         return hub
     }()
 
-    var image: UIImage?
+    var images: [UIImage] = []
 
-    var asyncImage: AsyncImage?
+    var asyncImages: [AsyncImage] = []
 
     var onFinishEditing: ((UIImage, [MediaEditorOperation]) -> ())?
 
@@ -34,13 +34,13 @@ public class MediaEditor: UINavigationController {
     }
 
     init(_ image: UIImage) {
-        self.image = image
+        self.images.append(image)
         super.init(rootViewController: hub)
         setup()
     }
 
     init(_ asyncImage: AsyncImage) {
-        self.asyncImage = asyncImage
+        self.asyncImages.append(asyncImage)
         super.init(rootViewController: hub)
         setup()
     }
@@ -81,18 +81,18 @@ public class MediaEditor: UINavigationController {
     }
 
     private func setupForAsync() {
-        if let thumb = asyncImage?.thumb {
+        if let thumb = asyncImages.first?.thumb {
             hub.show(image: thumb)
         } else {
-            asyncImage?.thumbnail(finishedRetrievingThumbnail: thumbnailAvailable)
+            asyncImages.first?.thumbnail(finishedRetrievingThumbnail: thumbnailAvailable)
         }
 
         showActivityIndicator()
-        asyncImage?.full(finishedRetrievingFullImage: fullImageAvailable)
+        asyncImages.first?.full(finishedRetrievingFullImage: fullImageAvailable)
     }
 
     func presentIfSingleImageAndCapability() {
-        guard let image = image, Self.capabilities.count == 1, let capabilityEntity = Self.capabilities.first else {
+        guard let image = images.first, images.count == 1, Self.capabilities.count == 1, let capabilityEntity = Self.capabilities.first else {
             return
         }
 
@@ -100,7 +100,7 @@ public class MediaEditor: UINavigationController {
     }
 
     private func cancel() {
-        asyncImage?.cancel()
+        asyncImages.forEach { $0.cancel() }
         dismiss(animated: true)
     }
 
@@ -132,7 +132,7 @@ public class MediaEditor: UINavigationController {
     }
 
     private func thumbnailAvailable(_ thumb: UIImage?) {
-        guard let thumb = thumb, image == nil else {
+        guard let thumb = thumb, images.first == nil else {
             return
         }
 
@@ -146,7 +146,7 @@ public class MediaEditor: UINavigationController {
             return
         }
 
-        self.image = image
+        self.images.append(image)
 
         DispatchQueue.main.async {
             self.hideActivityIndicator()

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -87,6 +87,8 @@ public class MediaEditor: UINavigationController {
 
         hub.apply(styles: styles)
 
+        hub.availableThumbs = images
+
         hub.numberOfThumbs = max(images.count, asyncImages.count)
 
         setupForAsync()

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,8 +25,34 @@
                                     </imageView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bCC-zp-fnr">
                                         <rect key="frame" x="0.0" y="730" width="414" height="44"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <subviews>
+                                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="aiP-80-hUB">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="FQk-zP-Mb0">
+                                                    <size key="itemSize" width="50" height="50"/>
+                                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                </collectionViewFlowLayout>
+                                                <cells>
+                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="thumbCell" id="FiQ-UG-fa8">
+                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="an7-K3-QRf">
+                                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                            <autoresizingMask key="autoresizingMask"/>
+                                                        </collectionViewCellContentView>
+                                                    </collectionViewCell>
+                                                </cells>
+                                            </collectionView>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="aiP-80-hUB" secondAttribute="bottom" id="8S6-Gh-W7H"/>
+                                            <constraint firstItem="aiP-80-hUB" firstAttribute="leading" secondItem="bCC-zp-fnr" secondAttribute="leading" id="8Yr-gt-DOs"/>
+                                            <constraint firstItem="aiP-80-hUB" firstAttribute="top" secondItem="bCC-zp-fnr" secondAttribute="top" id="Dda-mI-SKo"/>
+                                            <constraint firstAttribute="trailing" secondItem="aiP-80-hUB" secondAttribute="trailing" id="KCo-Vq-efz"/>
                                             <constraint firstAttribute="height" constant="44" id="cW8-4g-gpS"/>
                                         </constraints>
                                     </view>
@@ -147,6 +174,7 @@
                         <outlet property="horizontalToolbar" destination="oEl-Rm-OAA" id="Zrk-p2-D2B"/>
                         <outlet property="imageView" destination="5Tz-zw-SB3" id="ix9-cQ-25U"/>
                         <outlet property="mainStackView" destination="o0b-fF-tJw" id="5SY-51-tkZ"/>
+                        <outlet property="thumbsCollectionView" destination="aiP-80-hUB" id="k6N-kd-GNj"/>
                         <outlet property="thumbsToolbar" destination="bCC-zp-fnr" id="WdX-Xc-Zzs"/>
                         <outlet property="verticalToolbar" destination="DTT-LK-vW1" id="q5W-N8-2Tw"/>
                     </connections>

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -16,75 +16,75 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5Tz-zw-SB3">
-                                <rect key="frame" x="0.0" y="44" width="414" height="774"/>
-                            </imageView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iCM-A8-y8w">
-                                <rect key="frame" x="0.0" y="818" width="414" height="44"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o0b-fF-tJw">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
-                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DTT-LK-vW1">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5Tz-zw-SB3">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="774"/>
+                                    </imageView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iCM-A8-y8w">
+                                        <rect key="frame" x="0.0" y="774" width="414" height="44"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2D1-xm-eyg">
-                                                <rect key="frame" x="185" y="0.0" width="44" height="44"/>
+                                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DTT-LK-vW1">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2D1-xm-eyg">
+                                                        <rect key="frame" x="185" y="0.0" width="44" height="44"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="44" id="7gX-tZ-1Ed"/>
+                                                            <constraint firstAttribute="height" constant="44" id="Atz-rc-Q7i"/>
+                                                        </constraints>
+                                                        <state key="normal" image="xmark" catalog="system"/>
+                                                        <connections>
+                                                            <action selector="cancel:" destination="e8N-xf-0aT" eventType="touchUpInside" id="fAU-HY-XVa"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="44" id="7gX-tZ-1Ed"/>
-                                                    <constraint firstAttribute="height" constant="44" id="Atz-rc-Q7i"/>
+                                                    <constraint firstAttribute="bottom" secondItem="2D1-xm-eyg" secondAttribute="bottom" id="BAx-mY-VtM"/>
+                                                    <constraint firstAttribute="width" priority="999" constant="44" id="JCW-jV-DX6"/>
+                                                    <constraint firstItem="2D1-xm-eyg" firstAttribute="centerX" secondItem="DTT-LK-vW1" secondAttribute="centerX" id="aJW-fE-n0i"/>
                                                 </constraints>
-                                                <state key="normal" image="xmark" catalog="system"/>
-                                                <connections>
-                                                    <action selector="cancel:" destination="e8N-xf-0aT" eventType="touchUpInside" id="fAU-HY-XVa"/>
-                                                </connections>
-                                            </button>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oEl-Rm-OAA">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cCN-Nm-Ahb">
+                                                        <rect key="frame" x="10" y="0.0" width="53" height="44"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="53" id="Nfx-cX-gcv"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <state key="normal" title="Cancel"/>
+                                                        <connections>
+                                                            <action selector="cancel:" destination="e8N-xf-0aT" eventType="touchUpInside" id="r4U-1e-ql7"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstItem="cCN-Nm-Ahb" firstAttribute="top" secondItem="oEl-Rm-OAA" secondAttribute="top" id="4Z6-ri-im4"/>
+                                                    <constraint firstItem="cCN-Nm-Ahb" firstAttribute="leading" secondItem="oEl-Rm-OAA" secondAttribute="leading" constant="10" id="6uU-J0-waC"/>
+                                                    <constraint firstAttribute="height" constant="44" id="CUv-j6-ETf"/>
+                                                    <constraint firstAttribute="bottom" secondItem="cCN-Nm-Ahb" secondAttribute="bottom" id="oe7-cN-D4V"/>
+                                                </constraints>
+                                            </view>
                                         </subviews>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="2D1-xm-eyg" secondAttribute="bottom" id="BAx-mY-VtM"/>
-                                            <constraint firstItem="2D1-xm-eyg" firstAttribute="centerX" secondItem="DTT-LK-vW1" secondAttribute="centerX" id="aJW-fE-n0i"/>
-                                        </constraints>
-                                    </view>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oEl-Rm-OAA">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-                                        <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cCN-Nm-Ahb">
-                                                <rect key="frame" x="10" y="0.0" width="53" height="44"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="53" id="Nfx-cX-gcv"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <state key="normal" title="Cancel"/>
-                                                <connections>
-                                                    <action selector="cancel:" destination="e8N-xf-0aT" eventType="touchUpInside" id="r4U-1e-ql7"/>
-                                                </connections>
-                                            </button>
-                                        </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstItem="cCN-Nm-Ahb" firstAttribute="top" secondItem="oEl-Rm-OAA" secondAttribute="top" id="4Z6-ri-im4"/>
-                                            <constraint firstItem="cCN-Nm-Ahb" firstAttribute="leading" secondItem="oEl-Rm-OAA" secondAttribute="leading" constant="10" id="6uU-J0-waC"/>
-                                            <constraint firstAttribute="bottom" secondItem="cCN-Nm-Ahb" secondAttribute="bottom" id="oe7-cN-D4V"/>
+                                            <constraint firstItem="oEl-Rm-OAA" firstAttribute="top" secondItem="iCM-A8-y8w" secondAttribute="top" id="K45-AN-rjD"/>
+                                            <constraint firstAttribute="trailing" secondItem="oEl-Rm-OAA" secondAttribute="trailing" id="L03-Sw-oS5"/>
+                                            <constraint firstItem="oEl-Rm-OAA" firstAttribute="leading" secondItem="iCM-A8-y8w" secondAttribute="leading" id="Q5n-dN-HgH"/>
+                                            <constraint firstAttribute="bottom" secondItem="DTT-LK-vW1" secondAttribute="bottom" id="Ss5-Nl-fLj"/>
+                                            <constraint firstItem="DTT-LK-vW1" firstAttribute="top" secondItem="iCM-A8-y8w" secondAttribute="top" id="YLd-rG-mBM"/>
+                                            <constraint firstAttribute="bottom" secondItem="oEl-Rm-OAA" secondAttribute="bottom" id="q7o-6T-Chf"/>
+                                            <constraint firstAttribute="trailing" secondItem="DTT-LK-vW1" secondAttribute="trailing" id="wlu-jP-roh"/>
+                                            <constraint firstItem="DTT-LK-vW1" firstAttribute="leading" secondItem="iCM-A8-y8w" secondAttribute="leading" id="zSZ-lO-HSW"/>
                                         </constraints>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="oEl-Rm-OAA" firstAttribute="top" secondItem="iCM-A8-y8w" secondAttribute="top" id="K45-AN-rjD"/>
-                                    <constraint firstAttribute="trailing" secondItem="oEl-Rm-OAA" secondAttribute="trailing" id="L03-Sw-oS5"/>
-                                    <constraint firstItem="oEl-Rm-OAA" firstAttribute="leading" secondItem="iCM-A8-y8w" secondAttribute="leading" id="Q5n-dN-HgH"/>
-                                    <constraint firstAttribute="bottom" secondItem="DTT-LK-vW1" secondAttribute="bottom" id="Ss5-Nl-fLj"/>
-                                    <constraint firstItem="DTT-LK-vW1" firstAttribute="top" secondItem="iCM-A8-y8w" secondAttribute="top" id="YLd-rG-mBM"/>
-                                    <constraint firstAttribute="width" constant="44" id="bQX-RO-bfe"/>
-                                    <constraint firstAttribute="height" constant="44" id="cr2-lf-caP"/>
-                                    <constraint firstAttribute="bottom" secondItem="oEl-Rm-OAA" secondAttribute="bottom" id="q7o-6T-Chf"/>
-                                    <constraint firstAttribute="trailing" secondItem="DTT-LK-vW1" secondAttribute="trailing" id="wlu-jP-roh"/>
-                                    <constraint firstItem="DTT-LK-vW1" firstAttribute="leading" secondItem="iCM-A8-y8w" secondAttribute="leading" id="zSZ-lO-HSW"/>
-                                </constraints>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="bQX-RO-bfe"/>
-                                    </mask>
-                                </variation>
-                            </view>
+                            </stackView>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xsd-ER-63U">
                                 <rect key="frame" x="126.5" y="409" width="161" height="44"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ddb-h0-XWe">
@@ -124,26 +124,14 @@
                         </subviews>
                         <color key="backgroundColor" white="0.12" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="Xsd-ER-63U" firstAttribute="centerY" secondItem="5Tz-zw-SB3" secondAttribute="centerY" id="490-ov-U5m"/>
-                            <constraint firstItem="iCM-A8-y8w" firstAttribute="top" secondItem="5Tz-zw-SB3" secondAttribute="bottom" id="AAI-xh-WYk"/>
-                            <constraint firstItem="5Tz-zw-SB3" firstAttribute="top" secondItem="xJb-mz-iou" secondAttribute="top" id="Eki-uC-BmI"/>
-                            <constraint firstItem="xJb-mz-iou" firstAttribute="bottom" secondItem="5Tz-zw-SB3" secondAttribute="bottom" id="GwB-Cp-tbq"/>
-                            <constraint firstItem="Xsd-ER-63U" firstAttribute="centerX" secondItem="5Tz-zw-SB3" secondAttribute="centerX" id="HPT-dN-ceK"/>
-                            <constraint firstItem="iCM-A8-y8w" firstAttribute="top" secondItem="xJb-mz-iou" secondAttribute="top" id="HXW-El-TYa"/>
-                            <constraint firstItem="5Tz-zw-SB3" firstAttribute="leading" secondItem="xJb-mz-iou" secondAttribute="leading" id="LVp-Xe-Zw8"/>
-                            <constraint firstItem="xJb-mz-iou" firstAttribute="trailing" secondItem="iCM-A8-y8w" secondAttribute="trailing" id="SNe-zG-aps"/>
-                            <constraint firstItem="5Tz-zw-SB3" firstAttribute="leading" secondItem="iCM-A8-y8w" secondAttribute="leading" id="emH-tI-zXH"/>
-                            <constraint firstItem="iCM-A8-y8w" firstAttribute="bottom" secondItem="xJb-mz-iou" secondAttribute="bottom" id="hRG-Gy-RUt"/>
-                            <constraint firstItem="iCM-A8-y8w" firstAttribute="leading" secondItem="xJb-mz-iou" secondAttribute="leading" id="hi6-8K-g8S"/>
-                            <constraint firstItem="xJb-mz-iou" firstAttribute="trailing" secondItem="5Tz-zw-SB3" secondAttribute="trailing" id="rgw-7G-IsM"/>
+                            <constraint firstItem="o0b-fF-tJw" firstAttribute="leading" secondItem="xJb-mz-iou" secondAttribute="leading" id="ARz-6D-jmT"/>
+                            <constraint firstItem="Xsd-ER-63U" firstAttribute="centerX" secondItem="5Tz-zw-SB3" secondAttribute="centerX" id="CQX-LN-9aN"/>
+                            <constraint firstItem="xJb-mz-iou" firstAttribute="bottom" secondItem="o0b-fF-tJw" secondAttribute="bottom" id="QIG-ry-cgQ"/>
+                            <constraint firstItem="Xsd-ER-63U" firstAttribute="centerY" secondItem="5Tz-zw-SB3" secondAttribute="centerY" id="TRc-km-WRS"/>
+                            <constraint firstItem="o0b-fF-tJw" firstAttribute="top" secondItem="xJb-mz-iou" secondAttribute="top" id="VGD-hT-BgG"/>
+                            <constraint firstItem="xJb-mz-iou" firstAttribute="trailing" secondItem="o0b-fF-tJw" secondAttribute="trailing" constant="20" symbolic="YES" id="ucE-cD-JYq"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="xJb-mz-iou"/>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="GwB-Cp-tbq"/>
-                                <exclude reference="HXW-El-TYa"/>
-                            </mask>
-                        </variation>
                     </view>
                     <connections>
                         <outlet property="activityIndicatorLabel" destination="e4Q-QZ-yuo" id="p1R-24-vGe"/>
@@ -151,15 +139,8 @@
                         <outlet property="cancelButton" destination="cCN-Nm-Ahb" id="2yx-pN-P3d"/>
                         <outlet property="cancelIconButton" destination="2D1-xm-eyg" id="UqS-jv-SC1"/>
                         <outlet property="horizontalToolbar" destination="oEl-Rm-OAA" id="Zrk-p2-D2B"/>
-                        <outlet property="imageBottomLandscape" destination="GwB-Cp-tbq" id="3p5-wR-ZJI"/>
-                        <outlet property="imageBottomPortrait" destination="AAI-xh-WYk" id="co9-ey-LoG"/>
-                        <outlet property="imageLeadingLandscape" destination="emH-tI-zXH" id="9oX-jU-fAM"/>
-                        <outlet property="imageLeadingPortrait" destination="LVp-Xe-Zw8" id="gYv-pV-ULp"/>
                         <outlet property="imageView" destination="5Tz-zw-SB3" id="ix9-cQ-25U"/>
-                        <outlet property="toolbarHeightPortrait" destination="cr2-lf-caP" id="zCv-aL-w4y"/>
-                        <outlet property="toolbarTopLandscape" destination="HXW-El-TYa" id="uR4-u4-Oxv"/>
-                        <outlet property="toolbarTrailingPortrait" destination="SNe-zG-aps" id="IHQ-Xy-WkQ"/>
-                        <outlet property="toolbarWidthLandscape" destination="bQX-RO-bfe" id="2b1-0k-eCl"/>
+                        <outlet property="mainStackView" destination="o0b-fF-tJw" id="5SY-51-tkZ"/>
                         <outlet property="verticalToolbar" destination="DTT-LK-vW1" id="q5W-N8-2Tw"/>
                     </connections>
                 </viewController>

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -76,6 +76,7 @@
                                                             <subviews>
                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="wAG-en-yfG">
                                                                     <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
+                                                                    <color key="backgroundColor" white="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="44" id="EzH-BA-21t"/>
                                                                         <constraint firstAttribute="height" constant="44" id="Xv1-Ws-giP"/>

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -29,7 +29,7 @@
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="aiP-80-hUB">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="FQk-zP-Mb0">
+                                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="FQk-zP-Mb0">
                                                     <size key="itemSize" width="50" height="50"/>
                                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
@@ -37,10 +37,10 @@
                                                 </collectionViewFlowLayout>
                                                 <cells>
                                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="thumbCell" id="FiQ-UG-fa8" customClass="MediaEditorThumbCell" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
+                                                        <rect key="frame" x="0.0" y="-3" width="50" height="50"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="an7-K3-QRf">
-                                                            <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="wAG-en-yfG">
@@ -71,6 +71,7 @@
                                             <constraint firstItem="aiP-80-hUB" firstAttribute="leading" secondItem="bCC-zp-fnr" secondAttribute="leading" id="8Yr-gt-DOs"/>
                                             <constraint firstItem="aiP-80-hUB" firstAttribute="top" secondItem="bCC-zp-fnr" secondAttribute="top" id="Dda-mI-SKo"/>
                                             <constraint firstAttribute="trailing" secondItem="aiP-80-hUB" secondAttribute="trailing" id="KCo-Vq-efz"/>
+                                            <constraint firstAttribute="width" priority="999" constant="44" id="SPI-pL-LiJ"/>
                                             <constraint firstAttribute="height" constant="44" id="cW8-4g-gpS"/>
                                         </constraints>
                                     </view>
@@ -180,7 +181,7 @@
                             <constraint firstItem="xJb-mz-iou" firstAttribute="bottom" secondItem="o0b-fF-tJw" secondAttribute="bottom" id="QIG-ry-cgQ"/>
                             <constraint firstItem="Xsd-ER-63U" firstAttribute="centerY" secondItem="5Tz-zw-SB3" secondAttribute="centerY" id="TRc-km-WRS"/>
                             <constraint firstItem="o0b-fF-tJw" firstAttribute="top" secondItem="xJb-mz-iou" secondAttribute="top" id="VGD-hT-BgG"/>
-                            <constraint firstItem="xJb-mz-iou" firstAttribute="trailing" secondItem="o0b-fF-tJw" secondAttribute="trailing" constant="20" symbolic="YES" id="ucE-cD-JYq"/>
+                            <constraint firstItem="xJb-mz-iou" firstAttribute="trailing" secondItem="o0b-fF-tJw" secondAttribute="trailing" symbolic="YES" id="ucE-cD-JYq"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="xJb-mz-iou"/>
                     </view>

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -23,7 +23,7 @@
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="t2B-QE-aMZ">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="730"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ZBA-T2-zcM">
+                                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="ZBA-T2-zcM">
                                             <size key="itemSize" width="50" height="50"/>
                                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                             <size key="footerReferenceSize" width="0.0" height="0.0"/>
@@ -38,13 +38,13 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5Tz-zw-SB3">
-                                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                            <rect key="frame" x="10" y="0.0" width="30" height="50"/>
                                                         </imageView>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstAttribute="trailing" secondItem="5Tz-zw-SB3" secondAttribute="trailing" id="I27-cs-RvX"/>
+                                                        <constraint firstAttribute="trailing" secondItem="5Tz-zw-SB3" secondAttribute="trailing" constant="10" id="I27-cs-RvX"/>
                                                         <constraint firstAttribute="bottom" secondItem="5Tz-zw-SB3" secondAttribute="bottom" id="XiJ-mh-ln5"/>
-                                                        <constraint firstItem="5Tz-zw-SB3" firstAttribute="leading" secondItem="s4y-N0-CsG" secondAttribute="leading" id="lEG-gs-bu3"/>
+                                                        <constraint firstItem="5Tz-zw-SB3" firstAttribute="leading" secondItem="s4y-N0-CsG" secondAttribute="leading" constant="10" id="lEG-gs-bu3"/>
                                                         <constraint firstItem="5Tz-zw-SB3" firstAttribute="top" secondItem="s4y-N0-CsG" secondAttribute="top" id="lJc-ca-dXR"/>
                                                     </constraints>
                                                 </collectionViewCellContentView>

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -34,7 +34,6 @@
                                                             <constraint firstAttribute="width" constant="44" id="7gX-tZ-1Ed"/>
                                                             <constraint firstAttribute="height" constant="44" id="Atz-rc-Q7i"/>
                                                         </constraints>
-                                                        <state key="normal" image="xmark" catalog="system"/>
                                                         <connections>
                                                             <action selector="cancel:" destination="e8N-xf-0aT" eventType="touchUpInside" id="fAU-HY-XVa"/>
                                                         </connections>
@@ -149,7 +148,4 @@
             <point key="canvasLocation" x="73.913043478260875" y="-76.339285714285708"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="xmark" catalog="system" width="64" height="56"/>
-    </resources>
 </document>

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -20,9 +20,40 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o0b-fF-tJw">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5Tz-zw-SB3">
+                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="t2B-QE-aMZ">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="730"/>
-                                    </imageView>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ZBA-T2-zcM">
+                                            <size key="itemSize" width="50" height="50"/>
+                                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        </collectionViewFlowLayout>
+                                        <cells>
+                                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="imageCell" id="Ls1-Pp-3Ej" customClass="MediaEditorImageCell" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="s4y-N0-CsG">
+                                                    <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <subviews>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5Tz-zw-SB3">
+                                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                        </imageView>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstAttribute="trailing" secondItem="5Tz-zw-SB3" secondAttribute="trailing" id="I27-cs-RvX"/>
+                                                        <constraint firstAttribute="bottom" secondItem="5Tz-zw-SB3" secondAttribute="bottom" id="XiJ-mh-ln5"/>
+                                                        <constraint firstItem="5Tz-zw-SB3" firstAttribute="leading" secondItem="s4y-N0-CsG" secondAttribute="leading" id="lEG-gs-bu3"/>
+                                                        <constraint firstItem="5Tz-zw-SB3" firstAttribute="top" secondItem="s4y-N0-CsG" secondAttribute="top" id="lJc-ca-dXR"/>
+                                                    </constraints>
+                                                </collectionViewCellContentView>
+                                                <connections>
+                                                    <outlet property="imageView" destination="5Tz-zw-SB3" id="XOe-qd-G6m"/>
+                                                </connections>
+                                            </collectionViewCell>
+                                        </cells>
+                                    </collectionView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bCC-zp-fnr">
                                         <rect key="frame" x="0.0" y="730" width="414" height="44"/>
                                         <subviews>
@@ -177,10 +208,10 @@
                         <color key="backgroundColor" white="0.12" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="o0b-fF-tJw" firstAttribute="leading" secondItem="xJb-mz-iou" secondAttribute="leading" id="ARz-6D-jmT"/>
-                            <constraint firstItem="Xsd-ER-63U" firstAttribute="centerX" secondItem="5Tz-zw-SB3" secondAttribute="centerX" id="CQX-LN-9aN"/>
+                            <constraint firstItem="Xsd-ER-63U" firstAttribute="centerY" secondItem="t2B-QE-aMZ" secondAttribute="centerY" id="PZ6-dA-OIQ"/>
                             <constraint firstItem="xJb-mz-iou" firstAttribute="bottom" secondItem="o0b-fF-tJw" secondAttribute="bottom" id="QIG-ry-cgQ"/>
-                            <constraint firstItem="Xsd-ER-63U" firstAttribute="centerY" secondItem="5Tz-zw-SB3" secondAttribute="centerY" id="TRc-km-WRS"/>
                             <constraint firstItem="o0b-fF-tJw" firstAttribute="top" secondItem="xJb-mz-iou" secondAttribute="top" id="VGD-hT-BgG"/>
+                            <constraint firstItem="Xsd-ER-63U" firstAttribute="centerX" secondItem="t2B-QE-aMZ" secondAttribute="centerX" id="g6C-fC-std"/>
                             <constraint firstItem="xJb-mz-iou" firstAttribute="trailing" secondItem="o0b-fF-tJw" secondAttribute="trailing" symbolic="YES" id="ucE-cD-JYq"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="xJb-mz-iou"/>
@@ -191,7 +222,7 @@
                         <outlet property="cancelButton" destination="cCN-Nm-Ahb" id="2yx-pN-P3d"/>
                         <outlet property="cancelIconButton" destination="2D1-xm-eyg" id="UqS-jv-SC1"/>
                         <outlet property="horizontalToolbar" destination="oEl-Rm-OAA" id="Zrk-p2-D2B"/>
-                        <outlet property="imageView" destination="5Tz-zw-SB3" id="ix9-cQ-25U"/>
+                        <outlet property="imagesCollectionView" destination="t2B-QE-aMZ" id="Om9-9q-bLu"/>
                         <outlet property="mainStackView" destination="o0b-fF-tJw" id="5SY-51-tkZ"/>
                         <outlet property="thumbsCollectionView" destination="aiP-80-hUB" id="k6N-kd-GNj"/>
                         <outlet property="thumbsToolbar" destination="bCC-zp-fnr" id="WdX-Xc-Zzs"/>

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -57,7 +57,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bCC-zp-fnr">
                                         <rect key="frame" x="0.0" y="730" width="414" height="44"/>
                                         <subviews>
-                                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="aiP-80-hUB">
+                                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="aiP-80-hUB">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="FQk-zP-Mb0">

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -20,8 +20,15 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5Tz-zw-SB3">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="774"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="730"/>
                                     </imageView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bCC-zp-fnr">
+                                        <rect key="frame" x="0.0" y="730" width="414" height="44"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="cW8-4g-gpS"/>
+                                        </constraints>
+                                    </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iCM-A8-y8w">
                                         <rect key="frame" x="0.0" y="774" width="414" height="44"/>
                                         <subviews>
@@ -85,7 +92,7 @@
                                 </subviews>
                             </stackView>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xsd-ER-63U">
-                                <rect key="frame" x="126.5" y="409" width="161" height="44"/>
+                                <rect key="frame" x="126.5" y="387" width="161" height="44"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ddb-h0-XWe">
                                     <rect key="frame" x="0.0" y="0.0" width="161" height="44"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -140,6 +147,7 @@
                         <outlet property="horizontalToolbar" destination="oEl-Rm-OAA" id="Zrk-p2-D2B"/>
                         <outlet property="imageView" destination="5Tz-zw-SB3" id="ix9-cQ-25U"/>
                         <outlet property="mainStackView" destination="o0b-fF-tJw" id="5SY-51-tkZ"/>
+                        <outlet property="thumbsToolbar" destination="bCC-zp-fnr" id="WdX-Xc-Zzs"/>
                         <outlet property="verticalToolbar" destination="DTT-LK-vW1" id="q5W-N8-2Tw"/>
                     </connections>
                 </viewController>

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -28,7 +28,7 @@
                                         <subviews>
                                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="aiP-80-hUB">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="FQk-zP-Mb0">
                                                     <size key="itemSize" width="50" height="50"/>
                                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -36,13 +36,31 @@
                                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                 </collectionViewFlowLayout>
                                                 <cells>
-                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="thumbCell" id="FiQ-UG-fa8">
-                                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="thumbCell" id="FiQ-UG-fa8" customClass="MediaEditorThumbCell" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="an7-K3-QRf">
-                                                            <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
                                                             <autoresizingMask key="autoresizingMask"/>
+                                                            <subviews>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="wAG-en-yfG">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="44" id="EzH-BA-21t"/>
+                                                                        <constraint firstAttribute="height" constant="44" id="Xv1-Ws-giP"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstAttribute="trailing" secondItem="wAG-en-yfG" secondAttribute="trailing" id="Gzb-lo-DUc"/>
+                                                                <constraint firstAttribute="bottom" secondItem="wAG-en-yfG" secondAttribute="bottom" id="LPm-Xk-xkD"/>
+                                                                <constraint firstItem="wAG-en-yfG" firstAttribute="leading" secondItem="an7-K3-QRf" secondAttribute="leading" id="Niq-NF-G22"/>
+                                                                <constraint firstItem="wAG-en-yfG" firstAttribute="top" secondItem="an7-K3-QRf" secondAttribute="top" id="dyy-UI-LRM"/>
+                                                            </constraints>
                                                         </collectionViewCellContentView>
+                                                        <connections>
+                                                            <outlet property="thumbImageView" destination="wAG-en-yfG" id="zVe-Aj-hSD"/>
+                                                        </connections>
                                                     </collectionViewCell>
                                                 </cells>
                                             </collectionView>

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -31,6 +31,8 @@ class MediaEditorHub: UIViewController {
         }
     }
 
+    private(set) var isUserScrolling = false
+
     override func viewDidLoad() {
         super.viewDidLoad()
         hideActivityIndicator()
@@ -114,6 +116,7 @@ class MediaEditorHub: UIViewController {
             layout.scrollDirection = isLandscape ? .vertical : .horizontal
         }
         mainStackView.layoutIfNeeded()
+        imagesCollectionView.scrollToItem(at: IndexPath(row: selectedThumbIndex, section: 0), at: .right, animated: false)
     }
 
     private func highlightSelectedThumb(current: Int, before: Int) {
@@ -173,13 +176,21 @@ extension MediaEditorHub: UICollectionViewDelegate {
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard scrollView == imagesCollectionView else {
+        guard scrollView == imagesCollectionView, isUserScrolling else {
             return
         }
 
         let index = Int(round(scrollView.bounds.origin.x / imagesCollectionView.frame.width))
 
-        thumbsCollectionView.selectItem(at: IndexPath.init(row: index, section: 0), animated: true, scrollPosition: .right)
+        thumbsCollectionView.selectItem(at: IndexPath(row: index, section: 0), animated: true, scrollPosition: .right)
         selectedThumbIndex = index
+    }
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        isUserScrolling = true
+    }
+
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        isUserScrolling = false
     }
 }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -17,7 +17,7 @@ class MediaEditorHub: UIViewController {
 
     var numberOfThumbs = 0 {
         didSet {
-            reloadThumbsCollectionView()
+            reloadImagesAndReposition()
         }
     }
 
@@ -49,6 +49,15 @@ class MediaEditorHub: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         setupForOrientation()
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        setupForOrientation()
+        
+        coordinator.animate(alongsideTransition: { _ in
+            self.reloadImagesAndReposition()
+        })
     }
 
     @IBAction func cancel(_ sender: Any) {
@@ -109,11 +118,12 @@ class MediaEditorHub: UIViewController {
         activityIndicatorView.isHidden = true
     }
 
-    private func reloadThumbsCollectionView() {
+    private func reloadImagesAndReposition() {
         thumbsCollectionView.reloadData()
         imagesCollectionView.reloadData()
         thumbsCollectionView.layoutIfNeeded()
         thumbsCollectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .left)
+        imagesCollectionView.scrollToItem(at: IndexPath(row: self.selectedThumbIndex, section: 0), at: .right, animated: false)
         thumbsToolbar.isHidden = numberOfThumbs > 1 ? false : true
     }
 

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -12,7 +12,7 @@ class MediaEditorHub: UIViewController {
     @IBOutlet weak var thumbsToolbar: UIView!
     @IBOutlet weak var thumbsCollectionView: UICollectionView!
     @IBOutlet weak var imagesCollectionView: UICollectionView!
-    
+
     var onCancel: (() -> ())?
 
     var numberOfThumbs = 0 {

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -23,11 +23,14 @@ class MediaEditorHub: UIViewController {
 
     var availableThumbs: [Int: UIImage] = [:]
 
+    private var selectedThumbIndex = 0
+
     override func viewDidLoad() {
         super.viewDidLoad()
         hideActivityIndicator()
         setupForOrientation()
         thumbsCollectionView.dataSource = self
+        thumbsCollectionView.delegate = self
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -81,6 +84,8 @@ class MediaEditorHub: UIViewController {
 
     private func reloadThumbsCollectionView() {
         thumbsCollectionView.reloadData()
+        thumbsCollectionView.layoutIfNeeded()
+        thumbsCollectionView.selectItem(at: IndexPath(row: 0, section: 0), animated: false, scrollPosition: .left)
         thumbsToolbar.isHidden = numberOfThumbs > 1 ? false : true
     }
 
@@ -107,11 +112,26 @@ extension MediaEditorHub: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "thumbCell", for: indexPath)
-        let thumbCell = cell as? MediaEditorThumbCell
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "thumbCell", for: indexPath) as? MediaEditorThumbCell else {
+            return UICollectionViewCell()
+        }
 
-        thumbCell?.thumbImageView.image = availableThumbs[indexPath.row]
+        cell.thumbImageView.image = availableThumbs[indexPath.row]
+        indexPath.row == selectedThumbIndex ? cell.showBorder() : cell.hideBorder()
 
         return cell
+    }
+}
+
+extension MediaEditorHub: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let cell = collectionView.cellForItem(at: indexPath) as? MediaEditorThumbCell
+        cell?.showBorder()
+        selectedThumbIndex = indexPath.row
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        let cell = collectionView.cellForItem(at: indexPath) as? MediaEditorThumbCell
+        cell?.hideBorder()
     }
 }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -82,7 +82,7 @@ class MediaEditorHub: UIViewController {
 
     private func reloadThumbsCollectionView() {
         thumbsCollectionView.reloadData()
-        thumbsCollectionView.isHidden = numberOfThumbs > 0 ? false : true
+        thumbsToolbar.isHidden = numberOfThumbs > 1 ? false : true
     }
 
     private func setupForOrientation() {
@@ -108,7 +108,7 @@ extension MediaEditorHub: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "thumbCell", for: indexPath)
         let thumbCell = cell as? MediaEditorThumbCell
 
-        thumbCell?.thumbImageView.image = availableThumbs[indexPath.row]
+        thumbCell?.thumbImageView.image = availableThumbs.indices.contains(indexPath.row) ? availableThumbs[indexPath.row] : nil
 
         return cell
     }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -21,7 +21,7 @@ class MediaEditorHub: UIViewController {
         }
     }
 
-    var availableThumbs: [UIImage] = []
+    var availableThumbs: [Int: UIImage] = [:]
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -44,11 +44,10 @@ class MediaEditorHub: UIViewController {
     }
 
     func show(thumb: UIImage, at index: Int) {
-        guard let cell = thumbsCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorThumbCell else {
-            return
-        }
+        availableThumbs[index] = thumb
 
-        cell.thumbImageView.image = thumb
+        let cell = thumbsCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorThumbCell
+        cell?.thumbImageView.image = thumb
     }
 
     func apply(styles: MediaEditorStyles) {
@@ -111,7 +110,7 @@ extension MediaEditorHub: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "thumbCell", for: indexPath)
         let thumbCell = cell as? MediaEditorThumbCell
 
-        thumbCell?.thumbImageView.image = availableThumbs.indices.contains(indexPath.row) ? availableThumbs[indexPath.row] : nil
+        thumbCell?.thumbImageView.image = availableThumbs[indexPath.row]
 
         return cell
     }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -28,6 +28,7 @@ class MediaEditorHub: UIViewController {
     private(set) var selectedThumbIndex = 0 {
         didSet {
             highlightSelectedThumb(current: selectedThumbIndex, before: oldValue)
+            showOrHideActivityIndicator()
         }
     }
 
@@ -37,7 +38,7 @@ class MediaEditorHub: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        hideActivityIndicator()
+        showOrHideActivityIndicator()
         setupForOrientation()
         thumbsCollectionView.dataSource = self
         thumbsCollectionView.delegate = self
@@ -59,6 +60,8 @@ class MediaEditorHub: UIViewController {
 
         let imageCell = imagesCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorImageCell
         imageCell?.imageView.image = image
+
+        showOrHideActivityIndicator()
     }
 
     func show(thumb: UIImage, at index: Int) {
@@ -69,6 +72,8 @@ class MediaEditorHub: UIViewController {
 
         let imageCell = imagesCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorImageCell
         imageCell?.imageView.image = availableImages[index] ?? thumb
+
+        showOrHideActivityIndicator()
     }
 
     func apply(styles: MediaEditorStyles) {
@@ -130,6 +135,12 @@ class MediaEditorHub: UIViewController {
         let before = thumbsCollectionView.cellForItem(at: IndexPath(row: before, section: 0)) as? MediaEditorThumbCell
         before?.hideBorder()
         current?.showBorder()
+    }
+
+    private func showOrHideActivityIndicator() {
+        let imageAvailable = availableThumbs[selectedThumbIndex] ?? availableImages[selectedThumbIndex]
+
+        imageAvailable == nil ? showActivityIndicator() : hideActivityIndicator()
     }
 
     static func initialize() -> MediaEditorHub {
@@ -203,10 +214,18 @@ extension MediaEditorHub: UICollectionViewDelegate {
     }
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        guard scrollView == imagesCollectionView else {
+            return
+        }
+
         isUserScrolling = true
     }
 
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        guard scrollView == imagesCollectionView else {
+            return
+        }
+
         isUserScrolling = false
     }
 }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -38,7 +38,6 @@ class MediaEditorHub: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        showOrHideActivityIndicator()
         setupForOrientation()
         thumbsCollectionView.dataSource = self
         thumbsCollectionView.delegate = self
@@ -171,6 +170,7 @@ extension MediaEditorHub: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        // Thumbs Collection View
         if collectionView == thumbsCollectionView {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.thumbCellIdentifier, for: indexPath) as? MediaEditorThumbCell else {
                 return UICollectionViewCell()
@@ -182,11 +182,14 @@ extension MediaEditorHub: UICollectionViewDataSource {
             return cell
         }
 
+        // Images Collection View
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.imageCellIdentifier, for: indexPath) as? MediaEditorImageCell else {
             return UICollectionViewCell()
         }
 
         cell.imageView.image = availableImages[indexPath.row] ?? availableThumbs[indexPath.row]
+
+        showOrHideActivityIndicator()
 
         return cell
     }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -170,20 +170,26 @@ extension MediaEditorHub: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        // Thumbs Collection View
         if collectionView == thumbsCollectionView {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.thumbCellIdentifier, for: indexPath) as? MediaEditorThumbCell else {
-                return UICollectionViewCell()
-            }
-
-            cell.thumbImageView.image = availableThumbs[indexPath.row]
-            indexPath.row == selectedThumbIndex ? cell.showBorder(color: selectedColor) : cell.hideBorder()
-
-            return cell
+            return cellForThumbsCollectionView(cellForItemAt: indexPath)
         }
 
-        // Images Collection View
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.imageCellIdentifier, for: indexPath) as? MediaEditorImageCell else {
+        return cellForImagesCollectionView(cellForItemAt: indexPath)
+    }
+
+    private func cellForThumbsCollectionView(cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = thumbsCollectionView.dequeueReusableCell(withReuseIdentifier: Constants.thumbCellIdentifier, for: indexPath) as? MediaEditorThumbCell else {
+            return UICollectionViewCell()
+        }
+
+        cell.thumbImageView.image = availableThumbs[indexPath.row]
+        indexPath.row == selectedThumbIndex ? cell.showBorder(color: selectedColor) : cell.hideBorder()
+
+        return cell
+    }
+
+    private func cellForImagesCollectionView(cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = imagesCollectionView.dequeueReusableCell(withReuseIdentifier: Constants.imageCellIdentifier, for: indexPath) as? MediaEditorImageCell else {
             return UICollectionViewCell()
         }
 

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -132,6 +132,8 @@ class MediaEditorHub: UIViewController {
 
 }
 
+// MARK: - UICollectionViewDataSource
+
 extension MediaEditorHub: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return numberOfThumbs
@@ -159,11 +161,15 @@ extension MediaEditorHub: UICollectionViewDataSource {
     }
 }
 
+// MARK: - UICollectionViewDelegateFlowLayout
+
 extension MediaEditorHub: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return CGSize(width: imagesCollectionView.frame.width, height: imagesCollectionView.frame.height)
     }
 }
+
+// MARK: - UICollectionViewDelegate
 
 extension MediaEditorHub: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -10,6 +10,7 @@ class MediaEditorHub: UIViewController {
     @IBOutlet weak var horizontalToolbar: UIView!
     @IBOutlet weak var verticalToolbar: UIView!
     @IBOutlet weak var mainStackView: UIStackView!
+    @IBOutlet weak var thumbsToolbar: UIView!
 
     var onCancel: (() -> ())?
 
@@ -59,6 +60,14 @@ class MediaEditorHub: UIViewController {
 
     func hideActivityIndicator() {
         activityIndicatorView.isHidden = true
+    }
+
+    func showThumbsToolbar() {
+        thumbsToolbar.isHidden = false
+    }
+
+    func hideThumbsToolbar() {
+        thumbsToolbar.isHidden = true
     }
 
     private func setupForOrientation() {

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -11,13 +11,21 @@ class MediaEditorHub: UIViewController {
     @IBOutlet weak var verticalToolbar: UIView!
     @IBOutlet weak var mainStackView: UIStackView!
     @IBOutlet weak var thumbsToolbar: UIView!
+    @IBOutlet weak var thumbsCollectionView: UICollectionView!
 
     var onCancel: (() -> ())?
+
+    var numberOfThumbs = 0 {
+        didSet {
+            reloadThumbsCollectionView()
+        }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         hideActivityIndicator()
         setupForOrientation()
+        thumbsCollectionView.dataSource = self
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -62,12 +70,9 @@ class MediaEditorHub: UIViewController {
         activityIndicatorView.isHidden = true
     }
 
-    func showThumbsToolbar() {
-        thumbsToolbar.isHidden = false
-    }
-
-    func hideThumbsToolbar() {
-        thumbsToolbar.isHidden = true
+    private func reloadThumbsCollectionView() {
+        thumbsCollectionView.reloadData()
+        thumbsCollectionView.isHidden = numberOfThumbs > 0 ? false : true
     }
 
     private func setupForOrientation() {
@@ -82,4 +87,14 @@ class MediaEditorHub: UIViewController {
         return UIStoryboard(name: "MediaEditorHub", bundle: nil).instantiateViewController(withIdentifier: "hubViewController") as! MediaEditorHub
     }
 
+}
+
+extension MediaEditorHub: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return numberOfThumbs
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        return collectionView.dequeueReusableCell(withReuseIdentifier: "thumbCell", for: indexPath)
+    }
 }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -91,6 +91,9 @@ class MediaEditorHub: UIViewController {
         mainStackView.semanticContentAttribute = isLandscape ? .forceRightToLeft : .unspecified
         horizontalToolbar.isHidden = isLandscape
         verticalToolbar.isHidden = !isLandscape
+        if let layout = thumbsCollectionView.collectionViewLayout as? UICollectionViewFlowLayout {
+            layout.scrollDirection = isLandscape ? .vertical : .horizontal
+        }
     }
 
     static func initialize() -> MediaEditorHub {

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -178,22 +178,22 @@ extension MediaEditorHub: UICollectionViewDataSource {
     }
 
     private func cellForThumbsCollectionView(cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = thumbsCollectionView.dequeueReusableCell(withReuseIdentifier: Constants.thumbCellIdentifier, for: indexPath) as? MediaEditorThumbCell else {
-            return UICollectionViewCell()
-        }
+        let cell = thumbsCollectionView.dequeueReusableCell(withReuseIdentifier: Constants.thumbCellIdentifier, for: indexPath)
 
-        cell.thumbImageView.image = availableThumbs[indexPath.row]
-        indexPath.row == selectedThumbIndex ? cell.showBorder(color: selectedColor) : cell.hideBorder()
+        if let thumbCell = cell as? MediaEditorThumbCell {
+            thumbCell.thumbImageView.image = availableThumbs[indexPath.row]
+            indexPath.row == selectedThumbIndex ? thumbCell.showBorder(color: selectedColor) : thumbCell.hideBorder()
+        }
 
         return cell
     }
 
     private func cellForImagesCollectionView(cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = imagesCollectionView.dequeueReusableCell(withReuseIdentifier: Constants.imageCellIdentifier, for: indexPath) as? MediaEditorImageCell else {
-            return UICollectionViewCell()
-        }
+        let cell = imagesCollectionView.dequeueReusableCell(withReuseIdentifier: Constants.imageCellIdentifier, for: indexPath)
 
-        cell.imageView.image = availableImages[indexPath.row] ?? availableThumbs[indexPath.row]
+        if let imageCell = cell as? MediaEditorImageCell {
+            imageCell.imageView.image = availableImages[indexPath.row] ?? availableThumbs[indexPath.row]
+        }
 
         showOrHideActivityIndicator()
 

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -33,6 +33,8 @@ class MediaEditorHub: UIViewController {
 
     private(set) var isUserScrolling = false
 
+    private var selectedColor: UIColor?
+
     override func viewDidLoad() {
         super.viewDidLoad()
         hideActivityIndicator()
@@ -88,6 +90,10 @@ class MediaEditorHub: UIViewController {
         if let loadingLabel = styles[.loadingLabel] as? String {
             activityIndicatorLabel.text = loadingLabel
         }
+
+        if let color = styles[.selectedColor] as? UIColor {
+            selectedColor = color
+        }
     }
 
     func showActivityIndicator() {
@@ -130,6 +136,10 @@ class MediaEditorHub: UIViewController {
         return UIStoryboard(name: "MediaEditorHub", bundle: nil).instantiateViewController(withIdentifier: "hubViewController") as! MediaEditorHub
     }
 
+    private enum Constants {
+        static var thumbCellIdentifier = "thumbCell"
+        static var imageCellIdentifier = "imageCell"
+    }
 }
 
 // MARK: - UICollectionViewDataSource
@@ -141,17 +151,17 @@ extension MediaEditorHub: UICollectionViewDataSource {
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if collectionView == thumbsCollectionView {
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "thumbCell", for: indexPath) as? MediaEditorThumbCell else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.thumbCellIdentifier, for: indexPath) as? MediaEditorThumbCell else {
                 return UICollectionViewCell()
             }
 
             cell.thumbImageView.image = availableThumbs[indexPath.row]
-            indexPath.row == selectedThumbIndex ? cell.showBorder() : cell.hideBorder()
+            indexPath.row == selectedThumbIndex ? cell.showBorder(color: selectedColor) : cell.hideBorder()
 
             return cell
         }
 
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "imageCell", for: indexPath) as? MediaEditorImageCell else {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.imageCellIdentifier, for: indexPath) as? MediaEditorImageCell else {
             return UICollectionViewCell()
         }
 

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -23,7 +23,9 @@ class MediaEditorHub: UIViewController {
 
     var availableThumbs: [Int: UIImage] = [:]
 
-    private var selectedThumbIndex = 0 {
+    var availableImages: [Int: UIImage] = [:]
+
+    private(set) var selectedThumbIndex = 0 {
         didSet {
             highlightSelectedThumb(current: selectedThumbIndex, before: oldValue)
         }
@@ -48,8 +50,11 @@ class MediaEditorHub: UIViewController {
         onCancel?()
     }
 
-    func show(image: UIImage) {
-//        imageView.image = image
+    func show(image: UIImage, at index: Int) {
+        availableImages[index] = image
+
+        let imageCell = imagesCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorImageCell
+        imageCell?.imageView.image = image
     }
 
     func show(thumb: UIImage, at index: Int) {
@@ -59,7 +64,7 @@ class MediaEditorHub: UIViewController {
         cell?.thumbImageView.image = thumb
 
         let imageCell = imagesCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorImageCell
-        imageCell?.imageView.image = thumb
+        imageCell?.imageView.image = availableImages[index] ?? thumb
     }
 
     func apply(styles: MediaEditorStyles) {
@@ -144,7 +149,7 @@ extension MediaEditorHub: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
 
-        cell.imageView.image = availableThumbs[indexPath.row]
+        cell.imageView.image = availableImages[indexPath.row] ?? availableThumbs[indexPath.row]
 
         return cell
     }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -33,8 +33,8 @@ class MediaEditorHub: UIViewController {
         thumbsCollectionView.delegate = self
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
         setupForOrientation()
     }
 

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -9,24 +9,7 @@ class MediaEditorHub: UIViewController {
     @IBOutlet weak var activityIndicatorLabel: UILabel!
     @IBOutlet weak var horizontalToolbar: UIView!
     @IBOutlet weak var verticalToolbar: UIView!
-
-    @IBOutlet weak var toolbarTrailingPortrait: NSLayoutConstraint!
-    @IBOutlet weak var toolbarHeightPortrait: NSLayoutConstraint!
-    @IBOutlet weak var imageBottomPortrait: NSLayoutConstraint!
-    @IBOutlet weak var imageLeadingPortrait: NSLayoutConstraint!
-
-    @IBOutlet weak var toolbarTopLandscape: NSLayoutConstraint!
-    @IBOutlet weak var toolbarWidthLandscape: NSLayoutConstraint!
-    @IBOutlet weak var imageBottomLandscape: NSLayoutConstraint!
-    @IBOutlet weak var imageLeadingLandscape: NSLayoutConstraint!
-
-    var portraitConstraints: [NSLayoutConstraint] {
-        return [toolbarTrailingPortrait, toolbarHeightPortrait, imageBottomPortrait, imageLeadingPortrait]
-    }
-
-    var landscapeConstraints: [NSLayoutConstraint] {
-        return [toolbarTopLandscape, toolbarWidthLandscape, imageBottomLandscape, imageLeadingLandscape]
-    }
+    @IBOutlet weak var mainStackView: UIStackView!
 
     var onCancel: (() -> ())?
 
@@ -80,8 +63,8 @@ class MediaEditorHub: UIViewController {
 
     private func setupForOrientation() {
         let isLandscape = UIDevice.current.orientation.isLandscape
-        portraitConstraints.forEach { $0.isActive = !isLandscape }
-        landscapeConstraints.forEach { $0.isActive = isLandscape }
+        mainStackView.axis = isLandscape ? .horizontal : .vertical
+        mainStackView.semanticContentAttribute = isLandscape ? .forceRightToLeft : .unspecified
         horizontalToolbar.isHidden = isLandscape
         verticalToolbar.isHidden = !isLandscape
     }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -54,7 +54,7 @@ class MediaEditorHub: UIViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         setupForOrientation()
-        
+
         coordinator.animate(alongsideTransition: { _ in
             self.reloadImagesAndReposition()
         })

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -113,6 +113,7 @@ class MediaEditorHub: UIViewController {
         if let layout = thumbsCollectionView.collectionViewLayout as? UICollectionViewFlowLayout {
             layout.scrollDirection = isLandscape ? .vertical : .horizontal
         }
+        mainStackView.layoutIfNeeded()
     }
 
     private func highlightSelectedThumb(current: Int, before: Int) {

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -220,10 +220,10 @@ extension MediaEditorHub: UICollectionViewDelegate {
             return
         }
 
-        let index = Int(round(scrollView.bounds.origin.x / imagesCollectionView.frame.width))
+        let imageIndexBasedOnScroll = Int(round(scrollView.bounds.origin.x / imagesCollectionView.frame.width))
 
-        thumbsCollectionView.selectItem(at: IndexPath(row: index, section: 0), animated: true, scrollPosition: .right)
-        selectedThumbIndex = index
+        thumbsCollectionView.selectItem(at: IndexPath(row: imageIndexBasedOnScroll, section: 0), animated: true, scrollPosition: .right)
+        selectedThumbIndex = imageIndexBasedOnScroll
     }
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -21,6 +21,8 @@ class MediaEditorHub: UIViewController {
         }
     }
 
+    var availableThumbs: [UIImage] = []
+
     override func viewDidLoad() {
         super.viewDidLoad()
         hideActivityIndicator()
@@ -39,6 +41,14 @@ class MediaEditorHub: UIViewController {
 
     func show(image: UIImage) {
         imageView.image = image
+    }
+
+    func show(thumb: UIImage, at index: Int) {
+        guard let cell = thumbsCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorThumbCell else {
+            return
+        }
+
+        cell.thumbImageView.image = thumb
     }
 
     func apply(styles: MediaEditorStyles) {
@@ -95,6 +105,11 @@ extension MediaEditorHub: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        return collectionView.dequeueReusableCell(withReuseIdentifier: "thumbCell", for: indexPath)
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "thumbCell", for: indexPath)
+        let thumbCell = cell as? MediaEditorThumbCell
+
+        thumbCell?.thumbImageView.image = availableThumbs[indexPath.row]
+
+        return cell
     }
 }

--- a/WordPress/MediaEditor/MediaEditorImageCell.swift
+++ b/WordPress/MediaEditor/MediaEditorImageCell.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+class MediaEditorImageCell: UICollectionViewCell {
+    @IBOutlet weak var imageView: UIImageView!
+}

--- a/WordPress/MediaEditor/MediaEditorThumbCell.swift
+++ b/WordPress/MediaEditor/MediaEditorThumbCell.swift
@@ -3,12 +3,16 @@ import UIKit
 class MediaEditorThumbCell: UICollectionViewCell {
     @IBOutlet weak var thumbImageView: UIImageView!
 
-    func showBorder() {
+    func showBorder(color: UIColor? = nil) {
         layer.borderWidth = 1.5
-        layer.borderColor = UIColor(red: 0.133, green: 0.443, blue: 0.694, alpha: 1).cgColor
+        layer.borderColor = color?.cgColor ?? Constant.defaultSelectedColor
     }
 
     func hideBorder() {
         layer.borderWidth = 0
+    }
+
+    private enum Constant {
+        static var defaultSelectedColor = UIColor(red: 0.133, green: 0.443, blue: 0.694, alpha: 1).cgColor
     }
 }

--- a/WordPress/MediaEditor/MediaEditorThumbCell.swift
+++ b/WordPress/MediaEditor/MediaEditorThumbCell.swift
@@ -2,4 +2,13 @@ import UIKit
 
 class MediaEditorThumbCell: UICollectionViewCell {
     @IBOutlet weak var thumbImageView: UIImageView!
+
+    func showBorder() {
+        layer.borderWidth = 1.5
+        layer.borderColor = UIColor(red: 0.133, green: 0.443, blue: 0.694, alpha: 1).cgColor
+    }
+
+    func hideBorder() {
+        layer.borderWidth = 0
+    }
 }

--- a/WordPress/MediaEditor/MediaEditorThumbCell.swift
+++ b/WordPress/MediaEditor/MediaEditorThumbCell.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+class MediaEditorThumbCell: UICollectionViewCell {
+    @IBOutlet weak var thumbImageView: UIImageView!
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -338,9 +338,9 @@
 		31C9F82E1A2368A2008BB945 /* BlogDetailHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 31C9F82D1A2368A2008BB945 /* BlogDetailHeaderView.m */; };
 		31EC15081A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m in Sources */ = {isa = PBXBuildFile; fileRef = 31EC15071A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m */; };
 		321E292623A5F10900588610 /* FullScreenCommentReplyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 328CEC5D23A532BA00A6899E /* FullScreenCommentReplyViewController.swift */; };
-		325D3B3D23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 325D3B3C23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift */; };
 		323F8F3023A22C4C000BA49C /* SiteCreationRotatingMessageViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32C6CDDA23A1FF0D002556FF /* SiteCreationRotatingMessageViewTests.swift */; };
 		323F8F3123A22C8F000BA49C /* SiteCreationRotatingMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3221278523A0BD27002CA183 /* SiteCreationRotatingMessageView.swift */; };
+		325D3B3D23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 325D3B3C23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift */; };
 		32CA6EC02390C61F00B51347 /* PostListEditorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CA6EBF2390C61F00B51347 /* PostListEditorPresenter.swift */; };
 		37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 37022D901981BF9200F322B7 /* VerticallyStackedButton.m */; };
 		374CB16215B93C0800DD0EBC /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 374CB16115B93C0800DD0EBC /* AudioToolbox.framework */; };
@@ -1049,12 +1049,13 @@
 		8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */; };
 		8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */; };
 		8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */; };
+		8BC6020923900D8400EFE3D0 /* NullBlogPropertySanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC6020823900D8400EFE3D0 /* NullBlogPropertySanitizer.swift */; };
+		8BC6020D2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */; };
+		8BC6E04823BE385000C2D174 /* MediaEditorThumbCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC6E04723BE385000C2D174 /* MediaEditorThumbCell.swift */; };
 		8BD36E0023956FC500EFFF1C /* MediaEditorOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36DFF23956FC500EFFF1C /* MediaEditorOperation.swift */; };
 		8BD36E022395CAEA00EFFF1C /* MediaEditorOperation+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36E012395CAEA00EFFF1C /* MediaEditorOperation+Description.swift */; };
 		8BD36E062395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */; };
 		8BD36E082396CA7700EFFF1C /* TOCropViewController+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36E072396CA7700EFFF1C /* TOCropViewController+Ext.swift */; };
-		8BC6020923900D8400EFE3D0 /* NullBlogPropertySanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC6020823900D8400EFE3D0 /* NullBlogPropertySanitizer.swift */; };
-		8BC6020D2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BFE36FD230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */; };
 		8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */; };
@@ -3306,12 +3307,13 @@
 		8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorTests.swift; sourceTree = "<group>"; };
 		8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeeded.swift"; sourceTree = "<group>"; };
 		8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeededTests.swift"; sourceTree = "<group>"; };
+		8BC6020823900D8400EFE3D0 /* NullBlogPropertySanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullBlogPropertySanitizer.swift; sourceTree = "<group>"; };
+		8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullBlogPropertySanitizerTests.swift; sourceTree = "<group>"; };
+		8BC6E04723BE385000C2D174 /* MediaEditorThumbCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditorThumbCell.swift; sourceTree = "<group>"; };
 		8BD36DFF23956FC500EFFF1C /* MediaEditorOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditorOperation.swift; sourceTree = "<group>"; };
 		8BD36E012395CAEA00EFFF1C /* MediaEditorOperation+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaEditorOperation+Description.swift"; sourceTree = "<group>"; };
 		8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaEditorOperation+DescriptionTests.swift"; sourceTree = "<group>"; };
 		8BD36E072396CA7700EFFF1C /* TOCropViewController+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TOCropViewController+Ext.swift"; sourceTree = "<group>"; };
-		8BC6020823900D8400EFE3D0 /* NullBlogPropertySanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullBlogPropertySanitizer.swift; sourceTree = "<group>"; };
-		8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullBlogPropertySanitizerTests.swift; sourceTree = "<group>"; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLs.swift"; sourceTree = "<group>"; };
 		8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLsTests.swift"; sourceTree = "<group>"; };
@@ -7137,6 +7139,7 @@
 				8BBFBD98239EAA8D0086AD4E /* MediaEditorHub.swift */,
 				8BBFBDA523A01AE30086AD4E /* AsyncImage.swift */,
 				8BBFBDAB23A135B90086AD4E /* MediaEditorHub.storyboard */,
+				8BC6E04723BE385000C2D174 /* MediaEditorThumbCell.swift */,
 			);
 			path = MediaEditor;
 			sourceTree = "<group>";
@@ -11672,6 +11675,7 @@
 				17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */,
 				984B139221F66AC60004B6A2 /* SiteStatsPeriodViewModel.swift in Sources */,
 				98A437AE20069098004A8A57 /* DomainSuggestionsTableViewController.swift in Sources */,
+				8BC6E04823BE385000C2D174 /* MediaEditorThumbCell.swift in Sources */,
 				5D1D04761B7A50B100CDE646 /* ReaderStreamViewController.swift in Sources */,
 				B57B92BD1B73B08100DFF00B /* SeparatorsView.swift in Sources */,
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1030,6 +1030,7 @@
 		85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */; };
 		8B05D29123A9417E0063B9AA /* WPMediaEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B05D29023A9417E0063B9AA /* WPMediaEditor.swift */; };
 		8B05D29323AA572A0063B9AA /* GutenbergMediaEditorImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B05D29223AA572A0063B9AA /* GutenbergMediaEditorImage.swift */; };
+		8B241AA023BF5E5E000F2F14 /* MediaEditorImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B241A9F23BF5E5E000F2F14 /* MediaEditorImageCell.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */; };
 		8B8C814D2318073300A0E620 /* BasePostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8C814C2318073300A0E620 /* BasePostTests.swift */; };
@@ -3288,6 +3289,7 @@
 		85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationServiceTests.swift; sourceTree = "<group>"; };
 		8B05D29023A9417E0063B9AA /* WPMediaEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPMediaEditor.swift; sourceTree = "<group>"; };
 		8B05D29223AA572A0063B9AA /* GutenbergMediaEditorImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergMediaEditorImage.swift; sourceTree = "<group>"; };
+		8B241A9F23BF5E5E000F2F14 /* MediaEditorImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditorImageCell.swift; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewControllerTests.swift; sourceTree = "<group>"; };
 		8B8C814C2318073300A0E620 /* BasePostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePostTests.swift; sourceTree = "<group>"; };
@@ -7140,6 +7142,7 @@
 				8BBFBDA523A01AE30086AD4E /* AsyncImage.swift */,
 				8BBFBDAB23A135B90086AD4E /* MediaEditorHub.storyboard */,
 				8BC6E04723BE385000C2D174 /* MediaEditorThumbCell.swift */,
+				8B241A9F23BF5E5E000F2F14 /* MediaEditorImageCell.swift */,
 			);
 			path = MediaEditor;
 			sourceTree = "<group>";
@@ -11880,6 +11883,7 @@
 				17AD36D51D36C1A60044B10D /* WPStyleGuide+Search.swift in Sources */,
 				FF0148E51DFABBC9001AD265 /* NSFileManager+FolderSize.swift in Sources */,
 				731E88CB21C9A10B0055C014 /* ErrorStateViewController.swift in Sources */,
+				8B241AA023BF5E5E000F2F14 /* MediaEditorImageCell.swift in Sources */,
 				BE87E1A01BD4054F0075D45B /* WP3DTouchShortcutCreator.swift in Sources */,
 				D800D86C20997EB400E7C7E5 /* OtherMenuItemCreator.swift in Sources */,
 				742B7F3A209CB2B6002E3CC9 /* GIFPlaybackStrategy.swift in Sources */,

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
@@ -16,9 +16,10 @@ class MediaEditorHubTests: XCTestCase {
         _ = hub.view
         let image = UIImage()
 
-        hub.show(image: image)
+        hub.show(image: image, at: 0)
 
-        expect(hub.imageView.image).to(equal(image))
+        let firstImageCell = hub.collectionView(hub.imagesCollectionView, cellForItemAt: IndexPath(row: 0, section: 0)) as? MediaEditorImageCell
+        expect(firstImageCell?.imageView.image).to(equal(image))
     }
 
     func testTappingCancelButtonCallsOnCancel() {

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
@@ -40,15 +40,7 @@ class MediaEditorHubTests: XCTestCase {
 
         hub.apply(styles: [.cancelLabel: "foo"])
 
-        expect(hub.cancelButton.titleLabel?.text).to(equal("foo"))
-    }
-
-    func testHideActivityIndicatorView() {
-        let hub: MediaEditorHub = MediaEditorHub.initialize()
-
-        _ = hub.view
-
-        expect(hub.activityIndicatorView.isHidden).to(beTrue())
+        expect(hub.cancelButton.titleLabel?.text).toEventually(equal("foo"))
     }
 
     func testApplyLoadingLabel() {

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
@@ -58,7 +58,7 @@ class MediaEditorHubTests: XCTestCase {
         expect(hub.activityIndicatorLabel.text).to(equal("foo"))
     }
 
-    func testWhenInPortraitShowTheCorrectToolbarAndConstraints() {
+    func testWhenInPortraitShowTheCorrectToolbarAndStackViewAxis() {
         XCUIDevice.shared.orientation = .portrait
         let hub: MediaEditorHub = MediaEditorHub.initialize()
 
@@ -66,11 +66,11 @@ class MediaEditorHubTests: XCTestCase {
 
         expect(hub.horizontalToolbar.isHidden).to(beFalse())
         expect(hub.verticalToolbar.isHidden).to(beTrue())
-        expect(hub.portraitConstraints.allSatisfy { $0.isActive }).to(beTrue())
-        expect(hub.landscapeConstraints.allSatisfy { !$0.isActive }).to(beTrue())
+        expect(hub.mainStackView.axis).to(equal(.vertical))
+        expect(hub.mainStackView.semanticContentAttribute).to(equal(.unspecified))
     }
 
-    func testWhenInLandscapeShowTheCorrectToolbarAndConstraints() {
+    func testWhenInLandscapeShowTheCorrectToolbarAndStackViewAxis() {
         XCUIDevice.shared.orientation = .landscapeLeft
         let hub: MediaEditorHub = MediaEditorHub.initialize()
 
@@ -78,8 +78,8 @@ class MediaEditorHubTests: XCTestCase {
 
         expect(hub.horizontalToolbar.isHidden).to(beTrue())
         expect(hub.verticalToolbar.isHidden).to(beFalse())
-        expect(hub.portraitConstraints.allSatisfy { !$0.isActive }).to(beTrue())
-        expect(hub.landscapeConstraints.allSatisfy { $0.isActive }).to(beTrue())
+        expect(hub.mainStackView.axis).to(equal(.horizontal))
+        expect(hub.mainStackView.semanticContentAttribute).to(equal(.forceRightToLeft))
     }
 
 }

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -104,8 +104,9 @@ class MediaEditorTests: XCTestCase {
         asyncImage.thumb = UIImage()
 
         let mediaEditor = MediaEditor(asyncImage)
+        UIApplication.shared.topWindow?.addSubview(mediaEditor.view)
 
-        expect(mediaEditor.hub.imageView.image).to(equal(asyncImage.thumb))
+        expect((mediaEditor.hub.imagesCollectionView.cellForItem(at: IndexPath(row: 0, section: 0)) as? MediaEditorImageCell)?.imageView.image).toEventually(equal(asyncImage.thumb))
     }
 
     func testDoNotRequestThumbnailIfOneIsGiven() {
@@ -131,26 +132,29 @@ class MediaEditorTests: XCTestCase {
         let asyncImage = AsyncImageMock()
         let thumb = UIImage()
         let mediaEditor = MediaEditor(asyncImage)
+        UIApplication.shared.topWindow?.addSubview(mediaEditor.view)
 
         asyncImage.simulate(thumbHasBeenDownloaded: thumb)
 
-        expect(mediaEditor.hub.imageView.image).toEventually(equal(thumb))
+        expect((mediaEditor.hub.collectionView(mediaEditor.hub.imagesCollectionView, cellForItemAt: IndexPath(row: 0, section: 0)) as? MediaEditorImageCell)?.imageView.image).toEventually(equal(thumb))
     }
 
     func testWhenFullImageIsAvailableShowItInHub() {
         let asyncImage = AsyncImageMock()
         let fullImage = UIImage()
         let mediaEditor = MediaEditor(asyncImage)
+        UIApplication.shared.topWindow?.addSubview(mediaEditor.view)
 
         asyncImage.simulate(fullImageHasBeenDownloaded: fullImage)
 
-        expect(mediaEditor.hub.imageView.image).toEventually(equal(fullImage))
+        expect((mediaEditor.hub.collectionView(mediaEditor.hub.imagesCollectionView, cellForItemAt: IndexPath(row: 0, section: 0)) as? MediaEditorImageCell)?.imageView.image).toEventually(equal(fullImage))
     }
 
     func testWhenFullImageIsAvailableHideActivityIndicatorView() {
         let asyncImage = AsyncImageMock()
         let fullImage = UIImage()
         let mediaEditor = MediaEditor(asyncImage)
+        UIApplication.shared.topWindow?.addSubview(mediaEditor.view)
 
         asyncImage.simulate(fullImageHasBeenDownloaded: fullImage)
 
@@ -182,12 +186,13 @@ class MediaEditorTests: XCTestCase {
         let fullImage = UIImage(color: .white)!
         let thumbImage = UIImage(color: .black)!
         let mediaEditor = MediaEditor(asyncImage)
+        UIApplication.shared.topWindow?.addSubview(mediaEditor.view)
 
         asyncImage.simulate(fullImageHasBeenDownloaded: fullImage)
         asyncImage.simulate(thumbHasBeenDownloaded: thumbImage)
 
-        expect(mediaEditor.hub.imageView.image).toEventually(equal(fullImage))
-        expect(mediaEditor.hub.imageView.image).toEventuallyNot(equal(thumbImage))
+        expect((mediaEditor.hub.imagesCollectionView.cellForItem(at: IndexPath(row: 0, section: 0)) as? MediaEditorImageCell)?.imageView.image).toEventually(equal(fullImage))
+        expect((mediaEditor.hub.imagesCollectionView.cellForItem(at: IndexPath(row: 0, section: 0)) as? MediaEditorImageCell)?.imageView.image).toEventuallyNot(equal(thumbImage))
     }
 
     func testHidesThumbsToolbar() {

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -206,6 +206,20 @@ class MediaEditorTests: XCTestCase {
 
     // WHEN: Multiple images + one single capability
 
+    func testShowThumbs() {
+        let whiteImage = UIImage(color: .white)!
+        let blackImage = UIImage(color: .black)!
+
+        let mediaEditor = MediaEditor([whiteImage, blackImage])
+
+        let firstThumb = mediaEditor.hub.collectionView(mediaEditor.hub.thumbsCollectionView, cellForItemAt: IndexPath(row: 0, section: 0)) as? MediaEditorThumbCell
+        let secondThumb = mediaEditor.hub.collectionView(mediaEditor.hub.thumbsCollectionView, cellForItemAt: IndexPath(row: 1, section: 0)) as? MediaEditorThumbCell
+        expect(firstThumb?.thumbImageView.image).to(equal(whiteImage))
+        expect(secondThumb?.thumbImageView.image).to(equal(blackImage))
+    }
+
+    // WHEN: Multiple async images + one single capability
+
     func testShowThumbsToolbar() {
         let asyncImages = [AsyncImageMock(), AsyncImageMock()]
 

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -195,6 +195,24 @@ class MediaEditorTests: XCTestCase {
         expect(mediaEditor.hub.imageView.image).toEventually(equal(fullImage))
         expect(mediaEditor.hub.imageView.image).toEventuallyNot(equal(thumbImage))
     }
+
+    func testHidesThumbsToolbar() {
+        let asyncImage = AsyncImageMock()
+
+        let mediaEditor = MediaEditor(asyncImage)
+
+        expect(mediaEditor.hub.thumbsToolbar.isHidden).to(beTrue())
+    }
+
+    // WHEN: Multiple images + one single capability
+
+    func testShowThumbsToolbar() {
+        let asyncImages = [AsyncImageMock(), AsyncImageMock()]
+
+        let mediaEditor = MediaEditor(asyncImages)
+
+        expect(mediaEditor.hub.thumbsToolbar.isHidden).to(beFalse())
+    }
 }
 
 class MockCapability: MediaEditorCapability {

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -7,12 +7,6 @@ import Nimble
 class MediaEditorTests: XCTestCase {
     private let image = UIImage()
 
-    private var hub: MediaEditorHub {
-        let hub: MediaEditorHub = MediaEditorHub.initialize()
-        _ = hub.view
-        return hub
-    }
-
     override class func setUp() {
         super.setUp()
         MediaEditor.capabilities = [MockCapability.self]


### PR DESCRIPTION
Ref #13102

This PR adds the capability to show multiple images and to navigate between them on the Media Editor. Editing a selected image and tapping Done will be addressed in a future PR.

<img src="https://user-images.githubusercontent.com/7040243/71747863-94163980-2e4f-11ea-81e7-dff3a9ba4412.gif" width="300">

### To test

First, in `GutenbergViewController.swift` replace the function `gutenbergDidRequestFullscreenImage` by this one:

```swift
    func gutenbergDidRequestFullscreenImage(with mediaUrl: URL) {
        gutenbergDidRequestMediaEditor(with: mediaUrl, callback: { _ in })
    }
```

And inside `gutenbergDidRequestMediaEditor` give the `image` multiple times to the MediaEditor, like this (line 447):

```swift
let mediaEditor = WPMediaEditor([image, image, image, image, image, image, image, image, image, image])
```

You can test the same thing in Aztec, just pass the same image multiple times.

#### Swipe between the images

You can swipe between the images, the selected thumbnail (at the bottom) should be updated accordingly.

#### Navigate using the thumbnails

Tapping one thumbnail should display the image at the top. If the image isn't already loaded an activity indicator should appear.

#### Portrait and landscape, iPhone and iPad

If you rotate the device the interface should update accordingly.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
