### PR TITLE
Updated the default offline title for NoResultsViewController.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -514,8 +514,8 @@ private extension NoResultsViewController {
     }
 
     struct NoConnection {
-        static let title: String = NSLocalizedString("Unable to load this page right now.", comment: "Title for No results full page screen displayed when there is no connection")
-        static let subTitle: String = NSLocalizedString("Check your network connection and try again.", comment: "Subtitle for No results full page screen displayed when there is no connection")
+        static let title: String = NSLocalizedString("Unable to load this content right now.", comment: "Default title shown for no-results when the device is offline.")
+        static let subTitle: String = NSLocalizedString("Check your network connection and try again.", comment: "Default subtitle for no-results when there is no connection")
         static let imageName = "cloud"
     }
 }


### PR DESCRIPTION
This PR updates the default title for `NoResultsViewController` when the user is offline,  so it's more generic and appropriate for all cases.

VCs that want to have a more specific message can do so through the `NoResultsViewController` class interface.

Fixes #13604 

## To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
