### PR TITLE
[VoiceOver] Stats Overview Improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
@@ -61,7 +61,7 @@ class HorizontalAxisFormatter: IAxisValueFormatter {
             return ""
         }
 
-        return "\(formatter.string(from: weekStart)) – \(formatter.string(from: weekEnd))"
+        return "\(formatter.string(from: weekStart)) to \(formatter.string(from: weekEnd))"
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
@@ -4,15 +4,16 @@ import Charts
 // MARK: - Charts extensions
 
 extension BarChartData {
-    convenience init(entries: [BarChartDataEntry]) {
-        let dataSet = BarChartDataSet(values: entries)
+    convenience init(entries: [BarChartDataEntry], valueFormatter: IValueFormatter? = nil) {
+        let dataSet = BarChartDataSet(values: entries, label: nil, valueFormatter: valueFormatter)
         self.init(dataSets: [dataSet])
     }
 }
 
 extension BarChartDataSet {
-    convenience init(values: [BarChartDataEntry]) {
-        self.init(values: values, label: nil)
+    convenience init(values: [BarChartDataEntry], label: String?, valueFormatter: IValueFormatter?) {
+        self.init(values: values, label: label)
+        self.valueFormatter = valueFormatter
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -127,10 +127,10 @@ private final class PeriodChartDataTransformer {
         let visitorsChartData = BarChartData(dataSet: visitorsDataSet)
         chartData.append(visitorsChartData)
 
-        let likesChartData = BarChartData(entries: likeEntries)
+        let likesChartData = BarChartData(entries: likeEntries, valueFormatter: dataSetValueFormatter)
         chartData.append(likesChartData)
 
-        let commentsChartData = BarChartData(entries: commentEntries)
+        let commentsChartData = BarChartData(entries: commentEntries, valueFormatter: dataSetValueFormatter)
         chartData.append(commentsChartData)
 
         for barChart in chartData {

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -104,8 +104,10 @@ private final class PeriodChartDataTransformer {
 
         var chartData = [BarChartData]()
 
-        let viewsDataSet = BarChartDataSet(values: viewEntries)
-        let visitorsDataSet = BarChartDataSet(values: visitorEntries)
+        let viewsDataSet = BarChartDataSet(values: viewEntries,
+                                           label: NSLocalizedString("Views", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Views bar chart."))
+        let visitorsDataSet = BarChartDataSet(values: visitorEntries,
+                                              label: NSLocalizedString("Visitors", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Views bar chart."))
         let viewsDataSets = [ viewsDataSet, visitorsDataSet ]
         let viewsChartData = BarChartData(dataSets: viewsDataSets)
         chartData.append(viewsChartData)

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -53,6 +53,8 @@ private struct PeriodChartData: BarChartDataConvertible {
 // MARK: - PeriodChartDataTransformer
 
 private final class PeriodChartDataTransformer {
+    private static let dataSetValueFormatter = DefaultValueFormatter(decimals: 0)
+
     static func transform(data: StatsSummaryTimeIntervalData) -> (barChartData: [BarChartDataConvertible], barChartStyling: [BarChartStyling]) {
         let summaryData = data.summaryData
 
@@ -106,8 +108,11 @@ private final class PeriodChartDataTransformer {
 
         let viewsDataSet = BarChartDataSet(values: viewEntries,
                                            label: NSLocalizedString("Views", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Views bar chart."))
+        viewsDataSet.valueFormatter = dataSetValueFormatter
         let visitorsDataSet = BarChartDataSet(values: visitorEntries,
                                               label: NSLocalizedString("Visitors", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Views bar chart."))
+        visitorsDataSet.valueFormatter = dataSetValueFormatter
+
         let viewsDataSets = [ viewsDataSet, visitorsDataSet ]
         let viewsChartData = BarChartData(dataSets: viewsDataSets)
         chartData.append(viewsChartData)

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -53,6 +53,14 @@ private struct PeriodChartData: BarChartDataConvertible {
 // MARK: - PeriodChartDataTransformer
 
 private final class PeriodChartDataTransformer {
+    /// A formatter for the Chart values with no decimals
+    ///
+    /// The Charts' default formatter has a single decimal defined. This causes VoiceOver to
+    /// sometimes read the decimal part. For example, VoiceOver would says “29.0” for a visitors
+    /// value.
+    ///
+    /// - SeeAlso: ChartUtils.defaultValueFormatter()
+    ///
     private static let dataSetValueFormatter = DefaultValueFormatter(decimals: 0)
 
     static func transform(data: StatsSummaryTimeIntervalData) -> (barChartData: [BarChartDataConvertible], barChartStyling: [BarChartStyling]) {
@@ -107,12 +115,11 @@ private final class PeriodChartDataTransformer {
         var chartData = [BarChartData]()
 
         let viewsDataSet = BarChartDataSet(values: viewEntries,
-                                           label: NSLocalizedString("Views", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Views bar chart."))
-        viewsDataSet.valueFormatter = dataSetValueFormatter
+                                           label: NSLocalizedString("Views", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Views bar chart."),
+                                           valueFormatter: dataSetValueFormatter)
         let visitorsDataSet = BarChartDataSet(values: visitorEntries,
-                                              label: NSLocalizedString("Visitors", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Views bar chart."))
-        visitorsDataSet.valueFormatter = dataSetValueFormatter
-
+                                              label: NSLocalizedString("Visitors", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Views bar chart."),
+                                              valueFormatter: dataSetValueFormatter)
         let viewsDataSets = [ viewsDataSet, visitorsDataSet ]
         let viewsChartData = BarChartData(dataSets: viewsDataSets)
         chartData.append(viewsChartData)

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -117,7 +117,7 @@ private final class PeriodChartDataTransformer {
         let viewsChartData = BarChartData(dataSets: viewsDataSets)
         chartData.append(viewsChartData)
 
-        let visitorsChartData = BarChartData(entries: visitorEntries)
+        let visitorsChartData = BarChartData(dataSet: visitorsDataSet)
         chartData.append(visitorsChartData)
 
         let likesChartData = BarChartData(entries: likeEntries)

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -209,6 +209,21 @@
         }
     }
 
+    var tabAccessibilityHint: String {
+        switch self {
+        case .periodOverviewViews:
+            return TabAccessibilityHints.overviewViews
+        case .periodOverviewVisitors:
+            return TabAccessibilityHints.overviewVisitors
+        case .periodOverviewLikes:
+            return TabAccessibilityHints.overviewLikes
+        case .periodOverviewComments:
+            return TabAccessibilityHints.overviewComments
+        default:
+            return ""
+        }
+    }
+
     var totalFollowers: String {
         switch self {
         case .insightsFollowersWordPress:
@@ -361,6 +376,13 @@
         static let overviewVisitors = NSLocalizedString("Visitors", comment: "Label for Period Overview visitors")
         static let overviewLikes = NSLocalizedString("Likes", comment: "Label for Period Overview likes")
         static let overviewComments = NSLocalizedString("Comments", comment: "Label for Period Overview comments")
+    }
+
+    struct TabAccessibilityHints {
+        static let overviewViews = NSLocalizedString("Updates the bar chart to show views.", comment: "Accessibility hint for the Views button in Stats Overview.")
+        static let overviewVisitors = NSLocalizedString("Updates the bar chart to show visitors.", comment: "Accessibility hint for the Visitors button in Stats Overview.")
+        static let overviewLikes = NSLocalizedString("Updates the bar chart to show likes.", comment: "Accessibility hint for the Likes button in Stats Overview.")
+        static let overviewComments = NSLocalizedString("Updates the bar chart to show comments.", comment: "Accessibility hint for the Comments button in Stats Overview.")
     }
 
     struct TotalFollowers {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -10,6 +10,8 @@ struct OverviewTabData: FilterTabBarItem {
     var period: StatsPeriodUnit?
     var analyticsStat: WPAnalyticsStat?
 
+    private(set) var accessibilityHint: String?
+
     init(tabTitle: String,
          tabData: Int,
          tabDataStub: String? = nil,
@@ -17,7 +19,8 @@ struct OverviewTabData: FilterTabBarItem {
          differencePercent: Int,
          date: Date? = nil,
          period: StatsPeriodUnit? = nil,
-         analyticsStat: WPAnalyticsStat? = nil) {
+         analyticsStat: WPAnalyticsStat? = nil,
+         accessibilityHint: String? = nil) {
         self.tabTitle = tabTitle
         self.tabData = tabData
         self.tabDataStub = tabDataStub
@@ -26,6 +29,7 @@ struct OverviewTabData: FilterTabBarItem {
         self.date = date
         self.period = period
         self.analyticsStat = analyticsStat
+        self.accessibilityHint = accessibilityHint
     }
 
     var attributedTitle: NSAttributedString? {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -77,6 +77,13 @@ struct OverviewTabData: FilterTabBarItem {
         return self.tabTitle.localizedLowercase
     }
 
+    var accessibilityLabel: String? {
+        tabTitle
+    }
+
+    var accessibilityValue: String? {
+        return tabDataStub != nil ? "" : "\(tabData)"
+    }
 }
 
 class OverviewCell: UITableViewCell, NibLoadable {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -276,7 +276,8 @@ private extension SiteStatsPeriodViewModel {
                                            differencePercent: viewsData.percentage,
                                            date: periodDate,
                                            period: period,
-                                           analyticsStat: .statsOverviewTypeTappedViews)
+                                           analyticsStat: .statsOverviewTypeTappedViews,
+                                           accessibilityHint: StatSection.periodOverviewViews.tabAccessibilityHint)
 
         let visitorsData = intervalData(summaryType: .visitors)
         let visitorsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewVisitors.tabTitle,
@@ -285,7 +286,8 @@ private extension SiteStatsPeriodViewModel {
                                               differencePercent: visitorsData.percentage,
                                               date: periodDate,
                                               period: period,
-                                              analyticsStat: .statsOverviewTypeTappedVisitors)
+                                              analyticsStat: .statsOverviewTypeTappedVisitors,
+                                              accessibilityHint: StatSection.periodOverviewVisitors.tabAccessibilityHint)
 
         let likesData = intervalData(summaryType: .likes)
         // If Summary Likes is still loading, show dashes (instead of 0)
@@ -298,7 +300,8 @@ private extension SiteStatsPeriodViewModel {
                                            differencePercent: likesData.percentage,
                                            date: periodDate,
                                            period: period,
-                                           analyticsStat: .statsOverviewTypeTappedLikes)
+                                           analyticsStat: .statsOverviewTypeTappedLikes,
+                                           accessibilityHint: StatSection.periodOverviewLikes.tabAccessibilityHint)
 
         let commentsData = intervalData(summaryType: .comments)
         let commentsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewComments.tabTitle,
@@ -307,7 +310,8 @@ private extension SiteStatsPeriodViewModel {
                                               differencePercent: commentsData.percentage,
                                               date: periodDate,
                                               period: period,
-                                              analyticsStat: .statsOverviewTypeTappedComments)
+                                              analyticsStat: .statsOverviewTypeTappedComments,
+                                              accessibilityHint: StatSection.periodOverviewComments.tabAccessibilityHint)
 
         var barChartData = [BarChartDataConvertible]()
         var barChartStyling = [BarChartStyling]()

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -10,12 +10,14 @@ protocol FilterTabBarItem {
     var accessibilityIdentifier: String { get }
     var accessibilityLabel: String? { get }
     var accessibilityValue: String? { get }
+    var accessibilityHint: String? { get }
 }
 
 extension FilterTabBarItem {
     var attributedTitle: NSAttributedString? { return nil }
     var accessibilityLabel: String? { return nil }
     var accessibilityValue: String? { return nil }
+    var accessibilityHint: String? { return nil }
 }
 
 extension FilterTabBarItem where Self: RawRepresentable {
@@ -273,6 +275,7 @@ class FilterTabBar: UIControl {
         tab.accessibilityIdentifier = item.accessibilityIdentifier
         tab.accessibilityLabel = item.accessibilityLabel
         tab.accessibilityValue = item.accessibilityValue
+        tab.accessibilityHint = item.accessibilityHint
 
         tab.contentEdgeInsets = item.attributedTitle != nil ?
             AppearanceMetrics.buttonInsetsAttributedTitle :

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -8,10 +8,14 @@ protocol FilterTabBarItem {
     var title: String { get }
     var attributedTitle: NSAttributedString? { get }
     var accessibilityIdentifier: String { get }
+    var accessibilityLabel: String? { get }
+    var accessibilityValue: String? { get }
 }
 
 extension FilterTabBarItem {
     var attributedTitle: NSAttributedString? { return nil }
+    var accessibilityLabel: String? { return nil }
+    var accessibilityValue: String? { return nil }
 }
 
 extension FilterTabBarItem where Self: RawRepresentable {
@@ -267,6 +271,8 @@ class FilterTabBar: UIControl {
         tab.setAttributedTitle(addColor(deselectedTabColor, toAttributedString: item.attributedTitle), for: .normal)
 
         tab.accessibilityIdentifier = item.accessibilityIdentifier
+        tab.accessibilityLabel = item.accessibilityLabel
+        tab.accessibilityValue = item.accessibilityValue
 
         tab.contentEdgeInsets = item.attributedTitle != nil ?
             AppearanceMetrics.buttonInsetsAttributedTitle :


### PR DESCRIPTION
Fixes #12971. Refs #11995.

This prioritizes fixing the user-reported issue #12971. But I also included some little things along the way. 

## Improvements

### Stacked Bar Chart Labels

The user reported that it is not easy to identify Visitors from Views. This adds labels to the bar chart items. 

The label only applies in stacked bar charts. This is the default behavior from the Charts library. See `BarChartRenderer.createAccessibleElement` for that. 

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/71900508-3289ef80-311b-11ea-942c-2d0a17a8cb74.png)        |       ![image](https://user-images.githubusercontent.com/198826/71900565-4a617380-311b-11ea-96cd-065929b59282.png)

### Tab Buttons

VoiceOver reads these buttons without pause. Which is quite odd when you hear it. This PR improves that by making use of [`accessibilityLabel` and `accessibilityValue`](https://github.com/wordpress-mobile/WordPress-iOS/blob/4d966872a41140e9a3d483b6ebe369dfbe50f399/WordPress/Classes/ViewRelated/System/FilterTabBar.swift#L11-L13) for pausing. I also added hints. 

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/71900605-59e0bc80-311b-11ea-895e-73585ad98bea.png)        |       ![image](https://user-images.githubusercontent.com/198826/71900684-83014d00-311b-11ea-8ed8-03c924fb8c21.png)

### Decimal Values

The Visitors values are oddly read with a “point zero” by VoiceOver. This was because the Charts library's default formatter uses a single decimal point. I added a [custom formatter](https://github.com/wordpress-mobile/WordPress-iOS/blob/4d966872a41140e9a3d483b6ebe369dfbe50f399/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift#L56-L64) to fix this.

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/71900735-9c09fe00-311b-11ea-99f4-9d980e26386a.png)        |       ![image](https://user-images.githubusercontent.com/198826/71900793-c2c83480-311b-11ea-98eb-01b8451d7fde.png)

### Week Range

VoiceOver doesn't read the dash in the week range label very well. It just seems to ignore it and so the dates are read without pausing. I changed it so that the dash is now a `“to”`. Hopefully, this is more understandable when listened to.

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/71900869-e7bca780-311b-11ea-8ed8-ce96f44a33b4.png)        |       ![image](https://user-images.githubusercontent.com/198826/71900890-f1460f80-311b-11ea-947f-697af5c18c98.png)

## Outstanding Issues

There is a bug where the bar chart items are not selectable when you choose a different dimension (e.g. Views, Visitors, etc).

1. Open Stats → Days. One of the dimension (e.g. Views) is selected.
2. Slide finger over the bar chart. The hovered bar is read by VoiceOver.
3. Tap on another (e.g. Visitors)
4. Slide finger over the bar chart. VoiceOver reads “Bar chart depicting views…” instead of the bar item's label.

## Testing

1. Turn VoiceOver on.
2. Open Stats → Weeks tab.
3. The Views tab in the bar chart should be selected. If not, select it and select a different tab and go back to avoid the outstanding issue described above.
4. Confirm that a bar chart item's label is read before the value. For example, “Views, Jun 2019: 325”. 
5. Select the Visitors, Likes, or Comments tab but don't activate them yet. 
6. Confirm that there is a pause between the title and the value when VoiceOver reads them. 
7. Confirm that the hint is read after a slight pause. 
8. Navigate to the Visitors tab. 
9. Confirm that no decimal value is read when hovering over the bar items.
10. Select Stats → Weeks again. 
11. Confirm that hovering over a bar item will read “{date} **to** {date}". 

## Reviewing 

- What do you think of the tab button hints? Do they correctly describe what will happen when the buttons are tapped? 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
