### PR TITLE
Show new messaging when saving / publishing / scheduling / submitting pages.

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -363,7 +363,7 @@ class PostCoordinator: NSObject {
 
         context.perform {
             if status == .failed {
-                self.mainService.markAsFailedAndDraftIfNeeded(post: post)
+                self.mainService.markAsFailed(post: post)
             } else {
                 post.remoteStatus = status
             }

--- a/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
+++ b/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
@@ -2,35 +2,20 @@
 
     // MARK: - Updating the Remote Status
 
-    /// Updates the post after an upload failure.
-    ///
-    /// Local-only pages will be reverted back to `.draft` to avoid scenarios like this:
-    ///
-    /// 1. A locally published page upload failed
-    /// 2. The user presses the Page List's Retry button.
-    /// 3. The page upload is retried and the page is **published**.
-    ///
-    /// This is an unexpected behavior and can be surprising for the user. We'd want the user to
-    /// explicitly press on a “Publish” button instead.
-    ///
-    /// Posts' statuses are kept as is because we support automatic uploading of posts.
+    /// Updates posts and pages after an upload failure.
     ///
     /// - Important: This logic could have been placed in the setter for `remoteStatus`, but it's my belief
     ///     that our code will be much more resilient if we decouple the act of setting the `remoteStatus` value
     ///     and the logic behind processing an upload failure.  In fact I think the `remoteStatus` setter should
     ///     eventually be made private.
+    ///
     /// - SeeAlso: PostCoordinator.resume
     ///
-    func markAsFailedAndDraftIfNeeded(post: AbstractPost) {
+    func markAsFailed(post: AbstractPost) {
         guard post.remoteStatus != .failed else {
             return
         }
 
         post.remoteStatus = .failed
-
-        if !post.hasRemote() && post is Page {
-            post.status = .draft
-            post.dateModified = Date()
-        }
     }
 }

--- a/WordPress/Classes/Services/PostService+RefreshStatus.swift
+++ b/WordPress/Classes/Services/PostService+RefreshStatus.swift
@@ -16,7 +16,7 @@ extension PostService {
             do {
                 let postsPushing = try self.managedObjectContext.fetch(fetch)
                 for post in postsPushing {
-                    self.markAsFailedAndDraftIfNeeded(post: post)
+                    self.markAsFailed(post: post)
                 }
 
                 ContextManager.sharedInstance().save(self.managedObjectContext, withCompletionBlock: {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -288,7 +288,7 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
         [self.managedObjectContext performBlock:^{
             Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
-                [self markAsFailedAndDraftIfNeededWithPost:postInContext];
+                [self markAsFailedWithPost:postInContext];
                 [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
             }
             if (failure) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -72,6 +72,8 @@ class AbstractPostListViewController: UIViewController,
     @objc var tableViewController: UITableViewController!
     @objc var reloadTableViewBeforeAppearing = false
 
+    private var offlineNoticeShown = false
+
     @objc var tableView: UITableView {
         get {
             return self.tableViewController.tableView
@@ -1159,12 +1161,23 @@ class AbstractPostListViewController: UIViewController,
 
     // MARK: - NetworkAwareUI
 
-    func contentIsEmpty() -> Bool {
-        return tableViewHandler.resultsController.isEmpty()
+    func shouldPresentAlert() -> Bool {
+        guard !contentIsEmpty(),
+            !offlineNoticeShown else {
+
+            return false
+        }
+
+        offlineNoticeShown = true
+        return true
     }
 
     func noConnectionMessage() -> String {
         return ReachabilityUtils.noConnectionMessage()
+    }
+
+    func contentIsEmpty() -> Bool {
+        return tableViewHandler.resultsController.isEmpty()
     }
 
     // MARK: - Others

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -33,7 +33,7 @@ class PostCoordinatorTests: XCTestCase {
 
         postCoordinator.save(post)
 
-        expect(postServiceMock.didCallMarkAsFailedAndDraftIfNeeded).toEventually(beTrue())
+        expect(postServiceMock.didCallMarkAsFailed).toEventually(beTrue())
         expect(postServiceMock.didCallUploadPost).to(beFalse())
     }
 
@@ -443,7 +443,7 @@ private class PostServiceMock: PostService {
         let forceDraftIfCreating: Bool
     }
 
-    private(set) var didCallMarkAsFailedAndDraftIfNeeded = false
+    private(set) var didCallMarkAsFailed = false
     private(set) var didCallAutoSave = false
 
     private(set) var lastUploadPostInvocation: UploadPostInvocation?
@@ -471,8 +471,8 @@ private class PostServiceMock: PostService {
         didCallAutoSave = true
     }
 
-    override func markAsFailedAndDraftIfNeeded(post: AbstractPost) {
-        didCallMarkAsFailedAndDraftIfNeeded = true
+    override func markAsFailed(post: AbstractPost) {
+        didCallMarkAsFailed = true
     }
 }
 

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -4,8 +4,8 @@ import Nimble
 
 @testable import WordPress
 
-/// Test cases for PostService.markAsFailedAndDraftIfNeeded()
-class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
+/// Test cases for PostService.markAsFailed()
+class PostServiceMarkAsFailedTests: XCTestCase {
 
     private var context: NSManagedObjectContext!
 
@@ -27,7 +27,7 @@ class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
             .build()
         let postService = PostService()
 
-        postService.markAsFailedAndDraftIfNeeded(post: post)
+        postService.markAsFailed(post: post)
 
         expect(post.remoteStatus).to(equal(.failed))
         expect(post.status).to(equal(.pending))
@@ -41,7 +41,7 @@ class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
             .build()
         let postService = PostService()
 
-        postService.markAsFailedAndDraftIfNeeded(post: page)
+        postService.markAsFailed(post: page)
 
         expect(page.remoteStatus).to(equal(.failed))
         expect(page.status).to(equal(.draft))
@@ -56,7 +56,7 @@ class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
             .build()
         let postService = PostService()
 
-        postService.markAsFailedAndDraftIfNeeded(post: page)
+        postService.markAsFailed(post: page)
 
         expect(page.status).to(equal(.scheduled))
         expect(page.remoteStatus).to(equal(.failed))

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -33,7 +33,7 @@ class PostServiceMarkAsFailedTests: XCTestCase {
         expect(post.status).to(equal(.pending))
     }
 
-    func testMarksALocalPageAsFailedAndResetsItToDraft() {
+    func testMarksALocalPageAsFailedAndKeepItsStatus() {
         let page = PageBuilder(context)
             .with(status: .publish)
             .with(remoteStatus: .pushing)
@@ -44,8 +44,7 @@ class PostServiceMarkAsFailedTests: XCTestCase {
         postService.markAsFailed(post: page)
 
         expect(page.remoteStatus).to(equal(.failed))
-        expect(page.status).to(equal(.draft))
-        expect(page.dateModified).to(beCloseTo(Date(), within: 3))
+        expect(page.status).to(equal(.publish))
     }
 
     func testMarkingExistingPagesAsFailedWillNotRevertTheStatusToDraft() {


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/WordPress-iOS/issues/13378
Closes https://github.com/wordpress-mobile/WordPress-iOS/issues/13402
Closes https://github.com/wordpress-mobile/WordPress-iOS/issues/13379
Closes https://github.com/wordpress-mobile/WordPress-iOS/issues/13492

## Please note:

This PR targets a feature branch.  While this doesn't mean proper testing is not important, the feature being implemented isn't complete.

Some things that still need to be addressed:

- The messaging in the cells in the main pages list needs to be updated.
- Tracking needs to be implemented.

## Testing:

Please, test these steps while offline.

The test steps below should be completed once for saving a draft, once for publishing a page, once for submitting for review, and once for scheduling a page.

1. Create a new page.
2. Try saving as draft / publishing / submitting for review / scheduling a page.
3. Make sure that you see a notice that's appropriate for the action you took.  You can compare the notice with the ones shown for posts.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
