### PR TITLE
Add hide/show animation to floating action button

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -364,7 +364,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    [[WPTabBarController sharedInstance] showCreateButton];
+    if ([self.tabBarController isKindOfClass:[WPTabBarController class]]) {
+        [(WPTabBarController *)self.tabBarController showCreateButton];
+    }
     [self createUserActivity];
     [self startAlertTimer];
 }
@@ -373,12 +375,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewWillDisappear:animated];
     [self stopAlertTimer];
+    if ([self.tabBarController isKindOfClass:[WPTabBarController class]]) {
+        [(WPTabBarController *)self.tabBarController hideCreateButton];
+    }
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
     [super viewDidDisappear:animated];
-    [[WPTabBarController sharedInstance] hideCreateButton];
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -364,6 +364,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
+    [[WPTabBarController sharedInstance] showCreateButton];
     [self createUserActivity];
     [self startAlertTimer];
 }
@@ -372,6 +373,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewWillDisappear:animated];
     [self stopAlertTimer];
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [super viewDidDisappear:animated];
+    [[WPTabBarController sharedInstance] hideCreateButton];
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
@@ -1,4 +1,7 @@
+/// A rounded button with a shadow intended for use as a "Floating Action Button"
 class FloatingActionButton: UIButton {
+
+    var trailingConstraint: NSLayoutConstraint?
 
     convenience init(image: UIImage) {
         self.init(frame: .zero)
@@ -11,6 +14,7 @@ class FloatingActionButton: UIButton {
 
         backgroundColor = .accent
         tintColor = .white
+        clipsToBounds = true
 
         refreshShadow()
     }
@@ -19,9 +23,20 @@ class FloatingActionButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        layer.cornerRadius = frame.size.width / 2
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+
+        layer.cornerRadius = rect.size.width / 2
+    }
+
+    override func updateConstraints() {
+        super.updateConstraints()
+
+        // If we are missing our trailing constraint, re-activate it.
+        // This can happen because the trailing anchor is not yet in the view hierarchy when the button was added.
+        if constraint(for: .trailing, withRelation: .equal) == nil {
+            trailingConstraint?.isActive = true
+        }
     }
 
     private func refreshShadow() {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/HideShowCoordinator+HideShowCreate.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/HideShowCoordinator+HideShowCreate.swift
@@ -1,0 +1,81 @@
+extension WPTabBarController {
+    @objc func hideCreateButton() {
+        createButton.springAnimation(toShow: false)
+    }
+
+    @objc func showCreateButton() {
+        createButton.setNeedsUpdateConstraints() // See `FloatingActionButton` implementation for more info on why this is needed.
+        createButton.springAnimation(toShow: true)
+    }
+}
+
+// MARK: View Animations
+
+private extension UIView {
+
+    enum Constants {
+        enum Maximize {
+            static let damping: CGFloat = 0.7
+            static let duration: TimeInterval = 0.5
+            static let initialScale: CGFloat = 0.0
+            static let finalScale: CGFloat = 1.0
+        }
+        enum Minimize {
+            static let damping: CGFloat = 0.9
+            static let duration: TimeInterval = 0.25
+            static let initialScale: CGFloat = 1.0
+            static let finalScale: CGFloat = 0.001
+        }
+    }
+
+    /// Animates the showing and hiding of a view using a spring animation
+    /// - Parameter toShow: Whether to show the view
+    func springAnimation(toShow: Bool, context: UIViewControllerTransitionCoordinatorContext? = nil) {
+        if toShow {
+            guard isHidden == true else { return }
+            maximizeSpringAnimation(context: context)
+        } else {
+            guard isHidden == false else { return }
+            minimizeSpringAnimation(context: context)
+        }
+    }
+
+    /// Applies a spring animation, from size 1 to 0
+    func minimizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
+        let damping = Constants.Minimize.damping
+        let scaleInitial = Constants.Minimize.initialScale
+        let scaleFinal = Constants.Minimize.finalScale
+        let duration = Constants.Minimize.duration
+
+        scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context) { [weak self] success in
+            self?.transform = .identity
+            self?.isHidden = true
+        }
+    }
+
+    /// Applies a spring animation, from size 0 to 1
+    func maximizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
+        let damping = Constants.Maximize.damping
+        let scaleInitial = Constants.Maximize.initialScale
+        let scaleFinal = Constants.Maximize.finalScale
+        let duration = Constants.Maximize.duration
+
+        scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context)
+    }
+
+    func scaleAnimation(duration: TimeInterval, damping: CGFloat, scaleInitial: CGFloat, scaleFinal: CGFloat, context: UIViewControllerTransitionCoordinatorContext?, completion: ((Bool) -> Void)? = nil) {
+        setNeedsDisplay() // Make sure we redraw so that corners are rounded
+        transform = CGAffineTransform(scaleX: scaleInitial, y: scaleInitial)
+        isHidden = false
+
+        let animator = UIViewPropertyAnimator(duration: duration, dampingRatio: damping) {
+            self.transform  = CGAffineTransform(scaleX: scaleFinal, y: scaleFinal)
+        }
+
+        animator.addCompletion { (position) in
+            completion?(true)
+        }
+
+        animator.startAnimation()
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
@@ -1,5 +1,15 @@
 import Gridicons
 
+extension FloatingActionButton {
+    class func makeCreateButton() -> FloatingActionButton {
+        let button = FloatingActionButton(image: Gridicon.iconOfType(.create))
+        button.accessibilityLabel = NSLocalizedString("Create", comment: "Accessibility label for create floating action button")
+        button.accessibilityIdentifier = "floatingCreateButton"
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }
+}
+
 extension WPTabBarController {
 
     private enum Constants {
@@ -7,24 +17,39 @@ extension WPTabBarController {
         static let heightWidth: CGFloat = 56
     }
 
-    @objc func addFloatingButton() {
-        let button = FloatingActionButton(image: Gridicon.iconOfType(.create))
-        button.accessibilityLabel = NSLocalizedString("Create", comment: "Accessibility label for create floating action button")
-        button.accessibilityIdentifier = "floatingCreateButton"
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.addTarget(self, action: #selector(showPostViewController(_:)), for: .touchUpInside)
+    @objc private func showCreateSheet() {
+        showPostTab()
+    }
+
+    @objc func addCreateButton() -> FloatingActionButton? {
+        guard let trailingAnchor = blogListSplitViewController.viewControllers.first?.view.trailingAnchor else {
+            return nil
+        }
+        let button = addFloatingButton(trailingAnchor: trailingAnchor, bottomAnchor: tabBar.topAnchor)
+        button.addTarget(self, action: #selector(showCreateSheet), for: .touchUpInside)
+
+        return button
+    }
+
+    /// Adds a "Floating Action Button" to the UIViewController's `view`
+    /// - Parameters:
+    ///   - trailingAnchor: The trailing anchor to anchor the button to, separated by `Constants.padding`
+    ///   - bottomAnchor: The bottom anchor to anchor the button to, separated by `Constants.padding`
+    private func addFloatingButton(trailingAnchor: NSLayoutXAxisAnchor, bottomAnchor: NSLayoutYAxisAnchor) -> FloatingActionButton {
+        let button = FloatingActionButton.makeCreateButton()
 
         view.addSubview(button)
 
+        let trailingConstraint = button.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.padding)
+        button.trailingConstraint = trailingConstraint
+
         NSLayoutConstraint.activate([
-            button.bottomAnchor.constraint(equalTo: tabBar.topAnchor, constant: Constants.padding),
-            button.trailingAnchor.constraint(equalTo: view.safeTrailingAnchor, constant: Constants.padding),
+            trailingConstraint,
+            button.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constants.padding),
             button.heightAnchor.constraint(equalToConstant: Constants.heightWidth),
             button.widthAnchor.constraint(equalToConstant: Constants.heightWidth)
         ])
-    }
 
-    @objc func showPostViewController(_ sender: UIView) {
-        showPostTab()
+        return button
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+HideShowCreate.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+HideShowCreate.swift
@@ -30,40 +30,40 @@ private extension UIView {
 
     /// Animates the showing and hiding of a view using a spring animation
     /// - Parameter toShow: Whether to show the view
-    func springAnimation(toShow: Bool, context: UIViewControllerTransitionCoordinatorContext? = nil) {
+    func springAnimation(toShow: Bool) {
         if toShow {
             guard isHidden == true else { return }
-            maximizeSpringAnimation(context: context)
+            maximizeSpringAnimation()
         } else {
             guard isHidden == false else { return }
-            minimizeSpringAnimation(context: context)
+            minimizeSpringAnimation()
         }
     }
 
     /// Applies a spring animation, from size 1 to 0
-    func minimizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
+    func minimizeSpringAnimation() {
         let damping = Constants.Minimize.damping
         let scaleInitial = Constants.Minimize.initialScale
         let scaleFinal = Constants.Minimize.finalScale
         let duration = Constants.Minimize.duration
 
-        scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context) { [weak self] success in
+        scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal) { [weak self] success in
             self?.transform = .identity
             self?.isHidden = true
         }
     }
 
     /// Applies a spring animation, from size 0 to 1
-    func maximizeSpringAnimation(context: UIViewControllerTransitionCoordinatorContext?) {
+    func maximizeSpringAnimation() {
         let damping = Constants.Maximize.damping
         let scaleInitial = Constants.Maximize.initialScale
         let scaleFinal = Constants.Maximize.finalScale
         let duration = Constants.Maximize.duration
 
-        scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal, context: context)
+        scaleAnimation(duration: duration, damping: damping, scaleInitial: scaleInitial, scaleFinal: scaleFinal)
     }
 
-    func scaleAnimation(duration: TimeInterval, damping: CGFloat, scaleInitial: CGFloat, scaleFinal: CGFloat, context: UIViewControllerTransitionCoordinatorContext?, completion: ((Bool) -> Void)? = nil) {
+    func scaleAnimation(duration: TimeInterval, damping: CGFloat, scaleInitial: CGFloat, scaleFinal: CGFloat, completion: ((Bool) -> Void)? = nil) {
         setNeedsDisplay() // Make sure we redraw so that corners are rounded
         transform = CGAffineTransform(scaleX: scaleInitial, y: scaleInitial)
         isHidden = false

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -27,6 +27,7 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 
 @property (nonatomic, strong, readonly) WPSplitViewController *blogListSplitViewController;
 @property (nonatomic, strong, readonly) BlogListViewController *blogListViewController;
+@property (nonatomic, strong, readonly) UINavigationController *blogListNavigationController;
 @property (nonatomic, strong, readonly) ReaderMenuViewController *readerMenuViewController;
 @property (nonatomic, strong, readonly) NotificationsViewController *notificationsViewController;
 // will be removed when the new IA implementation completes
@@ -37,6 +38,7 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 @property (nonatomic, strong, readonly) MySitesCoordinator *mySitesCoordinator;
 @property (nonatomic, strong, readonly) ReaderCoordinator *readerCoordinator;
 @property (nonatomic, strong) id<ScenePresenter> meScenePresenter;
+@property (nonatomic, strong, readonly) UIButton *createButton;
 
 + (instancetype)sharedInstance;
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -68,6 +68,8 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 @property (nonatomic, strong) UIImage *meTabBarImageUnreadUnselected;
 @property (nonatomic, strong) UIImage *meTabBarImageUnreadSelected;
 
+@property (nonatomic, strong) UIButton *createButton;
+
 @end
 
 @implementation WPTabBarController
@@ -109,6 +111,11 @@ static CGFloat const WPTabBarIconSize = 32.0f;
         [self setViewControllers:[self tabViewControllers]];
 
         [self setSelectedViewController:self.blogListSplitViewController];
+        
+        if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
+            [self.createButton removeFromSuperview];
+            self.createButton = [self addCreateButton];
+        }
 
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(updateIconIndicators:)
@@ -416,8 +423,13 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     _meSplitViewController = nil;
     _notificationsNavigationController = nil;
     _notificationsSplitViewController = nil;
-
+    
     [self setViewControllers:[self tabViewControllers]];
+    
+    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
+        [self.createButton removeFromSuperview];
+        self.createButton = [self addCreateButton];
+    }
 
     // Reset the selectedIndex to the default MySites tab.
     self.selectedIndex = WPTabMySites;
@@ -960,10 +972,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (void)viewDidLoad {
     [super viewDidLoad];
     [self startObserversForTabAccessTracking];
-    
-    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
-        [self addFloatingButton];
-    }
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2039,7 +2039,7 @@
 		F543AF5923A84F200022F595 /* SchedulingCalendarViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543AF5823A84F200022F595 /* SchedulingCalendarViewControllerTests.swift */; };
 		F551E7F523F6EA3100751212 /* FloatingActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F423F6EA3100751212 /* FloatingActionButton.swift */; };
 		F551E7F723FC9A5C00751212 /* Collection+RotateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */; };
-		F551E7FF2404336000751212 /* HideShowCoordinator+HideShowCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7FE2404336000751212 /* HideShowCoordinator+HideShowCreate.swift */; };
+		F551E7FF2404336000751212 /* WPTabBarController+HideShowCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7FE2404336000751212 /* WPTabBarController+HideShowCreate.swift */; };
 		F565190323CF6D1D003FACAF /* WKCookieJarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */; };
 		F5660D03235CF73800020B1E /* SchedulingCalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */; };
 		F5660D07235D114500020B1E /* CalendarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D06235D114500020B1E /* CalendarCollectionView.swift */; };
