### PR TITLE
Stats Widgets: update Tracks

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,13 +11,13 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '1.8.12'
+    # pod 'WordPressShared', '1.8.13-beta.1'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'tracks_stats_widgets'
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => '4be5415'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -11,13 +11,13 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    # pod 'WordPressShared', '1.8.13-beta.1'
+    pod 'WordPressShared', '1.8.13-beta.1'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'tracks_stats_widgets'
+    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => '4be5415'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -390,7 +390,7 @@ PODS:
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
   - WordPressMocks (0.0.8)
-  - WordPressShared (1.8.12):
+  - WordPressShared (1.8.13-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.5.1)
@@ -470,7 +470,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.6)
   - WordPressKit (~> 4.5.6)
   - WordPressMocks (~> 0.0.8)
-  - WordPressShared (= 1.8.12)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `tracks_stats_widgets`)
   - WordPressUI (~> 1.5.1)
   - WPMediaPicker (~> 1.6.0)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1616ba1b8f5c02cf4f928410a92ce65e2e594f37/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
@@ -516,7 +516,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -590,6 +589,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 1616ba1b8f5c02cf4f928410a92ce65e2e594f37
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressShared:
+    :branch: tracks_stats_widgets
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1616ba1b8f5c02cf4f928410a92ce65e2e594f37/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
   ZendeskSDK:
@@ -606,6 +608,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 1616ba1b8f5c02cf4f928410a92ce65e2e594f37
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressShared:
+    :commit: ab1c4361977aa80a0420b89179051acad7e18575
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 4.0.0
@@ -680,7 +685,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: de9ef4de7c9d06d89f938f69b01d810aebe9dfc6
   WordPressKit: 5b37877f273fc4bc7289eb736df3bd3122535bd4
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
-  WordPressShared: a366420d82adcbb5b9538de7c966a86e133680fe
+  WordPressShared: a187d624d7daeb2d0a61ea6c358e6dc8139225aa
   WordPressUI: ce0ac522146dabcd0a68ace24c0104dfdf6f4b0d
   WPMediaPicker: e5d28197da6b467d4e5975d64a49255977e39455
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -688,6 +693,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 99679d8420a6d862773e2ddef0ebcc51b282317d
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: adc5196a2e7718e6ca7cc08ba1af44bd329557c1
+PODFILE CHECKSUM: 0a51fdd94b557856b221376a88e91a3480efb733
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -470,7 +470,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.6)
   - WordPressKit (~> 4.5.6)
   - WordPressMocks (~> 0.0.8)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `tracks_stats_widgets`)
+  - WordPressShared (= 1.8.13-beta.1)
   - WordPressUI (~> 1.5.1)
   - WPMediaPicker (~> 1.6.0)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1616ba1b8f5c02cf4f928410a92ce65e2e594f37/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
@@ -516,6 +516,7 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -589,9 +590,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 1616ba1b8f5c02cf4f928410a92ce65e2e594f37
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressShared:
-    :branch: tracks_stats_widgets
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1616ba1b8f5c02cf4f928410a92ce65e2e594f37/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
   ZendeskSDK:
@@ -608,9 +606,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 1616ba1b8f5c02cf4f928410a92ce65e2e594f37
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressShared:
-    :commit: ab1c4361977aa80a0420b89179051acad7e18575
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   ZendeskSDK:
     :git: https://github.com/zendesk/zendesk_sdk_ios
     :tag: 4.0.0
@@ -693,6 +688,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 99679d8420a6d862773e2ddef0ebcc51b282317d
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 0a51fdd94b557856b221376a88e91a3480efb733
+PODFILE CHECKSUM: dbc40b52c17ba0e83fc193729161b96726d49924
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/Services/TodayExtensionService.m
+++ b/WordPress/Classes/Services/TodayExtensionService.m
@@ -23,6 +23,7 @@
     NSNumber *previousSiteID = [sharedDefaults objectForKey:WPStatsTodayWidgetUserDefaultsSiteIdKey];
     if (siteID != previousSiteID) {
         [StatsDataHelper clearWidgetsData];
+        [WPAnalytics track:WPAnalyticsStatWidgetActiveSiteChanged];
     }
 
     // Save the site information to shared user defaults for use in the today widgets.

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1987,6 +1987,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatDebugDeletedOrphanedEntities:
             eventName = @"debug_deleted_orphaned_entities";
             break;
+        case WPAnalyticsStatWidgetActiveSiteChanged:
+            eventName = @"widget_active_site_changed";
+            break;
 
         // The following are yet to be implemented.
         //

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -136,7 +136,6 @@ extension AllTimeViewController: NCWidgetProviding {
             return
         }
 
-        tracks.trackExtensionAccessed()
         fetchData(completionHandler: completionHandler)
     }
 

