### PR TITLE
Add missing welcome notification indicator 

### DIFF
--- a/WordPress/Classes/Extensions/Notifications/NotificationName+Names.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationName+Names.swift
@@ -10,11 +10,16 @@ extension Foundation.Notification.Name {
     static var showAllSavedForLaterPosts: Foundation.NSNotification.Name {
         return Foundation.Notification.Name("org.wordpress.reader.savedforlaterposts.showall")
     }
+    
+    static var welcomeNotification: Foundation.NSNotification.Name {
+        return Foundation.Notification.Name("org.wordpress.notification.welcome")
+    }
 }
 
 @objc extension NSNotification {
     public static let ShowAllSavedForLaterPostsNotification = Foundation.Notification.Name.showAllSavedForLaterPosts
     public static let ReachabilityChangedNotification = Foundation.Notification.Name.reachabilityChanged
+    public static let WelcomeNotification = Foundation.Notification.Name.welcomeNotification
 }
 
 /// Keys for Notification's userInfo dictionary

--- a/WordPress/Classes/Extensions/Notifications/NotificationName+Names.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationName+Names.swift
@@ -10,16 +10,11 @@ extension Foundation.Notification.Name {
     static var showAllSavedForLaterPosts: Foundation.NSNotification.Name {
         return Foundation.Notification.Name("org.wordpress.reader.savedforlaterposts.showall")
     }
-    
-    static var welcomeNotification: Foundation.NSNotification.Name {
-        return Foundation.Notification.Name("org.wordpress.notification.welcome")
-    }
 }
 
 @objc extension NSNotification {
     public static let ShowAllSavedForLaterPostsNotification = Foundation.Notification.Name.showAllSavedForLaterPosts
     public static let ReachabilityChangedNotification = Foundation.Notification.Name.reachabilityChanged
-    public static let WelcomeNotification = Foundation.Notification.Name.welcomeNotification
 }
 
 /// Keys for Notification's userInfo dictionary

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -231,9 +231,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
                 navigationController.dismiss(animated: true)
             }
             
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01, execute: {
-                NotificationCenter.default.post(name: NSNotification.WelcomeNotification, object: ["sign_up": 1])
-                  })
+            UserDefaults.standard.set(false, forKey: UserDefaults.standard.welcomeNotificationSeenKey)
         }
 
         navigationController.pushViewController(epilogueViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -230,7 +230,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             } else {
                 navigationController.dismiss(animated: true)
             }
-            
+
             UserDefaults.standard.set(false, forKey: UserDefaults.standard.welcomeNotificationSeenKey)
         }
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -230,6 +230,10 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             } else {
                 navigationController.dismiss(animated: true)
             }
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01, execute: {
+                NotificationCenter.default.post(name: NSNotification.WelcomeNotification, object: ["sign_up": 1])
+                  })
         }
 
         navigationController.pushViewController(epilogueViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
@@ -119,4 +119,8 @@ extension UserDefaults {
             set(newValue, forKey: Keys.notificationPrimerInlineWasAcknowledged.rawValue)
         }
     }
