### PR TITLE
Stats background color in landscape

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 14.5
 -----
 * Post Settings: Fix issue where the status of a post showed "Scheduled" instead of "Published" after scheduling before the current date.
-* Dark Mode: General improvements
+* Stats: Fix background color in Dark Mode on wider screen sizes. 
  
 14.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 14.5
 -----
 * Post Settings: Fix issue where the status of a post showed "Scheduled" instead of "Published" after scheduling before the current date.
+* Dark Mode: General improvements
  
 14.4
 -----

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -38,7 +38,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 {
     [super viewDidLoad];
 
-    self.view.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+    self.view.backgroundColor = [UIColor groupTableViewBackgroundColor];
     self.navigationItem.title = NSLocalizedString(@"Stats", @"Stats window title");
     
     UINavigationController *statsNavVC = [[UIStoryboard storyboardWithName:@"SiteStatsDashboard" bundle:nil] instantiateInitialViewController];


### PR DESCRIPTION
Fixes #12951 by switching to use the grouped table view's background color. This is a grayer color than the original but I think it fits here.

To test:

| Before | After |
|--|--|
| <a href="https://user-images.githubusercontent.com/3250/76365420-e4e15d00-62ec-11ea-83fd-e143f1d03efc.png"><img src="https://user-images.githubusercontent.com/3250/76365420-e4e15d00-62ec-11ea-83fd-e143f1d03efc.png" width="500"></a> | <a href="https://user-images.githubusercontent.com/3250/76365019-ececcd00-62eb-11ea-8041-64c65c9c7dab.png"><img src="https://user-images.githubusercontent.com/3250/76365019-ececcd00-62eb-11ea-8041-64c65c9c7dab.png" width="500"></a> |
| <a href="https://user-images.githubusercontent.com/3250/76365443-f4f93c80-62ec-11ea-8e5b-ab8f2a401331.png"><img src="https://user-images.githubusercontent.com/3250/76365443-f4f93c80-62ec-11ea-8e5b-ab8f2a401331.png" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/76365022-ed856380-62eb-11ea-80ff-c250ee9f1013.png"><img src="https://user-images.githubusercontent.com/3250/76365022-ed856380-62eb-11ea-80ff-c250ee9f1013.png" width="500"></a> |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
