### PR TITLE
Fixes notch issue in notifications

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -110,6 +110,8 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        tableHeaderView.translatesAutoresizingMaskIntoConstraints = false
+
         setupNavigationBar()
         setupTableView()
         setupTableFooterView()
@@ -189,20 +191,12 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
     private func layoutHeaderIfNeeded() {
         precondition(tableHeaderView != nil)
-        // Fix: Update the Frame manually: Autolayout doesn't really help us, when it comes to Table Headers
-        let requiredSize = tableHeaderView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-        var headerFrame = tableHeaderView.frame
-        if headerFrame.height != requiredSize.height {
-            headerFrame.size.height = requiredSize.height
-            tableHeaderView.frame = headerFrame
-            adjustNoResultsViewSize()
+        tableHeaderView.setNeedsLayout()
+        tableHeaderView.layoutIfNeeded()
 
-            tableHeaderView.layoutIfNeeded()
-
-            // We reassign the tableHeaderView to force the UI to refresh. Yes, really.
-            tableView.tableHeaderView = tableHeaderView
-            tableView.setNeedsLayout()
-        }
+        // We reassign the tableHeaderView to force the UI to refresh. Yes, really.
+        tableView.tableHeaderView = tableHeaderView
+        tableView.setNeedsLayout()
     }
 
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
@@ -224,6 +218,8 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
                 selectFirstNotificationIfAppropriate()
             }
         }
+
+        tableView.tableHeaderView = tableHeaderView
     }
 
     // MARK: - State Restoration
@@ -477,9 +473,11 @@ private extension NotificationsViewController {
         tableHeaderView.translatesAutoresizingMaskIntoConstraints = false
         inlinePromptView.translatesAutoresizingMaskIntoConstraints = false
 
-        tableHeaderView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor).isActive = true
-        tableHeaderView.topAnchor.constraint(equalTo: tableView.topAnchor).isActive = true
-        tableHeaderView.widthAnchor.constraint(equalTo: tableView.widthAnchor).isActive = true
+        NSLayoutConstraint.activate([
+            tableHeaderView.topAnchor.constraint(equalTo: tableView.topAnchor),
+            tableHeaderView.safeLeadingAnchor.constraint(equalTo: tableView.safeLeadingAnchor),
+            tableHeaderView.safeTrailingAnchor.constraint(equalTo: tableView.safeTrailingAnchor)
+        ])
     }
 
     func setupTableView() {

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -32,7 +32,7 @@
                     <constraints>
                         <constraint firstItem="zK2-Ta-Z1W" firstAttribute="top" secondItem="AjL-Ni-9e0" secondAttribute="top" constant="16" id="84n-R2-3hp"/>
                         <constraint firstAttribute="bottom" secondItem="zK2-Ta-Z1W" secondAttribute="bottom" constant="8" id="H5r-aJ-Jgz"/>
-                        <constraint firstItem="zK2-Ta-Z1W" firstAttribute="leading" secondItem="AjL-Ni-9e0" secondAttribute="leading" constant="20" symbolic="YES" id="a2X-M1-Zdx"/>
+                        <constraint firstItem="zK2-Ta-Z1W" firstAttribute="leading" secondItem="AjL-Ni-9e0" secondAttribute="leadingMargin" id="a2X-M1-Zdx"/>
                         <constraint firstItem="zK2-Ta-Z1W" firstAttribute="trailing" secondItem="AjL-Ni-9e0" secondAttribute="trailingMargin" id="seF-xR-8yi"/>
                     </constraints>
                 </view>

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -208,11 +208,11 @@ class FilterTabBar: UIControl {
 
         addSubview(scrollView)
         NSLayoutConstraint.activate([
-            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.safeLeadingAnchor.constraint(equalTo: safeLeadingAnchor),
+            scrollView.safeTrailingAnchor.constraint(equalTo: safeTrailingAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppearanceMetrics.bottomDividerHeight),
             scrollView.topAnchor.constraint(equalTo: topAnchor)
-            ])
+        ])
 
         scrollView.addSubview(stackView)
 
@@ -226,7 +226,7 @@ class FilterTabBar: UIControl {
             stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -AppearanceMetrics.bottomDividerHeight),
             stackView.topAnchor.constraint(equalTo: topAnchor)
-            ])
+        ])
 
         addSubview(selectionIndicator)
         NSLayoutConstraint.activate([
@@ -241,7 +241,7 @@ class FilterTabBar: UIControl {
             divider.trailingAnchor.constraint(equalTo: trailingAnchor),
             divider.bottomAnchor.constraint(equalTo: bottomAnchor),
             divider.heightAnchor.constraint(equalToConstant: AppearanceMetrics.bottomDividerHeight)
-            ])
+        ])
     }
 
     // MARK: - Tabs


### PR DESCRIPTION
Fixes #13610. Simplifies the autolayout logic in the header view and fixes a problem with UI being shown under the notch. I tested this on iOS 11, 12, and 13 and didn't see any issues when hiding the extra content in the table header (as was mentioned in a comment from https://github.com/wordpress-mobile/WordPress-iOS/pull/12525)

<img width="964" alt="Screen Shot 2020-03-10 at 5 14 40 PM" src="https://user-images.githubusercontent.com/3250/76367573-13facd00-62f3-11ea-8cc0-4dc0d465f726.png">

<img width="964" alt="Screen Shot 2020-03-10 at 5 10 02 PM" src="https://user-images.githubusercontent.com/3250/76367313-540d8000-62f2-11ea-9d99-1f65f910ff61.png">

To test:
- Open the Notifications screen in landscape orientation on iPhone X and up.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
