### PR TITLE
Quick Actions: Add Drop Target API for iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Detail Header/NewBlogDetailHeaderView.swift
@@ -46,6 +46,8 @@ class NewBlogDetailHeaderView: UIView {
             let title = blogName != nil && blogName?.isEmpty == false ? blogName : blog?.displayURL as String?
             titleLabel.text = title
             subtitleLabel.text = blog?.displayURL as String?
+
+            siteIconView.allowsDropInteraction = delegate?.siteIconShouldAllowDroppedImages() == true
         }
     }
 
@@ -73,8 +75,12 @@ class NewBlogDetailHeaderView: UIView {
 
         self.init(frame: .zero)
 
-        siteIconView.callback = { [weak self] in
+        siteIconView.tapped = { [weak self] in
             self?.delegate?.siteIconTapped()
+        }
+
+        siteIconView.dropped = { [weak self] images in
+            self?.delegate?.siteIconReceivedDroppedImage(images.first)
         }
 
         let buttonsStackView = ActionRow(items: items)


### PR DESCRIPTION
#13318 

This adds support for the drag and drop API to the new Blog Detail Header view with quick actions. This mirrors the current version in the existing Blog Detail Header.

![DropTarget](https://user-images.githubusercontent.com/3250/74172422-76c25100-4bed-11ea-9e95-e7ece45cfaf7.gif)

To test:

- Drag and drop an image onto the Site Icon view
- Make sure site icon is updated

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
