### PR TITLE
Stats Widgets: reload table when stats are updated.

### DIFF
--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -12,6 +12,7 @@ class AllTimeViewController: UIViewController {
     private var statsValues: AllTimeWidgetStats? {
         didSet {
             updateStatsLabels()
+            tableView.reloadData()
         }
     }
 
@@ -244,7 +245,6 @@ private extension AllTimeViewController {
                                             visitors: allTimesStats?.visitorsCount,
                                             posts: allTimesStats?.postsCount,
                                             bestViews: allTimesStats?.bestViewsPerDayCount)
-                self.tableView.reloadData()
             }
             completionHandler(NCUpdateResult.newData)
         }

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -13,6 +13,7 @@ class TodayViewController: UIViewController {
     private var statsValues: TodayWidgetStats? {
         didSet {
             updateStatsLabels()
+            tableView.reloadData()
         }
     }
 
@@ -244,7 +245,6 @@ private extension TodayViewController {
                                                     visitors: todayInsight?.visitorsCount,
                                                     likes: todayInsight?.likesCount,
                                                     comments: todayInsight?.commentsCount)
-                self.tableView.reloadData()
             }
             completionHandler(NCUpdateResult.newData)
         }


### PR DESCRIPTION
Ref: #12702

This fixes an issue where the widgets would show the initial loading view when re-shown. The issue was I'd failed to reload the table when saved stats were loaded. Now the table is reloaded whenever `statsValues` is updated.

Known Issue: when the widgets are expanded, the footer sometimes "bounces" a bit. This exists on `develop` and isn't a result of this change. I'll look at that separately.

To test:
- In the app, select a site. Go to Stats > Widgets > `Use this site`.
- Add the `Today` and the `All-Time` widgets to the Today view.
- Scroll away from the Today view, wait a few seconds, then scroll back.
- Verify the dashes are not displayed before the data is refreshed.

Before | After
--------|-------
![reload_before](https://user-images.githubusercontent.com/1816888/72383821-79f31b80-36d9-11ea-9ac8-72a1df0b8261.gif)        |       ![reload_after](https://user-images.githubusercontent.com/1816888/72383840-81b2c000-36d9-11ea-864b-1e084fce253c.gif)

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
