### PR TITLE
Login Epilogue: updated My Sites list

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
@@ -19,20 +19,17 @@ extension WPStyleGuide {
     }
 
     @objc public class func configureCellForLogin(_ cell: WPBlogTableViewCell) {
-        // TODO: make this dynamic size once @elibud's dynamic type code is merged
-        cell.textLabel?.font = WPFontManager.systemSemiBoldFont(ofSize: 15.0)
-        cell.textLabel?.sizeToFit()
         cell.textLabel?.textColor = .text
+        cell.textLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .medium)
 
-        cell.detailTextLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
-        cell.detailTextLabel?.sizeToFit()
-        cell.detailTextLabel?.textColor = .text
+        cell.detailTextLabel?.textColor = .textSubtle
+        cell.detailTextLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
 
         cell.imageView?.layer.borderColor = UIColor.neutral(.shade10).cgColor
         cell.imageView?.layer.borderWidth = 1
         cell.imageView?.tintColor = .neutral(.shade30)
 
-        cell.backgroundColor = .listBackground
+        cell.backgroundColor = .basicBackground
     }
 
  }

--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
@@ -20,10 +20,10 @@ extension WPStyleGuide {
 
     @objc public class func configureCellForLogin(_ cell: WPBlogTableViewCell) {
         cell.textLabel?.textColor = .text
-        cell.textLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .medium)
+        cell.textLabel?.font = fontForTextStyle(.subheadline, fontWeight: .medium)
 
         cell.detailTextLabel?.textColor = .textSubtle
-        cell.detailTextLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        cell.detailTextLabel?.font = fontForTextStyle(.subheadline)
 
         cell.imageView?.layer.borderColor = UIColor.neutral(.shade10).cgColor
         cell.imageView?.layer.borderWidth = 1

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueSectionHeaderFooter.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueSectionHeaderFooter.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +15,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LOGGED IN AS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h2s-FQ-khG">
-                    <rect key="frame" x="20" y="20" width="354" height="17"/>
+                    <rect key="frame" x="16" y="20" width="362" height="17"/>
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="16" id="bF1-fB-08e"/>
                     </constraints>
@@ -27,9 +25,9 @@
                 </label>
             </subviews>
             <constraints>
-                <constraint firstItem="h2s-FQ-khG" firstAttribute="leading" secondItem="21a-RX-ZhF" secondAttribute="leading" constant="20" id="3Uz-6C-ppc"/>
+                <constraint firstItem="h2s-FQ-khG" firstAttribute="leading" secondItem="21a-RX-ZhF" secondAttribute="leading" constant="16" id="3Uz-6C-ppc"/>
                 <constraint firstItem="21a-RX-ZhF" firstAttribute="bottom" secondItem="h2s-FQ-khG" secondAttribute="bottom" constant="7" id="3bI-dr-T8V"/>
-                <constraint firstItem="21a-RX-ZhF" firstAttribute="trailing" secondItem="h2s-FQ-khG" secondAttribute="trailing" constant="20" id="mUk-yi-bRz"/>
+                <constraint firstItem="21a-RX-ZhF" firstAttribute="trailing" secondItem="h2s-FQ-khG" secondAttribute="trailing" constant="16" id="mUk-yi-bRz"/>
                 <constraint firstItem="h2s-FQ-khG" firstAttribute="top" secondItem="21a-RX-ZhF" secondAttribute="top" constant="20" id="siM-Nd-UFb"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FBE-8U-liw">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FBE-8U-liw">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qDW-L0-z8a">
-                                <rect key="frame" x="-4" y="20" width="383" height="519"/>
+                                <rect key="frame" x="-4" y="0.0" width="383" height="539"/>
                                 <connections>
                                     <segue destination="UFO-Sm-cpW" kind="embed" id="rhb-gY-oAu"/>
                                 </connections>
@@ -89,7 +87,6 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="LF6-fg-TWa" firstAttribute="top" secondItem="qDW-L0-z8a" secondAttribute="bottom" constant="-14" id="3xo-Xc-gY6"/>
                             <constraint firstItem="qDW-L0-z8a" firstAttribute="leading" secondItem="CSv-1Z-yIA" secondAttribute="leadingMargin" constant="-20" id="7zX-it-ASF"/>
@@ -118,11 +115,11 @@
         <scene sceneID="sgW-0t-bH0">
             <objects>
                 <tableViewController id="UFO-Sm-cpW" customClass="LoginEpilogueTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="154" sectionHeaderHeight="28" sectionFooterHeight="28" id="bES-Rc-GFi">
-                        <rect key="frame" x="0.0" y="0.0" width="383" height="519"/>
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" allowsSelection="NO" rowHeight="154" sectionHeaderHeight="28" sectionFooterHeight="28" id="bES-Rc-GFi">
+                        <rect key="frame" x="0.0" y="0.0" width="383" height="539"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
-                        <inset key="separatorInset" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="BlogCell" rowHeight="52" id="jbC-9p-MD0" customClass="LoginEpilogueBlogCell" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="383" height="52"/>
@@ -132,44 +129,41 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="diS-LA-oFB">
-                                            <rect key="frame" x="20" y="2" width="40" height="40"/>
+                                            <rect key="frame" x="16" y="6" width="40" height="40"/>
                                             <constraints>
-                                                <constraint firstAttribute="height" constant="40" id="4VT-eg-pia"/>
-                                                <constraint firstAttribute="width" constant="40" id="ODd-06-5TA"/>
+                                                <constraint firstAttribute="width" secondItem="diS-LA-oFB" secondAttribute="height" multiplier="1:1" id="EDm-IG-hab"/>
+                                                <constraint firstAttribute="width" constant="40" id="jXu-be-bSL"/>
                                             </constraints>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Masdftg" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sHR-j2-pY2">
-                                            <rect key="frame" x="72" y="2" width="57" height="18"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="18" id="R7w-fr-KPL"/>
-                                            </constraints>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mastg" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w2L-7L-x21">
-                                            <rect key="frame" x="72" y="24" width="37.5" height="16"/>
-                                            <accessibility key="accessibilityConfiguration" identifier="siteUrl"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="16" id="wjh-eu-vg5"/>
-                                            </constraints>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="top" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="NXb-mo-Pcc">
+                                            <rect key="frame" x="66" y="7" width="301" height="38"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Masdftg" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sHR-j2-pY2">
+                                                    <rect key="frame" x="0.0" y="0.0" width="57" height="18"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mastg" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w2L-7L-x21">
+                                                    <rect key="frame" x="0.0" y="22" width="37.5" height="16"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="siteUrl"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
                                     </subviews>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
-                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="diS-LA-oFB" secondAttribute="bottom" constant="10" id="0Hw-qs-uwj"/>
-                                        <constraint firstItem="diS-LA-oFB" firstAttribute="leading" secondItem="WSD-zl-Z4K" secondAttribute="leading" constant="20" id="2hH-m8-OhI"/>
-                                        <constraint firstAttribute="bottom" secondItem="w2L-7L-x21" secondAttribute="bottom" constant="12" id="A1p-yb-QUQ"/>
-                                        <constraint firstItem="sHR-j2-pY2" firstAttribute="leading" secondItem="diS-LA-oFB" secondAttribute="trailing" constant="12" id="Cvx-Jj-a6t"/>
-                                        <constraint firstItem="w2L-7L-x21" firstAttribute="top" secondItem="sHR-j2-pY2" secondAttribute="bottom" constant="4" id="OwV-pc-9CY"/>
-                                        <constraint firstItem="w2L-7L-x21" firstAttribute="leading" secondItem="sHR-j2-pY2" secondAttribute="leading" id="dyh-JD-mdD"/>
-                                        <constraint firstItem="sHR-j2-pY2" firstAttribute="top" secondItem="diS-LA-oFB" secondAttribute="top" id="e2f-fO-Hfw"/>
-                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="sHR-j2-pY2" secondAttribute="trailing" constant="20" id="f0o-9q-hP2"/>
-                                        <constraint firstItem="diS-LA-oFB" firstAttribute="top" secondItem="WSD-zl-Z4K" secondAttribute="top" constant="2" id="l6p-pV-WNp"/>
+                                        <constraint firstItem="diS-LA-oFB" firstAttribute="centerY" secondItem="WSD-zl-Z4K" secondAttribute="centerY" id="0PF-9R-ocT"/>
+                                        <constraint firstItem="diS-LA-oFB" firstAttribute="leading" secondItem="WSD-zl-Z4K" secondAttribute="leading" constant="16" id="2hH-m8-OhI"/>
+                                        <constraint firstItem="NXb-mo-Pcc" firstAttribute="leading" secondItem="diS-LA-oFB" secondAttribute="trailing" constant="10" id="9i8-uC-fyv"/>
+                                        <constraint firstAttribute="trailing" secondItem="NXb-mo-Pcc" secondAttribute="trailing" constant="16" id="LFS-A4-GTa"/>
+                                        <constraint firstItem="NXb-mo-Pcc" firstAttribute="centerY" secondItem="WSD-zl-Z4K" secondAttribute="centerY" id="tnf-pE-Y8t"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
                                     <outlet property="siteIcon" destination="diS-LA-oFB" id="bxR-sb-EKi"/>
                                     <outlet property="siteNameLabel" destination="sHR-j2-pY2" id="fqH-OJ-s9y"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -35,7 +35,7 @@ class LoginEpilogueTableViewController: UITableViewController {
         let userInfoNib = UINib(nibName: "EpilogueUserInfoCell", bundle: nil)
         tableView.register(userInfoNib, forCellReuseIdentifier: Settings.userCellReuseIdentifier)
 
-        view.backgroundColor = .listBackground
+        view.backgroundColor = .basicBackground
     }
 
     /// Initializes the EpilogueTableView so that data associated with the specified Endpoint is displayed.
@@ -78,7 +78,9 @@ extension LoginEpilogueTableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard indexPath.section == Sections.userInfoSection else {
             let wrappedPath = IndexPath(row: indexPath.row, section: indexPath.section-1)
-            return blogDataSource.tableView(tableView, cellForRowAt: wrappedPath)
+            let cell = blogDataSource.tableView(tableView, cellForRowAt: wrappedPath)
+            cell.backgroundColor = .basicBackground
+            return cell
         }
 
         let cell = tableView.dequeueReusableCell(withIdentifier: Settings.userCellReuseIdentifier) as! EpilogueUserInfoCell
@@ -106,6 +108,7 @@ extension LoginEpilogueTableViewController {
         }
 
         cell.titleLabel?.text = title(for: section)
+        cell.backgroundColor = .basicBackground
         cell.accessibilityIdentifier = "Login Cell"
 
         return cell
@@ -148,7 +151,6 @@ extension LoginEpilogueTableViewController {
 
         headerView.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
         headerView.textLabel?.textColor = .neutral(.shade50)
-        headerView.contentView.backgroundColor = .listBackground
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -103,6 +103,12 @@ extension LoginEpilogueTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+
+        // Don't show section header for User Info
+        guard section != Sections.userInfoSection else {
+            return nil
+        }
+
         guard let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: Settings.headerReuseIdentifier) as? EpilogueSectionHeaderFooter else {
             fatalError("Failed to get a section header cell")
         }
@@ -115,7 +121,7 @@ extension LoginEpilogueTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        if indexPath.section == 0 {
+        if indexPath.section == Sections.userInfoSection {
             return Settings.profileRowHeight
         }
 
@@ -131,6 +137,10 @@ extension LoginEpilogueTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        guard section != Sections.userInfoSection else {
+            return 0
+        }
+
         return UITableView.automaticDimension
     }
 
@@ -159,14 +169,14 @@ extension LoginEpilogueTableViewController {
 //
 private extension LoginEpilogueTableViewController {
 
-    /// Returns the title for the current section!.
+    /// Returns the title for the current section.
     ///
-    func title(for section: Int) -> String {
-        if section == Sections.userInfoSection {
-            return NSLocalizedString("Logged In As", comment: "Header for user info, shown after loggin in").localizedUppercase
+    func title(for section: Int) -> String? {
+        guard section != Sections.userInfoSection else {
+            return nil
         }
 
-        let rowCount = blogDataSource.tableView(tableView, numberOfRowsInSection: section-1)
+        let rowCount = blogDataSource.tableView(tableView, numberOfRowsInSection: section - 1)
         if rowCount > 1 {
             return NSLocalizedString("My Sites", comment: "Header for list of multiple sites, shown after loggin in").localizedUppercase
         }
@@ -176,7 +186,7 @@ private extension LoginEpilogueTableViewController {
 }
 
 
-// MARK: - Loading!
+// MARK: - Loading
 //
 private extension LoginEpilogueTableViewController {
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -112,7 +112,6 @@ extension LoginEpilogueTableViewController {
         }
 
         cell.titleLabel?.text = title(for: section)
-        cell.backgroundColor = .basicBackground
         cell.accessibilityIdentifier = "Login Cell"
 
         return cell
@@ -156,6 +155,10 @@ extension LoginEpilogueTableViewController {
         guard let headerView = view as? UITableViewHeaderFooterView else {
             return
         }
+
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = .basicBackground
+        headerView.backgroundView = backgroundView
 
         headerView.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
         headerView.textLabel?.textColor = .neutral(.shade50)

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -106,12 +106,9 @@ extension LoginEpilogueTableViewController {
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
 
         // Don't show section header for User Info
-        guard section != Sections.userInfoSection else {
+        guard section != Sections.userInfoSection,
+        let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: Settings.headerReuseIdentifier) as? EpilogueSectionHeaderFooter else {
             return nil
-        }
-
-        guard let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: Settings.headerReuseIdentifier) as? EpilogueSectionHeaderFooter else {
-            fatalError("Failed to get a section header cell")
         }
 
         cell.titleLabel?.text = title(for: section)

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -78,9 +78,7 @@ extension LoginEpilogueTableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard indexPath.section == Sections.userInfoSection else {
             let wrappedPath = IndexPath(row: indexPath.row, section: indexPath.section-1)
-            let cell = blogDataSource.tableView(tableView, cellForRowAt: wrappedPath)
-            cell.backgroundColor = .basicBackground
-            return cell
+            return blogDataSource.tableView(tableView, cellForRowAt: wrappedPath)
         }
 
         let cell = tableView.dequeueReusableCell(withIdentifier: Settings.userCellReuseIdentifier) as! EpilogueUserInfoCell

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -36,6 +36,9 @@ class LoginEpilogueTableViewController: UITableViewController {
         tableView.register(userInfoNib, forCellReuseIdentifier: Settings.userCellReuseIdentifier)
 
         view.backgroundColor = .basicBackground
+
+        // Hide separators on empty rows
+        tableView.tableFooterView = UIView()
     }
 
     /// Initializes the EpilogueTableView so that data associated with the specified Endpoint is displayed.

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -53,9 +53,8 @@ class LoginEpilogueViewController: UIViewController {
             fatalError()
         }
 
+        view.backgroundColor = .basicBackground
         refreshInterface(with: credentials)
-
-        view.backgroundColor = .neutral(.shade0)
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Ref #13413 

This updates the 'My Sites' section of the Login Epilogue to the new design. Specifically:
- 'LOGGED IN AS' section header removed (above the User Info block).
- Site labels' font and color updated.
- Added separator lines between site rows.
- Table and row background colors updated.

Not yet updated:
- User Info block (including the top and bottom separator lines).
- Bottom buttons.
- iPad specific layout.
- Accessibility.

To test:
- Log into the app.
- Verify the 'My Sites' list looks like the Zeplin design, or that on #13413 .


Light | Dark
--------|-------
![multiple_sites_light](https://user-images.githubusercontent.com/1816888/74892022-b6074500-5345-11ea-939f-7c746872ca99.png)        |       ![multiple_sites_dark](https://user-images.githubusercontent.com/1816888/74892033-bb648f80-5345-11ea-8228-3e4fa85929bb.png)
![single_site_light](https://user-images.githubusercontent.com/1816888/74892055-c91a1500-5345-11ea-8cad-9425c9ee0cc3.png)       |       ![single_site_dark](https://user-images.githubusercontent.com/1816888/74892061-cddec900-5345-11ea-8209-d7dfb08511cd.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
