### PR TITLE
Add symbol upload for installable builds

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -277,6 +277,16 @@ import "./ScreenshotFastfile"
       notify_testers: false 
     )
 
+    # Install SentryCLI prior to trying to upload dSYMs
+    sh("curl -sL https://sentry.io/get-cli/ | bash")
+
+    sentry_upload_dsym(
+      auth_token: get_required_env("SENTRY_AUTH_TOKEN"),
+      org_slug: 'a8c',
+      project_slug: 'wordpress-ios',
+      dsym_path: "./build/WordPress.app.dSYM.zip",
+    )
+
     download_url = Actions.lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]
     UI.message("Successfully built and uploaded installable build here: #{download_url}")
     install_url = "https://install.appcenter.ms/orgs/automattic/apps/WPiOS-One-Offs/"

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -284,7 +284,7 @@ import "./ScreenshotFastfile"
       auth_token: get_required_env("SENTRY_AUTH_TOKEN"),
       org_slug: 'a8c',
       project_slug: 'wordpress-ios',
-      dsym_path: "./build/WordPress.app.dSYM.zip",
+      dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH],
     )
 
     download_url = Actions.lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]


### PR DESCRIPTION
Cleans up a periodic alert in Sentry, and lets us get crash data for anything that happens in one.

**To test:**

Note the following section of the build log in CI:

```
[23:55:07]: --------------------------------
[23:55:07]: --- Step: sentry_upload_dsym ---
[23:55:07]: --------------------------------
[23:55:07]: sentry-cli 1.51.1 installed!
[23:55:07]: Starting sentry-cli...
[23:55:10]: > Found 11 debug information files
[23:55:11]: > Prepared debug information files for upload
[23:55:18]: > Uploaded 11 missing debug information files
[23:55:18]: > File upload complete:
[23:55:18]: 
[23:55:18]: PENDING fa53b492-4e3d-3dba-a76a-a5351184397b (WordPressNotificationContentExtension.appex.dSYM/Contents/Resources/DWARF/WordPressNotificationContentExtension; arm64 debug companion)
[23:55:18]: PENDING 5fbe1852-f6fc-3c42-a8b4-ab12f7d04d28 (Sentry.framework.dSYM/Contents/Resources/DWARF/Sentry; arm64 debug companion)
[23:55:18]: PENDING 98756fab-8999-3b1c-a78a-a5b17214348b (WordPressTodayWidget.appex.dSYM/Contents/Resources/DWARF/WordPressTodayWidget; arm64 debug companion)
[23:55:18]: PENDING 63469aa8-c71b-30dd-bb6e-83cbd55fb067 (WordPressNotificationServiceExtension.appex.dSYM/Contents/Resources/DWARF/WordPressNotificationServiceExtension; arm64 debug companion)
[23:55:18]: PENDING d0ea9161-d99b-3c6e-a1de-7b709125fbbc (WordPressDraftActionExtension.appex.dSYM/Contents/Resources/DWARF/WordPressDraftActionExtension; arm64 debug companion)
[23:55:18]: PENDING 7278a196-d242-36b7-b953-619b78a9ea97 (WordPressFlux.framework.dSYM/Contents/Resources/DWARF/WordPressFlux; armv7 debug companion)
[23:55:18]: PENDING 787c5a6f-01e6-3d2f-80fb-86e51a480c11 (WordPressFlux.framework.dSYM/Contents/Resources/DWARF/WordPressFlux; arm64 debug companion)
[23:55:18]: PENDING 3c527c9d-519b-3e79-9c26-506a923ae8c5 (WordPress.app.dSYM/Contents/Resources/DWARF/WordPress; arm64 debug companion)
[23:55:18]: PENDING 0c7d3458-cdbc-3e5a-aef2-c5af7c17913f (WordPressShareExtension.appex.dSYM/Contents/Resources/DWARF/WordPressShareExtension; arm64 debug companion)
[23:55:18]: PENDING 2e3e9577-e2ae-316b-9889-0ecdf951c5bf (WordPressAllTimeWidget.appex.dSYM/Contents/Resources/DWARF/WordPressAllTimeWidget; arm64 debug companion)
[23:55:18]: PENDING 7b01544c-1ba4-3ff7-90da-d4badee16635 (WordPressThisWeekWidget.appex.dSYM/Contents/Resources/DWARF/WordPressThisWeekWidget; arm64 debug companion)
[23:55:18]: Successfully uploaded dSYMs!
```