### PR TITLE
Stats: add accessibility label for abbreviated stats

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 fileprivate struct Unit {
-    let abbreviation: String
-    let name: String
+    let abbreviationFormat: String
+    let accessibilityLabelFormat: String
 }
 
 extension Double {
@@ -20,23 +20,36 @@ extension Double {
     }
 
     private var decimalFormatter: NumberFormatter {
-         get {
-             let formatter = Double._decimalFormatter
-             // Show at least one digit after the decimal
-             formatter.minimumFractionDigits = 1
-             return formatter
-         }
-     }
+        get {
+            let formatter = Double._decimalFormatter
+            // Show at least one digit after the decimal
+            formatter.minimumFractionDigits = 1
+            return formatter
+        }
+    }
 
     private static var _units: [Unit] {
         get {
             var unitsArray: [Unit] = []
-            unitsArray.append(Unit(abbreviation: "K", name: "thousand"))
-            unitsArray.append(Unit(abbreviation: "M", name: "million"))
-            unitsArray.append(Unit(abbreviation: "B", name: "billion"))
-            unitsArray.append(Unit(abbreviation: "T", name: "trillion"))
-            unitsArray.append(Unit(abbreviation: "P", name: "quadrillion"))
-            unitsArray.append(Unit(abbreviation: "E", name: "quintillion"))
+
+            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@K", comment: "Label displaying value in thousands. Ex: 66.6K."),
+                                   accessibilityLabelFormat: NSLocalizedString("%@ thousand", comment: "Accessibility label for value in thousands. Ex: 66.6 thousand.")))
+
+            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@M", comment: "Label displaying value in millions. Ex: 66.6M."),
+                                   accessibilityLabelFormat: NSLocalizedString("%@ million", comment: "Accessibility label for value in millions. Ex: 66.6 million.")))
+
+            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@B", comment: "Label displaying value in billions. Ex: 66.6B."),
+                                   accessibilityLabelFormat: NSLocalizedString("%@ billion", comment: "Accessibility label for value in billions. Ex: 66.6 billion.")))
+
+            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@T", comment: "Label displaying value in trillions. Ex: 66.6T."),
+                                   accessibilityLabelFormat: NSLocalizedString("%@ trillion", comment: "Accessibility label for value in trillions. Ex: 66.6 trillion.")))
+
+            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@P", comment: "Label displaying value in quadrillions. Ex: 66.6P."),
+                                   accessibilityLabelFormat: NSLocalizedString("%@ quadrillion", comment: "Accessibility label for value in quadrillion. Ex: 66.6 quadrillion.")))
+
+            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@E", comment: "Label displaying value in quintillions. Ex: 66.6E."),
+                                   accessibilityLabelFormat: NSLocalizedString("%@ quintillion", comment: "Accessibility label for value in quintillions. Ex: 66.6 quintillion.")))
+
             return unitsArray
         }
     }
