### PR TITLE
Fixes missing navigation title for a blog on resume

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -339,6 +339,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self animateDeselectionInteractively];
         self.restorableSelectedIndexPath = nil;
     }
+    
+    self.navigationItem.title = self.blog.settings.name;
 
     [self.headerView setBlog:self.blog];
 


### PR DESCRIPTION
Navigation Title should be filled out the same way it was when navigating from My Sites. Instead, resuming the app does not fill out the navigation title.

| Before | After |
|--|--|
| <a href="https://user-images.githubusercontent.com/3250/74261899-2d3f3800-4cb9-11ea-96ef-b8951fc9cee7.png"><img src="https://user-images.githubusercontent.com/3250/74261899-2d3f3800-4cb9-11ea-96ef-b8951fc9cee7.png" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/74262149-94f58300-4cb9-11ea-99a0-e24c80e9401e.png"><img src="https://user-images.githubusercontent.com/3250/74262149-94f58300-4cb9-11ea-99a0-e24c80e9401e.png" width="300"></a> |


To test:

1. Open Site from My Sites section
2. Background and then kill the app
3. Reopen the app (should return to the Site Details screen)
4. Navigation Title is empty

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ This seems pretty minor. Not sure what the threshold is for Release Notes.

