### PR TITLE
Fix sharing with Facebook.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 * Stats: added a This Week widget to display Views for the past week.
 * Block Editor: Reduced padding around text on Rich Text based blocks.
 * Block Editor: New block "Shortcode". You can now create and edit Shortcode blocks in the editor.
-
+* Publicize: connecting with Facebook is working again.
 * Web Views: the title and button colors in the header of web views was grey, and is now white.
  
 14.0

--- a/WordPress/Classes/Utility/WPWebViewController.h
+++ b/WordPress/Classes/Utility/WPWebViewController.h
@@ -1,4 +1,5 @@
 #import <UIKit/UIKit.h>
+@import WebKit;
 
 @class Blog;
 @class WPAccount;
@@ -9,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - WPWebViewController
 
-@interface WPWebViewController : UIViewController<UIWebViewDelegate>
+@interface WPWebViewController : UIViewController<WKNavigationDelegate>
 
 - (instancetype)initWithConfiguration:(WebViewControllerConfiguration *)configuration;
 

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -444,6 +444,7 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
         }
         
         decisionHandler(policy.action);
+        return;
     }
 
     [self refreshInterface];

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -91,15 +91,7 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     NSAssert(_toolbarBottomConstraint, @"Missing Outlet!");
 
     // TitleView
-    self.titleView                          = [NavigationTitleView new];
-    self.titleView.titleLabel.text          = NSLocalizedString(@"Loading...", @"Loading. Verb");
-    self.titleView.subtitleLabel.text       = self.url.host;
-
-    if (self.customTitle != nil) {
-        self.title = self.customTitle;
-    } else {
-        self.navigationItem.titleView = self.titleView;
-    }
+    [self setupTitle];
 
     // Buttons
     if (!self.optionsButton) {
@@ -194,6 +186,20 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     self.authenticator.safeRedirect = true;
 }
 
+- (void)setupTitle
+{
+    self.titleView = [NavigationTitleView new];
+    
+    [self refreshTitle];
+    [self refreshSubtitle];
+
+    if (self.customTitle != nil) {
+        self.title = self.customTitle;
+    } else {
+        self.navigationItem.titleView = self.titleView;
+    }
+}
+
 - (void)setupWebView
 {
     self.webView.navigationDelegate = self;
@@ -268,7 +274,9 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
 {
     self.backButton.enabled = self.webView.canGoBack;
     self.forwardButton.enabled = self.webView.canGoForward;
-    self.titleView.titleLabel.text = self.webView.loading ? nil : [self documentTitle];
+    
+    [self refreshTitle];
+    
     self.titleView.subtitleLabel.text = self.webView.URL.host;
 
     if ([self.webView.URL.absoluteString isEqualToString:@""]) {
@@ -276,6 +284,18 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     } else {
         self.optionsButton.enabled = !self.webView.loading;
     }
+}
+
+- (void)refreshSubtitle
+{
+    self.titleView.subtitleLabel.text = self.url.host;
+}
+
+- (void)refreshTitle
+{
+    NSString *const WPWebViewLoadingTitle = NSLocalizedString(@"Loading...", @"Loading. Verb");
+    
+    self.titleView.titleLabel.text = self.webView.loading ? WPWebViewLoadingTitle : [self documentTitle];
 }
 
 - (void)showBottomToolbarIfNeeded

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -128,13 +128,9 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
         self.navigationItem.rightBarButtonItem  = self.optionsButton;
     }
     
-    // Authenticator
-    //
-    // @diegoreymendez: While testing this VC for the migration from UIWebView to WKWebView I noticed this wasn't working
-    // at all in the simulator.  I'm not sure why this is necessary, but it seems like the authenticator is failing to redirect us
-    // if this isn't set to true.  @kokejb suggested this change - unfortunately evaluating why this is necessary goes far beyond the
-    // scope of my current work.  I just want the reader to know the context behind this adition.
-    self.authenticator.safeRedirect = true;
+    // Additional Setup
+    [self setupWebView];
+    [self setupAuthenticator];
 
     // Fire away!
     [self applyModalStyleIfNeeded];
