### PR TITLE
Add README with naming conventions in .github/workflows folder

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,28 @@
+## Workflows Naming Convention
+
+Whenever possible, follow this naming convention for workflows:
+
+```yaml
+# Use a short descriptive name for the whole workflow
+name: Validate PR Labels
+on: ...
+
+jobs:
+  # Use a present-tense verb as the name for the job, aligned with the workflow name
+  validate:
+    steps:
+      # Omit names for steps using an action
+      - uses: actions/checkout@v2
+
+      ...
+
+      # Keep using short present-tense names for steps that set up the stage
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      ...
+
+      # Use the same present-tense name as the job for its core step, if any
+      - name: Validate
+        run: ...
+```


### PR DESCRIPTION
Codifies @jkmassel naming suggestions from https://github.com/wordpress-mobile/WordPress-iOS/pull/13476#discussion_r380899847 so we can keep following them in the future.