### PR TITLE
Stats Widgets: Abbreviate large values

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * Fixed bugs with the "Save as Draft" action extension's navigation bar colors and iPad sizing in iOS 13.
 * Fixes appearance issues with navigation bar colors when logged out of the app.
 * Fixed a bug that was causing the App to crash when the user tapped on certain notifications.
+* Stats Today widgets: large numbers are now abbreviated.
 
 13.9
 -----

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1216,6 +1216,8 @@
 		98BFF57C2398406A008A1DCB /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CF3DB1EF1BE6800AF838E /* CocoaLumberjack.swift */; };
 		98BFF57E23984345008A1DCB /* AllTimeWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */; };
 		98BFF57F23984345008A1DCB /* AllTimeWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */; };
+		98C0CE9B23C559C800D0F27C /* Double+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C82B52193A7B900A06E84 /* Double+Stats.swift */; };
+		98C0CE9C23C559C800D0F27C /* Double+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C82B52193A7B900A06E84 /* Double+Stats.swift */; };
 		98CAD296221B4ED2003E8F45 /* StatSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CAD295221B4ED1003E8F45 /* StatSection.swift */; };
 		98D31B8F2396ED7F009CFF43 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E5283B19A7741A003A1A9C /* NotificationCenter.framework */; };
 		98D31B992396ED7F009CFF43 /* WordPressAllTimeWidget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 98D31B8E2396ED7E009CFF43 /* WordPressAllTimeWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -12370,6 +12372,7 @@
 				433ADC1C223B2A7E00ED9DE1 /* TextBundleWrapper.m in Sources */,
 				93E5284119A7741A003A1A9C /* TodayViewController.swift in Sources */,
 				938CF3DE1EF1BE8000AF838E /* CocoaLumberjack.swift in Sources */,
+				98C0CE9C23C559C800D0F27C /* Double+Stats.swift in Sources */,
 				93C2075A1CC7FF9C00C94D04 /* Tracks.swift in Sources */,
 				436110DA22C3ED44000773AD /* FeatureFlag.swift in Sources */,
 				436110DB22C3ED4C000773AD /* BuildConfiguration.swift in Sources */,
@@ -12402,6 +12405,7 @@
 				98A6B993239881860031AEBD /* MurielColor.swift in Sources */,
 				98D31BC223972A79009CFF43 /* SFHFKeychainUtils.m in Sources */,
 				98D31BAE239708FB009CFF43 /* Constants.m in Sources */,
+				98C0CE9B23C559C800D0F27C /* Double+Stats.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -37,12 +37,6 @@ class AllTimeViewController: UIViewController {
         }
     }
 
-    private let numberFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter
-    }()
-
     private let tracks = Tracks(appGroupName: WPAppGroupName)
 
     // MARK: - View
@@ -345,15 +339,12 @@ private extension AllTimeViewController {
 
     // MARK: - Helpers
 
-    func displayString(for value: Int) -> String {
-        return numberFormatter.string(from: NSNumber(value: value)) ?? String(value)
-    }
-
     func updateStatsLabels() {
-        viewCount = displayString(for: statsValues?.views ?? 0)
-        visitorCount = displayString(for: statsValues?.visitors ?? 0)
-        postCount = displayString(for: statsValues?.posts ?? 0)
-        bestCount = displayString(for: statsValues?.bestViews ?? 0)
+        let values = statsValues ?? AllTimeWidgetStats()
+        viewCount = values.views.abbreviatedString()
+        visitorCount = values.visitors.abbreviatedString()
+        postCount = values.posts.abbreviatedString()
+        bestCount = values.bestViews.abbreviatedString()
     }
 
     // MARK: - Constants

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -37,12 +37,6 @@ class TodayViewController: UIViewController {
         }
     }
 
-    private let numberFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter
-    }()
-
     private let tracks = Tracks(appGroupName: WPAppGroupName)
 
     // MARK: - View
@@ -345,15 +339,12 @@ private extension TodayViewController {
 
     // MARK: - Helpers
 
-    func displayString(for value: Int) -> String {
-        return numberFormatter.string(from: NSNumber(value: value)) ?? String(value)
-    }
-
     func updateStatsLabels() {
-        viewCount = displayString(for: statsValues?.views ?? 0)
-        visitorCount = displayString(for: statsValues?.visitors ?? 0)
-        likeCount = displayString(for: statsValues?.likes ?? 0)
-        commentCount = displayString(for: statsValues?.comments ?? 0)
+        let values = statsValues ?? TodayWidgetStats()
+        viewCount = values.views.abbreviatedString()
+        visitorCount = values.visitors.abbreviatedString()
+        likeCount = values.likes.abbreviatedString()
+        commentCount = values.comments.abbreviatedString()
     }
 
     // MARK: - Constants


### PR DESCRIPTION
Ref #12702 

This abbreviates the `Today` and `All-Time` widget values to match the app. That is, any number larger than 10,000 will get abbreviated.

To test:
- On a site with high traffic, go to Stats > Widgets > `Use this site`.
  - Tip: en.blog is a good one.
- If necessary, add the `Today` and `All-Time` stats to the Insights view. Make note of the values.
- Add the `Today` and `All-Time` widgets to the Today view.
- Verify the widget numbers are abbreviated as they are in the app.
  - Hack: `Today` is a bit difficult to verify. You can manually set the values in `TodayViewController:updateStatsLabels` to see the abbreviation. Of course this won't match the app, but it uses the same abbreviation logic.


**Insights All-Time:**
<img width="400" alt="app-all-time" src="https://user-images.githubusercontent.com/1816888/71942102-5f6cef80-3179-11ea-87ac-fd56c2cf89a3.png">

**Widget All-Time:**
<img width="400" alt="widget-all-time" src="https://user-images.githubusercontent.com/1816888/71942108-63007680-3179-11ea-9aa6-9769164a58f6.png">


PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
