### PR TITLE
Add feature flag + Create Button

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -9,6 +9,7 @@ enum FeatureFlag: Int, CaseIterable {
     case unifiedAuth
     case quickActions
     case meMove
+    case floatingCreateButton
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -31,6 +32,8 @@ enum FeatureFlag: Int, CaseIterable {
         case .quickActions:
             return BuildConfiguration.current == .localDeveloper
         case .meMove:
+            return BuildConfiguration.current == .localDeveloper
+        case .floatingCreateButton:
             return BuildConfiguration.current == .localDeveloper
         }
     }
@@ -64,6 +67,8 @@ extension FeatureFlag: OverrideableFlag {
             return "Quick Actions"
         case .meMove:
             return "Move the Me Scene to My Site"
+        case .floatingCreateButton:
+            return "Floating Create Button"
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -76,6 +76,8 @@ extension FeatureFlag: OverrideableFlag {
         switch self {
         case .debugMenu:
             return false
+        case .floatingCreateButton:
+            return true
         default:
             return true
         }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -77,7 +77,7 @@ extension FeatureFlag: OverrideableFlag {
         case .debugMenu:
             return false
         case .floatingCreateButton:
-            return true
+            return false
         default:
             return true
         }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
@@ -1,14 +1,16 @@
-import Gridicons
-
 class FloatingActionButton: UIButton {
+
+    convenience init(image: UIImage) {
+        self.init(frame: .zero)
+
+        setImage(image, for: .normal)
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
         backgroundColor = .accent
         tintColor = .white
-
-        setImage(Gridicon.iconOfType(.create), for: .normal)
 
         refreshShadow()
     }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
@@ -1,0 +1,40 @@
+import Gridicons
+
+class FloatingActionButton: UIButton {
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = .accent
+        tintColor = .white
+
+        setImage(Gridicon.iconOfType(.create), for: .normal)
+
+        refreshShadow()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = frame.size.width / 2
+    }
+
+    private func refreshShadow() {
+        layer.shadowColor = UIColor.gray(.shade20).cgColor
+        layer.shadowOffset = CGSize(width: 0, height: 0)
+        layer.shadowRadius = 3
+        if #available(iOS 12.0, *) {
+            layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 1 : 0
+        } else {
+            layer.shadowOpacity = 1
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        refreshShadow()
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
@@ -1,0 +1,27 @@
+extension WPTabBarController {
+
+    private enum Constants {
+        static let padding: CGFloat = -16
+        static let heightWidth: CGFloat = 56
+    }
+
+    @objc func addFloatingButton() {
+
+        let button = FloatingActionButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(showPostViewController(_:)), for: .touchUpInside)
+
+        view.addSubview(button)
+
+        NSLayoutConstraint.activate([
+            button.bottomAnchor.constraint(equalTo: tabBar.topAnchor, constant: Constants.padding),
+            button.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.padding),
+            button.heightAnchor.constraint(equalToConstant: Constants.heightWidth),
+            button.widthAnchor.constraint(equalToConstant: Constants.heightWidth)
+        ])
+    }
+
+    @objc func showPostViewController(_ sender: UIView) {
+        showPostTab()
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
@@ -10,6 +10,7 @@ extension WPTabBarController {
     @objc func addFloatingButton() {
         let button = FloatingActionButton(image: Gridicon.iconOfType(.create))
         button.accessibilityLabel = NSLocalizedString("Create", comment: "Accessibility label for create floating action button")
+        button.accessibilityIdentifier = "floatingCreateButton"
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(showPostViewController(_:)), for: .touchUpInside)
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
@@ -17,7 +17,7 @@ extension WPTabBarController {
 
         NSLayoutConstraint.activate([
             button.bottomAnchor.constraint(equalTo: tabBar.topAnchor, constant: Constants.padding),
-            button.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: Constants.padding),
+            button.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor, constant: Constants.padding),
             button.heightAnchor.constraint(equalToConstant: Constants.heightWidth),
             button.widthAnchor.constraint(equalToConstant: Constants.heightWidth)
         ])

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
@@ -1,3 +1,5 @@
+import Gridicons
+
 extension WPTabBarController {
 
     private enum Constants {
@@ -6,8 +8,8 @@ extension WPTabBarController {
     }
 
     @objc func addFloatingButton() {
-
-        let button = FloatingActionButton()
+        let button = FloatingActionButton(image: Gridicon.iconOfType(.create))
+        button.accessibilityLabel = NSLocalizedString("Create", comment: "Accessibility label for create floating action button")
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(showPostViewController(_:)), for: .touchUpInside)
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -466,7 +466,17 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)showTabForIndex:(NSInteger)tabIndex
 {
-    [self setSelectedIndex:tabIndex];
+    NSInteger newIndex = [self adjustedTabIndex:tabIndex];
+    [self setSelectedIndex:newIndex];
+}
+
+- (NSInteger)adjustedTabIndex:(NSInteger)oldIndex {
+    //TODO: Remove this change once `floatingCreateButton` feature flag is enabled
+    if ([Feature enabled:FeatureFlagFloatingCreateButton] && oldIndex > WPTabReader) {
+        return oldIndex + 1; // Adjust the index if we are hiding the new post button
+    } else {
+        return oldIndex;
+    }
 }
 
 - (void)showMySitesTab
@@ -643,7 +653,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)switchMySitesTabToMediaForBlog:(Blog *)blog
 {
-    if (self.selectedIndex == WPTabMySites) {
+    if ([self adjustedTabIndex:self.selectedIndex] == WPTabMySites) {
         UIViewController *topViewController = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
         if ([topViewController isKindOfClass:[MediaLibraryViewController class]]) {
             MediaLibraryViewController *mediaVC = (MediaLibraryViewController *)topViewController;
@@ -755,7 +765,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 {
     // Check which tab is currently selected
     NSString *currentlySelectedScreen = @"";
-    switch (self.selectedIndex) {
+    switch ([self adjustedTabIndex:self.selectedIndex]) {
         case WPTabMySites:
             currentlySelectedScreen = @"Blog List";
             break;
@@ -775,7 +785,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (Blog *)currentlyVisibleBlog
 {
-    if (self.selectedIndex != WPTabMySites) {
+    if ([self adjustedTabIndex:self.selectedIndex] != WPTabMySites) {
         return nil;
     }
 
@@ -790,6 +800,8 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (BOOL)tabBarController:(UITabBarController *)tabBarController shouldSelectViewController:(UIViewController *)viewController
 {
     NSUInteger newIndex = [tabBarController.viewControllers indexOfObject:viewController];
+    
+    newIndex = [self adjustedTabIndex:newIndex];
 
     if (newIndex == WPTabNewPost) {
         [self showPostTab];

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -983,6 +983,10 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (void)viewDidLoad {
     [super viewDidLoad];
     [self startObserversForTabAccessTracking];
+    
+    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
+        [self addFloatingButton];
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -992,10 +996,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     [self startWatchingQuickTours];
 
     [self trackTabAccessOnViewDidAppear];
-    
-    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
-        [self addFloatingButton];
-    }
 }
 
 - (void)viewDidLayoutSubviews

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -104,11 +104,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
         [[self tabBar] setAccessibilityLabel:NSLocalizedString(@"Main Navigation", nil)];
         [self setupColors];
 
-        [self setViewControllers:@[self.blogListSplitViewController,
-                                   self.readerSplitViewController,
-                                   self.newPostViewController,
-                                   self.meSplitViewController,
-                                   self.notificationsSplitViewController]];
+        [self setViewControllers:[self tabViewControllers]];
 
         [self setSelectedViewController:self.blogListSplitViewController];
 
@@ -419,11 +415,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     _notificationsNavigationController = nil;
     _notificationsSplitViewController = nil;
 
-    [self setViewControllers:@[self.blogListSplitViewController,
-                               self.readerSplitViewController,
-                               self.newPostViewController,
-                               self.meSplitViewController,
-                               self.notificationsSplitViewController]];
+    [self setViewControllers:[self tabViewControllers]];
 
     // Reset the selectedIndex to the default MySites tab.
     self.selectedIndex = WPTabMySites;
@@ -435,11 +427,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     _readerMenuViewController = nil;
     _readerSplitViewController = nil;
 
-    [self setViewControllers:@[self.blogListSplitViewController,
-                               self.readerSplitViewController,
-                               self.newPostViewController,
-                               self.meSplitViewController,
-                               self.notificationsSplitViewController]];
+    [self setViewControllers:[self tabViewControllers]];
 }
 
 #pragma mark - Navigation Coordinators
@@ -459,6 +447,22 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 }
 
 #pragma mark - Navigation Helpers
+
+- (NSArray<UIViewController *> *)tabViewControllers
+{
+    
+    NSMutableArray<UIViewController *> *allViewControllers = [NSMutableArray arrayWithArray:@[self.blogListSplitViewController,
+                                                        self.readerSplitViewController,
+                                                        self.newPostViewController,
+                                                        self.meSplitViewController,
+                                                        self.notificationsSplitViewController]];
+    
+    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
+        [allViewControllers removeObject:self.newPostViewController];
+    }
+    
+    return allViewControllers;
+}
 
 - (void)showTabForIndex:(NSInteger)tabIndex
 {
@@ -976,6 +980,10 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     [self startWatchingQuickTours];
 
     [self trackTabAccessOnViewDidAppear];
+    
+    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
+        [self addFloatingButton];
+    }
 }
 
 - (void)viewDidLayoutSubviews

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2023,12 +2023,14 @@
 		F1DB8D292288C14400906E2F /* Uploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DB8D282288C14400906E2F /* Uploader.swift */; };
 		F1DB8D2B2288C24500906E2F /* UploadsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DB8D2A2288C24500906E2F /* UploadsManager.swift */; };
 		F511F8A42356A4F400895E73 /* PublishSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F511F8A32356A4F400895E73 /* PublishSettingsViewController.swift */; };
+		F537F33B23F1FEB9003210FD /* WPTabBarController+CreateButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F537F33A23F1FEB9003210FD /* WPTabBarController+CreateButton.swift */; };
 		F53FF3A123E2377E001AD596 /* NewBlogDetailHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A023E2377E001AD596 /* NewBlogDetailHeaderView.swift */; };
 		F53FF3A323EA3E45001AD596 /* BlogDetailsViewController+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A223EA3E45001AD596 /* BlogDetailsViewController+Header.swift */; };
 		F53FF3A823EA723D001AD596 /* ActionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A723EA723D001AD596 /* ActionRow.swift */; };
 		F53FF3AA23EA725C001AD596 /* SiteIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A923EA725C001AD596 /* SiteIconView.swift */; };
 		F543AF5723A84E4D0022F595 /* PublishSettingsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543AF5623A84E4D0022F595 /* PublishSettingsControllerTests.swift */; };
 		F543AF5923A84F200022F595 /* SchedulingCalendarViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543AF5823A84F200022F595 /* SchedulingCalendarViewControllerTests.swift */; };
