### PR TITLE
Stats Widgets: clear stored data when site is changed

### DIFF
--- a/WordPress/Classes/Services/TodayExtensionService.m
+++ b/WordPress/Classes/Services/TodayExtensionService.m
@@ -2,6 +2,7 @@
 #import <NotificationCenter/NotificationCenter.h>
 #import "Constants.h"
 #import "SFHFKeychainUtils.h"
+#import "WordPress-Swift.h"
 
 @implementation TodayExtensionService
 
@@ -15,11 +16,16 @@
     NSParameterAssert(blogName != nil);
     NSParameterAssert(timeZone != nil);
     NSParameterAssert(oauth2Token.length > 0);
-    
-    [[NCWidgetController widgetController] setHasContent:YES forWidgetWithBundleIdentifier:@"org.wordpress.WordPressTodayWidget"];
-    
-    // Save the site information to shared user defaults for use in the today widget
+
     NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:WPAppGroupName];
+    
+    // If the widget site has changed, clear the widgets saved data.
+    NSNumber *previousSiteID = [sharedDefaults objectForKey:WPStatsTodayWidgetUserDefaultsSiteIdKey];
+    if (siteID != previousSiteID) {
+        [StatsDataHelper clearWidgetsData];
+    }
+
+    // Save the site information to shared user defaults for use in the today widgets.
     [sharedDefaults setObject:timeZone.name forKey:WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey];
     [sharedDefaults setObject:siteID forKey:WPStatsTodayWidgetUserDefaultsSiteIdKey];
     [sharedDefaults setObject:blogName forKey:WPStatsTodayWidgetUserDefaultsSiteNameKey];

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Helper class for getting/modifying Stats data for display purposes.
 ///
