### PR TITLE
[VoiceOver] Various improvements for Stats

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -18,6 +18,7 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
 
     @IBOutlet weak var actionLabel: UILabel!
     @IBOutlet weak var actionImageView: UIImageView!
+    @IBOutlet weak var actionButton: UIButton!
     @IBOutlet weak var disclosureImageView: UIImageView!
 
     @IBOutlet weak var topSeparatorLine: UIView!

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Gridicons
 
-class LatestPostSummaryCell: UITableViewCell, NibLoadable {
+class LatestPostSummaryCell: UITableViewCell, NibLoadable, Accessible {
 
     // MARK: - Properties
 
@@ -41,6 +41,7 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
     override func awakeFromNib() {
         super.awakeFromNib()
         applyStyles()
+        prepareForVoiceOver()
     }
 
     override func prepareForReuse() {
@@ -73,6 +74,10 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
         actionType = .viewMore
     }
 
+    func prepareForVoiceOver() {
+        actionButton.accessibilityLabel =
+            NSLocalizedString("View more", comment: "Accessibility label for the View more button in Stats' Post Summary.")
+    }
 }
 
 // MARK: - Private Extension

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.xib
@@ -170,6 +170,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="actionButton" destination="3OP-qA-To0" id="KWR-Es-zem"/>
                 <outlet property="actionImageView" destination="OZB-d7-5Vo" id="ZYF-8v-WcS"/>
                 <outlet property="actionLabel" destination="Xet-wC-hmj" id="amV-hg-OIZ"/>
                 <outlet property="actionStackView" destination="dj8-5c-J6O" id="gkV-Yq-6bI"/>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class PostingActivityCell: UITableViewCell, NibLoadable {
+class PostingActivityCell: UITableViewCell, NibLoadable, Accessible {
 
     // MARK: - Properties
 
@@ -23,6 +23,7 @@ class PostingActivityCell: UITableViewCell, NibLoadable {
         super.awakeFromNib()
         applyStyles()
         addLegend()
+        prepareForVoiceOver()
     }
 
     func configure(withData monthsData: [[PostingStreakEvent]], andDelegate delegate: SiteStatsInsightsDelegate?) {
@@ -33,6 +34,11 @@ class PostingActivityCell: UITableViewCell, NibLoadable {
     override func prepareForReuse() {
         super.prepareForReuse()
         removeExistingMonths()
+    }
+
+    func prepareForVoiceOver() {
+        viewMoreButton.accessibilityLabel =
+            NSLocalizedString("View more", comment: "Accessibility label for viewing more posting activity.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
@@ -40,6 +40,13 @@ class PostingActivityCell: UITableViewCell, NibLoadable, Accessible {
         viewMoreButton.accessibilityLabel =
             NSLocalizedString("View more", comment: "Accessibility label for viewing more posting activity.")
     }
+
+    override var accessibilityElements: [Any]? {
+        get {
+            monthsStackView.arrangedSubviews + [viewMoreButton].compactMap { $0 }
+        }
+        set { }
+    }
 }
 
 // MARK: - Private Extension

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
@@ -12,6 +12,7 @@ class PostingActivityCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var bottomSeparatorLine: UIView!
 
     @IBOutlet private var viewMoreView: UIView!
+    @IBOutlet private weak var viewMoreButton: UIButton!
 
     private typealias Style = WPStyleGuide.Stats
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.xib
@@ -112,6 +112,7 @@
                 <outlet property="legendView" destination="MNM-OS-iwT" id="3sj-wa-JnR"/>
                 <outlet property="monthsStackView" destination="BVC-pc-qhM" id="IlC-oK-tm8"/>
                 <outlet property="topSeparatorLine" destination="SrM-6z-hC1" id="AGS-zl-lmo"/>
+                <outlet property="viewMoreButton" destination="XhD-aG-GxJ" id="zDw-mj-d6m"/>
                 <outlet property="viewMoreLabel" destination="D7G-gg-9QM" id="6DH-YF-5A5"/>
                 <outlet property="viewMoreView" destination="A6f-g5-v7s" id="ISO-67-aVn"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
@@ -8,6 +8,7 @@ class TwoColumnCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var rowsStackView: UIStackView!
     @IBOutlet weak var viewMoreView: UIView!
     @IBOutlet weak var viewMoreLabel: UILabel!
+    @IBOutlet weak var viewMoreButton: UIButton!
     @IBOutlet weak var bottomSeparatorLine: UIView!
     @IBOutlet weak var rowsStackViewBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var viewMoreHeightConstraint: NSLayoutConstraint!

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class TwoColumnCell: UITableViewCell, NibLoadable {
+class TwoColumnCell: UITableViewCell, NibLoadable, Accessible {
 
     // MARK: - Properties
 
@@ -23,6 +23,7 @@ class TwoColumnCell: UITableViewCell, NibLoadable {
     override func awakeFromNib() {
         super.awakeFromNib()
         applyStyles()
+        prepareForVoiceOver()
     }
 
     override func prepareForReuse() {
@@ -36,6 +37,11 @@ class TwoColumnCell: UITableViewCell, NibLoadable {
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         addRows()
         toggleViewMore()
+    }
+
+    func prepareForVoiceOver() {
+        viewMoreButton.accessibilityLabel =
+            NSLocalizedString("View more", comment: "Accessibility label for View more button in Stats.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.xib
@@ -99,6 +99,7 @@
                 <outlet property="rowsStackView" destination="53U-Zk-ZGa" id="T8V-zp-KCA"/>
                 <outlet property="rowsStackViewBottomConstraint" destination="5cr-Nz-ZDr" id="gpX-JD-vtf"/>
                 <outlet property="topSeparatorLine" destination="NTK-eu-Zrd" id="9Sq-Ea-hi8"/>
+                <outlet property="viewMoreButton" destination="uon-fL-Zcd" id="qrf-iG-gty"/>
                 <outlet property="viewMoreHeightConstraint" destination="44e-cc-T7y" id="641-sy-IiJ"/>
                 <outlet property="viewMoreLabel" destination="1To-pb-uoT" id="nmB-Rf-6TI"/>
                 <outlet property="viewMoreView" destination="Cfy-Hl-Mjq" id="ljz-6d-bwT"/>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class CountriesMapCell: UITableViewCell, NibLoadable {
+class CountriesMapCell: UITableViewCell, NibLoadable, Accessible {
     private let countriesMapView = CountriesMapView.loadFromNib()
     private typealias Style = WPStyleGuide.Stats
 
@@ -18,9 +18,14 @@ class CountriesMapCell: UITableViewCell, NibLoadable {
     override func awakeFromNib() {
         super.awakeFromNib()
         selectionStyle = .none
+        prepareForVoiceOver()
     }
 
     func configure(with countriesMap: CountriesMap) {
         countriesMapView.setData(countriesMap)
+    }
+
+    func prepareForVoiceOver() {
+        accessibilityLabel = NSLocalizedString("World map showing views by country.", comment: "Accessibility label for the Stats' world map.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -94,10 +94,7 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
     }
 
     func prepareForVoiceOver() {
-        if let period = dateLabel.text {
-            let localizedLabel = NSLocalizedString("Current period: %@", comment: "Period Accessibility label. Prefix the current selected period. Ex. Current period: 2019")
-            dateLabel.accessibilityLabel = .localizedStringWithFormat(localizedLabel, period)
-        }
+        dateLabel.accessibilityLabel = displayDateAccessibilityLabel()
 
         backButton.accessibilityLabel = NSLocalizedString("Previous period", comment: "Accessibility label")
         backButton.accessibilityHint = NSLocalizedString("Tap to select the previous period", comment: "Accessibility hint")
@@ -158,6 +155,23 @@ private extension SiteStatsTableHeaderView {
             return "\(from)"
         }
     }
+
+    func displayDateAccessibilityLabel() -> String? {
+        guard let components = displayDateComponents() else {
+            return nil
+        }
+
+        let (from, to) = components
+
+        if let to = to {
+            let format = NSLocalizedString("Current period: %@ to %@", comment: "Week Period Accessibility label. Prefix the current selected period. Ex. Current period: Jan 6 to Jan 12.")
+            return .localizedStringWithFormat(format, from, to)
+        } else {
+            let format = NSLocalizedString("Current period: %@", comment: "Period Accessibility label. Prefix the current selected period. Ex. Current period: 2019")
+            return .localizedStringWithFormat(format, from)
+        }
+    }
+
     /// Returns the formatted dates for the current period.
     func displayDateComponents() -> (from: String, to: String?)? {
         guard let date = date, let period = period else {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -147,12 +147,12 @@ private extension SiteStatsTableHeaderView {
             return nil
         }
 
-        let (from, to) = components
+        let (fromDate, toDate) = components
 
-        if let to = to {
-            return "\(from) - \(to)"
+        if let toDate = toDate {
+            return "\(fromDate) - \(toDate)"
         } else {
-            return "\(from)"
+            return "\(fromDate)"
         }
     }
 
@@ -161,19 +161,19 @@ private extension SiteStatsTableHeaderView {
             return nil
         }
 
-        let (from, to) = components
+        let (fromDate, toDate) = components
 
-        if let to = to {
+        if let toDate = toDate {
             let format = NSLocalizedString("Current period: %@ to %@", comment: "Week Period Accessibility label. Prefix the current selected period. Ex. Current period: Jan 6 to Jan 12.")
-            return .localizedStringWithFormat(format, from, to)
+            return .localizedStringWithFormat(format, fromDate, toDate)
         } else {
             let format = NSLocalizedString("Current period: %@", comment: "Period Accessibility label. Prefix the current selected period. Ex. Current period: 2019")
-            return .localizedStringWithFormat(format, from)
+            return .localizedStringWithFormat(format, fromDate)
         }
     }
 
     /// Returns the formatted dates for the current period.
-    func displayDateComponents() -> (from: String, to: String?)? {
+    func displayDateComponents() -> (fromDate: String, toDate: String?)? {
         guard let date = date, let period = period else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -104,6 +104,13 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
 
         forwardButton.accessibilityLabel = NSLocalizedString("Next period", comment: "Accessibility label")
         forwardButton.accessibilityHint = NSLocalizedString("Tap to select the next period", comment: "Accessibility hint")
+
+        accessibilityElements = [
+            dateLabel,
+            timezoneLabel,
+            backButton,
+            forwardButton
+        ].compactMap { $0 }
     }
 
     func updateDate(with intervalDate: Date) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -146,6 +146,20 @@ private extension SiteStatsTableHeaderView {
     }
 
     func displayDate() -> String? {
+        guard let components = displayDateComponents() else {
+            return nil
+        }
+
+        let (from, to) = components
+
+        if let to = to {
+            return "\(from) - \(to)"
+        } else {
+            return "\(from)"
+        }
+    }
+    /// Returns the formatted dates for the current period.
+    func displayDateComponents() -> (from: String, to: String?)? {
         guard let date = date, let period = period else {
             return nil
         }
@@ -155,14 +169,14 @@ private extension SiteStatsTableHeaderView {
 
         switch period {
         case .day, .month, .year:
-            return dateFormatter.string(from: date)
+            return (dateFormatter.string(from: date), nil)
         case .week:
             let week = StatsPeriodHelper().weekIncludingDate(date)
             guard let weekStart = week?.weekStart, let weekEnd = week?.weekEnd else {
                 return nil
             }
 
-            return "\(dateFormatter.string(from: weekStart)) – \(dateFormatter.string(from: weekEnd))"
+            return (dateFormatter.string(from: weekStart), dateFormatter.string(from: weekEnd))
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -47,6 +47,8 @@ class StatsCellHeader: UITableViewCell, NibLoadable, Accessible {
         manageInsightButton.accessibilityTraits = .button
         manageInsightButton.accessibilityLabel = NSLocalizedString("Manage Insight", comment: "Accessibility label for button that displays Manage Insight options.")
         manageInsightButton.accessibilityHint = NSLocalizedString("Select to manage this Insight.", comment: "Accessibility hint for Manage Insight button.")
+
+        accessibilityElements = [headerLabel, manageInsightButton].compactMap { $0 }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -39,7 +39,7 @@ class StatsCellHeader: UITableViewCell, NibLoadable, Accessible {
         headerLabel.isAccessibilityElement = (headerLabel.text?.isEmpty == false)
         headerLabel.accessibilityElementsHidden = (headerLabel.text?.isEmpty == true)
         headerLabel.accessibilityLabel = headerLabel.text
-        headerLabel.accessibilityTraits = .staticText
+        headerLabel.accessibilityTraits = .header
 
         manageInsightImageView.isAccessibilityElement = false
         manageInsightButton.isAccessibilityElement = !manageInsightButton.isHidden


### PR DESCRIPTION
Refs #11995.

This is a collection of unrelated improvements for Stats. I just made a pass and improved as much as I can. 🙂 

## Improvements 

### [A] Header navigation order

23ad69c20a406196666234a8ea3bef1fc0c8ccb1 Changed the order so that when swiping right, the date and the timezone are accessed first. 

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/72011338-d5736400-3216-11ea-96a6-cd928d25843f.png)        |       ![image](https://user-images.githubusercontent.com/198826/72011371-ed4ae800-3216-11ea-8496-51600ed24457.png)

### [B] Header titles as `.header`

b23542d5c88080ed648a96cae8f616aa36dc9c2c Headers are now read with “Heading” by VoiceOver. 

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/72011579-677b6c80-3217-11ea-9046-e9f7e45bdff4.png)        |       ![image](https://user-images.githubusercontent.com/198826/72011657-8b3eb280-3217-11ea-84fb-74e1459f8478.png)

### [C] Insights section header navigation order

4f61ee112b754ef8cc0fc6f0851905485c4bcf00 Fixed the swiping order of the section header so that the title is accessed first before the Manage Insights button. 

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/72011940-15871680-3218-11ea-9ca2-cb0091371e16.png)        |       ![image](https://user-images.githubusercontent.com/198826/72011963-2768b980-3218-11ea-8f35-7f7008b5c669.png)

### [D] View More button accessibility labels

Fixed the labels of some of the View More buttons. They were previously read as just “Button”. 

- f0c179f63c7e659d9117188a9f24b007696ef30d
- d37c7d68e11dc72e721b38fd7f0374bc4df887f8
- b58c85f2c4c96b9db014a878ecf3005981c3cf3a

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/72012205-c42b5700-3218-11ea-9315-181346e41657.png)        |       ![image](https://user-images.githubusercontent.com/198826/72012376-12d8f100-3219-11ea-8bdb-0fc294f79d54.png)

### [E] Insights → Posting Activity navigation order

The navigation order is a bit odd. I have a hard time describing it so I made videos. 😄 Fixed in 68ea094456cfffb41d706bce9f1da015f19caa71.

Before | After 
--------|-------
[video](https://drive.google.com/file/d/1__uyiBtAD4uye5YQ4Ys6Fuj1ebHS7iNd/view?usp=sharing)     |       [video](https://drive.google.com/file/d/1uZ6lQKsbJanPi8a0kz5my-hSx0JvFzs1/view?usp=sharing)

### [F] Period header week range label

964576271d2064b41a83c5628ab7e00b50078271 The dash in the period header week range isn't read by VoiceOver. I replaced it with “to”. 

Before | After 
--------|-------
<img src="https://user-images.githubusercontent.com/198826/72013835-e5417700-321b-11ea-945f-6f02d808319d.png" width="240">        |       <img src="https://user-images.githubusercontent.com/198826/72013849-ef637580-321b-11ea-9a77-8efae83ba057.png" width="240">

### [G] World map label

20ef1c10814c118114462f30d9e7e075e5a87f99 The world map is read by VoiceOver using the minimum and maximum views. 

I pondered about making VoiceOver describe every little detail on the map. But I think describing what is “on that area of the screen” is good enough. Especially because we have the list of countries and views below the world map. 

I also thought about making the map inaccessible. I concluded that it's probably a bad idea because it covers a significant area of the screen. We might just make the user wonder more about what's on there.

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/72014472-25552980-321d-11ea-81db-4ebc49f6dbf4.png) |       ![image](https://user-images.githubusercontent.com/198826/72014526-49b10600-321d-11ea-9f04-81465e2a0eee.png)

## Testing

1. Turn VoiceOver on.
2. Navigate to Stats → Weeks. 
3. Confirm that:
    - [ ] **[A]** Navigating by swiping right would make VoiceOver navigate to the Date and Timezone first before the Back and Forward buttons
    - [ ] **[B]** The Posts and Pages and other section titles are read with “Heading”. 
    - [ ] **[F]** The week's date range is read with a “to”. For example, “January 6th to January 12th”. 
    - [ ] **[G]** The country map is read as “World map showing views by country.”. What do you think about this label? Is it descriptive enough? 
3. Navigate to Stats → Insights.
4. Confirm that:
    - [ ] **[C]** Navigating by swiping right would make VoiceOver navigate and read a section's title first before the Manage Insight button.
    - [ ] **[D]** All the View More buttons are read as “View More. Button” by VoiceOver. 
    - [ ] **[E]** Navigating by swiping right in the Posting Activity would navigate in this order: 
        1. Posting Activity title
        2. Manage Insight button
        3. First Month
        4. Second Month
        4. Third Month
        4. View More button

## Reviewing 

Only 1 reviewer is needed but anyone can review.

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
