### PR TITLE
[Gutenberg] Rollout phase 2

### DIFF
--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -50,7 +50,7 @@ import Foundation
 
     /// This method is intended to be called only after the db 87 to 88 migration
     ///
-    func migrateGlobalSettingToRemote(isGutenbergEnabled: Bool, overrideRemote: Bool = false) {
+    func migrateGlobalSettingToRemote(isGutenbergEnabled: Bool, overrideRemote: Bool = false, onSuccess: (() -> Void)? = nil) {
         guard let api = apiForDefaultAccount else {
             // SelfHosted non-jetpack sites won't sync with remote.
             return
@@ -61,6 +61,7 @@ import Foundation
         let service = EditorServiceRemote(wordPressComRestApi: api)
         service.postDesignateMobileEditorForAllSites(remoteEditor, setOnlyIfEmpty: !overrideRemote, success: { response in
             self.updateAllSites(with: response)
+            onSuccess?()
         }) { (error) in
             DDLogError("Error saving editor settings: \(error)")
         }

--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -50,7 +50,7 @@ import Foundation
 
     /// This method is intended to be called only after the db 87 to 88 migration
     ///
-    func migrateGlobalSettingToRemote(isGutenbergEnabled: Bool) {
+    func migrateGlobalSettingToRemote(isGutenbergEnabled: Bool, overrideRemote: Bool = false) {
         guard let api = apiForDefaultAccount else {
             // SelfHosted non-jetpack sites won't sync with remote.
             return
@@ -59,7 +59,7 @@ import Foundation
         let remoteEditor: EditorSettings.Mobile = isGutenbergEnabled ? .gutenberg : .aztec
 
         let service = EditorServiceRemote(wordPressComRestApi: api)
-        service.postDesignateMobileEditorForAllSites(remoteEditor, success: { response in
+        service.postDesignateMobileEditorForAllSites(remoteEditor, setOnlyIfEmpty: !overrideRemote, success: { response in
             self.updateAllSites(with: response)
         }) { (error) in
             DDLogError("Error saving editor settings: \(error)")

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -167,6 +167,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         if #available(iOS 13, *) {
             checkAppleIDCredentialState()
         }
+        GutenbergSettings().performGutenbergPhase2MigrationIfNeeded()
     }
 
     func application(_ application: UIApplication, shouldSaveApplicationState coder: NSCoder) -> Bool {

--- a/WordPress/Classes/Utility/Editor/GutenbergRollout.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergRollout.swift
@@ -1,0 +1,35 @@
+/// This structs helps encapsulate logic related to Gutenberg rollout phases.
+///
+struct GutenbergRollout {
+    enum Key {
+        static let userInRolloutGroup = "kUserInGutenbergRolloutGroup"
+    }
+    let database: KeyValueDatabase
+    private let phase2Percentage = 30
+    private let context = Environment.current.contextManager.mainContext
+
+    var isUserInRolloutGroup: Bool {
+        get {
+            database.bool(forKey: Key.userInRolloutGroup)
+        }
+        set {
+            database.set(newValue, forKey: Key.userInRolloutGroup)
+        }
+    }
+
+    func shouldPerformPhase2Migration(userId: Int) -> Bool {
+        return
+            isUserInRolloutGroup == false &&
+            atLeastOneSiteHasAztecEnabled() &&
+            isUserIdInPhase2RolloutPercentage(userId)
+    }
+
+    private func isUserIdInPhase2RolloutPercentage(_ userId: Int) -> Bool {
+        return userId % 100 >= (100 - phase2Percentage)
+    }
+
+    private func atLeastOneSiteHasAztecEnabled() -> Bool {
+        let allBlogs = BlogService(managedObjectContext: context).blogsForAllAccounts()
+        return allBlogs.contains { $0.editor == .aztec }
+    }
+}

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -104,12 +104,20 @@ class GutenbergSettings {
         let allBlogs = BlogService(managedObjectContext: context).blogsForAllAccounts()
         allBlogs.forEach { blog in
             if blog.editor == .aztec {
-                database.set(true, forKey: Key.showPhase2Dialog(for: blog))
+                setShowPhase2Dialog(true, for: blog)
                 database.set(true, forKey: Key.enabledOnce(for: blog))
             }
         }
         let editorSettingsService = EditorSettingsService(managedObjectContext: context)
         editorSettingsService.migrateGlobalSettingToRemote(isGutenbergEnabled: true, overrideRemote: true)
+    }
+
+    func shouldPresentInformativeDialog(for blog: Blog) -> Bool {
+        return database.bool(forKey: Key.showPhase2Dialog(for: blog))
+    }
+
+    func setShowPhase2Dialog(_ showDialog: Bool, for blog: Blog) {
+        database.set(showDialog, forKey: Key.showPhase2Dialog(for: blog))
     }
 
     /// Sets gutenberg enabled without registering the enabled action ("enabledOnce")

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -18,6 +18,7 @@ class GutenbergSettings {
         case viaSiteSettings = "via-site-settings"
         case onSiteCreation = "on-site-creation"
         case onBlockPostOpening = "on-block-post-opening"
+        case onProgressiveRolloutPhase2 = "on-progressive-rollout-phase-2"
     }
 
     // MARK: - Internal variables
@@ -65,6 +66,7 @@ class GutenbergSettings {
         if rollout.shouldPerformPhase2Migration(userId: account.userID.intValue) {
             setGutenbergEnabledForAllSites()
             rollout.isUserInRolloutGroup = true
+            trackSettingChange(to: true, from: .onProgressiveRolloutPhase2)
         }
     }
 
@@ -77,7 +79,9 @@ class GutenbergSettings {
             }
         }
         let editorSettingsService = EditorSettingsService(managedObjectContext: context)
-        editorSettingsService.migrateGlobalSettingToRemote(isGutenbergEnabled: true, overrideRemote: true)
+        editorSettingsService.migrateGlobalSettingToRemote(isGutenbergEnabled: true, overrideRemote: true, onSuccess: {
+            WPAnalytics.refreshMetadata()
+        })
     }
 
     func shouldPresentInformativeDialog(for blog: Blog) -> Bool {

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -1,39 +1,3 @@
-import Foundation
-
-struct GutenbergRollout {
-    enum Key {
-        static let userInRolloutGroup = "kUserInGutenbergRolloutGroup"
-    }
-    let database: KeyValueDatabase
-    private let phase2Percentage = 30
-    private let context = Environment.current.contextManager.mainContext
-
-    var isUserInRolloutGroup: Bool {
-        get {
-            database.bool(forKey: Key.userInRolloutGroup)
-        }
-        set {
-            database.set(newValue, forKey: Key.userInRolloutGroup)
-        }
-    }
-
-    func shouldPerformPhase2Migration(userId: Int) -> Bool {
-        return
-            isUserInRolloutGroup == false &&
-            atLeastOneSiteHasAztecEnabled() &&
-            isUserIdInPhase2RolloutPercentage(userId)
-    }
-
-    private func isUserIdInPhase2RolloutPercentage(_ userId: Int) -> Bool {
-        return userId % 100 >= (100 - phase2Percentage)
-    }
-
-    private func atLeastOneSiteHasAztecEnabled() -> Bool {
-        let allBlogs = BlogService(managedObjectContext: context).blogsForAllAccounts()
-        return allBlogs.contains { $0.editor == .aztec }
-    }
-}
-
 /// Takes care of storing and accessing Gutenberg settings.
 ///
 class GutenbergSettings {

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -54,9 +54,13 @@ class GutenbergSettings {
     }
 
     func performGutenbergPhase2MigrationIfNeeded() {
-        guard let account = AccountService(managedObjectContext: context).defaultWordPressComAccount() else {
+        guard
+            ReachabilityUtils.isInternetReachable(),
+            let account = AccountService(managedObjectContext: context).defaultWordPressComAccount()
+        else {
             return
         }
+
         var rollout = GutenbergRollout(database: database)
         if rollout.shouldPerformPhase2Migration(userId: account.userID.intValue) {
             setGutenbergEnabledForAllSites()

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -12,6 +12,10 @@ extension GutenbergViewController {
             "You’re now using the block editor for new pages — great! If you’d like to change to the classic editor, go to ‘My Site’ > ‘Site Settings’.",
             comment: "Popup content about why this post is being opened in block editor"
         )
+        static let phase2Message = NSLocalizedString(
+            "We made big improvements to the block editor and think it's worth a try!\n\nWe enabled it for new posts and pages but if you'd like to change to the classic editor, go to 'My Site' > 'Site Settings'.",
+            comment: "Popup content about why this post is being opened in block editor"
+        )
         static let title = NSLocalizedString(
             "Block editor enabled",
             comment: "Popup title about why this post is being opened in block editor"
@@ -21,9 +25,20 @@ extension GutenbergViewController {
 
     func showInformativeDialogIfNecessary() {
         if shouldPresentInformativeDialog {
-            let message = post is Page ? InfoDialog.pageMessage : InfoDialog.postMessage
-            GutenbergViewController.showInformativeDialog(on: self, message: message)
+            showMigrationInformativeDialog()
+        } else if shouldPresentPhase2informativeDialog {
+            showPhase2InformativeDialog()
         }
+    }
+
+    func showMigrationInformativeDialog() {
+        let message = post is Page ? InfoDialog.pageMessage : InfoDialog.postMessage
+        GutenbergViewController.showInformativeDialog(on: self, message: message)
+    }
+
+    func showPhase2InformativeDialog() {
+        GutenbergViewController.showInformativeDialog(on: self, message: InfoDialog.phase2Message)
+        GutenbergSettings().setShowPhase2Dialog(false, for: post.blog)
     }
 
     static func showInformativeDialog(

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -218,6 +218,9 @@ class GutenbergViewController: UIViewController, PostEditor {
     }
     private var isFirstGutenbergLayout = true
     var shouldPresentInformativeDialog = false
+    lazy var shouldPresentPhase2informativeDialog: Bool = {
+        return GutenbergSettings().shouldPresentInformativeDialog(for: post.blog)
+    }()
 
     // MARK: - Initializers
     required init(
@@ -316,7 +319,7 @@ class GutenbergViewController: UIViewController, PostEditor {
     }
 
     func focusTitleIfNeeded() {
-        guard !post.hasContent() && shouldPresentInformativeDialog == false else {
+        guard !post.hasContent(), shouldPresentInformativeDialog == false, shouldPresentPhase2informativeDialog == false else {
             return
         }
         gutenberg.setFocusOnTitle()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -312,6 +312,7 @@
 		1AED723A229D2E2C0036C5B8 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2B4EA11FD6654A007AE3E4 /* Logger.swift */; };
 		1D36FCB53C05724865D41F7A /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
+		1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */; };
 		2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296890780FE971DC00770264 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296890770FE971DC00770264 /* Security.framework */; };
@@ -2475,6 +2476,7 @@
 		1B77149F6C65D343E7E3AD09 /* Pods-WordPressUITests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressUITests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressUITests/Pods-WordPressUITests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergRollout.swift; sourceTree = "<group>"; };
 		2262D835FA89938EBF63EADF /* Pods-WordPressShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		27AE66536E0C5378203F9312 /* Pods-WordPressUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressUITests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressUITests/Pods-WordPressUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		28A0AAE50D9B0CCF005BE974 /* WordPress_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPress_Prefix.pch; sourceTree = "<group>"; };
@@ -9513,6 +9515,7 @@
 			children = (
 				F115308021B17E65002F1D65 /* EditorFactory.swift */,
 				FF54D4631D6F3FA900A0DC4D /* GutenbergSettings.swift */,
+				1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */,
 			);
 			path = Editor;
 			sourceTree = "<group>";
@@ -11033,6 +11036,7 @@
 				4054F4572214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataProperties.swift in Sources */,
 				9A2B28F52192121400458F2A /* RevisionOperation.swift in Sources */,
 				984B4EF320742FCC00F87888 /* ZendeskUtils.swift in Sources */,
+				1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */,
 				17E24F5420FCF1D900BD70A3 /* Routes+MySites.swift in Sources */,
 				0828D7FA1E6E09AE00C7C7D4 /* WPAppAnalytics+Media.swift in Sources */,
 				7ED3695520A9F091007B0D56 /* Blog+ImageSourceInformation.swift in Sources */,

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -46,6 +46,7 @@ class GutenbergSettingsTests: XCTestCase {
         contextManager = TestContextManager()
         context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         context.parent = contextManager.mainContext
+        Environment.replaceEnvironment(contextManager: contextManager)
         database = EphemeralKeyValueDatabase()
         settings = GutenbergSettings(database: database)
         blog = newTestBlog()
@@ -332,7 +333,7 @@ class GutenbergSettingsTests: XCTestCase {
         account.authToken = "auth"
         account.uuid = UUID().uuidString
         account.userID = NSNumber(value: userId)
-        try! context.save()
+        contextManager.saveContextAndWait(context)
         AccountService(managedObjectContext: context).setDefaultWordPressComAccount(account)
     }
 }

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -297,4 +297,42 @@ class GutenbergSettingsTests: XCTestCase {
             database.set(true, forKey: perSiteEnabledKey)
         }
     }
+
+    // mark - Phase 2
+
+    func testPhase2RolloutMigration() {
+        blog.mobileEditor = .aztec
+        setupAccount(withId: 80)
+        makeNetworkAvailable()
+
+        settings.performGutenbergPhase2MigrationIfNeeded()
+
+        XCTAssertTrue(database.bool(forKey: GutenbergSettings.Key.showPhase2Dialog(for: blog)))
+        XCTAssertTrue(GutenbergRollout(database: database).isUserInRolloutGroup)
+    }
+
+    func testPhase2RolloutMigrationIsTracked() {
+        blog.mobileEditor = .aztec
+        setupAccount(withId: 80)
+        makeNetworkAvailable()
+
+        settings.performGutenbergPhase2MigrationIfNeeded()
+
+        XCTAssertEqual(TestAnalyticsTracker.tracked.count, 1)
+
+        let trackEvent = TestAnalyticsTracker.tracked.first
+        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergEnabled)
+
+        let property = trackEvent?.properties["source"] as? String
+        XCTAssertEqual(property, GutenbergSettings.TracksSwitchSource.onProgressiveRolloutPhase2.rawValue)
+    }
+
+    func setupAccount(withId userId: Int) {
+        let account = ModelTestHelper.insertAccount(context: context)
+        account.authToken = "auth"
+        account.uuid = UUID().uuidString
+        account.userID = NSNumber(value: userId)
+        try! context.save()
+        AccountService(managedObjectContext: context).setDefaultWordPressComAccount(account)
+    }
 }


### PR DESCRIPTION
iOS side of https://github.com/wordpress-mobile/WordPress-Android/pull/11029

This PR implements the phase 2 of the Gutenberg rollout plan, targeting users that still have aztec as their default editor in any of there sites, and switching it to Gutenberg. With that we show a message explaining the change:
<img src="https://user-images.githubusercontent.com/9772967/71915364-e3c07200-317b-11ea-857f-b28ec12c4186.jpeg" width="400">


To test:
- Before checking out this branch: Set a site to use Aztec and another one using Gutenberg.
- Set `phase2Percentage` on `GutenbergRollout` to 100 and build.
- Check that the site using Aztec has now the switch set to Gutenberg.
- Open the editor and check that the message shows.
- Close and open the editor again, check that the message doesn't show anymore.
- Open the site that was previously set to Gutenberg.
- Check that it opens Gutenberg without any message.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
