### PR TITLE
[VoiceOver] Improvements for Post List 

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -33,6 +33,7 @@ static CGFloat const FeaturedImageSize = 120.0;
     [super awakeFromNib];
 
     [self applyStyles];
+    [self setupAccessibility];
 }
 
 - (void)prepareForReuse
@@ -179,6 +180,10 @@ static CGFloat const FeaturedImageSize = 120.0;
                                                }];
         
     }
+}
+
+- (void)setupAccessibility {
+    self.menuButton.accessibilityLabel = NSLocalizedString(@"More", @"Accessibility label for the More button in Page List.");
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1166,6 +1166,17 @@ class AbstractPostListViewController: UIViewController,
         dismissAllNetworkErrorNotices()
         super.present(viewControllerToPresent, animated: flag, completion: completion)
     }
+
+    // MARK: - Accessibility
+
+    override func accessibilityPerformEscape() -> Bool {
+        guard searchController.isActive else {
+            return super.accessibilityPerformEscape()
+        }
+
+        searchController.isActive = false
+        return true
+    }
 }
 
 extension AbstractPostListViewController: NetworkStatusDelegate {

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -324,7 +324,13 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
         let stickyChunk =
             post.isStickyPost ? NSLocalizedString("Sticky.", comment: "Accessibility label for a sticky post in the post list.") : nil
 
-        let statusChunk = viewModel.status
+        let statusChunk: String? = {
+            guard let status = viewModel.status else {
+                return nil
+            }
+
+            return "\(status)."
+        }()
 
         let excerptChunk: String? = {
             let excerpt = post.contentPreviewForDisplay()

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -62,6 +62,7 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
         configureStatusLabel()
         configureProgressView()
         configureActionBar()
+        configureAccessibility()
     }
 
     override func awakeFromNib() {
@@ -293,6 +294,52 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
         viewButton.isHidden = !primaryButtons.contains(.view)
         moreButton.isHidden = !primaryButtons.contains(.more)
         trashButton.isHidden = !primaryButtons.contains(.trash)
+    }
+
+    private func configureAccessibility() {
+        guard let viewModel = viewModel else {
+            accessibilityLabel = nil
+            return
+        }
+
+        let post = viewModel.post
+
+        let titleAndDateChunk: String = {
+            let format = NSLocalizedString("%@, %@.", comment: "Accessibility label for a post in the post list." +
+                    " The parameters are the title, and date respectively." +
+                    " For example, \"Let it Go, 1 hour ago.\"")
+            return String(format: format, post.titleForDisplay(), post.dateStringForDisplay())
+        }()
+
+        let authorChunk: String? = {
+            let author = viewModel.author
+            guard !author.isEmpty else {
+                return nil
+            }
+            let format = NSLocalizedString("By %@.", comment: "Accessibility label for the post author in the post list." +
+                " The parameter is the author name. For example, \"By Elsa.\"")
+            return String(format: format, author)
+        }()
+
+        let stickyChunk =
+            post.isStickyPost ? NSLocalizedString("Sticky.", comment: "Accessibility label for a sticky post in the post list.") : nil
+
+        let statusChunk = viewModel.status
+
+        let excerptChunk: String? = {
+            let excerpt = post.contentPreviewForDisplay()
+            guard !excerpt.isEmpty else {
+                return nil
+            }
+
+            let format = NSLocalizedString("Excerpt. %@.", comment: "Accessibility label for a post's excerpt in the post list." +
+                " The parameter is the post excerpt. For example, \"Excerpt. This is the first paragraph.\"")
+            return String(format: format, excerpt)
+        }()
+
+        accessibilityLabel = [titleAndDateChunk, authorChunk, stickyChunk, statusChunk, excerptChunk]
+            .compactMap { $0 }
+            .joined(separator: " ")
     }
 
     private func setupBorders() {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -51,7 +51,7 @@ class PostCardStatusViewModel: NSObject {
         super.init()
     }
 
-    private var status: String? {
+    var status: String? {
         // TODO Move these string constants to the StatusMessages enum
         if MediaCoordinator.shared.isUploadingMedia(for: post) {
             return NSLocalizedString("Uploading media...", comment: "Message displayed on a post's card while the post is uploading media")

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -55,6 +55,7 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
         applyStyles()
         setupReadableGuideForiPad()
         setupSeparator()
+        setupAccessibility()
     }
 
     private func resetGhostStyles() {
@@ -151,6 +152,11 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
                 }
             }
         }
+    }
+
+    private func setupAccessibility() {
+        menuButton.accessibilityLabel =
+            NSLocalizedString("More", comment: "Accessibility label for the More button in Post List (compact view).")
     }
 
     private enum Constants {


### PR DESCRIPTION
Closes #13205. 

## Improvements

### More Button Label

Added accessibility labels to the Post and Page List's More buttons.

Before | After 
--------|-------
![image](https://user-images.githubusercontent.com/198826/72106355-741dc480-32ec-11ea-8995-ae99c9632cb7.png)        |       ![image](https://user-images.githubusercontent.com/198826/72106391-8435a400-32ec-11ea-96dd-1aca73aaf7ad.png)

### Search Dismissal

Allowed dismissal of the search using VoiceOver escape gesture. 

### Post Cell (Expanded) Read Order 

Previously, when selecting a post with VoiceOver, VoiceOver would read the information like this:

```
{title}, {very long excerpt}, {6 days ago}, {author name}, {error/status}, middle dot
```

I changed it using these goals: 

- Easier to get to the important information first. 
- More clarity on what the text being read is. 

It's now read like this: 

```
{title}, {6 days ago}. By {author name}. {Sticky}. {error/status}. Excerpt. {very long excerpt}
```

I added the `“Excerpt”` static string in there as I believe it'll be a good indicator for the user that a possibly very long text will be read. They can then opt to just skip to a different UI element. Skipping would not be a problem anymore since the important information (e.g. title, error/status) were read first. 

Before | After 
--------|-------
[video (23s)](https://drive.google.com/file/d/1aH32_shc_yO28OIwREt0gcslPpAzOC03/view?usp=sharing)        |       [video (23s)](https://drive.google.com/file/d/1UTbae0yxqfQvv2vx6uj_wee2cY3uDYjb/view?usp=sharing)

## Testing

### More Button Label

1. Turn VoiceOver on.
2. Navigate to Site → Blog Posts.
3. Set the List Style to Compact. 
4. Select a post's More button. 
5. Confirm that VoiceOver says “More, Button”. 

Do similar steps for the Page List's More button.

Question: Is “More” the correct label for this? Is there anything better?

### Search Dismissal

1. Turn VoiceOver on.
2. Navigate to Site → Blog Posts.
3. Activate the search field so that the search view is shown. 
4. Perform the VoiceOver global gesture (make a Z using 2 fingers). 
5. Confirm that the search view was dismissed.

### Post Cell (Expanded) Read Order

1. Turn VoiceOver on.
2. Navigate to Site → Blog Posts.
3. Set the List Style to Expanded.
3. Select a post. 
4. Confirm that VoiceOver speaks the information as described in **Post Cell (Expanded) Read Order** above.

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
