### PR TITLE
Integrates new versions of WPKit and WPAuth to fix a signup issue.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -180,9 +180,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 0.16'
 
-    #pod 'WordPressAuthenticator', '~> 1.10.7'
+    pod 'WordPressAuthenticator', '~> 1.10.7.1'
     #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'release/1.10.7.1'
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '56e77268ad0aa3d19db7c3124e4f11b474ca9b6f'
+    #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '56e77268ad0aa3d19db7c3124e4f11b474ca9b6f'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.0.1'

--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.5.7'
+    #pod 'WordPressKit', '~> 4.5.7'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/datarequest-weak-reference'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0ab4bb57ae5ba77e8f705ab987d8affa7e188d18'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '7e979293adfa850bf333c09eaaba63ae0cc8b9f4'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 
@@ -180,8 +180,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 0.16'
 
-    pod 'WordPressAuthenticator', '~> 1.10.7'
+    #pod 'WordPressAuthenticator', '~> 1.10.7'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '66061db6b4c5cb3dec9c453fd2fc7365430b7e63'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.0.1'

--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 4.5.7'
+    pod 'WordPressKit', '~> 4.5.7.1'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/datarequest-weak-reference'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '13db93f88726cfb9503384723ceb727e99521398'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '13db93f88726cfb9503384723ceb727e99521398'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 
@@ -181,8 +181,8 @@ target 'WordPress' do
     pod 'Gridicons', '~> 0.16'
 
     #pod 'WordPressAuthenticator', '~> 1.10.7'
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '66061db6b4c5cb3dec9c453fd2fc7365430b7e63'
+    #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'release/1.10.7.1'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '56e77268ad0aa3d19db7c3124e4f11b474ca9b6f'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.0.1'

--- a/Podfile
+++ b/Podfile
@@ -45,7 +45,7 @@ end
 def wordpress_kit
     #pod 'WordPressKit', '~> 4.5.7'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/datarequest-weak-reference'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '7e979293adfa850bf333c09eaaba63ae0cc8b9f4'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '670c8d479ef75bc7119cfd059bafed76e7dd9a2a'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -45,7 +45,7 @@ end
 def wordpress_kit
     #pod 'WordPressKit', '~> 4.5.7'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/datarequest-weak-reference'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '670c8d479ef75bc7119cfd059bafed76e7dd9a2a'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '13db93f88726cfb9503384723ceb727e99521398'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -473,7 +473,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.15.0)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `66061db6b4c5cb3dec9c453fd2fc7365430b7e63`)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `670c8d479ef75bc7119cfd059bafed76e7dd9a2a`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `13db93f88726cfb9503384723ceb727e99521398`)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.5.1)
@@ -604,7 +604,7 @@ EXTERNAL SOURCES:
     :commit: 66061db6b4c5cb3dec9c453fd2fc7365430b7e63
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
-    :commit: 670c8d479ef75bc7119cfd059bafed76e7dd9a2a
+    :commit: 13db93f88726cfb9503384723ceb727e99521398
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.22.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
@@ -623,7 +623,7 @@ CHECKOUT OPTIONS:
     :commit: 66061db6b4c5cb3dec9c453fd2fc7365430b7e63
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
-    :commit: 670c8d479ef75bc7119cfd059bafed76e7dd9a2a
+    :commit: 13db93f88726cfb9503384723ceb727e99521398
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -710,6 +710,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 563750b8cf8be791de69eead159c27cd67a7b2f7
+PODFILE CHECKSUM: 2593c720c076aa0a9f6df2465a46e11253ee0234
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -473,7 +473,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.15.0)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `66061db6b4c5cb3dec9c453fd2fc7365430b7e63`)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `7e979293adfa850bf333c09eaaba63ae0cc8b9f4`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `670c8d479ef75bc7119cfd059bafed76e7dd9a2a`)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.5.1)
@@ -604,7 +604,7 @@ EXTERNAL SOURCES:
     :commit: 66061db6b4c5cb3dec9c453fd2fc7365430b7e63
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
-    :commit: 7e979293adfa850bf333c09eaaba63ae0cc8b9f4
+    :commit: 670c8d479ef75bc7119cfd059bafed76e7dd9a2a
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.22.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
@@ -623,7 +623,7 @@ CHECKOUT OPTIONS:
     :commit: 66061db6b4c5cb3dec9c453fd2fc7365430b7e63
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
-    :commit: 7e979293adfa850bf333c09eaaba63ae0cc8b9f4
+    :commit: 670c8d479ef75bc7119cfd059bafed76e7dd9a2a
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -710,6 +710,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 1e697880902b24f5d25adf97bc0a60c371f8a981
+PODFILE CHECKSUM: 563750b8cf8be791de69eead159c27cd67a7b2f7
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -370,7 +370,7 @@ PODS:
   - WordPress-Aztec-iOS (1.15.0)
   - WordPress-Editor-iOS (1.15.0):
     - WordPress-Aztec-iOS (= 1.15.0)
-  - WordPressAuthenticator (1.10.7):
+  - WordPressAuthenticator (1.10.7.1):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (~> 3.5)
@@ -382,7 +382,7 @@ PODS:
     - WordPressKit (~> 4.5.6-beta.1)
     - WordPressShared (~> 1.8)
     - WordPressUI (~> 1.4-beta.1)
