### PR TITLE
Return all images

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3490,7 +3490,12 @@ extension AztecPostViewController {
         let mediaEditor = WPMediaEditor(image)
 
         mediaEditor.edit(from: self,
-                              onFinishEditing: { [weak self] image, actions in
+                              onFinishEditing: { [weak self] images, actions in
+                                guard !actions.isEmpty, let image = images.first as? UIImage else {
+                                    // If the image wasn't edited, do nothing
+                                    return
+                                }
+
                                 self?.replace(attachment: imageAttachment, with: image, actions: actions)
         })
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -446,8 +446,8 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 
         let mediaEditor = WPMediaEditor(image)
         mediaEditor.edit(from: self,
-                              onFinishEditing: { [weak self] image, actions in
-                                guard !actions.isEmpty else {
+                              onFinishEditing: { [weak self] images, actions in
+                                guard !actions.isEmpty, let image = images.first as? UIImage else {
                                     // If the image wasn't edited, do nothing
                                     return
                                 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -447,7 +447,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         let mediaEditor = WPMediaEditor(image)
         mediaEditor.edit(from: self,
                               onFinishEditing: { [weak self] images, actions in
-                                guard !actions.isEmpty, let image = images.first as? UIImage else {
+                                guard let image = images.first?.editedImage else {
                                     // If the image wasn't edited, do nothing
                                     return
                                 }

--- a/WordPress/MediaEditor/AsyncImage.swift
+++ b/WordPress/MediaEditor/AsyncImage.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol AsyncImage {
+public protocol AsyncImage {
     var thumb: UIImage? { get }
 
     func thumbnail(finishedRetrievingThumbnail: @escaping (UIImage?) -> ())

--- a/WordPress/MediaEditor/AsyncImage.swift
+++ b/WordPress/MediaEditor/AsyncImage.swift
@@ -3,9 +3,38 @@ import UIKit
 public protocol AsyncImage {
     var thumb: UIImage? { get }
 
+    var isEdited: Bool { get set }
+
+    var editedImage: UIImage? { get set }
+
     func thumbnail(finishedRetrievingThumbnail: @escaping (UIImage?) -> ())
 
     func full(finishedRetrievingFullImage: @escaping (UIImage?) -> ())
 
     func cancel()
+}
+
+extension AsyncImage {
+    public var isEdited: Bool {
+        get {
+            return objc_getAssociatedObject(self, &AsyncImageKeys.isEdited) as? Bool ?? false
+        }
+        set {
+            objc_setAssociatedObject(self, &AsyncImageKeys.isEdited, newValue, .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+
+    public var editedImage: UIImage? {
+        get {
+            return objc_getAssociatedObject(self, &AsyncImageKeys.editedImage) as? UIImage ?? nil
+        }
+        set {
+            objc_setAssociatedObject(self, &AsyncImageKeys.editedImage, newValue, .OBJC_ASSOCIATION_RETAIN)
+        }
+    }
+}
+
+private enum AsyncImageKeys {
+    static var isEdited = "isEdited"
+    static var editedImage = "editedImage"
 }

--- a/WordPress/MediaEditor/Enums/MediaEditorStyle.swift
+++ b/WordPress/MediaEditor/Enums/MediaEditorStyle.swift
@@ -4,6 +4,7 @@ public typealias MediaEditorStyles = [MediaEditorStyle: Any]
 
 public enum MediaEditorStyle {
     case doneLabel
+    case doneColor
     case cancelLabel
     case cancelColor
     case resetIcon

--- a/WordPress/MediaEditor/Extensions/UIImage+AsyncImage.swift
+++ b/WordPress/MediaEditor/Extensions/UIImage+AsyncImage.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIImage: AsyncImage {
+    public var thumb: UIImage? {
+        return self
+    }
+
+    public func thumbnail(finishedRetrievingThumbnail: @escaping (UIImage?) -> ()) {}
+
+    public func full(finishedRetrievingFullImage: @escaping (UIImage?) -> ()) {}
+
+    public func cancel() {}
+}

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -25,7 +25,7 @@ public class MediaEditor: UINavigationController {
     var actions: [MediaEditorOperation] = []
 
     var isSingleImageAndCapability: Bool {
-        return (asyncImages.count == 1) || (images.count == 1 && asyncImages.count == 0) && Self.capabilities.count == 1
+        return ((asyncImages.count == 1) || (images.count == 1 && asyncImages.count == 0)) && Self.capabilities.count == 1
     }
 
     private(set) var currentCapability: MediaEditorCapability?
@@ -128,9 +128,11 @@ public class MediaEditor: UINavigationController {
         }
 
         if isSingleImageAndCapability {
-            hub.showActivityIndicator()
+            let index = selectedImageIndex
+            hub.loadingImage(at: index)
             hub.disableDoneButton()
             asyncImages.first?.full(finishedRetrievingFullImage: { [weak self] image in
+                self?.hub.loadedImage(at: index)
                 let offset = self?.selectedImageIndex ?? 0
                 self?.fullImageAvailable(image, offset: offset)
             })

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -128,7 +128,8 @@ public class MediaEditor: UINavigationController {
         }
 
         if isSingleImageAndCapability {
-            showActivityIndicator()
+            hub.showActivityIndicator()
+            hub.disableDoneButton()
             asyncImages.first?.full(finishedRetrievingFullImage: { [weak self] image in
                 let offset = self?.selectedImageIndex ?? 0
                 self?.fullImageAvailable(image, offset: offset)
@@ -248,20 +249,14 @@ public class MediaEditor: UINavigationController {
         self.images[offset] = image
 
         DispatchQueue.main.async {
-            self.hideActivityIndicator()
+            self.hub.hideActivityIndicator()
+
+            self.hub.enableDoneButton()
 
             self.presentIfSingleImageAndCapability()
 
             self.hub.show(image: image, at: offset)
         }
-    }
-
-    private func showActivityIndicator() {
-        hub.showActivityIndicator()
-    }
-
-    private func hideActivityIndicator() {
-        hub.hideActivityIndicator()
     }
 
     private enum Constants {

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -157,6 +157,7 @@ public class MediaEditor: UINavigationController {
     private func done() {
         let outputImages = isEditingPlainUIImages ? mapEditedImages() : mapEditedAsyncImages()
         onFinishEditing?(outputImages, actions)
+        dismiss(animated: true)
     }
 
     /*

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -95,6 +95,10 @@ public class MediaEditor: UINavigationController {
             self?.cancel()
         }
 
+        hub.onDone = { [weak self] in
+            self?.done()
+        }
+
         hub.apply(styles: styles)
 
         hub.availableThumbs = images
@@ -144,6 +148,10 @@ public class MediaEditor: UINavigationController {
         } else {
             dismissCapability()
         }
+    }
+
+    private func done() {
+        // Map images and return
     }
 
     private func cancelPendingAsyncImagesAndDismiss() {

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -151,7 +151,7 @@ public class MediaEditor: UINavigationController {
     }
 
     private func done() {
-        // Map images and return
+        onFinishEditing?(images.map { index, value in value }, actions)
     }
 
     private func cancelPendingAsyncImagesAndDismiss() {

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -18,7 +18,7 @@ public class MediaEditor: UINavigationController {
 
     var asyncImages: [AsyncImage] = []
 
-    var onFinishEditing: ((UIImage, [MediaEditorOperation]) -> ())?
+    var onFinishEditing: (([AsyncImage], [MediaEditorOperation]) -> ())?
 
     var onCancel: (() -> ())?
 
@@ -84,7 +84,7 @@ public class MediaEditor: UINavigationController {
         currentCapability = nil
     }
 
-    public func edit(from viewController: UIViewController? = nil, onFinishEditing: @escaping (UIImage, [MediaEditorOperation]) -> (), onCancel: (() -> ())? = nil) {
+    public func edit(from viewController: UIViewController? = nil, onFinishEditing: @escaping ([AsyncImage], [MediaEditorOperation]) -> (), onCancel: (() -> ())? = nil) {
         self.onFinishEditing = onFinishEditing
         self.onCancel = onCancel
         viewController?.present(self, animated: true)
@@ -172,7 +172,7 @@ public class MediaEditor: UINavigationController {
 
     private func finishEditing(image: UIImage) {
         if isSingleImageAndCapability {
-            onFinishEditing?(image, actions)
+            onFinishEditing?([image], actions)
             dismiss(animated: true)
         } else {
             hub.show(image: image, at: selectedImageIndex)

--- a/WordPress/MediaEditor/MediaEditorHub.storyboard
+++ b/WordPress/MediaEditor/MediaEditorHub.storyboard
@@ -157,6 +157,17 @@
                                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DTT-LK-vW1">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                                 <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E3p-rR-UYh">
+                                                        <rect key="frame" x="185" y="0.0" width="44" height="44"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="44" id="gdt-8t-xRy"/>
+                                                            <constraint firstAttribute="width" constant="44" id="pIJ-pV-Gj4"/>
+                                                        </constraints>
+                                                        <color key="tintColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <connections>
+                                                            <action selector="done:" destination="e8N-xf-0aT" eventType="touchUpInside" id="Pf0-oZ-qAE"/>
+                                                        </connections>
+                                                    </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2D1-xm-eyg">
                                                         <rect key="frame" x="185" y="0.0" width="44" height="44"/>
                                                         <constraints>
@@ -170,8 +181,10 @@
                                                 </subviews>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
+                                                    <constraint firstItem="E3p-rR-UYh" firstAttribute="centerX" secondItem="DTT-LK-vW1" secondAttribute="centerX" id="1QB-Fp-ceb"/>
                                                     <constraint firstAttribute="bottom" secondItem="2D1-xm-eyg" secondAttribute="bottom" id="BAx-mY-VtM"/>
                                                     <constraint firstAttribute="width" priority="999" constant="44" id="JCW-jV-DX6"/>
+                                                    <constraint firstItem="E3p-rR-UYh" firstAttribute="top" secondItem="DTT-LK-vW1" secondAttribute="top" id="a1i-YA-hd4"/>
                                                     <constraint firstItem="2D1-xm-eyg" firstAttribute="centerX" secondItem="DTT-LK-vW1" secondAttribute="centerX" id="aJW-fE-n0i"/>
                                                 </constraints>
                                             </view>
@@ -189,13 +202,28 @@
                                                             <action selector="cancel:" destination="e8N-xf-0aT" eventType="touchUpInside" id="r4U-1e-ql7"/>
                                                         </connections>
                                                     </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MW9-rG-pUQ">
+                                                        <rect key="frame" x="351" y="0.0" width="53" height="44"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="53" id="MAU-vg-0ly"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <color key="tintColor" red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                        <state key="normal" title="Done"/>
+                                                        <connections>
+                                                            <action selector="done:" destination="e8N-xf-0aT" eventType="touchUpInside" id="fem-2i-g5Q"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstItem="cCN-Nm-Ahb" firstAttribute="top" secondItem="oEl-Rm-OAA" secondAttribute="top" id="4Z6-ri-im4"/>
                                                     <constraint firstItem="cCN-Nm-Ahb" firstAttribute="leading" secondItem="oEl-Rm-OAA" secondAttribute="leading" constant="10" id="6uU-J0-waC"/>
                                                     <constraint firstAttribute="height" constant="44" id="CUv-j6-ETf"/>
+                                                    <constraint firstAttribute="trailing" secondItem="MW9-rG-pUQ" secondAttribute="trailing" constant="10" id="haq-nr-gjw"/>
+                                                    <constraint firstAttribute="bottom" secondItem="MW9-rG-pUQ" secondAttribute="bottom" id="jFO-Fh-nAH"/>
                                                     <constraint firstAttribute="bottom" secondItem="cCN-Nm-Ahb" secondAttribute="bottom" id="oe7-cN-D4V"/>
+                                                    <constraint firstItem="MW9-rG-pUQ" firstAttribute="top" secondItem="oEl-Rm-OAA" secondAttribute="top" id="pgt-xM-Eiw"/>
                                                 </constraints>
                                             </view>
                                         </subviews>
@@ -267,6 +295,8 @@
                         <outlet property="cancelButton" destination="cCN-Nm-Ahb" id="2yx-pN-P3d"/>
                         <outlet property="cancelIconButton" destination="2D1-xm-eyg" id="UqS-jv-SC1"/>
                         <outlet property="capabilitiesCollectionView" destination="YUc-Qf-Gm9" id="grx-bJ-0NB"/>
+                        <outlet property="doneButton" destination="MW9-rG-pUQ" id="7oe-3F-eud"/>
+                        <outlet property="doneIconButton" destination="E3p-rR-UYh" id="hYr-7M-9sh"/>
                         <outlet property="horizontalToolbar" destination="oEl-Rm-OAA" id="Zrk-p2-D2B"/>
                         <outlet property="imagesCollectionView" destination="t2B-QE-aMZ" id="Om9-9q-bLu"/>
                         <outlet property="mainStackView" destination="o0b-fF-tJw" id="5SY-51-tkZ"/>

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -155,6 +155,16 @@ class MediaEditorHub: UIViewController {
         activityIndicatorView.isHidden = true
     }
 
+    func disableDoneButton() {
+        doneButton.isEnabled = false
+        doneIconButton.isEnabled = false
+    }
+
+    func enableDoneButton() {
+        doneButton.isEnabled = true
+        doneIconButton.isEnabled = true
+    }
+
     func loadingImage(at index: Int) {
         indexesOfImagesBeingLoaded.append(index)
         showOrHideActivityIndicatorAndCapabilities()

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -2,6 +2,8 @@ import UIKit
 
 class MediaEditorHub: UIViewController {
 
+    @IBOutlet weak var doneButton: UIButton!
+    @IBOutlet weak var doneIconButton: UIButton!
     @IBOutlet weak var cancelButton: UIButton!
     @IBOutlet weak var cancelIconButton: UIButton!
     @IBOutlet weak var activityIndicatorView: UIVisualEffectView!
@@ -76,6 +78,9 @@ class MediaEditorHub: UIViewController {
         onCancel?()
     }
 
+    @IBAction func done(_ sender: Any) {
+    }
+
     func show(image: UIImage, at index: Int) {
         availableImages[index] = image
         availableThumbs[index] = image
@@ -108,13 +113,26 @@ class MediaEditorHub: UIViewController {
             cancelButton.setTitle(cancelLabel, for: .normal)
         }
 
+        if let doneLabel = styles[.doneLabel] as? String {
+            doneButton.setTitle(doneLabel, for: .normal)
+        }
+
         if let cancelColor = styles[.cancelColor] as? UIColor {
             cancelButton.tintColor = cancelColor
             cancelIconButton.tintColor = cancelColor
         }
 
+        if let doneColor = styles[.doneColor] as? UIColor {
+            doneButton.tintColor = doneColor
+            doneIconButton.tintColor = doneColor
+        }
+
         if let cancelIcon = styles[.cancelIcon] as? UIImage {
             cancelIconButton.setImage(cancelIcon, for: .normal)
+        }
+
+        if let doneIcon = styles[.doneIcon] as? UIImage {
+            doneIconButton.setImage(doneIcon, for: .normal)
         }
 
         if let loadingLabel = styles[.loadingLabel] as? String {

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -20,6 +20,8 @@ class MediaEditorHub: UIViewController {
 
     var onCancel: (() -> ())?
 
+    var onDone: (() -> ())?
+
     var numberOfThumbs = 0 {
         didSet {
             reloadImagesAndReposition()
@@ -79,6 +81,7 @@ class MediaEditorHub: UIViewController {
     }
 
     @IBAction func done(_ sender: Any) {
+        onDone?()
     }
 
     func show(image: UIImage, at index: Int) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1038,6 +1038,7 @@
 		8B93856E22DC08060010BF02 /* PageListSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */; };
 		8B939F4323832E5D00ACCB0F /* PostListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B939F4223832E5D00ACCB0F /* PostListViewControllerTests.swift */; };
 		8B9DE00323C3A02500AC63CB /* PHAsset+AsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9DE00223C3A02500AC63CB /* PHAsset+AsyncImage.swift */; };
+		8B9DE00623C4C8AF00AC63CB /* UIImage+AsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9DE00523C4C8AF00AC63CB /* UIImage+AsyncImage.swift */; };
 		8BB0360523C18089007D50FF /* MediaEditorCapabilityCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB0360423C18089007D50FF /* MediaEditorCapabilityCell.swift */; };
 		8BB4D1432379C9CB0078A803 /* MediaEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4D1422379C9CB0078A803 /* MediaEditor.swift */; };
 		8BB4D1462379CA730078A803 /* MediaEditorCropZoomRotateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB4D1452379CA730078A803 /* MediaEditorCropZoomRotateTests.swift */; };
@@ -3299,6 +3300,7 @@
 		8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListSectionHeaderView.swift; sourceTree = "<group>"; };
 		8B939F4223832E5D00ACCB0F /* PostListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListViewControllerTests.swift; sourceTree = "<group>"; };
 		8B9DE00223C3A02500AC63CB /* PHAsset+AsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PHAsset+AsyncImage.swift"; sourceTree = "<group>"; };
+		8B9DE00523C4C8AF00AC63CB /* UIImage+AsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+AsyncImage.swift"; sourceTree = "<group>"; };
 		8BB0360423C18089007D50FF /* MediaEditorCapabilityCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditorCapabilityCell.swift; sourceTree = "<group>"; };
 		8BB4D1422379C9CB0078A803 /* MediaEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditor.swift; sourceTree = "<group>"; };
 		8BB4D1452379CA730078A803 /* MediaEditorCropZoomRotateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaEditorCropZoomRotateTests.swift; sourceTree = "<group>"; };
@@ -7140,6 +7142,7 @@
 			isa = PBXGroup;
 			children = (
 				8B9DE00223C3A02500AC63CB /* PHAsset+AsyncImage.swift */,
+				8B9DE00523C4C8AF00AC63CB /* UIImage+AsyncImage.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -12208,6 +12211,7 @@
 				9A51DA1522E9E8C7005CC335 /* ChangeUsernameViewController.swift in Sources */,
 				5D6C4B121B604190005E3C43 /* RichTextView.swift in Sources */,
 				9A4E271D22EF33F5001F6A6B /* AccountSettingsStore.swift in Sources */,
+				8B9DE00623C4C8AF00AC63CB /* UIImage+AsyncImage.swift in Sources */,
 				4319AADE2090F00C0025D68E /* FancyAlertViewController+NotificationPrimer.swift in Sources */,
 				73FF7032221F469100541798 /* Charts+Support.swift in Sources */,
 				171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */,

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorHubTests.swift
@@ -35,6 +35,19 @@ class MediaEditorHubTests: XCTestCase {
         expect(didCallOnCancel).to(beTrue())
     }
 
+    func testTappingDoneButtonCallsOnDone() {
+        var didCallOnDone = false
+        let hub: MediaEditorHub = MediaEditorHub.initialize()
+        _ = hub.view
+        hub.onDone = {
+            didCallOnDone = true
+        }
+
+        hub.doneButton.sendActions(for: .touchUpInside)
+
+        expect(didCallOnDone).to(beTrue())
+    }
+
     func testApplyStyles() {
         let hub: MediaEditorHub = MediaEditorHub.initialize()
 

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -230,6 +230,25 @@ class MediaEditorTests: XCTestCase {
         expect(mediaEditor.hub.thumbsToolbar.isHidden).to(beTrue())
     }
 
+    func testWhenFinishEditingAsyncImageReturnTheAsyncImage() {
+        // Given
+        var returnedImages: [AsyncImage] = []
+        let asyncImage = AsyncImageMock()
+        let mediaEditor = MediaEditor(asyncImage)
+        asyncImage.simulate(fullImageHasBeenDownloaded: UIImage())
+        mediaEditor.onFinishEditing = { images, _ in
+            returnedImages = images
+        }
+        expect(mediaEditor.currentCapability).toEventuallyNot(beNil()) // Wait capability appear
+
+        // When
+        mediaEditor.currentCapability?.onFinishEditing(image, [.rotate])
+
+        // Then
+        expect(returnedImages.first?.isEdited).to(beTrue())
+        expect(returnedImages.first?.editedImage).to(equal(image))
+    }
+
     // WHEN: Multiple images + one single capability
 
     func testShowThumbs() {
@@ -384,6 +403,28 @@ class MediaEditorTests: XCTestCase {
         expect(mediaEditor.hub.availableThumbs[0]).toEventually(equal(fullImage))
         expect(mediaEditor.hub.availableImages[0]).to(equal(fullImage))
         expect(mediaEditor.images[0]).to(equal(fullImage))
+    }
+
+    func testWhenFinishEditingMultipleAsyncImageReturnAllAsyncImages() {
+        // Given
+        var returnedImages: [AsyncImage] = []
+        let firstImage = AsyncImageMock()
+        let seconImage = AsyncImageMock()
+        let mediaEditor = MediaEditor([firstImage, seconImage])
+        mediaEditor.capabilityTapped(0)
+        firstImage.simulate(fullImageHasBeenDownloaded: UIImage())
+        mediaEditor.onFinishEditing = { images, _ in
+            returnedImages = images
+        }
+        expect(mediaEditor.currentCapability).toEventuallyNot(beNil()) // Wait capability appear
+        mediaEditor.currentCapability?.onFinishEditing(image, [.rotate])
+
+        // When
+        mediaEditor.hub.doneButton.sendActions(for: .touchUpInside)
+
+        // Then
+        expect(returnedImages.first?.isEdited).to(beTrue())
+        expect(returnedImages.first?.editedImage).to(equal(image))
     }
 }
 

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -103,6 +103,18 @@ class MediaEditorTests: XCTestCase {
         expect(mediaEditor.actions).to(equal([.crop, .rotate]))
     }
 
+    func testWhenFinishEditingImagesReturnTheImages() {
+        var returnedImages: [UIImage] = []
+        let mediaEditor = MediaEditor(image)
+        mediaEditor.onFinishEditing = { images, _ in
+            returnedImages = images as! [UIImage]
+        }
+
+        mediaEditor.currentCapability?.onFinishEditing(image, [.rotate])
+
+        expect(returnedImages).to(equal([image]))
+    }
+
     // WHEN: Async image + one single capability
 
     func testRequestThumbAndFullImageQuality() {
@@ -291,6 +303,21 @@ class MediaEditorTests: XCTestCase {
         mediaEditor.currentCapability?.onCancel()
 
         expect(mediaEditor.visibleViewController).toEventually(equal(mediaEditor.hub))
+    }
+
+    func testWhenFinishEditingMultipleImagesReturnAllTheImages() {
+        var returnedImages: [UIImage] = []
+        let editedImage = UIImage(color: .black)!
+        let mediaEditor = MediaEditor([image, image])
+        mediaEditor.onFinishEditing = { images, _ in
+            returnedImages = images as! [UIImage]
+        }
+        mediaEditor.capabilityTapped(0)
+        mediaEditor.currentCapability?.onFinishEditing(editedImage, [.rotate])
+
+        mediaEditor.hub.doneButton.sendActions(for: .touchUpInside)
+
+        expect(returnedImages).to(equal([editedImage, image]))
     }
 
     // WHEN: Multiple async images + one single capability

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -249,6 +249,26 @@ class MediaEditorTests: XCTestCase {
         expect(returnedImages.first?.editedImage).to(equal(image))
     }
 
+
+    func testDisableDoneButtonWhileLoading() {
+        let asyncImage = AsyncImageMock()
+
+        let mediaEditor = MediaEditor(asyncImage)
+
+        expect(mediaEditor.hub.doneButton.isEnabled).to(beFalse())
+        expect(mediaEditor.hub.doneIconButton.isEnabled).to(beFalse())
+    }
+
+    func testEnableDoneButtonOnceImageIsLoaded() {
+        let asyncImage = AsyncImageMock()
+        let mediaEditor = MediaEditor(asyncImage)
+
+        asyncImage.simulate(fullImageHasBeenDownloaded: image)
+
+        expect(mediaEditor.hub.doneButton.isEnabled).toEventually(beTrue())
+        expect(mediaEditor.hub.doneIconButton.isEnabled).to(beTrue())
+    }
+
     // WHEN: Multiple images + one single capability
 
     func testShowThumbs() {

--- a/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
@@ -224,6 +224,9 @@ class AztecEditorScreen: BaseScreen {
         MediaPickerAlbumScreen().selectImage(atIndex: 0)
         insertMediaButton.tap()
 
+        // Tap Done in Media Editor
+        app.buttons["Done"].tap()
+
         // Wait for upload to finish
         waitFor(element: uploadProgressBar, predicate: "exists == false", timeout: 10)
 


### PR DESCRIPTION
Ref #13188

Depends on https://github.com/wordpress-mobile/WordPress-iOS/pull/13176

<img src="https://user-images.githubusercontent.com/7040243/71931161-ecb14380-317b-11ea-90ca-7a446cec26c3.gif" width="400">

This PR implements the feature to return all images after tapping "Done" in Media Editor. It will returned all the images — including the ones that were edited.

It also updates the integration with Aztec and Gutenberg.

## To test

*Note: We're using Aztec to test this PR to take advantage of the multiple images since Gutenberg doesn't have support for it yet. Our main goal's still Gutenberg.*

### Selecting multiple images

1. Using Aztec, selecting multiple images
2. Edit any image
3. Tap "Done"
4. The images should be uploaded — including the ones that were cropped/zoomed/rotated

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
