### PR TITLE
Add GitHub release creation to the release tooling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../release-toolkit
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit
+  revision: 2ce506a80ab496fd0bd450de3aabbbf3e6ed8b44
+  ref: 2ce506a80ab496fd0bd450de3aabbbf3e6ed8b44
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.8.2)
       activesupport (~> 4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,7 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: c8007b8c11c282ea3e9f97f722d1971271959770
-  tag: 0.8.0
+PATH
+  remote: ../release-toolkit
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.8.0)
+    fastlane-plugin-wpmreleasetoolkit (0.8.2)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)
@@ -136,7 +134,8 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    git (1.5.0)
+    git (1.6.0)
+      rchardet (~> 1.8)
     google-api-client (0.36.4)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.9)
@@ -189,23 +188,24 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
-    nokogiri (1.10.4)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.9.2)
+    oj (3.10.2)
     optimist (3.0.0)
     options (2.3.2)
     os (1.0.1)
-    parallel (1.18.0)
+    parallel (1.19.1)
     plist (3.5.0)
-    progress_bar (1.3.0)
+    progress_bar (1.3.1)
       highline (>= 1.6, < 3)
       options (~> 2.3.0)
     public_suffix (2.0.5)
     rake (12.3.3)
-    rake-compiler (1.0.8)
+    rake-compiler (1.1.0)
       rake
+    rchardet (1.8.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 2ce506a80ab496fd0bd450de3aabbbf3e6ed8b44
-  ref: 2ce506a80ab496fd0bd450de3aabbbf3e6ed8b44
+  revision: c0daa1febc6018a050a04fe4a6cfcbdd48daec37
+  tag: 0.9.0
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.8.2)
+    fastlane-plugin-wpmreleasetoolkit (0.9.0)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -177,6 +177,13 @@ import "./ScreenshotFastfile"
     ios_update_metadata(options) unless ios_current_branch_is_hotfix
     ios_bump_version_beta() unless ios_current_branch_is_hotfix
     ios_final_tag(options)
+
+    # Wrap up
+    version = ios_get_app_version()
+    removebranchprotection(repository:GHHELPER_REPO, branch: "release/#{version}")
+    setfrozentag(repository:GHHELPER_REPO, milestone: version, freeze: false)
+    create_new_milestone(repository:GHHELPER_REPO)
+    close_milestone(repository:GHHELPER_REPO, milestone: version)
   end
 
   #####################################################################################
@@ -275,7 +282,7 @@ import "./ScreenshotFastfile"
   # bundle exec fastlane build_and_upload_internal 
   # bundle exec fastlane build_and_upload_internal skip_confirm:true 
   #####################################################################################
-  desc "Builds and updates for distribution"
+  desc "Builds and uploads for distribution"
   lane :build_and_upload_internal do | options |
     ios_build_prechecks(skip_confirm: options[:skip_confirm], internal: true) unless (options[:skip_prechecks])
     ios_build_preflight() unless (options[:skip_prechecks])
@@ -321,42 +328,73 @@ import "./ScreenshotFastfile"
   # This lane builds the app and upload it for external distribution  
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_itc [skip_confirm:<skip confirm>]
+  # bundle exec fastlane build_and_upload_itc [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
   #
   # Example:
   # bundle exec fastlane build_and_upload_itc 
   # bundle exec fastlane build_and_upload_itc skip_confirm:true 
+  # bundle exec fastlane build_and_upload_itc create_release:true 
   #####################################################################################
-  desc "Builds and updates for distribution"
+  desc "Builds and uploads for distribution"
   lane :build_and_upload_itc do | options |
-    ios_build_prechecks(skip_confirm: options[:skip_confirm], external: true) unless (options[:skip_prechecks])
-    ios_build_preflight() unless (options[:skip_prechecks])
+    #ios_build_prechecks(skip_confirm: options[:skip_confirm], external: true) unless (options[:skip_prechecks])
+    #ios_build_preflight() unless (options[:skip_prechecks])
 
     appstore_code_signing
 
     gym(scheme: "WordPress", workspace: "../WordPress.xcworkspace",
-      clean: true,
+#      clean: true,
       export_team_id: get_required_env("EXT_EXPORT_TEAM_ID"), 
       derived_data_path: "../derived-data/itc/",
       export_options: { method: "app-store" }
     )
 
-    testflight(
-      skip_waiting_for_build_processing: true,
-      team_id: "299112",
-    )
+    #testflight(
+    #  skip_waiting_for_build_processing: true,
+    #  team_id: "299112",
+    #)
 
-    sh("cd .. && rm WordPress.ipa")
-    dSYM_PATH = File.dirname(Dir.pwd) + "/WordPress.app.dSYM.zip"
+    #sh("cd .. && rm WordPress.ipa")
+    #dSYM_PATH = File.dirname(Dir.pwd) + "/WordPress.app.dSYM.zip"
 
-    sentry_upload_dsym(
-      dsym_path: dSYM_PATH,
-      auth_token: get_required_env("SENTRY_AUTH_TOKEN"),
-      org_slug: 'a8c',
-      project_slug: 'wordpress-ios',
-    )
+    #sentry_upload_dsym(
+    #  dsym_path: dSYM_PATH,
+    #  auth_token: get_required_env("SENTRY_AUTH_TOKEN"),
+    #  org_slug: 'a8c',
+    #  project_slug: 'wordpress-ios',
+    #)
 
