### PR TITLE
Present Site creation flow in full screen mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -48,6 +48,8 @@ final class SiteCreationWizardLauncher {
         guard let wizardContent = wizard.content else {
             return nil
         }
+
+        wizardContent.modalPresentationStyle = .fullScreen
         return wizardContent
     }()
 }


### PR DESCRIPTION
Site creation flow was designed to be displayed in full screen.

Since iOS 13 the default presentation mode for modal is page sheet style that can be interactively dismissed with a downward swipe. This means that users can dismiss the modal anytime they want with a swipe down gesture, which is not the behavior we want in such a fundamental flow.

To test:
A. Site creation following signup
1. Signup 
2. Tap "Add New Site"
3. tap "Create WordPress.com site"
4. See the site creation flow in full screen

B. Site creation on adding new site
1. Tap "switch site" 
2. Tap + button in top right
3. Tap "create WordPress.com site"
4. See the site creation flow in full screen

Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1335657/73314965-a6338f80-41e3-11ea-9328-918591702800.PNG)  |  ![](https://user-images.githubusercontent.com/1335657/73314963-a6338f80-41e3-11ea-9472-152c55d682bb.PNG)



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
