### PR TITLE
Add dummy GitHub workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,12 @@
+name: Danger
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+jobs:
+  danger_issue_label_check:
+    name: "Check Labels"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Hello World"
+        run: echo 'Hello World 👋'
+


### PR DESCRIPTION
First step to implement https://github.com/wordpress-mobile/WordPress-iOS/issues/13366.

The idea is to start with something simple, that is commenting on issues that don't have a label, replicating [this Peril config](https://github.com/mokagio/peril-settings/blob/7a7d11f69351d446b8e3a50d9e14a7fdf43a21e4/peril-settings.json#L17-L19).

To test this, I'll be creating and editing issues on this repo (see #1).