### PR TITLE
Remove the Gutenberg dialog on new sites

### DIFF
--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -170,7 +170,7 @@ class GutenbergSettings {
     }
 
     func getDefaultEditor(for blog: Blog) -> MobileEditor {
-        return .aztec
+        return .gutenberg
     }
 }
 

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -5,12 +5,20 @@ class GutenbergSettings {
     enum Key {
         static let appWideEnabled = "kUserDefaultsGutenbergEditorEnabled"
         static func enabledOnce(for blog: Blog) -> String {
-            let url = (blog.url ?? "") as String
+            let url = urlStringFrom(blog)
             return "com.wordpress.gutenberg-autoenabled-" + url
         }
         static func showPhase2Dialog(for blog: Blog) -> String {
-            let url = (blog.url ?? "") as String
+            let url = urlStringFrom(blog)
             return "kShowGutenbergPhase2Dialog-" + url
+        }
+
+        private static func urlStringFrom(_ blog: Blog) -> String {
+            return (blog.url ?? "")
+            // New sites will add a slash at the end of URL.
+            // This is removed when the URL is refreshed from remote.
+            // Removing trailing '/' in case there is one for consistency.
+            .removingTrailingCharacterIfExists("/")
         }
     }
 
@@ -184,5 +192,14 @@ class GutenbergSettingsBridge: NSObject {
     @objc(postSettingsToRemoteForBlog:)
     static func postSettingsToRemote(for blog: Blog) {
         GutenbergSettings().postSettingsToRemote(for: blog)
+    }
+}
+
+private extension String {
+    func removingTrailingCharacterIfExists(_ character: Character) -> String {
+        if self.last == character {
+            return String(dropLast())
+        }
+        return self
     }
 }

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -178,6 +178,7 @@ class GutenbergSettings {
     }
 
     func getDefaultEditor(for blog: Blog) -> MobileEditor {
+        database.set(true, forKey: Key.enabledOnce(for: blog))
         return .gutenberg
     }
 }

