### PR TITLE
This Week widget: fix expanded height calculation

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetDifferenceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetDifferenceCell.swift
@@ -5,7 +5,7 @@ class WidgetDifferenceCell: UITableViewCell {
     // MARK: - Properties
 
     static let reuseIdentifier = "WidgetDifferenceCell"
-    static let defaultHeight: CGFloat = 56
+    static let defaultHeight: CGFloat = 56.5
 
     @IBOutlet private var dateLabel: UILabel!
     @IBOutlet private var dataLabel: UILabel!

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -16,6 +16,7 @@ class ThisWeekViewController: UIViewController {
     private var oauthToken: String?
     private let tracks = Tracks(appGroupName: WPAppGroupName)
     private let reachability: Reachability = .forInternetConnection()
+    private var calculatedDataRowHeight: CGFloat?
 
     private typealias WidgetCompletionBlock = (NCUpdateResult) -> Void
     private var widgetCompletionBlock: WidgetCompletionBlock?
@@ -401,12 +402,14 @@ private extension ThisWeekViewController {
         let dataRowHeight: CGFloat
 
         // This method is called before the rows are updated.
-        // So if a no connection cell was displayed, use the default height for data rows.
+        // So if a no connection cell was displayed, use either the previously calculated
+        // height or the default height for data rows.
         // Otherwise, use the actual height from the first data row.
         if tableView.visibleCells.first is WidgetNoConnectionCell {
-            dataRowHeight = WidgetDifferenceCell.defaultHeight
+            dataRowHeight = calculatedDataRowHeight ?? WidgetDifferenceCell.defaultHeight
         } else {
             dataRowHeight = tableView.rectForRow(at: IndexPath(row: 0, section: 0)).height
+            calculatedDataRowHeight = dataRowHeight
         }
 
         height += (dataRowHeight * CGFloat(numberOfRowsToDisplay() - 1))

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -40,6 +40,7 @@ class ThisWeekViewController: UIViewController {
     private var isReachable = true {
         didSet {
             setAvailableDisplayMode()
+            resizeView()
             tableView.separatorStyle = showNoConnection ? .none : .singleLine
 
             if isReachable != oldValue,

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -39,6 +39,7 @@ class ThisWeekViewController: UIViewController {
     private var isReachable = true {
         didSet {
             setAvailableDisplayMode()
+            tableView.separatorStyle = showNoConnection ? .none : .singleLine
 
             if isReachable != oldValue,
                 let completionHandler = widgetCompletionBlock {


### PR DESCRIPTION
Fixes #13312 

I couldn't exactly repro the issues in #13312, but from the video and screenshot it appears the expanded widget height is incorrect when going from connection > no connection > connection on some devices.

The issue is the height is calculated before the rows are rendered, so when going from no connection > connection, the `WidgetDifferenceCell.defaultHeight` was always used.

In order to have a more accurate expanded height, I've made these changes:
1. Changed the `WidgetDifferenceCell.defaultHeight` to be more inline with the actual height on most devices.
2. When the actual row height is calculated, it is now saved. It is then used when re-showing data rows when the connection is re-established.


To test:

The 'No network available' view is only displayed when:
- There is no connection (obviously).
- There is no saved data to display. Which only happens when the site for widgets is changed.

So, either follow the repro steps on #13312, or this abridged version:

- Run the app and be logged in.
- Add the _This Week_ widget to the Today view.
- Expand the widget.
- Disable the device’s internet connection.
- In the app:
  - Switch sites.
  - Go to Stats > Widgets > Use this site. (This will purge the saved data.)
- Return to the Today view. 'No network available' should be displayed.
- Enable the device’s internet connection without leaving the Today screen.
- When the data loads, verify the URL displays fully and there aren't extra rows at the bottom.

<img width="400" alt="expanded" src="https://user-images.githubusercontent.com/1816888/73397182-333c1e80-42a0-11ea-89d9-61e70f4172d4.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.