@@ -184,6 +180,23 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
 - (BOOL)expectsWidePanel
 {
     return YES;
+}
+
+#pragma mark - Setup
+
+/// While testing this VC for the migration from UIWebView to WKWebView I noticed redirects weren't working
+/// at all in the simulator.  I'm not sure why this is necessary, but it seems like the authenticator is failing to redirect us
+/// if this isn't set to true.  @kokejb suggested this change - unfortunately evaluating why this is necessary goes far beyond the
+/// scope of my current work.  I just want the reader to know the context behind this adition.
+///
+- (void)setupAuthenticator
+{
+    self.authenticator.safeRedirect = true;
+}
+
+- (void)setupWebView
+{
+    self.webView.navigationDelegate = self;
 }
 
 
@@ -417,6 +430,8 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
         [self refreshInterface];
     }
 */
+    [self refreshInterface];
+    
     decisionHandler(WKNavigationActionPolicyAllow);
 }
 

--- a/WordPress/Classes/Utility/WPWebViewController.xib
+++ b/WordPress/Classes/Utility/WPWebViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/WordPress/Classes/Utility/WPWebViewController.xib
+++ b/WordPress/Classes/Utility/WPWebViewController.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,7 +15,7 @@
                 <outlet property="toolbar" destination="AXg-oh-s2G" id="oAq-hv-8wQ"/>
                 <outlet property="toolbarBottomConstraint" destination="Nlf-af-GR4" id="ogC-wy-f35"/>
                 <outlet property="view" destination="1" id="14"/>
-                <outlet property="webView" destination="5" id="9"/>
+                <outlet property="webView" destination="IBv-yN-stu" id="MCJ-XA-unh"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -25,13 +23,14 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="436"/>
+                <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IBv-yN-stu">
+                    <rect key="frame" x="20" y="20" width="280" height="416"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <connections>
-                        <outlet property="delegate" destination="-1" id="22"/>
-                    </connections>
-                </webView>
+                    <wkWebViewConfiguration key="configuration" allowsInlineMediaPlayback="YES">
+                        <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" audio="YES" video="YES"/>
+                        <wkPreferences key="preferences"/>
+                    </wkWebViewConfiguration>
+                </wkWebView>
                 <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" translatesAutoresizingMaskIntoConstraints="NO" id="KoJ-2F-0M7" customClass="WebProgressView" customModule="WordPress" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="2.5"/>
                     <color key="progressTintColor" red="0.023529411764705882" green="0.23921568627450981" blue="0.43137254901960786" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -58,19 +57,20 @@
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="IBv-yN-stu" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="Cte-l4-V7j"/>
                 <constraint firstAttribute="trailing" secondItem="KoJ-2F-0M7" secondAttribute="trailing" id="ISH-w3-feS"/>
                 <constraint firstAttribute="bottom" secondItem="AXg-oh-s2G" secondAttribute="bottom" id="Nlf-af-GR4"/>
-                <constraint firstItem="5" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="Qem-AA-aZi"/>
+                <constraint firstItem="IBv-yN-stu" firstAttribute="top" secondItem="1" secondAttribute="top" constant="20" symbolic="YES" id="PbC-8b-MZC"/>
                 <constraint firstItem="KoJ-2F-0M7" firstAttribute="top" secondItem="1" secondAttribute="top" id="R7H-hb-JSn"/>
-                <constraint firstItem="5" firstAttribute="top" secondItem="1" secondAttribute="top" id="Rjd-Cu-o65"/>
                 <constraint firstItem="KoJ-2F-0M7" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="XPs-kd-Qp3"/>
