### PR TITLE
Login/Signup buttons: update colors when appearance changes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -187,9 +187,9 @@ target 'WordPress' do
     # While in PR
     #pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :branch => 'feature/Swift-5-migration'
 
-    # pod 'WordPressAuthenticator', '~> 1.11.0-beta.4'
+    pod 'WordPressAuthenticator', '~> 1.11.0-beta.4'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/12441-update_nux_buttons'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.0.1'

--- a/Podfile
+++ b/Podfile
@@ -187,9 +187,9 @@ target 'WordPress' do
     # While in PR
     #pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :branch => 'feature/Swift-5-migration'
 
-    pod 'WordPressAuthenticator', '~> 1.11.0-beta.2'
+    # pod 'WordPressAuthenticator', '~> 1.11.0-beta.4'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/update-wpkit-to-v4.6.0-beta.1'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/12441-update_nux_buttons'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.0.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -475,7 +475,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.16.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/12441-update_nux_buttons`)
+  - WordPressAuthenticator (~> 1.11.0-beta.4)
   - WordPressKit (~> 4.6.0-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.8.15)
@@ -521,6 +521,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -606,9 +607,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressAuthenticator:
-    :branch: fix/12441-update_nux_buttons
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -622,9 +620,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressAuthenticator:
-    :commit: 06264d405303b0b6ce47449ebb43f9cefaacd824
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -711,6 +706,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: e2f83618e40aca2391640cde564a6dc51bb7f72d
+PODFILE CHECKSUM: 5178c8b4ccd3705cd5acc25afc6cbf543e0ed8bf
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -372,7 +372,7 @@ PODS:
   - WordPress-Aztec-iOS (1.16.0)
   - WordPress-Editor-iOS (1.16.0):
     - WordPress-Aztec-iOS (= 1.16.0)
-  - WordPressAuthenticator (1.11.0-beta.2):
+  - WordPressAuthenticator (1.11.0-beta.4):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -381,7 +381,7 @@ PODS:
     - lottie-ios (= 2.5.2)
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 4.6.0-beta.1)
+    - WordPressKit (~> 4.6.0-beta.2)
     - WordPressShared (~> 1.8.13-beta)
     - WordPressUI (~> 1.4-beta.1)
   - WordPressKit (4.6.0-beta.2):
@@ -475,7 +475,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.16.0)
-  - WordPressAuthenticator (~> 1.11.0-beta.2)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/12441-update_nux_buttons`)
   - WordPressKit (~> 4.6.0-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.8.15)
@@ -521,7 +521,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -607,6 +606,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :branch: fix/12441-update_nux_buttons
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -620,6 +622,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :commit: 06264d405303b0b6ce47449ebb43f9cefaacd824
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -689,7 +694,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 64a2989d25befb5ce086fac440315f696026ffd5
   WordPress-Editor-iOS: 63ef6a532af2c92e3301421f5c4af41ad3be8721
-  WordPressAuthenticator: d7077030e7b5a38ad080821b3871c4a8ee131c8b
+  WordPressAuthenticator: 6a397573be47bd9f054e79f5241095614c430f82
   WordPressKit: 36f3dd07e27cee3153ea0d77b9802bc4fec48c19
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 02e0947034648cbd7251ffcc10f64d512f93a53b
@@ -706,6 +711,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 71f1c29351e877bb7b6f89959a22499fb01bda49
+PODFILE CHECKSUM: e2f83618e40aca2391640cde564a6dc51bb7f72d
 
 COCOAPODS: 1.8.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
   - Border color on Search bars.
   - Stats background color on wider screen sizes.
   - Media Picker action bar background color.
+  - Login and Signup button colors.
  
 14.4
 -----


### PR DESCRIPTION
Ref #12441 
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/199

This uses the Auth changes that updates the Login & Signup `NUXButton`s when light/dark mode toggled.

NOTE: These buttons are _not_ `NUXButton`s, and therefore are not fixed:
- Sign in with Apple. This will be updated on https://github.com/wordpress-mobile/WordPress-iOS/issues/13620.
- 'Connect another site' button on the login epilogue. This button will be removed with the new epilogue https://github.com/wordpress-mobile/WordPress-iOS/issues/13413, and thus won't be an issue soon.

To test:
- Log out of the app.
- On the initial view, toggle light/dark mode. 
- Verify the buttons update accordingly.

| ![initial_light](https://user-images.githubusercontent.com/1816888/76470599-2a1d9180-63b6-11ea-9d22-f38ae80dfb74.png) | ![initial_dark](https://user-images.githubusercontent.com/1816888/76470609-2f7adc00-63b6-11ea-885c-42530d79a520.png) |
|--------|-------|

- Select 'Log In'.
- Toggle light/dark mode. 
- Verify the buttons update accordingly (except for Apple).

| ![login_light](https://user-images.githubusercontent.com/1816888/76470644-4cafaa80-63b6-11ea-935b-45df2194412c.png) | ![login_dark](https://user-images.githubusercontent.com/1816888/76470680-605b1100-63b6-11ea-9e2f-d5e8d05a1f4e.png) |
|--------|-------|

- Select 'Sign up'.
- Toggle light/dark mode. 
- Verify the buttons update accordingly (except for Apple).

| ![signup_light](https://user-images.githubusercontent.com/1816888/76470746-81bbfd00-63b6-11ea-8f35-bd098398caf8.png) | ![signup_dark](https://user-images.githubusercontent.com/1816888/76470756-88e30b00-63b6-11ea-88f0-57988e09c440.png) |
|--------|-------|


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
