### PR TITLE
Wrong publish string in post settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 14.4
 -----
+* Post Settings: Fixes the display of posts which are to be immediately published.
  
 14.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 14.4
 -----
-* Post Settings: Fixes the display of posts which are to be immediately published.
+* Post Settings: Fixes the displayed publish date of posts which are to be immediately published.
  
 14.3
 -----

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -420,7 +420,7 @@
 
 - (BOOL)shouldPublishImmediately
 {
-    return [self originalIsDraft] && [self dateCreatedIsNilOrEqualToDateModified];
+    return [self originalIsDraft] && ![self hasFuturePublishDate];
 }
 
 - (NSString *)authorNameForDisplay

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -24,7 +24,7 @@ struct PublishSettingsViewModel {
     let dateTimeFormatter: DateFormatter
 
     init(post: AbstractPost, context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
-        if let dateCreated = post.dateCreated {
+        if let dateCreated = post.dateCreated, post.originalIsDraft() == false || post.hasFuturePublishDate() {
             state = post.hasFuturePublishDate() ? .scheduled(dateCreated) : .published(dateCreated)
         } else {
             state = .immediately

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -24,7 +24,7 @@ struct PublishSettingsViewModel {
     let dateTimeFormatter: DateFormatter
 
     init(post: AbstractPost, context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
-        if let dateCreated = post.dateCreated, post.originalIsDraft() == false || post.hasFuturePublishDate() {
+        if let dateCreated = post.dateCreated, post.shouldPublishImmediately() == false {
             state = post.hasFuturePublishDate() ? .scheduled(dateCreated) : .published(dateCreated)
         } else {
             state = .immediately

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/PublishSettingsControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/PublishSettingsControllerTests.swift
@@ -32,10 +32,25 @@ class PublishSettingsViewControllerTests: XCTestCase {
         }
     }
 
-    func testViewModelDatePublished() {
+    func testViewModelDateImmediately() {
         let testDate = Date()
 
         let post = PostBuilder(context).with(dateCreated: testDate).drafted().withRemote().build()
+
+        let viewModel = PublishSettingsViewModel(post: post)
+        XCTAssertNil(viewModel.date, "Date should not exist in view model")
+
+        if case PublishSettingsViewModel.State.immediately = viewModel.state {
+            // Success
+        } else {
+            XCTFail("View model should be immediately")
+        }
+    }
+
+    func testViewModelDatePublished() {
+        let testDate = Date()
+
+        let post = PostBuilder(context).with(dateCreated: testDate).published().withRemote().build()
 
         let viewModel = PublishSettingsViewModel(post: post)
         XCTAssertEqual(viewModel.date, testDate, "Date should exist in view model")


### PR DESCRIPTION
Fixes #13506 by adjusting the logic to determine whether a post should be immediately published.

To test:
* Create a post and save as Draft.
* Edit the draft, and view Post Settings.
* Notice the 'Publish Immediately' message.
* Tap 'Published Immediately'. Notice the 'Date and Time: Immediately' message.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
