### PR TITLE
Changes how the Post Signup Interstitial is displayed

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -222,24 +222,6 @@ static NSInteger HideSearchMinSites = 3;
         [[WordPressAppDelegate shared] showWelcomeScreenIfNeededAnimated:YES];
         return;
     }
-
-    BOOL shouldDisplayPSI = [PostSignUpInterstitialViewController shouldDisplayWithNumberOfBlogs:blogCount];
-
-    if (!shouldDisplayPSI) {
-        return;
-    }
-
-    [self showPostSignUpInterstitial];
-}
-
-- (void)showPostSignUpInterstitial
-{
-    PostSignUpInterstitialViewController *viewController = [[PostSignUpInterstitialViewController alloc] init];
-    viewController.modalPresentationStyle = UIModalPresentationFullScreen;
-
-    [self.navigationController presentViewController:viewController
-                                            animated:YES
-                                          completion:nil];
 }
 
 - (void)updateViewsForCurrentSiteCount

--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -84,11 +84,17 @@ class PostSignUpInterstitialViewController: UIViewController {
     }
 
     /// Determines whether or not the PSI should be displayed for the logged in user
-    /// - Parameters:
-    ///   - numberOfBlogs: The number of blogs the account has
-    @objc class func shouldDisplay(numberOfBlogs: Int) -> Bool {
+    @objc class func shouldDisplay() -> Bool {
+        let numberOfBlogs = self.numberOfBlogs()
+
         let coordinator = PostSignUpInterstitialCoordinator()
         return coordinator.shouldDisplay(numberOfBlogs: numberOfBlogs)
     }
+    
+    private class func numberOfBlogs() -> Int {
+        let context = ContextManager.sharedInstance().mainContext
+        let service = AccountService(managedObjectContext: context)
 
+        return service.defaultWordPressComAccount()?.blogs.count ?? 0
+    }
 }

