### PR TITLE
Add GitHub workflows to check PR diff size and milestone

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -45,3 +45,9 @@ jobs:
           yarn run danger ci \
             --dangerfile Automattic/peril-settings/org/pr/ios-macos.ts \
             --id consistency_checks
+
+      - name: Check Diff Size
+        run: |
+          yarn run danger ci \
+            --dangerfile Automattic/peril-settings/org/pr/diff-size.ts \
+            --id diff_size

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -5,12 +5,23 @@ on:
     # when the labels change, not only when a PR is opened/reopened or changes
     # are pushed to it.
     types: [opened, reopened, synchronize, labeled, unlabeled]
+  # In order to validate the milestone, we need to listen for the event on the
+  # issue, as there's no event for milestones in PRs –GitHub PRs are a special
+  # kind of issue. Un
+  issues:
+    types: [milestoned, demilestoned]
 
 jobs:
   danger:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    if:
+      # One of the checks we run is for milestones, but the event that triggers
+      # it is for issues. In order to run this workflow only for PRs, we need
+      # to check the context to see if this was triggered by a PR or a plain
+      # issue.
+      github.event.pull_request != null || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@v2
 
@@ -51,3 +62,9 @@ jobs:
           yarn run danger ci \
             --dangerfile Automattic/peril-settings/org/pr/diff-size.ts \
             --id diff_size
+
+      - name: Validate Milestone
+        run: |
+          yarn run danger ci \
+            --dangerfile Automattic/peril-settings/org/pr/milestone.ts \
+            --id milestone


### PR DESCRIPTION
Follows up on the https://github.com/wordpress-mobile/WordPress-iOS/issues/13366 work by migrating the [diff size](https://github.com/Automattic/peril-settings/blob/5d22258ca46c3649f2cb863cfac2d16f12c4cba0/org/pr/diff-size.ts)) and [milestone](https://github.com/Automattic/peril-settings/blob/5d22258ca46c3649f2cb863cfac2d16f12c4cba0/org/pr/milestone.ts) checks to Danger, adding them to the existing GitHub Actions workflow.

To test, please refer to the instructions on the original PRs: https://github.com/mokagio/WordPress-iOS/pull/22 for diff size and https://github.com/mokagio/WordPress-iOS/pull/27 for milestone.