### PR TITLE
Fixes a bug that was causing the share flow to be broken in internal.

### DIFF
--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -36,7 +36,7 @@ class MainShareViewController: UIViewController {
         // The problem with the original expression is that it didn't account for the bundle ID being different in
         // different build configurations (debug, internal, release).
         //
-        let isSaveAsDraftAction = Bundle.main.bundleIdentifier?.suffix("WordPressDraftAction".count) == "WordPressDraftAction"
+        let isSaveAsDraftAction = Bundle.main.bundleIdentifier?.hasSuffix("WordPressDraftAction") ?? false
 
         if isSaveAsDraftAction {
             origination = .saveToDraft

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -24,10 +24,21 @@ class MainShareViewController: UIViewController {
     fileprivate let editorController: ShareExtensionAbstractViewController = {
         let storyboard = UIStoryboard(name: "ShareExtension", bundle: nil)
 
-
         let origination: OriginatingExtension
 
-        if Bundle.main.bundleIdentifier == "org.wordpress.WordPressDraftAction" {
+        // Please forgive the following code - I believe there must be some other better way to architect our share
+        // extension so that we don't need to check for the bundle ID.  But for the purpose of this bugfix it'll have
+        // to do.
+        //
+        // This was proposed as a bug fix to the original expression:
+        //      Bundle.main.bundleIdentifier == "org.wordpress.WordPressDraftAction"
+        //
+        // The problem with the original expression is that it didn't account for the bundle ID being different in
+        // different build configurations (debug, internal, release).
+        //
+        let isSaveAsDraftAction = Bundle.main.bundleIdentifier?.suffix("WordPressDraftAction".count) == "WordPressDraftAction"
+
+        if isSaveAsDraftAction {
             origination = .saveToDraft
         } else {
             origination = .share


### PR DESCRIPTION
Fixes a bug that was causing the share extension to misbehave in internal releases.

More info: p5T066-1au=p2#comment-4322

## Testing:

1. Run WPiOS with the internal build configuration.
2. Open a page in Safari, share.
3. Scroll to the bottom and pick the "Share Draft (internal)" action.

In the share window sure the site picker is shown - the editor should not be shown.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
