### PR TITLE
Add the missing release note for the Block editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Block editor: Add support for changing image sizes in Image blocks
 * Block editor: Add support for upload options in Gallery block
 * Block editor: Added the Button block
+* Block editor: Added the Group block
 * Block editor: Add scroll support inside block picker and block settings
 * Block editor: Fix issue where adding emojis to the post title added strong HTML elements to the title of the post
 * Block editor: Fix issue where alignment of paragraph blocks was not always being respected when splitting the paragraph or reading the post's html content.


### PR DESCRIPTION
Fixes #

Adding the release note for "Group block". That line was overlooked during the release of gutenberg-mobile 1.23 release.

WP-Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/11368

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
