### PR TITLE
Cleanup: remove exampleFeature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -2,7 +2,6 @@
 /// different builds.
 @objc
 enum FeatureFlag: Int, CaseIterable {
-    case exampleFeature
     case jetpackDisconnect
     case domainCredit
     case signInWithApple
@@ -19,8 +18,6 @@ enum FeatureFlag: Int, CaseIterable {
         }
 
         switch self {
-        case .exampleFeature:
-            return true
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .domainCredit:
@@ -61,8 +58,6 @@ extension FeatureFlag: OverrideableFlag {
     /// Descriptions used to display the feature flag override menu in debug builds
     var description: String {
         switch self {
-        case .exampleFeature:
-            return "Example feature"
         case .jetpackDisconnect:
             return "Jetpack disconnect"
         case .domainCredit:
@@ -84,7 +79,7 @@ extension FeatureFlag: OverrideableFlag {
 
     var canOverride: Bool {
         switch self {
-        case .debugMenu, .exampleFeature:
+        case .debugMenu:
             return false
         default:
             return true


### PR DESCRIPTION
Supersedes: https://github.com/wordpress-mobile/WordPress-iOS/pull/13358

Removes an unused feature flag.

No testing needed since the feature flag wasn't really used.  Just build and run the unit tests and make sure all is fine.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
