### PR TITLE
Fixes weekday symbols regional offsets

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Block editor: Add support for upload options in Gallery block
 * Aztec and Block Editor: Fix the presentation of ordered lists with large numbers.
 * Added Quick Action buttons on the Site Details page to access the most frequently used parts of a site.
+* Post Settings: Adjusts the weekday symbols in the calendar depending on Regional settings. 
  
 14.2
 -----

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift
@@ -165,7 +165,9 @@ class CalendarHeaderView: UIStackView {
 /// A view containing weekday symbols horizontally aligned for use in a calendar header
 class WeekdaysHeaderView: UIStackView {
     convenience init(calendar: Calendar) {
-        self.init(arrangedSubviews: calendar.veryShortWeekdaySymbols.map({ symbol in
+        /// Adjust the weekday symbols array so that the first week day matches
+        let weekdaySymbols = calendar.veryShortWeekdaySymbols.rotateLeft(calendar.firstWeekday - 1)
+        self.init(arrangedSubviews: weekdaySymbols.map({ symbol in
             let label = UILabel()
             label.text = symbol
             label.textAlignment = .center
@@ -174,5 +176,16 @@ class WeekdaysHeaderView: UIStackView {
             return label
         }))
         self.distribution = .fillEqually
+    }
+}
+
+extension Collection {
+    /// Rotates the array to the left ([1,2,3,4] -> [2,3,4,1])
+    /// - Parameter offset: The offset by which to shift the array.
+    func rotateLeft(_ offset: Int) -> [Self.Element] {
+        let initialDigits = (abs(offset) % self.count)
+        let elementToPutAtEnd = Array(self[startIndex..<index(startIndex, offsetBy: initialDigits)])
+        let elementsToPutAtBeginning = Array(self[index(startIndex, offsetBy: initialDigits)..<endIndex])
+        return elementsToPutAtBeginning + elementToPutAtEnd
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2034,6 +2034,7 @@
 		F543AF5723A84E4D0022F595 /* PublishSettingsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543AF5623A84E4D0022F595 /* PublishSettingsControllerTests.swift */; };
 		F543AF5923A84F200022F595 /* SchedulingCalendarViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543AF5823A84F200022F595 /* SchedulingCalendarViewControllerTests.swift */; };
 		F551E7F523F6EA3100751212 /* FloatingActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F423F6EA3100751212 /* FloatingActionButton.swift */; };
+		F551E7F723FC9A5C00751212 /* Collection+RotateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */; };
 		F565190323CF6D1D003FACAF /* WKCookieJarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */; };
 		F5660D03235CF73800020B1E /* SchedulingCalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */; };
 		F5660D07235D114500020B1E /* CalendarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D06235D114500020B1E /* CalendarCollectionView.swift */; };
@@ -4598,6 +4599,7 @@
 		F543AF5623A84E4D0022F595 /* PublishSettingsControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSettingsControllerTests.swift; sourceTree = "<group>"; };
 		F543AF5823A84F200022F595 /* SchedulingCalendarViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewControllerTests.swift; sourceTree = "<group>"; };
 		F551E7F423F6EA3100751212 /* FloatingActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButton.swift; sourceTree = "<group>"; };
+		F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+RotateTests.swift"; sourceTree = "<group>"; };
 		F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKCookieJarTests.swift; sourceTree = "<group>"; };
 		F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewController.swift; sourceTree = "<group>"; };
 		F5660D06235D114500020B1E /* CalendarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionView.swift; sourceTree = "<group>"; };
@@ -7162,6 +7164,7 @@
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
 				1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */,
 				173D82E6238EE2A7008432DA /* FeatureFlagTests.swift */,
+				F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -13093,6 +13096,7 @@
 				08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */,
 				F543AF5723A84E4D0022F595 /* PublishSettingsControllerTests.swift in Sources */,
 				027AC5212278983F0033E56E /* DomainCreditEligibilityTests.swift in Sources */,
+				F551E7F723FC9A5C00751212 /* Collection+RotateTests.swift in Sources */,
 				E10F3DA11E5C2CE0008FAADA /* PostListFilterTests.swift in Sources */,
 				57D66B9D234BB78B005A2D74 /* PostServiceWPComTests.swift in Sources */,
 				8B939F4323832E5D00ACCB0F /* PostListViewControllerTests.swift in Sources */,

--- a/WordPress/WordPressTest/Collection+RotateTests.swift
+++ b/WordPress/WordPressTest/Collection+RotateTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import WordPress
+
+class CollectionRotateTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
+    func testRotateOne() {
+        let beforeCollection = [1, 2, 3, 4, 5]
+        let afterCollection = beforeCollection.rotateLeft(1)
+        XCTAssertEqual([2, 3, 4, 5, 1], afterCollection)
+    }
+
+    func testRotateSame() {
+        let beforeCollection = [1, 2, 3, 4, 5]
+        let afterCollection = beforeCollection.rotateLeft(0)
+        XCTAssertEqual(beforeCollection, afterCollection)
+    }
+
+    func testRotateNegative() {
+        let beforeCollection = [1, 2, 3, 4, 5]
+        let afterCollection = beforeCollection.rotateLeft(-1)
+        XCTAssertEqual([2, 3, 4, 5, 1], afterCollection)
+    }
+
+    func testRotateOutOfIndex() {
+        let beforeCollection = [1, 2, 3, 4, 5]
+        let afterCollection = beforeCollection.rotateLeft(5)
+        XCTAssertEqual([1, 2, 3, 4, 5], afterCollection)
+    }
+}


### PR DESCRIPTION
Uses the `firstWeekday` offset to adjust the weekday symbols displayed in the Post Scheduling calendar.

Fixes #13491 

<a href="https://user-images.githubusercontent.com/3250/74783971-1aea6e80-5264-11ea-8731-46c07a07add9.png"><img src="https://user-images.githubusercontent.com/3250/74783971-1aea6e80-5264-11ea-8731-46c07a07add9.png" width="300"></a>

To test (see steps in #13491):

- Change Region settings to a locale which uses a different starting weekday (Lithuania, for example)
- Enter Post Settings from a blog post
- Change the Published On / Scheduled date and view the weekday header.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
