### PR TITLE
Quick Actions: Add spotlight for Quick Start tour

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -9,6 +9,7 @@ extension BlogDetailsViewController {
             guard self?.blog.managedObjectContext != nil else {
                 return
             }
+            self?.refreshSiteIcon()
             self?.configureTableViewData()
             self?.reloadTableViewPreservingSelection()
             if let index = QuickStartTourGuide.find()?.currentElementInt(),

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -120,5 +120,6 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
 - (void)showPageList;
 - (void)showMediaLibrary;
 - (void)showStats;
+- (void)refreshSiteIcon;
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1057,6 +1057,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAnalytics track:WPAnalyticsStatSiteSettingsSiteIconRemoved];
 }
 
+- (void)refreshSiteIcon {
+    [self.headerView refreshIconImage];
+}
+
 - (void)updateBlogIconWithMedia:(Media *)media
 {
     self.blog.settings.iconMediaID = media.mediaID;

--- a/WordPress/Classes/ViewRelated/Blog/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Detail Header/NewBlogDetailHeaderView.swift
@@ -59,7 +59,7 @@ class NewBlogDetailHeaderView: UIView {
             siteIconView.imageView.image = UIImage.siteIconPlaceholder
         }
 
-        //TODO: Refresh spotlight view
+        siteIconView.spotlightIsShown = QuickStartTourGuide.find()?.isCurrentElement(.siteIcon) == true
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Blog/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Detail Header/NewBlogDetailHeaderView.swift
@@ -76,6 +76,9 @@ class NewBlogDetailHeaderView: UIView {
         self.init(frame: .zero)
 
         siteIconView.tapped = { [weak self] in
+            QuickStartTourGuide.find()?.visited(.siteIcon)
+            self?.siteIconView.spotlightIsShown = false
+
             self?.delegate?.siteIconTapped()
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/Detail Header/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Detail Header/SiteIconView.swift
@@ -5,17 +5,21 @@ class SiteIconView: UIView {
         static let borderRadius: CGFloat = 4
         static let imageRadius: CGFloat = 2
         static let imagePadding: CGFloat = 4
+        static let spotlightOffset: CGFloat = -8
     }
 
-    private let button: UIButton = {
-        let button = UIButton(frame: .zero)
-        button.backgroundColor = UIColor.secondaryButtonBackground
-        button.clipsToBounds = true
-        button.layer.borderColor = UIColor.secondaryButtonBorder.cgColor
-        button.layer.borderWidth = 1
-        button.layer.cornerRadius = Constants.borderRadius
-        return button
-    }()
+    /// Whether or not to show the spotlight animation to illustrate tapping the icon.
+    var spotlightIsShown: Bool = true {
+        didSet {
+            spotlightView.isHidden = !spotlightIsShown
+        }
+    }
+
+    /// A block to be called when the image button is tapped.
+    var tapped: (() -> Void)?
+
+    /// A block to be called when an image is dropped on to the view.
+    var dropped: (([UIImage]) -> Void)?
 
     let imageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
@@ -35,10 +39,25 @@ class SiteIconView: UIView {
         return indicatorView
     }()
 
-    var tapped: (() -> Void)?
-    var dropped: (([UIImage]) -> Void)?
-
     private var dropInteraction: UIDropInteraction?
+
+    private let button: UIButton = {
+        let button = UIButton(frame: .zero)
+        button.backgroundColor = UIColor.secondaryButtonBackground
+        button.clipsToBounds = true
+        button.layer.borderColor = UIColor.secondaryButtonBorder.cgColor
+        button.layer.borderWidth = 1
+        button.layer.cornerRadius = Constants.borderRadius
+        return button
+    }()
+
+    private let spotlightView: UIView = {
+        let spotlightView = QuickStartSpotlightView()
+        spotlightView.translatesAutoresizingMaskIntoConstraints = false
+
+        spotlightView.isHidden = true
+        return spotlightView
+    }()
 
     var allowsDropInteraction: Bool = false {
         didSet {
@@ -68,6 +87,14 @@ class SiteIconView: UIView {
         button.pinSubviewAtCenter(activityIndicator)
 
         addSubview(button)
+
+        addSubview(spotlightView)
+
+        NSLayoutConstraint.activate([
+            trailingAnchor.constraint(equalTo: spotlightView.trailingAnchor, constant: Constants.spotlightOffset),
+            bottomAnchor.constraint(equalTo: spotlightView.bottomAnchor, constant: Constants.spotlightOffset)
+        ])
+
         pinSubviewToAllEdges(button)
     }
 


### PR DESCRIPTION
https://github.com/wordpress-mobile/WordPress-iOS/issues/13318

This adds the Spotlight view to the new blog detail header's site icon during the Quick Start tour.

## New Animation

![QuickActionsTourAnimation](https://user-images.githubusercontent.com/3250/74201034-bdcc3880-4c25-11ea-84b9-a082c39855ff.gif)

## Old Animation

![OldDetailHeaderTourAnimation](https://user-images.githubusercontent.com/3250/74201044-c290ec80-4c25-11ea-9dda-9ede8ae5a121.gif)

To test:

- Create a new site
- Check that the Quick Start tour animation is displayed for the site icon on the blog detail page

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Not yet released.