--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -106,8 +106,10 @@ class PostSignUpInterstitialViewController: UIViewController {
 
     private class func numberOfBlogs() -> Int {
         let context = ContextManager.sharedInstance().mainContext
-        let service = AccountService(managedObjectContext: context)
+        let blogService = BlogService(managedObjectContext: context)
 
-        return service.defaultWordPressComAccount()?.blogs.count ?? 0
+        let blogCount = blogService.blogCountForAllAccounts()
+
+        return blogCount
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -40,6 +40,10 @@ class PostSignUpInterstitialViewController: UIViewController {
     @IBOutlet weak var addSelfHostedButton: UIButton!
     @IBOutlet weak var cancelButton: UIButton!
 
+    /// Closure to be executed upon dismissal.
+    ///
+    var onDismiss: (() -> Void)?
+
     let coordinator = PostSignUpInterstitialCoordinator()
 
     // MARK: - View Methods
@@ -53,25 +57,34 @@ class PostSignUpInterstitialViewController: UIViewController {
         coordinator.markAsSeen()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
+    }
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return UIDevice.isPad() ? .all : .portrait
     }
 
     // MARK: - IBAction's
     @IBAction func createSite(_ sender: Any) {
-        dismiss(animated: true) {
+        onDismiss?()
+
+        navigationController?.dismiss(animated: true) {
             NotificationCenter.default.post(name: .createSite, object: nil)
         }
     }
 
     @IBAction func addSelfHosted(_ sender: Any) {
-        dismiss(animated: true) {
+        onDismiss?()
+        navigationController?.dismiss(animated: true) {
             NotificationCenter.default.post(name: .addSelfHosted, object: nil)
         }
     }
 
     @IBAction func cancel(_ sender: Any) {
-        dismiss(animated: true, completion: nil)
+        onDismiss?()
+        navigationController?.dismiss(animated: true, completion: nil)
     }
 
     // MARK: - Private

--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -103,7 +103,7 @@ class PostSignUpInterstitialViewController: UIViewController {
         let coordinator = PostSignUpInterstitialCoordinator()
         return coordinator.shouldDisplay(numberOfBlogs: numberOfBlogs)
     }
-    
+
     private class func numberOfBlogs() -> Int {
         let context = ContextManager.sharedInstance().mainContext
         let service = AccountService(managedObjectContext: context)

--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -84,6 +84,8 @@ class PostSignUpInterstitialViewController: UIViewController {
 
     @IBAction func cancel(_ sender: Any) {
         onDismiss?()
+
+        WPTabBarController.sharedInstance().showReaderTab()
         navigationController?.dismiss(animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -9,6 +9,10 @@ class SignupEpilogueViewController: NUXViewController {
     var credentials: AuthenticatorCredentials?
     var socialService: SocialService?
 
+    /// Closure to be executed upon tapping the continue button.
+    ///
+    var onContinue: (() -> Void)?
+
     // MARK: - Outlets
 
     @IBOutlet private var buttonViewContainer: UIView! {
@@ -177,7 +181,7 @@ private extension SignupEpilogueViewController {
             }
             self.refreshAccountDetails() {
                 SVProgressHUD.dismiss()
-                self.navigationController?.dismiss(animated: true)
+                self.dismissEpilogue()
             }
         }
         changesMade = true
@@ -253,11 +257,20 @@ private extension SignupEpilogueViewController {
         }
     }
 
+    func dismissEpilogue() {
+        guard let onContinue = self.onContinue else {
+            self.navigationController?.dismiss(animated: true)
+            return
+        }
+
+        onContinue()
+    }
+
     func refreshAccountDetails(finished: @escaping () -> Void) {
         let context = ContextManager.sharedInstance().mainContext
         let service = AccountService(managedObjectContext: context)
         guard let account = service.defaultWordPressComAccount() else {
-            self.navigationController?.dismiss(animated: true)
+            self.dismissEpilogue()
             return
         }
         service.updateUserDetails(for: account, success: { () in

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -226,24 +226,38 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     /// WordPress.com account has no sites. Capicci?
     ///
     func shouldPresentLoginEpilogue(isJetpackLogin: Bool) -> Bool {
-        guard isJetpackLogin else {
-            return true
-        }
+//        guard isJetpackLogin else {
+//            return true
+//        }
 
         let context = ContextManager.sharedInstance().mainContext
         let service = AccountService(managedObjectContext: context)
         let numberOfBlogs = service.defaultWordPressComAccount()?.blogs?.count ?? 0
 
-        return numberOfBlogs > 0
+        if numberOfBlogs > 0 {
+            return true
+        }
+
+        let psiCoordinator = PostSignUpInterstitialCoordinator()
+        return psiCoordinator.shouldDisplay(numberOfBlogs: numberOfBlogs)
     }
 
     /// Indicates if the Signup Epilogue should be displayed.
     ///
     func shouldPresentSignupEpilogue() -> Bool {
-        return true
+        let context = ContextManager.sharedInstance().mainContext
+        let service = AccountService(managedObjectContext: context)
+        let numberOfBlogs = service.defaultWordPressComAccount()?.blogs?.count ?? 0
+
+        if numberOfBlogs > 0 {
+            return true
+        }
+
+        let psiCoordinator = PostSignUpInterstitialCoordinator()
+        return psiCoordinator.shouldDisplay(numberOfBlogs: numberOfBlogs)
     }
 
-    /// Whenever a WordPress.com acocunt has been created during the Auth flow, we'll add a new local WPCOM Account, and set it as
+    /// Whenever a WordPress.com account has been created during the Auth flow, we'll add a new local WPCOM Account, and set it as
     /// the new DefaultWordPressComAccount.
     ///
     func createdWordPressComAccount(username: String, authToken: String) {


### PR DESCRIPTION
Fixes #13458

## Details:
This PR changes how the PSI display logic that was introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/13459 is called. It's been moved from the `BlogListViewController` to the `WordPressAuthenticationManager`. 

The reason for this is:
- Ease of disabling the login epilogue view
- Ease of intercepting the signup epilogue view continue button
- Preventing a potential bug that would cause the PSI to display if you remove all your sites

## Testing

### Login with WP.com account with no sites
**Part 1:**
1. Launch the app
1. If you're logged in, log out
1. Tap Continue with WordPress.com
1. Login to an account that has no sites
Note: You should **not** be shown the login epilogue view (https://d.pr/i/8vJSs6)

You should be displayed the interstitial view

**Part 2:** 
1. Relaunch the app, you should not be displayed the interstitial

**Part 3:** 
1. Log out and log back in

You should not be displayed the interstitial view

### Login with WP.com account with sites
1. Launch the app
1. If you're logged in, log out
1. Tap login
1. Tap Continue with WordPress.com

You should be shown the login epilogue view

### Login with self hosted site
1. Launch the app
1. If you're logged in, log out
1. Tap login
1. Tap 'entering your site address'
1. Enter a site address
1. Enter your username/password
1. Tap Next

You should not be shown the interstitial, but you should see the login epilogue view

### Sign Up
**Part 1:**
1. Launch the app
1. If you're logged in, log out
1. Login to an account that has no sites
1. You should be shown the sign up epilogue view (https://d.pr/i/17YOhD)
1. Tap continue

You should be displayed the interstitial view

**Part 2:**
1. Log out and log back in

You should not be displayed the interstitial view

**PR submission checklist:**

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
