### PR TITLE
Notification Layout Issues

### DIFF
--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -98,7 +98,14 @@ class NotificationSyncMediator {
                 return
             }
 
-            self.deleteLocalMissingNotes(from: remoteHashes) {
+            let hackedHashes = [
+                RemoteNotification(document: [
+                    "id": 1234,
+                    "note_hash": 9999999
+                    ] as [String: AnyObject] )!
+            ]
+
+            self.deleteLocalMissingNotes(from: hackedHashes) {
 
                 self.determineUpdatedNotes(with: remoteHashes) { outdatedNoteIds in
                     guard outdatedNoteIds.isEmpty == false else {
@@ -107,12 +114,155 @@ class NotificationSyncMediator {
                     }
 
                     self.remote.loadNotes(noteIds: outdatedNoteIds) { error, remoteNotes in
-                        guard let remoteNotes = remoteNotes else {
-                            completion?(error, false)
-                            return
-                        }
-
-                        self.updateLocalNotes(with: remoteNotes) {
+let hackedNotes = [
+    RemoteNotification(document: [
+        "id": 1234,
+        "note_hash": 1234,
+        "type": "comment",
+        "read": 1,
+        "noticon": "\u{f814}",
+        "timestamp": "2020-03-05T09:06:52+00:00",
+        "icon": "https:\\/\\/1.gravatar.com",
+        "url": "https:\\/\\/something",
+        "subject": [[
+            "text": "Aaaaa Aaaaaa mentioned you on I created a simple...",
+            "ranges": [[
+                "type": "noticon",
+                "indices": [0, 0],
+                "value": "\u{f467}"
+            ], [
+                "type": "user",
+                "indices": [0, 12],
+                "url": "http:\\/\\/aaaaaaa.com",
+                "site_id": 999999999999,
+                "id": 999999999999
+            ], [
+                "type": "post",
+                "indices": [30, 51],
+                "url": "https:\\/\\/something",
+                "site_id": 999999999999,
+                "id": 999999999999
+            ]]
+        ], [
+            "text": "I just deployed an update of the IIII service that will check if sssss for a commit were really generated before using them to calculate a delta.\\nUntil now, the select from stats SQL \\u2026\\n",
+            "ranges": [[
+                "type": "comment",
+                "indices": [0, 185],
+                "url": "https:\\/\\/something",
+                "site_id": 999999999999,
+                "post_id": 999999999999,
+                "id": 999999999999
+            ]]
+        ]],
+        "body": [[
+            "text": "Aaaaa Aaaaaa",
+            "ranges": [[
+                "email": "test@test.com",
+                "url": "http:\\/\\/something",
+                "id": 999999999999,
+                "site_id": 999999999999,
+                "type": "user",
+                "indices": [0, 12]
+            ]],
+            "media": [[
+                "type": "image",
+                "indices": [0, 0],
+                "height": "256",
+                "width": "256",
+                "url": "https:\\/\\/1.gravatar.com\\/avatar"
+            ]],
+            "actions": [
+                "follow": false
+            ],
+            "meta": [
+                "links": [
+                ],
+                "ids": [
+                    "user": 999999999999,
+                    "site": 999999999999
+                ],
+                "titles": [
+                    "home": "Aaaaa Aaaaaa"
+                ]
+            ],
+            "type": "user"
+        ], [
+            "text": "I just deployed an update of the IIII sssssss that will check if stats for a commit were really generated before using them to calculate a delta.\n\nUntil now, the select from sssss SQL query simply returned zzzz rows, making one side of the delta empty.\n\nIf the needed stats are not available, xxxx will not proceed to post a comment.\n\nThis is a simple fix that I\u{2019}ve procrastinating on for too long. But now when we\u{2019}re having a lot of issues with unstable CI builds, the problem started happening much more often. Thanks @wwwww for callint it out 👍",
+            "ranges": [[
+                "url": "https:\\/\\/something/",
+                "indices": [520, 526]
+            ], [
+                "type": "code",
+                "indices": [162, 179]
+            ]],
+            "actions": [
+                "spam-comment": false,
+                "trash-comment": false,
+                "approve-comment": true,
+                "edit-comment": false,
+                "replyto-comment": true,
+                "like-comment": false
+            ],
+            "meta": [
+                "ids": [
+                    "comment": 999999999999,
+                    "user": 999999999999,
+                    "post": 999999999999,
+                    "site": 999999999999
+                ],
+                "links": []
+            ],
+            "type": "comment",
+            "nest_level": 0,
+        ], [
+            "text": "You replied to this comment.",
+            "ranges": [[
+                "type": "noticon",
+                "indices": [0, 0],
+                "value": "\u{f467}"
+            ], [
+                "type": "comment",
+                "indices": [4, 11],
+                "url": "https:\\/\\/something",
+                "site_id": 999999999999,
+                "post_id": 999999999999,
+                "id": 999999999999
+            ]]
+        ]],
+        "meta": [
+            "ids": [
+                "user": 999999999999,
+                "comment": 999999999999,
+                "post": 999999999999,
+                "site": 999999999999,
+                "reply_comment": 999999999999
+            ],
+            "links": [
+            ]
+        ],
+        "header": [[
+            "text": "Aaaaa Aaaaaaaa",
+            "ranges": [[
+                "type": "user",
+                "indices": [0, 14],
+                "url": "http:\\/\\/aaaaaaa\\/",
+                "site_id": 999999999999,
+                "id": 999999999999
+            ]],
+            "media": [[
+                "type": "image",
+                "indices": [0, 0],
+                "height": "256",
+                "width": "256",
+                "url": "https:\\/\\/2.gravatar.com"
+            ]]
+        ], [
+            "text": "I created a simple..."
+        ]],
+        "title": "Mention"
+    ] as [String: AnyObject])!
+]
+                        self.updateLocalNotes(with: hackedNotes) {
                             self.notifyNotificationsWereUpdated()
                             completion?(nil, true)
                         }

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -98,14 +98,7 @@ class NotificationSyncMediator {
                 return
             }
 
-            let hackedHashes = [
-                RemoteNotification(document: [
-                    "id": 1234,
-                    "note_hash": 9999999
-                    ] as [String: AnyObject] )!
-            ]
-
-            self.deleteLocalMissingNotes(from: hackedHashes) {
+            self.deleteLocalMissingNotes(from: remoteHashes) {
 
                 self.determineUpdatedNotes(with: remoteHashes) { outdatedNoteIds in
                     guard outdatedNoteIds.isEmpty == false else {
@@ -114,155 +107,12 @@ class NotificationSyncMediator {
                     }
 
                     self.remote.loadNotes(noteIds: outdatedNoteIds) { error, remoteNotes in
-let hackedNotes = [
-    RemoteNotification(document: [
-        "id": 1234,
-        "note_hash": 1234,
-        "type": "comment",
-        "read": 1,
-        "noticon": "\u{f814}",
-        "timestamp": "2020-03-05T09:06:52+00:00",
-        "icon": "https:\\/\\/1.gravatar.com",
-        "url": "https:\\/\\/something",
-        "subject": [[
-            "text": "Aaaaa Aaaaaa mentioned you on I created a simple...",
-            "ranges": [[
-                "type": "noticon",
-                "indices": [0, 0],
-                "value": "\u{f467}"
-            ], [
-                "type": "user",
-                "indices": [0, 12],
-                "url": "http:\\/\\/aaaaaaa.com",
-                "site_id": 999999999999,
-                "id": 999999999999
-            ], [
-                "type": "post",
-                "indices": [30, 51],
-                "url": "https:\\/\\/something",
-                "site_id": 999999999999,
-                "id": 999999999999
-            ]]
-        ], [
-            "text": "I just deployed an update of the IIII service that will check if sssss for a commit were really generated before using them to calculate a delta.\\nUntil now, the select from stats SQL \\u2026\\n",
-            "ranges": [[
-                "type": "comment",
-                "indices": [0, 185],
-                "url": "https:\\/\\/something",
-                "site_id": 999999999999,
-                "post_id": 999999999999,
-                "id": 999999999999
-            ]]
-        ]],
-        "body": [[
-            "text": "Aaaaa Aaaaaa",
-            "ranges": [[
-                "email": "test@test.com",
-                "url": "http:\\/\\/something",
-                "id": 999999999999,
-                "site_id": 999999999999,
-                "type": "user",
-                "indices": [0, 12]
-            ]],
-            "media": [[
-                "type": "image",
-                "indices": [0, 0],
-                "height": "256",
-                "width": "256",
-                "url": "https:\\/\\/1.gravatar.com\\/avatar"
-            ]],
-            "actions": [
-                "follow": false
-            ],
-            "meta": [
-                "links": [
-                ],
-                "ids": [
-                    "user": 999999999999,
-                    "site": 999999999999
-                ],
-                "titles": [
-                    "home": "Aaaaa Aaaaaa"
-                ]
-            ],
-            "type": "user"
-        ], [
-            "text": "I just deployed an update of the IIII sssssss that will check if stats for a commit were really generated before using them to calculate a delta.\n\nUntil now, the select from sssss SQL query simply returned zzzz rows, making one side of the delta empty.\n\nIf the needed stats are not available, xxxx will not proceed to post a comment.\n\nThis is a simple fix that I\u{2019}ve procrastinating on for too long. But now when we\u{2019}re having a lot of issues with unstable CI builds, the problem started happening much more often. Thanks @wwwww for callint it out 👍",
-            "ranges": [[
-                "url": "https:\\/\\/something/",
-                "indices": [520, 526]
-            ], [
-                "type": "code",
-                "indices": [162, 179]
-            ]],
-            "actions": [
-                "spam-comment": false,
-                "trash-comment": false,
-                "approve-comment": true,
-                "edit-comment": false,
-                "replyto-comment": true,
-                "like-comment": false
-            ],
-            "meta": [
-                "ids": [
-                    "comment": 999999999999,
-                    "user": 999999999999,
-                    "post": 999999999999,
-                    "site": 999999999999
-                ],
-                "links": []
-            ],
-            "type": "comment",
-            "nest_level": 0,
-        ], [
-            "text": "You replied to this comment.",
-            "ranges": [[
-                "type": "noticon",
-                "indices": [0, 0],
-                "value": "\u{f467}"
-            ], [
-                "type": "comment",
-                "indices": [4, 11],
-                "url": "https:\\/\\/something",
-                "site_id": 999999999999,
-                "post_id": 999999999999,
-                "id": 999999999999
-            ]]
-        ]],
-        "meta": [
-            "ids": [
-                "user": 999999999999,
-                "comment": 999999999999,
-                "post": 999999999999,
-                "site": 999999999999,
-                "reply_comment": 999999999999
-            ],
-            "links": [
-            ]
-        ],
-        "header": [[
-            "text": "Aaaaa Aaaaaaaa",
-            "ranges": [[
-                "type": "user",
-                "indices": [0, 14],
-                "url": "http:\\/\\/aaaaaaa\\/",
-                "site_id": 999999999999,
-                "id": 999999999999
-            ]],
-            "media": [[
-                "type": "image",
-                "indices": [0, 0],
-                "height": "256",
-                "width": "256",
-                "url": "https:\\/\\/2.gravatar.com"
-            ]]
-        ], [
-            "text": "I created a simple..."
-        ]],
-        "title": "Mention"
-    ] as [String: AnyObject])!
-]
-                        self.updateLocalNotes(with: hackedNotes) {
+                        guard let remoteNotes = remoteNotes else {
+                            completion?(error, false)
+                            return
+                        }
+
+                        self.updateLocalNotes(with: remoteNotes) {
                             self.notifyNotificationsWereUpdated()
                             completion?(nil, true)
                         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -412,6 +412,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 - (void)setupSeparators:(NoteBlockTableViewCell *)cell indexPath:(NSIndexPath *)indexPath
 {
     cell.isLastRow = (indexPath.row >= self.numberOfRows - 1);
+    [cell refreshSeparators];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -294,8 +294,6 @@ extension NotificationDetailsViewController: UITableViewDelegate, UITableViewDat
             fatalError()
         }
 
-        setupSeparators(cell, indexPath: indexPath)
-
         setup(cell, withContentGroupAt: indexPath)
 
         return cell
@@ -309,6 +307,12 @@ extension NotificationDetailsViewController: UITableViewDelegate, UITableViewDat
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         estimatedRowHeightsCache.setObject(cell.frame.height as AnyObject, forKey: indexPath as AnyObject)
+
+        guard let cell = cell as? NoteBlockTableViewCell else {
+            return
+        }
+
+        setupSeparators(cell, indexPath: indexPath)
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -574,6 +578,8 @@ private extension NotificationDetailsViewController {
     func setupSeparators(_ cell: NoteBlockTableViewCell, indexPath: IndexPath) {
         cell.isBadge = note.isBadge
         cell.isLastRow = (indexPath.row >= note.headerAndBodyContentGroups.count - 1)
+
+        cell.refreshSeparators()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -361,6 +361,6 @@ private extension NoteBlockActionsTableViewCell {
 
     struct Constants {
         static let buttonSpacing = CGFloat(20)
-        static let buttonSpacingCompact = CGFloat(9)
+        static let buttonSpacingCompact = CGFloat(2)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.swift
@@ -58,10 +58,14 @@ class NoteBlockCommentTableViewCell: NoteBlockTextTableViewCell {
 
     /// Indicates if the comment is approved, or not.
     ///
+    /// -   Note:
+    ///     After setting this property you should explicitly call `refreshSeparators` from within `UITableView.willDisplayCell`.
+    ///     We're not doing so from `didSet` anymore since doing so might yield invalid `intrinsicContentSize` calculations,
+    ///     which appears to be cached, and results in incorrect layouts.
+    ///
     @objc var isApproved: Bool = false {
         didSet {
             refreshApprovalColors()
-            refreshSeparators()
         }
     }
 
@@ -131,6 +135,13 @@ class NoteBlockCommentTableViewCell: NoteBlockTextTableViewCell {
 
     // MARK: - Approval Color Helpers
 
+    /// Updates the Separators Insets / Style. This API should be called from within `UITableView.willDisplayCell`.
+    ///
+    /// -   Note:
+    ///     `readableSeparatorInsets`, if executed from within `cellForRowAtIndexPath`, will produce an "invalid" layout cycle (since there won't
+    ///     be a superview). Such "Invalid" layout cycle appears to be yielding an invalid `intrinsicContentSize` calculation, which is then cached,
+    ///     and we end up with strings cutoff onScreen. =(
+    ///
     override func refreshSeparators() {
         // Left Separator
         separatorsView.leftVisible = !isApproved

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTableViewCell.swift
@@ -2,17 +2,25 @@ import Foundation
 import WordPressShared
 
 class NoteBlockTableViewCell: WPTableViewCell {
-    // MARK: - Public Properties
-    @objc var isBadge: Bool = false {
-        didSet {
-            refreshSeparators()
-        }
-    }
-    @objc var isLastRow: Bool = false {
-        didSet {
-            refreshSeparators()
-        }
-    }
+
+    /// Represents the (full, side to side) Separator Insets
+    ///
+    private let fullSeparatorInsets = UIEdgeInsets.zero
+
+    /// Indicates if the receiver represents a Badge Block
+    ///
+    /// - Note: After setting this property you should explicitly call `refreshSeparators` from within `UITableView.willDisplayCell`.
+    ///
+    @objc var isBadge = false
+
+    /// Indicates if the receiver is the last row in the group.
+    ///
+    /// - Note: After setting this property you should explicitly call `refreshSeparators` from within `UITableView.willDisplayCell`.
+    ///
+    @objc var isLastRow = false
+
+    /// Readability Insets
+    ///
     @objc var readableSeparatorInsets: UIEdgeInsets {
         var insets = UIEdgeInsets.zero
         let readableLayoutFrame = readableContentGuide.layoutFrame
@@ -20,18 +28,39 @@ class NoteBlockTableViewCell: WPTableViewCell {
         insets.right = frame.size.width - (readableLayoutFrame.origin.x + readableLayoutFrame.size.width)
         return insets
     }
+
+    /// Separators View
+    ///
     @objc var separatorsView: SeparatorsView = {
         let view = SeparatorsView()
         view.backgroundColor = .listForeground
         return view
     }()
 
+
+    // MARK: - Overridden Methods
+
     override func layoutSubviews() {
         super.layoutSubviews()
         refreshSeparators()
     }
 
-    // MARK: - Public Methods
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        backgroundView = separatorsView
+        backgroundColor = .listForeground
+    }
+
+
+    // MARK: - Public API
+
+    /// Updates the Separators Insets / Visibility. This API should be called from within `UITableView.willDisplayCell`.
+    ///
+    /// -   Note:
+    ///     `readableSeparatorInsets`, if executed from within `cellForRowAtIndexPath`, will produce an "invalid" layout cycle (since there won't
+    ///     be a superview). Such "Invalid" layout cycle appears to be yielding an invalid `intrinsicContentSize` calculation, which is then cached,
+    ///     and we end up with strings cutoff onScreen. =(
+    ///
     @objc func refreshSeparators() {
         // Exception: Badges require no separators
         if isBadge {
@@ -43,17 +72,8 @@ class NoteBlockTableViewCell: WPTableViewCell {
         separatorsView.bottomInsets = isLastRow ? fullSeparatorInsets : readableSeparatorInsets
         separatorsView.bottomVisible = true
     }
+
     @objc class func reuseIdentifier() -> String {
         return classNameWithoutNamespaces()
     }
-
-    // MARK: - View Methods
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        backgroundView = separatorsView
-        backgroundColor = .listForeground
-    }
-
-    // MARK: - Private
-    fileprivate let fullSeparatorInsets = UIEdgeInsets.zero
 }


### PR DESCRIPTION
### Description:
In this PR we're working around an Autolayout-Engine-Y (alledged) bug, which results in text getting cut off.

**PLUS** since I was in the neighborhood, I'm patching up the Comment Notification Actions spacing, since current layout yields cutoff text in smaller devices.

@diegoreymendez May I bug you with a hopefully quick one?


### Details:
After literally... hours of debugging, i've managed to pinpoint exactly what's going on.

0. **NoteBlockCommentTableViewCell** is the exact component that's getting cutoff
1. During cell initialization (before there's a superview) we set all of its properties
2. Whenever **NoteBlockCommentTableViewCell.isApproved** runs, we were executing the method **refreshSeparators**
3. The above lead, in a specific flow, into the execution of **NoteBlockTableViewCell.readableSeparatorInsets** without a proper superview
4. This translates into **UITableViewCell.readableContentGuide** being executed

The above should not be a problem. In theory. In practise, what actually happens is that the **intrinsicContentSize** for **RichTextView** is miscalculated (becuse the width constraints are unknown).

This invalid value shouldn't be bugging us, but **UIKit appears to be caching it**. And this is, precisely, the source of our bug.

In this PR we're simply deferring the execution of this entire sequence, up until `wilDisplayCell`, when there's an actual superview, and calculations won't be off.

Fixes #13646

### To test:
1. Checkout commit ff48e233f9
2. Launch WordPress into an **iPhone SE** Simulator
3. Open the Notifications Tab
4. Press over the only notification you've got
5. Verify that the text gets cut off (should end in `Thanks @wwwww for`)
6. Checkout commit d71fcb5f1f (HEAD of this branch)
7. Reopen the same notification as in (5)

- [x] Verify that the note now ends with `Thanks @wwwww for callint it out 👍`


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
