### PR TITLE
Update UI test instructions to use test plans

### DIFF
--- a/WordPress/WordPressUITests/README.md
+++ b/WordPress/WordPressUITests/README.md
@@ -8,7 +8,8 @@ Note that due to the mock server setup, tests cannot be run on physical devices 
 
 1. Follow the [build instructions](https://github.com/wordpress-mobile/WordPress-iOS#build-instructions) (steps 1-5) to clone the project, install the dependencies, and open the project in Xcode.
 2. `rake mocks` to start a local mock server.
-3. Run the tests in the `WordPressUITests` target on a simulator.
+3. With the `WordPress` scheme selected in Xcode, open the Test Navigator and select the `WordPressUITests` test plan.
+4. Run the tests on a simulator.
 
 ## Adding tests
 


### PR DESCRIPTION
This updates the UI testing instructions per the changes in https://github.com/wordpress-mobile/WordPress-iOS/pull/12930.

To test: Go through the instructions for running the UI tests locally and confirm they run.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
