### PR TITLE
Enable Post Preview for all users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,8 @@
 -----
 * Comment Editing: Fixed a bug that could cause the text selection to be on the wrong line 
 * Media editing: You can now crop, zoom in/out and rotate images that are inserted or being inserted in a post.
+* Post Preview: Added a new Desktop preview mode on iPhone and Mobile preview on iPad when previewing posts or pages.
+* Post Preview: Added new navigation, "Open in Safari" and Share options when previewing posts or pages.
 
 14.1
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -38,7 +38,7 @@ enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current ~= [.localDeveloper,
                                                   .a8cBranchTest]
         case .postPreview:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
+            return true
         case .postReblogging:
             return BuildConfiguration.current == .localDeveloper
         case .mediaEditor:


### PR DESCRIPTION
#13197 

Enables the `postPreview` flag for all users.

To test:

* Preview a Blog Post or Site Page
* Check that the new Post Preview UI (with Desktop preview) is available

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
