### PR TITLE
Fixed improper spacing on notice for saving drafts offline

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
@@ -30,9 +30,12 @@ class UntouchableViewController: UIViewController {
     }
 
     var offsetOnscreen: CGFloat {
+        // removed check for tabBarController.presentedViewController being nil here
+        // when saving a draft in offline mode the editing view is dismissed
+        // this causes the check for the presentedViewController to return nil
+        // thus placing the notice incorrectly, without the proper space for the tabBar
         guard let mainWindow = UIApplication.shared.delegate?.window,
-            let tabBarController = mainWindow?.rootViewController as? WPTabBarController,
-            tabBarController.presentedViewController == nil else {
+            let tabBarController = mainWindow?.rootViewController as? WPTabBarController else {
             return 0
         }
 


### PR DESCRIPTION
Removed check for tabBarController.presentedViewController being nil. When saving a draft in offline mode the editing view is dismissed - this causes the check for the presentedViewController to return nil, thus placing the notice incorrectly, without the proper space for the tabBar. Other notices continue to display as normal (removing the nil does not appear to have had negative effects).

Fixes #12799

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
