### PR TITLE
Show loading indicator when searching domains

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -101,6 +101,7 @@ final class SearchTextField: UITextField {
             activityIndicator = UIActivityIndicatorView(style: .gray)
         }
         activityIndicator.backgroundColor = UIColor.clear
+
         return activityIndicator
     }()
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -77,7 +77,7 @@ final class SearchTextField: UITextField {
         autocorrectionType = .no
         adjustsFontForContentSizeCategory = true
 
-        setIconImage()
+        setIconImage(view: searchIconImageView)
 
         NSLayoutConstraint.activate([
             heightAnchor.constraint(equalToConstant: Constants.searchHeight),
@@ -86,17 +86,35 @@ final class SearchTextField: UITextField {
         addTopBorder(withColor: .divider)
         addBottomBorder(withColor: .divider)
     }
-
-    private func setIconImage() {
+    
+    private lazy var searchIconImageView: UIImageView = {
         let iconSize = CGSize(width: Constants.iconDimension, height: Constants.iconDimension)
         let loupeIcon = Gridicon.iconOfType(.search, withSize: iconSize).imageWithTintColor(.listIcon)?.imageFlippedForRightToLeftLayoutDirection()
-        let imageView = UIImageView(image: loupeIcon)
+        return UIImageView(image: loupeIcon)
+    }()
+    
+    private lazy var spinner: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView(style: .gray)
+        activityIndicator.backgroundColor = UIColor.clear
+        return activityIndicator
+    }()
+    
+    func setIcon(isLoading: Bool) {
+        if isLoading {
+            setIconImage(view: spinner)
+            spinner.startAnimating()
+        } else {
+            setIconImage(view: searchIconImageView)
+            spinner.stopAnimating()
+        }
+    }
 
+    private func setIconImage(view: UIView) {
         if traitCollection.layoutDirection == .rightToLeft {
-            rightView = imageView
+            rightView = view
             rightViewMode = .always
         } else {
-            leftView = imageView
+            leftView = view
             leftViewMode = .always
         }
     }
@@ -105,7 +123,7 @@ final class SearchTextField: UITextField {
         super.traitCollectionDidChange(previousTraitCollection)
 
         if #available(iOS 13, *) {
-            setIconImage()
+            setIconImage(view: searchIconImageView)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -93,19 +93,24 @@ final class SearchTextField: UITextField {
         return UIImageView(image: loupeIcon)
     }()
     
-    private lazy var spinner: UIActivityIndicatorView = {
-        let activityIndicator = UIActivityIndicatorView(style: .gray)
+    private lazy var activityIndicator: UIActivityIndicatorView = {
+        let activityIndicator: UIActivityIndicatorView
+        if #available(iOS 13, *) {
+            activityIndicator = UIActivityIndicatorView(style: .medium)
+        } else {
+            activityIndicator = UIActivityIndicatorView(style: .gray)
+        }
         activityIndicator.backgroundColor = UIColor.clear
         return activityIndicator
     }()
     
     func setIcon(isLoading: Bool) {
         if isLoading {
-            setIconImage(view: spinner)
-            spinner.startAnimating()
+            setIconImage(view: activityIndicator)
+            activityIndicator.startAnimating()
         } else {
+            activityIndicator.stopAnimating()
             setIconImage(view: searchIconImageView)
-            spinner.stopAnimating()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -86,13 +86,13 @@ final class SearchTextField: UITextField {
         addTopBorder(withColor: .divider)
         addBottomBorder(withColor: .divider)
     }
-    
+
     private lazy var searchIconImageView: UIImageView = {
         let iconSize = CGSize(width: Constants.iconDimension, height: Constants.iconDimension)
         let loupeIcon = Gridicon.iconOfType(.search, withSize: iconSize).imageWithTintColor(.listIcon)?.imageFlippedForRightToLeftLayoutDirection()
         return UIImageView(image: loupeIcon)
     }()
-    
+
     private lazy var activityIndicator: UIActivityIndicatorView = {
         let activityIndicator: UIActivityIndicatorView
         if #available(iOS 13, *) {
@@ -103,7 +103,7 @@ final class SearchTextField: UITextField {
         activityIndicator.backgroundColor = UIColor.clear
         return activityIndicator
     }()
-    
+
     func setIcon(isLoading: Bool) {
         if isLoading {
             setIconImage(view: activityIndicator)

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -199,8 +199,10 @@ final class WebAddressWizardContent: UIViewController {
         guard let segmentID = siteCreator.segment?.identifier else {
             return
         }
-
+ 
+        updateIcon(isLoading: true)
         service.addresses(for: searchTerm, segmentID: segmentID) { [weak self] results in
+            self?.updateIcon(isLoading: false)
             switch results {
             case .failure(let error):
                 self?.handleError(error)
@@ -421,7 +423,7 @@ final class WebAddressWizardContent: UIViewController {
         self.tableViewProvider = provider
     }
 
-    private func query(from textField: UITextField?) -> String? {
+    private func query(from textField: SearchTextField?) -> String? {
         guard let text = textField?.text,
             !text.isEmpty else {
                 return siteCreator.information?.title
@@ -431,7 +433,7 @@ final class WebAddressWizardContent: UIViewController {
     }
 
     @objc
-    private func textChanged(sender: UITextField) {
+    private func textChanged(sender: SearchTextField) {
         search(withInputFrom: sender)
     }
 
@@ -452,7 +454,14 @@ final class WebAddressWizardContent: UIViewController {
 
     // MARK: - Search logic
 
-    private func search(withInputFrom textField: UITextField) {
+    func updateIcon(isLoading: Bool) {
+        guard let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader else {
+            return
+        }
+        header.textField.setIcon(isLoading: isLoading)
+    }
+
+    private func search(withInputFrom textField: SearchTextField) {
         guard let query = query(from: textField), query.isEmpty == false else {
             clearContent()
             return

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -423,7 +423,7 @@ final class WebAddressWizardContent: UIViewController {
         self.tableViewProvider = provider
     }
 
-    private func query(from textField: SearchTextField?) -> String? {
+    private func query(from textField: UITextField?) -> String? {
         guard let text = textField?.text,
             !text.isEmpty else {
                 return siteCreator.information?.title
@@ -433,7 +433,7 @@ final class WebAddressWizardContent: UIViewController {
     }
 
     @objc
-    private func textChanged(sender: SearchTextField) {
+    private func textChanged(sender: UITextField) {
         search(withInputFrom: sender)
     }
 
@@ -461,7 +461,7 @@ final class WebAddressWizardContent: UIViewController {
         header.textField.setIcon(isLoading: isLoading)
     }
 
-    private func search(withInputFrom textField: SearchTextField) {
+    private func search(withInputFrom textField: UITextField) {
         guard let query = query(from: textField), query.isEmpty == false else {
             clearContent()
             return

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -199,7 +199,7 @@ final class WebAddressWizardContent: UIViewController {
         guard let segmentID = siteCreator.segment?.identifier else {
             return
         }
- 
+
         updateIcon(isLoading: true)
         service.addresses(for: searchTerm, segmentID: segmentID) { [weak self] results in
             self?.updateIcon(isLoading: false)


### PR DESCRIPTION
Fixes #13592 

To test (in dark and light mode):
1. Add a new site
2. Get to the domain search screen
3. Search for a domain
4. see loading indicator when results are loading 
5. See loading indicator removed when done loading results 

Not loading|Loading
-|-
![](https://user-images.githubusercontent.com/1335657/76170806-a314b300-6142-11ea-96cd-9092ae92e7bd.png)|![](https://user-images.githubusercontent.com/1335657/76170807-a5770d00-6142-11ea-9482-f7d8ede3171a.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
