### PR TITLE
Fix media library pick while offline

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -365,7 +365,9 @@ class AztecPostViewController: UIViewController, PostEditor {
     /// Media Library Data Source
     ///
     lazy var mediaLibraryDataSource: MediaLibraryPickerDataSource = {
-        return MediaLibraryPickerDataSource(post: self.post)
+        let dataSource = MediaLibraryPickerDataSource(post: self.post)
+        dataSource.ignoreSyncErrors = true
+        return dataSource
     }()
 
     /// Device Photo Library Data Source

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -20,7 +20,9 @@ class GutenbergMediaPickerHelper: NSObject {
     /// Media Library Data Source
     ///
     fileprivate lazy var mediaLibraryDataSource: MediaLibraryPickerDataSource = {
-        return MediaLibraryPickerDataSource(post: self.post)
+        let dataSource = MediaLibraryPickerDataSource(post: self.post)
+        dataSource.ignoreSyncErrors = true
+        return dataSource
     }()
 
     /// Device Photo Library Data Source

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -16,6 +16,8 @@ class GutenbergMediaPickerHelper: NSObject {
 
     fileprivate let post: AbstractPost
     fileprivate unowned let context: UIViewController
+    fileprivate unowned var navigationPicker: WPNavigationMediaPickerViewController?
+    fileprivate let noResultsView = NoResultsViewController.controller()
 
     /// Media Library Data Source
     ///
@@ -57,7 +59,7 @@ class GutenbergMediaPickerHelper: NSObject {
         didPickMediaCallback = callback
 
         let picker = WPNavigationMediaPickerViewController()
-
+        navigationPicker = picker
         switch dataSourceType {
         case .device:
             picker.dataSource = devicePhotoLibraryDataSource
@@ -129,6 +131,31 @@ extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
 
         return nil
     }
+
+    func emptyViewController(forMediaPickerController picker: WPMediaPickerViewController) -> UIViewController? {
+        guard picker == navigationPicker?.mediaPicker else {
+            return nil
+        }
+        return noResultsView
+    }
+
+    func mediaPickerController(_ picker: WPMediaPickerViewController, didUpdateSearchWithAssetCount assetCount: Int) {
+        if (mediaLibraryDataSource.searchQuery?.count ?? 0) > 0 {
+            noResultsView.configureForNoSearchResult()
+        } else {
+            noResultsView.removeFromView()
+        }
+    }
+
+    func mediaPickerControllerWillBeginLoadingData(_ picker: WPMediaPickerViewController) {
+        noResultsView.configureForFetching()
+    }
+
+    func mediaPickerControllerDidEndLoadingData(_ picker: WPMediaPickerViewController) {
+        noResultsView.removeFromView()
+        noResultsView.configureForNoAssets(userCanUploadMedia: false)
+    }
+    
 }
 
 // MARK: - Media Editing

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -155,7 +155,7 @@ extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
         noResultsView.removeFromView()
         noResultsView.configureForNoAssets(userCanUploadMedia: false)
     }
-    
+
 }
 
 // MARK: - Media Editing

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.h
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.h
@@ -8,7 +8,7 @@
 
 @interface MediaLibraryGroup: NSObject <WPMediaGroup>
 
-- (instancetype)initWithBlog:(Blog *)blog;
+- (nonnull instancetype)initWithBlog:(Blog *_Nonnull)blog;
 
 @property (nonatomic, assign) WPMediaType filter;
 
@@ -16,14 +16,14 @@
 
 @interface MediaLibraryPickerDataSource : NSObject <WPMediaCollectionDataSource>
 
-- (instancetype)initWithBlog:(Blog *)blog;
+- (nonnull instancetype)initWithBlog:(Blog *_Nonnull)blog;
 
-- (instancetype)initWithPost:(AbstractPost *)post;
+- (nonnull instancetype)initWithPost:(AbstractPost *_Nonnull)post;
 
 /// If a search query is set, the media assets fetched by the data source
 /// will be filtered to only those whose name, caption, or description
 /// contain the search query.
-@property (nonatomic, copy) NSString *searchQuery;
+@property (nonatomic, copy, nullable) NSString *searchQuery;
 
 /// Defaults to `NO`.
 /// By default, the data source will only show media that has been synced to the

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -146,7 +146,7 @@
                                    successBlock();
                                }
                            } failure:^(NSError * _Nonnull error) {
-                               if (ignoreSyncError && successBlock) {
+                               if (localResultsAvailable && ignoreSyncError && successBlock) {
                                    successBlock();
                                    return;
                                }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -146,7 +146,7 @@
                                    successBlock();
                                }
                            } failure:^(NSError * _Nonnull error) {
-                               if (localResultsAvailable && ignoreSyncError && successBlock) {
+                               if (ignoreSyncError && successBlock) {
                                    successBlock();
                                    return;
                                }


### PR DESCRIPTION
Fixes #11426 

To test:
 - Start the app
 - Select a site where you opened the site Media Library before
 - Start a new post ( test with GB and Aztec)
 - Go offline
 - Tap on add media 
 - Select the option to pick from the site MEdia Library
 - Check if you are able to pick a cached media object and insert on the post

 - Start the app
 - Select a site where you **never** open the site Media Library on the device
 - Start a new post ( test with GB and Aztec)
 - Go offline
 - Tap on add media 
 - Select the option to pick from the site MEdia Library
 - Check that you see an alert that says that you are unable to sync with the server

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
