### PR TITLE
Updates some text for the reader's save-for-later feature.

### DIFF
--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+SavedPosts.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+SavedPosts.swift
@@ -4,7 +4,7 @@ import Gridicons
 extension FancyAlertViewController {
     private struct Strings {
         static let titleText = NSLocalizedString("Save Posts for Later", comment: "Title of alert informing users about the Reader Save for Later feature.")
-        static let bodyText = NSLocalizedString("Save this post, and come back to read it whenever you'd like. It will only be available on this device — saved posts don't sync to other devices (Yet! We're working on it).", comment: "Body text of alert informing users about the Reader Save for Later feature.")
+        static let bodyText = NSLocalizedString("Save this post, and come back to read it whenever you'd like. It will only be available on this device — saved posts don't sync to other devices.", comment: "Body text of alert informing users about the Reader Save for Later feature.")
         static let okTitle = NSLocalizedString("OK", comment: "OK Button title shown in alert informing users about the Reader Save for Later feature.")
     }
 


### PR DESCRIPTION
Fixes #13149 

Removed "(Yet! We're working on it)" from the alert that comes up when you save a reader post for later reading.

## Testing:

1. Launch the App and go to the reader.
2. Tap on a post.
3. Tap "Save" in the bottom left corner.

Make sure the part of the message that read "(Yet! We're working on it)" is no longer in the alert, as requested in #13149

## PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
