### PR TITLE
Handle concurrent calls to upload the same post

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -263,6 +263,11 @@ class PostCoordinator: NSObject {
 
     private func upload(post: AbstractPost, forceDraftIfCreating: Bool, completion: ((Result<AbstractPost, Error>) -> ())? = nil) {
         mainService.uploadPost(post, forceDraftIfCreating: forceDraftIfCreating, success: { [weak self] uploadedPost in
+            guard let uploadedPost = uploadedPost else {
+                completion?(.failure(SavingError.unknown))
+                return
+            }
+
             print("Post Coordinator -> upload succesfull: \(String(describing: uploadedPost.content))")
 
             SearchManager.shared.indexItem(uploadedPost)

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -117,8 +117,8 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
  */
 - (void)uploadPost:(AbstractPost *)post
 forceDraftIfCreating:(BOOL)forceDraftIfCreating
-           success:(nullable void (^)(AbstractPost *post))success
-           failure:(void (^)(NSError * _Nullable error))failure;
+           success:(nullable void (^)(AbstractPost * _Nullable post))success
+           failure:(nullable void (^)(NSError * _Nullable error))failure;
 
 /**
  Saves a post to the server.

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -8,7 +8,7 @@
 @class Page;
 @class RemotePost;
 @class PostServiceRemoteFactory;
-@class PostServiceQueueList;
+@class PostServiceUploadingList;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -8,6 +8,7 @@
 @class Page;
 @class RemotePost;
 @class PostServiceRemoteFactory;
+@class PostServiceQueueList;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -249,7 +249,7 @@ forceDraftIfCreating:NO
 - (void)uploadPost:(AbstractPost *)post
 forceDraftIfCreating:(BOOL)forceDraftIfCreating
            success:(nullable void (^)(AbstractPost * _Nullable post))success
-           failure:(nullable void (^)(NSError * _Nullable error))failure;
+           failure:(nullable void (^)(NSError * _Nullable error))failure
 {
     id<PostServiceRemote> remote = [self.postServiceRemoteFactory forBlog:post.blog];
     RemotePost *remotePost = [self remotePostWithPost:post];

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -243,8 +243,8 @@ forceDraftIfCreating:NO
 
 - (void)uploadPost:(AbstractPost *)post
 forceDraftIfCreating:(BOOL)forceDraftIfCreating
-           success:(void (^)(AbstractPost *post))success
-           failure:(void (^)(NSError *error))failure
+           success:(nullable void (^)(AbstractPost * _Nullable post))success
+           failure:(nullable void (^)(NSError * _Nullable error))failure;
 {
     id<PostServiceRemote> remote = [self.postServiceRemoteFactory forBlog:post.blog];
     RemotePost *remotePost = [self remotePostWithPost:post];

--- a/WordPress/Classes/Services/PostServiceQueueList.swift
+++ b/WordPress/Classes/Services/PostServiceQueueList.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+@objc class PostServiceQueueList: NSObject {
+    /// The current NSManagedObjectID being uploaded
+    private var ids: [NSManagedObjectID] = []
+
+    /// Shared Instance
+    static let shared = PostServiceQueueList()
+
+    private override init() {}
+
+    @objc class func sharedInstance() -> PostServiceQueueList {
+        return PostServiceQueueList.shared
+    }
+
+    /// Adds an id to the list of posts being uploaded
+    ///
+    /// - Parameter id: `NSManagedObjectID` of the post being uploaded
+    ///
+    @objc func uploading(_ id: NSManagedObjectID) {
+        ids.append(id)
+    }
+
+    /// Given an id, returns a Bool that indicates if the post is being uploaded in a single place
+    /// Ie.: there aren't multiple uploads for the same post going on.
+    ///
+    /// - Parameter id: `NSManagedObjectID` of the post being uploaded
+    ///
+    @objc func isSingleUpload(_ id: NSManagedObjectID) -> Bool {
+        return ids.filter { $0 == id }.count == 1
+    }
+
+    /// Remove a given id from the list of posts being uploaded
+    ///
+    /// - Parameter id: `NSManagedObjectID` of the post being uploaded
+    ///
+    @objc func finishedUploading(_ id: NSManagedObjectID) {
+        if let firstOccurrence = ids.firstIndex(of: id) {
+            ids.remove(at: firstOccurrence)
+        }
+    }
+}

--- a/WordPress/Classes/Services/PostServiceUploadingList.swift
+++ b/WordPress/Classes/Services/PostServiceUploadingList.swift
@@ -1,16 +1,18 @@
 import Foundation
 
-@objc class PostServiceQueueList: NSObject {
-    /// The current NSManagedObjectID being uploaded
+/// This Class stores ID of posts being uploaded.
+/// A single ID can be stored multiple times, which means it's being uploaded from concurrent calls
+@objc class PostServiceUploadingList: NSObject {
+    /// The current NSManagedObjectIDs being uploaded
     private var ids: [NSManagedObjectID] = []
 
     /// Shared Instance
-    static let shared = PostServiceQueueList()
+    static let shared = PostServiceUploadingList()
 
     private override init() {}
 
-    @objc class func sharedInstance() -> PostServiceQueueList {
-        return PostServiceQueueList.shared
+    @objc class func sharedInstance() -> PostServiceUploadingList {
+        return PostServiceUploadingList.shared
     }
 
     /// Adds an id to the list of posts being uploaded

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1038,6 +1038,7 @@
 		8B05D29123A9417E0063B9AA /* WPMediaEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B05D29023A9417E0063B9AA /* WPMediaEditor.swift */; };
 		8B05D29323AA572A0063B9AA /* GutenbergMediaEditorImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B05D29223AA572A0063B9AA /* GutenbergMediaEditorImage.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
+		8B6EA62323FDE50B004BA312 /* PostServiceQueueList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6EA62223FDE50B004BA312 /* PostServiceQueueList.swift */; };
 		8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */; };
 		8B8C814D2318073300A0E620 /* BasePostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8C814C2318073300A0E620 /* BasePostTests.swift */; };
 		8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */; };
