### PR TITLE
Adds support to PHAsset

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -8,6 +8,7 @@ enum FeatureFlag: Int, CaseIterable {
     case signInWithApple
     case postScheduling
     case debugMenu
+    case mediaEditor
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -34,6 +35,8 @@ enum FeatureFlag: Int, CaseIterable {
         case .debugMenu:
             return BuildConfiguration.current ~= [.localDeveloper,
                                                   .a8cBranchTest]
+        case .mediaEditor:
+            return true
         }
     }
 }
@@ -64,6 +67,8 @@ extension FeatureFlag: OverrideableFlag {
             return "Post scheduling improvements"
         case .debugMenu:
             return "Debug menu"
+        case .mediaEditor:
+            return "Media Editor"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3187,6 +3187,21 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
             return
         }
 
+        /*
+         Temporarilly enable Media Editor in internal builds.
+         This will be refactored soon.
+         */
+        if FeatureFlag.mediaEditor.enabled, let phAssets = assets as? [PHAsset] {
+            let mediaEditor = WPMediaEditor(phAssets)
+
+            mediaEditor.edit(from: self,
+                                  onFinishEditing: { [weak self] image, actions in
+                                    // Does nothing
+            })
+
+            return
+        }
+
         for asset in assets {
             switch asset {
             case let phAsset as PHAsset:

--- a/WordPress/MediaEditor/Extensions/PHAsset+AsyncImage.swift
+++ b/WordPress/MediaEditor/Extensions/PHAsset+AsyncImage.swift
@@ -1,0 +1,72 @@
+/**
+This is an extension to allow PHAsset in Media Editor.
+*/
+extension PHAsset: AsyncImage {
+    /**
+     PHAsset doesn't provide a thumbnail right away.
+     It will be requested in the thumbnail() method
+    */
+    public var thumb: UIImage? {
+        return nil
+    }
+
+    /**
+     Keep track of all ongoing image requests so they can be cancelled.
+    */
+    public var requests: [PHImageRequestID] {
+        get {
+            return objc_getAssociatedObject(self, &Keys.requests) as? [PHImageRequestID] ?? []
+        }
+        set {
+            objc_setAssociatedObject(self, &Keys.requests, newValue, .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+
+    /**
+     Fetch a thumbnail and then display a better quality one.
+    */
+    public func thumbnail(finishedRetrievingThumbnail: @escaping (UIImage?) -> ()) {
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .opportunistic
+        options.version = .current
+        options.resizeMode = .fast
+        let requestID = PHImageManager.default().requestImage(for: self, targetSize: self.pixelSize(), contentMode: .default, options: options) { image, info in
+            guard let image = image else {
+                finishedRetrievingThumbnail(nil)
+                return
+            }
+
+            finishedRetrievingThumbnail(image)
+        }
+        requests.append(requestID)
+    }
+
+    /**
+     Fetch the full quality image.
+    */
+    public func full(finishedRetrievingFullImage: @escaping (UIImage?) -> ()) {
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .highQualityFormat
+        options.version = .current
+        let requestID = PHImageManager.default().requestImage(for: self, targetSize: self.pixelSize(), contentMode: .default, options: options) { image, info in
+            guard let image = image else {
+                finishedRetrievingFullImage(nil)
+                return
+            }
+
+            finishedRetrievingFullImage(image)
+        }
+        requests.append(requestID)
+    }
+
+    /**
+     Cancel all ongoing requests
+    */
+    public func cancel() {
+        requests.forEach { PHImageManager.default().cancelImageRequest($0) }
+    }
+
+    private enum Keys {
+        static var requests = "requests"
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1037,6 +1037,7 @@
 		8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */; };
 		8B93856E22DC08060010BF02 /* PageListSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */; };
 		8B939F4323832E5D00ACCB0F /* PostListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B939F4223832E5D00ACCB0F /* PostListViewControllerTests.swift */; };
+		8B9DE00323C3A02500AC63CB /* PHAsset+AsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9DE00223C3A02500AC63CB /* PHAsset+AsyncImage.swift */; };
 		8BB0360523C18089007D50FF /* MediaEditorCapabilityCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB0360423C18089007D50FF /* MediaEditorCapabilityCell.swift */; };
 		8BB4D1432379C9CB0078A803 /* MediaEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4D1422379C9CB0078A803 /* MediaEditor.swift */; };
 		8BB4D1462379CA730078A803 /* MediaEditorCropZoomRotateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4D1452379CA730078A803 /* MediaEditorCropZoomRotateTests.swift */; };
