### PR TITLE
Change to light navigation bar for web previews

### DIFF
--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -477,7 +477,7 @@ fileprivate extension SearchManager {
 
         if FeatureFlag.postPreview.enabled {
             let controller = PreviewWebKitViewController(post: apost)
-            let navWrapper = UINavigationController(rootViewController: controller)
+            let navWrapper = LightNavigationController(rootViewController: controller)
             WPTabBarController.sharedInstance().present(navWrapper, animated: true)
         } else {
             let controller = PostPreviewViewController(post: apost)

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -202,7 +202,7 @@ class WebKitViewController: UIViewController {
 
     private func setupNavBarTitleView() {
         titleView.titleLabel.text = NSLocalizedString("Loading...", comment: "Loading. Verb")
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.0, *), navigationController is LightNavigationController == false {
             titleView.titleLabel.textColor = UIColor(light: .white, dark: .neutral(.shade70))
         } else {
             titleView.titleLabel.textColor = .neutral(.shade70)
@@ -284,7 +284,7 @@ class WebKitViewController: UIViewController {
     }
 
     private func styleBarButton(_ button: UIBarButtonItem) {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 13.0, *), navigationController is LightNavigationController == false {
             button.tintColor = UIColor(light: .white, dark: .neutral(.shade70))
         } else {
             button.tintColor = .listIcon

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -945,7 +945,7 @@ class AbstractPostListViewController: UIViewController,
             // NOTE: We'll set the title to match the title of the View action button.
             // If the button title changes we should also update the title here.
             controller.navigationItem.title = NSLocalizedString("View", comment: "Verb. The screen title shown when viewing a post inside the app.")
-            let navWrapper = UINavigationController(rootViewController: controller)
+            let navWrapper = LightNavigationController(rootViewController: controller)
             navigationController?.present(navWrapper, animated: true)
         } else {
             let controller = PostPreviewViewController(post: post)

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -238,7 +238,7 @@ class EditPostViewController: UIViewController {
 
         if FeatureFlag.postPreview.enabled {
             let controller = PreviewWebKitViewController(post: post)
-            let navWrapper = UINavigationController(rootViewController: controller)
+            let navWrapper = LightNavigationController(rootViewController: controller)
             postPost.present(navWrapper, animated: true) {}
         } else {
             let controller = PostPreviewViewController(post: post)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -89,7 +89,7 @@ extension PostEditor where Self: UIViewController {
                     }
                     previewController = PreviewWebKitViewController(post: self.post)
                 }
-                let navWrapper = UINavigationController(rootViewController: previewController)
+                let navWrapper = LightNavigationController(rootViewController: previewController)
                 self.navigationController?.present(navWrapper, animated: true)
             } else {
                 var previewController: PostPreviewViewController


### PR DESCRIPTION
This changes the navigation bar style from the default to a light navigation bar style but keeps the default modal presentation (the new covering style instead of fullscreen) for iOS 13.

Below are screenshots displaying the change in style:

![Before:After Navbar](https://user-images.githubusercontent.com/3250/72743447-eef6a300-3b68-11ea-91c2-2e7f0332601f.png)

<details>
<summary>All Screenshots</summary>

## iPhone

### Portrait

![iOS - Portrait](https://user-images.githubusercontent.com/3250/72739981-03836d00-3b62-11ea-8c36-12a5c054340b.png)

### Landscape

![iOS - Landscape](https://user-images.githubusercontent.com/3250/72740000-0e3e0200-3b62-11ea-906e-c1f7cc8fa2c3.png)

## iPad

### Portrait

![iPadOS - Portrait](https://user-images.githubusercontent.com/3250/72740017-18600080-3b62-11ea-91d8-19ed465d3010.png)

### Landscape

![iPadOS - Landscape](https://user-images.githubusercontent.com/3250/72740036-1dbd4b00-3b62-11ea-88e9-d4323a9f3ec7.png)

</details>

To test:
- Open a preview of a post or site page
- Check navigation bar styling

PR submission checklist:

- [x] ~I have considered adding unit tests where possible.~ Small styling change

- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Small styling change to un-shipped feature.
