### PR TITLE
Update Alamofire to 4.8

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.5.7'
+    pod 'WordPressKit', '~> 4.5.8-beta-1'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/datarequest-weak-reference'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0ab4bb57ae5ba77e8f705ab987d8affa7e188d18'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
@@ -57,7 +57,7 @@ def shared_with_all_pods
 end
 
 def shared_with_networking_pods
-    pod 'Alamofire', '4.7.3'
+    pod 'Alamofire', '4.8.0'
     pod 'Reachability', '3.2'
 
     wordpress_kit
@@ -160,7 +160,7 @@ target 'WordPress' do
     pod 'Starscream', '3.0.6'
     pod 'SVProgressHUD', '2.2.5'
     pod 'ZendeskSupportSDK', '5.0.0'
-    pod 'AlamofireNetworkActivityIndicator', '~> 2.3'
+    pod 'AlamofireNetworkActivityIndicator', '~> 2.4'
     pod 'FSInteractiveMap', :git => 'https://github.com/wordpress-mobile/FSInteractiveMap.git', :tag => '0.2.0'
     pod 'JTAppleCalendar', '~> 8.0.2'
 
@@ -181,7 +181,7 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 0.16'
 
-    pod 'WordPressAuthenticator', '~> 1.10.7'
+    pod 'WordPressAuthenticator', '~> 1.10.8-beta.1'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - 1PasswordExtension (1.8.5)
-  - Alamofire (4.7.3)
-  - AlamofireNetworkActivityIndicator (2.3.0):
-    - Alamofire (~> 4.7)
+  - Alamofire (4.8.0)
+  - AlamofireNetworkActivityIndicator (2.4.0):
+    - Alamofire (~> 4.8)
   - AppCenter (2.5.1):
     - AppCenter/Analytics (= 2.5.1)
     - AppCenter/Crashes (= 2.5.1)
@@ -372,20 +372,20 @@ PODS:
   - WordPress-Aztec-iOS (1.16.0)
   - WordPress-Editor-iOS (1.16.0):
     - WordPress-Aztec-iOS (= 1.16.0)
-  - WordPressAuthenticator (1.10.7):
+  - WordPressAuthenticator (1.10.8-beta.1):
     - 1PasswordExtension (= 1.8.5)
-    - Alamofire (= 4.7.3)
+    - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 4.4)
     - Gridicons (~> 0.15)
     - lottie-ios (= 2.5.2)
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.5.6-beta.1)
-    - WordPressShared (~> 1.8)
+    - WordPressKit (~> 4.5.8-beta-1)
+    - WordPressShared (~> 1.8.13-beta)
     - WordPressUI (~> 1.4-beta.1)
-  - WordPressKit (4.5.7):
-    - Alamofire (~> 4.7.3)
+  - WordPressKit (4.5.8-beta-1):
+    - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1)
@@ -417,8 +417,8 @@ PODS:
 
 DEPENDENCIES:
   - 1PasswordExtension (= 1.8.5)
-  - Alamofire (= 4.7.3)
-  - AlamofireNetworkActivityIndicator (~> 2.3)
+  - Alamofire (= 4.8.0)
+  - AlamofireNetworkActivityIndicator (~> 2.4)
   - AppCenter (= 2.5.1)
   - AppCenter/Distribute (= 2.5.1)
   - Automattic-Tracks-iOS (~> 0.4.3)
@@ -475,8 +475,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.16.0)
-  - WordPressAuthenticator (~> 1.10.7)
-  - WordPressKit (~> 4.5.7)
+  - WordPressAuthenticator (~> 1.10.8-beta.1)
+  - WordPressKit (~> 4.5.8-beta-1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.5.1)
@@ -623,8 +623,8 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
-  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
-  AlamofireNetworkActivityIndicator: 18346ff6d770d9513d0ac6f2d99706f40f93dbaa
+  Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
+  AlamofireNetworkActivityIndicator: 9acc3de3ca6645bf0efed462396b0df13dd3e7b8
   AppCenter: fddcbac6e4baae3d93a196ceb0bfe0e4ce407dec
   Automattic-Tracks-iOS: 5515b3e6a5e55183a244ca6cb013df26810fa994
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
@@ -689,8 +689,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 64a2989d25befb5ce086fac440315f696026ffd5
   WordPress-Editor-iOS: 63ef6a532af2c92e3301421f5c4af41ad3be8721
-  WordPressAuthenticator: 9141ea5a2e2b227252f3da6b3282a467f62588ba
-  WordPressKit: 2404e5f60d6564494f7add2a0a75d7b970dbefb0
+  WordPressAuthenticator: 0465a71894b17e5c646913448a3584cff0da1532
+  WordPressKit: 9386a6b1a7684c59f08e456c1cc3fed3d51f0d07
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: fde9523bd00696fc1dfa45ed5299e16de111ebcc
   WordPressUI: ce0ac522146dabcd0a68ace24c0104dfdf6f4b0d
@@ -706,6 +706,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: eb9ec335d9dab7cce4fd3e795e336942b6e4cebd
+PODFILE CHECKSUM: 6eff97cb386ec785f2090c1420c2eb2c4e7f40b5
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Ref #13427

### To test

There's no feature added.

Just run the app and perform some network requests: publish posts, upload media, etc.

### Parent PRs:

- `WordPressKit`: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/212
- `WordPressAuthenticator`: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/184

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
