### PR TITLE
Display "Done" label when editing already published images

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -185,8 +185,8 @@ target 'WordPress' do
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
-    pod 'MediaEditor', '~> 1.0.0'
-    # pod 'MediaEditor', :git => 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', :commit => 'a4178ed9b0f3622faafb41dd12503e26c5523a32'
+    #pod 'MediaEditor', '~> 1.0.0'
+    pod 'MediaEditor', :git => 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', :commit => '6e4f636b6f054fdaa604906faa00cd1b2128f1a1'
     # pod 'MediaEditor', :path => '../MediaEditor-iOS'
 
     aztec

--- a/Podfile
+++ b/Podfile
@@ -185,8 +185,8 @@ target 'WordPress' do
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
-    #pod 'MediaEditor', '~> 1.0.0'
-    pod 'MediaEditor', :git => 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', :commit => '6e4f636b6f054fdaa604906faa00cd1b2128f1a1'
+    pod 'MediaEditor', '~> 1.0.1'
+    # pod 'MediaEditor', :git => 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', :commit => 'a4178ed9b0f3622faafb41dd12503e26c5523a32'
     # pod 'MediaEditor', :path => '../MediaEditor-iOS'
 
     aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ PODS:
     - RNTAztecView
   - JTAppleCalendar (8.0.2)
   - lottie-ios (2.5.2)
-  - MediaEditor (1.0.0):
+  - MediaEditor (1.0.1):
     - TOCropViewController (~> 2.5.2)
   - MRProgress (0.8.3):
     - MRProgress/ActivityIndicator (= 0.8.3)
@@ -435,7 +435,7 @@ DEPENDENCIES:
   - Gridicons (~> 0.16)
   - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.22.0-merged-develop`)
   - JTAppleCalendar (~> 8.0.2)
-  - MediaEditor (~> 1.0.0)
+  - MediaEditor (from `https://github.com/wordpress-mobile/MediaEditor-iOS.git`, commit `6e4f636b6f054fdaa604906faa00cd1b2128f1a1`)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
   - NSObject-SafeExpectations (= 0.0.3)
@@ -505,7 +505,6 @@ SPEC REPOS:
     - GTMSessionFetcher
     - JTAppleCalendar
     - lottie-ios
-    - MediaEditor
     - MRProgress
     - Nimble
     - NSObject-SafeExpectations
@@ -552,6 +551,9 @@ EXTERNAL SOURCES:
   Gutenberg:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0-merged-develop
+  MediaEditor:
+    :commit: 6e4f636b6f054fdaa604906faa00cd1b2128f1a1
+    :git: https://github.com/wordpress-mobile/MediaEditor-iOS.git
   RCTRequired:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.22.0-merged-develop/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
@@ -617,6 +619,9 @@ CHECKOUT OPTIONS:
   Gutenberg:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0-merged-develop
+  MediaEditor:
+    :commit: 6e4f636b6f054fdaa604906faa00cd1b2128f1a1
+    :git: https://github.com/wordpress-mobile/MediaEditor-iOS.git
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0-merged-develop
@@ -646,7 +651,7 @@ SPEC CHECKSUMS:
   Gutenberg: 2efd3e4c77c7f199576f0487ccccd7af706c517d
   JTAppleCalendar: bb3dd3752e2bcc85cb798ab763fbdd6e142715fc
   lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
-  MediaEditor: 96af896a36e7db523ce1868d3d3602204a5fa870
+  MediaEditor: 7296cd01d7a0548fb2bc909aa72153b376a56a61
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
@@ -706,6 +711,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 3a6e1cb76e152e26ff42a9d00f59549b774d60f5
+PODFILE CHECKSUM: ab02551122d8e53229a58c2e2379011cf13a4a42
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -435,7 +435,7 @@ DEPENDENCIES:
   - Gridicons (~> 0.16)
   - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.22.0-merged-develop`)
   - JTAppleCalendar (~> 8.0.2)
-  - MediaEditor (from `https://github.com/wordpress-mobile/MediaEditor-iOS.git`, commit `6e4f636b6f054fdaa604906faa00cd1b2128f1a1`)
+  - MediaEditor (~> 1.0.1)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
   - NSObject-SafeExpectations (= 0.0.3)
