### PR TITLE
Quick Actions Accessibility + Tracks

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
@@ -5,19 +5,19 @@ extension BlogDetailsViewController {
         let headerView = NewBlogDetailHeaderView(items: [
             ActionRow.Item(image: Gridicon.iconOfType(.statsAlt), title: NSLocalizedString("Stats", comment: "Noun. Abbv. of Statistics. Links to a blog's Stats screen.")) { [weak self] in
                 self?.tableView.deselectSelectedRowWithAnimation(false)
-                self?.showStats()
+                self?.showStats(from: .button)
             },
             ActionRow.Item(image: Gridicon.iconOfType(.pages), title: NSLocalizedString("Pages", comment: "Noun. Title. Links to the blog's Pages screen.")) { [weak self] in
                 self?.tableView.deselectSelectedRowWithAnimation(false)
-                self?.showPageList()
+                self?.showPageList(from: .button)
             },
             ActionRow.Item(image: Gridicon.iconOfType(.posts), title: NSLocalizedString("Posts", comment: "Noun. Title. Links to the blog's Posts screen.")) { [weak self] in
                 self?.tableView.deselectSelectedRowWithAnimation(false)
-                self?.showPostList()
+                self?.showPostList(from: .button)
             },
             ActionRow.Item(image: Gridicon.iconOfType(.image), title: NSLocalizedString("Media", comment: "Noun. Title. Links to the blog's Media library.")) { [weak self] in
                 self?.tableView.deselectSelectedRowWithAnimation(false)
-                self?.showMediaLibrary()
+                self?.showMediaLibrary(from: .button)
             }
         ])
         return headerView

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -60,6 +60,12 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementPlans = 19,
 };
 
+typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
+    BlogDetailsNavigationSourceButton = 0,
+    BlogDetailsNavigationSourceRow = 1,
+    BlogDetailsNavigationSourceLink = 2
+};
+
 
 @interface BlogDetailsSection : NSObject
 
@@ -119,10 +125,10 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
 - (void)configureTableViewData;
 - (void)scrollToElement:(QuickStartTourElement)element;
 
-- (void)showPostList;
-- (void)showPageList;
-- (void)showMediaLibrary;
-- (void)showStats;
+- (void)showPostListFromSource:(BlogDetailsNavigationSource)source;
+- (void)showPageListFromSource:(BlogDetailsNavigationSource)source;
+- (void)showMediaLibraryFromSource:(BlogDetailsNavigationSource)source;
+- (void)showStatsFromSource:(BlogDetailsNavigationSource)sourc;;
 - (void)refreshSiteIcon;
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -399,14 +399,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             [self.tableView selectRowAtIndexPath:indexPath
                                         animated:NO
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
-            [self showStats];
+            [self showStatsFromSource:BlogDetailsNavigationSourceLink];
             break;
         case BlogDetailsSubsectionPosts:
             self.restorableSelectedIndexPath = indexPath;
             [self.tableView selectRowAtIndexPath:indexPath
                                         animated:NO
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
-            [self showPostList];
+            [self showPostListFromSource:BlogDetailsNavigationSourceLink];
             break;
         case BlogDetailsSubsectionThemes:
         case BlogDetailsSubsectionCustomize:
@@ -423,14 +423,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             [self.tableView selectRowAtIndexPath:indexPath
                                         animated:NO
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
-            [self showMediaLibrary];
+            [self showMediaLibraryFromSource:BlogDetailsNavigationSourceLink];
             break;
         case BlogDetailsSubsectionPages:
             self.restorableSelectedIndexPath = indexPath;
             [self.tableView selectRowAtIndexPath:indexPath
                                         animated:NO
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
-            [self showPageList];
+            [self showPageListFromSource:BlogDetailsNavigationSourceLink];
             break;
         case BlogDetailsSubsectionActivity:
             if ([self.blog supports:BlogFeatureActivity]) {
@@ -676,7 +676,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                   accessibilityIdentifier:@"Stats Row"
                                                     image:[Gridicon iconOfType:GridiconTypeStatsAlt]
                                                  callback:^{
-                                                     [weakSelf showStats];
+        [weakSelf showStatsFromSource:BlogDetailsNavigationSourceRow];
                                                  }];
     statsRow.quickStartIdentifier = QuickStartTourElementStats;
     [rows addObject:statsRow];
@@ -714,7 +714,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                              accessibilityIdentifier:@"Site Pages Row"
                                                     image:[Gridicon iconOfType:GridiconTypePages]
                                                  callback:^{
-                                                     [weakSelf showPageList];
+        [weakSelf showPageListFromSource:BlogDetailsNavigationSourceRow];
                                                  }];
     pagesRow.quickStartIdentifier = QuickStartTourElementPages;
     [rows addObject:pagesRow];
@@ -723,7 +723,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                   accessibilityIdentifier:@"Blog Post Row"
                                                     image:[[Gridicon iconOfType:GridiconTypePosts] imageFlippedForRightToLeftLayoutDirection]
                                                  callback:^{
-                                                     [weakSelf showPostList];
+        [weakSelf showPostListFromSource:BlogDetailsNavigationSourceRow];
                                                  }]];
 
 
@@ -731,7 +731,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                   accessibilityIdentifier:@"Media Row"
                                                     image:[Gridicon iconOfType:GridiconTypeImage]
                                                  callback:^{
-                                                     [weakSelf showMediaLibrary];
+        [weakSelf showMediaLibraryFromSource:BlogDetailsNavigationSourceRow];
                                                  }]];
 
     BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Comments", @"Noun. Title. Links to the blog's Comments screen.")