@@ -3395,6 +3396,7 @@
 		8B05D29023A9417E0063B9AA /* WPMediaEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPMediaEditor.swift; sourceTree = "<group>"; };
 		8B05D29223AA572A0063B9AA /* GutenbergMediaEditorImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergMediaEditorImage.swift; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
+		8B6EA62223FDE50B004BA312 /* PostServiceQueueList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceQueueList.swift; sourceTree = "<group>"; };
 		8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewControllerTests.swift; sourceTree = "<group>"; };
 		8B8C814C2318073300A0E620 /* BasePostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePostTests.swift; sourceTree = "<group>"; };
 		8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadMessages.swift; sourceTree = "<group>"; };
@@ -7506,6 +7508,7 @@
 				FF0D8145205809C8000EE505 /* PostCoordinator.swift */,
 				E1A6DBE319DC7D230071AC1E /* PostService.h */,
 				E1A6DBE419DC7D230071AC1E /* PostService.m */,
+				8B6EA62223FDE50B004BA312 /* PostServiceQueueList.swift */,
 				FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */,
 				2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */,
 				9A4F8F55218B88E000EEDCCC /* PostService+Revisions.swift */,
@@ -12575,6 +12578,7 @@
 				591AA5021CEF9BF20074934F /* Post+CoreDataProperties.swift in Sources */,
 				E19B17AE1E5C6944007517C6 /* BasePost.swift in Sources */,
 				7E7947A9210BAC1D005BB851 /* NotificationContentRange.swift in Sources */,
+				8B6EA62323FDE50B004BA312 /* PostServiceQueueList.swift in Sources */,
 				E1EBC36F1C118EA500F638E0 /* ImmuTable.swift in Sources */,
 				B59B18751CC7FB8D0055EB7C /* PersonViewController.swift in Sources */,
 				4054F4602214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataProperties.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1040,6 +1040,7 @@
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B6EA62323FDE50B004BA312 /* PostServiceUploadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */; };
 		8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */; };