@@ -4609,7 +4609,7 @@
 		F543AF5823A84F200022F595 /* SchedulingCalendarViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewControllerTests.swift; sourceTree = "<group>"; };
 		F551E7F423F6EA3100751212 /* FloatingActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButton.swift; sourceTree = "<group>"; };
 		F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+RotateTests.swift"; sourceTree = "<group>"; };
-		F551E7FE2404336000751212 /* HideShowCoordinator+HideShowCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HideShowCoordinator+HideShowCreate.swift"; sourceTree = "<group>"; };
+		F551E7FE2404336000751212 /* WPTabBarController+HideShowCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPTabBarController+HideShowCreate.swift"; sourceTree = "<group>"; };
 		F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKCookieJarTests.swift; sourceTree = "<group>"; };
 		F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewController.swift; sourceTree = "<group>"; };
 		F5660D06235D114500020B1E /* CalendarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionView.swift; sourceTree = "<group>"; };
@@ -9903,7 +9903,7 @@
 			children = (
 				F537F33A23F1FEB9003210FD /* WPTabBarController+CreateButton.swift */,
 				F551E7F423F6EA3100751212 /* FloatingActionButton.swift */,
-				F551E7FE2404336000751212 /* HideShowCoordinator+HideShowCreate.swift */,
+				F551E7FE2404336000751212 /* WPTabBarController+HideShowCreate.swift */,
 			);
 			path = "Floating Create Button";
 			sourceTree = "<group>";