+		F551E7F523F6EA3100751212 /* FloatingActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F423F6EA3100751212 /* FloatingActionButton.swift */; };
 		F565190323CF6D1D003FACAF /* WKCookieJarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */; };
 		F5660D03235CF73800020B1E /* SchedulingCalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */; };
 		F5660D07235D114500020B1E /* CalendarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D06235D114500020B1E /* CalendarCollectionView.swift */; };
@@ -4582,12 +4584,14 @@
 		F373612EEEEF10E500093FF3 /* Pods-WordPress.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F511F8A32356A4F400895E73 /* PublishSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSettingsViewController.swift; sourceTree = "<group>"; };
+		F537F33A23F1FEB9003210FD /* WPTabBarController+CreateButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPTabBarController+CreateButton.swift"; sourceTree = "<group>"; };
 		F53FF3A023E2377E001AD596 /* NewBlogDetailHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBlogDetailHeaderView.swift; sourceTree = "<group>"; };
 		F53FF3A223EA3E45001AD596 /* BlogDetailsViewController+Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+Header.swift"; sourceTree = "<group>"; };
 		F53FF3A723EA723D001AD596 /* ActionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionRow.swift; sourceTree = "<group>"; };
 		F53FF3A923EA725C001AD596 /* SiteIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIconView.swift; sourceTree = "<group>"; };
 		F543AF5623A84E4D0022F595 /* PublishSettingsControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSettingsControllerTests.swift; sourceTree = "<group>"; };
 		F543AF5823A84F200022F595 /* SchedulingCalendarViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewControllerTests.swift; sourceTree = "<group>"; };
+		F551E7F423F6EA3100751212 /* FloatingActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButton.swift; sourceTree = "<group>"; };
 		F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKCookieJarTests.swift; sourceTree = "<group>"; };
 		F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewController.swift; sourceTree = "<group>"; };
 		F5660D06235D114500020B1E /* CalendarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionView.swift; sourceTree = "<group>"; };
@@ -7261,6 +7265,7 @@
 		8584FDB619243AC40019C02E /* System */ = {
 			isa = PBXGroup;
 			children = (
+				F551E7F323F6EA1400751212 /* Floating Create Button */,
 				17A4A36A20EE551F0071C2CA /* Coordinators */,
 				1759F17E1FE145F90003EC81 /* Notices */,
 				17D433581EFD2ED500CAB602 /* Fancy Alerts */,
@@ -9859,6 +9864,15 @@
 			path = "Detail Header";
 			sourceTree = "<group>";
 		};
+		F551E7F323F6EA1400751212 /* Floating Create Button */ = {
+			isa = PBXGroup;
+			children = (
+				F537F33A23F1FEB9003210FD /* WPTabBarController+CreateButton.swift */,
+				F551E7F423F6EA3100751212 /* FloatingActionButton.swift */,
+			);
+			path = "Floating Create Button";
+			sourceTree = "<group>";
+		};
 		F57402A5235FF71F00374346 /* Scheduling */ = {
 			isa = PBXGroup;
 			children = (
@@ -11440,6 +11454,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F551E7F523F6EA3100751212 /* FloatingActionButton.swift in Sources */,
 				D816B8D42112D6E70052CE4D /* NewsCard.swift in Sources */,
 				B50C0C621EF42AF200372C65 /* TextList+WordPress.swift in Sources */,
 				B5722E421D51A28100F40C5E /* Notification.swift in Sources */,
@@ -11691,6 +11706,7 @@
 				FF00889F204E01AE007CCE66 /* MediaQuotaCell.swift in Sources */,
 				F5844B6B235EAF3D007C6557 /* HalfScreenPresentationController.swift in Sources */,
 				E6805D311DCD399600168E4F /* WPRichTextImage.swift in Sources */,
+				F537F33B23F1FEB9003210FD /* WPTabBarController+CreateButton.swift in Sources */,
 				7E4123C120F4097B00DF8486 /* FormattableContentRange.swift in Sources */,
 				08D978581CD2AF7D0054F19A /* MenuItemSourceHeaderView.m in Sources */,
 				BE1071FC1BC75E7400906AFF /* WPStyleGuide+Blog.swift in Sources */,

--- a/WordPress/WordPressUITests/Screens/TabNavComponent.swift
+++ b/WordPress/WordPressUITests/Screens/TabNavComponent.swift
@@ -13,7 +13,7 @@ class TabNavComponent: BaseScreen {
         let tabBars = XCUIApplication().tabBars["Main Navigation"]
         mySitesTabButton = tabBars.buttons["mySitesTabButton"]
         readerTabButton = tabBars.buttons["readerTabButton"]
-        writeTabButton = tabBars.buttons["Write"]
+        writeTabButton = XCUIApplication().buttons["Create"]
         notificationsTabButton = tabBars.buttons["notificationsTabButton"]
         meTabButton = tabBars.buttons["meTabButton"]
         super.init(element: meTabButton)

--- a/WordPress/WordPressUITests/Screens/TabNavComponent.swift
+++ b/WordPress/WordPressUITests/Screens/TabNavComponent.swift
@@ -13,7 +13,7 @@ class TabNavComponent: BaseScreen {
         let tabBars = XCUIApplication().tabBars["Main Navigation"]
         mySitesTabButton = tabBars.buttons["mySitesTabButton"]
         readerTabButton = tabBars.buttons["readerTabButton"]
-        writeTabButton = XCUIApplication().buttons["Create"]
+        writeTabButton = XCUIApplication().buttons["floatingCreateButton"]
         notificationsTabButton = tabBars.buttons["notificationsTabButton"]
         meTabButton = tabBars.buttons["meTabButton"]
         super.init(element: meTabButton)


### PR DESCRIPTION
#13320

Adds the new Floating Action Button to create a post. This is mostly to check the visual design of the button with other functionality coming in follow up PRs.

#### iPhone
![iPhone](https://user-images.githubusercontent.com/3250/74556553-8908fb80-4f1b-11ea-8df8-61e54bfa3f8c.png)

#### iPad
![iPad](https://user-images.githubusercontent.com/3250/74558193-126dfd00-4f1f-11ea-9037-8ebc85303f68.png)

### Notes
- Button is shown on all screens. To simplify review, a separate PR will properly hide the button depending on which screen is shown.
- There is no list sliding up from the bottom to select a Site Page or Blog Post. This will be added in a separate PR.

### Testing

- Open Application to any tab
- Notice Create Button in bottom right

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
