### PR TITLE
Allow media updates while media pages are loading.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -46,7 +46,7 @@ def wordpress_kit
     #pod 'WordPressKit', '~> 4.5.9'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => '4.5.9-beta.1'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/datarequest-weak-reference'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'cbca60c0c301ccc91028c95b82b730054616beb0'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '24af2c192fd628f4c5bb3e9be6c8312cb45260fe'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -43,10 +43,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.5.9'
+    #pod 'WordPressKit', '~> 4.5.9'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => '4.5.9-beta.1'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/datarequest-weak-reference'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '13db93f88726cfb9503384723ceb727e99521398'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'cbca60c0c301ccc91028c95b82b730054616beb0'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -44,9 +44,9 @@ end
 
 def wordpress_kit
     #pod 'WordPressKit', '~> 4.5.9'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => '4.5.9-beta.1'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => '4.6.0-beta.3'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/datarequest-weak-reference'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '24af2c192fd628f4c5bb3e9be6c8312cb45260fe'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '24af2c192fd628f4c5bb3e9be6c8312cb45260fe'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -476,7 +476,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.16.0)
   - WordPressAuthenticator (~> 1.10.9)
-  - WordPressKit (~> 4.5.9)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `cbca60c0c301ccc91028c95b82b730054616beb0`)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.8.15)
   - WordPressUI (~> 1.5.1)
@@ -522,7 +522,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -607,6 +606,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressKit:
+    :commit: cbca60c0c301ccc91028c95b82b730054616beb0
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -620,6 +622,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressKit:
+    :commit: cbca60c0c301ccc91028c95b82b730054616beb0
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -706,6 +711,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 060e541360fa0582e88e92f8c064f5e766f09a60
+PODFILE CHECKSUM: d445e18bb2f63317977f52f7892190937dafbda1
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -476,7 +476,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.16.0)
   - WordPressAuthenticator (~> 1.10.9)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `cbca60c0c301ccc91028c95b82b730054616beb0`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `24af2c192fd628f4c5bb3e9be6c8312cb45260fe`)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.8.15)
   - WordPressUI (~> 1.5.1)
@@ -607,7 +607,7 @@ EXTERNAL SOURCES:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressKit:
-    :commit: cbca60c0c301ccc91028c95b82b730054616beb0
+    :commit: 24af2c192fd628f4c5bb3e9be6c8312cb45260fe
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
@@ -623,7 +623,7 @@ CHECKOUT OPTIONS:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressKit:
-    :commit: cbca60c0c301ccc91028c95b82b730054616beb0
+    :commit: 24af2c192fd628f4c5bb3e9be6c8312cb45260fe
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -711,6 +711,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: d445e18bb2f63317977f52f7892190937dafbda1
+PODFILE CHECKSUM: a8ec9903e4e4db246b7d56c5024820f0659138fc
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -572,14 +572,30 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
                         success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure
 {
+    __block BOOL onePageLoad = NO;
     NSManagedObjectID *blogObjectID = [blog objectID];
     [self.managedObjectContext performBlock:^{
         Blog *blogInContext = (Blog *)[self.managedObjectContext objectWithID:blogObjectID];
         NSSet *originalLocalMedia = blogInContext.media;
         id<MediaServiceRemote> remote = [self remoteForBlog:blogInContext];
-        [remote getMediaLibraryWithSuccess:^(NSArray *media) {
+        [remote getMediaLibraryWithPageLoad:^(NSArray *media) {
+                                    [self.managedObjectContext performBlock:^{
+                                        void (^completion)(void) = nil;
+                                        if (!onePageLoad) {
+                                            onePageLoad = YES;
+                                            completion = success;
+                                        }
+                                        [self mergeMedia:media forBlog:blogInContext baseMedia:originalLocalMedia deleteUnreferencedMedia:NO completionHandler:completion];
+                                    }];
+                                }
+                               success:^(NSArray *media) {
                                    [self.managedObjectContext performBlock:^{
-                                       [self mergeMedia:media forBlog:blogInContext baseMedia:originalLocalMedia completionHandler:success];
+                                       void (^completion)(void) = nil;
+                                       if (!onePageLoad) {
+                                           onePageLoad = YES;
+                                           completion = success;
+                                       }
+                                       [self mergeMedia:media forBlog:blogInContext baseMedia:originalLocalMedia deleteUnreferencedMedia:YES completionHandler:completion];
                                    }];
                                }
                                failure:^(NSError *error) {
@@ -752,6 +768,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 - (void)mergeMedia:(NSArray *)media
            forBlog:(Blog *)blog
          baseMedia:(NSSet *)originalBlogMedia
+deleteUnreferencedMedia:(BOOL)deleteUnreferencedMedia
  completionHandler:(void (^)(void))completion
 {
     NSParameterAssert(blog);
@@ -767,12 +784,14 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
             [mediaToKeep addObject:local];
         }
     }
-    NSMutableSet *mediaToDelete = [NSMutableSet setWithSet:originalBlogMedia];
-    [mediaToDelete minusSet:mediaToKeep];
-    for (Media *deleteMedia in mediaToDelete) {
-        // only delete media that is server based
-        if ([deleteMedia.mediaID intValue] > 0) {
-            [self.managedObjectContext deleteObject:deleteMedia];
+    if (deleteUnreferencedMedia) {
+        NSMutableSet *mediaToDelete = [NSMutableSet setWithSet:originalBlogMedia];
+        [mediaToDelete minusSet:mediaToKeep];
+        for (Media *deleteMedia in mediaToDelete) {
+            // only delete media that is server based
+            if ([deleteMedia.mediaID intValue] > 0) {
+                [self.managedObjectContext deleteObject:deleteMedia];
+            }
         }
     }
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -590,12 +590,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
                                 }
                                success:^(NSArray *media) {
                                    [self.managedObjectContext performBlock:^{
-                                       void (^completion)(void) = nil;
-                                       if (!onePageLoad) {
-                                           onePageLoad = YES;
-                                           completion = success;
-                                       }
-                                       [self mergeMedia:media forBlog:blogInContext baseMedia:originalLocalMedia deleteUnreferencedMedia:YES completionHandler:completion];
+                                       [self mergeMedia:media forBlog:blogInContext baseMedia:originalLocalMedia deleteUnreferencedMedia:YES completionHandler:success];
                                    }];
                                }
                                failure:^(NSError *error) {


### PR DESCRIPTION
Fixes #11644

This PR changes the MediaService sync code to allow updates of the local CoreData database for each media page loaded from the server. This should allow the user to interact with media libraries quicker and get updates quickly. 

The only downside of this approach is that we are only able to show deletions after all the media library is in sync. This was already was a limitation before, and can only be addressed with changes on the server endpoint.

Related changes on WordPressKit: 

To test:
 - Between each test scenario, you need to change the site being used or logout the user
 - Scenario 1
   - Load the app
   - Open a blog/site that has a large media collection
   - Open the media library
   - See if it shows the initial library contents quickly
   - Check that all loads in the end
 - Scenario 2 ( Test Aztec and Gutenberg)
   - Load the app
   - Open a blog/site that has a large media collection
   - Create a new post
   - Add a media object from the site media library

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
