### PR TITLE
Adds show / hide animations for Create Button

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
@@ -1,6 +1,8 @@
 /// A rounded button with a shadow intended for use as a "Floating Action Button"
 class FloatingActionButton: UIButton {
 
+    var trailingConstraint: NSLayoutConstraint?
+
     convenience init(image: UIImage) {
         self.init(frame: .zero)
 
@@ -12,6 +14,7 @@ class FloatingActionButton: UIButton {
 
         backgroundColor = .accent
         tintColor = .white
+        clipsToBounds = true
 
         refreshShadow()
     }
@@ -20,9 +23,20 @@ class FloatingActionButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        layer.cornerRadius = frame.size.width / 2
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+
+        layer.cornerRadius = rect.size.width / 2
+    }
+
+    override func updateConstraints() {
+        super.updateConstraints()
+
+        // If we are missing our trailing constraint, re-activate it.
+        // This can happen because the trailing anchor is not yet in the view hierarchy when the button was added.
+        if constraint(for: .trailing, withRelation: .equal) == nil {
+            trailingConstraint?.isActive = true
+        }
     }
 
     private func refreshShadow() {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
@@ -1,3 +1,4 @@
+/// A rounded button with a shadow intended for use as a "Floating Action Button"
 class FloatingActionButton: UIButton {
 
     convenience init(image: UIImage) {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/HideShowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/HideShowCoordinator.swift
@@ -71,9 +71,9 @@ private class NavigationDelegate: NSObject, UINavigationControllerDelegate {
 
 // MARK: View Animations
 
-extension UIView {
+private extension UIView {
 
-    private enum Constants {
+    enum Constants {
         enum Maximize {
             static let damping: CGFloat = 0.7
             static let duration: TimeInterval = 0.5
@@ -90,7 +90,7 @@ extension UIView {
 
     /// Animates the showing and hiding of a view using a spring animation
     /// - Parameter toShow: Whether to show the view
-    fileprivate func springAnimation(toShow: Bool, context: UIViewControllerTransitionCoordinatorContext? = nil) {
+    func springAnimation(toShow: Bool, context: UIViewControllerTransitionCoordinatorContext? = nil) {
         if toShow {
             guard isHidden == true else { return }
             maximizeSpringAnimation(context: context)
@@ -101,7 +101,7 @@ extension UIView {
     }
 
     /// Applies a spring animation, from size 1 to 0
-    private func minimizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
+    func minimizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
         let damping = Constants.Minimize.damping
         let scaleInitial = Constants.Minimize.initialScale
         let scaleFinal = Constants.Minimize.finalScale
@@ -114,7 +114,7 @@ extension UIView {
     }
 
     /// Applies a spring animation, from size 0 to 1
-    private func maximizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
+    func maximizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
         let damping = Constants.Maximize.damping
         let scaleInitial = Constants.Maximize.initialScale
         let scaleFinal = Constants.Maximize.finalScale
@@ -123,7 +123,7 @@ extension UIView {
         scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context)
     }
 
-    private func scaleAnimation(duration: TimeInterval, damping: CGFloat, scaleInitial: CGFloat, scaleFinal: CGFloat, context: UIViewControllerTransitionCoordinatorContext?, completion: ((Bool) -> Void)? = nil) {
+    func scaleAnimation(duration: TimeInterval, damping: CGFloat, scaleInitial: CGFloat, scaleFinal: CGFloat, context: UIViewControllerTransitionCoordinatorContext?, completion: ((Bool) -> Void)? = nil) {
         setNeedsDisplay() // Make sure we redraw so that corners are rounded
         transform = CGAffineTransform(scaleX: scaleInitial, y: scaleInitial)
         isHidden = false

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/HideShowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/HideShowCoordinator.swift
@@ -73,6 +73,21 @@ private class NavigationDelegate: NSObject, UINavigationControllerDelegate {
 
 extension UIView {
 
+    private enum Constants {
+        enum Maximize {
+            static let damping: CGFloat = 0.7
+            static let duration: TimeInterval = 0.5
+            static let initialScale: CGFloat = 0.0
+            static let finalScale: CGFloat = 1.0
+        }
+        enum Minimize {
+            static let damping: CGFloat = 0.9
+            static let duration: TimeInterval = 0.25
+            static let initialScale: CGFloat = 1.0
+            static let finalScale: CGFloat = 0.001
+        }
+    }
+
     /// Animates the showing and hiding of a view using a spring animation
     /// - Parameter toShow: Whether to show the view
     fileprivate func springAnimation(toShow: Bool, context: UIViewControllerTransitionCoordinatorContext? = nil) {
@@ -87,10 +102,10 @@ extension UIView {
 
     /// Applies a spring animation, from size 1 to 0
     private func minimizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
-        let damping: CGFloat = 0.9
-        let scaleInitial: CGFloat = 1.0
-        let scaleFinal: CGFloat = 0.001
-        let duration = 0.25
+        let damping = Constants.Minimize.damping
+        let scaleInitial = Constants.Minimize.initialScale
+        let scaleFinal = Constants.Minimize.finalScale
+        let duration = Constants.Minimize.duration
 
         scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context) { [weak self] success in
             self?.transform = .identity
@@ -100,10 +115,10 @@ extension UIView {
 
     /// Applies a spring animation, from size 0 to 1
     private func maximizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
-        let damping: CGFloat = 0.7
-        let scaleInitial: CGFloat = 0.0
-        let scaleFinal: CGFloat = 1.0
-        let duration = 0.5
+        let damping = Constants.Maximize.damping
+        let scaleInitial = Constants.Maximize.initialScale
+        let scaleFinal = Constants.Maximize.finalScale
+        let duration = Constants.Maximize.duration
 
         scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context)
     }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/HideShowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/HideShowCoordinator.swift
@@ -13,6 +13,12 @@
         let observation = tabBarController.observe(\.selectedViewController, options: []) { (tabBarController, change) in
             if let viewController = tabBarController.selectedViewController {
                 let shouldShow = showFor(viewController)
+
+                // If a constraint relies on a a different tab, it may need to be reactivated
+                if shouldShow {
+                    view.setNeedsUpdateConstraints()
+                }
+
                 view.springAnimation(toShow: shouldShow)
             }
         }
@@ -84,8 +90,9 @@ extension UIView {
         let damping: CGFloat = 0.9
         let scaleInitial: CGFloat = 1.0
         let scaleFinal: CGFloat = 0.001
+        let duration = 0.25
 
-        scaleAnimation(damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context) { [weak self] success in
+        scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context) { [weak self] success in
             self?.transform = .identity
             self?.isHidden = true
         }
@@ -96,13 +103,13 @@ extension UIView {
         let damping: CGFloat = 0.7
         let scaleInitial: CGFloat = 0.0
         let scaleFinal: CGFloat = 1.0
-
-        scaleAnimation(damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context)
-    }
-
-    private func scaleAnimation(damping: CGFloat, scaleInitial: CGFloat, scaleFinal: CGFloat, context: UIViewControllerTransitionCoordinatorContext?, completion: ((Bool) -> Void)? = nil) {
         let duration = 0.5
 
+        scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context)
+    }
+
+    private func scaleAnimation(duration: TimeInterval, damping: CGFloat, scaleInitial: CGFloat, scaleFinal: CGFloat, context: UIViewControllerTransitionCoordinatorContext?, completion: ((Bool) -> Void)? = nil) {
+        setNeedsDisplay() // Make sure we redraw so that corners are rounded
         transform = CGAffineTransform(scaleX: scaleInitial, y: scaleInitial)
         isHidden = false
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/HideShowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/HideShowCoordinator.swift
@@ -1,0 +1,119 @@
+/// A class to hide/show a particular view based on view controller presentations
+@objc class HideShowCoordinator: NSObject {
+
+    private var tabBarObserver: NSKeyValueObservation?
+    private var navigationDelegate: UINavigationControllerDelegate?
+
+    /// Observes changes to the selected tab in order to show / hide `view` depending on the logic in `showFor`
+    /// - Parameters:
+    ///   - tabBarController: The Tab Bar Controller to observe
+    ///   - showFor: A block to determine whether or not to show `view` upon a change to `viewController`
+    ///   - view: The view to show and hide
+    func observe(_ tabBarController: UITabBarController, showFor: @escaping (UIViewController) -> Bool, view: UIView) {
+        let observation = tabBarController.observe(\.selectedViewController, options: []) { (tabBarController, change) in
+            if let viewController = tabBarController.selectedViewController {
+                let shouldShow = showFor(viewController)
+                view.springAnimation(toShow: shouldShow)
+            }
+        }
+        tabBarObserver = observation
+    }
+
+    /// Observes changes to the top view controller in the navigation stack in order to show / hide `view` depending on the logic in `showFor`
+    /// - Parameters:
+    ///   - tabBarController: The Tab Bar Controller to observe
+    ///   - showFor: A block to determine whether or not to show `view` upon a change to `viewController`
+    ///   - view: The view to show and hide
+    func observe(_ navigationController: UINavigationController, showFor: @escaping (UIViewController) -> Bool, view: UIView) {
+        let delegate = NavigationDelegate(didShow: { (navController, viewController, animated) in
+            let shouldShow = showFor(viewController)
+            if let transitionCoordinator = viewController.transitionCoordinator, transitionCoordinator.isInteractive {
+                transitionCoordinator.animateAlongsideTransition(in: view, animation: { context in
+                    view.springAnimation(toShow: shouldShow, context: context)
+                }, completion: nil)
+            } else {
+                view.springAnimation(toShow: shouldShow)
+            }
+        })
+
+        navigationController.delegate = delegate
+
+        navigationDelegate = delegate
+    }
+}
+
+private class NavigationDelegate: NSObject, UINavigationControllerDelegate {
+
+    let didShow: (UINavigationController, UIViewController, Bool) -> Void
+
+    init(didShow: @escaping (UINavigationController, UIViewController, Bool) -> Void) {
+        self.didShow = didShow
+    }
+
+    func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        if viewController.transitionCoordinator?.initiallyInteractive == true {
+            didShow(navigationController, viewController, animated)
+        }
+    }
+
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        if viewController.transitionCoordinator?.initiallyInteractive == false {
+            didShow(navigationController, viewController, animated)
+        }
+    }
+}
+
+// MARK: View Animations
+
+extension UIView {
+
+    /// Animates the showing and hiding of a view using a spring animation
+    /// - Parameter toShow: Whether to show the view
+    fileprivate func springAnimation(toShow: Bool, context: UIViewControllerTransitionCoordinatorContext? = nil) {
+        if toShow {
+            guard isHidden == true else { return }
+            maximizeSpringAnimation(context: context)
+        } else {
+            guard isHidden == false else { return }
+            minimizeSpringAnimation(context: context)
+        }
+    }
+
+    /// Applies a spring animation, from size 1 to 0
+    private func minimizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
+        let damping: CGFloat = 0.9
+        let scaleInitial: CGFloat = 1.0
+        let scaleFinal: CGFloat = 0.001
+
+        scaleAnimation(damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context) { [weak self] success in
+            self?.transform = .identity
+            self?.isHidden = true
+        }
+    }
+
+    /// Applies a spring animation, from size 0 to 1
+    private func maximizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
+        let damping: CGFloat = 0.7
+        let scaleInitial: CGFloat = 0.0
+        let scaleFinal: CGFloat = 1.0
+
+        scaleAnimation(damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context)
+    }
+
+    private func scaleAnimation(damping: CGFloat, scaleInitial: CGFloat, scaleFinal: CGFloat, context: UIViewControllerTransitionCoordinatorContext?, completion: ((Bool) -> Void)? = nil) {
+        let duration = 0.5
+
+        transform = CGAffineTransform(scaleX: scaleInitial, y: scaleInitial)
+        isHidden = false
+
+        let animator = UIViewPropertyAnimator(duration: duration, dampingRatio: damping) {
+            self.transform  = CGAffineTransform(scaleX: scaleFinal, y: scaleFinal)
+        }
+
+        animator.addCompletion { (position) in
+            completion?(true)
+        }
+
+        animator.startAnimation()
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
@@ -1,5 +1,16 @@
 import Gridicons
 
+extension FloatingActionButton {
+    class func createButton() -> UIButton {
+        let button = FloatingActionButton(image: Gridicon.iconOfType(.create))
+        button.accessibilityLabel = NSLocalizedString("Create", comment: "Accessibility label for create floating action button")
+        button.accessibilityIdentifier = "floatingCreateButton"
+        button.translatesAutoresizingMaskIntoConstraints = false
+
+        return button
+    }
+}
+
 extension WPTabBarController {
 
     private enum Constants {
@@ -7,24 +18,62 @@ extension WPTabBarController {
         static let heightWidth: CGFloat = 56
     }
 
-    @objc func addFloatingButton() {
-        let button = FloatingActionButton(image: Gridicon.iconOfType(.create))
-        button.accessibilityLabel = NSLocalizedString("Create", comment: "Accessibility label for create floating action button")
-        button.accessibilityIdentifier = "floatingCreateButton"
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.addTarget(self, action: #selector(showPostViewController(_:)), for: .touchUpInside)
+    @objc func showCreateSheet() {
+        showPostTab()
+    }
+
+    @objc func setupCreateButton() -> HideShowCoordinator? {
+        guard let trailingAnchor = blogListSplitViewController.viewControllers.first?.view.trailingAnchor else {
+            return nil
+        }
+        let button = addFloatingButton(trailingAnchor: trailingAnchor, bottomAnchor: tabBar.topAnchor)
+        button.addTarget(self, action: #selector(showCreateSheet), for: .touchUpInside)
+
+        let coordinator = setupHideShowCoordinator(view: button)
+
+        return coordinator
+    }
+
+    /// Sets up the HideShowCoordinator object
+    /// - Parameter view: The view to hide & show
+    private func setupHideShowCoordinator(view: UIView) -> HideShowCoordinator {
+        let coordinator = HideShowCoordinator()
+
+        let showForNavigation: (UIViewController) -> Bool = { viewController in
+            let classes = [BlogDetailsViewController.self, PostListViewController.self, PageListViewController.self]
+            let vcType = type(of: viewController)
+            return classes.contains { classType in
+                return vcType == classType
+            }
+        }
+
+        coordinator.observe(blogListNavigationController, showFor: showForNavigation, view: view)
+
+        let showForTab: (UIViewController) -> Bool = { [weak self] viewController in
+            return viewController == self?.blogListSplitViewController
+        }
+
+        coordinator.observe(self, showFor: showForTab, view: view)
+
+        return coordinator
+    }
+
+    /// Adds a "Floating Action Button" to the UIViewController's `view`
+    /// - Parameters:
+    ///   - trailingAnchor: The trailing anchor to anchor the button to, separated by `Constants.padding`
+    ///   - bottomAnchor: The bottom anchor to anchor the button to, separated by `Constants.padding`
+    private func addFloatingButton(trailingAnchor: NSLayoutXAxisAnchor, bottomAnchor: NSLayoutYAxisAnchor) -> UIButton {
+        let button = FloatingActionButton.createButton()
 
         view.addSubview(button)
 
         NSLayoutConstraint.activate([
-            button.bottomAnchor.constraint(equalTo: tabBar.topAnchor, constant: Constants.padding),
-            button.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor, constant: Constants.padding),
+            button.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constants.padding),
+            button.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.padding),
             button.heightAnchor.constraint(equalToConstant: Constants.heightWidth),
             button.widthAnchor.constraint(equalToConstant: Constants.heightWidth)
         ])
-    }
 
-    @objc func showPostViewController(_ sender: UIView) {
-        showPostTab()
+        return button
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
@@ -1,7 +1,7 @@
 import Gridicons
 
 extension FloatingActionButton {
-    class func createButton() -> FloatingActionButton {
+    class func makeCreateButton() -> FloatingActionButton {
         let button = FloatingActionButton(image: Gridicon.iconOfType(.create))
         button.accessibilityLabel = NSLocalizedString("Create", comment: "Accessibility label for create floating action button")
         button.accessibilityIdentifier = "floatingCreateButton"
@@ -17,25 +17,23 @@ extension WPTabBarController {
         static let heightWidth: CGFloat = 56
     }
 
-    @objc func showCreateSheet() {
+    @objc private func showCreateSheet() {
         showPostTab()
     }
 
-    @objc func setupCreateButton() -> HideShowCoordinator? {
+    @objc func addCreateButton() -> FloatingActionButton? {
         guard let trailingAnchor = blogListSplitViewController.viewControllers.first?.view.trailingAnchor else {
             return nil
         }
         let button = addFloatingButton(trailingAnchor: trailingAnchor, bottomAnchor: tabBar.topAnchor)
         button.addTarget(self, action: #selector(showCreateSheet), for: .touchUpInside)
 
-        let coordinator = setupHideShowCoordinator(view: button)
-
-        return coordinator
+        return button
     }
 
     /// Sets up the HideShowCoordinator object
     /// - Parameter view: The view to hide & show
-    private func setupHideShowCoordinator(view: UIView) -> HideShowCoordinator {
+    @objc func setupHideShowCoordinator(view: UIView) -> HideShowCoordinator {
         let coordinator = HideShowCoordinator()
 
         let showForNavigation: (UIViewController) -> Bool = { viewController in
@@ -61,8 +59,8 @@ extension WPTabBarController {
     /// - Parameters:
     ///   - trailingAnchor: The trailing anchor to anchor the button to, separated by `Constants.padding`
     ///   - bottomAnchor: The bottom anchor to anchor the button to, separated by `Constants.padding`
-    private func addFloatingButton(trailingAnchor: NSLayoutXAxisAnchor, bottomAnchor: NSLayoutYAxisAnchor) -> UIButton {
-        let button = FloatingActionButton.createButton()
+    private func addFloatingButton(trailingAnchor: NSLayoutXAxisAnchor, bottomAnchor: NSLayoutYAxisAnchor) -> FloatingActionButton {
+        let button = FloatingActionButton.makeCreateButton()
 
         view.addSubview(button)
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
@@ -1,12 +1,11 @@
 import Gridicons
 
 extension FloatingActionButton {
-    class func createButton() -> UIButton {
+    class func createButton() -> FloatingActionButton {
         let button = FloatingActionButton(image: Gridicon.iconOfType(.create))
         button.accessibilityLabel = NSLocalizedString("Create", comment: "Accessibility label for create floating action button")
         button.accessibilityIdentifier = "floatingCreateButton"
         button.translatesAutoresizingMaskIntoConstraints = false
-
         return button
     }
 }
@@ -67,9 +66,12 @@ extension WPTabBarController {
 
         view.addSubview(button)
 
+        let trailingConstraint = button.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.padding)
+        button.trailingConstraint = trailingConstraint
+
         NSLayoutConstraint.activate([
+            trailingConstraint,
             button.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constants.padding),
-            button.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.padding),
             button.heightAnchor.constraint(equalToConstant: Constants.heightWidth),
             button.widthAnchor.constraint(equalToConstant: Constants.heightWidth)
         ])

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -26,6 +26,7 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 
 @property (nonatomic, strong, readonly) WPSplitViewController *blogListSplitViewController;
 @property (nonatomic, strong, readonly) BlogListViewController *blogListViewController;
+@property (nonatomic, strong, readonly) UINavigationController *blogListNavigationController;
 @property (nonatomic, strong, readonly) ReaderMenuViewController *readerMenuViewController;
 @property (nonatomic, strong, readonly) NotificationsViewController *notificationsViewController;
 @property (nonatomic, strong, readonly) MeViewController *meViewController;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -68,6 +68,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 @property (nonatomic, strong) UIImage *meTabBarImageUnreadUnselected;
 @property (nonatomic, strong) UIImage *meTabBarImageUnreadSelected;
 
+@property (nonatomic, strong) UIButton *createButton;
 @property (nonatomic, strong) HideShowCoordinator *hideShowCoordinator;
 
 @end
@@ -111,7 +112,9 @@ static CGFloat const WPTabBarIconSize = 32.0f;
         [self setSelectedViewController:self.blogListSplitViewController];
         
         if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
-            self.hideShowCoordinator = [self setupCreateButton];
+            [self.createButton removeFromSuperview];
+            self.createButton = [self addCreateButton];
+            self.hideShowCoordinator = [self setupHideShowCoordinatorWithView:self.createButton];
         }
 
         [[NSNotificationCenter defaultCenter] addObserver:self
@@ -420,8 +423,14 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     _meSplitViewController = nil;
     _notificationsNavigationController = nil;
     _notificationsSplitViewController = nil;
-
+    
     [self setViewControllers:[self tabViewControllers]];
+    
+    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
+        [self.createButton removeFromSuperview];
+        self.createButton = [self addCreateButton];
+        self.hideShowCoordinator = [self setupHideShowCoordinatorWithView:self.createButton];
+    }
 
     // Reset the selectedIndex to the default MySites tab.
     self.selectedIndex = WPTabMySites;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -68,6 +68,8 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 @property (nonatomic, strong) UIImage *meTabBarImageUnreadUnselected;
 @property (nonatomic, strong) UIImage *meTabBarImageUnreadSelected;
 
+@property (nonatomic, strong) HideShowCoordinator *hideShowCoordinator;
+
 @end
 
 @implementation WPTabBarController
@@ -107,6 +109,10 @@ static CGFloat const WPTabBarIconSize = 32.0f;
         [self setViewControllers:[self tabViewControllers]];
 
         [self setSelectedViewController:self.blogListSplitViewController];
+        
+        if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
+            self.hideShowCoordinator = [self setupCreateButton];
+        }
 
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(updateIconIndicators:)
@@ -986,10 +992,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (void)viewDidLoad {
     [super viewDidLoad];
     [self startObserversForTabAccessTracking];
-    
-    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
-        [self addFloatingButton];
-    }
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2037,6 +2037,7 @@
 		F543AF5923A84F200022F595 /* SchedulingCalendarViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543AF5823A84F200022F595 /* SchedulingCalendarViewControllerTests.swift */; };
 		F551E7F523F6EA3100751212 /* FloatingActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F423F6EA3100751212 /* FloatingActionButton.swift */; };
 		F551E7F723FC9A5C00751212 /* Collection+RotateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */; };
+		F551E7FF2404336000751212 /* HideShowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7FE2404336000751212 /* HideShowCoordinator.swift */; };
 		F565190323CF6D1D003FACAF /* WKCookieJarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */; };
 		F5660D03235CF73800020B1E /* SchedulingCalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */; };
 		F5660D07235D114500020B1E /* CalendarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D06235D114500020B1E /* CalendarCollectionView.swift */; };
@@ -4604,6 +4605,7 @@
 		F543AF5823A84F200022F595 /* SchedulingCalendarViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewControllerTests.swift; sourceTree = "<group>"; };
 		F551E7F423F6EA3100751212 /* FloatingActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButton.swift; sourceTree = "<group>"; };
 		F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+RotateTests.swift"; sourceTree = "<group>"; };
+		F551E7FE2404336000751212 /* HideShowCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HideShowCoordinator.swift; sourceTree = "<group>"; };
 		F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKCookieJarTests.swift; sourceTree = "<group>"; };
 		F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewController.swift; sourceTree = "<group>"; };
 		F5660D06235D114500020B1E /* CalendarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionView.swift; sourceTree = "<group>"; };
@@ -9887,6 +9889,7 @@
 			children = (
 				F537F33A23F1FEB9003210FD /* WPTabBarController+CreateButton.swift */,
 				F551E7F423F6EA3100751212 /* FloatingActionButton.swift */,
+				F551E7FE2404336000751212 /* HideShowCoordinator.swift */,
 			);
 			path = "Floating Create Button";
 			sourceTree = "<group>";
@@ -11511,6 +11514,7 @@
 				FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */,
 				9874767321963D330080967F /* SiteStatsInformation.swift in Sources */,
 				738B9A5821B85CF20005062B /* TitleSubtitleHeader.swift in Sources */,
+				F551E7FF2404336000751212 /* HideShowCoordinator.swift in Sources */,
 				43290CF4214F755400F6B398 /* FancyAlertViewController+QuickStart.swift in Sources */,
 				7E4123CC20F418A500DF8486 /* ActivityActionsParser.swift in Sources */,
 				40F46B6B22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift in Sources */,


### PR DESCRIPTION
#13320 

This adds the hide/show functionality to the Floating Create Button and repositions the button to sit over the primary view controller in the split view controller.

<a href="https://user-images.githubusercontent.com/3250/75187309-0cd69b00-5707-11ea-8ce1-5174f09a0d41.gif"><img src="https://user-images.githubusercontent.com/3250/75187309-0cd69b00-5707-11ea-8ce1-5174f09a0d41.gif" width="300"></a>

![iPadFAB](https://user-images.githubusercontent.com/3250/75187329-16600300-5707-11ea-9f00-bff60babbbd9.gif)

To test:

- View Blog Details, Post or Site Pages list views to see the create button
- All other views should hide the button

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Not released
