### PR TITLE
Add Media Editor to Gutenberg and Aztec flows

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3217,10 +3217,6 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, previewViewControllerFor assets: [WPMediaAsset], selectedIndex selected: Int) -> UIViewController? {
-        /*
-         Temporarilly enable Media Editor in internal builds.
-         This will be refactored soon.
-         */
         if FeatureFlag.mediaEditor.enabled, let phAssets = assets as? [PHAsset], phAssets.allSatisfy({ $0.mediaType == .image }) {
             edit(fromMediaPicker: picker, assets: phAssets)
             return nil

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3494,8 +3494,9 @@ extension AztecPostViewController {
                                 }
 
                                 self?.dismissMediaPicker()
-            }, onCancel: { [weak self] in
-                self?.dismissMediaPicker()
+            }, onCancel: {
+                // Dismiss the Preview screen in Media Picker
+                picker.navigationController?.popViewController(animated: false)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3191,27 +3191,6 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
             return
         }
 
-        /*
-         Temporarilly enable Media Editor in internal builds.
-         This will be refactored soon.
-         */
-        if FeatureFlag.mediaEditor.enabled, let phAssets = assets as? [PHAsset], phAssets.allSatisfy({ $0.mediaType == .image }) {
-            let mediaEditor = WPMediaEditor(phAssets)
-
-            mediaEditor.edit(from: self,
-                                  onFinishEditing: { [weak self] images, actions in
-                                    images.forEach { mediaEditorImage in
-                                        if let image = mediaEditorImage.editedImage {
-                                            self?.insertImage(image: image)
-                                        } else if let phAsset = mediaEditorImage as? PHAsset {
-                                            self?.insertDeviceMedia(phAsset: phAsset)
-                                        }
-                                    }
-            })
-
-            return
-        }
-
         for asset in assets {
             switch asset {
             case let phAsset as PHAsset:
@@ -3238,8 +3217,17 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, previewViewControllerFor assets: [WPMediaAsset], selectedIndex selected: Int) -> UIViewController? {
-        mediaPreviewHelper = MediaPreviewHelper(assets: assets)
-        return mediaPreviewHelper?.previewViewController(selectedIndex: selected)
+        /*
+         Temporarilly enable Media Editor in internal builds.
+         This will be refactored soon.
+         */
+        if FeatureFlag.mediaEditor.enabled, let phAssets = assets as? [PHAsset], phAssets.allSatisfy({ $0.mediaType == .image }) {
+            edit(fromMediaPicker: picker, assets: phAssets)
+            return nil
+        } else {
+            mediaPreviewHelper = MediaPreviewHelper(assets: assets)
+            return mediaPreviewHelper?.previewViewController(selectedIndex: selected)
+        }
     }
 
     private func updateFormatBarInsertAssetCount() {
@@ -3492,7 +3480,33 @@ extension AztecPostViewController: PostEditorNavigationBarManagerDelegate {
 // MARK: - Media Editing
 //
 extension AztecPostViewController {
-    func edit(_ imageAttachment: ImageAttachment) {
+    private func edit(fromMediaPicker picker: WPMediaPickerViewController, assets: [PHAsset]) {
+        let mediaEditor = WPMediaEditor(assets)
+
+        mediaEditor.edit(from: picker,
+                              onFinishEditing: { [weak self] images, actions in
+                                images.forEach { mediaEditorImage in
+                                    if let image = mediaEditorImage.editedImage {
+                                        self?.insertImage(image: image)
+                                    } else if let phAsset = mediaEditorImage as? PHAsset {
+                                        self?.insertDeviceMedia(phAsset: phAsset)
+                                    }
+                                }
+
+                                self?.dismissMediaPicker()
+            }, onCancel: { [weak self] in
+                self?.dismissMediaPicker()
+        })
+    }
+
+    private func dismissMediaPicker() {
+        unregisterChangeObserver()
+        mediaLibraryDataSource.searchCancelled()
+        closeMediaPickerInputViewController()
+        dismiss(animated: false)
+    }
+
+    private func edit(_ imageAttachment: ImageAttachment) {
         guard let image = imageAttachment.image else {
             return
         }

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -229,7 +229,6 @@ public class MediaEditor: UINavigationController {
             dismiss(animated: true)
         } else {
             hub.show(image: image, at: selectedImageIndex)
-            images[selectedImageIndex] = image
             dismissCapability()
         }
     }

--- a/WordPress/MediaEditor/MediaEditor.swift
+++ b/WordPress/MediaEditor/MediaEditor.swift
@@ -192,6 +192,7 @@ public class MediaEditor: UINavigationController {
     }
 
     private func cancelPendingAsyncImagesAndDismiss() {
+        onCancel?()
         asyncImages.forEach { $0.cancel() }
         dismiss(animated: true)
     }

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -63,10 +63,6 @@ class MediaEditorHub: UIViewController {
         capabilitiesCollectionView.delegate = self
         imagesCollectionView.dataSource = self
         imagesCollectionView.delegate = self
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         selectLastAsset()
     }
 

--- a/WordPress/MediaEditor/MediaEditorHub.swift
+++ b/WordPress/MediaEditor/MediaEditorHub.swift
@@ -63,6 +63,10 @@ class MediaEditorHub: UIViewController {
         capabilitiesCollectionView.delegate = self
         imagesCollectionView.dataSource = self
         imagesCollectionView.delegate = self
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         selectLastAsset()
     }
 

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -413,9 +413,9 @@ class MediaEditorTests: XCTestCase {
         let firstImage = AsyncImageMock()
         let seconImage = AsyncImageMock()
         let mediaEditor = MediaEditor([firstImage, seconImage])
-        mediaEditor.capabilityTapped(0)
+        tapFirstCapability(in: mediaEditor)
 
-        firstImage.simulate(fullImageHasBeenDownloaded: fullImage)
+        seconImage.simulate(fullImageHasBeenDownloaded: fullImage)
 
         expect(mediaEditor.currentCapability).toEventuallyNot(beNil())
         expect(mediaEditor.visibleViewController).to(equal(mediaEditor.currentCapability?.viewController))
@@ -441,8 +441,8 @@ class MediaEditorTests: XCTestCase {
         let firstImage = AsyncImageMock()
         let seconImage = AsyncImageMock()
         let mediaEditor = MediaEditor([firstImage, seconImage])
-        mediaEditor.capabilityTapped(0)
-        firstImage.simulate(fullImageHasBeenDownloaded: UIImage())
+        tapFirstCapability(in: mediaEditor)
+        seconImage.simulate(fullImageHasBeenDownloaded: UIImage())
         mediaEditor.onFinishEditing = { images, _ in
             returnedImages = images
         }
@@ -453,8 +453,8 @@ class MediaEditorTests: XCTestCase {
         mediaEditor.hub.doneButton.sendActions(for: .touchUpInside)
 
         // Then
-        expect(returnedImages.first?.isEdited).to(beTrue())
-        expect(returnedImages.first?.editedImage).to(equal(image))
+        expect(returnedImages[1].isEdited).to(beTrue())
+        expect(returnedImages[1].editedImage).to(equal(image))
     }
 
     func testUpdateEditedImagesIndexesAfterEditingAnImage() {
@@ -462,7 +462,7 @@ class MediaEditorTests: XCTestCase {
         let firstImage = AsyncImageMock()
         let seconImage = AsyncImageMock()
         let mediaEditor = MediaEditor([firstImage, seconImage])
-        mediaEditor.capabilityTapped(0)
+        tapFirstCapability(in: mediaEditor)
         firstImage.simulate(fullImageHasBeenDownloaded: image)
         seconImage.simulate(fullImageHasBeenDownloaded: UIImage())
         expect(mediaEditor.currentCapability).toEventuallyNot(beNil()) // Wait capability appear
@@ -471,7 +471,14 @@ class MediaEditorTests: XCTestCase {
         mediaEditor.currentCapability?.onFinishEditing(image, [.rotate])
 
         // Then
-        expect(mediaEditor.editedImagesIndexes).to(equal([0]))
+        expect(mediaEditor.editedImagesIndexes).to(equal([1]))
+    }
+
+    // Wait for the last image to be selected and then
+    // tap the first capability.
+    private func tapFirstCapability(in mediaEditor: MediaEditor) {
+        expect(mediaEditor.selectedImageIndex).toEventually(equal(1))
+        mediaEditor.capabilityTapped(0)
     }
 
 }

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -413,9 +413,9 @@ class MediaEditorTests: XCTestCase {
         let firstImage = AsyncImageMock()
         let seconImage = AsyncImageMock()
         let mediaEditor = MediaEditor([firstImage, seconImage])
-        tapFirstCapability(in: mediaEditor)
+        mediaEditor.capabilityTapped(0)
 
-        seconImage.simulate(fullImageHasBeenDownloaded: fullImage)
+        firstImage.simulate(fullImageHasBeenDownloaded: fullImage)
 
         expect(mediaEditor.currentCapability).toEventuallyNot(beNil())
         expect(mediaEditor.visibleViewController).to(equal(mediaEditor.currentCapability?.viewController))
@@ -441,8 +441,8 @@ class MediaEditorTests: XCTestCase {
         let firstImage = AsyncImageMock()
         let seconImage = AsyncImageMock()
         let mediaEditor = MediaEditor([firstImage, seconImage])
-        tapFirstCapability(in: mediaEditor)
-        seconImage.simulate(fullImageHasBeenDownloaded: UIImage())
+        mediaEditor.capabilityTapped(0)
+        firstImage.simulate(fullImageHasBeenDownloaded: UIImage())
         mediaEditor.onFinishEditing = { images, _ in
             returnedImages = images
         }
@@ -453,15 +453,8 @@ class MediaEditorTests: XCTestCase {
         mediaEditor.hub.doneButton.sendActions(for: .touchUpInside)
 
         // Then
-        expect(returnedImages[1].isEdited).to(beTrue())
-        expect(returnedImages[1].editedImage).to(equal(image))
-    }
-
-    // Wait for the last image to be selected and then
-    // tap the first capability.
-    private func tapFirstCapability(in mediaEditor: MediaEditor) {
-        expect(mediaEditor.selectedImageIndex).toEventually(equal(1))
-        mediaEditor.capabilityTapped(0)
+        expect(returnedImages.first?.isEdited).to(beTrue())
+        expect(returnedImages.first?.editedImage).to(equal(image))
     }
 
     func testUpdateEditedImagesIndexesAfterEditingAnImage() {

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -413,9 +413,9 @@ class MediaEditorTests: XCTestCase {
         let firstImage = AsyncImageMock()
         let seconImage = AsyncImageMock()
         let mediaEditor = MediaEditor([firstImage, seconImage])
-        mediaEditor.capabilityTapped(0)
+        tapFirstCapability(in: mediaEditor)
 
-        firstImage.simulate(fullImageHasBeenDownloaded: fullImage)
+        seconImage.simulate(fullImageHasBeenDownloaded: fullImage)
 
         expect(mediaEditor.currentCapability).toEventuallyNot(beNil())
         expect(mediaEditor.visibleViewController).to(equal(mediaEditor.currentCapability?.viewController))
@@ -441,8 +441,8 @@ class MediaEditorTests: XCTestCase {
         let firstImage = AsyncImageMock()
         let seconImage = AsyncImageMock()
         let mediaEditor = MediaEditor([firstImage, seconImage])
-        mediaEditor.capabilityTapped(0)
-        firstImage.simulate(fullImageHasBeenDownloaded: UIImage())
+        tapFirstCapability(in: mediaEditor)
+        seconImage.simulate(fullImageHasBeenDownloaded: UIImage())
         mediaEditor.onFinishEditing = { images, _ in
             returnedImages = images
         }
@@ -453,8 +453,15 @@ class MediaEditorTests: XCTestCase {
         mediaEditor.hub.doneButton.sendActions(for: .touchUpInside)
 
         // Then
-        expect(returnedImages.first?.isEdited).to(beTrue())
-        expect(returnedImages.first?.editedImage).to(equal(image))
+        expect(returnedImages[1].isEdited).to(beTrue())
+        expect(returnedImages[1].editedImage).to(equal(image))
+    }
+
+    // Wait for the last image to be selected and then
+    // tap the first capability.
+    private func tapFirstCapability(in mediaEditor: MediaEditor) {
+        expect(mediaEditor.selectedImageIndex).toEventually(equal(1))
+        mediaEditor.capabilityTapped(0)
     }
 
     func testUpdateEditedImagesIndexesAfterEditingAnImage() {

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -357,6 +357,18 @@ class MediaEditorTests: XCTestCase {
         expect(returnedImages).to(equal([editedImage, image]))
     }
 
+    func testWhenCancelEditingMultipleImagesCallOnCancel() {
+        var didCallOnCancel = false
+        let mediaEditor = MediaEditor([image, image])
+        mediaEditor.onCancel = {
+            didCallOnCancel = true
+        }
+
+        mediaEditor.hub.cancelIconButton.sendActions(for: .touchUpInside)
+
+        expect(didCallOnCancel).to(beTrue())
+    }
+
     // WHEN: Multiple async images + one single capability
 
     func testShowThumbsToolbar() {

--- a/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
+++ b/WordPress/WordPressTest/MediaEditor/MediaEditorTests.swift
@@ -413,9 +413,9 @@ class MediaEditorTests: XCTestCase {
         let firstImage = AsyncImageMock()
         let seconImage = AsyncImageMock()
         let mediaEditor = MediaEditor([firstImage, seconImage])
-        tapFirstCapability(in: mediaEditor)
+        mediaEditor.capabilityTapped(0)
 
-        seconImage.simulate(fullImageHasBeenDownloaded: fullImage)
+        firstImage.simulate(fullImageHasBeenDownloaded: fullImage)
 
         expect(mediaEditor.currentCapability).toEventuallyNot(beNil())
         expect(mediaEditor.visibleViewController).to(equal(mediaEditor.currentCapability?.viewController))
@@ -441,8 +441,8 @@ class MediaEditorTests: XCTestCase {
         let firstImage = AsyncImageMock()
         let seconImage = AsyncImageMock()
         let mediaEditor = MediaEditor([firstImage, seconImage])
-        tapFirstCapability(in: mediaEditor)
-        seconImage.simulate(fullImageHasBeenDownloaded: UIImage())
+        mediaEditor.capabilityTapped(0)
+        firstImage.simulate(fullImageHasBeenDownloaded: UIImage())
         mediaEditor.onFinishEditing = { images, _ in
             returnedImages = images
         }
@@ -453,8 +453,8 @@ class MediaEditorTests: XCTestCase {
         mediaEditor.hub.doneButton.sendActions(for: .touchUpInside)
 
         // Then
-        expect(returnedImages[1].isEdited).to(beTrue())
-        expect(returnedImages[1].editedImage).to(equal(image))
+        expect(returnedImages.first?.isEdited).to(beTrue())
+        expect(returnedImages.first?.editedImage).to(equal(image))
     }
 
     func testUpdateEditedImagesIndexesAfterEditingAnImage() {
@@ -462,23 +462,16 @@ class MediaEditorTests: XCTestCase {
         let firstImage = AsyncImageMock()
         let seconImage = AsyncImageMock()
         let mediaEditor = MediaEditor([firstImage, seconImage])
-        tapFirstCapability(in: mediaEditor)
+        mediaEditor.capabilityTapped(0)
         firstImage.simulate(fullImageHasBeenDownloaded: image)
-        seconImage.simulate(fullImageHasBeenDownloaded: UIImage())
+        seconImage.simulate(fullImageHasBeenDownloaded: image)
         expect(mediaEditor.currentCapability).toEventuallyNot(beNil()) // Wait capability appear
 
         // When
         mediaEditor.currentCapability?.onFinishEditing(image, [.rotate])
 
         // Then
-        expect(mediaEditor.editedImagesIndexes).to(equal([1]))
-    }
-
-    // Wait for the last image to be selected and then
-    // tap the first capability.
-    private func tapFirstCapability(in mediaEditor: MediaEditor) {
-        expect(mediaEditor.selectedImageIndex).toEventually(equal(1))
-        mediaEditor.capabilityTapped(0)
+        expect(mediaEditor.editedImagesIndexes).to(equal([0]))
     }
 
 }

--- a/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
@@ -224,9 +224,6 @@ class AztecEditorScreen: BaseScreen {
         MediaPickerAlbumScreen().selectImage(atIndex: 0)
         insertMediaButton.tap()
 
-        // Tap Done in Media Editor
-        app.buttons["Done"].tap()
-
         // Wait for upload to finish
         waitFor(element: uploadProgressBar, predicate: "exists == false", timeout: 10)
 


### PR DESCRIPTION
Fixes #13218

## To test

### Gutenberg

As for now, Gutenberg doesn't support multiple images. However, the flow is already implemented and you can test. In order to do so, in the method `gutenbergDidRequestMediaFromDevicePicker` change `allowMultipleSelection` to `true`.

1. Create a new post using Gutenberg
2. Insert a block image
3. Tap "Add image" > "Choose from device"
4. Select images (only the first selected will be uploaded)
5. Tap "Preview X"
6. Edit the first image
7. Tap Done
8. Check that the image was uploaded correctly

### Aztec

1. Create a new post using Aztec
2. Tap "+"
3. Tap <img src="https://user-images.githubusercontent.com/7040243/72288781-8f5c3d00-3628-11ea-8257-7f128c7015f1.png" height="28px">
4. Select as many images as you want
5. Tap "Preview X"
6. Edit the images and tap Done
7. All the images should be correctly uploaded

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
