### PR TITLE
Integrates WPKit 4.6.0-beta.5

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,8 +43,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 4.5.9'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => '4.6.0-beta.3'
+    pod 'WordPressKit', '~> 4.6.0-beta.5'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => '4.6.0-beta.3'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/datarequest-weak-reference'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '24af2c192fd628f4c5bb3e9be6c8312cb45260fe'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
@@ -54,7 +54,7 @@ def shared_with_all_pods
     wordpress_shared
     pod 'CocoaLumberjack', '3.5.2'
     pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
-    pod 'NSObject-SafeExpectations', '0.0.3'
+    pod 'NSObject-SafeExpectations', '0.0.4'
 end
 
 def shared_with_networking_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -102,7 +102,7 @@ PODS:
   - MRProgress/Stopable (0.8.3):
     - MRProgress/Helper
   - Nimble (7.3.4)
-  - NSObject-SafeExpectations (0.0.3)
+  - NSObject-SafeExpectations (0.0.4)
   - "NSURL+IDN (0.3)"
   - OCMock (3.4.3)
   - OHHTTPStubs (6.1.0):
@@ -384,10 +384,10 @@ PODS:
     - WordPressKit (~> 4.6.0-beta.2)
     - WordPressShared (~> 1.8.13-beta)
     - WordPressUI (~> 1.4-beta.1)
-  - WordPressKit (4.6.0-beta.3):
+  - WordPressKit (4.6.0-beta.5):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
-    - NSObject-SafeExpectations (= 0.0.3)
+    - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1)
     - WordPressShared (~> 1.8.13-beta)
     - wpxmlrpc (= 0.8.5-beta.1)
@@ -438,7 +438,7 @@ DEPENDENCIES:
   - MediaEditor (~> 1.0.1)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
-  - NSObject-SafeExpectations (= 0.0.3)
+  - NSObject-SafeExpectations (= 0.0.4)
   - "NSURL+IDN (= 0.3)"
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
@@ -476,7 +476,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.16.0)
   - WordPressAuthenticator (~> 1.11.0-beta.4)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, tag `4.6.0-beta.3`)
+  - WordPressKit (~> 4.6.0-beta.5)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.8.15)
   - WordPressUI (~> 1.5.1)
@@ -522,6 +522,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -606,9 +607,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressKit:
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-    :tag: 4.6.0-beta.3
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -622,9 +620,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressKit:
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-    :tag: 4.6.0-beta.3
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -654,7 +649,7 @@ SPEC CHECKSUMS:
   MediaEditor: 7296cd01d7a0548fb2bc909aa72153b376a56a61
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
-  NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
+  NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   "NSURL+IDN": 82355a0afd532fe1de08f6417c134b49b1a1c4b3
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
@@ -695,7 +690,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 64a2989d25befb5ce086fac440315f696026ffd5
   WordPress-Editor-iOS: 63ef6a532af2c92e3301421f5c4af41ad3be8721
   WordPressAuthenticator: 6a397573be47bd9f054e79f5241095614c430f82
-  WordPressKit: 8bc057220b1e30f3e0ace953bbca37d623ee56d7
+  WordPressKit: 1b4b330f8a5817eccd9b221690dc1151a4c0958e
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 02e0947034648cbd7251ffcc10f64d512f93a53b
   WordPressUI: ce0ac522146dabcd0a68ace24c0104dfdf6f4b0d
@@ -711,6 +706,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 4cb8bdf167c806f1795412ca8bde873aa700d7da
+PODFILE CHECKSUM: 6e99cf4b1ea0ad1779fe1aca7116946008bb47b3
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Integrates the fix for this issue: https://github.com/wordpress-mobile/WordPressKit-iOS/issues/228

## To test:

Go to the list of plans for a site and check that the console doesn't report any message like this one:

```2020-03-04 15:56:59:708 Error parsing plans response for site dataCorrupted(Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "rawPrice", intValue: nil)], debugDescription: "Parsed JSON number <9.5> does not fit in Int.", underlyingError: nil))```

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
