### PR TITLE
Updated News Card to announce Offline Support

### DIFF
--- a/WordPress/News.strings
+++ b/WordPress/News.strings
@@ -1,11 +1,11 @@
 /* News Card title. */
-"Title" = "Clearer Stats";
+"Title" = "Offline Support";
 
 /* News Card content. */
-"Content" = "The stats experience just vastly improved, with a broad range of innovations in both the UI and backend.";
+"Content" = "Our mobile apps now support offline publishing and editing.";
 
 /* News Card link. */
-"URL" = "https://en.blog.wordpress.com/2019/07/16/more-stats-better-stats-faster-stats-a-whole-new-mobile-experience/";
+"URL" = "https://en.blog.wordpress.com/2020/01/30/improved-offline-publishing/";
 
 /* Build version this card applies to. */
-"version" = "12.6";
+"version" = "14.1";


### PR DESCRIPTION
Fixes #10525 

To test:
1. Open the Reader 
2. See the new card with updated content and link to offline support blog post on en.blog

![Simulator Screen Shot - iPhone 11 Pro - 2020-01-31 at 15 22 17](https://user-images.githubusercontent.com/1335657/73581391-e2622c80-443d-11ea-8a7a-b689ff0e173c.png)



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
