### PR TITLE
Enable Post Preview feature for internal testing

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -38,7 +38,7 @@ enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current ~= [.localDeveloper,
                                                   .a8cBranchTest]
         case .postPreview:
-            return BuildConfiguration.current == .localDeveloper
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .postReblogging:
             return BuildConfiguration.current == .localDeveloper
         case .mediaEditor:


### PR DESCRIPTION
#13197 

Enables the `postPreview` feature flag for internal builds.

To test:

- Preview a Blog Post or Site Page
- Check that the new Post Preview UI (with Desktop preview) is available

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Not yet released
