### PR TITLE
Strips HTML from the comment view/edit on the site detail views

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 14.2
 -----
-* Comment Editing: Fixed a bug that could cause the text selection to be on the wrong line 
+* Comment Editing: Fixed a bug that could cause the text selection to be on the wrong line
+* Comments: Fixed an bug that could cause HTML markup to be displayed in the comment content
 * Media editing: You can now crop, zoom in/out and rotate images that are inserted or being inserted in a post.
 
 14.1

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -149,11 +149,11 @@ NSString * const CommentStatusDraft = @"draft";
 
 - (NSString *)contentForDisplay
 {
-    // Unescape HTML characters and add <br /> tags
-    NSString *commentContent = [[self.content stringByDecodingXMLCharacters] trim];    
-    NSRegularExpression *removeNewlinesAfterHtmlTags = [NSRegularExpression regularExpressionWithPattern:@"(?<=\\>)\n\n" options:0 error:nil];
-    commentContent = [removeNewlinesAfterHtmlTags stringByReplacingMatchesInString:commentContent options:0 range:NSMakeRange(0, [commentContent length]) withTemplate:@""];
-    commentContent = [commentContent stringByReplacingOccurrencesOfString:@"\n" withString:@"<br />"];
+    //Strip HTML from the comment content
+    NSString *commentContent = [self.content stringByDecodingXMLCharacters];
+    commentContent = [commentContent trim];
+    commentContent = [commentContent stringByStrippingHTML];
+    commentContent = [commentContent stringByNormalizingWhitespace];    
 
     return commentContent;
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -560,7 +560,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 - (void)editComment
 {
     EditCommentViewController *editViewController = [EditCommentViewController newEditViewController];
-    editViewController.content = self.comment.content;
+    editViewController.content = [self.comment contentForDisplay];
 
     __typeof(self) __weak weakSelf = self;
     editViewController.onCompletion = ^(BOOL hasNewContent, NSString *newContent) {


### PR DESCRIPTION
Fixes #10015

**Description**
After some deliberation with @leandroalonso we decided to strip the HTML from the comments for now. 

This PR strips the HTML from the comment view, and the edit comments view.

**To test:**
1. Tap the My Sites section
2. Select a site
3. Tap the Comments item
4. Locate a comment with HTML content
5. Tap to view more of the comment
5.a. Tap the Edit option to edit the plain text of the comment

**Video Demos**

| Device | Version | Link |
|---|---|---|
| iPhone 8 | 11.4 | https://d.pr/i/6Pscbz |
| iPhone 8 | 12.4 | https://d.pr/i/QAMK0A |
| iPhone 8 | 13.3 | https://d.pr/i/dFbSjS |
|---|---|---|
| iPhone 11 Pro Max | 13.3 | https://d.pr/i/xONIan |
|---|---|---|
| iPad Air | 11.4 | https://d.pr/i/eExl9L |
| iPad Air (3rd Gen) | 12.4 | https://d.pr/i/uS5KG4 |
| iPad Air (3rd Gen) | 13.3 | https://d.pr/i/eZ7yeG |

**PR submission checklist:**

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
