### PR TITLE
Fix crash on logout after using Reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1033,7 +1033,11 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
 
     fileprivate func configureCommentActionButton() {
-        let title = post!.commentCount.stringValue
+        guard let commentCount = post?.commentCount else {
+            return
+        }
+
+        let title = commentCount.stringValue
         let image = UIImage(named: "icon-reader-comment")?.imageFlippedForRightToLeftLayoutDirection()
         let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageFlippedForRightToLeftLayoutDirection()
         configureActionButton(commentButton, title: title, image: image, highlightedImage: highlightImage, selected: false)


### PR DESCRIPTION
Fixes #13451

### To test

1. Open the Reader
2. Open any post on Reader (tap on post's card)
3. Tap "Me" on the tab bar
4. Log Out
5. The app should not crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
