### PR TITLE
Wait to activate trailing constraint until update

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
@@ -32,11 +32,7 @@ class FloatingActionButton: UIButton {
     override func updateConstraints() {
         super.updateConstraints()
 
-        // If we are missing our trailing constraint, re-activate it.
-        // This can happen because the trailing anchor is not yet in the view hierarchy when the button was added.
-        if constraint(for: .trailing, withRelation: .equal) == nil {
-            trailingConstraint?.isActive = true
-        }
+        trailingConstraint?.isActive = true
     }
 
     private func refreshShadow() {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/WPTabBarController+CreateButton.swift
@@ -40,11 +40,11 @@ extension WPTabBarController {
 
         view.addSubview(button)
 
+        /// A trailing constraint that is activated in `updateConstraints` at a later time when everything should be set up
         let trailingConstraint = button.trailingAnchor.constraint(equalTo: trailingAnchor, constant: Constants.padding)
         button.trailingConstraint = trailingConstraint
 
         NSLayoutConstraint.activate([
-            trailingConstraint,
             button.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constants.padding),
             button.heightAnchor.constraint(equalToConstant: Constants.heightWidth),
             button.widthAnchor.constraint(equalToConstant: Constants.heightWidth)


### PR DESCRIPTION
Many thanks to @emilylaguna for reporting this issue!

When the My Sites tab is not in the view hierarchy at the time the floating Create button is added to the tab bar, constraint exceptions can result.

This _shouldn't_ be possible with the move of the Me button to the Blog Details screen (upon logout, you're always back at the My Sites tab), but this commit should ensure that the exception doesn't occur and activates the FAB trailing constraint in a single location.

To test:
* Disable the `meMove` feature flag
* Log out of an account from the Me tab
* Log back in to that account
* Should crash the app with an autolayout exception.

PR submission checklist:

- [x] ~I have considered adding unit tests where possible.~ UI tests have been updated to use the default value for this flag and I can't reproduce without adjusting the value.
- [x] ~I have considered adding accessibility improvements for my changes.~
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Not released.
