### PR TITLE
WordPressComSyncService: Synchronizing Settings

### DIFF
--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -127,6 +127,17 @@ class AccountSettingsService {
         }
     }
 
+    func updateDisplayName(_ displayName: String, finished: ((Bool, Error?) -> ())? = nil) {
+        remote.updateSetting(.displayName(displayName), success: {
+            finished?(true, nil)
+        }) { error in
+            DDLogError("Error saving account settings change \(error)")
+            NotificationCenter.default.post(name: NSNotification.Name.AccountSettingsServiceChangeSaveFailed, object: self, userInfo: [NSUnderlyingErrorKey: error])
+
+            finished?(false, error)
+        }
+    }
+
     func updatePassword(_ password: String, finished: ((Bool, Error?) -> ())? = nil) {
         remote.updatePassword(password, success: {
             finished?(true, nil)

--- a/WordPress/Classes/Services/WordPressComSyncService.swift
+++ b/WordPress/Classes/Services/WordPressComSyncService.swift
@@ -6,7 +6,7 @@ import WordPressKit
 ///
 class WordPressComSyncService {
 
-    /// Syncs account and blog information for the authenticated wpcom user.
+    /// Syncs account, blog and settings for the authenticated wpcom user.
     ///
     /// - Parameters:
     ///     - authToken: The authentication token.
@@ -18,6 +18,7 @@ class WordPressComSyncService {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
         accountService.createOrUpdateAccount(withAuthToken: authToken, success: { account in
+            self.syncSettings(account: account)
             self.syncOrAssociateBlogs(account: account, isJetpackLogin: isJetpackLogin, onSuccess: onSuccess, onFailure: onFailure)
         }, failure: { error in
             onFailure(error)
@@ -61,5 +62,15 @@ class WordPressComSyncService {
 
             BlogSyncFacade().syncBlogs(for: account, success: onSuccessInternal, failure: onFailureInternal)
         }
+    }
+
+    /// Syncs the Account Settings
+    ///
+    /// - Parameters:
+    ///     - account: the WPAccount for which to sync the settings.
+    ///
+    func syncSettings(account: WPAccount) {
+        let service = AccountSettingsService(userID: account.userID.intValue, api: account.wordPressComRestApi)
+        service.refreshSettings()
     }
 }

--- a/WordPress/Classes/Services/WordPressComSyncService.swift
+++ b/WordPress/Classes/Services/WordPressComSyncService.swift
@@ -6,7 +6,7 @@ import WordPressKit
 ///
 class WordPressComSyncService {
 
-    /// Syncs account, blog and settings for the authenticated wpcom user.
+    /// Syncs account and blog information for the authenticated wpcom user.
     ///
     /// - Parameters:
     ///     - authToken: The authentication token.
@@ -18,7 +18,6 @@ class WordPressComSyncService {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
         accountService.createOrUpdateAccount(withAuthToken: authToken, success: { account in
-            self.syncSettings(account: account)
             self.syncOrAssociateBlogs(account: account, isJetpackLogin: isJetpackLogin, onSuccess: onSuccess, onFailure: onFailure)
         }, failure: { error in
             onFailure(error)
@@ -62,15 +61,5 @@ class WordPressComSyncService {
 
             BlogSyncFacade().syncBlogs(for: account, success: onSuccessInternal, failure: onFailureInternal)
         }
-    }
-
-    /// Syncs the Account Settings
-    ///
-    /// - Parameters:
-    ///     - account: the WPAccount for which to sync the settings.
-    ///
-    func syncSettings(account: WPAccount) {
-        let service = AccountSettingsService(userID: account.userID.intValue, api: account.wordPressComRestApi)
-        service.refreshSettings()
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -212,24 +212,19 @@ private extension SignupEpilogueViewController {
     }
 
     func changeDisplayName(to newDisplayName: String, finished: @escaping (() -> Void)) {
-
         let context = ContextManager.sharedInstance().mainContext
-
         guard let defaultAccount = AccountService(managedObjectContext: context).defaultWordPressComAccount(),
-        let restApi = defaultAccount.wordPressComRestApi else {
-            finished()
-            return
+            let restApi = defaultAccount.wordPressComRestApi else {
+                finished()
+                return
         }
 
         let accountSettingService = AccountSettingsService(userID: defaultAccount.userID.intValue, api: restApi)
-        let accountSettingsChange = AccountSettingsChange.displayName(newDisplayName)
 
-        accountSettingService.saveChange(accountSettingsChange) { success in
-            if success {
-                WordPressAuthenticator.track(.signupEpilogueDisplayNameUpdateSucceeded, properties: self.tracksProperties())
-            } else {
-                WordPressAuthenticator.track(.signupEpilogueDisplayNameUpdateFailed, properties: self.tracksProperties())
-            }
+        accountSettingService.updateDisplayName(newDisplayName) { (success, _) in
+            let event: WPAnalyticsStat = success ? .signupEpilogueDisplayNameUpdateSucceeded : .signupEpilogueDisplayNameUpdateFailed
+            WordPressAuthenticator.track(event, properties: self.tracksProperties())
+
             finished()
         }
     }


### PR DESCRIPTION
### Details:
In this PR we're adding new API to **AccountSettingsService**, that deals with Display Name changes, and wiring it in the Signup Epilogue. Why:

- Former mechanism involved using `AccountSettingsChange`, meant to keep Core Data in consistent state, in the scenario of a REST call failure
- The Signup Epilogue **isn't tied up** (AKA does not populate) its fields from Core Data
- The **AccountSettings** are not synchronized in the Epilogue
- And furthermore, the Epilogue **does not need** the **AccountSettings**

For the reasons above, it makes 1000% sense to mimic the same mechanisms used in the Epilogue to (A) Change Passwords or (B) Change Username, without going thru `AccountSettingsChange` (which is not really needed here).

Fixes #13594

cc @diegoreymendez WDYT? (Thanks in advance!!

### To test:

1. Fresh install the app
2. Signup for a new WordPress.com account (with your email)
3. Click over the Magic Link

- [x] Verify you get the Signup Epilogue right after the Magic Link is processed
- [x] Verify that you can set a custom password
- [x] Verify that you can change the Display Name
- [x] Verify that pressing over **Continue** effectively dismisses the Epilogue

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
