### PR TITLE
All-Time Widget: show no connection view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
@@ -71,6 +71,7 @@ extension AllTimeWidgetStats {
 
     private static var dataFileURL: URL? {
         guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName) else {
+            DDLogError("AllTimeWidgetStats: unable to get file URL for \(WPAppGroupName).")
             return nil
         }
         return url.appendingPathComponent(dataFileName)

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import NotificationCenter
 import WordPressKit
 import WordPressUI
+import Reachability
 
 class AllTimeViewController: UIViewController {
 
@@ -32,12 +33,30 @@ class AllTimeViewController: UIViewController {
 
     private var isConfigured = false {
         didSet {
-            // If unconfigured, don't allow the widget to be expanded/compacted.
-            extensionContext?.widgetLargestAvailableDisplayMode = isConfigured ? .expanded : .compact
+            setAvailableDisplayMode()
         }
     }
 
+    private var isReachable = true {
+        didSet {
+            setAvailableDisplayMode()
+
+            if isReachable != oldValue,
+                let completionHandler = widgetCompletionBlock {
+                widgetPerformUpdate(completionHandler: completionHandler)
+            }
+        }
+    }
+
+    private var showNoConnection: Bool {
+        return !isReachable && statsValues == nil
+    }
+
     private let tracks = Tracks(appGroupName: WPAppGroupName)
+    private let reachability: Reachability = .forInternetConnection()
+
+    private typealias WidgetCompletionBlock = (NCUpdateResult) -> Void
+    private var widgetCompletionBlock: WidgetCompletionBlock?
 
     // MARK: - View
 
@@ -50,11 +69,13 @@ class AllTimeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         loadSavedData()
+        setupReachability()
         resizeView()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        reachability.stopNotifier()
         saveData()
     }
 
@@ -64,16 +85,31 @@ class AllTimeViewController: UIViewController {
         let updatedRowCount = numberOfRowsToDisplay()
 
         // If the number of rows has not changed, do nothing.
-        guard updatedRowCount != tableView.visibleCells.count else {
+        guard updatedRowCount != tableView.numberOfRows(inSection: 0) else {
             return
         }
 
         coordinator.animate(alongsideTransition: { _ in
             self.tableView.performBatchUpdates({
-                let lastDataRowIndexPath = [IndexPath(row: 1, section: 0)]
+
+                var indexPathsToInsert = [IndexPath]()
+                var indexPathsToDelete = [IndexPath]()
+
+                // If no connection was displayed, then rows are just being added.
+                // Otherwise, a data row is being inserted/deleted.
+                if self.tableView.visibleCells.first is WidgetNoConnectionCell {
+                    let indexRange = (1..<updatedRowCount)
+                    let indexPaths = indexRange.map({ return IndexPath(row: $0, section: 0) })
+                    indexPathsToInsert.append(contentsOf: indexPaths)
+                } else {
+                    let lastDataRowIndexPath = IndexPath(row: 1, section: 0)
+                    indexPathsToInsert.append(lastDataRowIndexPath)
+                    indexPathsToDelete.append(lastDataRowIndexPath)
+                }
+
                 updatedRowCount > self.minRowsToDisplay() ?
-                    self.tableView.insertRows(at: lastDataRowIndexPath, with: .fade) :
-                    self.tableView.deleteRows(at: lastDataRowIndexPath, with: .fade)
+                    self.tableView.insertRows(at: indexPathsToInsert, with: .fade) :
+                    self.tableView.deleteRows(at: indexPathsToDelete, with: .fade)
             })
         })
     }
@@ -85,10 +121,12 @@ class AllTimeViewController: UIViewController {
 extension AllTimeViewController: NCWidgetProviding {
 
     func widgetPerformUpdate(completionHandler: (@escaping (NCUpdateResult) -> Void)) {
+        widgetCompletionBlock = completionHandler
         retrieveSiteConfiguration()
+        isReachable = reachability.isReachable()
 
-        if !isConfigured {
-            DDLogError("All Time Widget: Missing site ID, timeZone or oauth2Token")
+        if !isConfigured || !isReachable {
+            DDLogError("All Time Widget: unable to update. Configured: \(isConfigured) Reachable: \(isReachable)")
 
             DispatchQueue.main.async { [weak self] in
                 self?.tableView.reloadData()
@@ -118,7 +156,11 @@ extension AllTimeViewController: UITableViewDelegate, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard isConfigured else {
+        if showNoConnection {
+            return noConnectionCellFor(indexPath: indexPath)
+        }
+
+        if !isConfigured {
             return unconfiguredCellFor(indexPath: indexPath)
         }
 
@@ -127,17 +169,17 @@ extension AllTimeViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
 
+        if !isConfigured || showNoConnection,
+            let maxCompactSize = extensionContext?.widgetMaximumSize(for: .compact) {
+            // Use the max compact height for unconfigured view.
+            return maxCompactSize.height
+        }
+
         if showUrl() && indexPath.row == numberOfRowsToDisplay() - 1 {
             return WidgetUrlCell.height
         }
 
-        guard !isConfigured,
-            let maxCompactSize = extensionContext?.widgetMaximumSize(for: .compact) else {
-                return UITableView.automaticDimension
-        }
-
-        // Use the max compact height for unconfigured view.
-        return maxCompactSize.height
+        return UITableView.automaticDimension
     }
 
 }
@@ -146,10 +188,11 @@ extension AllTimeViewController: UITableViewDelegate, UITableViewDataSource {
 
 private extension AllTimeViewController {
 
-    // MARK: - Launch Containing App
+    // MARK: - Tap Gesture Handling
 
-    @IBAction func launchContainingApp() {
-        guard let extensionContext = extensionContext,
+    @IBAction func handleTapGesture() {
+        guard !isConfigured,
+            let extensionContext = extensionContext,
             let containingAppURL = appURL() else {
                 DDLogError("All Time Widget: Unable to get extensionContext or appURL.")
                 return
@@ -258,6 +301,17 @@ private extension AllTimeViewController {
 
         let urlCellNib = UINib(nibName: String(describing: WidgetUrlCell.self), bundle: Bundle(for: WidgetUrlCell.self))
         tableView.register(urlCellNib, forCellReuseIdentifier: WidgetUrlCell.reuseIdentifier)
+
+        let noConnectionCellNib = UINib(nibName: String(describing: WidgetNoConnectionCell.self), bundle: Bundle(for: WidgetNoConnectionCell.self))
+        tableView.register(noConnectionCellNib, forCellReuseIdentifier: WidgetNoConnectionCell.reuseIdentifier)
+    }
+
+    func noConnectionCellFor(indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: WidgetNoConnectionCell.reuseIdentifier, for: indexPath) as? WidgetNoConnectionCell else {
+            return UITableViewCell()
+        }
+
+        return cell
     }
 
     func unconfiguredCellFor(indexPath: IndexPath) -> UITableViewCell {
@@ -307,6 +361,11 @@ private extension AllTimeViewController {
 
     // MARK: - Expand / Compact View Helpers
 
+    func setAvailableDisplayMode() {
+        // If unconfigured or no connection, don't allow the widget to be expanded.
+        extensionContext?.widgetLargestAvailableDisplayMode = !showNoConnection && isConfigured ? .expanded : .compact
+    }
+
     func minRowsToDisplay() -> Int {
         return showUrl() ? 2 : 1
     }
@@ -330,7 +389,17 @@ private extension AllTimeViewController {
 
     func expandedHeight() -> CGFloat {
         var height: CGFloat = 0
-        let dataRowHeight = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).height
+        let dataRowHeight: CGFloat
+
+        // This method is called before the rows are updated.
+        // So if a no connection cell was displayed, use the default height for data rows.
+        // Otherwise, use the actual height from the first data row.
+        if tableView.visibleCells.first is WidgetNoConnectionCell {
+            dataRowHeight = WidgetTwoColumnCell.defaultHeight
+        } else {
+            dataRowHeight = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).height
+        }
+
         let numRows = numberOfRowsToDisplay()
 
         if showUrl() {
@@ -341,6 +410,21 @@ private extension AllTimeViewController {
         }
 
         return height
+    }
+    // MARK: - Reachability
+
+    func setupReachability() {
+        isReachable = reachability.isReachable()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(reachabilityChanged),
+                                               name: NSNotification.Name.reachabilityChanged,
+                                               object: nil)
+        reachability.startNotifier()
+    }
+
+    @objc func reachabilityChanged() {
+        isReachable = reachability.isReachable()
     }
 
     // MARK: - Helpers

--- a/WordPress/WordPressAllTimeWidget/MainInterface.storyboard
+++ b/WordPress/WordPressAllTimeWidget/MainInterface.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dmJ-J5-sb0">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="dmJ-J5-sb0">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -33,7 +33,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x26-Qc-pdE" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <tapGestureRecognizer id="OVJ-q1-B1z">
                     <connections>
-                        <action selector="launchContainingApp" destination="dmJ-J5-sb0" id="dmI-ca-JZc"/>
+                        <action selector="handleTapGesture" destination="dmJ-J5-sb0" id="eTZ-Ix-vHA"/>
                     </connections>
                 </tapGestureRecognizer>
             </objects>

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -37,7 +37,7 @@ class TodayViewController: UIViewController {
         }
     }
 
-    private var isReachable: Bool = true {
+    private var isReachable = true {
         didSet {
             setAvailableDisplayMode()
 


### PR DESCRIPTION
Ref #13271

For the _All-Time_ widget, a `No network available` message is displayed if:
- There is no network connection.
- There is no saved data.

If there is saved data, it will be displayed.

To test:

Side note: In the simulator, the widget was never notified when the network connection was re-established. I suggest testing on a real device as the reachability notifications work as expected. 

Since `No network available` will only be displayed if there is no saved data, the data needs to be purged, and then the network disabled.

---
- In the app, go to Stats > Widgets > `Use this site`.
- Add the _All-Time_ widget to the Today view.
- Return to the app and change the site used for widgets (so the saved data is purged).
- Disable internet connection.
- Return to the Today view.
- Verify the no connection view is displayed.

![no_connection](https://user-images.githubusercontent.com/1816888/73107403-f7c5dc80-3eba-11ea-9b27-1f3029c995f8.jpeg)

---
- Enable internet connection.
- Verify the data loads.

![loaded](https://user-images.githubusercontent.com/1816888/73107408-fd232700-3eba-11ea-902c-be19fd288d39.jpeg)

---
- Disable internet connection again.
- Verify the data is still displayed.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
