### PR TITLE
Today Widget: show no connection view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
@@ -71,6 +71,7 @@ extension TodayWidgetStats {
 
     private static var dataFileURL: URL? {
         guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName) else {
+            DDLogError("TodayWidgetStats: unable to get file URL for \(WPAppGroupName).")
             return nil
         }
         return url.appendingPathComponent(dataFileName)

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetTwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetTwoColumnCell.swift
@@ -5,6 +5,7 @@ class WidgetTwoColumnCell: UITableViewCell {
     // MARK: - Properties
 
     static let reuseIdentifier = "WidgetTwoColumnCell"
+    static let defaultHeight: CGFloat = 78
 
     @IBOutlet private var leftItemLabel: UILabel!
     @IBOutlet private var leftDataLabel: UILabel!

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
@@ -4,6 +4,16 @@ enum WidgetType {
     case today
     case allTime
     case thisWeek
+    case noConnection
+
+    var configureLabelFont: UIFont {
+        switch self {
+        case .noConnection:
+            return UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .headline).pointSize)
+        default:
+            return UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize)
+        }
+    }
 }
 
 class WidgetUnconfiguredCell: UITableViewCell {
@@ -15,12 +25,15 @@ class WidgetUnconfiguredCell: UITableViewCell {
     @IBOutlet private var configureLabel: UILabel!
     @IBOutlet private var separatorLine: UIView!
     @IBOutlet private var separatorVisualEffectView: UIVisualEffectView!
-    @IBOutlet private var openWordPressLabel: UILabel!
+    @IBOutlet private var actionLabel: UILabel!
+
+    private(set) var widgetType: WidgetType?
 
     // MARK: - View
 
     func configure(for widgetType: WidgetType) {
-        configureView(for: widgetType)
+        self.widgetType = widgetType
+        configureView()
     }
 
 }
@@ -29,7 +42,12 @@ class WidgetUnconfiguredCell: UITableViewCell {
 
 private extension WidgetUnconfiguredCell {
 
-    func configureView(for widgetType: WidgetType) {
+    func configureView() {
+        guard let widgetType = widgetType else {
+            return
+        }
+
+        configureLabel.font = widgetType.configureLabelFont
 
         configureLabel.text = {
             switch widgetType {
@@ -39,12 +57,14 @@ private extension WidgetUnconfiguredCell {
                 return LocalizedText.configureAllTime
             case .thisWeek:
                 return LocalizedText.configureThisWeek
+            case .noConnection:
+                return LocalizedText.noConnection
             }
         }()
 
-        openWordPressLabel.text = LocalizedText.openWordPress
+        actionLabel.text = widgetType == .noConnection ? LocalizedText.retry : LocalizedText.openWordPress
         configureLabel.textColor = WidgetStyles.primaryTextColor
-        openWordPressLabel.textColor = WidgetStyles.primaryTextColor
+        actionLabel.textColor = WidgetStyles.primaryTextColor
         WidgetStyles.configureSeparator(separatorLine)
         separatorVisualEffectView.effect = WidgetStyles.separatorVibrancyEffect
     }
@@ -54,6 +74,8 @@ private extension WidgetUnconfiguredCell {
         static let configureAllTime = NSLocalizedString("Display your all-time site stats here. Configure in the WordPress app in your site stats.", comment: "Unconfigured stats all-time widget helper text")
         static let configureThisWeek = NSLocalizedString("Display your site stats for this week here. Configure in the WordPress app in your site stats.", comment: "Unconfigured stats this week widget helper text")
         static let openWordPress = NSLocalizedString("Open WordPress", comment: "Today widget label to launch WP app")
+        static let noConnection = NSLocalizedString("No network available", comment: "Displayed in the Stats widgets when there is no network")
+        static let retry = NSLocalizedString("Retry", comment: "Stats widgets label to reload the widget")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -56,7 +56,7 @@
                                             <blurEffect style="light"/>
                                         </vibrancyEffect>
                                     </visualEffectView>
-                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open WordPress" textAlignment="center" lineBreakMode="tailTruncation" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zTQ-mH-dxy" userLabel="Open WordPress Label">
+                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Open WordPress" textAlignment="center" lineBreakMode="tailTruncation" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zTQ-mH-dxy" userLabel="Action Label">
                                         <rect key="frame" x="0.0" y="16.5" width="288" height="31.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -90,8 +90,8 @@
             </constraints>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="actionLabel" destination="zTQ-mH-dxy" id="4ua-GK-Siw"/>
                 <outlet property="configureLabel" destination="BeG-f7-LNj" id="JmX-XL-Xav"/>
-                <outlet property="openWordPressLabel" destination="zTQ-mH-dxy" id="1bT-PO-Kbd"/>
                 <outlet property="separatorLine" destination="ke9-nm-91h" id="59e-Kh-Ifx"/>
                 <outlet property="separatorVisualEffectView" destination="9MM-O1-Ae9" id="uRN-tS-eA1"/>
             </connections>

--- a/WordPress/WordPressTodayWidget/MainInterface.storyboard
+++ b/WordPress/WordPressTodayWidget/MainInterface.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="aC5-E5-DQ6">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="aC5-E5-DQ6">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -33,7 +33,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KvB-u2-42u" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <tapGestureRecognizer id="g0c-fj-JDq">
                     <connections>
-                        <action selector="launchContainingApp" destination="aC5-E5-DQ6" id="NhF-46-NzT"/>
+                        <action selector="handleTapGesture" destination="aC5-E5-DQ6" id="BMt-gs-uDY"/>
                     </connections>
                 </tapGestureRecognizer>
             </objects>

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -47,6 +47,10 @@ class TodayViewController: UIViewController {
         }
     }
 
+    private var showNoConnection: Bool {
+        return !isReachable && statsValues == nil
+    }
+
     private let tracks = Tracks(appGroupName: WPAppGroupName)
     private let reachability: Reachability = .forInternetConnection()
 
@@ -131,7 +135,7 @@ extension TodayViewController: UITableViewDelegate, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard isConfigured, isReachable else {
+        guard isConfigured, !showNoConnection else {
             return unconfiguredCellFor(indexPath: indexPath)
         }
 
@@ -140,7 +144,7 @@ extension TodayViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
 
-        if !isConfigured || !isReachable,
+        if !isConfigured || showNoConnection,
             let maxCompactSize = extensionContext?.widgetMaximumSize(for: .compact) {
             // Use the max compact height for unconfigured view.
             return maxCompactSize.height
@@ -287,7 +291,7 @@ private extension TodayViewController {
             return UITableViewCell()
         }
 
-        isReachable ? cell.configure(for: .today) : cell.configure(for: .noConnection)
+        showNoConnection ? cell.configure(for: .noConnection) : cell.configure(for: .today)
         return cell
     }
 
@@ -331,11 +335,11 @@ private extension TodayViewController {
 
     func setAvailableDisplayMode() {
         // If unconfigured or no connection, don't allow the widget to be expanded.
-        extensionContext?.widgetLargestAvailableDisplayMode = isReachable && isConfigured ? .expanded : .compact
+        extensionContext?.widgetLargestAvailableDisplayMode = !showNoConnection && isConfigured ? .expanded : .compact
     }
 
     func minRowsToDisplay() -> Int {
-        if !isReachable {
+        if showNoConnection {
             return 1
         }
 
@@ -343,7 +347,7 @@ private extension TodayViewController {
     }
 
     func maxRowsToDisplay() -> Int {
-        if !isReachable {
+        if showNoConnection {
             return 1
         }
 

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -159,9 +159,18 @@ extension TodayViewController: UITableViewDelegate, UITableViewDataSource {
 
 private extension TodayViewController {
 
-    // MARK: - Launch Containing App
+    // MARK: - Tap Gesture Handling
 
-    @IBAction func launchContainingApp() {
+    @IBAction func handleTapGesture() {
+
+        // If showing the No Connection view, attempt to reload.
+        if let unconfiguredCell = tableView.visibleCells.first as? WidgetUnconfiguredCell,
+            unconfiguredCell.widgetType == .noConnection {
+            tableView.reloadData()
+            return
+        }
+
+        // Otherwise, open the app.
         guard let extensionContext = extensionContext,
             let containingAppURL = appURL() else {
                 DDLogError("Today Widget: Unable to get extensionContext or appURL.")

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -41,8 +41,9 @@ class TodayViewController: UIViewController {
         didSet {
             setAvailableDisplayMode()
 
-            if isReachable != oldValue {
-                tableView.reloadData()
+            if isReachable != oldValue,
+                let completionHandler = widgetCompletionBlock {
+                widgetPerformUpdate(completionHandler: completionHandler)
             }
         }
     }
@@ -53,6 +54,9 @@ class TodayViewController: UIViewController {
 
     private let tracks = Tracks(appGroupName: WPAppGroupName)
     private let reachability: Reachability = .forInternetConnection()
+
+    private typealias WidgetCompletionBlock = (NCUpdateResult) -> Void
+    private var widgetCompletionBlock: WidgetCompletionBlock?
 
     // MARK: - View
 
@@ -116,6 +120,7 @@ class TodayViewController: UIViewController {
 extension TodayViewController: NCWidgetProviding {
 
     func widgetPerformUpdate(completionHandler: (@escaping (NCUpdateResult) -> Void)) {
+        widgetCompletionBlock = completionHandler
         retrieveSiteConfiguration()
         isReachable = reachability.isReachable()
 
@@ -184,8 +189,9 @@ private extension TodayViewController {
 
         // If showing the No Connection view, attempt to reload.
         if let unconfiguredCell = tableView.visibleCells.first as? WidgetUnconfiguredCell,
-            unconfiguredCell.widgetType == .noConnection {
-            tableView.reloadData()
+            unconfiguredCell.widgetType == .noConnection,
+            let completionHandler = widgetCompletionBlock {
+            widgetPerformUpdate(completionHandler: completionHandler)
             return
         }
 

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -391,7 +391,7 @@ private extension TodayViewController {
 
     func expandedHeight() -> CGFloat {
         var height: CGFloat = 0
-        var dataRowHeight: CGFloat = 0
+        let dataRowHeight: CGFloat
 
         // This method is called before the rows are updated.
         // So if an unconfigured cell was displayed, use the default height for data rows.

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -75,6 +75,7 @@ class TodayViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        reachability.stopNotifier()
         saveData()
     }
 


### PR DESCRIPTION
Ref #12702

For the _Today_ widget, a `No network available` message is displayed if:
- There is no network connection.
- There is no saved data.

If there is saved data, it will be displayed.

To test:

Side note: In the simulator, the widget was never notified when the network connection was re-established. I suggest testing on a real device as the reachability notifications work as expected. 

Since `No network available` will only be displayed if there is no saved data, the data needs to be purged, and then the network disabled.

---
- In the app, go to Stats > Widgets > `Use this site`.
- Add the _Today_ widget to the Today view.
- Return to the app and change the site used for widgets (so the saved data is purged).
- Disable internet connection.
- Return to the Today view.
- Verify the no connection view is displayed.

![no_connection](https://user-images.githubusercontent.com/1816888/72947986-12744600-3d41-11ea-895f-4cf7aca509be.jpeg)

---
- Enable internet connection.
- Verify the data loads.

![loaded](https://user-images.githubusercontent.com/1816888/72947979-0f795580-3d41-11ea-8bd6-754055fb59be.jpeg)

---
- Disable internet connection again.
- Verify the data is still displayed.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
