### PR TITLE
Testing: Shut down simulators instead of closing Simulator app before UI test runs

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -11186,7 +11186,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Close all simulators so on next launch they use the settings below\nkillall Simulator\n\n# Disable the hardware keyboard in the simulator\ndefaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false\n";
+			shellScript = "# Close all simulators so on next launch they use the settings below\nxcrun simctl shutdown all\n\n# Disable the hardware keyboard in the simulator\ndefaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false\n";
 		};
 		E00F6488DE2D86BDC84FBB0B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
@SergioEstevao reported that with `killall Simulator` local UI test runs were failing to run with this error:

> The test runner encountered an error (Failed to prepare device ‘iPhone X’ for impending launch. (Underlying error: Timed out waiting for Simulator.app to become ready.))

At his suggestion, I'm replacing that command with `xcrun simctl shutdown all`, which closes any open simulators instead of closing the Simulator app entirely before running the UI tests. (Closing the simulator is required to make sure the hardware keyboard is disabled in test runs, but it turns out that closing the Simulator app was overkill.)

@SergioEstevao can you check whether this resolves the problem you were seeing?

To test:

* Run `rake mocks` to start the mock server.
* In Xcode, select the `WordPress` scheme and run the tests using the `WordPressUITests` test plan.
* Confirm the simulator is restarted and the UI tests run and pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