@@ -11528,7 +11528,7 @@
 				FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */,
 				9874767321963D330080967F /* SiteStatsInformation.swift in Sources */,
 				738B9A5821B85CF20005062B /* TitleSubtitleHeader.swift in Sources */,
-				F551E7FF2404336000751212 /* HideShowCoordinator+HideShowCreate.swift in Sources */,
+				F551E7FF2404336000751212 /* WPTabBarController+HideShowCreate.swift in Sources */,
 				43290CF4214F755400F6B398 /* FancyAlertViewController+QuickStart.swift in Sources */,
 				7E4123CC20F418A500DF8486 /* ActivityActionsParser.swift in Sources */,
 				40F46B6B22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2039,6 +2039,7 @@
 		F543AF5923A84F200022F595 /* SchedulingCalendarViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543AF5823A84F200022F595 /* SchedulingCalendarViewControllerTests.swift */; };
 		F551E7F523F6EA3100751212 /* FloatingActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F423F6EA3100751212 /* FloatingActionButton.swift */; };
 		F551E7F723FC9A5C00751212 /* Collection+RotateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */; };
+		F551E7FF2404336000751212 /* HideShowCoordinator+HideShowCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F551E7FE2404336000751212 /* HideShowCoordinator+HideShowCreate.swift */; };
 		F565190323CF6D1D003FACAF /* WKCookieJarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */; };
 		F5660D03235CF73800020B1E /* SchedulingCalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */; };
 		F5660D07235D114500020B1E /* CalendarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D06235D114500020B1E /* CalendarCollectionView.swift */; };
