### PR TITLE
#13440: Adjusts mobile preview on tablets

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -127,7 +127,7 @@ class WebKitViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .basicBackground
+        view.backgroundColor = UIColor(light: UIColor.muriel(color: .gray, .shade0), dark: .basicBackground)
 
         let stackView = UIStackView(arrangedSubviews: [
             progressView,
@@ -143,7 +143,7 @@ class WebKitViewController: UIViewController {
             view.topAnchor.constraint(equalTo: stackView.topAnchor),
             view.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
         ]
-        edgeConstraints.forEach({ $0.priority = UILayoutPriority.defaultHigh })
+        edgeConstraints.forEach({ $0.priority = UILayoutPriority(rawValue: UILayoutPriority.defaultHigh.rawValue - 1) })
 
         NSLayoutConstraint.activate(edgeConstraints)
 
@@ -320,7 +320,7 @@ class WebKitViewController: UIViewController {
     func setWidth(_ width: CGFloat?) {
         if let width = width {
             widthConstraint?.constant = width
-            widthConstraint?.priority = UILayoutPriority.required
+            widthConstraint?.priority = UILayoutPriority.defaultHigh
         } else {
             widthConstraint?.priority = UILayoutPriority.defaultLow
         }

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -66,6 +66,7 @@ class WebKitViewController: UIViewController {
 
     private var reachabilityObserver: Any?
     private var tapLocation = CGPoint(x: 0.0, y: 0.0)
+    private var widthConstraint: NSLayoutConstraint?
 
     private struct WebViewErrors {
         static let frameLoadInterrupted = 102
@@ -126,6 +127,8 @@ class WebKitViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        view.backgroundColor = .basicBackground
+
         let stackView = UIStackView(arrangedSubviews: [
             progressView,
             webView
@@ -133,7 +136,23 @@ class WebKitViewController: UIViewController {
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(stackView)
-        view.pinSubviewToAllEdges(stackView)
+
+        let edgeConstraints = [
+            view.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+            view.topAnchor.constraint(equalTo: stackView.topAnchor),
+            view.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
+        ]
+        edgeConstraints.forEach({ $0.priority = UILayoutPriority.defaultHigh })
+
+        NSLayoutConstraint.activate(edgeConstraints)
+
+        view.pinSubviewAtCenter(stackView)
+
+        let stackWidthConstraint = stackView.widthAnchor.constraint(equalToConstant: 0)
+        stackWidthConstraint.priority = UILayoutPriority.defaultLow
+        widthConstraint = stackWidthConstraint
+        NSLayoutConstraint.activate([stackWidthConstraint])
 
         configureNavigation()
         configureToolbar()
@@ -294,6 +313,15 @@ class WebKitViewController: UIViewController {
 
     private func styleToolBarButtons() {
         navigationController?.toolbar.items?.forEach(styleToolBarButton)
+    }
+
+    func setWidth(_ width: CGFloat?) {
+        if let width = width {
+            widthConstraint?.constant = width
+            widthConstraint?.priority = UILayoutPriority.required
+        } else {
+            widthConstraint?.priority = UILayoutPriority.defaultLow
+        }
     }
 
     // MARK: Helpers

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -315,6 +315,8 @@ class WebKitViewController: UIViewController {
         navigationController?.toolbar.items?.forEach(styleToolBarButton)
     }
 
+    /// Sets the width of the web preview
+    /// - Parameter width: The width value to set the webView to
     func setWidth(_ width: CGFloat?) {
         if let width = width {
             widthConstraint?.constant = width

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -15,7 +15,7 @@ class PreviewWebKitViewController: WebKitViewController {
             if selectedDevice != oldValue {
                 switch selectedDevice {
                 case .mobile:
-                    setWidth(400)
+                    setWidth(Constants.mobilePreviewWidth)
                 default:
                     setWidth(nil)
                 }
@@ -219,6 +219,8 @@ class PreviewWebKitViewController: WebKitViewController {
         static let publishButtonColor = UIColor.muriel(color: MurielColor.accent)
 
         static let blankURL = URL(string: "about:blank")
+
+        static let mobilePreviewWidth: CGFloat = 460
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -13,6 +13,12 @@ class PreviewWebKitViewController: WebKitViewController {
     private var selectedDevice: PreviewDeviceSelectionViewController.PreviewDevice = .default {
         didSet {
             if selectedDevice != oldValue {
+                switch selectedDevice {
+                case .mobile:
+                    setWidth(400)
+                default:
+                    setWidth(nil)
+                }
                 webView.reload()
             }
             showLabel(device: selectedDevice)


### PR DESCRIPTION
Adjusts the web view's actual width to provide Mobile Preview on tablets.

This is different than the Android version (which was already just keeping the same Default + Desktop previews). I originally added the Mobile preview on tablet because iOS 13 is intended to use a more "desktop like" web experience. This is less obvious because the theme designs are responsive and the preview is presented in a popover, taking up a smaller portion of the screen.

The preview in the Calypso editor on the web appears to adjust the iframe width. I think it makes sense to copy that behavior on the mobile clients so it is consistent.

 | Default | Mobile |
|--|--|
| <a href="https://user-images.githubusercontent.com/3250/74798414-efc74580-528a-11ea-9902-6f4b1bfd25d2.png"><img src="https://user-images.githubusercontent.com/3250/74798414-efc74580-528a-11ea-9902-6f4b1bfd25d2.png" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/74798425-f5249000-528a-11ea-9804-c1530432470d.png"><img src="https://user-images.githubusercontent.com/3250/74798425-f5249000-528a-11ea-9804-c1530432470d.png" width="300"></a> |

 | Default | Mobile |
|--|--|
| <a href="https://user-images.githubusercontent.com/3250/74798476-14bbb880-528b-11ea-9fda-2364e074f0a0.png"><img src="https://user-images.githubusercontent.com/3250/74798476-14bbb880-528b-11ea-9fda-2364e074f0a0.png" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/74798487-1dac8a00-528b-11ea-83c9-5a81e6b64e19.png"><img src="https://user-images.githubusercontent.com/3250/74798487-1dac8a00-528b-11ea-83c9-5a81e6b64e19.png" width="300"></a> |


Fixes #13440 

To test:

- Open the list of blog posts
- Tap on the View button to open a web preview
- Change the preview style to "Mobile" by tapping the button in the lower right.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
