### PR TITLE
[Gutenberg] Bump phase 2 rollout to 100%

### DIFF
--- a/WordPress/Classes/Utility/Editor/GutenbergRollout.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergRollout.swift
@@ -5,7 +5,7 @@ struct GutenbergRollout {
         static let userInRolloutGroup = "kUserInGutenbergRolloutGroup"
     }
     let database: KeyValueDatabase
-    private let phase2Percentage = 30
+    private let phase2Percentage = 100
     private let context = Environment.current.contextManager.mainContext
 
     var isUserInRolloutGroup: Bool {

--- a/WordPress/WordPressUITests/Screens/BaseScreen.swift
+++ b/WordPress/WordPressUITests/Screens/BaseScreen.swift
@@ -102,6 +102,19 @@ class BaseScreen {
     func pop() {
         navBackButton.tap()
     }
+
+    @discardableResult
+    func dismissNotificationAlertIfNeeded(_ action: FancyAlertComponent.Action = .cancel) -> Self {
+        if FancyAlertComponent.isLoaded() {
+            switch action {
+            case .accept:
+                FancyAlertComponent().acceptAlert()
+            case .cancel:
+                FancyAlertComponent().cancelAlert()
+            }
+        }
+        return self
+    }
 }
 
 private extension XCUIElement {

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -11,7 +11,7 @@ class BlockEditorScreen: BaseScreen {
 
     // Editor area
     // Title
-    let titleView = XCUIApplication().textViews.containing(.staticText, identifier: "Add title").element(boundBy: 0) // Uses a localized string
+    let titleView = XCUIApplication().otherElements["Post title. Empty"].firstMatch // Uses a localized string
     // Paragraph block
     let paragraphView = XCUIApplication().otherElements["Paragraph Block. Row 1. Empty"].textViews.element(boundBy: 0)
     // Image block

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -141,12 +141,6 @@ class BlockEditorScreen: BaseScreen {
         }
     }
 
-    func dismissBlockEditorEnabledDialog() {
-        if FancyAlertComponent.isLoaded() {
-            FancyAlertComponent().acceptAlert()
-        }
-    }
-
     static func isLoaded() -> Bool {
         return XCUIApplication().navigationBars["Gutenberg Editor Navigation Bar"].buttons["Close"].exists
     }

--- a/WordPress/WordPressUITests/Screens/FancyAlertComponent.swift
+++ b/WordPress/WordPressUITests/Screens/FancyAlertComponent.swift
@@ -5,6 +5,11 @@ class FancyAlertComponent: BaseScreen {
     let defaultAlertButton: XCUIElement
     let cancelAlertButton: XCUIElement
 
+    enum Action {
+        case accept
+        case cancel
+    }
+
     struct ElementIDs {
         static let defaultButton = "fancy-alert-view-default-button"
         static let cancelButton = "fancy-alert-view-cancel-button"

--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -41,13 +41,6 @@ class MySiteScreen: BaseScreen {
         super.init(element: blogTable)
     }
 
-    func dismissNotificationAlertIfNeeded() -> MySiteScreen {
-        if FancyAlertComponent.isLoaded() {
-            FancyAlertComponent().cancelAlert()
-        }
-        return self
-    }
-
     func showSiteSwitcher() -> MySitesScreen {
         navBackButton.tap()
         return MySitesScreen()

--- a/WordPress/WordPressUITests/Screens/PostsScreen.swift
+++ b/WordPress/WordPressUITests/Screens/PostsScreen.swift
@@ -88,7 +88,7 @@ struct EditorScreen {
 
     func dismissDialogsIfNeeded() {
         if self.isGutenbergEditor {
-            blockEditor.dismissBlockEditorEnabledDialog()
+            blockEditor.dismissNotificationAlertIfNeeded(.accept)
         }
     }
 

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -25,6 +25,7 @@ class EditorGutenbergTests: XCTestCase {
         let title = getRandomPhrase()
         let content = getRandomContent()
         editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
             .publish()
@@ -39,6 +40,7 @@ class EditorGutenbergTests: XCTestCase {
         let category = getCategory()
         let tag = getTag()
         editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
             .addImage()


### PR DESCRIPTION
WPiOS side of https://github.com/wordpress-mobile/WordPress-Android/pull/11240

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/12888

This PR bumps the gutenberg rollout to 100% of users.

**Note:** this targets 14.1, we were waiting for 14.0 feedback before making that changes.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
