### PR TITLE
Issue/12142 media thumbnails cleanup

### DIFF
--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -99,14 +99,13 @@ class MediaThumbnailService: LocalCoreDataService {
             }
 
             // If the Media asset is available locally, export thumbnails from the local asset.
-            if let localAssetURL = mediaInContext.absoluteLocalURL {
-                if exporter.supportsThumbnailExport(forFile: localAssetURL) {
+            if let localAssetURL = mediaInContext.absoluteLocalURL,
+                exporter.supportsThumbnailExport(forFile: localAssetURL) {
                     self.exportQueue.async {
                         exporter.exportThumbnail(forFile: localAssetURL,
                                                  onCompletion: onThumbnailExport,
                                                  onError: onThumbnailExportError)
-                    }
-                }
+                    }                
                 return
             }
 

--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -105,7 +105,7 @@ class MediaThumbnailService: LocalCoreDataService {
                         exporter.exportThumbnail(forFile: localAssetURL,
                                                  onCompletion: onThumbnailExport,
                                                  onError: onThumbnailExportError)
-                    }                
+                    }
                 return
             }
 

--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -249,6 +249,14 @@ class MediaFileManager: NSObject {
                         onCompletion()
                     }
                 }
+
+                // Update media objects local urls that were deleted to be updated to nil
+                let editedObjectsRequest = NSBatchUpdateRequest(entityName: Media.classNameWithoutNamespaces())
+                editedObjectsRequest.predicate = NSCompoundPredicate(notPredicateWithSubpredicate: predicate)
+                editedObjectsRequest.propertiesToUpdate = [localURLProperty: NSNull(), localThumbnailURLProperty: NSNull()]
+                editedObjectsRequest.resultType = .updatedObjectsCountResultType
+                try context.execute(editedObjectsRequest)
+                try context.save()
             } catch {
                 DDLogError("Error while attempting to clean local media: \(error.localizedDescription)")
                 if let onError = onError {
@@ -257,6 +265,7 @@ class MediaFileManager: NSObject {
                     }
                 }
             }
+
         }
     }
 


### PR DESCRIPTION
Fixes #12142 

This PR improves the behaviour of the media thumbnails generation by doing two changes:
 - Make sure the thumbnail generation doesn't get to a dead end when the local URL no longer exists on the file system.
 - Improves the clear media cache method to update the media objects affected, and remove the reference to a local URL after those files are deleted. 

To test:
 - Start the app
 - Open the media library of a site
 - Add some media files from the local device library
 - After the update is complete go to App Settings
 - Clear the media cache
 - Go back to the media library of the site
 - Make sure the files that were added previously load correctly.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
