### PR TITLE
[Gutenberg] Support Multiple uploads in Gallery

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergStockPhotos.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergStockPhotos.swift
@@ -25,7 +25,7 @@ class GutenbergStockPhotos {
 }
 
 extension GutenbergStockPhotos: StockPhotosPickerDelegate {
-    
+
     func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia]) {
         defer {
             mediaPickerCallback = nil
@@ -38,13 +38,9 @@ extension GutenbergStockPhotos: StockPhotosPickerDelegate {
 
         // For blocks that support multiple uploads this will upload all images.
         // If multiple uploads are not supported then it will seperate them out to Image Blocks.
-        if (multipleSelection) {
-            insertOnBlock(with: assets)
-        } else {
-            insertSingleImages(assets)
-        }
+        multipleSelection ? insertOnBlock(with: assets) : insertSingleImages(assets)
     }
-    
+
     /// Adds the given image object to the requesting block and seperates multiple images to seperate image blocks
     /// - Parameter asset: Stock Media object to add.
     func insertSingleImages(_ assets: [StockPhotosMedia]) {
@@ -63,7 +59,7 @@ extension GutenbergStockPhotos: StockPhotosPickerDelegate {
         guard let callback = mediaPickerCallback else {
             return assertionFailure("Image picked without callback")
         }
-        
+
         let mediaInfo = assets.compactMap({ (asset) -> MediaInfo? in
             guard let media = self.mediaInserter.insert(exportableAsset: asset, source: .giphy) else {
                 return nil
@@ -71,7 +67,7 @@ extension GutenbergStockPhotos: StockPhotosPickerDelegate {
             let mediaUploadID = media.gutenbergUploadID
             return MediaInfo(id: mediaUploadID, url: asset.URL.absoluteString, type: media.mediaTypeString)
         })
-        
+
         callback(mediaInfo)
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergStockPhotos.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergStockPhotos.swift
@@ -5,6 +5,7 @@ class GutenbergStockPhotos {
     private var mediaPickerCallback: MediaPickerDidPickMediaCallback?
     private let mediaInserter: GutenbergMediaInserterHelper
     private unowned var gutenberg: Gutenberg
+    private var multipleSelection = false
 
     init(gutenberg: Gutenberg, mediaInserter: GutenbergMediaInserterHelper) {
         self.mediaInserter = mediaInserter
@@ -19,10 +20,12 @@ class GutenbergStockPhotos {
         picker.delegate = self
         mediaPickerCallback = callback
         picker.presentPicker(origin: origin, blog: post.blog)
+        self.multipleSelection = multipleSelection
     }
 }
 
 extension GutenbergStockPhotos: StockPhotosPickerDelegate {
+    
     func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia]) {
         defer {
             mediaPickerCallback = nil
@@ -33,30 +36,44 @@ extension GutenbergStockPhotos: StockPhotosPickerDelegate {
             return
         }
 
+        // For blocks that support multiple uploads this will upload all images.
+        // If multiple uploads are not supported then it will seperate them out to Image Blocks.
+        if (multipleSelection) {
+            insertOnBlock(with: assets)
+        } else {
+            insertSingleImages(assets)
+        }
+    }
+    
+    /// Adds the given image object to the requesting block and seperates multiple images to seperate image blocks
+    /// - Parameter asset: Stock Media object to add.
+    func insertSingleImages(_ assets: [StockPhotosMedia]) {
         // Append the first item via callback given by Gutenberg.
         if let firstItem = assets.first {
-            insertOnBlock(with: firstItem)
+            insertOnBlock(with: [firstItem])
         }
         // Append the rest of images via `.appendMedia` event.
         // Ideally we would send all picked images via the given callback, but that seems to not be possible yet.
         appendOnNewBlocks(assets: assets.dropFirst())
     }
 
-    /// Adds the given image object to the requesting Image Block
-    /// - Parameter asset: Stock Media object to add.
-    func insertOnBlock(with asset: StockPhotosMedia) {
+    /// Adds the given images  to the requesting block
+    /// - Parameter assets: Stock Media objects to add.
+    func insertOnBlock(with assets: [StockPhotosMedia]) {
         guard let callback = mediaPickerCallback else {
             return assertionFailure("Image picked without callback")
         }
-
-        guard let media = self.mediaInserter.insert(exportableAsset: asset, source: .giphy) else {
-            callback([])
-            return
-        }
-        let mediaUploadID = media.gutenbergUploadID
-        callback([MediaInfo(id: mediaUploadID, url: asset.URL.absoluteString, type: media.mediaTypeString)])
+        
+        let mediaInfo = assets.compactMap({ (asset) -> MediaInfo? in
+            guard let media = self.mediaInserter.insert(exportableAsset: asset, source: .giphy) else {
+                return nil
+            }
+            let mediaUploadID = media.gutenbergUploadID
+            return MediaInfo(id: mediaUploadID, url: asset.URL.absoluteString, type: media.mediaTypeString)
+        })
+        
+        callback(mediaInfo)
     }
-
 
     /// Create a new image block for each of the image objects in the slice.
     /// - Parameter assets: Stock Media objects to append.


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1863

## To Test:

### Gallary Block:
1. Add a Gallary Block.
2. Open the Free Photo Library.
3. Choose one (or many) images.
4. Select add
**_Expect:_** All images should be added to the Gallery Block in the selected order

### Image Block:
1. Add an Image block.
2. Open the Free Photo Library.
3. Choose one (or many) images.
4. Select add

**_Expect:_** All images should be added as separate Image Blocks

###  Media & Text:
1. Add a Media & Text Block.
2. Open the Free Photo Library.
3. Choose one (or many) images.
4. Select add

**_Expect:_** The first image should be added to the Media block and the rest of the images should be added as separate Image Blocks

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