+
+    @objc var welcomeNotificationSeenKey: String {
+        return "welcomeNotificationSeen"
+    }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -832,7 +832,7 @@ private extension NotificationsViewController {
 
     func markWelcomeNotificationAsSeenIfNeeded() {
         let welcomeNotificationSeenKey = userDefaults.welcomeNotificationSeenKey
-        if !userDefaults.bool(forKey: welcomeNotificationSeenKey){
+        if !userDefaults.bool(forKey: welcomeNotificationSeenKey) {
             userDefaults.set(true, forKey: welcomeNotificationSeenKey)
             resetApplicationBadge()
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -170,6 +170,8 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         markSelectedNotificationAsRead()
 
         registerUserActivity()
+
+        markWelcomeNotificationAsSeenIfNeeded()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -826,6 +828,14 @@ private extension NotificationsViewController {
         }
 
         NotificationSyncMediator()?.markAsUnread(note)
+    }
+
+    func markWelcomeNotificationAsSeenIfNeeded() {
+        let welcomeNotificationSeenKey = userDefaults.welcomeNotificationSeenKey
+        if !userDefaults.bool(forKey: welcomeNotificationSeenKey){
+            userDefaults.set(true, forKey: welcomeNotificationSeenKey)
+            resetApplicationBadge()
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -70,6 +70,8 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 @property (nonatomic, strong) CreateButtonCoordinator *createButtonCoordinator;
 
+@property (nonatomic, assign) BOOL isFromSignup;
+
 @end
 
 @implementation WPTabBarController
@@ -150,6 +152,11 @@ static CGFloat const WPTabBarIconSize = 32.0f;
                                                  selector:@selector(switchReaderTabToSavedPosts)
                                                      name:NSNotification.ShowAllSavedForLaterPostsNotification
                                                    object:nil];
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(showNotificationBadge:)
+                                                            name:NSNotification.WelcomeNotification
+                                                          object:nil];
 
         // Watch for application badge number changes
         [[UIApplication sharedApplication] addObserver:self
@@ -569,6 +576,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)showNotificationsTab
 {
+    self.isFromSignup = NO;
     [self showTabForIndex:WPTabNotifications];
 }
 
@@ -913,7 +921,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     // Discount Zendesk unread notifications when determining if we need to show the notificationsTabBarImageUnread.
     NSInteger count = [[UIApplication sharedApplication] applicationIconBadgeNumber] - [ZendeskUtils unreadNotificationsCount];
     UITabBarItem *notificationsTabBarItem = self.notificationsNavigationController.tabBarItem;
-    if (count > 0) {
+    if (count > 0 || self.isFromSignup) {
         notificationsTabBarItem.image = self.notificationsTabBarImageUnread;
         notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");
     } else {
@@ -941,6 +949,16 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 {
     UIImage *readerTabBarImage = [UIImage imageNamed:@"icon-tab-reader"];
     self.readerNavigationController.tabBarItem.image = readerTabBarImage;
+}
+
+- (void) showNotificationBadge:(NSNotification *)notification
+{
+    if ([((NSDictionary*) notification.object) valueForKey:@"sign_up"]) {
+        self.isFromSignup = YES;
+    }
+    UITabBarItem *notificationsTabBarItem = self.notificationsNavigationController.tabBarItem;
+    notificationsTabBarItem.image = self.notificationsTabBarImageUnread;
+    notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");
 }
 
 - (void)updateMeNotificationIcon

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -913,7 +913,12 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     // Discount Zendesk unread notifications when determining if we need to show the notificationsTabBarImageUnread.
     NSInteger count = [[UIApplication sharedApplication] applicationIconBadgeNumber] - [ZendeskUtils unreadNotificationsCount];
     UITabBarItem *notificationsTabBarItem = self.notificationsNavigationController.tabBarItem;
-    if (count > 0 || self.isFromSignup) {
+
+    NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
+    NSString *welcomeNotificationSeenKey = standardUserDefaults.welcomeNotificationSeenKey;
+    BOOL welcomeNotificationSeen = [standardUserDefaults boolForKey: welcomeNotificationSeenKey];
+
+    if (count > 0 || !welcomeNotificationSeen) {
         notificationsTabBarItem.image = self.notificationsTabBarImageUnread;
         notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");
     } else {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -70,8 +70,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 @property (nonatomic, strong) CreateButtonCoordinator *createButtonCoordinator;
 
-@property (nonatomic, assign) BOOL isFromSignup;
-
 @end
 
 @implementation WPTabBarController
@@ -152,11 +150,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
                                                  selector:@selector(switchReaderTabToSavedPosts)
                                                      name:NSNotification.ShowAllSavedForLaterPostsNotification
                                                    object:nil];
-        
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(showNotificationBadge:)
-                                                            name:NSNotification.WelcomeNotification
-                                                          object:nil];
 
         // Watch for application badge number changes
         [[UIApplication sharedApplication] addObserver:self
@@ -576,7 +569,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)showNotificationsTab
 {
-    self.isFromSignup = NO;
     [self showTabForIndex:WPTabNotifications];
 }
 
@@ -949,16 +941,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 {
     UIImage *readerTabBarImage = [UIImage imageNamed:@"icon-tab-reader"];
     self.readerNavigationController.tabBarItem.image = readerTabBarImage;
-}
-
-- (void) showNotificationBadge:(NSNotification *)notification
-{
-    if ([((NSDictionary*) notification.object) valueForKey:@"sign_up"]) {
-        self.isFromSignup = YES;
-    }
-    UITabBarItem *notificationsTabBarItem = self.notificationsNavigationController.tabBarItem;
-    notificationsTabBarItem.image = self.notificationsTabBarImageUnread;
-    notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");
 }
 
 - (void)updateMeNotificationIcon

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -914,11 +914,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     NSInteger count = [[UIApplication sharedApplication] applicationIconBadgeNumber] - [ZendeskUtils unreadNotificationsCount];
     UITabBarItem *notificationsTabBarItem = self.notificationsNavigationController.tabBarItem;
 
-    NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
-    NSString *welcomeNotificationSeenKey = standardUserDefaults.welcomeNotificationSeenKey;
-    BOOL welcomeNotificationSeen = [standardUserDefaults boolForKey: welcomeNotificationSeenKey];
-
-    if (count > 0 || !welcomeNotificationSeen) {
+    if (count > 0 || ![self welcomeNotificationSeen]) {
         notificationsTabBarItem.image = self.notificationsTabBarImageUnread;
         notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");
     } else {
@@ -940,6 +936,13 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     if( UIApplication.sharedApplication.isCreatingScreenshots ) {
         [self hideReaderBadge:nil];
     }
+}
+
+-(BOOL) welcomeNotificationSeen
+{
+    NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
+    NSString *welcomeNotificationSeenKey = standardUserDefaults.welcomeNotificationSeenKey;
+    return [standardUserDefaults boolForKey: welcomeNotificationSeenKey];
 }
 
 - (void) hideReaderBadge:(NSNotification *)notification

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -913,7 +913,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     // Discount Zendesk unread notifications when determining if we need to show the notificationsTabBarImageUnread.
     NSInteger count = [[UIApplication sharedApplication] applicationIconBadgeNumber] - [ZendeskUtils unreadNotificationsCount];
     UITabBarItem *notificationsTabBarItem = self.notificationsNavigationController.tabBarItem;
-
     if (count > 0 || ![self welcomeNotificationSeen]) {
         notificationsTabBarItem.image = self.notificationsTabBarImageUnread;
         notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");


### PR DESCRIPTION
Fixes #13593 

As of iOS 8, the application must register for user notifications using -[UIApplication registerUserNotificationSettings:] before being able to set the icon badge which we are relying on when setting the notification tab bar item's to it's unread state. 

Since we don't prompt the user to allow notification (registerUserNotificationSettings) right after signup, we need to show the "unread notification" icon in a different way.

This PR, adds a user defaults key named "welcomeNotificationSeen" and sets it to false right after signup (when the user taps continue on the signup epilogue. 

`updateNotificationBadgeVisibility` in WPTabController, in addition to checking the `applicationIconBadgeNumber` is now also looking for the value of the new UserDefaults key to determine if to show the unread notification icon.

The value will be set to true (marks the notification as read) only when the user opens the notification controller. 

To test:
1. Go through Signup for WordPress.com 
2. See signup epilogue screen
3. tap continue
4. Skip or don't skip site creation
5. See dot in notification tabbar item 
6. See that dot persists till you tap on the notification tab bar item

![20200310_175739](https://user-images.githubusercontent.com/1335657/76371822-ca14e580-62f8-11ea-9630-923c51091980.GIF)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
