### PR TITLE
Media Picker action bar: customize appearance

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -178,9 +178,9 @@ target 'WordPress' do
 
     pod 'NSURL+IDN', '0.3'
 
-    # pod 'WPMediaPicker', '~> 1.6.1-beta.1'
+    pod 'WPMediaPicker', '~> 1.6.1-beta.1'
     ## while PR is in review:
-    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :branch => 'fix/12759-action_bar_background'
+    # pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :branch => ''
     # pod 'WPMediaPicker', :path => '../MediaPicker-iOS'
 
     pod 'Gridicons', '~> 0.20-beta.1'

--- a/Podfile
+++ b/Podfile
@@ -178,9 +178,10 @@ target 'WordPress' do
 
     pod 'NSURL+IDN', '0.3'
 
-    pod 'WPMediaPicker', '~> 1.6.0'
+    # pod 'WPMediaPicker', '~> 1.6.1-beta.1'
     ## while PR is in review:
-    ## pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '7c3cb8f00400b9316a803640b42bb88a66bbc648'
+    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :branch => 'fix/12759-action_bar_background'
+    # pod 'WPMediaPicker', :path => '../MediaPicker-iOS'
 
     pod 'Gridicons', '~> 0.20-beta.1'
     # While in PR

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -480,7 +480,7 @@ DEPENDENCIES:
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.8.15)
   - WordPressUI (~> 1.5.1)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, branch `fix/12759-action_bar_background`)
+  - WPMediaPicker (~> 1.6.1-beta.1)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
@@ -526,6 +526,7 @@ SPEC REPOS:
     - WordPressMocks
     - WordPressShared
     - WordPressUI
+    - WPMediaPicker
     - wpxmlrpc
     - ZendeskCommonUISDK
     - ZendeskCoreSDK
@@ -606,9 +607,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WPMediaPicker:
-    :branch: fix/12759-action_bar_background
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -622,9 +620,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WPMediaPicker:
-    :commit: 0088e4d9d5e8841c92fbc7b0109841ac78fe9b2f
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -711,6 +706,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: d079cfc67e97c494d475eb6a0fb0a40410f673a6
+PODFILE CHECKSUM: 71f1c29351e877bb7b6f89959a22499fb01bda49
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -396,7 +396,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.5.1)
-  - WPMediaPicker (1.6.0)
+  - WPMediaPicker (1.6.1-beta.1)
   - wpxmlrpc (0.8.5-beta.1)
   - Yoga (1.14.0)
   - ZendeskCommonUISDK (4.0.0):
@@ -480,7 +480,7 @@ DEPENDENCIES:
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.8.15)
   - WordPressUI (~> 1.5.1)
-  - WPMediaPicker (~> 1.6.0)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, branch `fix/12759-action_bar_background`)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
@@ -526,7 +526,6 @@ SPEC REPOS:
     - WordPressMocks
     - WordPressShared
     - WordPressUI
-    - WPMediaPicker
     - wpxmlrpc
     - ZendeskCommonUISDK
     - ZendeskCoreSDK
@@ -607,6 +606,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WPMediaPicker:
+    :branch: fix/12759-action_bar_background
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -620,6 +622,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WPMediaPicker:
+    :commit: 0088e4d9d5e8841c92fbc7b0109841ac78fe9b2f
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -694,7 +699,7 @@ SPEC CHECKSUMS:
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 02e0947034648cbd7251ffcc10f64d512f93a53b
   WordPressUI: ce0ac522146dabcd0a68ace24c0104dfdf6f4b0d
-  WPMediaPicker: e5d28197da6b467d4e5975d64a49255977e39455
+  WPMediaPicker: 33752b2045b18dc2c9ea4ac5165a7c6bf0111d5d
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
   Yoga: c920bf12bf8146aa5cd118063378c2cf5682d16c
   ZendeskCommonUISDK: 3c432801e31abff97d6e30441ea102eaef6b99e2
@@ -706,6 +711,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: ae7ddfb9992fe9edcf3567f27cfb45bf8b7607ae
+PODFILE CHECKSUM: d079cfc67e97c494d475eb6a0fb0a40410f673a6
 
 COCOAPODS: 1.8.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,10 @@
 14.5
 -----
 * Post Settings: Fix issue where the status of a post showed "Scheduled" instead of "Published" after scheduling before the current date.
-* Dark Mode: fix border color on Search bars.
-* Stats: Fix background color in Dark Mode on wider screen sizes. 
+* Dark Mode fixes:
+  - Border color on Search bars.
+  - Stats background color on wider screen sizes.
+  - Media Picker action bar background color.
  
 14.4
 -----

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -844,6 +844,8 @@ extension WordPressAppDelegate {
         cellAppearance.setCellTintColor(.primary)
 
         UIButton.appearance(whenContainedInInstancesOf: [WPActionBar.self]).tintColor = .primary
+        WPActionBar.appearance().barBackgroundColor = .basicBackground
+        WPActionBar.appearance().lineColor = .basicBackground
 
         customizeAppearanceForTextElements()
     }


### PR DESCRIPTION
Fixes #12759 
Media Picker PR: https://github.com/wordpress-mobile/MediaPicker-iOS/pull/346

This sets the Media Picker's `WPActionBar` appearance to use dynamic colors.

To test:
- Go to a view that allows media multiple selection (ex: Media Library > add, edit post > media gallery > add media).

| ![media_library](https://user-images.githubusercontent.com/1816888/76461508-a65ba900-63a5-11ea-810c-37137559ac9b.png) | ![post_gallery](https://user-images.githubusercontent.com/1816888/76461520-ad82b700-63a5-11ea-9985-a75bb908d9ea.png) |
|--------|-------|


- Select multiple items so that the action bar at the bottom appears.
- Switch between light and dark modes. 
- Verify the action bar updates accordingly.

| ![light](https://user-images.githubusercontent.com/1816888/76461604-d1de9380-63a5-11ea-98b0-31fbacf2352e.png) | ![dark](https://user-images.githubusercontent.com/1816888/76461618-dacf6500-63a5-11ea-9876-f94c0c7305f5.png) |
|--------|-------|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