+		8B821F3C240020E2006B697E /* PostServiceUploadingListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B821F3B240020E2006B697E /* PostServiceUploadingListTests.swift */; };
 		8B8C814D2318073300A0E620 /* BasePostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8C814C2318073300A0E620 /* BasePostTests.swift */; };
 		8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */; };
 		8B93856E22DC08060010BF02 /* PageListSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */; };
@@ -3398,6 +3399,7 @@
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceUploadingList.swift; sourceTree = "<group>"; };
 		8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewControllerTests.swift; sourceTree = "<group>"; };
+		8B821F3B240020E2006B697E /* PostServiceUploadingListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceUploadingListTests.swift; sourceTree = "<group>"; };
 		8B8C814C2318073300A0E620 /* BasePostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePostTests.swift; sourceTree = "<group>"; };
 		8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadMessages.swift; sourceTree = "<group>"; };
 		8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -8642,6 +8644,7 @@
 				8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */,
 				08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */,
 				8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */,
+				8B821F3B240020E2006B697E /* PostServiceUploadingListTests.swift */,
 				8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */,
 				08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */,
 				5DE8A0401912D95B00B2FF59 /* ReaderPostServiceTest.m */,
@@ -13091,6 +13094,7 @@
 				F17A2A2023BFBD84001E96AC /* UIView+ExistingConstraints.swift in Sources */,
 				9A9D34FD23607CCC00BC95A3 /* AsyncOperationTests.swift in Sources */,
 				B5552D821CD1061F00B26DF6 /* StringExtensionsTests.swift in Sources */,
+				8B821F3C240020E2006B697E /* PostServiceUploadingListTests.swift in Sources */,
 				73178C3521BEE9AC00E37C9A /* TitleSubtitleHeaderTests.swift in Sources */,
 				08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */,
 				BEA0E4851BD83565000AEE81 /* WP3DTouchShortcutCreatorTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1038,7 +1038,7 @@
 		8B05D29123A9417E0063B9AA /* WPMediaEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B05D29023A9417E0063B9AA /* WPMediaEditor.swift */; };
 		8B05D29323AA572A0063B9AA /* GutenbergMediaEditorImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B05D29223AA572A0063B9AA /* GutenbergMediaEditorImage.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
-		8B6EA62323FDE50B004BA312 /* PostServiceQueueList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6EA62223FDE50B004BA312 /* PostServiceQueueList.swift */; };
+		8B6EA62323FDE50B004BA312 /* PostServiceUploadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */; };
 		8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */; };
 		8B8C814D2318073300A0E620 /* BasePostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8C814C2318073300A0E620 /* BasePostTests.swift */; };
 		8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */; };
@@ -3396,7 +3396,7 @@
 		8B05D29023A9417E0063B9AA /* WPMediaEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPMediaEditor.swift; sourceTree = "<group>"; };
 		8B05D29223AA572A0063B9AA /* GutenbergMediaEditorImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergMediaEditorImage.swift; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
-		8B6EA62223FDE50B004BA312 /* PostServiceQueueList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceQueueList.swift; sourceTree = "<group>"; };
+		8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceUploadingList.swift; sourceTree = "<group>"; };
 		8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewControllerTests.swift; sourceTree = "<group>"; };
 		8B8C814C2318073300A0E620 /* BasePostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePostTests.swift; sourceTree = "<group>"; };
 		8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadMessages.swift; sourceTree = "<group>"; };
@@ -7508,7 +7508,7 @@
 				FF0D8145205809C8000EE505 /* PostCoordinator.swift */,
 				E1A6DBE319DC7D230071AC1E /* PostService.h */,
 				E1A6DBE419DC7D230071AC1E /* PostService.m */,
