### PR TITLE
Stats Widgets: fix opening app when widgets are tapped

### DIFF
--- a/WordPress/Classes/Utility/AccountHelper.swift
+++ b/WordPress/Classes/Utility/AccountHelper.swift
@@ -73,6 +73,9 @@ import Foundation
         // Also clear the spotlight index
         SearchManager.shared.deleteAllSearchableItems()
 
+        // Clear Today Widgets' stored data
+        StatsDataHelper.clearWidgetsData()
+
         // Delete donated user activities (e.g., for Siri Shortcuts)
         if #available(iOS 12.0, *) {
             NSUserActivity.deleteAllSavedUserActivities {}

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -191,7 +191,7 @@ private extension AllTimeViewController {
     // MARK: - Tap Gesture Handling
 
     @IBAction func handleTapGesture() {
-        guard !isConfigured,
+        guard isReachable,
             let extensionContext = extensionContext,
             let containingAppURL = appURL() else {
                 DDLogError("All Time Widget: Unable to get extensionContext or appURL.")

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -183,7 +183,7 @@ private extension ThisWeekViewController {
     // MARK: - Tap Gesture Handling
 
     @IBAction func handleTapGesture() {
-        guard !isConfigured,
+        guard isReachable,
             let extensionContext = extensionContext,
             let containingAppURL = appURL() else {
                 DDLogError("This Week Widget: Unable to get extensionContext or appURL.")

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -191,7 +191,7 @@ private extension TodayViewController {
     // MARK: - Tap Gesture Handling
 
     @IBAction func handleTapGesture() {
-        guard !isConfigured,
+        guard isReachable,
             let extensionContext = extensionContext,
             let containingAppURL = appURL() else {
                 DDLogError("Today Widget: Unable to get extensionContext or appURL.")


### PR DESCRIPTION
Fixes #13293 

This fixes two issues:
1. Tapping the widgets was not opening the app. Cause: The `handleTapGesture` methods were checking the wrong state.
2. The 'no network available' view was not being displayed after logging out of the app. Cause: The widgets' stored data was not being cleared on logout.

To test:

Note: In the simulator, the widgets don't receive the notification when the network connection is re-established (you have to scroll away from the Today view and back to update the widgets). You might want to test on a real device as the reachability notifications work as expected.

---
- Log out of the app.
- Add the 3 Stats widgets to the Today view.
- The unconfigured view should be displayed.
- Verify tapping the widgets opens the app.

![unconfigured](https://user-images.githubusercontent.com/1816888/73300056-927d2e80-41cd-11ea-8aa9-4c7e338ab044.jpeg)

---
- Disconnect your network.
- The 'no network available' view should be displayed.
- Verify tapping the widgets does _not_ open the app.

![no_connection](https://user-images.githubusercontent.com/1816888/73300068-98730f80-41cd-11ea-86f7-0115b38d200a.jpeg)

---
- Reconnect your network.
- The unconfigured view should be displayed again.
- Verify tapping the widgets opens the app.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
