### PR TITLE
Search bar: update border color when dark/light mode toggled.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 14.5
 -----
 * Post Settings: Fix issue where the status of a post showed "Scheduled" instead of "Published" after scheduling before the current date.
+* Dark Mode: fix border color on Search bars.
  
 14.4
 -----

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Search.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Search.swift
@@ -3,13 +3,14 @@ import WordPressShared
 
 extension WPStyleGuide {
 
+    fileprivate static let barTintColor: UIColor = .neutral(.shade10)
+
     @objc public class func configureSearchBar(_ searchBar: UISearchBar) {
         searchBar.accessibilityIdentifier = "Search"
         searchBar.autocapitalizationType = .none
         searchBar.autocorrectionType = .no
         searchBar.isTranslucent = false
-        searchBar.barTintColor = .neutral(.shade10)
-        searchBar.layer.borderColor = UIColor.neutral(.shade10).cgColor
+        searchBar.barTintColor = WPStyleGuide.barTintColor
         searchBar.layer.borderWidth = 1.0
         searchBar.returnKeyType = .done
         if #available(iOS 13.0, *) {
@@ -46,5 +47,15 @@ extension WPStyleGuide {
                                                            attributes: WPStyleGuide.defaultSearchBarTextAttributesSwifted(.neutral(.shade30)))
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self]).attributedPlaceholder =
             attributedPlaceholderText
+    }
+}
+
+extension UISearchBar {
+    // Per Apple's documentation (https://developer.apple.com/documentation/xcode/supporting_dark_mode_in_your_interface),
+    // `cgColor` objects do not adapt to appearance changes (i.e. toggling light/dark mode).
+    // `tintColorDidChange` is called when the appearance changes, so re-set the border color when this occurs.
+    open override func tintColorDidChange() {
+        super.tintColorDidChange()
+        layer.borderColor = WPStyleGuide.barTintColor.cgColor
     }
 }


### PR DESCRIPTION
Fixes #13364 

This fixes the border color of the Search bar when light/dark mode toggled. 

To test:
- Go to any view with a Search bar. (ex: Site Pages, Blog Posts, Themes)
- Switch between light and dark modes.
- Verify the Search bar border color is updated accordingly.

![search_bar_border](https://user-images.githubusercontent.com/1816888/76368488-0d218980-62f6-11ea-9403-d176091ec633.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