@@ -4608,6 +4609,7 @@
 		F543AF5823A84F200022F595 /* SchedulingCalendarViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewControllerTests.swift; sourceTree = "<group>"; };
 		F551E7F423F6EA3100751212 /* FloatingActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingActionButton.swift; sourceTree = "<group>"; };
 		F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+RotateTests.swift"; sourceTree = "<group>"; };
+		F551E7FE2404336000751212 /* HideShowCoordinator+HideShowCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HideShowCoordinator+HideShowCreate.swift"; sourceTree = "<group>"; };
 		F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKCookieJarTests.swift; sourceTree = "<group>"; };
 		F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewController.swift; sourceTree = "<group>"; };
 		F5660D06235D114500020B1E /* CalendarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionView.swift; sourceTree = "<group>"; };
@@ -9901,6 +9903,7 @@
 			children = (
 				F537F33A23F1FEB9003210FD /* WPTabBarController+CreateButton.swift */,
 				F551E7F423F6EA3100751212 /* FloatingActionButton.swift */,
+				F551E7FE2404336000751212 /* HideShowCoordinator+HideShowCreate.swift */,
 			);
 			path = "Floating Create Button";
 			sourceTree = "<group>";
@@ -11525,6 +11528,7 @@
 				FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */,
 				9874767321963D330080967F /* SiteStatsInformation.swift in Sources */,
 				738B9A5821B85CF20005062B /* TitleSubtitleHeader.swift in Sources */,