@@ -90,9 +103,8 @@ extension Double {
         roundedNum = self < 0 ? -roundedNum : roundedNum
         let formattedValue = roundedNum.formatWithFractions()
 
-        let format = NSLocalizedString("%@%@", comment: "Label displaying abbreviated value. The first parameter is the value, the second is the unit. Ex: 55.5M, 66.6K.")
-        let formattedString = String.localizedStringWithFormat(format, formattedValue, unit.abbreviation)
-        formattedString.accessibilityLabel = String.localizedStringWithFormat(format, formattedValue, unit.name)
+        let formattedString = String.localizedStringWithFormat(unit.abbreviationFormat, formattedValue)
+        formattedString.accessibilityLabel = String.localizedStringWithFormat(unit.accessibilityLabelFormat, formattedValue)
 
         return formattedString
     }

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
@@ -96,16 +96,20 @@ extension Double {
         var unit: Unit
 
         if unsignedRoundedNum == 1000.0 {
+            guard exp >= units.startIndex else {
+                return self.formatWithCommas()
+            }
+
             roundedNum = 1
             unit = units[exp]
         } else {
-            roundedNum = unsignedRoundedNum
             let unitIndex = exp - 1
 
             guard unitIndex >= units.startIndex else {
                 return self.formatWithCommas()
             }
 
+            roundedNum = unsignedRoundedNum
             unit = units[unitIndex]
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
@@ -100,7 +100,13 @@ extension Double {
             unit = units[exp]
         } else {
             roundedNum = unsignedRoundedNum
-            unit = units[exp-1]
+            let unitIndex = exp - 1
+
+            guard unitIndex >= units.startIndex else {
+                return self.formatWithCommas()
+            }
+
+            unit = units[unitIndex]
         }
 
         roundedNum = self < 0 ? -roundedNum : roundedNum

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
@@ -7,56 +7,59 @@ fileprivate struct Unit {
 
 extension Double {
 
-    private static var _numberFormatter: NumberFormatter = NumberFormatter()
-    private static var _decimalFormatter: NumberFormatter = NumberFormatter()
-
     private var numberFormatter: NumberFormatter {
         get {
-            let formatter = Double._numberFormatter
-            // Add commas to value
-            formatter.numberStyle = .decimal
-            return formatter
+            struct Cache {
+                static let formatter: NumberFormatter = {
+                    let formatter = NumberFormatter()
+                    // Add commas to value
+                    formatter.numberStyle = .decimal
+                    return formatter
+                }()
+            }
+
+            return Cache.formatter
         }
     }
 
     private var decimalFormatter: NumberFormatter {
         get {
-            let formatter = Double._decimalFormatter
-            // Show at least one digit after the decimal
-            formatter.minimumFractionDigits = 1
-            return formatter
-        }
-    }
+            struct Cache {
+                static let formatter: NumberFormatter = {
+                    let formatter = NumberFormatter()
+                    // Show at least one digit after the decimal
+                    formatter.minimumFractionDigits = 1
+                    return formatter
+                }()
+            }
 
-    private static var _units: [Unit] {
-        get {
-            var unitsArray: [Unit] = []
-
-            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@K", comment: "Label displaying value in thousands. Ex: 66.6K."),
-                                   accessibilityLabelFormat: NSLocalizedString("%@ thousand", comment: "Accessibility label for value in thousands. Ex: 66.6 thousand.")))
-
-            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@M", comment: "Label displaying value in millions. Ex: 66.6M."),
-                                   accessibilityLabelFormat: NSLocalizedString("%@ million", comment: "Accessibility label for value in millions. Ex: 66.6 million.")))
-
-            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@B", comment: "Label displaying value in billions. Ex: 66.6B."),
-                                   accessibilityLabelFormat: NSLocalizedString("%@ billion", comment: "Accessibility label for value in billions. Ex: 66.6 billion.")))
-
-            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@T", comment: "Label displaying value in trillions. Ex: 66.6T."),
-                                   accessibilityLabelFormat: NSLocalizedString("%@ trillion", comment: "Accessibility label for value in trillions. Ex: 66.6 trillion.")))
-
-            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@P", comment: "Label displaying value in quadrillions. Ex: 66.6P."),
-                                   accessibilityLabelFormat: NSLocalizedString("%@ quadrillion", comment: "Accessibility label for value in quadrillion. Ex: 66.6 quadrillion.")))
-
-            unitsArray.append(Unit(abbreviationFormat: NSLocalizedString("%@E", comment: "Label displaying value in quintillions. Ex: 66.6E."),
-                                   accessibilityLabelFormat: NSLocalizedString("%@ quintillion", comment: "Accessibility label for value in quintillions. Ex: 66.6 quintillion.")))
-
-            return unitsArray
+            return Cache.formatter
         }
     }
 
     private var units: [Unit] {
         get {
-            return Double._units
+            struct Cache {
+                static let units: [Unit] = {
+                    var units: [Unit] = []
+
+                    units.append(Unit(abbreviationFormat: NSLocalizedString("%@K", comment: "Label displaying value in thousands. Ex: 66.6K."), accessibilityLabelFormat: NSLocalizedString("%@ thousand", comment: "Accessibility label for value in thousands. Ex: 66.6 thousand.")))
+
+                    units.append(Unit(abbreviationFormat: NSLocalizedString("%@M", comment: "Label displaying value in millions. Ex: 66.6M."), accessibilityLabelFormat: NSLocalizedString("%@ million", comment: "Accessibility label for value in millions. Ex: 66.6 million.")))
+
+                    units.append(Unit(abbreviationFormat: NSLocalizedString("%@B", comment: "Label displaying value in billions. Ex: 66.6B."), accessibilityLabelFormat: NSLocalizedString("%@ billion", comment: "Accessibility label for value in billions. Ex: 66.6 billion.")))
+
+                    units.append(Unit(abbreviationFormat: NSLocalizedString("%@T", comment: "Label displaying value in trillions. Ex: 66.6T."), accessibilityLabelFormat: NSLocalizedString("%@ trillion", comment: "Accessibility label for value in trillions. Ex: 66.6 trillion.")))
+
+                    units.append(Unit(abbreviationFormat: NSLocalizedString("%@P", comment: "Label displaying value in quadrillions. Ex: 66.6P."), accessibilityLabelFormat: NSLocalizedString("%@ quadrillion", comment: "Accessibility label for value in quadrillion. Ex: 66.6 quadrillion.")))
+
+                    units.append(Unit(abbreviationFormat: NSLocalizedString("%@E", comment: "Label displaying value in quintillions. Ex: 66.6E."), accessibilityLabelFormat: NSLocalizedString("%@ quintillion", comment: "Accessibility label for value in quintillions. Ex: 66.6 quintillion.")))
+
+                    return units
+                }()
+            }
+
+            return Cache.units
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
@@ -90,11 +90,9 @@ extension Double {
         roundedNum = self < 0 ? -roundedNum : roundedNum
         let formattedValue = roundedNum.formatWithFractions()
 
-        let displayFormat = NSLocalizedString("%@%@", comment: "Label displaying abbreviated value. The first parameter is the value, the second is the unit. Ex: 55.5M, 66.6K.")
-        let formattedString = String.localizedStringWithFormat(displayFormat, formattedValue, unit.abbreviation)
-
-        let accessibleFormat = NSLocalizedString("%@%@", comment: "Accessibility label for abbreviated values. The first parameter is the value, the second is the unit name. Ex: 55.5 million, 66.6 thousand.")
-        formattedString.accessibilityLabel = String.localizedStringWithFormat(accessibleFormat, formattedValue, unit.name)
+        let format = NSLocalizedString("%@%@", comment: "Label displaying abbreviated value. The first parameter is the value, the second is the unit. Ex: 55.5M, 66.6K.")
+        let formattedString = String.localizedStringWithFormat(format, formattedValue, unit.abbreviation)
+        formattedString.accessibilityLabel = String.localizedStringWithFormat(format, formattedValue, unit.name)
 
         return formattedString
     }

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+fileprivate struct Unit {
+    let abbreviation: String
+    let name: String
+}
+
 extension Double {
 
     private static var _numberFormatter: NumberFormatter = NumberFormatter()
@@ -23,6 +28,25 @@ extension Double {
          }
      }
 
+    private static var _units: [Unit] {
+        get {
+            var unitsArray: [Unit] = []
+            unitsArray.append(Unit(abbreviation: "K", name: "thousand"))
+            unitsArray.append(Unit(abbreviation: "M", name: "million"))
+            unitsArray.append(Unit(abbreviation: "B", name: "billion"))
+            unitsArray.append(Unit(abbreviation: "T", name: "trillion"))
+            unitsArray.append(Unit(abbreviation: "P", name: "quadrillion"))
+            unitsArray.append(Unit(abbreviation: "E", name: "quintillion"))
+            return unitsArray
+        }
+    }
+
+    private var units: [Unit] {
+        get {
+            return Double._units
+        }
+    }
+
     /// Provides a short, friendly representation of the current Double value. If the value is
     /// below 10,000, the decimal is stripped and the string returned will look like an Int. If the value
     /// is above 10,000, the value is rounded to the nearest tenth and the appropriate abbreviation
@@ -42,7 +66,6 @@ extension Double {
     ///  - 1000000000000 becomes "1t"
 
     func abbreviatedString(forHeroNumber: Bool = false) -> String {
-
         let absValue = fabs(self)
         let abbreviationLimit = forHeroNumber ? 100000.0 : 10000.0
 
@@ -51,12 +74,10 @@ extension Double {
         }
 
         let exp: Int = Int(log10(absValue) / 3.0)
-        let units: [String] = ["K", "M", "B", "T", "P", "E"]
-
         let unsignedRoundedNum: Double = Foundation.round(10 * absValue / pow(1000.0, Double(exp))) / 10
 
         var roundedNum: Double
-        var unit: String
+        var unit: Unit
 
         if unsignedRoundedNum == 1000.0 {
             roundedNum = 1
@@ -67,9 +88,15 @@ extension Double {
         }
 
         roundedNum = self < 0 ? -roundedNum : roundedNum
+        let formattedValue = roundedNum.formatWithFractions()
 
         let displayFormat = NSLocalizedString("%@%@", comment: "Label displaying abbreviated value. The first parameter is the value, the second is the unit. Ex: 55.5M, 66.6K.")
-        return .localizedStringWithFormat(displayFormat, roundedNum.formatWithFractions(), unit)
+        let formattedString = String.localizedStringWithFormat(displayFormat, formattedValue, unit.abbreviation)
+
+        let accessibleFormat = NSLocalizedString("%@%@", comment: "Accessibility label for abbreviated values. The first parameter is the value, the second is the unit name. Ex: 55.5 million, 66.6 thousand.")
+        formattedString.accessibilityLabel = String.localizedStringWithFormat(accessibleFormat, formattedValue, unit.name)
+
+        return formattedString
     }
 
     private func formatWithCommas() -> String {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/StatsTwoColumnRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/StatsTwoColumnRow.swift
@@ -37,8 +37,8 @@ class StatsTwoColumnRow: UIView, NibLoadable {
         rightItemLabel.text = rowData.rightColumnName
         rightDataLabel.text = rowData.rightColumnData
 
-        leftDataLabel.accessibilityLabel = rowData.leftColumnData.accessibilityLabel ?? rowData.leftColumnData
-        rightDataLabel.accessibilityLabel = rowData.rightColumnData.accessibilityLabel ?? rowData.rightColumnData
+        leftDataLabel.accessibilityLabel = rowData.leftColumnData.accessibilityLabel
+        rightDataLabel.accessibilityLabel = rowData.rightColumnData.accessibilityLabel
 
         applyStyles()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/StatsTwoColumnRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/StatsTwoColumnRow.swift
@@ -37,6 +37,9 @@ class StatsTwoColumnRow: UIView, NibLoadable {
         rightItemLabel.text = rowData.rightColumnName
         rightDataLabel.text = rowData.rightColumnData
 
+        leftDataLabel.accessibilityLabel = rowData.leftColumnData.accessibilityLabel ?? rowData.leftColumnData
+        rightDataLabel.accessibilityLabel = rowData.rightColumnData.accessibilityLabel ?? rowData.rightColumnData
+
         applyStyles()
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -184,7 +184,8 @@ class StatsTotalRow: UIView, NibLoadable, Accessible {
         isAccessibilityElement = true
 
         let itemTitle = itemLabel.text ?? ""
-        let dataTitle = dataLabel.text ?? ""
+        let dataTitle = dataLabel.text?.accessibilityLabel ?? dataLabel.text ?? ""
+
         accessibilityLabel = [itemTitle, dataTitle].joined(separator: ", ")
 
         if let statSection = rowData?.statSection, statSection == .insightsAddInsight {

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetTwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetTwoColumnCell.swift
@@ -25,6 +25,9 @@ class WidgetTwoColumnCell: UITableViewCell {
         leftDataLabel.text = leftItemData
         rightItemLabel.text = rightItemName
         rightDataLabel.text = rightItemData
+
+        leftDataLabel.accessibilityLabel = leftItemData.accessibilityLabel
+        rightDataLabel.accessibilityLabel = rightItemData.accessibilityLabel
     }
 
 }


### PR DESCRIPTION
Ref: #12702, #11995

This change adds an accessibility label to abbreviated stats so that the unit name is read instead of the abbreviated letter. For example, “54.8M” is now read as “54 point 8 million” instead of "54 point 8 m".

The accessibility label is not yet utilized _everywhere_ an abbreviated value is displayed, but does hit most. Specifically:
- `StatsTotalRow` - used by all non-specialized stat cards.
- `StatsTwoColumnRow` - used by Insights two-column stat cards. (`Today`, `All-Time`, `Follower Totals`, `This Year`)
- `WidgetTwoColumnCell` - used by the `Today` and `All-Time` widgets.

Also, as an added bonus, the abbreviated strings are now translated.


To test:

Prereqs:
- Run the app & enable VoiceOver.
- Select a high volume site and go to Stats. Hogwarts or en.blog are usually good for this.

---
Stats Total Row:
- Select a stat row on any non-specialized card with an abbreviated value. 
- Verify the value is read correctly.

<img width="400" alt="stat_row_abbrev" src="https://user-images.githubusercontent.com/1816888/72114428-b5b86a80-3300-11ea-8300-23691d31d017.png">

- Select a stat row on any non-specialized with an unabbreviated value.
- Verify the value is read correctly.

<img width="400" alt="stat_row_unabbrev" src="https://user-images.githubusercontent.com/1816888/72114425-b224e380-3300-11ea-8617-a5edcf9d0b62.png">

---
Stats Two Column:
- Go to Insights.
- Select a two-column stat card.
- Verify both abbreviated and unabbreviated values are read correctly.

<img width="400" alt="stats_two_column" src="https://user-images.githubusercontent.com/1816888/72114479-e3051880-3300-11ea-87f4-2a4c4f904f36.png">

---
Widgets Two Column:
- On the high volume site Stats, select `Widgets` on the nav bar, then `Use this site`.
- Go to your device's Today view and add the `Today` and/or `All-Time` widget(s).
- Select a data row. (Note widgets are tables, so the rows are read separately.)
- Verify the values are read correctly.

<img width="400" alt="widget_two_column" src="https://user-images.githubusercontent.com/1816888/72114607-67579b80-3301-11ea-950c-1764a849382b.png">

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
