### PR TITLE
Set up GitHub workflows to run basic checks and validate PR labels via Danger

### DIFF
--- a/.github/workflows/danger-pr-labels.yml
+++ b/.github/workflows/danger-pr-labels.yml
@@ -1,0 +1,18 @@
+name: Validated PR Labels
+on:
+  pull_request:
+    # The restrictions on the types of pull_request event that can trigger this
+    # workflow is intentional. We only want to run label related checks on a
+    # new or reopened PR, or when its labels change.
+    types: [opened, reopened, labeled, unlabeled]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR Labels
+        uses: danger/danger-js@9.1.8
+        with:
+          args: "--dangerfile Automattic/peril-settings/org/pr/label.ts"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/danger-prs.yml
+++ b/.github/workflows/danger-prs.yml
@@ -1,0 +1,18 @@
+name: iOS Consistency Checks
+on:
+  pull_request:
+    # The restrictions on the types of pull_request event that can trigger this
+    # workflow is intentional. We only want to run these sanity checks when the
+    # PR is opened or reopened, or its branch receives a push.
+    types: [opened, reopened, synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Consistency Checks
+        uses: danger/danger-js@9.1.8
+        with:
+          args: "--dangerfile Automattic/peril-settings/org/pr/ios-macos.ts"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is the first step to implement https://github.com/wordpress-mobile/WordPress-iOS/issues/13366.

This adds a GitHub workflows that run the [shared Peril settings](https://github.com/Automattic/peril-settings) to:
-  [validate the PR's labels](https://github.com/Automattic/peril-settings/blob/f8b40cef2adae13967ddd55c3fd917c3b0f200b6/org/pr/labels.ts)
- [preform consistency checks on the iOS code](https://github.com/Automattic/peril-settings/blob/f8b40cef2adae13967ddd55c3fd917c3b0f200b6/org/pr/ios-macos.ts)

![screencapture-github-mokagio-WordPress-iOS-pull-6-2020-02-11-14_42_08](https://user-images.githubusercontent.com/1218433/74210103-8cfc0a00-4cde-11ea-94fb-8ef55472fca7.png)

This setup uses the [Danger GitHub Action](https://github.com/marketplace/actions/danger-js-action). I like it because we don't have to add anything to our repo in order to run Danger, but it comes with a time overhead on CI because the action needs to be fetched and built. 

Using the action is fine for now, I think, but we might want to do a performance comparison with a local Danger setup later on. It might be worth takin on the cost of maintaining a local setup if we can get a noticeably faster feedback loop for those opening the PR.

The code here is a squash of the work done on https://github.com/mokagio/WordPress-iOS/pull/6. To test how it behaves, visit that PR and:

- Add/remove labels
- Push commits that would hit one of the Danger rules

There's more info in that PR, as well as screenshots of the tests that I run.