### PR TITLE
[VoiceOver] Improvements for Stats Header Buttons and View More

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -98,9 +98,11 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
 
         backButton.accessibilityLabel = NSLocalizedString("Previous period", comment: "Accessibility label")
         backButton.accessibilityHint = NSLocalizedString("Tap to select the previous period", comment: "Accessibility hint")
+        backButton.accessibilityTraits = backButton.isEnabled ? [.button] : [.button, .notEnabled]
 
         forwardButton.accessibilityLabel = NSLocalizedString("Next period", comment: "Accessibility label")
         forwardButton.accessibilityHint = NSLocalizedString("Tap to select the next period", comment: "Accessibility hint")
+        forwardButton.accessibilityTraits = forwardButton.isEnabled ? [.button] : [.button, .notEnabled]
 
         accessibilityElements = [
             dateLabel,

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -27,7 +27,6 @@ class ViewMoreRow: UIView, NibLoadable, Accessible {
 
         accessibilityLabel = viewMoreLabel.text
         accessibilityTraits = .button
-        accessibilityHint = NSLocalizedString("Tap for more detail.", comment: "Accessibility hint")
     }
 }
 


### PR DESCRIPTION
Refs #11995. This is a continuation of https://github.com/wordpress-mobile/WordPress-iOS/pull/13202. 

## Improvements

### Header buttons

The Previous and Next period buttons are not read with “dimmed” by VoiceOver if they are disabled. This usually happens automatically. Fixed in 7646774. 

⚠️ Note: All the UI elements in `SiteStatsTableHeaderView` automatically get a `.header` trait. As a result, the buttons will be read as “Button title, dimmed, Button, **Heading**, ...”. It seems that iOS automatically adds `.header` to the elements of a `UITableView` header. I spent an hour or so on this the other day but couldn't figure out a way to stop it from happening. 

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/72095737-49c10c80-32d6-11ea-8c69-e3b3e8512f15.png)        |       ![image](https://user-images.githubusercontent.com/198826/72095785-63625400-32d6-11ea-957b-4680538fe7b0.png)

### View More button hints

As agreed in https://github.com/wordpress-mobile/WordPress-iOS/pull/13202#issuecomment-572649766, we will just remove the hints for the View More buttons. Removed in b3a80e4.

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/72096726-0798ca80-32d8-11ea-9395-4090552b811d.png)      |       ![image](https://user-images.githubusercontent.com/198826/72096688-f64fbe00-32d7-11ea-951a-3b4e4ab70e49.png)


## Testing

1. Navigate to Stats → Years
2. Confirm that the Previous and Next period buttons will be read with “dimmed” if they are disabled. 
3. Navigate to Stats → Insights and other tabs.
4. Confirm that all the View More buttons will just be read as “View more, Button”. Did I miss anything? 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
