### PR TITLE
Fix #13258: Post time string uses site time zone

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,13 +11,13 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    #pod 'WordPressShared', '1.8.11'
+    pod 'WordPressShared', '1.8.12-beta.2'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'fix/post-timezone'
+    #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
 end
 

--- a/Podfile
+++ b/Podfile
@@ -11,13 +11,13 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '1.8.11'
+    #pod 'WordPressShared', '1.8.11'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'fix/post-timezone'
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -315,7 +315,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.6)
   - WordPressKit (~> 4.5.6)
   - WordPressMocks (~> 0.0.7)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `fix/post-timezone`)
+  - WordPressShared (= 1.8.12-beta.2)
   - WordPressUI (~> 1.5.0)
   - WPMediaPicker (~> 1.6.0)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.20.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -359,6 +359,7 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -424,9 +425,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.20.1
-  WordPressShared:
-    :branch: fix/post-timezone
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.20.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -443,9 +441,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.20.1
-  WordPressShared:
-    :commit: 0c8be0e85ae8a61052ae555f5e966871f98af1e5
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 4.0.0
@@ -522,6 +517,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 99679d8420a6d862773e2ddef0ebcc51b282317d
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: f7e771186eab95ec650d7f5101df4abdc725e515
+PODFILE CHECKSUM: c2469efc0fe1d253a767ff7e3751f1be8f6213f4
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -240,7 +240,7 @@ PODS:
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
   - WordPressMocks (0.0.7)
-  - WordPressShared (1.8.11):
+  - WordPressShared (1.8.12-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.5.0)
@@ -315,7 +315,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.6)
   - WordPressKit (~> 4.5.6)
   - WordPressMocks (~> 0.0.7)
-  - WordPressShared (= 1.8.11)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `fix/post-timezone`)
   - WordPressUI (~> 1.5.0)
   - WPMediaPicker (~> 1.6.0)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.20.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -359,7 +359,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -425,6 +424,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.20.1
+  WordPressShared:
+    :branch: fix/post-timezone
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.20.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
   ZendeskSDK:
@@ -441,6 +443,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.20.1
+  WordPressShared:
+    :commit: 0c8be0e85ae8a61052ae555f5e966871f98af1e5
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 4.0.0
@@ -509,7 +514,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: de9ef4de7c9d06d89f938f69b01d810aebe9dfc6
   WordPressKit: 5b37877f273fc4bc7289eb736df3bd3122535bd4
   WordPressMocks: 64d77a10fba970a0e98760af651ba8ea6a54fcb8
-  WordPressShared: 39ce162e3efe0c85b40790ef654e5a0452c45bbb
+  WordPressShared: 76ed7f386c199f3c407e0d63fc49605f93ca406a
   WordPressUI: 4a4adafd2b052e94e4846c0a0203761773dc4fd5
   WPMediaPicker: e5d28197da6b467d4e5975d64a49255977e39455
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -517,6 +522,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 99679d8420a6d862773e2ddef0ebcc51b282317d
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 90666f7478212c26b34f282a64293c438611c118
+PODFILE CHECKSUM: f7e771186eab95ec650d7f5101df4abdc725e515
 
 COCOAPODS: 1.8.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -20,7 +20,6 @@
 * Stats: fixed issue that could cause incorrect Stats to be displayed when viewing Stats from a widget.
 * Stats Today widgets: large numbers are now abbreviated.
 * Fixed a bug where files imported from other apps were being renamed to a random name.
-* Fixed a bug where the Post might show a different date in lists than in the Post Settings screen.
 
 13.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -20,6 +20,7 @@
 * Stats: fixed issue that could cause incorrect Stats to be displayed when viewing Stats from a widget.
 * Stats Today widgets: large numbers are now abbreviated.
 * Fixed a bug where files imported from other apps were being renamed to a random name.
+* Fixed a bug where the Post might show a different date in lists than in the Post Settings screen.
 
 13.9
 -----

--- a/WordPress/Classes/Extensions/AbstractPost+Dates.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+Dates.swift
@@ -12,14 +12,21 @@ extension AbstractPost {
         let blogService = BlogService(managedObjectContext: context)
         let timeZone = blogService.timeZone(for: blog)
 
+        // Unpublished post shows relative or date string
         if originalIsDraft() || status == .pending {
             return dateModified?.mediumString(timeZone: timeZone)
-        } else if isScheduled() {
-            return dateCreated?.mediumStringWithTime(timeZone: timeZone)
-        } else if shouldPublishImmediately() {
-            return NSLocalizedString("Publish Immediately", comment: "A short phrase indicating a post is due to be immedately published.")
-        } else {
-            return dateCreated?.mediumString(timeZone: timeZone)
         }
+
+        // Scheduled Post shows date with time to be clear about when it goes live
+        if isScheduled() {
+            return dateCreated?.mediumStringWithTime(timeZone: timeZone)
+        }
+
+        // Publish Immediately shows hard coded string
+        if shouldPublishImmediately() {
+            return NSLocalizedString("Publish Immediately", comment: "A short phrase indicating a post is due to be immedately published.")
+        }
+
+        return dateCreated?.mediumString(timeZone: timeZone)
     }
 }

