### PR TITLE
Desktop Preview Feature UI

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,6 @@
 14.1
 -----
 * Fixes a bug that could cause some web page previews to remain unauthenticated even after logging in.
-* Post Preview: Adds new UI for blog and site page previews.
-* Post Preview: Adds preview for Desktop devices to blog and site page previews.
  
 14.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 14.1
 -----
 * Fixes a bug that could cause some web page previews to remain unauthenticated even after logging in.
+* Post Preview: Adds new UI for blog and site page previews.
+* Post Preview: Adds preview for Desktop devices to blog and site page previews.
  
 14.0
 -----

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -298,8 +298,8 @@ class WebKitViewController: UIViewController {
     // MARK: Reachability Helpers
 
     private func reloadWhenConnectionRestored() {
-        reachabilityObserver = ReachabilityUtils.observeOnceInternetAvailable {
-            self.loadWebViewRequest()
+        reachabilityObserver = ReachabilityUtils.observeOnceInternetAvailable { [weak self] in
+            self?.loadWebViewRequest()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceLabel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceLabel.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+class PreviewDeviceLabel: UILabel {
+    @IBInspectable var insets: UIEdgeInsets = .zero {
+        didSet {
+            invalidateIntrinsicContentSize()
+            setNeedsLayout()
+        }
+    }
+
+    // MARK: Initialization
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupView()
+    }
+
+    fileprivate func setupView() {
+        textAlignment = .center
+        layer.masksToBounds = true
+
+        cornerRadius = 4.0
+    }
+
+    // MARK: Padding
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: insets))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        var size = super.intrinsicContentSize
+        size.width += insets.left + insets.right
+        size.height += insets.top + insets.bottom
+        return size
+    }
+
+    @IBInspectable var cornerRadius: CGFloat {
+        get {
+            return layer.cornerRadius
+        }
+        set {
+            layer.cornerRadius = newValue
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
@@ -34,11 +34,9 @@ class PreviewDeviceSelectionViewController: UIViewController {
         super.viewDidLoad()
         let blurEffect: UIBlurEffect
         if #available(iOS 13.0, *) {
-            blurEffect = UIBlurEffect(style: .systemUltraThinMaterial)
-//            view.backgroundColor = .clear
+            blurEffect = UIBlurEffect(style: .systemMaterial)
         } else {
-            blurEffect = UIBlurEffect(style: .extraLight)
-//            view.backgroundColor = .clear
+            blurEffect = UIBlurEffect(style: .light)
         }
 
         let effectView = UIVisualEffectView(effect: blurEffect)

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+class PreviewDeviceSelectionViewController: UIViewController {
+    enum PreviewDevice: CaseIterable {
+        case desktop
+        case `default`
+
+        var title: String {
+            switch self {
+            case .desktop:
+                return "Desktop"
+            case .`default`:
+                return "Default"
+            }
+        }
+    }
+
+    var selectedOption: PreviewDevice = .default
+
+    var dismissHandler: ((PreviewDevice) -> Void)?
+
+    lazy var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView .translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = .clear
+        tableView.alwaysBounceVertical = false
+        tableView.separatorInset = .zero
+        return tableView
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let blurEffect: UIBlurEffect
+        if #available(iOS 13.0, *) {
+            blurEffect = UIBlurEffect(style: .systemUltraThinMaterial)
+//            view.backgroundColor = .clear
+        } else {
+            blurEffect = UIBlurEffect(style: .extraLight)
+//            view.backgroundColor = .clear
+        }
+
+        let effectView = UIVisualEffectView(effect: blurEffect)
+
+        effectView.backgroundColor = .clear
+        effectView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.backgroundColor = .clear
+        view.addSubview(effectView)
+        view.pinSubviewToAllEdges(effectView)
+
+        effectView.contentView.addSubview(tableView)
+
+        effectView.contentView.pinSubviewToAllEdges(tableView)
+
+        tableView.separatorEffect = UIVibrancyEffect(blurEffect: blurEffect)
+
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+    }
+
+    override var preferredContentSize: CGSize {
+        get {
+            tableView.layoutIfNeeded()
+            return CGSize(width: 240, height: tableView.contentSize.height)
+        }
+        set {
+            // No-op - Cell is calculated from the table view's contentSize
+        }
+    }
+}
+
+extension PreviewDeviceSelectionViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return PreviewDevice.allCases.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+
+        cell.backgroundColor = .clear
+
+        let device = PreviewDevice.allCases[indexPath.row]
+
+        cell.textLabel?.text = device.title
+        cell.textLabel?.font = WPStyleGuide.regularTextFont()
+
+
+        if device == selectedOption {
+            cell.accessoryType = .checkmark
+        } else {
+            cell.accessoryType = .none
+        }
+
+        return cell
+    }
+
+    // This is a "hack" that prevents the bottom cell's separator from being shown.
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        let view = UIView()
+        view.backgroundColor = .clear
+        return view
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 0.1
+    }
+}
+
+extension PreviewDeviceSelectionViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        dismissHandler?(PreviewDevice.allCases[indexPath.row])
+        dismiss(animated: true, completion: nil)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
@@ -4,13 +4,24 @@ class PreviewDeviceSelectionViewController: UIViewController {
     enum PreviewDevice: CaseIterable {
         case desktop
         case `default`
+        case mobile
 
         var title: String {
             switch self {
             case .desktop:
-                return "Desktop"
+                return NSLocalizedString("Desktop", comment: "Title for the desktop web preview")
             case .`default`:
-                return "Default"
+                return NSLocalizedString("Default", comment: "Title for the default web preview")
+            case .mobile:
+                return NSLocalizedString("Mobile", comment: "Title for the mobile web preview")
+            }
+        }
+
+        static var available: [PreviewDevice] {
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                return [.mobile, .default]
+            } else {
+                return [.desktop, .default]
             }
         }
     }
