### PR TITLE
Stats Widgets: show failed loading view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
@@ -9,9 +9,9 @@ enum WidgetType {
     var configureLabelFont: UIFont {
         switch self {
         case .loadingFailed:
-            return UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .headline).pointSize)
+            return WidgetStyles.headlineFont
         default:
-            return UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize)
+            return WidgetStyles.footnoteNote
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/Shared Views/WidgetUnconfiguredCell.swift
@@ -4,6 +4,16 @@ enum WidgetType {
     case today
     case allTime
     case thisWeek
+    case loadingFailed
+
+    var configureLabelFont: UIFont {
+        switch self {
+        case .loadingFailed:
+            return UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .headline).pointSize)
+        default:
+            return UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize)
+        }
+    }
 }
 
 class WidgetUnconfiguredCell: UITableViewCell {
@@ -45,10 +55,13 @@ private extension WidgetUnconfiguredCell {
                 return LocalizedText.configureAllTime
             case .thisWeek:
                 return LocalizedText.configureThisWeek
+            case .loadingFailed:
+                return LocalizedText.loadingFailed
             }
         }()
 
-        actionLabel.text = LocalizedText.openWordPress
+        configureLabel.font = widgetType.configureLabelFont
+        actionLabel.text = widgetType == .loadingFailed ? LocalizedText.retry : LocalizedText.openWordPress
         configureLabel.textColor = WidgetStyles.primaryTextColor
         actionLabel.textColor = WidgetStyles.primaryTextColor
         WidgetStyles.configureSeparator(separatorLine)
