### PR TITLE
Reader Comments: update content when appearance changes.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
   - Stats background color on wider screen sizes.
   - Media Picker action bar background color.
   - Login and Signup button colors.
+  - Reader comments colors.
  
 14.4
 -----

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -81,17 +81,27 @@ class ReaderCommentCell: UITableViewCell {
         super.awakeFromNib()
 
         setupContentView()
-        setupReplyButton()
-        setupLikeButton()
         applyStyles()
     }
 
+    override func tintColorDidChange() {
+        // Update colors when toggling light/dark mode.
+        super.tintColorDidChange()
+        applyStyles()
+    }
 
     // MARK: = Setup
 
     @objc func applyStyles() {
+
+        setupReplyButton()
+        setupLikeButton()
+
         WPStyleGuide.applyReaderCardSiteButtonStyle(authorButton)
         WPStyleGuide.applyReaderCardBylineLabelStyle(timeLabel)
+
+        WPStyleGuide.applyReaderActionButtonStyle(replyButton)
+        WPStyleGuide.applyReaderActionButtonStyle(likeButton)
 
         authorButton.titleLabel?.lineBreakMode = .byTruncatingTail
 
@@ -116,8 +126,6 @@ class ReaderCommentCell: UITableViewCell {
 
         let title = NSLocalizedString("Reply", comment: "Verb. Title of the Reader comments screen reply button. Tapping the button sends a reply to a comment or post.")
         replyButton.setTitle(title, for: .normal)
-
-        WPStyleGuide.applyReaderActionButtonStyle(replyButton)
     }
 
 
@@ -130,8 +138,6 @@ class ReaderCommentCell: UITableViewCell {
         likeButton.setImage(star, for: .highlighted)
         likeButton.setImage(star, for: .selected)
         likeButton.setImage(star, for: [.selected, .highlighted])
-
-        WPStyleGuide.applyReaderActionButtonStyle(likeButton)
     }
 
     // MARK: - Configuration

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -280,11 +280,10 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     [headerWrapper addSubview:headerView];
 
     // Border
-    CGSize borderSize = CGSizeMake(CGRectGetWidth(self.view.bounds), 1.0);
-    UIImage *borderImage = [UIImage imageWithColor:[UIColor murielNeutral5] havingSize:borderSize];
-    UIImageView *borderView = [[UIImageView alloc] initWithImage:borderImage];
+    CGRect borderRect = CGRectMake(0, 0, CGRectGetWidth(self.view.bounds), 1.0);
+    UIView *borderView = [[UIView alloc] initWithFrame:borderRect];
+    borderView.backgroundColor = [UIColor murielNeutral5];
     borderView.translatesAutoresizingMaskIntoConstraints = NO;
-    borderView.contentMode = UIViewContentModeScaleAspectFill;
     [headerWrapper addSubview:borderView];
 
     // Layout


### PR DESCRIPTION
Fixes #13638 

This allows the Reader Comments view to update when light/dark mode toggled.

To test:
- Go to the Reader.
- On a post with comments, select Comments.
- Switch light/dark mode.
- Verify the view updates accordingly, specifically:
  - The header bottom border (i.e. the "Comments on" block).
  - Comment text color.
  - Action bar icons (i.e. Reply, Likes).

![reader_comments](https://user-images.githubusercontent.com/1816888/76575743-bcd93180-6485-11ea-92ce-66942ada04db.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
