### PR TITLE
Displays offline messages only when the user is offline

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -30,6 +30,8 @@ class PostCardStatusViewModel: NSObject {
 
     private let autoUploadInteractor = PostAutoUploadInteractor()
 
+    private let isInternetReachable: Bool
+
     var progressBlock: ((Float) -> Void)? = nil {
         didSet {
             if let _ = oldValue, let uuid = progressObserverUUID {
@@ -46,8 +48,9 @@ class PostCardStatusViewModel: NSObject {
         }
     }
 
-    init(post: Post) {
+    init(post: Post, isInternetReachable: Bool = ReachabilityUtils.isInternetReachable()) {
         self.post = post
+        self.isInternetReachable = isInternetReachable
         super.init()
     }
 
@@ -89,6 +92,10 @@ class PostCardStatusViewModel: NSObject {
 
         if MediaCoordinator.shared.isUploadingMedia(for: post) || post.remoteStatus == .pushing {
             return .neutral(.shade30)
+        }
+
+        if post.isFailed && isInternetReachable {
+            return .error
         }
 
         if post.isRevision() {
@@ -235,6 +242,10 @@ class PostCardStatusViewModel: NSObject {
 
         if post.wasAutoUploadCancelled {
             return post.hasPermanentFailedMedia() ? PostAutoUploadMessages.failedMedia : StatusMessages.localChanges
+        }
+
+        if post.isFailed && isInternetReachable {
+            return defaultFailedMessage
         }
 
         if let autoUploadMessage = PostAutoUploadMessages.attemptFailures(for: post, withState: autoUploadInteractor.autoUploadAttemptState(of: post)) {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -159,7 +159,11 @@ class PostCardStatusViewModel: NSObject {
                 buttons.append(.retry)
             }
 
-            if canCancelAutoUpload {
+            if post.isFailed && isInternetReachable {
+                buttons.append(.retry)
+            }
+
+            if canCancelAutoUpload && !isInternetReachable {
                 buttons.append(.cancelAutoUpload)
             }
 

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -8,10 +8,12 @@ struct PostNoticeViewModel {
     private let post: AbstractPost
     private let postCoordinator: PostCoordinator
     private let autoUploadInteractor = PostAutoUploadInteractor()
+    private let isInternetReachable: Bool
 
-    init(post: AbstractPost, postCoordinator: PostCoordinator = PostCoordinator.shared) {
+    init(post: AbstractPost, postCoordinator: PostCoordinator = PostCoordinator.shared, isInternetReachable: Bool = ReachabilityUtils.isInternetReachable()) {
         self.post = post
         self.postCoordinator = postCoordinator
+        self.isInternetReachable = isInternetReachable
     }
 
     /// Returns the Notice represented by this view model.
@@ -111,6 +113,10 @@ struct PostNoticeViewModel {
             } else {
                 return PostAutoUploadMessages.postFailedToUpload
             }
+        }
+
+        guard !isInternetReachable else {
+            return defaultTitle
         }
 
         if let autoUploadMessage = PostAutoUploadMessages.attemptFailures(for: post, withState: autoUploadInteractor.autoUploadAttemptState(of: post)) {
@@ -221,7 +227,7 @@ struct PostNoticeViewModel {
     }
 
     private var failureAction: FailureAction {
-        return autoUploadInteractor.canCancelAutoUpload(of: post) ? .cancel : .retry
+        return autoUploadInteractor.canCancelAutoUpload(of: post) && !isInternetReachable ? .cancel : .retry
     }
 
     // MARK: - Action Handlers

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -28,6 +28,7 @@ class PostNoticeViewModelTests: XCTestCase {
         struct Expectation {
             let scenario: String
             let post: Post
+            let isInternetReachable: Bool
             let title: String
             let actionTitle: String
         }
@@ -37,68 +38,85 @@ class PostNoticeViewModelTests: XCTestCase {
             Expectation(
                 scenario: "Local draft",
                 post: createPost(.draft),
+                isInternetReachable: false,
                 title: PostAutoUploadMessages.draftWillBeUploaded,
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
                 scenario: "Draft with confirmed local changes",
                 post: createPost(.draft, hasRemote: true),
+                isInternetReachable: false,
                 title: PostAutoUploadMessages.draftWillBeUploaded,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Local published draft",
                 post: createPost(.publish),
+                isInternetReachable: false,
                 title: PostAutoUploadMessages.postWillBePublished,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Published post with confirmed local changes",
                 post: createPost(.publish, hasRemote: true),
+                isInternetReachable: false,
                 title: PostAutoUploadMessages.postWillBePublished,
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Locally scheduled post",
                 post: createPost(.scheduled),
+                isInternetReachable: false,
                 title: i18n("We'll schedule your post when your device is back online."),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Scheduled post with confirmed local changes",
                 post: createPost(.scheduled, hasRemote: true),
+                isInternetReachable: false,
                 title: i18n("We'll schedule your post when your device is back online."),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Post with at least 1 auto upload to publish attempt",
                 post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 2),
+                isInternetReachable: false,
                 title: i18n("We couldn't publish this post, but we'll try again later."),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Post with the maximum number of auto upload to publish attempts",
                 post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 3),
+                isInternetReachable: false,
                 title: i18n("We couldn't complete this action, and didn't publish this post."),
                 actionTitle: FailureActionTitles.retry
             ),
             Expectation(
                 scenario: "Draft with at least 1 auto upload attempt",
                 post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 2),
+                isInternetReachable: false,
                 title: i18n("We couldn't complete this action, but we'll try again later."),
                 actionTitle: FailureActionTitles.cancel
             ),
             Expectation(
                 scenario: "Draft with the maximum number of auto upload attempts",
                 post: createPost(.draft, hasRemote: true, autoUploadAttemptsCount: 3),
+                isInternetReachable: false,
                 title: i18n("We couldn't complete this action."),
                 actionTitle: FailureActionTitles.retry
             ),
+            Expectation(
+                scenario: "Draft with at least 1 auto upload attempt",
+                post: createPost(.publish, hasRemote: true, autoUploadAttemptsCount: 2),
+                isInternetReachable: true,
+                title: i18n("Post failed to upload"),
+                actionTitle: FailureActionTitles.retry
+            )
         ]
 
         expectations.forEach { expectation in
             // Act
-            let notice = PostNoticeViewModel(post: expectation.post).notice
+            let notice = PostNoticeViewModel(post: expectation.post, isInternetReachable: expectation.isInternetReachable).notice
 
             // Assert
             expect({

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -74,7 +74,7 @@ class PostCardStatusViewModelTests: XCTestCase {
 
         // Act and Assert
         expectations.forEach { scenario, post, expectedButtonGroups in
-            let viewModel = PostCardStatusViewModel(post: post)
+            let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: false)
 
             expect({
                 guard viewModel.buttonGroups == expectedButtonGroups else {

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -89,6 +89,28 @@ class PostCardStatusViewModelTests: XCTestCase {
             }).to(succeed())
         }
     }
+
+    /// If the post fails to upload and there is internet connectivity, show "Upload failed" message
+    ///
+    func testReturnFailedMessageIfPostFailedAndThereIsConnectivity() {
+        let post = PostBuilder(context).revision().with(remoteStatus: .failed).confirmedAutoUpload().build()
+
+        let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: true)
+
+        expect(viewModel.status).to(equal(i18n("Upload failed")))
+        expect(viewModel.statusColor).to(equal(.error))
+    }
+
+    /// If the post fails to upload and there is NO internet connectivity, show a message that we'll publish when the user is back online
+    ///
+    func testReturnWillUploadLaterMessageIfPostFailedAndThereIsConnectivity() {
+        let post = PostBuilder(context).revision().with(remoteStatus: .failed).confirmedAutoUpload().build()
+
+        let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: false)
+
+        expect(viewModel.status).to(equal(i18n("We'll publish the post when your device is back online.")))
+        expect(viewModel.statusColor).to(equal(.warning))
+    }
 }
 
 private extension ButtonGroups {


### PR DESCRIPTION
Fixes #13280

# To test

You can test this in two different ways:

1. By having a self-hosted website that is disabled added in your app;
2. Or by intercepting the result (like using Charles proxy) and returning an error;

### When Offline

1. Create a new post
2. Publish it
3. Check that the message states that your post will be published later when you're online

### When Online

1. Crate a new post
2. Publish it (the publish action should fail in the server)
3. Check that the app shows a "Failed to upload" message

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
