### PR TITLE
Enable Quick Actions feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 14.3
 -----
 * Block editor: Add support for upload options in Gallery block
+* Added Quick Action buttons on the Site Details page to access the most frequently used parts of a site.
  
 14.2
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -29,7 +29,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .unifiedAuth:
             return BuildConfiguration.current == .localDeveloper
         case .quickActions:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .meMove:
             return BuildConfiguration.current == .localDeveloper
         }


### PR DESCRIPTION
Closes #13318 

To test:
- Open Blog Details page
- Use Quick Actions buttons to access parts of a blog

<a href="https://user-images.githubusercontent.com/3250/74666326-85b18200-515e-11ea-89f7-c08d12462c6c.png"><img src="https://user-images.githubusercontent.com/3250/74666326-85b18200-515e-11ea-89f7-c08d12462c6c.png" width="300"></a>   <a href="https://user-images.githubusercontent.com/3250/74666439-b691b700-515e-11ea-8dbb-171fe225f9c0.png"><img src="https://user-images.githubusercontent.com/3250/74666439-b691b700-515e-11ea-8dbb-171fe225f9c0.png" width="300"></a>

![Screen Shot 2020-02-17 at 8 20 33 AM](https://user-images.githubusercontent.com/3250/74666331-8813dc00-515e-11ea-8c7a-b31567cfad0d.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
