### PR TITLE
Use filename of files exported from other apps to name media objects.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * Fixed bugs with the "Save as Draft" action extension's navigation bar colors and iPad sizing in iOS 13.
 * Fixes appearance issues with navigation bar colors when logged out of the app.
 * Fixed a bug that was causing the App to crash when the user tapped on certain notifications.
+* Fixed a bug where files imported from other apps were being renamed to a random name.
 
 13.9
 -----

--- a/WordPress/Classes/Utility/Media/MediaImageExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaImageExporter.swift
@@ -75,7 +75,7 @@ class MediaImageExporter: MediaExporter {
     }
 
     convenience init(url: URL) {
-        self.init(image: nil, filename: nil, data: nil, url: url, caption: nil)
+        self.init(image: nil, filename: url.lastPathComponent, data: nil, url: url, caption: nil)
     }
 
     convenience init(data: Data, filename: String?, typeHint: String? = nil) {
@@ -184,7 +184,7 @@ class MediaImageExporter: MediaExporter {
                 throw ImageExportError.imageSourceIsAnUnknownType
             }
             return exportImageSource(source,
-                              filename: UUID().uuidString,
+                              filename: filename,
                               type: options.exportImageType ?? utType as String,
                               onCompletion: onCompletion,
                               onError: onError)

--- a/WordPress/WordPressTest/MediaURLExporterTests.swift
+++ b/WordPress/WordPressTest/MediaURLExporterTests.swift
@@ -17,8 +17,11 @@ class MediaURLExporterTests: XCTestCase {
         let exporter = MediaURLExporter(url: url)
         exporter.mediaDirectoryType = .temporary
         exporter.export(onCompletion: { (urlExport) in
-                        MediaExporterTests.cleanUpExportedMedia(atURL: urlExport.url)
                         expect.fulfill()
+                        let exportFileName = urlExport.url.lastPathComponent.replacingMatches(of: "." + urlExport.url.pathExtension, with: "")
+                        let originalFileName = url.lastPathComponent.replacingMatches(of: "." + url.pathExtension, with: "")
+                        XCTAssertEqual(exportFileName, originalFileName)
+                        MediaExporterTests.cleanUpExportedMedia(atURL: urlExport.url)
         }) { (error) in
             XCTFail("Error: an error occurred testing a URL export: \(error.toNSError())")
             expect.fulfill()


### PR DESCRIPTION
Fixes #13018

With this PR we will use the last path component to name the exported file. This will then be used to name the media asset when importing the url
to the media library.

To test:
1. Choose an image from your iPhoto library and save to files. Select either iCloud Drive or On My iPad).**Note**: Make sure the file is a JPEG or PNG, by default the new iPhone devices save images on HEIC format that are not accepted directly in WordPress sites. To go around this you can go to Camera settings and select to save the photos in a "Compatible format"
2. Rename the image and save.
3. Open the WordPress app and go to Media > + to add a new image.
4. Select 'Other Apps' to open files library (whether you select from On My iPad or iCloud Drive the same behaviour happens)
5. Select the renamed image to add to your site. 
6. After it uploads, click on the image to verify file info, check that the file kept the original file name ( lowercased and without extension)

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
