### PR TITLE
Removes obsolete lines of code.

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -220,10 +220,6 @@ class MediaItemViewController: UITableViewController {
         controller.navigationItem.titleView = nil
         controller.title = media.title ?? ""
 
-        if let webView = controller.view.subviews.first as? UIWebView {
-            webView.backgroundColor = .lightGray
-        }
-
         navigationController?.pushViewController(controller, animated: true)
     }
 


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/WordPress-iOS/issues/13199

This method addresses some old code for the purpose of migrating from `UIWebView` to `WKWebView`.

https://github.com/wordpress-mobile/WordPress-iOS/blob/428de4c95de908768333206e9de9d87167467de6/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift#L214-L228

## Rationale:

`WebViewControllerFactory` [instantiates `WebKitViewController`](https://github.com/wordpress-mobile/WordPress-iOS/blob/428de4c95de908768333206e9de9d87167467de6/WordPress/Classes/Utility/WebViewControllerFactory.swift#L9), which [is implemented using `WKWebView`](https://github.com/wordpress-mobile/WordPress-iOS/blob/428de4c95de908768333206e9de9d87167467de6/WordPress/Classes/Utility/WebKitViewController.swift#L7).

The lines of code in the method above that refer to `UIWebView` aren't really working right now at all.  They're old code that wasn't updated when `WebViewControllerFactory` started using `WKWebView`.

This was tested by placing a breakpoint insider the IF block, which never triggered under any circumstance.

For this reason, I'm simply removing these old lines of code, which can be added back if necessary.

As an additional note, the UI looks fine even without those lines.

## To test:

My suggestion would be to follow the rationale described above to see if the change makes sense.  This change can't really be tested since the removed lines were never executed.

It can be validated though, by uploading a PDF to the device files, and then following these steps:

1. Go to one of your sites.
2. Go to Media.
3. Tap + to add a file, select "Other Apps", and select the PDF.
4. Once you'r back in the Media Library, tap on the PDF file.
5. Tap on the table header (the row showing the PDF icon) so that you can see the preview.

Make sure the preview looks fine.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
