### PR TITLE
This Week widget: fix reloading view, abbreviate values

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetDifferenceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetDifferenceCell.swift
@@ -11,12 +11,6 @@ class WidgetDifferenceCell: UITableViewCell {
     @IBOutlet private var differenceView: UIView!
     @IBOutlet private var differenceLabel: UILabel!
 
-    private var numberFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter
-    }()
-
     private var percentFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .percent
@@ -67,7 +61,7 @@ private extension WidgetDifferenceCell {
             return
         }
 
-        dataLabel.text = numberFormatter.string(from: NSNumber(value: day.viewsCount)) ?? String(day.viewsCount)
+        dataLabel.text = day.viewsCount.abbreviatedString()
         differenceLabel.text = percentFormatter.string(for: day.dailyChangePercent)
 
         guard !isToday else {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1152,6 +1152,7 @@
 		984B139221F66AC60004B6A2 /* SiteStatsPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B139121F66AC50004B6A2 /* SiteStatsPeriodViewModel.swift */; };
 		984B139421F66B2D0004B6A2 /* StatsPeriodStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B139321F66B2D0004B6A2 /* StatsPeriodStore.swift */; };
 		984B4EF320742FCC00F87888 /* ZendeskUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B4EF220742FCC00F87888 /* ZendeskUtils.swift */; };
+		984BE91523CE72D600B37D90 /* Double+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C82B52193A7B900A06E84 /* Double+Stats.swift */; };
 		984F86FB21DEDB070070E0E3 /* TopTotalsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984F86FA21DEDB060070E0E3 /* TopTotalsCell.swift */; };
 		98563DDD21BF30C40006F5E9 /* TabbedTotalsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */; };
 		98563DDE21BF30C40006F5E9 /* TabbedTotalsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98563DDC21BF30C40006F5E9 /* TabbedTotalsCell.xib */; };
@@ -12634,6 +12635,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				984BE91523CE72D600B37D90 /* Double+Stats.swift in Sources */,
 				983AE84C2399AC5B00E5B7F6 /* SFHFKeychainUtils.m in Sources */,
 				98F93184239AF76900E4E96E /* CocoaLumberjack.swift in Sources */,
 				98E419DF2399B62A00D8C822 /* Tracks.swift in Sources */,

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -10,11 +10,16 @@ class ThisWeekViewController: UIViewController {
     @IBOutlet private var tableView: UITableView!
 
     private var siteUrl: String = Constants.noDataLabel
-    private var statsValues: ThisWeekWidgetStats?
     private var siteID: NSNumber?
     private var timeZone: TimeZone?
     private var oauthToken: String?
     private let tracks = Tracks(appGroupName: WPAppGroupName)
+
+    private var statsValues: ThisWeekWidgetStats? {
+        didSet {
+            tableView.reloadData()
+        }
+    }
 
     private var haveSiteUrl: Bool {
         siteUrl != Constants.noDataLabel
@@ -240,7 +245,6 @@ private extension ThisWeekViewController {
             DispatchQueue.main.async {
                 let summaryData = summary?.summaryData.reversed() ?? []
                 self.statsValues = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData))
-                self.tableView.reloadData()
             }
             completionHandler(NCUpdateResult.newData)
         }


### PR DESCRIPTION
Ref #13044 

This addresses two issues with the _This Week_ widget:
- The first two rows showing the initial loading view when re-loaded.
- Abbreviates values over 10,000.

Known Issue: when expanding the widget, the footer still jumps from the top to the bottom. I'll address this in a future PR.

To test:

---
Reloading:
- In the app, select a site. Go to Stats > Widgets > `Use this site`.
- Add the `This Week` widget to the Today view.
- Scroll away from the Today view, wait a few seconds, then scroll back.
- Verify the dashes are not displayed before the data is refreshed.

Before | After
--------|-------
![reload_before](https://user-images.githubusercontent.com/1816888/72394958-28f12080-36f5-11ea-8dbe-213462550493.gif)        |       ![reload_after](https://user-images.githubusercontent.com/1816888/72394967-33abb580-36f5-11ea-94e3-61323b8a6fc2.gif)

---
Abbreviated Values:
- On a high volume site, view the `This Week` widget.
- Verify `Views` higher than 10,000 are abbreviated.
- Hack tip: This can be a bit hard to verify. You can test the abbreviations by:

In `ThisWeekViewController:statCellFor`, replace this line:
`cell.configure(day: statsValues.days[indexPath.row], isToday: indexPath.row == 0)`

With something like this, setting the `viewsCount` to a number larger than 10,000:

```
let day = statsValues.days[indexPath.row]
let testDay = ThisWeekWidgetDay(date: day.date, viewsCount: 999999, dailyChangePercent: day.dailyChangePercent)
cell.configure(day: testDay, isToday: indexPath.row == 0)
```

<img width="400" alt="abbreviated_views" src="https://user-images.githubusercontent.com/1816888/72395195-f09e1200-36f5-11ea-9837-24e51c5928be.png">

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
