### PR TITLE
Integrates WPKit and WPAuth into 14.3.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.5.8'
+    pod 'WordPressKit', '~> 4.5.9-beta'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/datarequest-weak-reference'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0ab4bb57ae5ba77e8f705ab987d8affa7e188d18'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
@@ -181,7 +181,7 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 0.16'
 
-    pod 'WordPressAuthenticator', '~> 1.10.8'
+    pod 'WordPressAuthenticator', '~> 1.10.9-beta'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -372,7 +372,7 @@ PODS:
   - WordPress-Aztec-iOS (1.16.0)
   - WordPress-Editor-iOS (1.16.0):
     - WordPress-Aztec-iOS (= 1.16.0)
-  - WordPressAuthenticator (1.10.8):
+  - WordPressAuthenticator (1.10.9-beta.1):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -381,10 +381,10 @@ PODS:
     - lottie-ios (= 2.5.2)
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.5.8-beta-1)
+    - WordPressKit (~> 4.5.9-beta)
     - WordPressShared (~> 1.8.13-beta)
     - WordPressUI (~> 1.4-beta.1)
-  - WordPressKit (4.5.8):
+  - WordPressKit (4.5.9-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -475,8 +475,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.16.0)
-  - WordPressAuthenticator (~> 1.10.8)
-  - WordPressKit (~> 4.5.8)
+  - WordPressAuthenticator (~> 1.10.9-beta)
+  - WordPressKit (~> 4.5.9-beta)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.14)
   - WordPressUI (~> 1.5.1)
@@ -689,8 +689,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 64a2989d25befb5ce086fac440315f696026ffd5
   WordPress-Editor-iOS: 63ef6a532af2c92e3301421f5c4af41ad3be8721
-  WordPressAuthenticator: 0bc92d42c942e7139c3a75d5988b4b3649eb32e2
-  WordPressKit: 2a21df0466083d073cbd85efdff4b50280a5c675
+  WordPressAuthenticator: 64239e90c2bb2b1885789da6510575744674a65d
+  WordPressKit: 54b1c041c59b871e91a331f24a2fb5d347e070b0
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 9f48b2eb1ecd0f912fdfe0f4e971ffe60f9458c7
   WordPressUI: ce0ac522146dabcd0a68ace24c0104dfdf6f4b0d
@@ -706,6 +706,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 75d1e01bc7a84c81fda4e28935e8dc6261d030a9
+PODFILE CHECKSUM: ac0cd4682fb44e5e25123b7ddc3ffa7a42fad785
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Same as https://github.com/wordpress-mobile/WordPress-iOS/pull/13585 but for 14.3.

Use the same testing steps.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