-  - WordPressKit (4.5.7):
+  - WordPressKit (4.5.7.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -472,8 +472,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.15.0)
-  - WordPressAuthenticator (~> 1.10.7)
-  - WordPressKit (~> 4.5.7)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `66061db6b4c5cb3dec9c453fd2fc7365430b7e63`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `7e979293adfa850bf333c09eaaba63ae0cc8b9f4`)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.5.1)
@@ -518,8 +518,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -602,6 +600,12 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0
+  WordPressAuthenticator:
+    :commit: 66061db6b4c5cb3dec9c453fd2fc7365430b7e63
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressKit:
+    :commit: 7e979293adfa850bf333c09eaaba63ae0cc8b9f4
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.22.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -615,6 +619,12 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0
+  WordPressAuthenticator:
+    :commit: 66061db6b4c5cb3dec9c453fd2fc7365430b7e63
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressKit:
+    :commit: 7e979293adfa850bf333c09eaaba63ae0cc8b9f4
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -683,8 +693,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 004a458e7c4a7b0e6ed1f40695f4ce3b35ba040f
   WordPress-Editor-iOS: 56846c373c8f9e6276d5c3827c71aec6156b2abc
-  WordPressAuthenticator: 9141ea5a2e2b227252f3da6b3282a467f62588ba
-  WordPressKit: 2404e5f60d6564494f7add2a0a75d7b970dbefb0
+  WordPressAuthenticator: 606d296024c5fbd8b347fd81861a0c86f9f8b163
+  WordPressKit: 72628bc40c4e74a508636f166fbd9183f47fc395
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: fde9523bd00696fc1dfa45ed5299e16de111ebcc
   WordPressUI: ce0ac522146dabcd0a68ace24c0104dfdf6f4b0d
@@ -700,6 +710,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 438094ffc6901397b1bd180c9953420c9116a473
+PODFILE CHECKSUM: 1e697880902b24f5d25adf97bc0a60c371f8a981
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -472,7 +472,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.15.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `56e77268ad0aa3d19db7c3124e4f11b474ca9b6f`)
+  - WordPressAuthenticator (~> 1.10.7.1)
   - WordPressKit (~> 4.5.7.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.13)
@@ -518,6 +518,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -601,9 +602,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0
-  WordPressAuthenticator:
-    :commit: 56e77268ad0aa3d19db7c3124e4f11b474ca9b6f
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.22.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -617,9 +615,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0
-  WordPressAuthenticator:
-    :commit: 56e77268ad0aa3d19db7c3124e4f11b474ca9b6f
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -705,6 +700,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 4bc16080bf5bda08fe2babfcf97a44d6894e9e6b
+PODFILE CHECKSUM: 417b56abdd56a0687085e383cda9928aa67ea082
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -379,8 +379,8 @@ PODS:
     - lottie-ios (= 2.5.2)
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.5.6-beta.1)
-    - WordPressShared (~> 1.8)
+    - WordPressKit (~> 4.5.7.1)
+    - WordPressShared (~> 1.8.0)
     - WordPressUI (~> 1.4-beta.1)
   - WordPressKit (4.5.7.1):
     - Alamofire (~> 4.7.3)
@@ -472,8 +472,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.15.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `66061db6b4c5cb3dec9c453fd2fc7365430b7e63`)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `13db93f88726cfb9503384723ceb727e99521398`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `56e77268ad0aa3d19db7c3124e4f11b474ca9b6f`)
+  - WordPressKit (~> 4.5.7.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.13)
   - WordPressUI (~> 1.5.1)
@@ -518,6 +518,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -601,11 +602,8 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0
   WordPressAuthenticator:
-    :commit: 66061db6b4c5cb3dec9c453fd2fc7365430b7e63
+    :commit: 56e77268ad0aa3d19db7c3124e4f11b474ca9b6f
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-  WordPressKit:
-    :commit: 13db93f88726cfb9503384723ceb727e99521398
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.22.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -620,11 +618,8 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.22.0
   WordPressAuthenticator:
-    :commit: 66061db6b4c5cb3dec9c453fd2fc7365430b7e63
+    :commit: 56e77268ad0aa3d19db7c3124e4f11b474ca9b6f
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-  WordPressKit:
-    :commit: 13db93f88726cfb9503384723ceb727e99521398
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -693,7 +688,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 004a458e7c4a7b0e6ed1f40695f4ce3b35ba040f
   WordPress-Editor-iOS: 56846c373c8f9e6276d5c3827c71aec6156b2abc
-  WordPressAuthenticator: 606d296024c5fbd8b347fd81861a0c86f9f8b163
+  WordPressAuthenticator: 7168e7e3c6d1f3d88714363a881a51d18f595435
   WordPressKit: 72628bc40c4e74a508636f166fbd9183f47fc395
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: fde9523bd00696fc1dfa45ed5299e16de111ebcc
@@ -710,6 +705,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 2593c720c076aa0a9f6df2465a46e11253ee0234
+PODFILE CHECKSUM: 4bc16080bf5bda08fe2babfcf97a44d6894e9e6b
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
## Description

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/13583

This PR improves the error handling so that we don't ignore some error responses.

## Testing:

#### Test 1:

Try signing up with a valid email account.  It should send you the magic link.

#### Test 2:

Try signing up with an invalid email provider.  For example "tester@mailinator.com".
You should see an error prompting you to use a different email provider.

#### Test 3:

Try singing up with a used email address (you can try with the email of your existing account).
You should see an error letting you know the email address is not available.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
