### PR TITLE
Stats Widgets: update separator line color

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetFooterView.swift
@@ -1,5 +1,4 @@
 import UIKit
-import NotificationCenter
 
 class WidgetFooterView: UITableViewHeaderFooterView {
 

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetFooterView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import NotificationCenter
 
 class WidgetFooterView: UITableViewHeaderFooterView {
 
@@ -7,6 +8,7 @@ class WidgetFooterView: UITableViewHeaderFooterView {
     static let reuseIdentifier = "WidgetFooterView"
 
     @IBOutlet private var separatorLine: UIView!
+    @IBOutlet private var separatorVisualEffect: UIVisualEffectView!
     @IBOutlet private var siteUrlLabel: UILabel!
     @IBOutlet private var backgroundColorView: UIView!
 
@@ -27,8 +29,17 @@ class WidgetFooterView: UITableViewHeaderFooterView {
 
 private extension WidgetFooterView {
     func configureColors() {
-        separatorLine.backgroundColor = UIColor(light: .divider, dark: .textSubtle)
         siteUrlLabel.textColor = .textSubtle
         backgroundColorView.backgroundColor = .clear
+
+        if #available(iOS 13, *) {
+            separatorLine.backgroundColor = UIColor(white: 1.0, alpha: 0.5)
+            separatorLine.tintColor = UIColor(white: 1.0, alpha: 0.5)
+            separatorVisualEffect.effect = UIVibrancyEffect.widgetEffect(forVibrancyStyle: .separator)
+        } else {
+            separatorLine.backgroundColor = .divider
+            separatorLine.tintColor = .divider
+            separatorVisualEffect.effect = UIVibrancyEffect.widgetSecondary()
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetFooterView.swift
@@ -8,7 +8,7 @@ class WidgetFooterView: UITableViewHeaderFooterView {
     static let reuseIdentifier = "WidgetFooterView"
 
     @IBOutlet private var separatorLine: UIView!
-    @IBOutlet private var separatorVisualEffect: UIVisualEffectView!
+    @IBOutlet private var separatorVisualEffectView: UIVisualEffectView!
     @IBOutlet private var siteUrlLabel: UILabel!
     @IBOutlet private var backgroundColorView: UIView!
 
@@ -29,17 +29,9 @@ class WidgetFooterView: UITableViewHeaderFooterView {
 
 private extension WidgetFooterView {
     func configureColors() {
-        siteUrlLabel.textColor = .textSubtle
+        siteUrlLabel.textColor = WidgetStyles.secondaryTextColor
         backgroundColorView.backgroundColor = .clear
-
-        if #available(iOS 13, *) {
-            separatorLine.backgroundColor = UIColor(white: 1.0, alpha: 0.5)
-            separatorLine.tintColor = UIColor(white: 1.0, alpha: 0.5)
-            separatorVisualEffect.effect = UIVibrancyEffect.widgetEffect(forVibrancyStyle: .separator)
-        } else {
-            separatorLine.backgroundColor = .divider
-            separatorLine.tintColor = .divider
-            separatorVisualEffect.effect = UIVibrancyEffect.widgetSecondary()
-        }
+        WidgetStyles.configureSeparator(separatorLine)
+        WidgetStyles.configureSeparatorVisualEffectView(separatorVisualEffectView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetFooterView.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetFooterView.xib
@@ -72,7 +72,7 @@
             <connections>
                 <outlet property="backgroundColorView" destination="Cyd-Yd-Bok" id="tnD-Kc-G7Q"/>
                 <outlet property="separatorLine" destination="txP-Kv-gSY" id="zbg-Oo-iy2"/>
-                <outlet property="separatorVisualEffect" destination="hXp-MF-wn4" id="ihh-t6-1od"/>
+                <outlet property="separatorVisualEffectView" destination="hXp-MF-wn4" id="czX-oh-JPJ"/>
                 <outlet property="siteUrlLabel" destination="Y4f-Rk-ldQ" id="8Tu-IB-bkB"/>
             </connections>
             <point key="canvasLocation" x="-317.39130434782612" y="188.50446428571428"/>

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetFooterView.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetFooterView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -19,13 +19,32 @@
                     <rect key="frame" x="0.0" y="0.0" width="414" height="32"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hJM-IQ-N5L" userLabel="Separator Line">
+                <visualEffectView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hXp-MF-wn4">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
-                    <color key="backgroundColor" name="Gray40"/>
+                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="mXo-xz-aq8">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="txP-Kv-gSY" userLabel="Separator Line">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="tintColor" name="Gray40"/>
+                            </view>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="txP-Kv-gSY" secondAttribute="trailing" id="3zT-12-kXC"/>
+                            <constraint firstItem="txP-Kv-gSY" firstAttribute="top" secondItem="mXo-xz-aq8" secondAttribute="top" id="QPc-Mm-GKW"/>
+                            <constraint firstItem="txP-Kv-gSY" firstAttribute="leading" secondItem="mXo-xz-aq8" secondAttribute="leading" id="S5o-35-68e"/>
+                            <constraint firstAttribute="bottom" secondItem="txP-Kv-gSY" secondAttribute="bottom" id="qTr-gP-Gu8"/>
+                        </constraints>
+                    </view>
                     <constraints>
-                        <constraint firstAttribute="height" constant="0.5" id="Evl-gp-tVN"/>
+                        <constraint firstAttribute="height" constant="0.5" id="NKL-MP-Vfd"/>
                     </constraints>
-                </view>
+                    <vibrancyEffect>
+                        <blurEffect style="light"/>
+                    </vibrancyEffect>
+                </visualEffectView>
                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="my.wordpress.com" textAlignment="natural" lineBreakMode="tailTruncation" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y4f-Rk-ldQ" userLabel="Site Url Label">
                     <rect key="frame" x="16" y="8.5" width="382" height="15.5"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
@@ -35,16 +54,16 @@
             </subviews>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="Y4f-Rk-ldQ" secondAttribute="trailing" constant="16" id="B9L-ae-Mdm"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="hJM-IQ-N5L" secondAttribute="trailing" id="BWI-6f-aDI"/>
-                <constraint firstItem="Y4f-Rk-ldQ" firstAttribute="top" secondItem="hJM-IQ-N5L" secondAttribute="bottom" constant="8" id="ENj-Q1-acW"/>
+                <constraint firstAttribute="top" secondItem="hXp-MF-wn4" secondAttribute="top" id="IKg-nz-Yz5"/>
                 <constraint firstItem="Cyd-Yd-Bok" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="KHr-S5-XNh"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="Y4f-Rk-ldQ" secondAttribute="bottom" constant="8" id="N5s-BL-zhf"/>
-                <constraint firstItem="hJM-IQ-N5L" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="OaW-qD-dHy"/>
                 <constraint firstAttribute="bottom" secondItem="Cyd-Yd-Bok" secondAttribute="bottom" id="ROB-hO-Wcy"/>
+                <constraint firstItem="hXp-MF-wn4" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="VAM-Wq-sfZ"/>
+                <constraint firstItem="Y4f-Rk-ldQ" firstAttribute="top" secondItem="hXp-MF-wn4" secondAttribute="bottom" constant="8" id="dae-f0-Ubq"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Cyd-Yd-Bok" secondAttribute="trailing" id="lvZ-xs-fle"/>
                 <constraint firstItem="Y4f-Rk-ldQ" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="pec-ED-2Pc"/>
                 <constraint firstItem="Cyd-Yd-Bok" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="ucm-9C-ZaM"/>
-                <constraint firstItem="hJM-IQ-N5L" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="vzI-Fm-gis"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="hXp-MF-wn4" secondAttribute="trailing" id="viU-IM-IV5"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
@@ -52,7 +71,8 @@
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
                 <outlet property="backgroundColorView" destination="Cyd-Yd-Bok" id="tnD-Kc-G7Q"/>
-                <outlet property="separatorLine" destination="hJM-IQ-N5L" id="lf3-gt-J9w"/>
+                <outlet property="separatorLine" destination="txP-Kv-gSY" id="zbg-Oo-iy2"/>
+                <outlet property="separatorVisualEffect" destination="hXp-MF-wn4" id="ihh-t6-1od"/>
                 <outlet property="siteUrlLabel" destination="Y4f-Rk-ldQ" id="8Tu-IB-bkB"/>
             </connections>
             <point key="canvasLocation" x="-317.39130434782612" y="188.50446428571428"/>

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetTwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetTwoColumnCell.swift
@@ -33,9 +33,9 @@ class WidgetTwoColumnCell: UITableViewCell {
 
 private extension WidgetTwoColumnCell {
     func configureColors() {
-        leftItemLabel.textColor = .text
-        leftDataLabel.textColor = .text
-        rightItemLabel.textColor = .text
-        rightDataLabel.textColor = .text
+        leftItemLabel.textColor = WidgetStyles.primaryTextColor
+        leftDataLabel.textColor = WidgetStyles.primaryTextColor
+        rightItemLabel.textColor = WidgetStyles.primaryTextColor
+        rightDataLabel.textColor = WidgetStyles.primaryTextColor
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
@@ -1,5 +1,4 @@
 import UIKit
-import NotificationCenter
 
 enum WidgetType {
     case today

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import NotificationCenter
 
 enum WidgetType {
     case today
@@ -13,6 +14,7 @@ class WidgetUnconfiguredCell: UITableViewCell {
 
     @IBOutlet private var configureLabel: UILabel!
     @IBOutlet private var separatorLine: UIView!
+    @IBOutlet private var separatorVisualEffect: UIVisualEffectView!
     @IBOutlet private var openWordPressLabel: UILabel!
 
     // MARK: - View
@@ -39,10 +41,18 @@ private extension WidgetUnconfiguredCell {
         }()
 
         openWordPressLabel.text = LocalizedText.openWordPress
-
         configureLabel.textColor = .text
         openWordPressLabel.textColor = .text
-        separatorLine.backgroundColor = UIColor(light: .divider, dark: .textSubtle)
+
+        if #available(iOS 13, *) {
+            separatorLine.backgroundColor = UIColor(white: 1.0, alpha: 0.5)
+            separatorLine.tintColor = UIColor(white: 1.0, alpha: 0.5)
+            separatorVisualEffect.effect = UIVibrancyEffect.widgetEffect(forVibrancyStyle: .separator)
+        } else {
+            separatorLine.backgroundColor = .divider
+            separatorLine.tintColor = .divider
+            separatorVisualEffect.effect = UIVibrancyEffect.widgetSecondary()
+        }
     }
 
     enum LocalizedText {

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
@@ -14,7 +14,7 @@ class WidgetUnconfiguredCell: UITableViewCell {
 
     @IBOutlet private var configureLabel: UILabel!
     @IBOutlet private var separatorLine: UIView!
-    @IBOutlet private var separatorVisualEffect: UIVisualEffectView!
+    @IBOutlet private var separatorVisualEffectView: UIVisualEffectView!
     @IBOutlet private var openWordPressLabel: UILabel!
 
     // MARK: - View
@@ -41,18 +41,10 @@ private extension WidgetUnconfiguredCell {
         }()
 
         openWordPressLabel.text = LocalizedText.openWordPress
-        configureLabel.textColor = .text
-        openWordPressLabel.textColor = .text
-
-        if #available(iOS 13, *) {
-            separatorLine.backgroundColor = UIColor(white: 1.0, alpha: 0.5)
-            separatorLine.tintColor = UIColor(white: 1.0, alpha: 0.5)
-            separatorVisualEffect.effect = UIVibrancyEffect.widgetEffect(forVibrancyStyle: .separator)
-        } else {
-            separatorLine.backgroundColor = .divider
-            separatorLine.tintColor = .divider
-            separatorVisualEffect.effect = UIVibrancyEffect.widgetSecondary()
-        }
+        configureLabel.textColor = WidgetStyles.primaryTextColor
+        openWordPressLabel.textColor = WidgetStyles.primaryTextColor
+        WidgetStyles.configureSeparator(separatorLine)
+        WidgetStyles.configureSeparatorVisualEffectView(separatorVisualEffectView)
     }
 
     enum LocalizedText {

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.xib
@@ -93,7 +93,7 @@
                 <outlet property="configureLabel" destination="BeG-f7-LNj" id="JmX-XL-Xav"/>
                 <outlet property="openWordPressLabel" destination="zTQ-mH-dxy" id="1bT-PO-Kbd"/>
                 <outlet property="separatorLine" destination="ke9-nm-91h" id="59e-Kh-Ifx"/>
-                <outlet property="separatorVisualEffect" destination="9MM-O1-Ae9" id="kqo-dY-OzW"/>
+                <outlet property="separatorVisualEffectView" destination="9MM-O1-Ae9" id="uRN-tS-eA1"/>
             </connections>
             <point key="canvasLocation" x="-106" y="147"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -30,13 +30,32 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="esr-2y-uLo">
                                 <rect key="frame" x="0.0" y="48" width="288" height="48"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ke9-nm-91h" userLabel="Separator Line">
+                                    <visualEffectView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9MM-O1-Ae9">
                                         <rect key="frame" x="-16" y="8" width="320" height="0.5"/>
-                                        <color key="backgroundColor" name="Gray40"/>
+                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="f0r-aX-Lqg">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="0.5"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ke9-nm-91h" userLabel="Separator Line">
+                                                    <rect key="frame" x="0.0" y="0.0" width="320" height="0.5"/>
+                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="tintColor" name="Gray40"/>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="ke9-nm-91h" secondAttribute="bottom" id="MKb-61-MrF"/>
+                                                <constraint firstAttribute="trailing" secondItem="ke9-nm-91h" secondAttribute="trailing" id="jOh-8U-P34"/>
+                                                <constraint firstItem="ke9-nm-91h" firstAttribute="leading" secondItem="f0r-aX-Lqg" secondAttribute="leading" id="jRd-a2-CVg"/>
+                                                <constraint firstItem="ke9-nm-91h" firstAttribute="top" secondItem="f0r-aX-Lqg" secondAttribute="top" id="zV7-09-nse"/>
+                                            </constraints>
+                                        </view>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="0.5" id="1k6-km-IFb"/>
+                                            <constraint firstAttribute="height" constant="0.5" id="iCl-xD-ecX"/>
                                         </constraints>
-                                    </view>
+                                        <vibrancyEffect>
+                                            <blurEffect style="light"/>
+                                        </vibrancyEffect>
+                                    </visualEffectView>
                                     <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open WordPress" textAlignment="center" lineBreakMode="tailTruncation" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zTQ-mH-dxy" userLabel="Open WordPress Label">
                                         <rect key="frame" x="0.0" y="16.5" width="288" height="31.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
@@ -46,10 +65,10 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="ke9-nm-91h" firstAttribute="top" secondItem="esr-2y-uLo" secondAttribute="top" constant="8" id="Fgo-ME-2FH"/>
                                     <constraint firstAttribute="trailing" secondItem="zTQ-mH-dxy" secondAttribute="trailing" id="HzB-Ci-tiL"/>
-                                    <constraint firstItem="zTQ-mH-dxy" firstAttribute="top" secondItem="ke9-nm-91h" secondAttribute="bottom" constant="8" id="avy-PY-R4Y"/>
+                                    <constraint firstItem="9MM-O1-Ae9" firstAttribute="top" secondItem="esr-2y-uLo" secondAttribute="top" constant="8" id="Unf-FW-XJX"/>
                                     <constraint firstItem="zTQ-mH-dxy" firstAttribute="leading" secondItem="esr-2y-uLo" secondAttribute="leading" id="pys-2R-IuN"/>
+                                    <constraint firstItem="zTQ-mH-dxy" firstAttribute="top" secondItem="9MM-O1-Ae9" secondAttribute="bottom" constant="8" id="qt6-MQ-atd"/>
                                     <constraint firstAttribute="bottom" secondItem="zTQ-mH-dxy" secondAttribute="bottom" id="rg6-UN-q8D"/>
                                 </constraints>
                             </view>
@@ -66,14 +85,15 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="njF-e1-oar" firstAttribute="trailing" secondItem="ke9-nm-91h" secondAttribute="trailing" id="iEa-x3-8ma"/>
-                <constraint firstItem="ke9-nm-91h" firstAttribute="leading" secondItem="njF-e1-oar" secondAttribute="leading" id="pvM-uZ-KDd"/>
+                <constraint firstItem="njF-e1-oar" firstAttribute="trailing" secondItem="9MM-O1-Ae9" secondAttribute="trailing" id="Nb8-FO-ob2"/>
+                <constraint firstItem="9MM-O1-Ae9" firstAttribute="leading" secondItem="njF-e1-oar" secondAttribute="leading" id="yhw-Qy-yMt"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="configureLabel" destination="BeG-f7-LNj" id="JmX-XL-Xav"/>
                 <outlet property="openWordPressLabel" destination="zTQ-mH-dxy" id="1bT-PO-Kbd"/>
                 <outlet property="separatorLine" destination="ke9-nm-91h" id="59e-Kh-Ifx"/>
+                <outlet property="separatorVisualEffect" destination="9MM-O1-Ae9" id="kqo-dY-OzW"/>
             </connections>
             <point key="canvasLocation" x="-106" y="147"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NotificationCenter
 
 class WidgetStyles: NSObject {
 

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
@@ -8,7 +8,7 @@ class WidgetStyles: NSObject {
 
     private static var separatorColor: UIColor = {
         if #available(iOS 13, *) {
-            return UIColor(white: 1.0, alpha: 0.5)
+            return .separator
         } else {
             return .divider
         }

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+class WidgetStyles: NSObject {
+
+    static let primaryTextColor: UIColor = .text
+    static let secondaryTextColor: UIColor = .textSubtle
+
+    private static var separatorColor: UIColor = {
+        if #available(iOS 13, *) {
+            return UIColor(white: 1.0, alpha: 0.5)
+        } else {
+            return .divider
+        }
+    }()
+
+    static func configureSeparator(_ separator: UIView) {
+        // Both colors are need for the vibrancy effect.
+        separator.backgroundColor = separatorColor
+        separator.tintColor = separatorColor
+    }
+
+    static func configureSeparatorVisualEffectView(_ visualEffectView: UIVisualEffectView) {
+        if #available(iOS 13, *) {
+            visualEffectView.effect = UIVibrancyEffect.widgetEffect(forVibrancyStyle: .separator)
+        } else {
+            visualEffectView.effect = UIVibrancyEffect.widgetSecondary()
+        }
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1148,6 +1148,7 @@
 		985793C922F23D7000643DBF /* CustomizeInsightsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 985793C722F23D7000643DBF /* CustomizeInsightsCell.xib */; };
 		98579BC7203DD86F004086E4 /* EpilogueSectionHeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98579BC5203DD86D004086E4 /* EpilogueSectionHeaderFooter.swift */; };
 		98579BC8203DD86F004086E4 /* EpilogueSectionHeaderFooter.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98579BC6203DD86E004086E4 /* EpilogueSectionHeaderFooter.xib */; };
+		985ED0E223C686CA00B8D06A /* ColorPalette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 435B76292297484200511813 /* ColorPalette.xcassets */; };
 		985F06B52303866200949733 /* WelcomeScreenLoginComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985F06B42303866200949733 /* WelcomeScreenLoginComponent.swift */; };
 		9865257D2194D77F0078B916 /* SiteStatsInsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9865257C2194D77E0078B916 /* SiteStatsInsightsViewModel.swift */; };
 		98656BD82037A1770079DE67 /* SignupEpilogueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98656BD72037A1770079DE67 /* SignupEpilogueViewController.swift */; };
@@ -10376,6 +10377,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				98A6B9942398821B0031AEBD /* WidgetTwoColumnCell.xib in Resources */,
+				985ED0E223C686CA00B8D06A /* ColorPalette.xcassets in Resources */,
 				98D31BBD23971F4B009CFF43 /* Localizable.strings in Resources */,
 				98A6B996239882350031AEBD /* WidgetUnconfiguredCell.xib in Resources */,
 				98D7ECCE23983D0800B87710 /* MainInterface.storyboard in Resources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1149,6 +1149,9 @@
 		98579BC7203DD86F004086E4 /* EpilogueSectionHeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98579BC5203DD86D004086E4 /* EpilogueSectionHeaderFooter.swift */; };
 		98579BC8203DD86F004086E4 /* EpilogueSectionHeaderFooter.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98579BC6203DD86E004086E4 /* EpilogueSectionHeaderFooter.xib */; };
 		985ED0E223C686CA00B8D06A /* ColorPalette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 435B76292297484200511813 /* ColorPalette.xcassets */; };
+		985ED0E423C6950600B8D06A /* WidgetStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985ED0E323C6950600B8D06A /* WidgetStyles.swift */; };
+		985ED0E723C6964500B8D06A /* WidgetStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985ED0E323C6950600B8D06A /* WidgetStyles.swift */; };
+		985ED0E823C6964600B8D06A /* WidgetStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985ED0E323C6950600B8D06A /* WidgetStyles.swift */; };
 		985F06B52303866200949733 /* WelcomeScreenLoginComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985F06B42303866200949733 /* WelcomeScreenLoginComponent.swift */; };
 		9865257D2194D77F0078B916 /* SiteStatsInsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9865257C2194D77E0078B916 /* SiteStatsInsightsViewModel.swift */; };
 		98656BD82037A1770079DE67 /* SignupEpilogueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98656BD72037A1770079DE67 /* SignupEpilogueViewController.swift */; };
@@ -3437,6 +3440,7 @@
 		985793C722F23D7000643DBF /* CustomizeInsightsCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomizeInsightsCell.xib; sourceTree = "<group>"; };
 		98579BC5203DD86D004086E4 /* EpilogueSectionHeaderFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EpilogueSectionHeaderFooter.swift; sourceTree = "<group>"; };
 		98579BC6203DD86E004086E4 /* EpilogueSectionHeaderFooter.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EpilogueSectionHeaderFooter.xib; sourceTree = "<group>"; };
+		985ED0E323C6950600B8D06A /* WidgetStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetStyles.swift; sourceTree = "<group>"; };
 		985F06B42303866200949733 /* WelcomeScreenLoginComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeScreenLoginComponent.swift; sourceTree = "<group>"; };
 		9865257C2194D77E0078B916 /* SiteStatsInsightsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsInsightsViewModel.swift; sourceTree = "<group>"; };
 		98656BD72037A1770079DE67 /* SignupEpilogueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupEpilogueViewController.swift; sourceTree = "<group>"; };
@@ -7509,6 +7513,7 @@
 			children = (
 				989064F9237CC1A300218CD2 /* Data */,
 				9890650C237CC1E700218CD2 /* Shared Views */,
+				985ED0E323C6950600B8D06A /* WidgetStyles.swift */,
 			);
 			path = "Today Widgets";
 			sourceTree = "<group>";
