### PR TITLE
Tweak Quick Start Highlight Font

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -347,7 +347,7 @@ private extension String {
 
     private enum Fonts {
         static let regular = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .medium)
-        static let highlight = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+        static let highlight = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
     }
 
     private enum Constants {


### PR DESCRIPTION
Fixes #13619. This PR updates the Quick Start snack bar highlight text to use a regular font weight instead of semibold.

![quickstart-font](https://user-images.githubusercontent.com/4780/76351851-013dc380-6306-11ea-8924-8b4afcb394fa.png)

**To test:**

* To make this easier to test, I added a new tool to the Debug menu (available via Me > App Settings > Debug). Tap "Enable Quick Start for Site" and choose a site to add Quick Start to. 
* Close the modal that appears, and navigate to the site in My Sites.
* Follow the instructions to set a site icon, by tapping the site's icon.
* The next notice that's displayed should contain a highlighted section, and should appear in regular text not semibold.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @elibud 
