### PR TITLE
Disable stripping of HTML when editing a comment from the CommentViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -560,7 +560,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 - (void)editComment
 {
     EditCommentViewController *editViewController = [EditCommentViewController newEditViewController];
-    editViewController.content = [self.comment contentForDisplay];
+    editViewController.content = self.comment.content;
 
     __typeof(self) __weak weakSelf = self;
     editViewController.onCompletion = ^(BOOL hasNewContent, NSString *newContent) {


### PR DESCRIPTION
Reference: #10015 

**Description**
We decided to allow HTML markup to be displayed in the comment editor again after a discussion on what would be a better experience for the user. 

**To test:**
1. Launch the app and login if needed
2. Tap the My Sites tab
3. Select a site from the list
4. Tap the Comments item
5. Locate a comment with that contains HTML
6. Tap on it 
**Expectation:** You will be brought to the comment detail view, you should *not* see the HTML markup here: https://d.pr/i/2it2uF
7. Tap the Edit button
**Expectation:** You should see the  HTML markup: https://d.pr/i/ocUSgL

**Demo**
<img src="https://cdn-std.droplr.net/files/acc_895035/rPpZMu" width="50%"/>

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