+				F551E7FF2404336000751212 /* HideShowCoordinator+HideShowCreate.swift in Sources */,
 				43290CF4214F755400F6B398 /* FancyAlertViewController+QuickStart.swift in Sources */,
 				7E4123CC20F418A500DF8486 /* ActivityActionsParser.swift in Sources */,
 				40F46B6B22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift in Sources */,

--- a/WordPress/WordPressUITests/Screens/TabNavComponent.swift
+++ b/WordPress/WordPressUITests/Screens/TabNavComponent.swift
@@ -29,7 +29,7 @@ class TabNavComponent: BaseScreen {
     func gotoMySiteScreen() -> MySiteScreen {
         // Avoid transitioning to the sites list if MySites is already on screen
         if !MySiteScreen.isVisible {
-            mySitesTabButton.tap()
+            gotoMySitesScreen().switchToSite(withTitle: "infocusphotographers.com")
         }
         return MySiteScreen()
     }
@@ -47,6 +47,7 @@ class TabNavComponent: BaseScreen {
     }
 
     func gotoBlockEditorScreen() -> BlockEditorScreen {
+        gotoMySiteScreen()
         writeTabButton.tap()
         return BlockEditorScreen()
     }

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -21,10 +21,12 @@ class MainNavigationTests: XCTestCase {
     func testTabBarNavigation() {
         mySiteScreen
             .tabBar.gotoMySitesScreen()
-            .tabBar.gotoReaderScreen()
-            .tabBar.gotoNotificationsScreen()
             .tabBar.gotoBlockEditorScreen()
             .closeEditor()
+
+        _ = mySiteScreen
+            .tabBar.gotoReaderScreen()
+            .tabBar.gotoNotificationsScreen()
 
         XCTContext.runActivity(named: "Confirm Notifications screen and main navigation bar are loaded.") { (activity) in
             XCTAssert(NotificationsScreen.isLoaded(), "Notifications screen isn't loaded.")


### PR DESCRIPTION
#13320 

This adds the hide/show functionality to the Create Floating Action Button and repositions the button to sit over the primary view controller in the split view controller.

We've decided to only show the Create button on the Blog Detail screen. Because of that, the implementation has changed to simply show/hide the button when that screen is appearing or disappearing. This simplifies some of the previously complex (and fragile) logic in #13544.

<a href="https://user-images.githubusercontent.com/3250/75308936-e69b2300-580c-11ea-86b6-fcdf1da65505.gif"><img src="https://user-images.githubusercontent.com/3250/75308936-e69b2300-580c-11ea-86b6-fcdf1da65505.gif" width="300"></a>

![iPhoneLandscape](https://user-images.githubusercontent.com/3250/75308943-e8fd7d00-580c-11ea-8e0f-2d8f7f4c99ef.gif)

To test:

- View Blog Details page to see the create button
- All other views should hide the button

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Not yet released