+                <constraint firstItem="AXg-oh-s2G" firstAttribute="top" secondItem="IBv-yN-stu" secondAttribute="bottom" symbolic="YES" id="Y8P-zj-I7e"/>
                 <constraint firstAttribute="trailing" secondItem="AXg-oh-s2G" secondAttribute="trailing" id="c0p-pM-tqz"/>
-                <constraint firstItem="AXg-oh-s2G" firstAttribute="top" secondItem="5" secondAttribute="bottom" id="cW6-TV-6na"/>
+                <constraint firstAttribute="trailing" secondItem="IBv-yN-stu" secondAttribute="trailing" constant="20" symbolic="YES" id="f9S-JN-LYn"/>
                 <constraint firstItem="AXg-oh-s2G" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="hjY-y9-jer"/>
-                <constraint firstAttribute="trailing" secondItem="5" secondAttribute="trailing" id="vUg-E4-QFJ"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="129.59999999999999" y="136.73163418290855"/>
         </view>
     </objects>
 </document>

--- a/WordPress/Classes/Utility/WebViewAuthenticator.swift
+++ b/WordPress/Classes/Utility/WebViewAuthenticator.swift
@@ -26,6 +26,7 @@ class WebViewAuthenticator: NSObject {
     /// If true, the authenticator will assume that redirect URLs are allowed and
     /// won't use the special WordPress.com redirect URL
     ///
+    @objc
     var safeRedirect = false
 
     init(credentials: Credentials) {

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
@@ -1,3 +1,5 @@
+@import WebKit;
+
 #import "SharingAuthorizationWebViewController.h"
 #import "Blog.h"
 #import "WPUserAgent.h"
@@ -87,9 +89,9 @@ static NSString * const SharingAuthorizationAccessDenied = @"error=access_denied
 }
 
 
-- (void)saveHostForRequest:(NSURLRequest *)request
+- (void)saveHostFromURL:(NSURL *)url
 {
-    NSString *host = request.URL.host;
+    NSString *host = url.host;
     if (!host || [host containsString:@"wordpress"] || [self.hosts containsObject:host]) {
         return;
     }
@@ -136,10 +138,10 @@ static NSString * const SharingAuthorizationAccessDenied = @"error=access_denied
     }
 }
 