@@ -1248,6 +1248,29 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 #pragma mark - Private methods
 
+- (void)trackEvent:(WPAnalyticsStat)event fromSource:(BlogDetailsNavigationSource)source {
+    
+    NSString *sourceString;
+    
+    switch (source) {
+        case BlogDetailsNavigationSourceRow:
+            sourceString = @"row";
+            break;
+            
+        case BlogDetailsNavigationSourceLink:
+            sourceString = @"link";
+            break;
+            
+        case BlogDetailsNavigationSourceButton:
+            sourceString = @"button";
+            break;
+            
+        default:
+            break;
+    }
+    
+    [WPAppAnalytics track:event withProperties:@{@"tap_source": sourceString} withBlog:self.blog];
+}
 
 - (void)preloadBlogData
 {
@@ -1371,27 +1394,27 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
-- (void)showPostList
+- (void)showPostListFromSource:(BlogDetailsNavigationSource)source
 {
-    [WPAppAnalytics track:WPAnalyticsStatOpenedPosts withBlog:self.blog];
+    [self trackEvent:WPAnalyticsStatOpenedPosts fromSource:source];
     PostListViewController *controller = [PostListViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
-- (void)showPageList
+- (void)showPageListFromSource:(BlogDetailsNavigationSource)source
 {
-    [WPAppAnalytics track:WPAnalyticsStatOpenedPages withBlog:self.blog];
+    [self trackEvent:WPAnalyticsStatOpenedPages fromSource:source];
     PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide find] visited:QuickStartTourElementPages];
 }
 
-- (void)showMediaLibrary
+- (void)showMediaLibraryFromSource:(BlogDetailsNavigationSource)source
 {
-    [WPAppAnalytics track:WPAnalyticsStatOpenedMediaLibrary withBlog:self.blog];
+    [self trackEvent:WPAnalyticsStatOpenedMediaLibrary fromSource:source];
     MediaLibraryViewController *controller = [[MediaLibraryViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
@@ -1451,9 +1474,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [[QuickStartTourGuide find] visited:QuickStartTourElementSharing];
 }
 
-- (void)showStats
+- (void)showStatsFromSource:(BlogDetailsNavigationSource)source
 {
-    [WPAppAnalytics track:WPAnalyticsStatStatsAccessed withBlog:self.blog];
+    [self trackEvent:WPAnalyticsStatStatsAccessed fromSource:source];
     StatsViewController *statsView = [StatsViewController new];
     statsView.blog = self.blog;
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/ActionRow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/ActionRow.swift
@@ -39,6 +39,9 @@ class ActionButton: UIView {
         button.setImage(image, for: .normal)
         titleLabel.text = title
 
+        button.accessibilityLabel = title
+        accessibilityElements = [button]
+
         let stackView = UIStackView(arrangedSubviews: [
             button,
             titleLabel

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -2,8 +2,6 @@ class NewBlogDetailHeaderView: UIView {
 
     @objc var delegate: BlogDetailHeaderViewDelegate?
 
-    //TODO: Add drop target
-
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = WPStyleGuide.fontForTextStyle(.title2, fontWeight: .bold)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
@@ -86,6 +86,9 @@ class SiteIconView: UIView {
         button.addSubview(activityIndicator)
         button.pinSubviewAtCenter(activityIndicator)
 
+        button.accessibilityLabel = NSLocalizedString("Site Icon", comment: "Accessibility label for site icon button")
+        accessibilityElements = [button]
+
         addSubview(button)
 
         addSubview(spotlightView)


### PR DESCRIPTION
Finishes the remaining items from #13318 (before enabling the feature flag).

- Adjusts accessibility elements for Quick Action buttons and Site Icon button
- Adds a `tap_source` property to the existing Tracks events for the quick actions:
  - From the table: `row`
  - From quick actions: `button`
  - from another source (deep link or other action): `link`

To test:

- View the Blog Details Header using Accessibility to check that the Quick Actions and Site Icon buttons are accessible.
- Check that events fired when tapping on the Quick Actions buttons contain `tap_source: row`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