-class StatsDataHelper {
+@objc class StatsDataHelper: NSObject {
 
     // Max number of rows to display on Insights and Period stat cards.
     static let maxRowsToDisplay = 6
@@ -119,6 +119,12 @@ class StatsDataHelper {
             StatsTotalRowData(name: StatsDataHelper.displayMonth(forDate: $0.date),
                               data: $0.viewsCount.abbreviatedString())
         }
+    }
+
+    // MARK: - Widget Stored Data Support
+
+    @objc class func clearWidgetsData() {
+        TodayWidgetStats.clearSavedData()
     }
 
     // MARK: - Helpers

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -125,6 +125,7 @@ import Foundation
 
     @objc class func clearWidgetsData() {
         TodayWidgetStats.clearSavedData()
+        AllTimeWidgetStats.clearSavedData()
     }
 
     // MARK: - Helpers

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -126,6 +126,7 @@ import Foundation
     @objc class func clearWidgetsData() {
         TodayWidgetStats.clearSavedData()
         AllTimeWidgetStats.clearSavedData()
+        ThisWeekWidgetStats.clearSavedData()
     }
 
     // MARK: - Helpers

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
@@ -21,11 +21,11 @@ struct AllTimeWidgetStats: Codable {
 
 extension AllTimeWidgetStats {
 
-    static func loadSavedData() -> AllTimeWidgetStats {
+    static func loadSavedData() -> AllTimeWidgetStats? {
         guard let sharedDataFileURL = dataFileURL,
             FileManager.default.fileExists(atPath: sharedDataFileURL.path) == true else {
                 DDLogError("AllTimeWidgetStats: data file '\(dataFileName)' does not exist.")
-                return AllTimeWidgetStats()
+                return nil
         }
 
         let decoder = PropertyListDecoder()
@@ -34,7 +34,7 @@ extension AllTimeWidgetStats {
             return try decoder.decode(AllTimeWidgetStats.self, from: data)
         } catch {
             DDLogError("Failed loading AllTimeWidgetStats data: \(error.localizedDescription)")
-            return AllTimeWidgetStats()
+            return nil
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
@@ -38,6 +38,19 @@ extension AllTimeWidgetStats {
         }
     }
 
+    static func clearSavedData() {
+        guard let dataFileURL = AllTimeWidgetStats.dataFileURL else {
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(at: dataFileURL)
+        }
+        catch {
+            DDLogError("AllTimeWidgetStats: failed deleting data file '\(dataFileName)': \(error.localizedDescription)")
+        }
+    }
+
     func saveData() {
         guard let dataFileURL = AllTimeWidgetStats.dataFileURL else {
                 return

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/ThisWeekWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/ThisWeekWidgetStats.swift
@@ -49,6 +49,19 @@ extension ThisWeekWidgetStats {
         }
     }
 
+    static func clearSavedData() {
+        guard let dataFileURL = ThisWeekWidgetStats.dataFileURL else {
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(at: dataFileURL)
+        }
+        catch {
+            DDLogError("ThisWeekWidgetStats: failed deleting data file '\(dataFileName)': \(error.localizedDescription)")
+        }
+    }
+
     func saveData() {
         guard let dataFileURL = ThisWeekWidgetStats.dataFileURL else {
             return

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/ThisWeekWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/ThisWeekWidgetStats.swift
@@ -32,11 +32,11 @@ extension ThisWeekWidgetStats {
         return 7
     }
 
-    static func loadSavedData() -> ThisWeekWidgetStats {
+    static func loadSavedData() -> ThisWeekWidgetStats? {
         guard let sharedDataFileURL = dataFileURL,
             FileManager.default.fileExists(atPath: sharedDataFileURL.path) == true else {
                 DDLogError("ThisWeekWidgetStats: data file '\(dataFileName)' does not exist.")
-                return ThisWeekWidgetStats()
+                return nil
         }
 
         let decoder = PropertyListDecoder()
@@ -45,7 +45,7 @@ extension ThisWeekWidgetStats {
             return try decoder.decode(ThisWeekWidgetStats.self, from: data)
         } catch {
             DDLogError("Failed loading ThisWeekWidgetStats data: \(error.localizedDescription)")
-            return ThisWeekWidgetStats()
+            return nil
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
@@ -21,12 +21,11 @@ struct TodayWidgetStats: Codable {
 
 extension TodayWidgetStats {
 
-    static func loadSavedData() -> TodayWidgetStats {
+    static func loadSavedData() -> TodayWidgetStats? {
         guard let sharedDataFileURL = dataFileURL,
             FileManager.default.fileExists(atPath: sharedDataFileURL.path) == true else {
                 DDLogError("TodayWidgetStats: data file '\(dataFileName)' does not exist.")
-                // TODO: fix this - don't return zeros.
-                return TodayWidgetStats()
+                return nil
         }
 
         let decoder = PropertyListDecoder()
@@ -35,8 +34,7 @@ extension TodayWidgetStats {
             return try decoder.decode(TodayWidgetStats.self, from: data)
         } catch {
             DDLogError("TodayWidgetStats: Failed loading data: \(error.localizedDescription)")
-            // TODO: fix this - don't return zeros.
-            return TodayWidgetStats()
+            return nil
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
@@ -25,6 +25,7 @@ extension TodayWidgetStats {
         guard let sharedDataFileURL = dataFileURL,
             FileManager.default.fileExists(atPath: sharedDataFileURL.path) == true else {
                 DDLogError("TodayWidgetStats: data file '\(dataFileName)' does not exist.")
+                // TODO: fix this - don't return zeros.
                 return TodayWidgetStats()
         }
 
@@ -33,8 +34,22 @@ extension TodayWidgetStats {
             let data = try Data(contentsOf: sharedDataFileURL)
             return try decoder.decode(TodayWidgetStats.self, from: data)
         } catch {
-            DDLogError("Failed loading TodayWidgetStats data: \(error.localizedDescription)")
+            DDLogError("TodayWidgetStats: Failed loading data: \(error.localizedDescription)")
+            // TODO: fix this - don't return zeros.
             return TodayWidgetStats()
+        }
+    }
+
+    static func clearSavedData() {
+        guard let dataFileURL = TodayWidgetStats.dataFileURL else {
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(at: dataFileURL)
+        }
+        catch {
+            DDLogError("TodayWidgetStats: failed deleting data file '\(dataFileName)': \(error.localizedDescription)")
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetDifferenceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetDifferenceCell.swift
@@ -57,7 +57,6 @@ private extension WidgetDifferenceCell {
 
     func configureLabels(day: ThisWeekWidgetDay?, isToday: Bool) {
         guard let day = day else {
-            initializeLabels()
             return
         }
 

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -90,8 +90,8 @@ extension AllTimeViewController: NCWidgetProviding {
         if !isConfigured {
             DDLogError("All Time Widget: Missing site ID, timeZone or oauth2Token")
 
-            DispatchQueue.main.async {
-                self.tableView.reloadData()
+            DispatchQueue.main.async { [weak self] in
+                self?.tableView.reloadData()
             }
 
             completionHandler(NCUpdateResult.failed)
@@ -223,8 +223,8 @@ private extension AllTimeViewController {
 
             DDLogDebug("All Time Widget: Fetched StatsAllTimesInsight data.")
 
-            DispatchQueue.main.async {
-                self.statsValues = AllTimeWidgetStats(views: allTimesStats?.viewsCount,
+            DispatchQueue.main.async { [weak self] in
+                self?.statsValues = AllTimeWidgetStats(views: allTimesStats?.viewsCount,
                                             visitors: allTimesStats?.visitorsCount,
                                             posts: allTimesStats?.postsCount,
                                             bestViews: allTimesStats?.bestViewsPerDayCount)

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -346,7 +346,10 @@ private extension AllTimeViewController {
     // MARK: - Helpers
 
     func updateStatsLabels() {
-        let values = statsValues ?? AllTimeWidgetStats()
+        guard let values = statsValues else {
+            return
+        }
+
         viewCount = values.views.abbreviatedString()
         visitorCount = values.visitors.abbreviatedString()
         postCount = values.posts.abbreviatedString()

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -88,8 +88,8 @@ extension ThisWeekViewController: NCWidgetProviding {
         if !isConfigured {
             DDLogError("This Week Widget: Missing site ID, timeZone or oauth2Token")
 
-            DispatchQueue.main.async {
-                self.tableView.reloadData()
+            DispatchQueue.main.async { [weak self] in
+                self?.tableView.reloadData()
             }
 
             completionHandler(NCUpdateResult.failed)
@@ -221,9 +221,9 @@ private extension ThisWeekViewController {
 
             DDLogDebug("This Week Widget: Fetched summary data.")
 
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
                 let summaryData = summary?.summaryData.reversed() ?? []
-                self.statsValues = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData))
+                self?.statsValues = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData))
             }
             completionHandler(NCUpdateResult.newData)
         }

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -59,16 +59,14 @@ class ThisWeekViewController: UIViewController {
         let rowDifference = abs(updatedRowCount - tableView.numberOfRows(inSection: 0))
 
         // If the number of rows has not changed, do nothing.
-        guard rowDifference != 0,
-        let statsValues = statsValues else {
+        guard rowDifference != 0 else {
             return
         }
 
         coordinator.animate(alongsideTransition: { _ in
             self.tableView.performBatchUpdates({
                 // Create IndexPaths for rows to be inserted / deleted.
-                // Include endIndex to account for url row.
-                let indexRange = (Constants.minRows...statsValues.days.endIndex)
+                let indexRange = (Constants.minRows..<self.maxRowsToDisplay())
                 let indexPaths = indexRange.map({ return IndexPath(row: $0, section: 0) })
 
                 updatedRowCount > Constants.minRows ?
@@ -309,13 +307,21 @@ private extension ThisWeekViewController {
 
     func numberOfRowsToDisplay() -> Int {
         guard isConfigured,
-            extensionContext?.widgetActiveDisplayMode == .expanded,
-            let numDays = statsValues?.days.count else {
+            extensionContext?.widgetActiveDisplayMode == .expanded else {
                 return Constants.minRows
+        }
+        return maxRowsToDisplay()
+    }
+
+    func maxRowsToDisplay() -> Int {
+        guard let values = statsValues,
+            !values.days.isEmpty else {
+                // Add one for URL row
+                return ThisWeekWidgetStats.maxDaysToDisplay + 1
         }
 
         // Add one for URL row
-        return numDays + 1
+        return values.days.count + 1
     }
 
     func resizeView(withMaximumSize size: CGSize? = nil) {

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -90,8 +90,8 @@ extension TodayViewController: NCWidgetProviding {
         if !isConfigured {
             DDLogError("Today Widget: Missing site ID, timeZone or oauth2Token")
 
-            DispatchQueue.main.async {
-                self.tableView.reloadData()
+            DispatchQueue.main.async { [weak self] in
+                self?.tableView.reloadData()
             }
 
             completionHandler(NCUpdateResult.failed)
@@ -223,8 +223,8 @@ private extension TodayViewController {
 
             DDLogDebug("Today Widget: Fetched StatsTodayInsight data.")
 
-            DispatchQueue.main.async {
-                self.statsValues = TodayWidgetStats(views: todayInsight?.viewsCount,
+            DispatchQueue.main.async { [weak self] in
+                self?.statsValues = TodayWidgetStats(views: todayInsight?.viewsCount,
                                                     visitors: todayInsight?.visitorsCount,
                                                     likes: todayInsight?.likesCount,
                                                     comments: todayInsight?.commentsCount)

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -346,7 +346,10 @@ private extension TodayViewController {
     // MARK: - Helpers
 
     func updateStatsLabels() {
-        let values = statsValues ?? TodayWidgetStats()
+        guard let values = statsValues else {
+            return
+        }
+
         viewCount = values.views.abbreviatedString()
         visitorCount = values.visitors.abbreviatedString()
         likeCount = values.likes.abbreviatedString()


### PR DESCRIPTION
Ref #12702 

When changing the site used for widgets, the stored data for the old site is now purged.

To test:
The easiest way to test this is to prevent the widgets from fetching data for the new site.

- In the app, go to Stats > Widgets > `Use this site`.
- Add the 3 WordPress widgets to the Today view.
- Return to the app and change the site used for widgets.
- Disable your internet connection.
- Return to the Today view.
- Verify all the widgets show dashes (because no data was loaded from the plists and new data cannot be fetched).

**Note:** I'm currently working on a "no connection" view, so showing dashes in this state is temporary. This is just the easiest way to verify the data is purged.

<img width="455" alt="no_data" src="https://user-images.githubusercontent.com/1816888/72832687-9c89b500-3c42-11ea-88e5-fa234748e485.png">


PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
