### PR TITLE
This Week Widget: show no connection view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/ThisWeekWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/ThisWeekWidgetStats.swift
@@ -111,6 +111,7 @@ extension ThisWeekWidgetStats {
 
     private static var dataFileURL: URL? {
         guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName) else {
+            DDLogError("ThisWeekWidgetStats: unable to get file URL for \(WPAppGroupName).")
             return nil
         }
         return url.appendingPathComponent(dataFileName)

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetDifferenceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetDifferenceCell.swift
@@ -5,6 +5,7 @@ class WidgetDifferenceCell: UITableViewCell {
     // MARK: - Properties
 
     static let reuseIdentifier = "WidgetDifferenceCell"
+    static let defaultHeight: CGFloat = 56
 
     @IBOutlet private var dateLabel: UILabel!
     @IBOutlet private var dataLabel: UILabel!

--- a/WordPress/WordPressThisWeekWidget/MainInterface.storyboard
+++ b/WordPress/WordPressThisWeekWidget/MainInterface.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="XKX-aN-6Ny">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="XKX-aN-6Ny">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -33,7 +33,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xkY-3H-gAF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <tapGestureRecognizer id="Ins-3Y-e7C">
                     <connections>
-                        <action selector="launchContainingApp" destination="XKX-aN-6Ny" id="Crb-wd-hw3"/>
+                        <action selector="handleTapGesture" destination="XKX-aN-6Ny" id="Rpp-wg-dzj"/>
                     </connections>
                 </tapGestureRecognizer>
             </objects>


### PR DESCRIPTION
Ref #13271

For the _This Week_ widget, a `No network available` message is displayed if:
- There is no network connection.
- There is no saved data.

If there is saved data, it will be displayed.

To test:

Side note: In the simulator, the widget was never notified when the network connection was re-established. I suggest testing on a real device as the reachability notifications work as expected. 

Since `No network available` will only be displayed if there is no saved data, the data needs to be purged, and then the network disabled.

---
- In the app, go to Stats > Widgets > `Use this site`.
- Add the _This Week_ widget to the Today view.
- Return to the app and change the site used for widgets (so the saved data is purged).
- Disable internet connection.
- Return to the Today view.
- Verify the no connection view is displayed.

![no_connection](https://user-images.githubusercontent.com/1816888/73113375-cbb55600-3ed0-11ea-9e5f-b5767cd4760e.jpeg)

---
- Enable internet connection.
- Verify the data loads.

![loaded](https://user-images.githubusercontent.com/1816888/73113380-d07a0a00-3ed0-11ea-88b9-7a7274dfc840.jpeg)

---
- Disable internet connection again.
- Verify the data is still displayed.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
