### PR TITLE
Changes some colors from WPWebViewController.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * Fixes a bug that could cause some web page previews to remain unauthenticated even after logging in.
 * Stats: added a This Week widget to display Views for the past week.
+* Web Views: the title and button colors in the header of web views was grey, and is now white.
  
 14.0
 -----

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -161,11 +161,11 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     navigationBar.barStyle                  = UIBarStyleDefault;
     [navigationBar setBackgroundImage:navBackgroundImage forBarMetrics:UIBarMetricsDefault];
 
-    self.titleView.titleLabel.textColor     = [UIColor murielNeutral70];
-    self.titleView.subtitleLabel.textColor  = [UIColor murielNeutral30];
+    self.titleView.titleLabel.textColor     = [UIColor whiteColor];
+    self.titleView.subtitleLabel.textColor  = [UIColor whiteColor];
 
-    self.dismissButton.tintColor            = [UIColor murielNeutral20];
-    self.optionsButton.tintColor            = [UIColor murielNeutral20];
+    self.dismissButton.tintColor            = [UIColor whiteColor];
+    self.optionsButton.tintColor            = [UIColor whiteColor];
 
     self.navigationItem.leftBarButtonItem   = self.dismissButton;
 }


### PR DESCRIPTION
This PR fixes the color of the title, subtitle and header buttons in WPWebViewController.

The color change was discussed with @mbshakti .

| Before | After |
|--------|------|
<img width="487" alt="Screen Shot 2020-01-22 at 4 45 35 PM" src="https://user-images.githubusercontent.com/1836005/72929310-5b73cc80-3d38-11ea-9ecf-a080ff74bc66.png"> | <img width="487" alt="Screen Shot 2020-01-22 at 4 46 26 PM" src="https://user-images.githubusercontent.com/1836005/72929193-27001080-3d38-11ea-884c-e50a72760fe8.png">




## Testing:

1. Go to "My Sites"
2. Select a site from your list of sites.
3. Tap on "Sharing"
4. Tap on "Facebook" or any of the other services.
5. Tap "Connect"

Make sure the title, subtitle and close button looks like the "after" image above.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
