### PR TITLE
Add automation for release wrap up steps

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -177,6 +177,13 @@ import "./ScreenshotFastfile"
     ios_update_metadata(options) unless ios_current_branch_is_hotfix
     ios_bump_version_beta() unless ios_current_branch_is_hotfix
     ios_final_tag(options)
+
+    # Wrap up
+    version = ios_get_app_version()
+    removebranchprotection(repository:GHHELPER_REPO, branch: "release/#{version}")
+    setfrozentag(repository:GHHELPER_REPO, milestone: version, freeze: false)
+    create_new_milestone(repository:GHHELPER_REPO)
+    close_milestone(repository:GHHELPER_REPO, milestone: version)
   end
 
   #####################################################################################


### PR DESCRIPTION
This PR adds some steps to the `release_finalize` Fastlane action: 
- removing the branch protection.
- removing the frozen tag.
- closing the milestone.
- creating a new milestone. 

### To test:
Testing is a bit tricky as it requires to change the state of the release. 
The easiest way is probably to mock up a release and to test only the new steps in the lane. The following steps use `14.4` as test version because it doesn't affect the current release (`14.2`) and the milestone currently used in develop (`14.3`).

*Set up*
1. Checkout a `release/14.4` branch out of this branch.
2. Change the version in `Version.public.xcconfig` to 14.4.
3. Comment the `ios_update_metadata(options)`, `ios_bump_version_beta()` and `ios_final_tag(options)` steps in the lane as they will fail. 
4. Commit and push the branch.
5. Enable branch protection for `release/14.4` in GitHub. 
6. Add the frozen tag to the `14.4` milestone in GitHub.

*Test*
7. Run `bundle exec fastlane finalize_release`.
8. Verify that the `14.4` milestone is closed and the frozen tag removed.
9. Verify that the branch protection for the `release/14.4` branch has been removed. 
10. Verify that a new milestone is created in GitHub with the correct due date (currently the last milestone is `14.5`, so `14.6` should be created). 

*Wrap up*
11. Reopen the `14.4` milestone.
12. Delete the `release/14.4` branch. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