-    sh("cd .. && rm WordPress.app.dSYM.zip")
+    #sh("cd .. && rm WordPress.app.dSYM.zip")
+
+    if (options[:create_release])
+      archive_zip_path = File.dirname(Dir.pwd) + "/WordPress.xarchive.zip"
+      zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
+
+      create_release(repository:GHHELPER_REPO, 
+        version:'10.10', 
+        release_notes_file_path:'../WordPress/Resources/release_notes.txt',
+        release_assets:"#{archive_zip_path}"
+      )
+
+      sh("rm #{archive_zip_path}") 
+    end
+  end
+
+  #####################################################################################
+  # build_release
+  # -----------------------------------------------------------------------------------
+  # This lane builds the app, create a GH release and upload it for external distribution  
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_release [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane build_release 
+  # bundle exec fastlane build_release skip_confirm:true 
+  #####################################################################################
+  desc "Builds, create release and uploads for distribution"
+  lane :build_release do | options |
+    build_and_upload_itc(skip_confirm: options[:skip_confirm], create_release: true)
   end
 
 ########################################################################

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -337,41 +337,42 @@ import "./ScreenshotFastfile"
   #####################################################################################
   desc "Builds and uploads for distribution"
   lane :build_and_upload_itc do | options |
-    #ios_build_prechecks(skip_confirm: options[:skip_confirm], external: true) unless (options[:skip_prechecks])
-    #ios_build_preflight() unless (options[:skip_prechecks])
+    ios_build_prechecks(skip_confirm: options[:skip_confirm], external: true) unless (options[:skip_prechecks])
+    ios_build_preflight() unless (options[:skip_prechecks])
 
     appstore_code_signing
 
     gym(scheme: "WordPress", workspace: "../WordPress.xcworkspace",
-#      clean: true,
+      clean: true,
       export_team_id: get_required_env("EXT_EXPORT_TEAM_ID"), 
       derived_data_path: "../derived-data/itc/",
       export_options: { method: "app-store" }
     )
 
-    #testflight(
-    #  skip_waiting_for_build_processing: true,
-    #  team_id: "299112",
-    #)
+    testflight(
+      skip_waiting_for_build_processing: true,
+      team_id: "299112",
+    )
 
-    #sh("cd .. && rm WordPress.ipa")
-    #dSYM_PATH = File.dirname(Dir.pwd) + "/WordPress.app.dSYM.zip"
+    sh("cd .. && rm WordPress.ipa")
+    dSYM_PATH = File.dirname(Dir.pwd) + "/WordPress.app.dSYM.zip"
 
-    #sentry_upload_dsym(
-    #  dsym_path: dSYM_PATH,
-    #  auth_token: get_required_env("SENTRY_AUTH_TOKEN"),
-    #  org_slug: 'a8c',
-    #  project_slug: 'wordpress-ios',
-    #)
+    sentry_upload_dsym(
+      dsym_path: dSYM_PATH,
+      auth_token: get_required_env("SENTRY_AUTH_TOKEN"),
+      org_slug: 'a8c',
+      project_slug: 'wordpress-ios',
+    )
 
-    #sh("cd .. && rm WordPress.app.dSYM.zip")
+    sh("cd .. && rm WordPress.app.dSYM.zip")
 
     if (options[:create_release])
       archive_zip_path = File.dirname(Dir.pwd) + "/WordPress.xarchive.zip"
       zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
 
+      version = ios_get_app_version()
       create_release(repository:GHHELPER_REPO, 
-        version:'10.10', 
+        version: version, 
         release_notes_file_path:'../WordPress/Resources/release_notes.txt',
         release_assets:"#{archive_zip_path}"
       )

--- a/Scripts/fastlane/Pluginfile
+++ b/Scripts/fastlane/Pluginfile
@@ -6,6 +6,6 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '2ce506a80ab496fd0bd450de3aabbbf3e6ed8b44'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.0'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.7.1'

--- a/Scripts/fastlane/Pluginfile
+++ b/Scripts/fastlane/Pluginfile
@@ -6,7 +6,6 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.0'
-gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../../wordpress-mobile/release-toolkit'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '2ce506a80ab496fd0bd450de3aabbbf3e6ed8b44'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.7.1'

--- a/Scripts/fastlane/Pluginfile
+++ b/Scripts/fastlane/Pluginfile
@@ -6,6 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.0'
+#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.8.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../../wordpress-mobile/release-toolkit'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.7.1'


### PR DESCRIPTION
This PR adds a new `build_release` lane, based on the `build_and_upload_itc` one, that, after the build, creates the GitHub release and upload the xarchive.

### To test:
1. Tag a commit with a version that we don't use (for example `10.10`) and push the tag.
2. Update `Version.public.xcconfig` to use the same version.

The easy way:
3.a. Comment out the `ios_build_prechecks`, `ios_build_preflight`, `testflight` and `sentry_upload_dsym` from the `build_and_upload_itc` lane.

The complex way:
3.b Checkout a new `release/10.10` (or what you used) branch out of this one and push it.

4. Run `bundle exec fastlane build_release`.
5. Verify that after the build, a new 10.10 release has been drafted in GitHub and the XArchive and the release notes have been uploaded.

*Clean Up*
6. Delete the release from GitHub.
7. Delete the tag you added at the step 1 from your local repository and from GitHub.
8. If you followed the _complex way_, remove the test branch from GitHub and clean up AppCenter and TestFlight.

_Note_: I'll update this PR before merging it to use a released version of the `release-toolkit`.
  
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