--- a/WordPress/Classes/Extensions/AbstractPost+Dates.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+Dates.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension AbstractPost {
+
+    /// The string to display to the user representing a post's date.
+    ///
+    /// - **Scheduled**: Displays time + date
+    /// - **Immediately**: Displays "Publish Immediately" string
+    /// - **Published or Draft**: Shows relative date when < 7 days
+    public func displayDate() -> String? {
+        let context = managedObjectContext ?? ContextManager.sharedInstance().mainContext
+        let blogService = BlogService(managedObjectContext: context)
+        let timeZone = blogService.timeZone(for: blog)
+
+        if originalIsDraft() || status == .pending {
+            return dateModified?.mediumString(timeZone: timeZone)
+        } else if isScheduled() {
+            return dateCreated?.mediumStringWithTime(timeZone: timeZone)
+        } else if shouldPublishImmediately() {
+            return NSLocalizedString("Publish Immediately", comment: "A short phrase indicating a post is due to be immedately published.")
+        } else {
+            return dateCreated?.mediumString(timeZone: timeZone)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -235,7 +235,11 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
             return
         }
 
-        dateLabel.text = post.dateStringForDisplay()
+        if FeatureFlag.postScheduling.enabled {
+            dateLabel.text = post.displayDate()
+        } else {
+            dateLabel.text = post.dateStringForDisplay()
+        }
     }
 
     private func configureAuthor() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1990,6 +1990,7 @@
 		F5660D07235D114500020B1E /* CalendarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D06235D114500020B1E /* CalendarCollectionView.swift */; };
 		F5660D09235D1CDD00020B1E /* CalendarMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D08235D1CDD00020B1E /* CalendarMonthView.swift */; };
 		F57402A7235FF9C300374346 /* SchedulingDate+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57402A6235FF9C300374346 /* SchedulingDate+Helpers.swift */; };
+		F580C3CB23D8F9B40038E243 /* AbstractPost+Dates.swift in Sources */ = {isa = PBXBuildFile; fileRef = F580C3CA23D8F9B40038E243 /* AbstractPost+Dates.swift */; };
 		F582060223A85495005159A9 /* SiteDateFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = F582060123A85495005159A9 /* SiteDateFormatters.swift */; };
 		F582060423A88379005159A9 /* TimePickerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F582060323A88379005159A9 /* TimePickerViewControllerTests.swift */; };
 		F5844B6B235EAF3D007C6557 /* HalfScreenPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5844B6A235EAF3D007C6557 /* HalfScreenPresentationController.swift */; };
@@ -4466,6 +4467,7 @@
 		F5660D06235D114500020B1E /* CalendarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionView.swift; sourceTree = "<group>"; };
 		F5660D08235D1CDD00020B1E /* CalendarMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthView.swift; sourceTree = "<group>"; };
 		F57402A6235FF9C300374346 /* SchedulingDate+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SchedulingDate+Helpers.swift"; sourceTree = "<group>"; };
+		F580C3CA23D8F9B40038E243 /* AbstractPost+Dates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+Dates.swift"; sourceTree = "<group>"; };
 		F582060123A85495005159A9 /* SiteDateFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDateFormatters.swift; sourceTree = "<group>"; };
 		F582060323A88379005159A9 /* TimePickerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePickerViewControllerTests.swift; sourceTree = "<group>"; };
 		F5844B6A235EAF3D007C6557 /* HalfScreenPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfScreenPresentationController.swift; sourceTree = "<group>"; };
@@ -8219,6 +8221,7 @@
 				086C4D0C1E81F7920011D960 /* Media */,
 				B587798319B799EB00E57C5A /* Notifications */,
 				7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */,
+				F580C3CA23D8F9B40038E243 /* AbstractPost+Dates.swift */,
 				8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */,
 				E1AB5A061E0BF17500574B4E /* Array.swift */,
 				9A2CD5362146B8C700AE5055 /* Array+Page.swift */,
@@ -11079,6 +11082,7 @@
 				4054F4572214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataProperties.swift in Sources */,
 				9A2B28F52192121400458F2A /* RevisionOperation.swift in Sources */,
 				984B4EF320742FCC00F87888 /* ZendeskUtils.swift in Sources */,
+				F580C3CB23D8F9B40038E243 /* AbstractPost+Dates.swift in Sources */,
 				1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */,
 				17E24F5420FCF1D900BD70A3 /* Routes+MySites.swift in Sources */,
 				0828D7FA1E6E09AE00C7C7D4 /* WPAppAnalytics+Media.swift in Sources */,


### PR DESCRIPTION
Fixes #13258 where the Post list displayed a time string which did not take into account the site time zone, unlike Post Settings.

- Uses [new version](https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/240) of WordPressShared which includes overrides for time zones.
- Adds a new `displayDate()` helper which duplicates the logic from `dateStringForDisplay()` with new time zones passed in.

### To test

Follow instructions in #13258 or:

- Set a site time zone two hours away from your own.
- Schedule a post for a time of your choosing.
- Note that the Post List will show a time different than the time in Post Settings.

Note that Scheduling always exhibits this behavior, Drafts and Published will exhibit this behavior only if the elapsed time is greater than 7 days because the relative time formatter should be correct without any time zone adjustment.

PR submission checklist:

- [x] **I have considered adding unit tests where possible.** Unit tests added to WordPressShared

- [x] **I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.** Feature was released in 14.0 so the fix doesn't need an addition.
