### PR TITLE
Fixes navigation issue when external resources load

### DIFF
--- a/WordPress/Classes/Utility/LinkBehavior.swift
+++ b/WordPress/Classes/Utility/LinkBehavior.swift
@@ -9,7 +9,7 @@ enum LinkBehavior {
     func handle(navigationAction: WKNavigationAction, for webView: WKWebView) -> WKNavigationActionPolicy {
 
         // We only want to apply this policy for links, not for all resource loads
-        guard navigationAction.navigationType == .linkActivated else {
+        guard navigationAction.navigationType == .linkActivated && navigationAction.request.url == navigationAction.request.mainDocumentURL else {
             return .allow
         }
 


### PR DESCRIPTION
Fixes an issue where external resource loads open a new window in Safari.

| Before        | After           |
|:-------------:|:-------------:|
| <img src="https://user-images.githubusercontent.com/3250/72836768-7f58e480-3c4a-11ea-9df2-6e507d2609a9.gif" width="300">      | <img src="https://user-images.githubusercontent.com/3250/72836772-8253d500-3c4a-11ea-8402-e2e1673493d2.gif" width="300"> | <img src="https://user-images.githubusercontent.com/3250/72836772-8253d500-3c4a-11ea-8402-e2e1673493d2.gif" width="300"> |


To test:

- Open a site preview page on a custom domain loads resources from an external domain (I used a comment form for this)
- Notice that a request to an external domain opens in Safari

PR submission checklist:

- [x] ~I have considered adding unit tests where possible.~

- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Feature not released
