### PR TITLE
Adds analytics for the Post Signup Interstitial

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,13 +11,13 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.13'
+    # pod 'WordPressShared', '~> 1.8.14-beta.1'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'issue/12880-add-welcome-interstitial-analytics'
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => 'efe5a065f3ace331353595ef85eef502baa23497'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -392,7 +392,7 @@ PODS:
     - WordPressShared (~> 1.8.13-beta)
     - wpxmlrpc (= 0.8.4)
   - WordPressMocks (0.0.8)
-  - WordPressShared (1.8.13):
+  - WordPressShared (1.8.14-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.5.1)
@@ -478,7 +478,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.10.7)
   - WordPressKit (~> 4.5.7)
   - WordPressMocks (~> 0.0.8)
-  - WordPressShared (~> 1.8.13)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `issue/12880-add-welcome-interstitial-analytics`)
   - WordPressUI (~> 1.5.1)
   - WPMediaPicker (~> 1.6.0)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/46239f3db87242fa639698f3138204c9816be85c/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
@@ -524,7 +524,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -607,6 +606,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 46239f3db87242fa639698f3138204c9816be85c
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressShared:
+    :branch: issue/12880-add-welcome-interstitial-analytics
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/46239f3db87242fa639698f3138204c9816be85c/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -620,6 +622,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 46239f3db87242fa639698f3138204c9816be85c
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressShared:
+    :commit: 203e019072da4baba987046b485d1da5c30f22da
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -692,7 +697,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 9141ea5a2e2b227252f3da6b3282a467f62588ba
   WordPressKit: 2404e5f60d6564494f7add2a0a75d7b970dbefb0
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
-  WordPressShared: fde9523bd00696fc1dfa45ed5299e16de111ebcc
+  WordPressShared: 9ce74a48bbcf045588129555a4700868ed57a3f7
   WordPressUI: ce0ac522146dabcd0a68ace24c0104dfdf6f4b0d
   WPMediaPicker: e5d28197da6b467d4e5975d64a49255977e39455
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -706,6 +711,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: eb9ec335d9dab7cce4fd3e795e336942b6e4cebd
+PODFILE CHECKSUM: 97ae1e0b1d13b4c2aec67562867f94995f6ce3a1
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1991,6 +1991,18 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"widget_active_site_changed";
             break;
 
+        case WPAnalyticsStatWelcomeNoSitesInterstitialShown:
+            eventName = @"welcome_no_sites_interstitial_shown";
+            break;
+
+        case WPAnalyticsStatWelcomeNoSitesInterstitialButtonTapped:
+            eventName = @"welcome_no_sites_interstitial_button_tapped";
+            break;
+
+        case WPAnalyticsStatWelcomeNoSitesInterstitialDismissed:
+            eventName = @"welcome_no_sites_interstitial_dismissed";
+            break;
+
         // The following are yet to be implemented.
         //
         // If you get test failures in WPAnalyticsTrackerAutomatticTracksTests, it's most likely

--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -55,6 +55,8 @@ class PostSignUpInterstitialViewController: UIViewController {
         configureI18N()
 
         coordinator.markAsSeen()
+
+        WPAnalytics.track(.welcomeNoSitesInterstitialShown)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -69,10 +71,11 @@ class PostSignUpInterstitialViewController: UIViewController {
     // MARK: - IBAction's
     @IBAction func createSite(_ sender: Any) {
         onDismiss?()
-
         navigationController?.dismiss(animated: true) {
             NotificationCenter.default.post(name: .createSite, object: nil)
         }
+
+        WPAnalytics.track(.welcomeNoSitesInterstitialButtonTapped, withProperties: ["button": "create_new_site"])
     }
 
     @IBAction func addSelfHosted(_ sender: Any) {
@@ -80,6 +83,8 @@ class PostSignUpInterstitialViewController: UIViewController {
         navigationController?.dismiss(animated: true) {
             NotificationCenter.default.post(name: .addSelfHosted, object: nil)
         }
+
+        WPAnalytics.track(.welcomeNoSitesInterstitialButtonTapped, withProperties: ["button": "add_self_hosted_site"])
     }
 
     @IBAction func cancel(_ sender: Any) {
@@ -87,6 +92,8 @@ class PostSignUpInterstitialViewController: UIViewController {
 
         WPTabBarController.sharedInstance().showReaderTab()
         navigationController?.dismiss(animated: true, completion: nil)
+
+        WPAnalytics.track(.welcomeNoSitesInterstitialDismissed)
     }
 
     // MARK: - Private


### PR DESCRIPTION
Fixes #12880 
Shared PR: https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/249

**To test:**
1. Launch the app
1. If you're logged in, log out
1. Tap Continue with WordPress.com
1. Login to an account that has no sites
1. When the PSI is displayed, verify this in the console:
`🔵 Tracked: welcome_no_sites_interstitial_shown`

1. Tap the create site button, and verify this in the console:
`🔵 Tracked: welcome_no_sites_interstitial_button_tapped <button: create_new_site>`

1. Tap the add self-hosted site button, and verify this in the console:
`🔵 Tracked: welcome_no_sites_interstitial_button_tapped <button: add_self_hosted_site>`

1. Tap the Not Right Now option, and verify this in the console:
`🔵 Tracked: welcome_no_sites_interstitial_dismissed`

Note: In order to test each button option you will need to either: 
- Delete and relaunch the app after each button press since the PSI will not be displayed again for your account. 
- Login using a different account for each action

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
