### PR TITLE
Migrated PostCompactCell and PostCardCell to use PostUploadProgressVi…

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -35,6 +35,7 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
     }()
 
     private var post: Post?
+    private var progressViewController: PostUploadProgressViewController? = nil
     private var viewModel: PostCardStatusViewModel?
     private var currentLoadedFeaturedImage: String?
     private weak var interactivePostViewDelegate: InteractivePostViewDelegate?
@@ -52,7 +53,15 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
         }
 
         self.post = post
+        
+        progressViewController = PostUploadProgressViewController(with: post, onUploadComplete: { [weak self] in
+            self?.configure()
+        })
 
+        configure()
+    }
+    
+    private func configure() {
         resetGhost()
         configureFeaturedImage()
         configureTitle()
@@ -261,24 +270,11 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
     }
 
     private func configureProgressView() {
-        guard let viewModel = viewModel else {
+        guard let progressViewController = progressViewController else {
             return
         }
 
-        let shouldHide = viewModel.shouldHideProgressView
-
-        progressView.isHidden = shouldHide
-
-        progressView.progress = viewModel.progress
-
-        if !shouldHide && viewModel.progressBlock == nil {
-            viewModel.progressBlock = { [weak self] progress in
-                self?.progressView.setProgress(progress, animated: true)
-                if progress >= 1.0, let post = self?.post {
-                    self?.configure(with: post)
-                }
-            }
-        }
+        progressViewController.configure(progressView)
     }
 
     private func configureActionBar() {

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -53,14 +53,14 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
         }
 
         self.post = post
-        
+
         progressViewController = PostUploadProgressViewController(with: post, onUploadComplete: { [weak self] in
             self?.configure()
         })
 
         configure()
     }
-    
+
     private func configure() {
         resetGhost()
         configureFeaturedImage()

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -26,27 +26,10 @@ class PostCardStatusViewModel: NSObject {
     }
 
     let post: Post
-    private var progressObserverUUID: UUID? = nil
 
     private let autoUploadInteractor = PostAutoUploadInteractor()
 
     private let isInternetReachable: Bool
-
-    var progressBlock: ((Float) -> Void)? = nil {
-        didSet {
-            if let _ = oldValue, let uuid = progressObserverUUID {
-                MediaCoordinator.shared.removeObserver(withUUID: uuid)
-            }
-
-            if let progressBlock = progressBlock {
-                progressObserverUUID = MediaCoordinator.shared.addObserver({ [weak self] (_, _) in
-                    if let post = self?.post {
-                        progressBlock(Float(MediaCoordinator.shared.totalProgress(for: post)))
-                    }
-                }, forMediaFor: post)
-            }
-        }
-    }
 
     init(post: Post, isInternetReachable: Bool = ReachabilityUtils.isInternetReachable()) {
         self.post = post
@@ -120,18 +103,6 @@ class PostCardStatusViewModel: NSObject {
             return .error
         default:
             return .neutral(.shade70)
-        }
-    }
-
-    var shouldHideProgressView: Bool {
-        return !(MediaCoordinator.shared.isUploadingMedia(for: post) || post.remoteStatus == .pushing)
-    }
-
-    var progress: Float {
-        if post.remoteStatus == .pushing {
-            return 1.0
-        } else {
-            return Float(MediaCoordinator.shared.totalProgress(for: post))
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -34,14 +34,14 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
 
     func configure(with post: Post) {
         self.post = post
-        
+
         progressViewController = PostUploadProgressViewController(with: post, onUploadComplete: { [weak self] in
             self?.configure()
         })
-        
+
         configure()
     }
-    
+
     private func configure() {
         resetGhostStyles()
         configureTitle()

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -30,10 +30,19 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
         }
     }
     private var viewModel: PostCardStatusViewModel?
+    private var progressViewController: PostUploadProgressViewController? = nil
 
     func configure(with post: Post) {
         self.post = post
-
+        
+        progressViewController = PostUploadProgressViewController(with: post, onUploadComplete: { [weak self] in
+            self?.configure()
+        })
+        
+        configure()
+    }
+    
+    private func configure() {
         resetGhostStyles()
         configureTitle()
         configureDate()
@@ -134,24 +143,11 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
     }
 
     private func configureProgressView() {
-        guard let viewModel = viewModel else {
+        guard let progressViewController = progressViewController else {
             return
         }
 
-        let shouldHide = viewModel.shouldHideProgressView
-
-        progressView.isHidden = shouldHide
-
-        progressView.progress = viewModel.progress
-
-        if !shouldHide && viewModel.progressBlock == nil {
-            viewModel.progressBlock = { [weak self] progress in
-                self?.progressView.setProgress(progress, animated: true)
-                if progress >= 1.0, let post = self?.post {
-                    self?.configure(with: post)
-                }
-            }
-        }
+        progressViewController.configure(progressView)
     }
 
     private func setupAccessibility() {


### PR DESCRIPTION
This is a follow up to: https://github.com/wordpress-mobile/WordPress-iOS/pull/13532

We're making use of the new created classes to remove some redundant code.

## To test:

Testing is easier if you have Apple's Link Conditioner installed with a "Very Bad Network" configuration.

### Test 1:

1. Go to the list of posts, and select the "Draft" filter (otherwise you own't see the post while it's uploading).
2. Create a new post, add an image to it (**having an image is important!**).
3. Publish it before the image finishes uploading.

Notice that there's a progress bar for the page upload, and that it moves ahead as it's uploading.

### Test 2:

Repeat test 1 in the posts list in compact mode.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
