### PR TITLE
Crop media when showing multiple images

### DIFF
--- a/WordPress/MediaEditor/Capabilities/Crop/MediaEditorCropZoomRotate.swift
+++ b/WordPress/MediaEditor/Capabilities/Crop/MediaEditorCropZoomRotate.swift
@@ -1,7 +1,12 @@
 import UIKit
 import TOCropViewController
+import Gridicons
 
 class MediaEditorCropZoomRotate: NSObject, MediaEditorCapability {
+    static var name = "Crop, Zoom, Rotate"
+
+    static var icon = Gridicon.iconOfType(.crop)
+
     var image: UIImage
 
     var onFinishEditing: (UIImage, [MediaEditorOperation]) -> ()

--- a/WordPress/MediaEditor/Capabilities/MediaEditorCapability.swift
+++ b/WordPress/MediaEditor/Capabilities/MediaEditorCapability.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 public protocol MediaEditorCapability {
+    static var name: String { get }
+
+    static var icon: UIImage { get }
+
     var image: UIImage { get set }
 
     var viewController: UIViewController { get }

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -101,6 +101,8 @@ public class MediaEditor: UINavigationController {
 
         hub.numberOfThumbs = max(images.count, asyncImages.count)
 
+        hub.capabilities = Self.capabilities.reduce(into: []) { $0.append(($1.name, $1.icon)) }
+
         setupForAsync()
 
         presentIfSingleImageAndCapability()
@@ -207,6 +209,6 @@ public class MediaEditor: UINavigationController {
 
 extension MediaEditor: MediaEditorHubDelegate {
     func capabilityTapped(_ index: Int) {
-        
+
     }
 }

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -233,19 +233,19 @@ extension MediaEditor: MediaEditorHubDelegate {
             let image = images[selectedImageIndex]
             present(capability: Self.capabilities[index], with: image)
         } else {
-            hub.showActivityIndicator()
             let offset = selectedImageIndex
+            hub.loadingImage(at: offset)
             asyncImages[selectedImageIndex].full(finishedRetrievingFullImage: { [weak self] image in
-                guard let image = image else {
-                    return
-                }
+                DispatchQueue.main.async {
 
-                self?.fullImageAvailable(image, offset: offset)
+                    self?.hub.loadedImage(at: offset)
 
-                if self?.selectedImageIndex == offset {
-                    DispatchQueue.main.async {
+                    self?.fullImageAvailable(image, offset: offset)
+
+                    if self?.selectedImageIndex == offset, let image = image {
                         self?.present(capability: Self.capabilities[index], with: image)
                     }
+
                 }
             })
         }

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -138,11 +138,17 @@ public class MediaEditor: UINavigationController {
 
     private func cancel() {
         if currentCapability == nil {
-            asyncImages.forEach { $0.cancel() }
-            dismiss(animated: true)
+            cancelPendingAsyncImagesAndDismiss()
+        } else if isSingleImageAndCapability {
+            cancelPendingAsyncImagesAndDismiss()
         } else {
             dismissCapability()
         }
+    }
+
+    private func cancelPendingAsyncImagesAndDismiss() {
+        asyncImages.forEach { $0.cancel() }
+        dismiss(animated: true)
     }
 
     private func present(capability capabilityEntity: MediaEditorCapability.Type, with image: UIImage) {

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -72,6 +72,8 @@ public class MediaEditor: UINavigationController {
     public override func viewDidLoad() {
         super.viewDidLoad()
 
+        hub.delegate = self
+
         modalTransitionStyle = .crossDissolve
         modalPresentationStyle = .fullScreen
         navigationBar.isHidden = true
@@ -200,5 +202,11 @@ public class MediaEditor: UINavigationController {
 
     private enum Constants {
         static let transitionDuration = 0.3
+    }
+}
+
+extension MediaEditor: MediaEditorHubDelegate {
+    func capabilityTapped(_ index: Int) {
+        
     }
 }

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -233,7 +233,21 @@ extension MediaEditor: MediaEditorHubDelegate {
             let image = images[selectedImageIndex]
             present(capability: Self.capabilities[index], with: image)
         } else {
-            // Async
+            hub.showActivityIndicator()
+            let offset = selectedImageIndex
+            asyncImages[selectedImageIndex].full(finishedRetrievingFullImage: { [weak self] image in
+                guard let image = image else {
+                    return
+                }
+
+                self?.fullImageAvailable(image, offset: offset)
+
+                if self?.selectedImageIndex == offset {
+                    DispatchQueue.main.async {
+                        self?.present(capability: Self.capabilities[index], with: image)
+                    }
+                }
+            })
         }
     }
 }

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -14,7 +14,7 @@ public class MediaEditor: UINavigationController {
         return hub
     }()
 
-    var images: [UIImage] = []
+    var images: [Int: UIImage] = [:]
 
     var asyncImages: [AsyncImage] = []
 
@@ -42,13 +42,13 @@ public class MediaEditor: UINavigationController {
     }
 
     init(_ image: UIImage) {
-        self.images.append(image)
+        self.images = [0: image]
         super.init(rootViewController: hub)
         setup()
     }
 
     init(_ images: [UIImage]) {
-        self.images = images
+        self.images = images.enumerated().reduce(into: [:]) { $0[$1.offset] = $1.element }
         super.init(rootViewController: hub)
         setup()
     }
@@ -97,7 +97,7 @@ public class MediaEditor: UINavigationController {
 
         hub.apply(styles: styles)
 
-        hub.availableThumbs = images.enumerated().reduce(into: [:]) { $0[$1.offset] = $1.element }
+        hub.availableThumbs = images
 
         hub.numberOfThumbs = max(images.count, asyncImages.count)
 
@@ -129,7 +129,7 @@ public class MediaEditor: UINavigationController {
     }
 
     func presentIfSingleImageAndCapability() {
-        guard isSingleImageAndCapability, let image = images.first, let capabilityEntity = Self.capabilities.first else {
+        guard isSingleImageAndCapability, let image = images[0], let capabilityEntity = Self.capabilities.first else {
             return
         }
 
@@ -209,7 +209,7 @@ public class MediaEditor: UINavigationController {
             return
         }
 
-        self.images.append(image)
+        self.images[offset] = image
 
         DispatchQueue.main.async {
             self.hideActivityIndicator()
@@ -235,8 +235,7 @@ public class MediaEditor: UINavigationController {
 
 extension MediaEditor: MediaEditorHubDelegate {
     func capabilityTapped(_ index: Int) {
-        if images.indices.contains(selectedImageIndex) {
-            let image = images[selectedImageIndex]
+        if let image = images[selectedImageIndex] {
             present(capability: Self.capabilities[index], with: image)
         } else {
             let offset = selectedImageIndex

--- a/WordPress/MediaEditor/MediaEditorCapabilityCell.swift
+++ b/WordPress/MediaEditor/MediaEditorCapabilityCell.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+class MediaEditorCapabilityCell: UICollectionViewCell {
+    @IBOutlet weak var iconButton: UIButton!
+}

--- a/WordPress/MediaEditor/MediaEditorCapabilityCell.swift
+++ b/WordPress/MediaEditor/MediaEditorCapabilityCell.swift
@@ -2,4 +2,10 @@ import UIKit
 
 class MediaEditorCapabilityCell: UICollectionViewCell {
     @IBOutlet weak var iconButton: UIButton!
+
+    func configure(_ capabilityInfo: (String, UIImage)) {
+        let (name, icon) = capabilityInfo
+        iconButton.setImage(icon, for: .normal)
+        iconButton.accessibilityHint = name
+    }
 }

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -20,8 +20,52 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="o0b-fF-tJw">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
+                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="YUc-Qf-Gm9">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="CWq-nn-G4B"/>
+                                            <constraint firstAttribute="width" priority="999" constant="44" id="YUf-mr-8Ht"/>
+                                        </constraints>
+                                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="3i8-4g-zqe">
+                                            <size key="itemSize" width="50" height="50"/>
+                                            <size key="estimatedItemSize" width="44" height="44"/>
+                                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        </collectionViewFlowLayout>
+                                        <cells>
+                                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="capabilityCell" id="Z78-n9-pAQ" customClass="MediaEditorCapabilityCell" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="-3" width="50" height="50"/>
+                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Yi2-iG-hCx">
+                                                    <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <subviews>
+                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Wz-bX-y3d">
+                                                            <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="44" id="8Z3-NE-bqz"/>
+                                                                <constraint firstAttribute="width" constant="44" id="rx5-sT-4h7"/>
+                                                            </constraints>
+                                                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </button>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstAttribute="bottom" secondItem="7Wz-bX-y3d" secondAttribute="bottom" id="Ao4-wB-PzR"/>
+                                                        <constraint firstItem="7Wz-bX-y3d" firstAttribute="top" secondItem="Yi2-iG-hCx" secondAttribute="top" id="BcH-Qa-nSY"/>
+                                                        <constraint firstAttribute="trailing" secondItem="7Wz-bX-y3d" secondAttribute="trailing" id="EHp-JR-iSY"/>
+                                                        <constraint firstItem="7Wz-bX-y3d" firstAttribute="leading" secondItem="Yi2-iG-hCx" secondAttribute="leading" id="kws-2X-UzP"/>
+                                                    </constraints>
+                                                </collectionViewCellContentView>
+                                                <connections>
+                                                    <outlet property="iconButton" destination="7Wz-bX-y3d" id="lwy-eC-2Ta"/>
+                                                </connections>
+                                            </collectionViewCell>
+                                        </cells>
+                                    </collectionView>
                                     <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="t2B-QE-aMZ">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="730"/>
+                                        <rect key="frame" x="0.0" y="44" width="414" height="686"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="ZBA-T2-zcM">
                                             <size key="itemSize" width="50" height="50"/>
@@ -170,7 +214,7 @@
                                 </subviews>
                             </stackView>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xsd-ER-63U">
-                                <rect key="frame" x="126.5" y="387" width="161" height="44"/>
+                                <rect key="frame" x="126.5" y="409" width="161" height="44"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ddb-h0-XWe">
                                     <rect key="frame" x="0.0" y="0.0" width="161" height="44"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -222,6 +266,7 @@
                         <outlet property="activityIndicatorView" destination="Xsd-ER-63U" id="boC-Kk-1td"/>
                         <outlet property="cancelButton" destination="cCN-Nm-Ahb" id="2yx-pN-P3d"/>
                         <outlet property="cancelIconButton" destination="2D1-xm-eyg" id="UqS-jv-SC1"/>
+                        <outlet property="capabilitiesCollectionView" destination="YUc-Qf-Gm9" id="grx-bJ-0NB"/>
                         <outlet property="horizontalToolbar" destination="oEl-Rm-OAA" id="Zrk-p2-D2B"/>
                         <outlet property="imagesCollectionView" destination="t2B-QE-aMZ" id="Om9-9q-bLu"/>
                         <outlet property="mainStackView" destination="o0b-fF-tJw" id="5SY-51-tkZ"/>

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -14,6 +14,8 @@ class MediaEditorHub: UIViewController {
     @IBOutlet weak var imagesCollectionView: UICollectionView!
     @IBOutlet weak var capabilitiesCollectionView: UICollectionView!
 
+    weak var delegate: MediaEditorHubDelegate?
+
     var onCancel: (() -> ())?
 
     var numberOfThumbs = 0 {
@@ -240,8 +242,11 @@ extension MediaEditorHub: UICollectionViewDelegateFlowLayout {
 
 extension MediaEditorHub: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard collectionView == thumbsCollectionView else {
-            return
+        if collectionView == thumbsCollectionView {
+            selectedThumbIndex = indexPath.row
+            imagesCollectionView.scrollToItem(at: indexPath, at: .right, animated: true)
+        } else if collectionView == capabilitiesCollectionView {
+            delegate?.capabilityTapped(indexPath.row)
         }
     }
 
@@ -271,4 +276,8 @@ extension MediaEditorHub: UICollectionViewDelegate {
 
         isUserScrolling = false
     }
+}
+
+protocol MediaEditorHubDelegate: class {
+    func capabilityTapped(_ index: Int)
 }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -22,7 +22,11 @@ class MediaEditorHub: UIViewController {
         }
     }
 
-    var capabilities: [(String, UIImage)] = []
+    var capabilities: [(String, UIImage)] = [] {
+        didSet {
+            setupCapabilities()
+        }
+    }
 
     var availableThumbs: [Int: UIImage] = [:]
 
@@ -46,6 +50,8 @@ class MediaEditorHub: UIViewController {
         thumbsCollectionView.delegate = self
         imagesCollectionView.dataSource = self
         imagesCollectionView.delegate = self
+        capabilitiesCollectionView.dataSource = self
+        capabilitiesCollectionView.delegate = self
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -160,8 +166,6 @@ class MediaEditorHub: UIViewController {
 
     private func setupCapabilities() {
         capabilitiesCollectionView.isHidden = capabilities.count > 1 || numberOfThumbs > 1 ? false : true
-        capabilitiesCollectionView.dataSource = self
-        capabilitiesCollectionView.delegate = self
         capabilitiesCollectionView.reloadData()
     }
 
@@ -211,6 +215,10 @@ extension MediaEditorHub: UICollectionViewDataSource {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.capabCellIdentifier, for: indexPath) as? MediaEditorCapabilityCell else {
             return UICollectionViewCell()
         }
+
+        let (name, icon) = capabilities[indexPath.row]
+        cell.iconButton.setImage(icon, for: .normal)
+        cell.iconButton.accessibilityHint = name
 
         return cell
     }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -37,7 +37,7 @@ class MediaEditorHub: UIViewController {
     private(set) var selectedThumbIndex = 0 {
         didSet {
             highlightSelectedThumb(current: selectedThumbIndex, before: oldValue)
-            showOrHideActivityIndicator()
+            showOrHideActivityIndicatorAndCapabilities()
         }
     }
 
@@ -86,7 +86,7 @@ class MediaEditorHub: UIViewController {
         let cell = thumbsCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorThumbCell
         cell?.thumbImageView.image = image
 
-        showOrHideActivityIndicator()
+        showOrHideActivityIndicatorAndCapabilities()
     }
 
     func show(thumb: UIImage, at index: Int) {
@@ -98,7 +98,7 @@ class MediaEditorHub: UIViewController {
         let imageCell = imagesCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorImageCell
         imageCell?.imageView.image = availableImages[index] ?? thumb
 
-        showOrHideActivityIndicator()
+        showOrHideActivityIndicatorAndCapabilities()
     }
 
     func apply(styles: MediaEditorStyles) {
@@ -135,13 +135,13 @@ class MediaEditorHub: UIViewController {
     }
 
     func loadingImage(at index: Int) {
-        showActivityIndicator()
         indexesOfImagesBeingLoaded.append(index)
+        showOrHideActivityIndicatorAndCapabilities()
     }
 
     func loadedImage(at index: Int) {
         indexesOfImagesBeingLoaded = indexesOfImagesBeingLoaded.filter { $0 != index }
-        showOrHideActivityIndicator()
+        showOrHideActivityIndicatorAndCapabilities()
     }
 
     private func reloadImagesAndReposition() {
@@ -176,12 +176,28 @@ class MediaEditorHub: UIViewController {
         current?.showBorder()
     }
 
-    private func showOrHideActivityIndicator() {
+    private func showOrHideActivityIndicatorAndCapabilities() {
         let imageAvailable = availableThumbs[selectedThumbIndex] ?? availableImages[selectedThumbIndex]
 
         let isBeingLoaded = imageAvailable == nil || indexesOfImagesBeingLoaded.contains(selectedThumbIndex)
 
-        isBeingLoaded ? showActivityIndicator() : hideActivityIndicator()
+        if isBeingLoaded {
+            showActivityIndicator()
+            disableCapabilities()
+        } else {
+            hideActivityIndicator()
+            enableCapabilities()
+        }
+    }
+
+    private func disableCapabilities() {
+        capabilitiesCollectionView.isUserInteractionEnabled = false
+        capabilitiesCollectionView.layer.opacity = 0.5
+    }
+
+    private func enableCapabilities() {
+        capabilitiesCollectionView.isUserInteractionEnabled = true
+        capabilitiesCollectionView.layer.opacity = 1
     }
 
     private func setupCapabilities() {
@@ -226,7 +242,7 @@ extension MediaEditorHub: UICollectionViewDataSource {
 
             cell.imageView.image = availableImages[indexPath.row] ?? availableThumbs[indexPath.row]
 
-            showOrHideActivityIndicator()
+            showOrHideActivityIndicatorAndCapabilities()
 
             return cell
         }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -76,9 +76,13 @@ class MediaEditorHub: UIViewController {
 
     func show(image: UIImage, at index: Int) {
         availableImages[index] = image
+        availableThumbs[index] = image
 
         let imageCell = imagesCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorImageCell
         imageCell?.imageView.image = image
+
+        let cell = thumbsCollectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? MediaEditorThumbCell
+        cell?.thumbImageView.image = image
 
         showOrHideActivityIndicator()
     }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -45,6 +45,8 @@ class MediaEditorHub: UIViewController {
 
     private var selectedColor: UIColor?
 
+    private var indexesOfImagesBeingLoaded: [Int] = []
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupForOrientation()
@@ -132,6 +134,16 @@ class MediaEditorHub: UIViewController {
         activityIndicatorView.isHidden = true
     }
 
+    func loadingImage(at index: Int) {
+        showActivityIndicator()
+        indexesOfImagesBeingLoaded.append(index)
+    }
+
+    func loadedImage(at index: Int) {
+        indexesOfImagesBeingLoaded = indexesOfImagesBeingLoaded.filter { $0 != index }
+        showOrHideActivityIndicator()
+    }
+
     private func reloadImagesAndReposition() {
         thumbsCollectionView.reloadData()
         imagesCollectionView.reloadData()
@@ -167,7 +179,9 @@ class MediaEditorHub: UIViewController {
     private func showOrHideActivityIndicator() {
         let imageAvailable = availableThumbs[selectedThumbIndex] ?? availableImages[selectedThumbIndex]
 
-        imageAvailable == nil ? showActivityIndicator() : hideActivityIndicator()
+        let isBeingLoaded = imageAvailable == nil || indexesOfImagesBeingLoaded.contains(selectedThumbIndex)
+
+        isBeingLoaded ? showActivityIndicator() : hideActivityIndicator()
     }
 
     private func setupCapabilities() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1037,6 +1037,7 @@
 		8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */; };
 		8B93856E22DC08060010BF02 /* PageListSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */; };
 		8B939F4323832E5D00ACCB0F /* PostListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B939F4223832E5D00ACCB0F /* PostListViewControllerTests.swift */; };
+		8BB0360523C18089007D50FF /* MediaEditorCapabilityCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB0360423C18089007D50FF /* MediaEditorCapabilityCell.swift */; };
 		8BB4D1432379C9CB0078A803 /* MediaEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4D1422379C9CB0078A803 /* MediaEditor.swift */; };
 		8BB4D1462379CA730078A803 /* MediaEditorCropZoomRotateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4D1452379CA730078A803 /* MediaEditorCropZoomRotateTests.swift */; };
 		8BBFBD97239AEB500086AD4E /* MediaEditorCropZoomRotate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBFBD96239AEB500086AD4E /* MediaEditorCropZoomRotate.swift */; };
@@ -3296,6 +3297,7 @@
 		8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadMessages.swift; sourceTree = "<group>"; };
 		8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListSectionHeaderView.swift; sourceTree = "<group>"; };
 		8B939F4223832E5D00ACCB0F /* PostListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListViewControllerTests.swift; sourceTree = "<group>"; };
+		8BB0360423C18089007D50FF /* MediaEditorCapabilityCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditorCapabilityCell.swift; sourceTree = "<group>"; };
 		8BB4D1422379C9CB0078A803 /* MediaEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditor.swift; sourceTree = "<group>"; };
 		8BB4D1452379CA730078A803 /* MediaEditorCropZoomRotateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditorCropZoomRotateTests.swift; sourceTree = "<group>"; };
 		8BBFBD96239AEB500086AD4E /* MediaEditorCropZoomRotate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditorCropZoomRotate.swift; sourceTree = "<group>"; };
@@ -7143,6 +7145,7 @@
 				8BBFBDAB23A135B90086AD4E /* MediaEditorHub.storyboard */,
 				8BC6E04723BE385000C2D174 /* MediaEditorThumbCell.swift */,
 				8B241A9F23BF5E5E000F2F14 /* MediaEditorImageCell.swift */,
+				8BB0360423C18089007D50FF /* MediaEditorCapabilityCell.swift */,
 			);
 			path = MediaEditor;
 			sourceTree = "<group>";
@@ -12243,6 +12246,7 @@
 				1714F8D020E6DA8900226DCB /* RouteMatcher.swift in Sources */,
 				591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */,
 				E1CA0A6C1FA73053004C4BBE /* PluginStore.swift in Sources */,
+				8BB0360523C18089007D50FF /* MediaEditorCapabilityCell.swift in Sources */,
 				E11DA4931E03E03F00CF07A8 /* Pinghub.swift in Sources */,
 				E1B912831BB01047003C25B9 /* PeopleRoleBadgeLabel.swift in Sources */,
 				40FC6B7F2072E3EC00B9A1CD /* ActivityDetailViewController.swift in Sources */,

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
@@ -75,4 +75,15 @@ class MediaEditorHubTests: XCTestCase {
         expect(hub.mainStackView.semanticContentAttribute).to(equal(.forceRightToLeft))
     }
 
+    func testShowButtonWithTheCapabilityIcon() {
+        let hub: MediaEditorHub = MediaEditorHub.initialize()
+        hub.loadViewIfNeeded()
+        let icon = UIImage()
+
+        hub.capabilities = [("Foo", icon)]
+
+        let capabilityCell = hub.collectionView(hub.capabilitiesCollectionView, cellForItemAt: IndexPath(row: 0, section: 0)) as? MediaEditorCapabilityCell
+        expect(capabilityCell?.iconButton.imageView?.image).to(equal(icon))
+    }
+
 }

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
@@ -86,4 +86,23 @@ class MediaEditorHubTests: XCTestCase {
         expect(capabilityCell?.iconButton.imageView?.image).to(equal(icon))
     }
 
+    func testCallsDelegateWhenCapabilityIsTapped() {
+        let hub: MediaEditorHub = MediaEditorHub.initialize()
+        hub.loadViewIfNeeded()
+        let delegateMock = MediaEditorHubDelegateMock()
+        hub.delegate = delegateMock
+
+        hub.collectionView(hub.capabilitiesCollectionView, didSelectItemAt: IndexPath(row: 1, section: 0))
+
+        expect(delegateMock.didCallCapabilityTappedWithIndex).to(equal(1))
+    }
+
+}
+
+private class MediaEditorHubDelegateMock: MediaEditorHubDelegate {
+    var didCallCapabilityTappedWithIndex: Int?
+
+    func capabilityTapped(_ index: Int) {
+        didCallCapabilityTappedWithIndex = index
+    }
 }

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
@@ -97,6 +97,49 @@ class MediaEditorHubTests: XCTestCase {
         expect(delegateMock.didCallCapabilityTappedWithIndex).to(equal(1))
     }
 
+    func testShowActivityIndicatorWhenLoadingAnImage() {
+        let hub: MediaEditorHub = MediaEditorHub.initialize()
+        hub.loadViewIfNeeded()
+
+        hub.loadingImage(at: 1)
+
+        expect(hub.activityIndicatorView.isHidden).to(beFalse())
+    }
+
+    func testDoNotShowActivityIndicatorIfImageIsNotBeingLoaded() {
+        let hub: MediaEditorHub = MediaEditorHub.initialize()
+        hub.availableThumbs = [0: UIImage(), 1: UIImage()]
+        hub.loadViewIfNeeded()
+        hub.loadingImage(at: 0)
+
+        hub.collectionView(hub.thumbsCollectionView, didSelectItemAt: IndexPath(row: 1, section: 0))
+
+        expect(hub.activityIndicatorView.isHidden).to(beTrue())
+    }
+
+    func testShowActivityIndicatorWhenSwipingToAnImageBeingLoaded() {
+        let hub: MediaEditorHub = MediaEditorHub.initialize()
+        hub.availableThumbs = [0: UIImage(), 1: UIImage()]
+        hub.loadViewIfNeeded()
+        hub.loadingImage(at: 1)
+        hub.loadingImage(at: 0)
+
+        hub.collectionView(hub.thumbsCollectionView, didSelectItemAt: IndexPath(row: 1, section: 0))
+
+        expect(hub.activityIndicatorView.isHidden).to(beFalse())
+    }
+
+    func testHideActivityIndicatorWhenImageIsLoaded() {
+        let hub: MediaEditorHub = MediaEditorHub.initialize()
+        hub.availableThumbs = [0: UIImage(), 1: UIImage()]
+        hub.loadViewIfNeeded()
+        hub.loadingImage(at: 0)
+
+        hub.loadedImage(at: 0)
+
+        expect(hub.activityIndicatorView.isHidden).to(beTrue())
+    }
+
 }
 
 private class MediaEditorHubDelegateMock: MediaEditorHubDelegate {

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
@@ -129,6 +129,16 @@ class MediaEditorHubTests: XCTestCase {
         expect(hub.activityIndicatorView.isHidden).to(beFalse())
     }
 
+    func testDisableCapabilitiesWhenImageIsBeingLoaded() {
+        let hub: MediaEditorHub = MediaEditorHub.initialize()
+        hub.availableThumbs = [0: UIImage(), 1: UIImage()]
+        hub.loadViewIfNeeded()
+
+        hub.loadingImage(at: 0)
+
+        expect(hub.capabilitiesCollectionView.isUserInteractionEnabled).to(beFalse())
+    }
+
     func testHideActivityIndicatorWhenImageIsLoaded() {
         let hub: MediaEditorHub = MediaEditorHub.initialize()
         hub.availableThumbs = [0: UIImage(), 1: UIImage()]
@@ -138,6 +148,17 @@ class MediaEditorHubTests: XCTestCase {
         hub.loadedImage(at: 0)
 
         expect(hub.activityIndicatorView.isHidden).to(beTrue())
+    }
+
+    func testEnableCapabilitiesWhenImageIsLoaded() {
+        let hub: MediaEditorHub = MediaEditorHub.initialize()
+        hub.availableThumbs = [0: UIImage(), 1: UIImage()]
+        hub.loadViewIfNeeded()
+        hub.loadingImage(at: 0)
+
+        hub.loadedImage(at: 0)
+
+        expect(hub.capabilitiesCollectionView.isUserInteractionEnabled).to(beTrue())
     }
 
 }

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -229,6 +229,10 @@ class MediaEditorTests: XCTestCase {
 }
 
 class MockCapability: MediaEditorCapability {
+    static var name = "MockCapability"
+
+    static var icon = UIImage()
+
     var applyCalled = false
 
     var image: UIImage

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -39,7 +39,7 @@ class MediaEditorTests: XCTestCase {
         expect(currentCapability?.applyCalled).to(beTrue())
     }
 
-    func editPresentsFromTheGivenViewController() {
+    func testEditPresentsFromTheGivenViewController() {
         let viewController = UIViewControllerMock()
         let mediaEditor = MediaEditor(image)
 

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -72,12 +72,13 @@ class MediaEditorTests: XCTestCase {
 
     func testWhenCancelingDismissTheMediaEditor() {
         let viewController = UIViewController()
+        UIApplication.shared.topWindow?.addSubview(viewController.view)
         let mediaEditor = MediaEditor(image)
         viewController.present(mediaEditor, animated: false)
 
         mediaEditor.currentCapability?.onCancel()
 
-        expect(viewController.presentedViewController).to(beNil())
+        expect(viewController.presentedViewController).toEventually(beNil())
     }
 
     func testWhenFinishEditingCallOnFinishEditing() {
@@ -276,6 +277,20 @@ class MediaEditorTests: XCTestCase {
         expect(mediaEditor.images[0]).to(equal(editedImage))
         expect(mediaEditor.hub.availableImages[0]).to(equal(editedImage))
         expect(mediaEditor.hub.availableThumbs[0]).to(equal(editedImage))
+    }
+
+    func testWhenCancelingDismissTheCapabilityAndGoesBackToHub() {
+        let viewController = UIViewController()
+        UIApplication.shared.topWindow?.addSubview(viewController.view)
+        let whiteImage = UIImage(color: .white)!
+        let blackImage = UIImage(color: .black)!
+        let mediaEditor = MediaEditor([whiteImage, blackImage])
+        viewController.present(mediaEditor, animated: false)
+        mediaEditor.capabilityTapped(0)
+
+        mediaEditor.currentCapability?.onCancel()
+
+        expect(mediaEditor.visibleViewController).toEventually(equal(mediaEditor.hub))
     }
 
     // WHEN: Multiple async images + one single capability

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -287,6 +287,62 @@ class MediaEditorTests: XCTestCase {
 
         expect(mediaEditor.hub.thumbsToolbar.isHidden).to(beFalse())
     }
+
+    func testWhenGivenMultipleAsyncImagesPresentsTheHub() {
+        let asyncImages = [AsyncImageMock(), AsyncImageMock()]
+
+        let mediaEditor = MediaEditor(asyncImages)
+
+        expect(mediaEditor.currentCapability).to(beNil())
+        expect(mediaEditor.visibleViewController).to(equal(mediaEditor.hub))
+    }
+
+    func testTappingACapabilityDoesntPresentItRightAway() {
+        let asyncImages = [AsyncImageMock(), AsyncImageMock()]
+        let mediaEditor = MediaEditor(asyncImages)
+
+        mediaEditor.capabilityTapped(0)
+
+        expect(mediaEditor.currentCapability).to(beNil())
+        expect(mediaEditor.visibleViewController).to(equal(mediaEditor.hub))
+    }
+
+    func testTappingACapabilityStartsTheRequestForTheFullImage() {
+        let firstImage = AsyncImageMock()
+        let seconImage = AsyncImageMock()
+        let mediaEditor = MediaEditor([firstImage, seconImage])
+
+        mediaEditor.capabilityTapped(0)
+
+        expect(firstImage.didCallFull).to(beTrue())
+    }
+
+    func testWhenTheFullImageIsAvailableShowTheCapability() {
+        let fullImage = UIImage()
+        let firstImage = AsyncImageMock()
+        let seconImage = AsyncImageMock()
+        let mediaEditor = MediaEditor([firstImage, seconImage])
+        mediaEditor.capabilityTapped(0)
+
+        firstImage.simulate(fullImageHasBeenDownloaded: fullImage)
+
+        expect(mediaEditor.currentCapability).toEventuallyNot(beNil())
+        expect(mediaEditor.visibleViewController).to(equal(mediaEditor.currentCapability?.viewController))
+    }
+
+    func testWhenTheFullImageIsAvailableUpdateTheImageReferences() {
+        let fullImage = UIImage()
+        let firstImage = AsyncImageMock()
+        let seconImage = AsyncImageMock()
+        let mediaEditor = MediaEditor([firstImage, seconImage])
+        mediaEditor.capabilityTapped(0)
+
+        firstImage.simulate(fullImageHasBeenDownloaded: fullImage)
+
+        expect(mediaEditor.hub.availableThumbs[0]).toEventually(equal(fullImage))
+        expect(mediaEditor.hub.availableImages[0]).to(equal(fullImage))
+        expect(mediaEditor.images[0]).to(equal(fullImage))
+    }
 }
 
 class MockCapability: MediaEditorCapability {

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -30,6 +30,14 @@ class MediaEditorTests: XCTestCase {
         expect(mediaEditor.modalPresentationStyle).to(equal(.fullScreen))
     }
 
+    func testHubDelegate() {
+        let mediaEditor = MediaEditor(image)
+
+        let hubDelegate = mediaEditor.hub.delegate as? MediaEditor
+
+        expect(hubDelegate).to(equal(mediaEditor))
+    }
+
     func testSettingStylesChangingTheCurrentShownCapability() {
         let mediaEditor = MediaEditor(image)
 

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -231,6 +231,53 @@ class MediaEditorTests: XCTestCase {
         expect(secondThumb?.thumbImageView.image).to(equal(blackImage))
     }
 
+    func testPresentsTheHub() {
+        let whiteImage = UIImage(color: .white)!
+        let blackImage = UIImage(color: .black)!
+
+        let mediaEditor = MediaEditor([whiteImage, blackImage])
+
+        expect(mediaEditor.currentCapability).to(beNil())
+        expect(mediaEditor.visibleViewController).to(equal(mediaEditor.hub))
+    }
+
+    func testTappingACapabilityPresentsIt() {
+        let whiteImage = UIImage(color: .white)!
+        let blackImage = UIImage(color: .black)!
+        let mediaEditor = MediaEditor([whiteImage, blackImage])
+
+        mediaEditor.capabilityTapped(0)
+
+        expect(mediaEditor.currentCapability).toNot(beNil())
+        expect(mediaEditor.visibleViewController).to(equal(mediaEditor.currentCapability?.viewController))
+    }
+
+    func testCallingOnCancelWhenShowingACapabilityGoesBackToHub() {
+        let whiteImage = UIImage(color: .white)!
+        let blackImage = UIImage(color: .black)!
+        let mediaEditor = MediaEditor([whiteImage, blackImage])
+        mediaEditor.capabilityTapped(0)
+
+        mediaEditor.currentCapability?.onCancel()
+
+        expect(mediaEditor.currentCapability).to(beNil())
+        expect(mediaEditor.visibleViewController).to(equal(mediaEditor.hub))
+    }
+
+    func testCallingOnFinishWhenShowingACapabilityUpdatesTheImage() {
+        let whiteImage = UIImage(color: .white)!
+        let blackImage = UIImage(color: .black)!
+        let editedImage = UIImage()
+        let mediaEditor = MediaEditor([whiteImage, blackImage])
+        mediaEditor.capabilityTapped(0)
+
+        mediaEditor.currentCapability?.onFinishEditing(editedImage, [.crop])
+
+        expect(mediaEditor.images[0]).to(equal(editedImage))
+        expect(mediaEditor.hub.availableImages[0]).to(equal(editedImage))
+        expect(mediaEditor.hub.availableThumbs[0]).to(equal(editedImage))
+    }
+
     // WHEN: Multiple async images + one single capability
 
     func testShowThumbsToolbar() {

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -38,6 +38,12 @@ class MediaEditorTests: XCTestCase {
         expect(hubDelegate).to(equal(mediaEditor))
     }
 
+    func testGivesTheListOfCapabilitiesIconsAndNames() {
+        let mediaEditor = MediaEditor(image)
+
+        expect(mediaEditor.hub.capabilities.count).to(equal(1))
+    }
+
     func testSettingStylesChangingTheCurrentShownCapability() {
         let mediaEditor = MediaEditor(image)
 


### PR DESCRIPTION
Fixes #13104

Depends on https://github.com/wordpress-mobile/WordPress-iOS/pull/13171

<img src="https://user-images.githubusercontent.com/7040243/71826261-4b8f9380-307c-11ea-90f0-09fa99b2e171.gif" width="400">

This PR shows all the available capabilities (so far, only crop/zoom/rotate) and the user can manipulate the image.

### To test

First, in `GutenbergViewController.swift` replace the function `gutenbergDidRequestFullscreenImage` by this one:

```swift
    func gutenbergDidRequestFullscreenImage(with mediaUrl: URL) {
        gutenbergDidRequestMediaEditor(with: mediaUrl, callback: { _ in })
    }
```

And inside `gutenbergDidRequestMediaEditor` give the `image` multiple times to the MediaEditor, like this (line 447):

```swift
let mediaEditor = WPMediaEditor([image, image, image, image, image, image, image, image, image, image])
```

You can test the same thing in Aztec, just pass the same image multiple times.

#### Loading an image

1. Tap the crop button
2. If the "Loading image" appears, note that the crop button is slightly faded and can't be used
3. When the image is available, the crop button should be available again

#### Cropping an image

1. Tap the crop button
2. Change the image
3. Tap "Done"
4. Check that the image and the thumbnail is updated

#### Cropping an image and canceling

1. Tap the crop button
2. Change the image
3. Tap "Cancel"
4. Check that the image and the thumbnail remains the same

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