-				8B6EA62223FDE50B004BA312 /* PostServiceQueueList.swift */,
+				8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */,
 				FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */,
 				2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */,
 				9A4F8F55218B88E000EEDCCC /* PostService+Revisions.swift */,
@@ -12578,7 +12578,7 @@
 				591AA5021CEF9BF20074934F /* Post+CoreDataProperties.swift in Sources */,
 				E19B17AE1E5C6944007517C6 /* BasePost.swift in Sources */,
 				7E7947A9210BAC1D005BB851 /* NotificationContentRange.swift in Sources */,
-				8B6EA62323FDE50B004BA312 /* PostServiceQueueList.swift in Sources */,
+				8B6EA62323FDE50B004BA312 /* PostServiceUploadingList.swift in Sources */,
 				E1EBC36F1C118EA500F638E0 /* ImmuTable.swift in Sources */,
 				B59B18751CC7FB8D0055EB7C /* PersonViewController.swift in Sources */,
 				4054F4602214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataProperties.swift in Sources */,

--- a/WordPress/WordPressTest/PostServiceUploadingListTests.swift
+++ b/WordPress/WordPressTest/PostServiceUploadingListTests.swift
@@ -43,7 +43,7 @@ class PostServiceUploadingListTests: XCTestCase {
         expect(uploadingList.isSingleUpload(post.objectID)).to(beFalse())
     }
 
-    /// If a post is added twice and then the upload finishes, return trye
+    /// If a post is added twice and then the upload of one finishes, return true
     ///
     func testReturnTrueForMultipleUploadIfOneOfThemIsRemoved() {
         let post = PostBuilder(context).build()

--- a/WordPress/WordPressTest/PostServiceUploadingListTests.swift
+++ b/WordPress/WordPressTest/PostServiceUploadingListTests.swift
@@ -1,0 +1,58 @@
+import UIKit
+import XCTest
+import Nimble
+
+@testable import WordPress
+
+/// Test cases for PostService.markAsFailedAndDraftIfNeeded()
+class PostServiceUploadingListTests: XCTestCase {
+
+    private var context: NSManagedObjectContext!
+
+    override func setUp() {
+        super.setUp()
+        context = TestContextManager().mainContext
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        context = nil
+        ContextManager.overrideSharedInstance(nil)
+    }
+
+    /// Returns true if a single post is added to the list
+    ///
+    func testReturnTrueForSingleUpload() {
+        let post = PostBuilder(context).build()
+        let uploadingList = PostServiceUploadingList.shared
+
+        uploadingList.uploading(post.objectID)
+
+        expect(uploadingList.isSingleUpload(post.objectID)).to(beTrue())
+    }
+
+    /// Returns false if the same post is added twice to the list
+    ///
+    func testReturnFalseForMultipleUpload() {
+        let post = PostBuilder(context).build()
+        let uploadingList = PostServiceUploadingList.shared
+
+        uploadingList.uploading(post.objectID)
+        uploadingList.uploading(post.objectID)
+
+        expect(uploadingList.isSingleUpload(post.objectID)).to(beFalse())
+    }
+
+    /// If a post is added twice and then the upload finishes, return trye
+    ///
+    func testReturnTrueForMultipleUploadIfOneOfThemIsRemoved() {
+        let post = PostBuilder(context).build()
+        let uploadingList = PostServiceUploadingList.shared
+
+        uploadingList.uploading(post.objectID)
+        uploadingList.uploading(post.objectID)
+        uploadingList.finishedUploading(post.objectID)
+
+        expect(uploadingList.isSingleUpload(post.objectID)).to(beTrue())
+    }
+}


### PR DESCRIPTION
Fixes #13430
Fixes #13429 

### To test

Follow the steps described by @rachelmcr:

1. Create a new post
2. Enter some post content and save the post as a draft.
3. Add more post content and select "Preview" from the ellipsis menu.
4. Immediately (while the status bar still shows "Generating preview") tap "Update" to save the post

The app should not crash.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