@@ -11073,6 +11078,7 @@
 				E1222B671F878E4700D23173 /* WebViewControllerFactory.swift in Sources */,
 				E1D86E691B2B414300DD2192 /* WordPress-32-33.xcmappingmodel in Sources */,
 				9A2B28E8219046ED00458F2A /* ShowRevisionsListManger.swift in Sources */,
+				985ED0E423C6950600B8D06A /* WidgetStyles.swift in Sources */,
 				5DB3BA0818D11D8D00F3F3E9 /* PublishDatePickerView.m in Sources */,
 				57CCB3812358ED07003ECD0C /* WordPress-91-92.xcmappingmodel in Sources */,
 				5D2B30B91B7411C700DA15F3 /* ReaderCardDiscoverAttributionView.swift in Sources */,
@@ -12386,6 +12392,7 @@
 				1752D4FB238D702F002B79E7 /* KeyValueDatabase.swift in Sources */,
 				9890650B237CC1DF00218CD2 /* WidgetFooterView.swift in Sources */,
 				170BEC89239153120017AEC1 /* FeatureFlagOverrideStore.swift in Sources */,
+				985ED0E723C6964500B8D06A /* WidgetStyles.swift in Sources */,
 				93E3D3C819ACE8E300B1C509 /* SFHFKeychainUtils.m in Sources */,
 				934884AB19B73BA6004028D8 /* Constants.m in Sources */,
 			);
