### PR TITLE
Remove duplicate gallery image size release note

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 * Aztec and Block Editor: Fix the presentation of ordered lists with large numbers.
 * Added Quick Action buttons on the Site Details page to access the most frequently used parts of a site.
-* Block editor: Add support for changing image sizes in Gallery and Image blocks
+* Block editor: Add support for changing image sizes in Image blocks
 * Block editor: Add support for upload options in Gallery block
 * Block editor: Added the Button block
 * Block editor: Add scroll support inside block picker and block settings


### PR DESCRIPTION
Removes gallery image size release note from 14.3 because that was added (and included in the release notes) in 14.2.

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
