### PR TITLE
Fix UI unit tests

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -37,7 +37,8 @@ class PostEditorNavigationBarManager {
         let button = UIButton(type: .system)
         button.setImage(image, for: .normal)
         button.frame = CGRect(origin: .zero, size: image.size)
-        button.accessibilityLabel = NSLocalizedString("More", comment: "Action button to display more available options")
+        button.accessibilityLabel = NSLocalizedString("More Post Options", comment: "Action button to display more available options")
+        button.accessibilityIdentifier = "more_post_options"
         button.addTarget(self, action: #selector(moreWasPressed), for: .touchUpInside)
         button.setContentHuggingPriority(.required, for: .horizontal)
         return button

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -37,7 +37,7 @@ class PostEditorNavigationBarManager {
         let button = UIButton(type: .system)
         button.setImage(image, for: .normal)
         button.frame = CGRect(origin: .zero, size: image.size)
-        button.accessibilityLabel = NSLocalizedString("More Post Options", comment: "Action button to display more available options")
+        button.accessibilityLabel = NSLocalizedString("More Options", comment: "Action button to display more available options")
         button.accessibilityIdentifier = "more_post_options"
         button.addTarget(self, action: #selector(moreWasPressed), for: .touchUpInside)
         button.setContentHuggingPriority(.required, for: .horizontal)

--- a/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
@@ -19,7 +19,7 @@ class AztecEditorScreen: BaseScreen {
 
     let editorCloseButton = XCUIApplication().navigationBars["Azctec Editor Navigation Bar"].buttons["Close"]
     let publishButton = XCUIApplication().buttons["Publish"]
-    let moreButton = XCUIApplication().buttons["More"]
+    let moreButton = XCUIApplication().buttons["more_post_options"]
     let uploadProgressBar = XCUIApplication().progressIndicators["Progress"]
 
     let titleView = XCUIApplication().textViews["Title"]

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -7,7 +7,7 @@ class BlockEditorScreen: BaseScreen {
     let editorNavBar = XCUIApplication().navigationBars["Gutenberg Editor Navigation Bar"]
     let editorCloseButton = XCUIApplication().navigationBars["Gutenberg Editor Navigation Bar"].buttons["Close"]
     let publishButton = XCUIApplication().buttons["Publish"]
-    let moreButton = XCUIApplication().buttons["More"]
+    let moreButton = XCUIApplication().buttons["more_post_options"]
 
     // Editor area
     // Title


### PR DESCRIPTION
This PR changes the accessibility label for the more button on the Post View Controller and also adds an accessibility identifier to make the UI tests more robust.

To test:
 - Run the UI tests
 - Check that they all pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
