### PR TITLE
Enlarge tappable area behind the `Me` gravatar button

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
@@ -36,7 +36,7 @@ extension BlogListViewController {
 private extension UIBarButtonItem {
     /// gravatar configuration parameters
     struct GravatarConfiguration {
-        static let radius: CGFloat = 24.0
+        static let radius: CGFloat = 32
         static let tappableWidth: CGFloat = 44
         static let fallBackImage = Gridicon.iconOfType(.user)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
@@ -37,63 +37,92 @@ private extension UIBarButtonItem {
     /// gravatar configuration parameters
     struct GravatarConfiguration {
         static let radius: CGFloat = 24.0
-        static let fallBackImage = Gridicon.iconOfType(.userCircle)
+        static let tappableWidth: CGFloat = 44
+        static let fallBackImage = Gridicon.iconOfType(.user)
     }
 
     /// Assign the gravatar CircularImageView to the customView property and attach the passed target/action.
-    /// If email is nil, fall back to the gravatar icon. Adds `Me` accessibility traits to the button
     convenience init(email: String?, style: UIBarButtonItem.Style = .plain, target: Any?, action: Selector?) {
-        guard let email = email else {
-            self.init(image: GravatarConfiguration.fallBackImage,
-                      style: style,
-                      target: target,
-                      action: action)
-            makeMeButtonAccessible()
-            return
-        }
         self.init()
         makeMeButtonAccessible()
-
-        customView = makeGravatarView(with: email)
+        customView = makeGravatarTappableView(with: email)
         addTapToCustomView(target: target, action: action)
     }
 
     /// Create the gravatar CircluarImageView with a fade animation on tap.
-    func makeGravatarView(with email: String) -> CircularImageView {
+    /// If no valid email is provided, fall back to the circled user icon
+    func makeGravatarTappableView(with email: String?) -> UIImageView {
         let gravatarImageView = CircularImageView()
+
         gravatarImageView.isUserInteractionEnabled = true
         gravatarImageView.animatesTouch = true
+        setSize(of: gravatarImageView, size: GravatarConfiguration.radius)
+        gravatarImageView.contentMode = .scaleAspectFit
+        gravatarImageView.setBorder()
 
-        gravatarImageView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint(item: gravatarImageView,
+        if let email = email {
+            gravatarImageView.downloadGravatarWithEmail(email, placeholderImage: GravatarConfiguration.fallBackImage)
+        } else {
+            gravatarImageView.image = GravatarConfiguration.fallBackImage
+        }
+        let tappableView = embedInTappableArea(gravatarImageView)
+
+        return tappableView
+    }
+
+    /// adds a 'tap' action to customView
+    func addTapToCustomView(target: Any?, action: Selector?) {
+        let tapRecognizer = UITapGestureRecognizer(target: target, action: action)
+        customView?.addGestureRecognizer(tapRecognizer)
+    }
+
+    /// embeds a view in a larger tappable area, vertically centered and aligned to the right
+    func embedInTappableArea(_ imageView: UIImageView) -> UIImageView {
+        let tappableView = UIImageView()
+        setSize(of: tappableView, size: GravatarConfiguration.tappableWidth)
+        tappableView.addSubview(imageView)
+        NSLayoutConstraint(item: imageView,
+                           attribute: .centerY,
+                           relatedBy: .equal,
+                           toItem: tappableView,
+                           attribute: .centerY,
+                           multiplier: 1,
+                           constant: 0)
+            .isActive = true
+
+        NSLayoutConstraint(item: imageView,
+                           attribute: .trailingMargin,
+                       relatedBy: .equal,
+                       toItem: tappableView,
+                       attribute: .trailingMargin,
+                       multiplier: 1,
+                       constant: 0)
+        .isActive = true
+
+        tappableView.isUserInteractionEnabled = true
+        return tappableView
+    }
+
+    /// constrains a squared UIImageView to a set size
+    func setSize(of imageView: UIImageView, size: CGFloat) {
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint(item: imageView,
                            attribute: .width,
                            relatedBy: .equal,
                            toItem: nil,
                            attribute: .notAnAttribute,
                            multiplier: 1,
-                           constant: GravatarConfiguration.radius)
+                           constant: size)
             .isActive = true
 
-        NSLayoutConstraint(item: gravatarImageView,
+        NSLayoutConstraint(item: imageView,
                            attribute: .height,
                            relatedBy: .equal,
                            toItem: nil,
                            attribute: .notAnAttribute,
                            multiplier: 1,
-                           constant: GravatarConfiguration.radius)
+                           constant: size)
             .isActive = true
-
-        gravatarImageView.contentMode = .scaleAspectFit
-
-        gravatarImageView.downloadGravatarWithEmail(email, placeholderImage: GravatarConfiguration.fallBackImage)
-        return gravatarImageView
-    }
-
-    /// adds a 'tap' action to customView
-    func addTapToCustomView(target: Any?, action: Selector?) {
-        customView?.isUserInteractionEnabled = true
-        let tapRecognizer = UITapGestureRecognizer(target: target, action: action)
-        customView?.addGestureRecognizer(tapRecognizer)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
@@ -51,7 +51,7 @@ private extension UIBarButtonItem {
 
     /// Create the gravatar CircluarImageView with a fade animation on tap.
     /// If no valid email is provided, fall back to the circled user icon
-    func makeGravatarTappableView(with email: String?) -> UIImageView {
+    func makeGravatarTappableView(with email: String?) -> UIView {
         let gravatarImageView = CircularImageView()
 
         gravatarImageView.isUserInteractionEnabled = true
@@ -77,8 +77,8 @@ private extension UIBarButtonItem {
     }
 
     /// embeds a view in a larger tappable area, vertically centered and aligned to the right
-    func embedInTappableArea(_ imageView: UIImageView) -> UIImageView {
-        let tappableView = UIImageView()
+    func embedInTappableArea(_ imageView: UIImageView) -> UIView {
+        let tappableView = UIView()
         setSize(of: tappableView, size: GravatarConfiguration.tappableWidth)
         tappableView.addSubview(imageView)
         NSLayoutConstraint(item: imageView,
@@ -104,9 +104,9 @@ private extension UIBarButtonItem {
     }
 
     /// constrains a squared UIImageView to a set size
-    func setSize(of imageView: UIImageView, size: CGFloat) {
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint(item: imageView,
+    func setSize(of view: UIView, size: CGFloat) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint(item: view,
                            attribute: .width,
                            relatedBy: .equal,
                            toItem: nil,
@@ -115,7 +115,7 @@ private extension UIBarButtonItem {
                            constant: size)
             .isActive = true
 
-        NSLayoutConstraint(item: imageView,
+        NSLayoutConstraint(item: view,
                            attribute: .height,
                            relatedBy: .equal,
                            toItem: nil,

--- a/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
@@ -5,7 +5,7 @@ import UIKit
 /// Add a UIBarButtonItem to the navigation bar that  presents the Me scene.
 extension BlogDetailsViewController {
     @objc
-    private func presentHandler() {
+    func presentHandler() {
         meScenePresenter.present(on: self, animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutViewController.swift
@@ -155,12 +155,8 @@ open class AboutViewController: UITableViewController {
     }
 
     private func present(webViewController: UIViewController) {
-        if presentingViewController != nil {
-            navigationController?.pushViewController(webViewController, animated: true)
-        } else {
-            let navController = UINavigationController(rootViewController: webViewController)
-            present(navController, animated: true)
-        }
+        let navController = UINavigationController(rootViewController: webViewController)
+        present(navController, animated: true)
     }
 
     fileprivate func displayRatingPrompt() {

--- a/WordPress/Classes/ViewRelated/Views/CircularImageView.swift
+++ b/WordPress/Classes/ViewRelated/Views/CircularImageView.swift
@@ -76,3 +76,18 @@ extension CircularImageView {
         }
     }
 }
+
+/// Border options
+extension CircularImageView {
+
+    private struct StandardBorder {
+        static let color = UIColor.white
+        static let width = CGFloat(2)
+    }
+    /// sets border color and width to the circular image view. Defaults to StandardBorder values
+    func setBorder(color: UIColor = StandardBorder.color, width: CGFloat = StandardBorder.width) {
+        self.layer.borderColor = color.cgColor
+        self.layer.borderWidth = width
+    }
+
+}

--- a/WordPress/WordPressTest/BlogDetailsViewController+MeButtonTests.swift
+++ b/WordPress/WordPressTest/BlogDetailsViewController+MeButtonTests.swift
@@ -73,8 +73,9 @@ class BlogDetailsViewControllerTests: XCTestCase {
         scenePresenter?.presentExpectation = expectation(description: "Me was presented")
         // When
 
-        guard let target = blogDetailsViewController?.target(forAction: #selector(BlogDetailsViewController.presentHandler), withSender: blogDetailsViewController) else {
-            XCTFail("Cippa")
+        guard let target = blogDetailsViewController?.target(forAction: #selector(BlogDetailsViewController.presentHandler),
+                                                             withSender: blogDetailsViewController) else {
+            XCTFail("Target not found")
             return
         }
 

--- a/WordPress/WordPressTest/BlogDetailsViewController+MeButtonTests.swift
+++ b/WordPress/WordPressTest/BlogDetailsViewController+MeButtonTests.swift
@@ -66,13 +66,21 @@ class BlogDetailsViewControllerTests: XCTestCase {
             return
         }
         controller.addMeButtonToNavigationBar()
-        guard let meButton = controller.navigationItem.rightBarButtonItem else {
+        guard controller.navigationItem.rightBarButtonItem != nil else {
             XCTFail("Me Button not installed")
             return
         }
         scenePresenter?.presentExpectation = expectation(description: "Me was presented")
         // When
-        _ = meButton.target?.perform(meButton.action)
+
+        guard let target = blogDetailsViewController?.target(forAction: #selector(BlogDetailsViewController.presentHandler), withSender: blogDetailsViewController) else {
+            XCTFail("Cippa")
+            return
+        }
+
+        let actionableTarget = target as AnyObject
+        _ = actionableTarget.perform(#selector(BlogDetailsViewController.presentHandler))
+
         // Then
         guard let presentedController = scenePresenter?.presentedViewController else {
             XCTFail("Presented controller was not instantiated")


### PR DESCRIPTION
##### Changes in this PR

- Add a larger transparent view behind the gravatar `Me` button to enlarge the tappable area. To keep the same position of the gravatar, this is vertically centered in the transparent view, and aligned to the right (trailing margin set to 0). The size of the transparent view is 44 x 44

- Add a white border to the gravatar

![borderGravatar](https://user-images.githubusercontent.com/34376330/75488519-1ca7e680-5976-11ea-86f8-196e0eb4c4c1.png)


- Present modally the web views from `AboutViewController()

![acknowledgements](https://user-images.githubusercontent.com/34376330/75488645-5b3da100-5976-11ea-955d-aeec70104be3.png)


Ref #13319

To test:

- go to `My Site`
- Check that the `Me` gravatar button: 
  - works as expected
  - has a comfortable tap area
 - Go to App Settings -> About
  - check that the web views (e.g. Acknowledgement) are presented modally and no bottom bar persists in the `Me` screen after they are dismissed. 
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