@@ -3297,6 +3298,7 @@
 		8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadMessages.swift; sourceTree = "<group>"; };
 		8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListSectionHeaderView.swift; sourceTree = "<group>"; };
 		8B939F4223832E5D00ACCB0F /* PostListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListViewControllerTests.swift; sourceTree = "<group>"; };
+		8B9DE00223C3A02500AC63CB /* PHAsset+AsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PHAsset+AsyncImage.swift"; sourceTree = "<group>"; };
 		8BB0360423C18089007D50FF /* MediaEditorCapabilityCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditorCapabilityCell.swift; sourceTree = "<group>"; };
 		8BB4D1422379C9CB0078A803 /* MediaEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditor.swift; sourceTree = "<group>"; };
 		8BB4D1452379CA730078A803 /* MediaEditorCropZoomRotateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditorCropZoomRotateTests.swift; sourceTree = "<group>"; };
@@ -7134,11 +7136,20 @@
 			path = Controllers;
 			sourceTree = "<group>";
 		};
+		8B9DE00423C3A18600AC63CB /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				8B9DE00223C3A02500AC63CB /* PHAsset+AsyncImage.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		8BB4D1412379C9B50078A803 /* MediaEditor */ = {
 			isa = PBXGroup;
 			children = (
 				8BBFBDA023A009900086AD4E /* Capabilities */,
 				8BBFBDA223A009CA0086AD4E /* Enums */,
+				8B9DE00423C3A18600AC63CB /* Extensions */,
 				8BB4D1422379C9CB0078A803 /* MediaEditor.swift */,
 				8BBFBD98239EAA8D0086AD4E /* MediaEditorHub.swift */,
 				8BBFBDA523A01AE30086AD4E /* AsyncImage.swift */,
@@ -11328,6 +11339,7 @@
 				B50C0C5F1EF42A4A00372C65 /* AztecPostViewController.swift in Sources */,
 				2FA6511321F26949009AA935 /* SiteVerticalsPromptService.swift in Sources */,
 				FF28B3F11AEB251200E11AAE /* InfoPListTranslator.m in Sources */,
+				8B9DE00323C3A02500AC63CB /* PHAsset+AsyncImage.swift in Sources */,
 				086E1FE01BBB35D2002D86CA /* MenusViewController.m in Sources */,
 				9F3EFCA3208E308A00268758 /* UIViewController+Notice.swift in Sources */,
 				8B93856E22DC08060010BF02 /* PageListSectionHeaderView.swift in Sources */,


### PR DESCRIPTION
Fixes #13175

Depends on https://github.com/wordpress-mobile/WordPress-iOS/pull/13174

<img src="https://user-images.githubusercontent.com/7040243/71837904-46d7d900-3096-11ea-9f0f-4071eb38ab45.gif" width="400" />

This PR adds support to use `PHAsset`s in the Media Editor.

I've also added a Feature Flag to allow it to be tested in Aztec (Gutenberg is our main target but it doesn't support multiple images yet).

### To test

#### Single image

1. Add a single image and insert it
2. The Media Editor should appear and show the crop/zoom/rotate capability right away

#### Multiple images

1. Add multiple images and tap "Insert X"
2. The Media Editor should appear showing all the selected images

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
