### PR TITLE
Update hotfix tooling

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -142,7 +142,7 @@ import "./ScreenshotFastfile"
   #####################################################################################
   # new_hotfix_release
   # -----------------------------------------------------------------------------------
-  # This lane updates the release branch for a new hotix release. 
+  # This lane creates the release branch for a new hotix release. 
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane new_hotfix_release [skip_confirm:<skip confirm>] [version:<version>]
@@ -155,7 +155,6 @@ import "./ScreenshotFastfile"
   lane :new_hotfix_release do | options |
     prev_ver = ios_hotfix_prechecks(options)
     ios_bump_version_hotfix(previous_version: prev_ver, version: options[:version])
-    ios_tag_build()
   end
 
   #####################################################################################
@@ -184,6 +183,23 @@ import "./ScreenshotFastfile"
     setfrozentag(repository:GHHELPER_REPO, milestone: version, freeze: false)
     create_new_milestone(repository:GHHELPER_REPO)
     close_milestone(repository:GHHELPER_REPO, milestone: version)
+  end
+
+  #####################################################################################
+  # new_hotfix_release
+  # -----------------------------------------------------------------------------------
+  # This lane finalizes the hotix branch. 
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane finalize_hotfix_release [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane finalize_hotfix_release skip_confirm:true  
+  #####################################################################################
+  desc "Creates a new hotfix branch from the given tag"
+  lane :finalize_hotfix_release do | options |
+    ios_finalize_prechecks(options)
+    ios_tag_build()
   end
 
   #####################################################################################

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -186,9 +186,9 @@ import "./ScreenshotFastfile"
   end
 
   #####################################################################################
-  # new_hotfix_release
+  # finalize_hotfix_release
   # -----------------------------------------------------------------------------------
-  # This lane finalizes the hotix branch. 
+  # This lane finalizes the hotfix branch. 
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane finalize_hotfix_release [skip_confirm:<skip confirm>]


### PR DESCRIPTION
This PR fixes the hotfix branch creation tooling. 
The current implementation tags the branch as soon as it's created, which means that the tag has to be manually deleted and re-added after the changes are merged. 
This PR removes the tagging step from the creation lane and adds a short lane only for tagging. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