--- a/WordPress/WordPressTest/EditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsServiceTests.swift
@@ -66,14 +66,14 @@ class EditorSettingsServiceTest: XCTestCase {
 
         // Should call POST local settings to remote (migration)
         XCTAssertTrue(remoteApi.postMethodCalled)
-        XCTAssertTrue(remoteApi.URLStringPassedIn?.contains("platform=mobile&editor=aztec") ?? false)
+        XCTAssertTrue(remoteApi.URLStringPassedIn?.contains("platform=mobile&editor=gutenberg") ?? false)
         // Respond with mobile editor set on the server
-        let finalResponse = responseWith(mobileEditor: "aztec")
+        let finalResponse = responseWith(mobileEditor: "gutenberg")
         remoteApi.successBlockPassedIn?(finalResponse, HTTPURLResponse())
 
         waitForExpectations(timeout: 0.1) { (error) in
             // The default value should be now on local and remote
-            XCTAssertEqual(blog.mobileEditor, .aztec)
+            XCTAssertEqual(blog.mobileEditor, .gutenberg)
         }
     }
 

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -113,84 +113,84 @@ class GutenbergSettingsTests: XCTestCase {
 
     // Thests for defaults when `mobile_editor` haven't been sync from remote
 
-    func testSelfHostedDefaultsToAztec() {
+    func testSelfHostedDefaultsToGutenberg() {
         blog = newTestBlog(isWPComAPIEnabled: false)
         post = newTestPost(with: blog)
-        XCTAssertFalse(mustUseGutenberg)
+        XCTAssertTrue(mustUseGutenberg)
     }
 
-    func testWPComAccountsDefaultsToAztec() {
-        XCTAssertFalse(mustUseGutenberg)
+    func testWPComAccountsDefaultsToGutenberg() {
+        XCTAssertTrue(mustUseGutenberg)
     }
 
     // MARK: - Tracks tests
 
     func testTracksOnBlockPostOpening() {
-        settings.setGutenbergEnabled(true, for: blog, source: .onBlockPostOpening)
+        settings.setGutenbergEnabled(false, for: blog, source: .onBlockPostOpening)
 
         XCTAssertEqual(TestAnalyticsTracker.tracked.count, 1)
 
         let trackEvent = TestAnalyticsTracker.tracked.first
-        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergEnabled)
+        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergDisabled)
 
         let property = trackEvent?.properties["source"] as? String
         XCTAssertEqual(property, GutenbergSettings.TracksSwitchSource.onBlockPostOpening.rawValue)
     }
 
     func testTracksOnSiteCreation() {
-        settings.softSetGutenbergEnabled(true, for: blog, source: .onSiteCreation)
+        settings.softSetGutenbergEnabled(false, for: blog, source: .onSiteCreation)
 
         XCTAssertEqual(TestAnalyticsTracker.tracked.count, 1)
 
         let trackEvent = TestAnalyticsTracker.tracked.first
-        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergEnabled)
+        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergDisabled)
 
         let property = trackEvent?.properties["source"] as? String
         XCTAssertEqual(property, GutenbergSettings.TracksSwitchSource.onSiteCreation.rawValue)
     }
 
     func testTracksViaSiteSettings() {
-        settings.setGutenbergEnabled(true, for: blog, source: .viaSiteSettings)
+        settings.setGutenbergEnabled(false, for: blog, source: .viaSiteSettings)
 
         XCTAssertEqual(TestAnalyticsTracker.tracked.count, 1)
 
         let trackEvent = TestAnalyticsTracker.tracked.first
-        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergEnabled)
+        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergDisabled)
 
         let property = trackEvent?.properties["source"] as? String
         XCTAssertEqual(property, GutenbergSettings.TracksSwitchSource.viaSiteSettings.rawValue)
     }
 
     func testTracksEventOnlyOnceWhenEditorDoesNotChange() {
-        settings.softSetGutenbergEnabled(true, for: blog, source: .onSiteCreation)
-        settings.setGutenbergEnabled(true, for: blog, source: .viaSiteSettings)
-        settings.setGutenbergEnabled(true, for: blog, source: .onBlockPostOpening)
+        settings.softSetGutenbergEnabled(false, for: blog, source: .onSiteCreation)
+        settings.setGutenbergEnabled(false, for: blog, source: .viaSiteSettings)
+        settings.setGutenbergEnabled(false, for: blog, source: .onBlockPostOpening)
 
         XCTAssertEqual(TestAnalyticsTracker.tracked.count, 1)
 
         let trackEvent = TestAnalyticsTracker.tracked.first
-        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergEnabled)
+        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergDisabled)
 
         let property = trackEvent?.properties["source"] as? String
         XCTAssertEqual(property, GutenbergSettings.TracksSwitchSource.onSiteCreation.rawValue)
     }
 
     func testTracksSwitchEventOnAndOff() {
-        settings.setGutenbergEnabled(true, for: blog, source: .viaSiteSettings)
         settings.setGutenbergEnabled(false, for: blog, source: .viaSiteSettings)
+        settings.setGutenbergEnabled(true, for: blog, source: .viaSiteSettings)
 
         XCTAssertEqual(TestAnalyticsTracker.tracked.count, 2)
 
         // First event (Switch ON)
         var trackEvent = TestAnalyticsTracker.tracked.first
-        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergEnabled)
+        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergDisabled)
 
         var property = trackEvent?.properties["source"] as? String
         XCTAssertEqual(property, GutenbergSettings.TracksSwitchSource.viaSiteSettings.rawValue)
 
         // Second event (Switch OFF)
         trackEvent = TestAnalyticsTracker.tracked.last
-        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergDisabled)
+        XCTAssertEqual(trackEvent?.stat, WPAnalyticsStat.appSettingsGutenbergEnabled)
 
         property = trackEvent?.properties["source"] as? String
         XCTAssertEqual(property, GutenbergSettings.TracksSwitchSource.viaSiteSettings.rawValue)

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -200,6 +200,13 @@ class GutenbergSettingsTests: XCTestCase {
 
     // Autoenable on new installs
 
+    func testDoNotAutoenableWithTrailingSlashURL() {
+        blog.url = "https://wordpress.com/" // From site creation flow
+        settings.setGutenbergEnabled(true, for: blog)
+        blog.url = "https://wordpress.com" // After refreshing with remote
+        XCTAssertFalse(shouldAutoenableGutenberg)
+    }
+
     func testDoNotAutoenableIfUsersSwitchesToGutenberg() {
         settings.setGutenbergEnabled(true, for: blog)
 


### PR DESCRIPTION
Remove the Gutenberg dialog that was showning after creating a new site by setting gutenberg as default.

Since Aztec was set as default, the logic run the migration to gutenberg and set the dialog to be shown.

Just setting gutenberg as default should have been enough, but there was an issue where the URL string on the site creation flow appends a trailing `/`. This URL is used as the key for gutenberg `enabledOnce` setting. After refreshing the URL from remote, the trailing `/` was removed, creating a different key, so `enabledOnce` was returning false (and showing the dialog when it shouldn't).

This PR solves that issue ensuring that there are no trailing `/`s when saving the `enabledOnce` setting.

**To test:**

Test 1:
- Create a new site.
- Create a new post, make sure the block editor is showing and there is no dialog about it.

Test 2:
- Create a new user.
- Create a new site.
- Create a new post, make sure the block editor is showing and there is no dialog about it.

Test 3:
- Add a self hosted site.
- Create a new post, make sure the block editor is showing and there is no dialog about it.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


cc @maxme 