### PR TITLE
Fix 13436: Preview Publish dismiss Editor w/ Confirm

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -149,11 +149,29 @@ class PreviewWebKitViewController: WebKitViewController {
         return items
     }
 
-    // MARK: Button Actionss
+    // MARK: Button Actions
 
     @objc private func publishButtonPressed(_ sender: UIBarButtonItem) {
-        PostCoordinator.shared.publish(post)
-        dismiss(animated: true, completion: nil)
+        let title = NSLocalizedString("Are you sure you want to publish?", comment: "Title of the message shown when the user taps Publish in the post list.")
+
+        let cancelTitle = NSLocalizedString("Cancel", comment: "Button shown when the author is asked for publishing confirmation.")
+        let publishTitle = NSLocalizedString("Publish", comment: "Button shown when the author is asked for publishing confirmation.")
+
+        let style: UIAlertController.Style = UIDevice.isPad() ? .alert : .actionSheet
+        let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
+
+        alertController.addCancelActionWithTitle(cancelTitle)
+        alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
+            PostCoordinator.shared.publish(self.post)
+
+            if let editorVC = (self.presentingViewController?.presentingViewController as? EditPostViewController) {
+                editorVC.closeEditor(true, showPostEpilogue: false, from: self)
+            } else {
+                self.dismiss(animated: true, completion: nil)
+            }
+        }
+
+        present(alertController, animated: true)
     }
 
     @objc private func previewButtonPressed(_ sender: UIBarButtonItem) {


### PR DESCRIPTION
Fixes #13436 by dismissing the editor after publishing and adding a confirmation dialog.
Fixes #13438 by taking the user straight to the post list so that post settings are not as easy to change while publishing.

It seems like there are a couple of options to fix the issue:
1. Dismiss both the preview and the editor and go back to the Post List. (Equivalent to using Publish Now)
2. Go back to the Editor with the post fully published and everything updated.
3. Go back to the Editor with the status changed to Published so that if you “Cancel” instead of hitting the additional Publish button in the navigation bar, the Publish would be cancelled. (equivalent of changing the Post's Status to Published in Post Settings)

The first option has the benefit of being a small code change and completely avoiding potential questions about how to handle cancelling out of the Editor or waiting on the Publish action to complete. I checked with @osullivanchris on this and we think dismissing both views is fine for this case.

| Before | After |
|--|--|
| <a href="https://user-images.githubusercontent.com/3250/74374527-d3636e80-4d9b-11ea-825a-d1937a766a31.gif"><img src="https://user-images.githubusercontent.com/3250/74374527-d3636e80-4d9b-11ea-825a-d1937a766a31.gif" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/74373935-a9f61300-4d9a-11ea-8bc7-a230e08d3a76.gif"><img src="https://user-images.githubusercontent.com/3250/74373935-a9f61300-4d9a-11ea-8bc7-a230e08d3a76.gif" width="300"></a> |

To test:

- Open a post preview via the editor
- Press the Publish button in the bottom left
- Notice new confirmation dialog
- Editor should dismiss along with the preview upon publishing.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Not yet released