@@ -70,7 +81,7 @@ class PreviewDeviceSelectionViewController: UIViewController {
 
 extension PreviewDeviceSelectionViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return PreviewDevice.allCases.count
+        return PreviewDevice.available.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -78,7 +89,7 @@ extension PreviewDeviceSelectionViewController: UITableViewDataSource {
 
         cell.backgroundColor = .clear
 
-        let device = PreviewDevice.allCases[indexPath.row]
+        let device = PreviewDevice.available[indexPath.row]
 
         cell.textLabel?.text = device.title
         cell.textLabel?.font = WPStyleGuide.regularTextFont()
@@ -107,7 +118,7 @@ extension PreviewDeviceSelectionViewController: UITableViewDataSource {
 
 extension PreviewDeviceSelectionViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        dismissHandler?(PreviewDevice.allCases[indexPath.row])
+        dismissHandler?(PreviewDevice.available[indexPath.row])
         dismiss(animated: true, completion: nil)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -14,8 +14,8 @@ class PreviewWebKitViewController: WebKitViewController {
         didSet {
             if selectedDevice != oldValue {
                 webView.reload()
-                showLabel(device: selectedDevice)
             }
+            showLabel(device: selectedDevice)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -1,4 +1,5 @@
 import Gridicons
+import WebKit
 
 /// An augmentation of WebKitViewController to provide Previewing for different devices
 class PreviewWebKitViewController: WebKitViewController {
@@ -158,6 +159,16 @@ extension PreviewWebKitViewController {
         popoverPresentationController.sourceView = navigationController.toolbar.superview
     }
 }
+
+// MARK: WKNavigationDelegate
+
+extension PreviewWebKitViewController {
+    func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        if selectedDevice == .desktop {
+            // Change the viewport scale to match a desktop environment
+            webView.evaluateJavaScript("let originalVp = document.querySelector('meta[name=viewport]').cloneNode(true); originalVp.setAttribute('name', 'original_viewport' ); document.querySelector('head').appendChild(originalVp); parent = document.querySelector('meta[name=viewport]'); parent.setAttribute('content','initial-scale=0');", completionHandler: nil)
+        }
+    }
 }
 
 // MARK: NoResultsViewController Delegate

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -12,8 +12,10 @@ class PreviewWebKitViewController: WebKitViewController {
 
     private var selectedDevice: PreviewDeviceSelectionViewController.PreviewDevice = .default {
         didSet {
-            webView.reload()
-            showLabel(device: selectedDevice)
+            if selectedDevice != oldValue {
+                webView.reload()
+                showLabel(device: selectedDevice)
+            }
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -10,7 +10,11 @@ class PreviewWebKitViewController: WebKitViewController {
 
     private weak var noResultsViewController: NoResultsViewController?
 
-    private var selectedDevice: PreviewDeviceSelectionViewController.PreviewDevice = .default
+    private var selectedDevice: PreviewDeviceSelectionViewController.PreviewDevice = .default {
+        didSet {
+            showLabel(device: selectedDevice)
+        }
+    }
 
     lazy var publishButton: UIBarButtonItem = {
         let publishButton = UIBarButtonItem(title: NSLocalizedString("Publish", comment: "Label for the publish (verb) button. Tapping publishes a draft post."),
@@ -25,6 +29,13 @@ class PreviewWebKitViewController: WebKitViewController {
         return UIBarButtonItem(image: Gridicon.iconOfType(.computer), style: .plain, target: self, action: #selector(PreviewWebKitViewController.previewButtonPressed(_:)))
     }()
 
+    lazy var deviceLabel: PreviewDeviceLabel = {
+        let label = PreviewDeviceLabel()
+        label.insets = UIEdgeInsets(top: 6, left: 6, bottom: 8, right: 8)
+        label.backgroundColor = UIColor.text.withAlphaComponent(0.8)
+        label.textColor = .textInverted
+        return label
+    }()
 
     /// Creates a view controller displaying a preview web view.
     /// - Parameters:
@@ -62,7 +73,10 @@ class PreviewWebKitViewController: WebKitViewController {
         if webView.url?.absoluteString == "about:blank" {
             showNoResults(withTitle: NSLocalizedString("No Preview URL available", comment: "missing preview URL for blog post preview") )
         }
+        setupDeviceLabel()
     }
+
+    // MARK: Toolbar Items
 
     override func configureToolbarButtons() {
         super.configureToolbarButtons()
@@ -99,6 +113,8 @@ class PreviewWebKitViewController: WebKitViewController {
         return items
     }
 
+    // MARK: Button Actionss
+
     @objc private func publishButtonPressed(_ sender: UIBarButtonItem) {
         PostCoordinator.shared.publish(post)
         dismiss(animated: true, completion: nil)
@@ -125,6 +141,26 @@ class PreviewWebKitViewController: WebKitViewController {
         view.addSubview(controller.view)
         view.pinSubviewToAllEdges(controller.view)
         noResultsViewController?.didMove(toParent: self)
+    }
+
+    // MARK: Selected Device Label
+
+    private func setupDeviceLabel() {
+        view.addSubview(deviceLabel)
+
+        deviceLabel.translatesAutoresizingMaskIntoConstraints = false
+        deviceLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        deviceLabel.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+        view.addConstraints([
+            deviceLabel.rightAnchor.constraint(equalTo: view.safeRightAnchor, constant: 4),
+            deviceLabel.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: 4)
+        ])
+        showLabel(device: selectedDevice)
+    }
+
+    private func showLabel(device: PreviewDeviceSelectionViewController.PreviewDevice) {
+        deviceLabel.isHidden = device == .default
+        deviceLabel.text = device.title
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -86,7 +86,7 @@ class PreviewWebKitViewController: WebKitViewController {
         setToolbarItems(items, animated: false)
     }
 
-    private func toolbarItems(linkBehavior: LinkBehavior) -> [UIBarButtonItem] {
+    func toolbarItems(linkBehavior: LinkBehavior) -> [UIBarButtonItem] {
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
         let items: [UIBarButtonItem]

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -92,7 +92,7 @@ class PreviewWebKitViewController: WebKitViewController {
         let items: [UIBarButtonItem]
 
         switch linkBehavior {
-        case .all, .hostOnly:
+        case .all:
             items = [
                 backButton,
                 space,
@@ -102,6 +102,28 @@ class PreviewWebKitViewController: WebKitViewController {
                 space,
                 safariButton
             ]
+        case .hostOnly:
+            if canPublish {
+                items = [
+                    backButton,
+                    space,
+                    forwardButton,
+                    space,
+                    previewButton
+                ]
+            } else {
+                items = [
+                    backButton,
+                    space,
+                    forwardButton,
+                    space,
+                    shareButton,
+                    space,
+                    safariButton,
+                    space,
+                    previewButton
+                ]
+            }
         case .urlOnly:
             if canPublish {
                 items = [publishButton, space, previewButton]

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -12,6 +12,7 @@ class PreviewWebKitViewController: WebKitViewController {
 
     private var selectedDevice: PreviewDeviceSelectionViewController.PreviewDevice = .default {
         didSet {
+            webView.reload()
             showLabel(device: selectedDevice)
         }
     }
@@ -147,7 +148,6 @@ class PreviewWebKitViewController: WebKitViewController {
         popoverContentController.selectedOption = selectedDevice
         popoverContentController.dismissHandler = { [weak self] option in
             self?.selectedDevice = option
-            self?.webView.reload()
         }
 
         popoverContentController.modalPresentationStyle = .popover
@@ -157,7 +157,6 @@ class PreviewWebKitViewController: WebKitViewController {
 
     private func showNoResults(withTitle title: String) {
         let controller = NoResultsViewController.controllerWith(title: title)
-        controller.delegate = self
         noResultsViewController = controller
         addChild(controller)
         view.addSubview(controller.view)
@@ -211,7 +210,9 @@ extension PreviewWebKitViewController {
         // Reset our source rect and view for a transition to a new size
         guard let navigationController = navigationController,
             let popoverPresentationController = presentedViewController?.presentationController as? UIPopoverPresentationController,
-            popoverPresentationController.presentedViewController is PreviewDeviceSelectionViewController else { return }
+            popoverPresentationController.presentedViewController is PreviewDeviceSelectionViewController else {
+                return
+        }
 
         popoverPresentationController.sourceRect = CGRect(x: navigationController.toolbar.frame.maxX - 36, y: navigationController.toolbar.frame.minY - 2, width: 0, height: 0)
         popoverPresentationController.sourceView = navigationController.toolbar.superview
@@ -226,14 +227,5 @@ extension PreviewWebKitViewController {
             // Change the viewport scale to match a desktop environment
             webView.evaluateJavaScript("let originalVp = document.querySelector('meta[name=viewport]').cloneNode(true); originalVp.setAttribute('name', 'original_viewport' ); document.querySelector('head').appendChild(originalVp); parent = document.querySelector('meta[name=viewport]'); parent.setAttribute('content','initial-scale=0');", completionHandler: nil)
         }
-    }
-}
-
-// MARK: NoResultsViewController Delegate
-
-extension PreviewWebKitViewController: NoResultsViewControllerDelegate {
-    func actionButtonPressed() {
-        noResultsViewController?.removeFromView()
-        webView.reload()
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -4,9 +4,9 @@ import WebKit
 /// An augmentation of WebKitViewController to provide Previewing for different devices
 class PreviewWebKitViewController: WebKitViewController {
 
-    private let canPublish: Bool
-
     let post: AbstractPost
+
+    private let canPublish: Bool
 
     private weak var noResultsViewController: NoResultsViewController?
 
@@ -72,7 +72,7 @@ class PreviewWebKitViewController: WebKitViewController {
         setToolbarItems(items, animated: false)
     }
 
-    func toolbarItems(linkBehavior: LinkBehavior) -> [UIBarButtonItem] {
+    private func toolbarItems(linkBehavior: LinkBehavior) -> [UIBarButtonItem] {
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
         let items: [UIBarButtonItem]
@@ -113,7 +113,7 @@ class PreviewWebKitViewController: WebKitViewController {
         }
 
         popoverContentController.modalPresentationStyle = .popover
-        popoverContentController.popoverPresentationController!.delegate = self
+        popoverContentController.popoverPresentationController?.delegate = self
         self.present(popoverContentController, animated: true, completion: nil)
     }
 
@@ -177,8 +177,5 @@ extension PreviewWebKitViewController: NoResultsViewControllerDelegate {
     func actionButtonPressed() {
         noResultsViewController?.removeFromView()
         webView.reload()
-    }
-
-    func dismissButtonPressed() {
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1996,6 +1996,7 @@
 		F5844B6B235EAF3D007C6557 /* HalfScreenPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5844B6A235EAF3D007C6557 /* HalfScreenPresentationController.swift */; };
 		F59AAC10235E430F00385EE6 /* ChosenValueRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59AAC0F235E430E00385EE6 /* ChosenValueRow.swift */; };
 		F59AAC16235EA46D00385EE6 /* LightNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59AAC15235EA46D00385EE6 /* LightNavigationController.swift */; };
+		F5B8A60F23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B8A60E23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift */; };
 		F5D03DFF2370E28D0043F287 /* LightNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59AAC15235EA46D00385EE6 /* LightNavigationController.swift */; };
 		F5D03E002370E28E0043F287 /* LightNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59AAC15235EA46D00385EE6 /* LightNavigationController.swift */; };
 		F5D0A64923C8FA1500B20D27 /* LinkBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D0A64823C8FA1500B20D27 /* LinkBehavior.swift */; };
@@ -4476,6 +4477,7 @@
 		F5844B6A235EAF3D007C6557 /* HalfScreenPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfScreenPresentationController.swift; sourceTree = "<group>"; };
 		F59AAC0F235E430E00385EE6 /* ChosenValueRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChosenValueRow.swift; sourceTree = "<group>"; };
 		F59AAC15235EA46D00385EE6 /* LightNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightNavigationController.swift; sourceTree = "<group>"; };
+		F5B8A60E23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDeviceSelectionViewController.swift; sourceTree = "<group>"; };
 		F5D0A64823C8FA1500B20D27 /* LinkBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkBehavior.swift; sourceTree = "<group>"; };
 		F5D0A64D23CC159400B20D27 /* PreviewWebKitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewWebKitViewController.swift; sourceTree = "<group>"; };
 		F5D0A64F23CC15A800B20D27 /* PreviewNonceHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewNonceHandler.swift; sourceTree = "<group>"; };
@@ -9620,6 +9622,7 @@
 			children = (
 				F5D0A64D23CC159400B20D27 /* PreviewWebKitViewController.swift */,
 				F5D0A64F23CC15A800B20D27 /* PreviewNonceHandler.swift */,
+				F5B8A60E23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift */,
 			);
 			path = Preview;
 			sourceTree = "<group>";
@@ -11757,6 +11760,7 @@
 				B532D4EE199D4418006E4DF6 /* NoteBlockImageTableViewCell.swift in Sources */,
 				93FA59DD18D88C1C001446BC /* PostCategoryService.m in Sources */,
 				436D564F211E122D00CEAA33 /* RegisterDomainDetailsServiceProxy.swift in Sources */,
+				F5B8A60F23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift in Sources */,
 				08D345511CD7F50900358E8C /* MenusSelectionItem.m in Sources */,
 				E62AFB6D1DC8E593007484FC /* WPTextAttachment.swift in Sources */,
 				738B9A5521B85CF20005062B /* TitleSubtitleTextfieldHeader.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1991,6 +1991,7 @@
 		F5660D07235D114500020B1E /* CalendarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D06235D114500020B1E /* CalendarCollectionView.swift */; };
 		F5660D09235D1CDD00020B1E /* CalendarMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D08235D1CDD00020B1E /* CalendarMonthView.swift */; };
 		F57402A7235FF9C300374346 /* SchedulingDate+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57402A6235FF9C300374346 /* SchedulingDate+Helpers.swift */; };
+		F580C3C123D22E2D0038E243 /* PreviewDeviceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F580C3C023D22E2D0038E243 /* PreviewDeviceLabel.swift */; };
 		F582060223A85495005159A9 /* SiteDateFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = F582060123A85495005159A9 /* SiteDateFormatters.swift */; };
 		F582060423A88379005159A9 /* TimePickerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F582060323A88379005159A9 /* TimePickerViewControllerTests.swift */; };
 		F5844B6B235EAF3D007C6557 /* HalfScreenPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5844B6A235EAF3D007C6557 /* HalfScreenPresentationController.swift */; };
@@ -4472,6 +4473,7 @@
 		F5660D06235D114500020B1E /* CalendarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionView.swift; sourceTree = "<group>"; };
 		F5660D08235D1CDD00020B1E /* CalendarMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthView.swift; sourceTree = "<group>"; };
 		F57402A6235FF9C300374346 /* SchedulingDate+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SchedulingDate+Helpers.swift"; sourceTree = "<group>"; };
+		F580C3C023D22E2D0038E243 /* PreviewDeviceLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDeviceLabel.swift; sourceTree = "<group>"; };
 		F582060123A85495005159A9 /* SiteDateFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDateFormatters.swift; sourceTree = "<group>"; };
 		F582060323A88379005159A9 /* TimePickerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePickerViewControllerTests.swift; sourceTree = "<group>"; };
 		F5844B6A235EAF3D007C6557 /* HalfScreenPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfScreenPresentationController.swift; sourceTree = "<group>"; };
@@ -9620,6 +9622,7 @@
 		F5D0A64C23CC157100B20D27 /* Preview */ = {
 			isa = PBXGroup;
 			children = (
+				F580C3C023D22E2D0038E243 /* PreviewDeviceLabel.swift */,
 				F5D0A64D23CC159400B20D27 /* PreviewWebKitViewController.swift */,
 				F5D0A64F23CC15A800B20D27 /* PreviewNonceHandler.swift */,
 				F5B8A60E23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift */,
@@ -11127,6 +11130,7 @@
 				E1D7FF381C74EB0E00E7E5E5 /* PlanService.swift in Sources */,
 				F1655B4822A6C2FA00227BFB /* Routes+Mbar.swift in Sources */,
 				32CA6EC02390C61F00B51347 /* PostListEditorPresenter.swift in Sources */,
+				F580C3C123D22E2D0038E243 /* PreviewDeviceLabel.swift in Sources */,
 				5D7DEA2919D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift in Sources */,
 				40C403F62215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift in Sources */,
 				82FC61251FA8ADAD00A1757E /* ActivityListViewController.swift in Sources */,

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/PreviewWebKitViewControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/PreviewWebKitViewControllerTests.swift
@@ -42,6 +42,7 @@ class PreviewWebKitViewControllerTests: XCTestCase {
                        "Preview toolbar for draft should not contain Safari button.")
         XCTAssertFalse(items.contains(vc.backButton), "Preview toolbar for draft should not contain back button.")
         XCTAssertFalse(items.contains(vc.forwardButton), "Preview toolbar for draft should not contain foward button.")
+        XCTAssertTrue(items.contains(vc.previewButton), "Preview toolbar for draft should contain preview button.")
     }
 
     func testPublishedToolbarItems() {
@@ -56,6 +57,7 @@ class PreviewWebKitViewControllerTests: XCTestCase {
         XCTAssertTrue(items.contains(vc.safariButton), "Preview toolbar for post should contain Safari button.")
         XCTAssertFalse(items.contains(vc.backButton), "Preview toolbar for post should not contain back button.")
         XCTAssertFalse(items.contains(vc.forwardButton), "Preview toolbar for post should not contain forward button.")
+        XCTAssertTrue(items.contains(vc.previewButton), "Preview toolbar for post should contain preview button.")
     }
 
     func testSitePageToolbarItems() {
@@ -70,5 +72,6 @@ class PreviewWebKitViewControllerTests: XCTestCase {
         XCTAssertTrue(items.contains(vc.safariButton), "Preview toolbar for page should contain Safari button.")
         XCTAssertTrue(items.contains(vc.backButton), "Preview toolbar for page should contain back button.")
         XCTAssertTrue(items.contains(vc.forwardButton), "Preview toolbar for page should contain forward button.")
+        XCTAssertTrue(items.contains(vc.previewButton), "Preview toolbar for page should contain preview button.")
     }
 }


### PR DESCRIPTION
Part of #13197

This adds UI and basic functionality to switch between Desktop and Mobile previews:

![Mobile Preview](https://user-images.githubusercontent.com/3250/72636938-69cb7e00-391d-11ea-99f6-f81dcf2d7416.png)

![iPad Selection](https://user-images.githubusercontent.com/3250/72646098-858d4f00-3932-11ea-9b93-d06dbe36d612.png)

![iPhone Selected Landscape](https://user-images.githubusercontent.com/3250/72637316-42c17c00-391e-11ea-886a-fd9d2b446785.png)

To test:

- View a blog or site page preview
- Try switching between device previews

A few things still to come:

- Need to use the new device preview icon shown in #13197. I believe a new icon needs to be added to gridicons.
- I think we may want to use the [`contentMode` API](https://developer.apple.com/documentation/webkit/wkwebpagepreferences/contentmode) or other User Agent modification to increase the chance of showing the true Desktop styling.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