--- a/WordPress/WordPressAllTimeWidget/Tracks+AllTimeWidget.swift
+++ b/WordPress/WordPressAllTimeWidget/Tracks+AllTimeWidget.swift
@@ -4,10 +4,8 @@ import Foundation
 /// This extension implements helper tracking methods, meant for Today Widget Usage.
 ///
 extension Tracks {
+
     // MARK: - Public Methods
-    public func trackExtensionAccessed() {
-        trackExtensionEvent(.accessed)
-    }
 
     public func trackExtensionStatsLaunched(_ siteID: Int) {
         let properties = ["site_id": siteID]
@@ -23,14 +21,15 @@ extension Tracks {
     }
 
     // MARK: - Private Helpers
+
     fileprivate func trackExtensionEvent(_ event: ExtensionEvents, properties: [String: AnyObject]? = nil) {
         track(event.rawValue, properties: properties)
     }
 
 
     // MARK: - Private Enums
+
     fileprivate enum ExtensionEvents: String {
-        case accessed           = "wpios_all_time_extension_accessed"
         case statsLaunched      = "wpios_all_time_extension_stats_launched"
         case configureLaunched  = "wpios_all_time_extension_configure_launched"
         case displayModeChanged = "wpios_all_time_extension_display_mode_changed"

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -133,7 +133,6 @@ extension ThisWeekViewController: NCWidgetProviding {
             return
         }
 
-        tracks.trackExtensionAccessed()
         fetchData(completionHandler: completionHandler)
     }
 

--- a/WordPress/WordPressThisWeekWidget/Tracks+ThisWeekWidget.swift
+++ b/WordPress/WordPressThisWeekWidget/Tracks+ThisWeekWidget.swift
@@ -4,10 +4,8 @@ import Foundation
 /// This extension implements helper tracking methods, meant for Today Widget Usage.
 ///
 extension Tracks {
+
     // MARK: - Public Methods
-    public func trackExtensionAccessed() {
-        trackExtensionEvent(.accessed)
-    }
 
     public func trackExtensionStatsLaunched(_ siteID: Int) {
         let properties = ["site_id": siteID]
@@ -23,14 +21,15 @@ extension Tracks {
     }
 
     // MARK: - Private Helpers
+
     fileprivate func trackExtensionEvent(_ event: ExtensionEvents, properties: [String: AnyObject]? = nil) {
         track(event.rawValue, properties: properties)
     }
 
 
     // MARK: - Private Enums
+
     fileprivate enum ExtensionEvents: String {
-        case accessed           = "wpios_week_views_extension_accessed"
         case statsLaunched      = "wpios_week_views_extension_stats_launched"
         case configureLaunched  = "wpios_week_views_extension_configure_launched"
         case displayModeChanged = "wpios_week_views_extension_display_mode_changed"

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -136,7 +136,6 @@ extension TodayViewController: NCWidgetProviding {
             return
         }
 
-        tracks.trackExtensionAccessed()
         fetchData(completionHandler: completionHandler)
     }
 

--- a/WordPress/WordPressTodayWidget/Tracks+TodayWidget.swift
+++ b/WordPress/WordPressTodayWidget/Tracks+TodayWidget.swift
@@ -4,10 +4,8 @@ import Foundation
 /// This extension implements helper tracking methods, meant for Today Widget Usage.
 ///
 extension Tracks {
+
     // MARK: - Public Methods
-    public func trackExtensionAccessed() {
-        trackExtensionEvent(.accessed)
-    }
 
     public func trackExtensionStatsLaunched(_ siteID: Int) {
         let properties = ["site_id": siteID]
@@ -23,14 +21,15 @@ extension Tracks {
     }
 
     // MARK: - Private Helpers
+
     fileprivate func trackExtensionEvent(_ event: ExtensionEvents, properties: [String: AnyObject]? = nil) {
         track(event.rawValue, properties: properties)
     }
 
 
     // MARK: - Private Enums
+
     fileprivate enum ExtensionEvents: String {
-        case accessed           = "wpios_today_extension_accessed"
         case statsLaunched      = "wpios_today_extension_stats_launched"
         case configureLaunched  = "wpios_today_extension_configure_launched"
         case displayModeChanged = "wpios_today_extension_display_mode_changed"


### PR DESCRIPTION
Fixes #13272 
Shared PR: https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/245

The `stats_launched` and `configure_launched` Tracks defined in #13272 were already implemented. So only these changes were needed:
- Added Track for when the widget site changes.
- Removed the `extension_accessed` Track from all 3 widgets.

To test:
- Go to Stats > Widgets > Use this site.
- Verify this in the console:
`🔵 Tracked: widget_active_site_changed`


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
