### PR TITLE
Fixes an issue where comments made in the Reader may not appear after adding successfully

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Media editing: You can now crop, zoom in/out and rotate images that are inserted or being inserted in a post.
 * Post Preview: Added a new Desktop preview mode on iPhone and Mobile preview on iPad when previewing posts or pages.
 * Post Preview: Added new navigation, "Open in Safari" and Share options when previewing posts or pages.
+* Reader: Fixed an issue where a new comment may not appear
 
 14.1
 -----

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -417,6 +417,11 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     // post and content provided.
     Comment *comment = [self createHierarchicalCommentWithContent:content withParent:nil postID:post.postID siteID:post.siteID];
     BOOL isPrivateSite = post.isPrivate;
+    
+    // This fixes an issue where the comment may not appear for some posts after a successful posting
+    // More information: https://github.com/wordpress-mobile/WordPress-iOS/issues/13259
+    comment.post = post;
+
     NSManagedObjectID *commentID = comment.objectID;
     void (^successBlock)(RemoteComment *remoteComment) = ^void(RemoteComment *remoteComment) {
         [self.managedObjectContext performBlock:^{
@@ -466,6 +471,11 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     // post and content provided.
     Comment *comment = [self createHierarchicalCommentWithContent:content withParent:commentID postID:post.postID siteID:post.siteID];
     BOOL isPrivateSite = post.isPrivate;
+    
+    // This fixes an issue where the comment may not appear for some posts after a successful posting
+    // More information: https://github.com/wordpress-mobile/WordPress-iOS/issues/13259
+    comment.post = post;
+
     NSManagedObjectID *commentObjectID = comment.objectID;
     void (^successBlock)(RemoteComment *remoteComment) = ^void(RemoteComment *remoteComment) {
         // Update and save the comment

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1278,7 +1278,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         guard let post = self.post else {
             return
         }
-        
+
         ReaderCommentAction().execute(post: post, origin: self)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -36,6 +36,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     fileprivate struct DetailConstants {
         static let LikeCountKeyPath = "likeCount"
+        static let CommentCountKeyPath = "commentCount"
         static let MarginOffset = CGFloat(8.0)
     }
 
@@ -131,12 +132,14 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     @objc open var post: ReaderPost? {
         didSet {
             oldValue?.removeObserver(self, forKeyPath: DetailConstants.LikeCountKeyPath)
+            oldValue?.removeObserver(self, forKeyPath: DetailConstants.CommentCountKeyPath)
             oldValue?.inUse = false
 
             if let newPost = post, let context = newPost.managedObjectContext {
                 newPost.inUse = true
                 ContextManager.sharedInstance().save(context)
                 newPost.addObserver(self, forKeyPath: DetailConstants.LikeCountKeyPath, options: .new, context: nil)
+                newPost.addObserver(self, forKeyPath: DetailConstants.CommentCountKeyPath, options: .new, context: nil)
             }
             if isViewLoaded {
                 configureView()
@@ -238,6 +241,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             post.inUse = false
             ContextManager.sharedInstance().save(context)
             post.removeObserver(self, forKeyPath: DetailConstants.LikeCountKeyPath)
+            post.removeObserver(self, forKeyPath: DetailConstants.CommentCountKeyPath)
         }
         NotificationCenter.default.removeObserver(self)
     }
@@ -359,13 +363,27 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         }
     }
 
-
     open override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
-        if (object! as! NSObject == post!) && (keyPath! == DetailConstants.LikeCountKeyPath) {
+        guard
+            let object = object as? NSObject,
+            let keyPath = keyPath
+        else {
+            return
+        }
+
+        if object != post {
+            return
+        }
+
+        if keyPath == DetailConstants.LikeCountKeyPath {
             // Note: The intent here is to update the action buttons, specifically the
             // like button, *after* both likeCount and isLiked has changed. The order
             // of the properties is important.
             configureLikeActionButton(true)
+        }
+
+        else if keyPath == DetailConstants.CommentCountKeyPath {
+            configureCommentActionButton()
         }
     }
 
@@ -1257,8 +1275,11 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             return
         }
 
-        let controller = ReaderCommentsViewController(post: post)
-        navigationController?.pushViewController(controller!, animated: true)
+        guard let post = self.post else {
+            return
+        }
+        
+        ReaderCommentAction().execute(post: post, origin: self)
     }
 
 


### PR DESCRIPTION
Fixes #13259 

**Description**
You can read more about the source of this issue here: https://github.com/wordpress-mobile/WordPress-iOS/issues/13259#issuecomment-582589196

Since when adding a new comment there is a chance the post it's added to is the wrong post until a network sync, this PR will reassign the Comment's post property to the originating Post object. 

This allows it to appear after being added. 

**To test:**
1. Tap the Reader Tab
2. Tap Followed Sites
3. Locate a Post and tap the name of the site
4. Tap the post to open the post detail
5. Tap the comment icon 
6. Leave a Comment

**Video Demos**

| Device | Version | Link |
|---|---|---|
| iPhone 8 | 11.4 | https://d.pr/i/0tu82q |
| iPhone 8 | 12.4 | https://d.pr/i/Yj6yxw |
| iPhone 8 | 13.3 | https://d.pr/i/w8AMXT |
|---|---|---|
| iPhone 11 Pro Max | 13.3 | https://d.pr/i/fx9Naw |
|---|---|---|
| iPad Air | 11.4 | https://d.pr/i/BN6QPc |
| iPad Air (3rd Gen) | 12.4 | https://d.pr/i/a9CjDQ |
| iPad Air (3rd Gen) | 13.3 | https://d.pr/i/wjFRYc |

**PR submission checklist:**

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
