### PR TITLE
Fix reblog for private sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -905,7 +905,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             }
         }
         // Show reblog only if logged in
-        if ReaderHelpers.isLoggedIn() {
+        if ReaderHelpers.isLoggedIn(), !post.isPrivate() {
             configureReblogButton()
         }
         configureSaveForLaterButton()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -497,7 +497,8 @@ import Gridicons
     fileprivate var shouldShowReblogActionButton: Bool {
         // reblog button is hidden if there's no content
         guard FeatureFlag.postReblogging.enabled,
-            contentProvider != nil,
+            let provider = contentProvider,
+            !provider.isPrivate(),
             loggedInActionVisibility.isEnabled else {
             return false
         }


### PR DESCRIPTION
Fixes #13418 

#### Reblog button has been removed from private sites

To test:

- run the app
- make sure you have one or more private site(s) in the list of `Followed Sites` in the `Reader`
- Go to the `Reader -> Followed Sites -> Manage` and select any of the private sites
- Verify that the `reblog` button does not appear
- Enter any post detail from the post list
- Verify that the `reblog` button does not appear

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
