### PR TITLE
Add bounds checking to notification styles

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * Stats: fixed issue that could cause incorrect Stats to be displayed when viewing Stats from a widget.
 * Stats Today widgets: large numbers are now abbreviated.
 * Fixed a bug where files imported from other apps were being renamed to a random name.
+* Fixes a crash that could happen in the notifications tab.
 
 13.9
 -----

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
@@ -25,6 +25,14 @@ extension FormattableContentRange {
     }
 
     func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, at shiftedRange: NSRange) {
+
+        var shiftedRange = shiftedRange
+
+        // Don't attempt to apply styles past the end of a string – it will cause a crash
+        if shiftedRange.upperBound > string.length {
+            shiftedRange = NSRange(location: shiftedRange.location, length: string.length - shiftedRange.location)
+        }
+
         if let rangeStyle = styles.rangeStylesMap?[kind] {
             string.addAttributes(rangeStyle, range: shiftedRange)
         }

--- a/WordPress/WordPressTest/FormattableContentFormatterTests.swift
+++ b/WordPress/WordPressTest/FormattableContentFormatterTests.swift
@@ -58,6 +58,17 @@ final class FormattableContentFormatterTests: XCTestCase {
         XCTAssertEqual(formattedText.string, Constants.textExpectation)
     }
 
+    func testInvalidRange() {
+        let postProperties = NotificationContentRange.Properties(range: NSRange(location: 0, length: 1))
+
+        let content = FormattableTextContent(text: "", ranges: [
+            NotificationContentRange(kind: .post, properties: postProperties)
+        ])
+
+        let formattedText = formatter.render(content: content, with: SubjectContentStyles())
+        XCTAssert(formattedText.length == 0)
+    }
+
     private func contentWithNoticon() -> FormattableTextContent {
         let range = FormattableNoticonRange(value: Constants.noticon, range: Constants.range)
         return FormattableTextContent(text: Constants.text, ranges: [range])


### PR DESCRIPTION
Fixes a crash that can happen when given invalid ranges – if the range extended past the end of the string, the app would crash. That doesn't happen anymore.

Fixes #

**To test:**
- Comment out the bounds check, run the new test, see that the app crashes
- Un-comment out the bounds check, run the tests again, see that they pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