@@ -60,6 +73,8 @@ private extension WidgetUnconfiguredCell {
         static let configureAllTime = NSLocalizedString("Display your all-time site stats here. Configure in the WordPress app in your site stats.", comment: "Unconfigured stats all-time widget helper text")
         static let configureThisWeek = NSLocalizedString("Display your site stats for this week here. Configure in the WordPress app in your site stats.", comment: "Unconfigured stats this week widget helper text")
         static let openWordPress = NSLocalizedString("Open WordPress", comment: "Today widget label to launch WP app")
+        static let loadingFailed = NSLocalizedString("Couldn't load data", comment: "Message displayed when a Stats widget failed to load data.")
+        static let retry = NSLocalizedString("Retry", comment: "Stats widgets label to reload the widget.")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
@@ -5,6 +5,8 @@ class WidgetStyles: NSObject {
 
     static let primaryTextColor: UIColor = .text
     static let secondaryTextColor: UIColor = .textSubtle
+    static let headlineFont = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .headline).pointSize)
+    static let footnoteNote = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize)
 
     static var separatorColor: UIColor = {
         if #available(iOS 13, *) {

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -51,6 +51,20 @@ class ThisWeekViewController: UIViewController {
         return !isReachable && statsValues == nil
     }
 
+    private var loadingFailed = false {
+        didSet {
+            setAvailableDisplayMode()
+
+            if loadingFailed != oldValue {
+                tableView.reloadData()
+            }
+        }
+    }
+
+    private var failedState: Bool {
+        return !isConfigured || showNoConnection || loadingFailed
+    }
+
     // MARK: - View
 
     override func viewDidLoad() {
@@ -155,7 +169,7 @@ extension ThisWeekViewController: UITableViewDelegate, UITableViewDataSource {
             return noConnectionCellFor(indexPath: indexPath)
         }
 
-        if !isConfigured {
+        if !isConfigured || loadingFailed {
             return unconfiguredCellFor(indexPath: indexPath)
         }
 
@@ -163,7 +177,7 @@ extension ThisWeekViewController: UITableViewDelegate, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if !isConfigured || showNoConnection,
+        if failedState,
             let maxCompactSize = extensionContext?.widgetMaximumSize(for: .compact) {
             // Use the max compact height for unconfigured view.
             return maxCompactSize.height
@@ -181,6 +195,15 @@ private extension ThisWeekViewController {
     // MARK: - Tap Gesture Handling
 
     @IBAction func handleTapGesture() {
+
+        // If showing the loading failed view, reload the widget.
+        if loadingFailed,
+            let completionHandler = widgetCompletionBlock {
+            widgetPerformUpdate(completionHandler: completionHandler)
+            return
+        }
+
+        // Otherwise, open the app.
         guard isReachable,
             let extensionContext = extensionContext,
             let containingAppURL = appURL() else {
@@ -252,7 +275,10 @@ private extension ThisWeekViewController {
         let weekEndingDate = Date().convert(from: siteTimeZone).normalizedDate()
 
         // Include an extra day. It's needed to get the dailyChange for the last day.
-        statsRemote.getData(for: .day, endingOn: weekEndingDate, limit: ThisWeekWidgetStats.maxDaysToDisplay + 1) { [unowned self] (summary: StatsSummaryTimeIntervalData?, error: Error?) in
+        statsRemote.getData(for: .day, endingOn: weekEndingDate, limit: ThisWeekWidgetStats.maxDaysToDisplay + 1) { [weak self] (summary: StatsSummaryTimeIntervalData?, error: Error?) in
+
+            self?.loadingFailed = (error != nil)
+
             if error != nil {
                 DDLogError("This Week Widget: Error fetching summary: \(String(describing: error?.localizedDescription))")
                 completionHandler(.failed)
@@ -326,7 +352,7 @@ private extension ThisWeekViewController {
             return UITableViewCell()
         }
 
-        cell.configure(for: .thisWeek)
+        loadingFailed ? cell.configure(for: .loadingFailed) : cell.configure(for: .thisWeek)
         return cell
     }
 
@@ -366,8 +392,8 @@ private extension ThisWeekViewController {
     // MARK: - Expand / Compact View Helpers
 
     func setAvailableDisplayMode() {
-        // If unconfigured or no connection, don't allow the widget to be expanded.
-        extensionContext?.widgetLargestAvailableDisplayMode = isConfigured && !showNoConnection ? .expanded : .compact
+        // If something went wrong, don't allow the widget to be expanded.
+        extensionContext?.widgetLargestAvailableDisplayMode = failedState ? .compact : .expanded
     }
 
     func numberOfRowsToDisplay() -> Int {

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -52,6 +52,20 @@ class TodayViewController: UIViewController {
         return !isReachable && statsValues == nil
     }
 
+    private var loadingFailed = false {
+        didSet {
+            setAvailableDisplayMode()
+
+            if loadingFailed != oldValue {
+                tableView.reloadData()
+            }
+        }
+    }
+
+    private var failedState: Bool {
+        return !isConfigured || showNoConnection || loadingFailed
+    }
+
     private let tracks = Tracks(appGroupName: WPAppGroupName)
     private let reachability: Reachability = .forInternetConnection()
 
@@ -158,7 +172,7 @@ extension TodayViewController: UITableViewDelegate, UITableViewDataSource {
             return noConnectionCellFor(indexPath: indexPath)
         }
 
-        if !isConfigured {
+        if !isConfigured || loadingFailed {
             return unconfiguredCellFor(indexPath: indexPath)
         }
 
@@ -167,7 +181,7 @@ extension TodayViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
 
-        if !isConfigured || showNoConnection,
+        if failedState,
             let maxCompactSize = extensionContext?.widgetMaximumSize(for: .compact) {
             // Use the max compact height for unconfigured view.
             return maxCompactSize.height
@@ -189,6 +203,15 @@ private extension TodayViewController {
     // MARK: - Tap Gesture Handling
 
     @IBAction func handleTapGesture() {
+
+        // If showing the loading failed view, reload the widget.
+        if loadingFailed,
+            let completionHandler = widgetCompletionBlock {
+            widgetPerformUpdate(completionHandler: completionHandler)
+            return
+        }
+
+        // Otherwise, open the app.
         guard isReachable,
             let extensionContext = extensionContext,
             let containingAppURL = appURL() else {
@@ -255,7 +278,9 @@ private extension TodayViewController {
             return
         }
 
-        statsRemote.getInsight { (todayInsight: StatsTodayInsight?, error) in
+        statsRemote.getInsight { [weak self] (todayInsight: StatsTodayInsight?, error) in
+            self?.loadingFailed = (error != nil)
+
             if error != nil {
                 DDLogError("Today Widget: Error fetching StatsTodayInsight: \(String(describing: error?.localizedDescription))")
                 completionHandler(.failed)
@@ -325,7 +350,7 @@ private extension TodayViewController {
             return UITableViewCell()
         }
 
-        cell.configure(for: .today)
+        loadingFailed ? cell.configure(for: .loadingFailed) : cell.configure(for: .today)
         return cell
     }
 
@@ -368,8 +393,8 @@ private extension TodayViewController {
     // MARK: - Expand / Compact View Helpers
 
     func setAvailableDisplayMode() {
-        // If unconfigured or no connection, don't allow the widget to be expanded.
-        extensionContext?.widgetLargestAvailableDisplayMode = !showNoConnection && isConfigured ? .expanded : .compact
+        // If something went wrong, don't allow the widget to be expanded.
+        extensionContext?.widgetLargestAvailableDisplayMode = failedState ? .compact : .expanded
     }
 
     func minRowsToDisplay() -> Int {


### PR DESCRIPTION
Ref #12702 

For all the Stats widgets, if fetching data fails, a `Couldn't load data` view is displayed.

To test:

A bit of hackery is needed to force data fetching to fail. In the `retrieveSiteConfiguration` method in all three VCs, you can replace this line:

```
siteID = sharedDefaults.object(forKey: WPStatsTodayWidgetUserDefaultsSiteIdKey) as? NSNumber
```

With this magic:

```
if loadingFailed {
    siteID = sharedDefaults.object(forKey: WPStatsTodayWidgetUserDefaultsSiteIdKey) as? NSNumber
} else {
    siteID = 9999999999999999
}
```

That will cause the first attempt to fail by setting an invalid `siteID`, and the second attempt to succeed by setting the correct `siteID`.

Now, to actually test:
- In the app, go to Stats > Widgets > Use this site.
- Add the Stats widgets to the device's Today view.
- Initially, stored data will be displayed. But once the data fetching is attempted and fails, the failure view will be displayed.

<img width="400" alt="fail" src="https://user-images.githubusercontent.com/1816888/73493914-e5431b80-4370-11ea-9fd5-d7f664671df1.png">

- Tap the widgets.
- They should load data successfully and update accordingly.

<img width="400" alt="loaded" src="https://user-images.githubusercontent.com/1816888/73493856-c93f7a00-4370-11ea-8395-e65fc4231c67.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
