### PR TITLE
Stats: restore selected site ID when widget Stats modal is dismissed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * Fixed bugs with the "Save as Draft" action extension's navigation bar colors and iPad sizing in iOS 13.
 * Fixes appearance issues with navigation bar colors when logged out of the app.
 * Fixed a bug that was causing the App to crash when the user tapped on certain notifications.
+* Stats fixed issue that could cause incorrect Stats to be displayed when viewing Stats from a widget.
 
 13.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 * Fixed bugs with the "Save as Draft" action extension's navigation bar colors and iPad sizing in iOS 13.
 * Fixes appearance issues with navigation bar colors when logged out of the app.
 * Fixed a bug that was causing the App to crash when the user tapped on certain notifications.
-* Stats fixed issue that could cause incorrect Stats to be displayed when viewing Stats from a widget.
+* Stats: fixed issue that could cause incorrect Stats to be displayed when viewing Stats from a widget.
 
 13.9
 -----

--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -77,7 +77,15 @@ import AutomatticTracks
 
         let statsViewController = StatsViewController()
         statsViewController.blog = blog
+
+        let currentSiteID = SiteStatsInformation.sharedInstance.siteID
+
         statsViewController.dismissBlock = {
+            // The currently selected site could be different from the URL site.
+            // After the Stats modal is dismissed, restore the selected site's ID
+            // so the Stats view displays the correct stats.
+            SiteStatsInformation.sharedInstance.siteID = currentSiteID
+
             WPTabBarController.sharedInstance()?.dismiss(animated: true, completion: nil)
         }
 


### PR DESCRIPTION
Fixes #13194 

The problem was that the site ID used for stats was being overwritten by the site ID from the widget. To resolve this, the selected site ID is restored when the widget's Stats modal is dismissed. The Stats view is then refreshed for the correct site ID.

To test:

- Add the `Today` and/or the `All-Time` widget to the Today view.
- In the app:
  - Select a site. Go to Stats > Widgets > `Use this site`.
  - Select a different site, and go to Stats.
- Close the app.
- Return to the Today view and tap a widget.
- The app is launched, and a modal is displayed with the Stats for the widget site.
- Tap `Done` to close the modal.
- Verify the Stats view then displays the Stats for the selected site (not the widget site).

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
