### PR TITLE
Make sure we are not checking for failed media on an empty array.

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -645,9 +645,7 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
 
         let allFailedMediaHaveAssociatedPost = mediaProgressCoordinator.failedMedia.allSatisfy { $0.hasAssociatedPost() }
 
-        if !mediaProgressCoordinator.failedMedia.isEmpty,
-           !allFailedMediaErrorsAreMissingFilesErrors,
-           !allFailedMediaHaveAssociatedPost,
+        if mediaProgressCoordinator.failedMedia.isEmpty || (!allFailedMediaErrorsAreMissingFilesErrors && !allFailedMediaHaveAssociatedPost),
            mediaProgressCoordinator == mediaLibraryProgressCoordinator || mediaProgressCoordinator.hasFailedMedia {
 
             let model = MediaProgressCoordinatorNoticeViewModel(mediaProgressCoordinator: mediaProgressCoordinator)

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -641,13 +641,14 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
         // the media library.
         // If the errors are causes by a missing file, we want to ignore that too.
 
-        let mediaErrorsAreMissingFilesErrors = mediaProgressCoordinator.failedMedia.allSatisfy { $0.hasMissingFileError }
+        let allFailedMediaErrorsAreMissingFilesErrors = mediaProgressCoordinator.failedMedia.allSatisfy { $0.hasMissingFileError }
 
-        let allMediaHaveAssociatedPost = mediaProgressCoordinator.failedMedia.allSatisfy { $0.hasAssociatedPost() }
+        let allFailedMediaHaveAssociatedPost = mediaProgressCoordinator.failedMedia.allSatisfy { $0.hasAssociatedPost() }
 
-        if !mediaErrorsAreMissingFilesErrors,
-            !allMediaHaveAssociatedPost,
-            mediaProgressCoordinator == mediaLibraryProgressCoordinator || mediaProgressCoordinator.hasFailedMedia {
+        if !mediaProgressCoordinator.failedMedia.isEmpty,
+           !allFailedMediaErrorsAreMissingFilesErrors,
+           !allFailedMediaHaveAssociatedPost,
+           mediaProgressCoordinator == mediaLibraryProgressCoordinator || mediaProgressCoordinator.hasFailedMedia {
 
             let model = MediaProgressCoordinatorNoticeViewModel(mediaProgressCoordinator: mediaProgressCoordinator)
             if let notice = model?.notice {


### PR DESCRIPTION
This PR makes the media upload notifications to show again.

I think that the behaviour of `allSatisfy` may have changed between
Swift versions because it looks this was working correctly before.

To test:
 - Open the app and go to a media library of a site
 - Press on the + button and multiple media
 - Wait for the uploads to finish
 - See if the notification/toast is showed correctly

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
