### PR TITLE
[VoiceOver] Fix VoiceOver reading the previous bar chart

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -205,6 +205,13 @@ private extension OverviewCell {
         resetChartContainerView()
         chartContainerView.addSubview(chartView)
 
+        // There's a weird bug that happens when the user switches to a different tab
+        // (Views, Visitors, Likes, or Comments). VoiceOver would read the previous chart's
+        // accessibility label and would even not allow you to select the individual bar chart items.
+        //
+        // Forcing the `accessibilityElements` fixes this. ¯\_(ツ)_/¯
+        chartContainerView.accessibilityElements = [chartView]
+
         NSLayoutConstraint.activate([
             chartView.leadingAnchor.constraint(equalTo: chartContainerView.leadingAnchor),
             chartView.trailingAnchor.constraint(equalTo: chartContainerView.trailingAnchor),


### PR DESCRIPTION
Fixes #13191. Refs #11995. 

## Findings

I tried a few things to figure out the reason for this. 

### Are views created on top of each other?

Nope

### Do we need to inform VoiceOver that something has changed?

I tried posting `.layoutChanged` and `.screenChanged` notifications and that didn't work. 

### Is it running on a background thread?

Nope. The tab press event is on the main thread. 

### Experiment: Do not recreate the chart view

I experimented by not recreating the `ChartView` after it's been created once. I just removed it from the view hierarchy. It looks like even though the `ChartView` is no longer in the view hierarchy, VoiceOver would still consider it as accessible. ¯\\\_(ツ)\_/¯

<img src="https://user-images.githubusercontent.com/198826/71921776-ba392380-3146-11ea-9cca-c344dddc9dfd.png" width="320">

## Solution

By luck, I found that forcing `chartContainerView` to declare its `accessibilityElements` fixes this. 

https://github.com/wordpress-mobile/WordPress-iOS/blob/5e04dff5ff0c56b6e00fa72bebec3630213463dd/WordPress/Classes/ViewRelated/Stats/Period%20Stats/Overview/OverviewCell.swift#L213

I'm still not sure why VoiceOver wouldn't automatically detect the newly created `ChartView` in [`configureChartView`](https://github.com/wordpress-mobile/WordPress-iOS/blob/5e04dff5ff0c56b6e00fa72bebec3630213463dd/WordPress/Classes/ViewRelated/Stats/Period%20Stats/Overview/OverviewCell.swift#L192). But this is a safe use of `accessibilityElements` anyway so I believe it's an okay fix. 😬 

## Testing

1. Turn VoiceOver on.
1. Open Stats → Days. One of the dimension (e.g. Views) should be selected.
2. Slide your finger over the bar chart. The hovered bar chart item should be read by VoiceOver.
3. Tap on another tab (e.g. Visitors)
4. Slide your finger over the bar chart. 
5. Confirm that you can access the individual bar chart items.
6. Confirm that hovering over a bar chart's empty area would make VoiceOver read the correct “Bar chart depicting (Likes|Visitors|etc)” message.

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