@@ -12408,6 +12415,7 @@
 				98D31BC223972A79009CFF43 /* SFHFKeychainUtils.m in Sources */,
 				98D31BAE239708FB009CFF43 /* Constants.m in Sources */,
 				98C0CE9B23C559C800D0F27C /* Double+Stats.swift in Sources */,
+				985ED0E823C6964600B8D06A /* WidgetStyles.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Ref #12702 , https://github.com/wordpress-mobile/WordPress-iOS/pull/13148#issuecomment-567896870

This updates the widget separator lines to be more in line with the system widget style.
- The separator in the unconfigured view.
- The footer separator in the configured view.

To test:

---
**Unconfigured View:**
- Start with a fresh install, or be logged out of the app.
- Add the `Today` and `All-Time` widgets to your Today view.
- Verify the separator line looks more like that on system widgets (in this example, Shortcuts).

Light:
![unconfigured_light](https://user-images.githubusercontent.com/1816888/72027183-4af12b80-323b-11ea-920b-6ee49eb6c858.jpeg)

Dark:
![unconfigured_dark](https://user-images.githubusercontent.com/1816888/72027210-60665580-323b-11ea-87b2-3308068b19d3.jpeg)

---
**Configured View:**
- Log into the app.
- Go to Stats > Widgets > Use this site.
- Return to the Today view.
- On the WP widgets, verify the separator line looks more like that on system widgets (in this example, Shortcuts).

Light:
![configured_light](https://user-images.githubusercontent.com/1816888/72027254-7ffd7e00-323b-11ea-9a0a-fdded384aca0.jpeg)

Dark:
![configured_dark](https://user-images.githubusercontent.com/1816888/72027257-84299b80-323b-11ea-90c6-a0ff2e3bdb50.jpeg)

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
