### PR TITLE
Fix crash in Post List Action Sheet

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 14.3
 -----
- 
+
 14.2
 -----
 * Comment Editing: Fixed a bug that could cause the text selection to be on the wrong line
@@ -18,6 +18,7 @@
 * Reader: Fixed an issue where a new comment may not appear.
 * Reader: Added Post Reblogging feature. You can now reblog a post from the reader to your site(s). There is a new "reblog" button in the post action bar.
           Tapping on it allows to choose the site where to post, and opens the editor of your choice with pre-populated content from the original post.
+* Fixed a bug that was causing the app to crash when the user tapped "Retry" on Post List
 
 14.1
 -----

--- a/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
@@ -65,9 +65,11 @@ class PostActionSheet {
                         self?.interactivePostViewDelegate?.retry(post)
                     }
                 case .edit:
-                    break // Not available in Action Sheet
+                    actionSheetController.addDefaultActionWithTitle(Titles.edit) { [weak self] _ in
+                        self?.interactivePostViewDelegate?.edit(post)
+                    }
                 case .more:
-                    break // Not available in Action Sheet
+                    CrashLogging.logMessage("Cannot handle unexpected button for post action sheet: \(button). This is a configuration error.", level: .error)
                 }
         }
 
@@ -90,5 +92,6 @@ class PostActionSheet {
         static let trash = NSLocalizedString("Move to Trash", comment: "Label for a option that moves a post to the trash folder")
         static let view = NSLocalizedString("View", comment: "Label for the view post button. Tapping displays the post as it appears on the web.")
         static let retry = NSLocalizedString("Retry", comment: "Retry uploading the post.")
+        static let edit = NSLocalizedString("Edit", comment: "Edit the post.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
@@ -60,8 +60,14 @@ class PostActionSheet {
                     actionSheetController.addDefaultActionWithTitle(Titles.cancelAutoUpload) { [weak self] _ in
                         self?.interactivePostViewDelegate?.cancelAutoUpload(post)
                     }
-                default:
-                    CrashLogging.logMessage("Cannot handle unexpected button for post action sheet: \(button). This is a configuration error.", level: .error)
+                case .retry:
+                    actionSheetController.addDefaultActionWithTitle(Titles.retry) { [weak self] _ in
+                        self?.interactivePostViewDelegate?.retry(post)
+                    }
+                case .edit:
+                    break // Not available in Action Sheet
+                case .more:
+                    break // Not available in Action Sheet
                 }
         }
 
@@ -83,5 +89,6 @@ class PostActionSheet {
         static let delete = NSLocalizedString("Delete Permanently", comment: "Label for the delete post option. Tapping permanently deletes a post.")
         static let trash = NSLocalizedString("Move to Trash", comment: "Label for a option that moves a post to the trash folder")
         static let view = NSLocalizedString("View", comment: "Label for the view post button. Tapping displays the post as it appears on the web.")
+        static let retry = NSLocalizedString("Retry", comment: "Retry uploading the post.")
     }
 }

--- a/WordPress/WordPressTest/PostActionSheetTests.swift
+++ b/WordPress/WordPressTest/PostActionSheetTests.swift
@@ -127,6 +127,15 @@ class PostActionSheetTests: XCTestCase {
         XCTAssertTrue(interactivePostViewDelegateMock.didCallCancelAutoUpload)
     }
 
+    func testCallsDelegateWhenRetryIsTapped() {
+        let viewModel = PostCardStatusViewModel(post: PostBuilder().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 5).build())
+
+        postActionSheet.show(for: viewModel, from: view, isCompactOrSearching: true)
+        tap(Titles.retry, in: viewControllerMock.viewControllerPresented)
+
+        XCTAssertTrue(interactivePostViewDelegateMock.didCallRetry)
+    }
+
     func tap(_ label: String, in alertController: UIAlertController?) {
         typealias AlertHandler = @convention(block) (UIAlertAction) -> Void
 


### PR DESCRIPTION
Fixes #13514

### To test

I wasn't able to reproduce the case where the "Retry" action appears in the Action Sheet (normally is the 2nd option in the Post Card).

However, I'm sure that his change will fix the crash and the option will appear.

Also, I made the `switch` exhaustive instead of using a `default`.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
