### PR TITLE
Add editor startup time

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -560,6 +560,10 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 
     func gutenbergDidMount(unsupportedBlockNames: [String]) {
         if !editorSession.started {
+            // Note that this method is also used to track startup performance
+            // It assumes this is being called when the editor has finished loading
+            // If you need to refactor this, please ensure that the startup_time_ms property
+            // is still reflecting the actual startup time of the editor
             editorSession.start(unsupportedBlocks: unsupportedBlockNames)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -10,6 +10,7 @@ struct PostEditorAnalyticsSession {
     var hasUnsupportedBlocks = false
     var outcome: Outcome? = nil
     var template: String?
+    private let startTime = DispatchTime.now().uptimeNanoseconds
 
     init(editor: Editor, post: AbstractPost) {
         currentEditor = editor
@@ -40,7 +41,12 @@ struct PostEditorAnalyticsSession {
     }
 
     private func startEventProperties(with unsupportedBlocks: [String]) -> [String: Any] {
+        // On Android, we are tracking this in milliseconds, which seems like a good enough time scale
+        // Let's make sure to round the value and send an integer for consistency
+        let startupTimeNanoseconds = DispatchTime.now().uptimeNanoseconds - startTime
+        let startupTimeMilliseconds = Int(Double(startupTimeNanoseconds) / 1_000_000)
         return [
+            Property.startupTime: startupTimeMilliseconds,
             Property.unsupportedBlocks: unsupportedBlocks
         ].merging(commonProperties, uniquingKeysWith: { $1 })
     }
@@ -82,6 +88,7 @@ private extension PostEditorAnalyticsSession {
         static let outcome = "outcome"
         static let sessionId = "session_id"
         static let template = "template"
+        static let startupTime = "startup_time_ms"
     }
 
     var commonProperties: [String: String] {


### PR DESCRIPTION
Adds startup time to the `editor_session_start` event.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1988
Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/11411

To test:

Look at the tracks logs in the console and ensure the `startup_time_ms` gets added to `editor_session_start` and it reflects the actual startup time of the editor.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