-- (AuthorizeAction)requestedAuthorizeAction:(NSURLRequest *)request
+- (AuthorizeAction)requestedAuthorizeAction:(NSURL *)url
 {
-    NSString *requested = [request.URL absoluteString];
-
+    NSString *requested = [url absoluteString];
+    
     // Path oauth declines are handled by a redirect to a path.com URL, so check this first.
     NSRange denyRange = [requested rangeOfString:SharingAuthorizationPathDecline];
     if (denyRange.location != NSNotFound) {
@@ -189,37 +191,31 @@ static NSString * const SharingAuthorizationAccessDenied = @"error=access_denied
 
 #pragma mark - WKWebViewNavigationDelegate
 
-
-
-#pragma mark - WebView Delegate Methods
-/*
-- (BOOL)webView:(UIWebView *)webView
-    shouldStartLoadWithRequest:(NSURLRequest *)request
-                navigationType:(UIWebViewNavigationType)navigationType
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
 {
     // Prevent a second verify load by someone happy clicking.
     if (self.loadingVerify) {
-        return NO;
+        decisionHandler(WKNavigationActionPolicyCancel);
     }
 
-    AuthorizeAction action = [self requestedAuthorizeAction:request];
+    AuthorizeAction action = [self requestedAuthorizeAction:webView.URL];
     switch (action) {
         case AuthorizeActionNone:
         case AuthorizeActionUnknown:
         case AuthorizeActionRequest:
-            return [super webView:webView shouldStartLoadWithRequest:request navigationType:navigationType];
+            [super webView:webView decidePolicyForNavigationAction:navigationAction decisionHandler:decisionHandler];
 
         case AuthorizeActionVerify:
             self.loadingVerify = YES;
-            return YES;
+            decisionHandler(WKNavigationActionPolicyAllow);
 
         case AuthorizeActionDeny:
             [self dismiss];
-            return NO;
+            decisionHandler(WKNavigationActionPolicyCancel);
     }
 }
 
-- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
+- (void)webView:(WKWebView *)webView didFailNavigation:(null_unspecified WKNavigation *)navigation withError:(NSError *)error
 {
     if (self.loadingVerify && error.code == NSURLErrorCancelled) {
         // Authenticating to Facebook and Twitter can return an false
@@ -227,19 +223,18 @@ static NSString * const SharingAuthorizationAccessDenied = @"error=access_denied
         [self handleAuthorizationAllowed];
         return;
     }
-    [super webView:webView didFailLoadWithError:error];
+    [super webView:webView didFailNavigation:navigation withError:error];
 }
 
-- (void)webViewDidFinishLoad:(UIWebView *)webView
+- (void)webView:(WKWebView *)webView didFinishNavigation:(null_unspecified WKNavigation *)navigation
 {
-    [self saveHostForRequest:webView.request];
+    [self saveHostFromURL:webView.URL];
 
     if (self.loadingVerify) {
         [self handleAuthorizationAllowed];
     } else {
-        [super webViewDidFinishLoad:webView];
+        [super webView:webView didFinishNavigation:navigation];
     }
 }
- */
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
@@ -199,7 +199,7 @@ static NSString * const SharingAuthorizationAccessDenied = @"error=access_denied
         return;
     }
 
-    AuthorizeAction action = [self requestedAuthorizeAction:webView.URL];
+    AuthorizeAction action = [self requestedAuthorizeAction:navigationAction.request.URL];
     switch (action) {
         case AuthorizeActionNone:
         case AuthorizeActionUnknown:

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
@@ -196,6 +196,7 @@ static NSString * const SharingAuthorizationAccessDenied = @"error=access_denied
     // Prevent a second verify load by someone happy clicking.
     if (self.loadingVerify) {
         decisionHandler(WKNavigationActionPolicyCancel);
+        return;
     }
 
     AuthorizeAction action = [self requestedAuthorizeAction:webView.URL];

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
@@ -187,6 +187,9 @@ static NSString * const SharingAuthorizationAccessDenied = @"error=access_denied
     return AuthorizeActionUnknown;
 }
 
+#pragma mark - WKWebViewNavigationDelegate
+
+
 
 #pragma mark - WebView Delegate Methods
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
@@ -205,14 +205,17 @@ static NSString * const SharingAuthorizationAccessDenied = @"error=access_denied
         case AuthorizeActionUnknown:
         case AuthorizeActionRequest:
             [super webView:webView decidePolicyForNavigationAction:navigationAction decisionHandler:decisionHandler];
+            return;
 
         case AuthorizeActionVerify:
             self.loadingVerify = YES;
             decisionHandler(WKNavigationActionPolicyAllow);
+            return;
 
         case AuthorizeActionDeny:
             [self dismiss];
             decisionHandler(WKNavigationActionPolicyCancel);
+            return;
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.m
@@ -192,7 +192,7 @@ static NSString * const SharingAuthorizationAccessDenied = @"error=access_denied
 
 
 #pragma mark - WebView Delegate Methods
-
+/*
 - (BOOL)webView:(UIWebView *)webView
     shouldStartLoadWithRequest:(NSURLRequest *)request
                 navigationType:(UIWebViewNavigationType)navigationType
@@ -240,5 +240,6 @@ static NSString * const SharingAuthorizationAccessDenied = @"error=access_denied
         [super webViewDidFinishLoad:webView];
     }
 }
+ */
 
 @end


### PR DESCRIPTION
Fixes #13356 

This PR implements sharing using `WKWebView` instead of `UIWebView`.  Unfortunately this is the easiest way to resolve the connection issues we were facing with Facebook.

All services were tested.

## To test:

Just test sharing with all the available services.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