@@ -505,6 +505,7 @@ SPEC REPOS:
     - GTMSessionFetcher
     - JTAppleCalendar
     - lottie-ios
+    - MediaEditor
     - MRProgress
     - Nimble
     - NSObject-SafeExpectations
@@ -551,9 +552,6 @@ EXTERNAL SOURCES:
   Gutenberg:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0-merged-develop
-  MediaEditor:
-    :commit: 6e4f636b6f054fdaa604906faa00cd1b2128f1a1
-    :git: https://github.com/wordpress-mobile/MediaEditor-iOS.git
   RCTRequired:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.22.0-merged-develop/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
@@ -619,9 +617,6 @@ CHECKOUT OPTIONS:
   Gutenberg:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0-merged-develop
-  MediaEditor:
-    :commit: 6e4f636b6f054fdaa604906faa00cd1b2128f1a1
-    :git: https://github.com/wordpress-mobile/MediaEditor-iOS.git
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0-merged-develop
@@ -711,6 +706,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: ab02551122d8e53229a58c2e2379011cf13a4a42
+PODFILE CHECKSUM: 06bd3daae92f95f1d25f55845edf4d8f51dc8db1
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/Utility/WPMediaEditor.swift
+++ b/WordPress/Classes/Utility/WPMediaEditor.swift
@@ -6,11 +6,19 @@ import Gridicons
  Displays the Media Editor with our custom styles and tracking
  */
 class WPMediaEditor: MediaEditor {
+    var alreadyPublishedImage: Bool = false {
+        didSet {
+            if alreadyPublishedImage {
+                hub.doneButton.setTitle(Constants.doneLabel, for: .normal)
+            }
+        }
+    }
+
     override var styles: MediaEditorStyles {
         get {
             return [
                 .insertLabel: NSLocalizedString("Insert %@", comment: "Button title used in media editor. Placeholder will be the number of items that will be inserted."),
-                .doneLabel: NSLocalizedString("Done", comment: "Done editing an image"),
+                .doneLabel: Constants.doneLabel,
                 .cancelLabel: NSLocalizedString("Cancel", comment: "Cancel editing an image"),
                 .errorLoadingImageMessage: NSLocalizedString("We couldn't retrieve this media.\nPlease tap to retry.", comment: "Description that appears when a media fails to load in the Media Editor."),
                 .cancelColor: UIColor.white,
@@ -45,5 +53,9 @@ class WPMediaEditor: MediaEditor {
         }
 
         WPAnalytics.track(.mediaEditorUsed, withProperties: ["actions": actions.description])
+    }
+
+    private enum Constants {
+        static var doneLabel = NSLocalizedString("Done", comment: "Done editing an image")
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3557,6 +3557,7 @@ extension AztecPostViewController {
         }
 
         let mediaEditor = WPMediaEditor(image)
+        mediaEditor.alreadyPublishedImage = true
 
         mediaEditor.edit(from: self,
                               onFinishEditing: { [weak self] images, actions in

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -451,6 +451,8 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         let image = GutenbergMediaEditorImage(url: mediaUrl, post: post)
 
         let mediaEditor = WPMediaEditor(image)
+        mediaEditor.alreadyPublishedImage = true
+        
         mediaEditor.edit(from: self,
                               onFinishEditing: { [weak self] images, actions in
                                 guard let image = images.first?.editedImage else {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -452,7 +452,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 
         let mediaEditor = WPMediaEditor(image)
         mediaEditor.alreadyPublishedImage = true
-        
+
         mediaEditor.edit(from: self,
                               onFinishEditing: { [weak self] images, actions in
                                 guard let image = images.first?.editedImage else {


### PR DESCRIPTION
Fixes #13425 

### To test

#### Gutenberg

1. Edit an already published image
2. Check that the label says "Done" instead of "Insert 1"

#### Aztec

1. Edit an already published image
2. Check that the label says "Done" instead of "Insert 1"

Scenario 2:

1. Add multiple images and tap "Preview X"
2. Check that the label says "Insert X"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
