### PR TITLE
Fix gallery size labels

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -141,7 +141,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => '047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0'
+    gutenberg :commit => 'bdc663a39fda2d80588e2142a9acb47ec9b6ebee'
 
     ## Third party libraries
     ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -268,13 +268,13 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `bdc663a39fda2d80588e2142a9acb47ec9b6ebee`)
   - JTAppleCalendar (~> 8.0.2)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
@@ -284,30 +284,30 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-DevSupport (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-DevSupport.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - React-RCTWebSocket (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTWebSocket.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-DevSupport (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-DevSupport.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - React-RCTWebSocket (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTWebSocket.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `bdc663a39fda2d80588e2142a9acb47ec9b6ebee`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -318,7 +318,7 @@ DEPENDENCIES:
   - WordPressShared (= 1.8.11)
   - WordPressUI (~> 1.5.1-beta)
   - WPMediaPicker (~> 1.6.0)
-  - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
+  - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (from `https://github.com/zendesk/zendesk_sdk_ios`, tag `4.0.0`)
   - ZIPFoundation (~> 0.9.8)
 
@@ -367,66 +367,66 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :commit: 047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0
+    :commit: bdc663a39fda2d80588e2142a9acb47ec9b6ebee
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json
   React-DevSupport:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-DevSupport.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-DevSupport.podspec.json
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-slider:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json
   React-RCTWebSocket:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/React-RCTWebSocket.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/React-RCTWebSocket.podspec.json
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :commit: 047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0
+    :commit: bdc663a39fda2d80588e2142a9acb47ec9b6ebee
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bdc663a39fda2d80588e2142a9acb47ec9b6ebee/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 4.0.0
@@ -436,10 +436,10 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :commit: 047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0
+    :commit: bdc663a39fda2d80588e2142a9acb47ec9b6ebee
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNTAztecView:
-    :commit: 047a8f4bd3c95f5e8a39991dfe1157203bc8fcd0
+    :commit: bdc663a39fda2d80588e2142a9acb47ec9b6ebee
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
@@ -517,6 +517,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 99679d8420a6d862773e2ddef0ebcc51b282317d
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: f9d45067c59a1df23c437f570720348c3f01e8bd
+PODFILE CHECKSUM: a7421803f5375bba36f17fc077e6e0e9a622ee64
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
### Related PRs

`gutenberg`: https://github.com/WordPress/gutenberg/pull/19800
`gutenberg-mobile`: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1798
`WordPress-Android`: https://github.com/wordpress-mobile/WordPress-Android/pull/11124

## Description
This PR fixes the image size option labels in the gallery block settings. The image size options were added for web, but on mobile, the labels were undefined. This resulted in "blank" buttons, and in the beta build for iOS this also resulted in a crash.

This PR should fix the following issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/1792

## How has this been tested?
Tested on Android via WordPress-Android, and iOS via WordPress-iOS:

Steps:

* Create a gallery block with some images
* Tap the gallery
* Tap the gallery settings icon (the gear)
* Tap "Images size"

**Expected result:**

* The app should not crash
* The image size options should be visible in the menu

Steps:

* Tap one of the image size options (e.g. thumbnail)

**Expected result:**

The image resolution should change (to a lower quality with thumbnail, higher quality with large or full).

## Screenshots <!-- if applicable -->
<img src="https://user-images.githubusercontent.com/8507675/72871344-4eee7480-3d36-11ea-9c90-ed103eaa61e1.gif" width="360">

## Types of changes
On mobile, the `name` property in imageSizes is undefined, but `label` is already set. So this PR defaults to using the `label` if it is truthy, and falls back to using the `name` if not.


To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
