### PR TITLE
Login Epilogue: Update site icon border color when appearance mode changes.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
@@ -26,12 +26,21 @@ extension WPStyleGuide {
         cell.textLabel?.font = UIFont.systemFont(ofSize: fontSize, weight: .medium)
         cell.detailTextLabel?.font = UIFont.systemFont(ofSize: fontSize, weight: .regular)
 
-        cell.imageView?.layer.borderColor = UIColor.neutral(.shade10).cgColor
-        cell.imageView?.layer.borderWidth = 1
         cell.imageView?.tintColor = .neutral(.shade30)
+        cell.imageView?.layer.borderWidth = 1
 
         cell.selectionStyle = .none
         cell.backgroundColor = .basicBackground
     }
 
- }
+}
+
+extension LoginEpilogueBlogCell {
+    // Per Apple's documentation (https://developer.apple.com/documentation/xcode/supporting_dark_mode_in_your_interface),
+    // `cgColor` objects do not adapt to appearance changes (i.e. toggling light/dark mode).
+    // `tintColorDidChange` is called when the appearance changes, so re-set the border color when this occurs.
+    override func tintColorDidChange() {
+        super.tintColorDidChange()
+        imageView?.layer.borderColor = UIColor.neutral(.shade10).cgColor
+    }
+}


### PR DESCRIPTION
Fixes #n/a
Ref #13413 

This updates the border on the site icons to update when toggling light/dark mode.

To test:
- Log into the app with an account that has sites.
- On the epilogue, switch between light/dark mode.
- Verify the site icon image border updates accordingly.

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/76558123-5c84c880-6462-11ea-8583-4f86dec978e1.png) |  ![after](https://user-images.githubusercontent.com/1816888/76557875-f304ba00-6461-11ea-9345-b6092dbbcc19.png) |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
