### PR TITLE
[Dark Mode] Posts list: Re-set ghost style when switching filter tabs.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -204,6 +204,13 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         filterTabBariOS10TopConstraint.isActive = false
     }
 
+
+    override func selectedFilterDidChange(_ filterBar: FilterTabBar) {
+        updateGhostableTableViewOptions()
+        super.selectedFilterDidChange(filterBar)
+    }
+
+
     /// Update the `GhostOptions` to correctly show compact or default cells
     private func updateGhostableTableViewOptions() {
         let ghostOptions = GhostOptions(displaysSectionHeader: false, reuseIdentifier: postCellIdentifier, rowsPerSection: [10])


### PR DESCRIPTION
Fixes #13326 

This fixes an issue where the ghost cells in the Blog Posts list would appear white instead of showing the ghost animation.

Note: there is a [separate issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/13364) with the Search bar border color.

To test:
- Set the device to dark mode.
- On a slow network, go to Blog Posts.
- Switch between tabs.
- Verify the ghost cells animate.

Before | After
--------|-------
![before](https://user-images.githubusercontent.com/1816888/73705436-2873f600-46b3-11ea-917f-22e2d36b8902.gif)        |       ![after](https://user-images.githubusercontent.com/1816888/73705317-d7640200-46b2-11ea-81bd-13d080269e47.gif)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
