### PR TITLE
Fix noto font loading on Gutenberg

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -260,6 +260,7 @@ class GutenbergViewController: UIViewController, PostEditor {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        WPFontManager.loadNotoFontFamily()
         createRevisionOfPost(loadAutosaveRevision: loadAutosaveRevision)
         setupGutenbergView()
         configureNavigationBar()


### PR DESCRIPTION
This PR fixes the loading of the Noto font when opening Gutenberg.

![Simulator Screen Shot - iPhone 11 - 2020-01-31 at 16 22 37](https://user-images.githubusercontent.com/651601/73555645-eb56fc00-4445-11ea-8acd-f8a8fd910e48.png) 

To test:
 - Start the app
 - Immediately press the Write new Post button on the interface on a blog that has GB active
 - Check that the font loaded correctly ( check the lowercase `g` as in the screenshot above)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
