### PR TITLE
Adjusts the tab index when updating Me Icon

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -466,16 +466,19 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)showTabForIndex:(NSInteger)tabIndex
 {
-    NSInteger newIndex = [self adjustedTabIndex:tabIndex];
+    NSInteger newIndex = [self adjustedTabIndex:tabIndex toTabType:false];
     [self setSelectedIndex:newIndex];
 }
 
-- (NSInteger)adjustedTabIndex:(NSInteger)oldIndex {
+/// Adjusts the passed tabIndex to a new value depending on the enabled feature flags
+/// @param tabIndex The index that may need adjustment.
+/// @param toTabType Whether the new index is being converted to the WPTabType index. If true, the index should come from the tab bar.
+- (NSInteger)adjustedTabIndex:(NSInteger)tabIndex toTabType:(BOOL)toTabType {
     //TODO: Remove this change once `floatingCreateButton` feature flag is enabled
-    if ([Feature enabled:FeatureFlagFloatingCreateButton] && oldIndex > WPTabReader) {
-        return oldIndex + 1; // Adjust the index if we are hiding the new post button
+    if ([Feature enabled:FeatureFlagFloatingCreateButton] && tabIndex > WPTabReader) {
+        return tabIndex + (toTabType ? -1 : 1); // Adjust the index if we are hiding the new post button
     } else {
-        return oldIndex;
+        return tabIndex;
     }
 }
 
@@ -653,7 +656,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)switchMySitesTabToMediaForBlog:(Blog *)blog
 {
-    if ([self adjustedTabIndex:self.selectedIndex] == WPTabMySites) {
+    if ([self adjustedTabIndex:self.selectedIndex toTabType:false] == WPTabMySites) {
         UIViewController *topViewController = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
         if ([topViewController isKindOfClass:[MediaLibraryViewController class]]) {
             MediaLibraryViewController *mediaVC = (MediaLibraryViewController *)topViewController;
@@ -765,7 +768,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 {
     // Check which tab is currently selected
     NSString *currentlySelectedScreen = @"";
-    switch ([self adjustedTabIndex:self.selectedIndex]) {
+    switch ([self adjustedTabIndex:self.selectedIndex toTabType:false]) {
         case WPTabMySites:
             currentlySelectedScreen = @"Blog List";
             break;
@@ -785,7 +788,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (Blog *)currentlyVisibleBlog
 {
-    if ([self adjustedTabIndex:self.selectedIndex] != WPTabMySites) {
+    if ([self adjustedTabIndex:self.selectedIndex toTabType:false] != WPTabMySites) {
         return nil;
     }
 
@@ -801,7 +804,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 {
     NSUInteger newIndex = [tabBarController.viewControllers indexOfObject:viewController];
     
-    newIndex = [self adjustedTabIndex:newIndex];
+    newIndex = [self adjustedTabIndex:newIndex toTabType:false];
 
     if (newIndex == WPTabNewPost) {
         [self showPostTab];
@@ -932,7 +935,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)updateMeNotificationIcon
 {
-    UITabBarItem *meTabBarItem = self.tabBar.items[WPTabMe];
+    UITabBarItem *meTabBarItem = self.tabBar.items[[self adjustedTabIndex:WPTabMe toTabType:true]];
 
     if ([ZendeskUtils showSupportNotificationIndicator]) {
         meTabBarItem.image = self.meTabBarImageUnreadUnselected;


### PR DESCRIPTION
Fixes an issue where the incorrect tab bar icon was used for the Notifications section.

Thanks for pointing this out @Gio2018!

Notice the Notifications icon in the _Before_ image

| Before | After |
|--|--|
| ![Before-TabFix](https://user-images.githubusercontent.com/3250/74787139-a4516f00-526b-11ea-8d0c-c9465bb3f96b.gif) | ![After-TabFix](https://user-images.githubusercontent.com/3250/74787143-a87d8c80-526b-11ea-8c8a-45bacacaf7f6.gif) |



To test:
- Tap on any tab in the tab bar
- Notice that the Notifications icon changes to the Me tab's icon

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Not yet released.
