### PR TITLE
Stats Widgets: Update only if data has changed.

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/AllTimeWidgetStats.swift
@@ -78,3 +78,12 @@ extension AllTimeWidgetStats {
     }
 
 }
+
+extension AllTimeWidgetStats: Equatable {
+    static func == (lhs: AllTimeWidgetStats, rhs: AllTimeWidgetStats) -> Bool {
+        return lhs.views == rhs.views &&
+            lhs.visitors == rhs.visitors &&
+            lhs.posts == rhs.posts &&
+            lhs.bestViews == rhs.bestViews
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/ThisWeekWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/ThisWeekWidgetStats.swift
@@ -118,3 +118,17 @@ extension ThisWeekWidgetStats {
     }
 
 }
+
+extension ThisWeekWidgetStats: Equatable {
+    static func == (lhs: ThisWeekWidgetStats, rhs: ThisWeekWidgetStats) -> Bool {
+        return lhs.days.elementsEqual(rhs.days)
+    }
+}
+
+extension ThisWeekWidgetDay: Equatable {
+    static func == (lhs: ThisWeekWidgetDay, rhs: ThisWeekWidgetDay) -> Bool {
+        return lhs.date == rhs.date &&
+        lhs.viewsCount == rhs.viewsCount &&
+        lhs.dailyChangePercent == rhs.dailyChangePercent
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Data/TodayWidgetStats.swift
@@ -78,3 +78,12 @@ extension TodayWidgetStats {
     }
 
 }
+
+extension TodayWidgetStats: Equatable {
+    static func == (lhs: TodayWidgetStats, rhs: TodayWidgetStats) -> Bool {
+        return lhs.views == rhs.views &&
+            lhs.visitors == rhs.visitors &&
+            lhs.likes == rhs.likes &&
+            lhs.comments == rhs.comments
+    }
+}

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -271,13 +271,14 @@ private extension AllTimeViewController {
                                                       bestViews: allTimesStats?.bestViewsPerDayCount)
 
                 // Update the widget only if the data has changed.
-                if updatedStats != self?.statsValues {
-                    self?.statsValues = updatedStats
-                    completionHandler(.newData)
-                    self?.saveData()
-                } else {
+                guard updatedStats != self?.statsValues else {
                     completionHandler(.noData)
+                    return
                 }
+
+                self?.statsValues = updatedStats
+                completionHandler(.newData)
+                self?.saveData()
             }
         }
     }

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -266,13 +266,14 @@ private extension ThisWeekViewController {
                 let updatedStats = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData))
 
                 // Update the widget only if the data has changed.
-                if updatedStats != self?.statsValues {
-                    self?.statsValues = updatedStats
-                    completionHandler(.newData)
-                    self?.saveData()
-                } else {
+                guard updatedStats != self?.statsValues else {
                     completionHandler(.noData)
+                    return
                 }
+
+                self?.statsValues = updatedStats
+                completionHandler(.newData)
+                self?.saveData()
             }
         }
     }

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -70,7 +70,6 @@ class ThisWeekViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         reachability.stopNotifier()
-        saveData()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -129,7 +128,7 @@ extension ThisWeekViewController: NCWidgetProviding {
                 self?.tableView.reloadData()
             }
 
-            completionHandler(NCUpdateResult.failed)
+            completionHandler(.failed)
             return
         }
 
@@ -256,7 +255,7 @@ private extension ThisWeekViewController {
         statsRemote.getData(for: .day, endingOn: weekEndingDate, limit: ThisWeekWidgetStats.maxDaysToDisplay + 1) { [unowned self] (summary: StatsSummaryTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogError("This Week Widget: Error fetching summary: \(String(describing: error?.localizedDescription))")
-                completionHandler(NCUpdateResult.failed)
+                completionHandler(.failed)
                 return
             }
 
@@ -264,9 +263,17 @@ private extension ThisWeekViewController {
 
             DispatchQueue.main.async { [weak self] in
                 let summaryData = summary?.summaryData.reversed() ?? []
-                self?.statsValues = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData))
+                let updatedStats = ThisWeekWidgetStats(days: ThisWeekWidgetStats.daysFrom(summaryData: summaryData))
+
+                // Update the widget only if the data has changed.
+                if updatedStats != self?.statsValues {
+                    self?.statsValues = updatedStats
+                    completionHandler(.newData)
+                    self?.saveData()
+                } else {
+                    completionHandler(.noData)
+                }
             }
-            completionHandler(NCUpdateResult.newData)
         }
     }
 

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -271,13 +271,14 @@ private extension TodayViewController {
                                                     comments: todayInsight?.commentsCount)
 
                 // Update the widget only if the data has changed.
-                if updatedStats != self?.statsValues {
-                    self?.statsValues = updatedStats
-                    completionHandler(.newData)
-                    self?.saveData()
-                } else {
+                guard updatedStats != self?.statsValues else {
                     completionHandler(.noData)
+                    return
                 }
+
+                self?.statsValues = updatedStats
+                completionHandler(.newData)
+                self?.saveData()
             }
         }
     }


### PR DESCRIPTION
Ref #12702

As noted here https://github.com/wordpress-mobile/WordPress-iOS/pull/13233#pullrequestreview-343277093, the widgets shouldn't update if the data has not changed. Accordingly:
- Each widget now compares the new data with the old.
- If the data has changed, the widget will update.
- If the data has not changed, the widget will not update.

To test:
There really isn't a way to test widgets aren't updated, but you can test that they are.
- In the app, go to Stats > Widgets > Use this site.
  - Note: en.blog might be a good one since it updates fairly frequently.
- Add the 3 Stats widgets to the Today view.
- Scroll away from the Today view, and back. Verify the stats update (assuming there is new data to show).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
