### PR TITLE
Post Reblogging - Add wp:image markup to posts reblogged with Block Editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,8 @@
 * Media editing: You can now crop, zoom in/out and rotate images that are inserted or being inserted in a post.
 * Post Preview: Added a new Desktop preview mode on iPhone and Mobile preview on iPad when previewing posts or pages.
 * Post Preview: Added new navigation, "Open in Safari" and Share options when previewing posts or pages.
+* Reader: Added Post Reblogging feature. You can now reblog a post from the reader to your site(s). There is a new "reblog" button in the post action bar.
+          Tapping on it allows to choose the site where to post, and opens the editor of your choice with pre-populated content from the original post.
 
 14.1
 -----

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -175,6 +175,8 @@ extern NSString *const WPBlogUpdatedNotification;
 
 - (NSArray<Blog *> *)blogsForAllAccounts;
 
+- (NSArray<Blog *> *)blogsForWPComAccounts;
+
 - (NSArray *)blogsWithNoAccount;
 
 - (NSArray *)blogsWithPredicate:(NSPredicate *)predicate;

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -175,7 +175,7 @@ extern NSString *const WPBlogUpdatedNotification;
 
 - (NSArray<Blog *> *)blogsForAllAccounts;
 
-- (NSArray<Blog *> *)blogsForWPComAccounts;
+- (NSArray<Blog *> *)visibleBlogsForWPComAccounts;
 
 - (NSArray *)blogsWithNoAccount;
 

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -485,11 +485,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
 
 - (NSInteger)blogCountVisibleForWPComAccounts
 {
-    NSArray *subpredicates = @[
-                            [self predicateForVisibleBlogs],
-                            [NSPredicate predicateWithFormat:@"account != NULL"],
-                            ];
-    NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
+    NSPredicate *predicate = [self predicateForVisibleBlogsWPComAccounts];
     return [self blogCountWithPredicate:predicate];
 }
 
@@ -510,9 +506,10 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     return [self blogsWithPredicate:nil];
 }
 
-- (NSArray<Blog *> *)blogsForWPComAccounts
+- (NSArray<Blog *> *)visibleBlogsForWPComAccounts
 {
-    return [self blogsWithPredicate:[NSPredicate predicateWithFormat:@"account != NULL"]];
+    NSPredicate *predicate = [self predicateForVisibleBlogsWPComAccounts];
+    return [self blogsWithPredicate:predicate];
 }
 
 - (NSDictionary *)blogsForAllAccountsById
@@ -854,6 +851,18 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
 - (NSPredicate *)predicateForVisibleBlogs
 {
     return [NSPredicate predicateWithFormat:@"visible = YES"];
+}
+
+
+- (NSPredicate *)predicateForVisibleBlogsWPComAccounts
+{
+    NSArray *subpredicates = @[
+                            [self predicateForVisibleBlogs],
+                            [NSPredicate predicateWithFormat:@"account != NULL"],
+                            ];
+    NSPredicate *predicate = [NSCompoundPredicate andPredicateWithSubpredicates:subpredicates];
+
+    return predicate;
 }
 
 - (NSPredicate *)predicateForNoAccount

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -510,6 +510,11 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     return [self blogsWithPredicate:nil];
 }
 
