### PR TITLE
Add a lane to update certificates and profiles

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -363,6 +363,27 @@ import "./ScreenshotFastfile"
     sh("cd .. && rm WordPress.app.dSYM.zip")
   end
 
+########################################################################
+# Cnfigure Lanes
+########################################################################
+  #####################################################################################
+  # update_certs_and_profiles
+  # -----------------------------------------------------------------------------------
+  # This lane downloads all the required certs and profiles and, 
+  # if not run on CI it creates the missing ones.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane update_certs_and_profiles 
+  #
+  # Example:
+  # bundle exec fastlane update_certs_and_profiles 
+  #####################################################################################
+  lane :update_certs_and_profiles do | options |
+    alpha_code_signing
+    internal_code_signing
+    appstore_code_signing
+  end
+
   ########################################################################
   # Fastlane match code signing
   ########################################################################  


### PR DESCRIPTION
This PR adds a simple public lane that can be used by developers to generate new Match handled profiles for new components.

To test:
1. Run `bundle exec fastlane update_certs_and_profiles` and verify that the provisioning profiles for alpha, internal and production builds are installed. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
