### PR TITLE
Removed the domain credit feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -3,7 +3,6 @@
 @objc
 enum FeatureFlag: Int, CaseIterable {
     case jetpackDisconnect
-    case domainCredit
     case signInWithApple
     case debugMenu
     case postPreview
@@ -19,8 +18,6 @@ enum FeatureFlag: Int, CaseIterable {
         switch self {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
-        case .domainCredit:
-            return true
         case .signInWithApple:
             // SIWA can NOT be enabled for internal builds
             // Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/12332#issuecomment-521994963
@@ -57,8 +54,6 @@ extension FeatureFlag: OverrideableFlag {
         switch self {
         case .jetpackDisconnect:
             return "Jetpack disconnect"
-        case .domainCredit:
-            return "Use domain credits"
         case .signInWithApple:
             return "Sign in with Apple"
         case .debugMenu:

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -614,7 +614,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)configureTableViewData
 {
     NSMutableArray *marr = [NSMutableArray array];
-    if ([Feature enabled:FeatureFlagDomainCredit] && [DomainCreditEligibilityChecker canRedeemDomainCreditWithBlog:self.blog]) {
+    if ([DomainCreditEligibilityChecker canRedeemDomainCreditWithBlog:self.blog]) {
         if (!self.hasLoggedDomainCreditPromptShownEvent) {
             [WPAnalytics track:WPAnalyticsStatDomainCreditPromptShown];
             self.hasLoggedDomainCreditPromptShownEvent = YES;


### PR DESCRIPTION
Removes the domain credit feature flag, since it was set `true` nearly 9 months ago now.

## To test:

1. Make sure you have a WP.com testing blog that has credit, and doesn't have a registered domain.
2. Run the app, go to the blog mentioned in step 1.
3. Make sure you see a "Register Domain" row on top of the site details screen (as shown below).

![IMG_6817BC4C4705-1](https://user-images.githubusercontent.com/1836005/73749595-741db280-473a-11ea-8098-9a27a81e2388.jpeg)

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