+- (NSArray<Blog *> *)blogsForWPComAccounts
+{
+    return [self blogsWithPredicate:[NSPredicate predicateWithFormat:@"account != NULL"]];
+}
+
 - (NSDictionary *)blogsForAllAccountsById
 {
     NSMutableDictionary *blogMap = [NSMutableDictionary dictionary];

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -37,7 +37,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .postPreview:
             return true
         case .postReblogging:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .mediaEditor:
             return true
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
@@ -41,6 +41,9 @@ extension PostEditor where Self: UIViewController {
         // On iPad Devices, we'll disable the Picker's SearchController's "Autohide Navbar Feature", since
         // upon dismissal, it may force the NavigationBar to show up, even when it was initially hidden.
         selectorViewController.displaysNavigationBarWhenSearching = WPDeviceIdentification.isiPad()
+        if postIsReblogged {
+            selectorViewController.displaysOnlyDefaultAccountSites = true
+        }
 
         // Setup Navigation
         let navigationController = AdaptiveNavigationController(rootViewController: selectorViewController)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -134,7 +134,7 @@ extension PostEditor {
 
     var currentBlogCount: Int {
         let service = BlogService(managedObjectContext: mainContext)
-        return service.blogCountForAllAccounts()
+        return postIsReblogged ? service.blogCountForWPComAccounts() : service.blogCountForAllAccounts()
     }
 
     var isSingleSiteMode: Bool {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -886,7 +886,10 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
                 configureCommentActionButton()
             }
         }
-        configureReblogButton()
+        // Show reblog only if logged in
+        if ReaderHelpers.isLoggedIn() {
+            configureReblogButton()
+        }
         configureSaveForLaterButton()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -497,7 +497,8 @@ import Gridicons
     fileprivate var shouldShowReblogActionButton: Bool {
         // reblog button is hidden if there's no content
         guard FeatureFlag.postReblogging.enabled,
-            contentProvider != nil else {
+            contentProvider != nil,
+            loggedInActionVisibility.isEnabled else {
             return false
         }
         return true

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogFormatter.swift
@@ -30,10 +30,6 @@ private extension ReaderReblogFormatter {
         return "<!-- wp:image {\"className\":\"\(size)\"} -->\n" + gutenbergFigure(image: image, size: size) + "\n<!-- /wp:image -->"
     }
 
-    static func embedInWpParagraph(html: String) -> String {
-        return "<!-- wp:paragraph -->\n<p>\(html)</p>\n<!-- /wp:paragraph -->"
-    }
-
     static func embedInWpQuote(html: String) -> String {
         return "<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\">\(html)</blockquote>\n<!-- /wp:quote -->"
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogFormatter.swift
@@ -7,8 +7,7 @@ struct ReaderReblogFormatter {
     }
 
     static func gutenbergImage(image: String) -> String {
-        let imageInHtml = htmlImage(image: image)
-        return embedInWpParagraph(html: imageInHtml)
+        return embedInWpImage(image: image)
     }
 
 
@@ -27,6 +26,10 @@ struct ReaderReblogFormatter {
 // MARK: - Gutenberg formatter helpers
 private extension ReaderReblogFormatter {
 
+    static func embedInWpImage(image: String, size: String = "size-large") -> String {
+        return "<!-- wp:image {\"className\":\"\(size)\"} -->\n" + gutenbergFigure(image: image, size: size) + "\n<!-- /wp:image -->"
+    }
+
     static func embedInWpParagraph(html: String) -> String {
         return "<!-- wp:paragraph -->\n<p>\(html)</p>\n<!-- /wp:paragraph -->"
     }
@@ -34,9 +37,13 @@ private extension ReaderReblogFormatter {
     static func embedInWpQuote(html: String) -> String {
         return "<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\">\(html)</blockquote>\n<!-- /wp:quote -->"
     }
+
+    private static func gutenbergFigure(image: String, size: String) -> String {
+        return "<figure class=\"wp-block-image \(size)\">" + htmlImage(image: image) + "</figure>"
+    }
 }
 
-// MARK: - Aztec formatter helpers
+// MARK: - Aztec (standard HTML) formatter helpers
 extension ReaderReblogFormatter {
 
     static func hyperLink(url: String, text: String) -> String {
@@ -44,7 +51,7 @@ extension ReaderReblogFormatter {
     }
 
     private static func htmlImage(image: String) -> String {
-        return "<img src=\"\(image)\">"
+        return "<img src=\"\(image)\" alt=\"\"/>"
     }
 
     private static func embedInQuote(html: String) -> String {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
@@ -3,10 +3,10 @@ class ReaderReblogPresenter {
     private let postService: PostService
 
     private struct NoSitesConfiguration {
-        static let noSitesTitle = NSLocalizedString("No available sites",
-                                                    comment: "A short message that informs the user no sites could be found.")
-        static let noSitesSubtitle = NSLocalizedString("Once you create a site, you can reblog content that you like to your own site.",
-                                                       comment: "A subtitle with more detailed info for the user when no sites could be found.")
+        static let noSitesTitle = NSLocalizedString("No available WordPress.com sites",
+                                                    comment: "A short message that informs the user no WordPress.com sites could be found.")
+        static let noSitesSubtitle = NSLocalizedString("Once you create a WordPress.com site, you can reblog content that you like to your own site.",
+                                                       comment: "A subtitle with more detailed info for the user when no WordPress.com sites could be found.")
         static let manageSitesLabel = NSLocalizedString("Manage Sites",
                                                         comment: "Button title. Tapping lets the user manage the sites they follow.")
         static let backButtonTitle = NSLocalizedString("Back",
@@ -28,13 +28,13 @@ class ReaderReblogPresenter {
                        readerPost: ReaderPost,
                        origin: UIViewController) {
 
-        let blogCount = blogService.blogCountForAllAccounts()
+        let blogCount = blogService.blogCountForWPComAccounts()
 
         switch blogCount {
         case 0:
             presentNoSitesScene(origin: origin)
         case 1:
-            guard let blog = blogService.blogsForAllAccounts().first else {
+            guard let blog = blogService.blogsForWPComAccounts().first else {
                 return
             }
             presentEditor(with: readerPost, blog: blog, origin: origin)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
@@ -150,6 +150,7 @@ private extension ReaderReblogPresenter {
 // MARK: - Post updates
 private extension Post {
     /// Formats the new Post content for reblogging, using an existing ReaderPost
+    /// Uses the passed imageSize to obtain a Photon URL for the featured image
     func prepareForReblog(with readerPost: ReaderPost, imageSize: CGSize) {
         // update the post
         update(with: readerPost)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
@@ -28,13 +28,13 @@ class ReaderReblogPresenter {
                        readerPost: ReaderPost,
                        origin: UIViewController) {
 
-        let blogCount = blogService.blogCountForWPComAccounts()
+        let blogCount = blogService.blogCountVisibleForWPComAccounts()
 
         switch blogCount {
         case 0:
             presentNoSitesScene(origin: origin)
         case 1:
-            guard let blog = blogService.blogsForWPComAccounts().first else {
+            guard let blog = blogService.visibleBlogsForWPComAccounts().first else {
                 return
             }
             presentEditor(with: readerPost, blog: blog, origin: origin)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
@@ -65,6 +65,7 @@ private extension ReaderReblogPresenter {
 
         selectorViewController.displaysNavigationBarWhenSearching = WPDeviceIdentification.isiPad()
         selectorViewController.dismissOnCancellation = true
+        selectorViewController.displaysOnlyDefaultAccountSites = true
 
         let navigationController = getNavigationController(selectorViewController)
 

--- a/WordPress/WordPressTest/ReaderPostCardCellTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCardCellTests.swift
@@ -217,6 +217,6 @@ final class ReaderPostCardCellTests: XCTestCase {
             XCTFail("Reblog button not found.")
             return
         }
-        XCTAssertFalse(button.isHidden, "Reblog button should not be visible.")
+        XCTAssertTrue(button.isHidden, "Reblog button should not be visible.")
     }
 }

--- a/WordPress/WordPressTest/ReaderReblogActionTests.swift
+++ b/WordPress/WordPressTest/ReaderReblogActionTests.swift
@@ -17,11 +17,11 @@ class MockBlogService: BlogService {
 
     var blogCount = 1
 
-    override func blogCountForAllAccounts() -> Int {
+    override func blogCountForWPComAccounts() -> Int {
         return blogCount
     }
 
-    override func blogsForAllAccounts() -> [Blog] {
+    override func blogsForWPComAccounts() -> [Blog] {
         blogsForAllAccountsExpectation?.fulfill()
         return [Blog(context: self.managedObjectContext), Blog(context: self.managedObjectContext)]
     }

--- a/WordPress/WordPressTest/ReaderReblogActionTests.swift
+++ b/WordPress/WordPressTest/ReaderReblogActionTests.swift
@@ -17,11 +17,11 @@ class MockBlogService: BlogService {
 
     var blogCount = 1
 
-    override func blogCountForWPComAccounts() -> Int {
+    override func blogCountVisibleForWPComAccounts() -> Int {
         return blogCount
     }
 
-    override func blogsForWPComAccounts() -> [Blog] {
+    override func visibleBlogsForWPComAccounts() -> [Blog] {
         blogsForAllAccountsExpectation?.fulfill()
         return [Blog(context: self.managedObjectContext), Blog(context: self.managedObjectContext)]
     }

--- a/WordPress/WordPressTest/ReaderReblogActionTests.swift
+++ b/WordPress/WordPressTest/ReaderReblogActionTests.swift
@@ -158,6 +158,10 @@ class ReblogFormatterTests: XCTestCase {
         // When
         let wpImage = ReaderReblogFormatter.gutenbergImage(image: image)
         // Then
-        XCTAssertEqual("<!-- wp:paragraph -->\n<p><img src=\"image.jpg\"></p>\n<!-- /wp:paragraph -->", wpImage)
+        XCTAssertEqual("<!-- wp:image {\"className\":\"size-large\"} -->\n" +
+                       "<figure class=\"wp-block-image size-large\">" +
+                       "<img src=\"image.jpg\" alt=\"\"/>" +
+                       "</figure>\n<!-- /wp:image -->",
+                       wpImage)
     }
 }


### PR DESCRIPTION
### This PR adds the `wp:image` markup to posts that are reblogged via the Block Editor. Hotlink images provisioned via `Photon`.
#### Reblog button is now invisible to users that are not logged in, because `Photon` is not allowed on self hosted sites.
#### Self hosted sites now are not listed in the blog selector for reblogging, because `Photon` is not allowed on self hosted sites.
#### Feature flag updated to enable test for all users.
#### Release notes have been updated.

Ref #12960

To test:
wp:image markup
- Make sure you have a test blog with Block Editor enabled
- Navigate to the reader and choose a post with a featured image
- Either from post list or post detail, tap on `reblog`, and choose the site with block editor enabled
- verify that the image is displayed after the title and before the summary

Reblog button visibility
- log in with a self hosted site (Login -> Login with WordPress -> Login by entering your site address)
- Navigate to the reader, and verify that the reblog button is not visible on any post

Self hosted sites not visible in the blog selector
- Login with a user that has at least one self hosted site
- Navigate to the reader, tap the reblog button and verify that:
  - If the user has no WordPress.com sites (regardless self hosted sites), the no sites screen is presented
  - if the user has only one WordPress.com site (regardless self hosted site): 
    - the editor is presented directly (no blog selector)
    - The blog selector button does not show on the nav bar, in the editor.
  - if the user has more than one WordPress.com site:
     - the blog selector is presented, but no self hosted site is listed in the blog selector
     - when choosing the blog selector from the editor nav bar, self hosted sites are not listed in there.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
