### PR TITLE
Update Jetpack install flow to use most recent colors.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -187,9 +187,9 @@ target 'WordPress' do
     # While in PR
     #pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :branch => 'feature/Swift-5-migration'
 
-    # pod 'WordPressAuthenticator', '~> 1.11.0-beta.7'
+    pod 'WordPressAuthenticator', '~> 1.11.0-beta.7'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/13441-update_signup_button_style'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.0.1'

--- a/Podfile
+++ b/Podfile
@@ -187,9 +187,9 @@ target 'WordPress' do
     # While in PR
     #pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :branch => 'feature/Swift-5-migration'
 
-    pod 'WordPressAuthenticator', '~> 1.11.0-beta.6'
+    # pod 'WordPressAuthenticator', '~> 1.11.0-beta.7'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'develop'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/13441-update_signup_button_style'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.0.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -475,7 +475,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.16.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/13441-update_signup_button_style`)
+  - WordPressAuthenticator (~> 1.11.0-beta.7)
   - WordPressKit (~> 4.6.0-beta.6)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.8.16-beta.1)
@@ -521,6 +521,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -606,9 +607,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressAuthenticator:
-    :branch: fix/13441-update_signup_button_style
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -622,9 +620,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressAuthenticator:
-    :commit: fed705442008cd767fc5e1acb10bba1cd9b23a8e
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -711,6 +706,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: ba4a66cc0a26ed20cc1e7ebb38c78ab77858ae77
+PODFILE CHECKSUM: 0b7dddea1ccc55454128bfd3bd8189800dde7351
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -372,7 +372,7 @@ PODS:
   - WordPress-Aztec-iOS (1.16.0)
   - WordPress-Editor-iOS (1.16.0):
     - WordPress-Aztec-iOS (= 1.16.0)
-  - WordPressAuthenticator (1.11.0-beta.6):
+  - WordPressAuthenticator (1.11.0-beta.7):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -475,7 +475,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.16.0)
-  - WordPressAuthenticator (~> 1.11.0-beta.6)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/13441-update_signup_button_style`)
   - WordPressKit (~> 4.6.0-beta.6)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.8.16-beta.1)
@@ -521,7 +521,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -607,6 +606,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :branch: fix/13441-update_signup_button_style
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/d377b883c761c2a71d29bd631f3d3227b3e313a2/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -620,6 +622,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: d377b883c761c2a71d29bd631f3d3227b3e313a2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :commit: fed705442008cd767fc5e1acb10bba1cd9b23a8e
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -689,7 +694,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 64a2989d25befb5ce086fac440315f696026ffd5
   WordPress-Editor-iOS: 63ef6a532af2c92e3301421f5c4af41ad3be8721
-  WordPressAuthenticator: f42d1f3d5a9aa050133ee38394b9c342b2763766
+  WordPressAuthenticator: 7797c5147ed5f5a32edbd620ab512988987bb8cc
   WordPressKit: c6f6f2b4a47bd042bfb35f4f7b0225fd857d5007
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: ddcb40e608bc0f0162cce5e8df006584febcec50
@@ -706,6 +711,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: e57cadf568e5de5aa6aa8530bdafdd29366f6d5c
+PODFILE CHECKSUM: a6cc7be4980da8ed1ae7171a230be1f9c8fd45ad
 
 COCOAPODS: 1.8.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
   - Media Picker action bar background color.
   - Login and Signup button colors.
   - Reader comments colors.
+  - Jetpack install flow colors.
  
 14.4
 -----

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift
@@ -46,13 +46,13 @@ class JetpackRemoteInstallStateView: UIViewController {
 
 private extension JetpackRemoteInstallStateView {
     func setupUI() {
-        view.backgroundColor = .neutral(.shade5)
+        WPStyleGuide.configureColors(view: view, tableView: nil)
 
         titleLabel.font = WPStyleGuide.fontForTextStyle(.title2)
-        titleLabel.textColor = .neutral(.shade40)
+        titleLabel.textColor = .text
 
         descriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)
-        descriptionLabel.textColor = .neutral(.shade70)
+        descriptionLabel.textColor = .textSubtle
 
         mainButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 20, bottom: 12, right: 20)
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
@@ -60,7 +60,7 @@ class JetpackLoginViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .neutral(.shade5)
+        WPStyleGuide.configureColors(view: view, tableView: nil)
         setupControls()
     }
 
@@ -78,7 +78,7 @@ class JetpackLoginViewController: UIViewController {
         toggleHidingImageView(for: traitCollection)
 
         descriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)
-        descriptionLabel.textColor = .neutral(.shade70)
+        descriptionLabel.textColor = .text
 
         tacButton.titleLabel?.numberOfLines = 0
 
@@ -146,7 +146,7 @@ class JetpackLoginViewController: UIViewController {
                                                 lineBreakMode: .byWordWrapping,
                                                 alignment: .center)
         let attributes: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.footnote),
-                                                         .foregroundColor: UIColor.neutral(.shade70),
+                                                         .foregroundColor: UIColor.textSubtle,
                                                          .paragraphStyle: paragraph]
         let attributedTitle = NSMutableAttributedString(string: Constants.Buttons.termsAndConditionsTitle,
                                                         attributes: attributes)


### PR DESCRIPTION
Fixes #13441 
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/202

This updates the Jetpack install flow to use the correct color scheme.

To test:
- Follow the steps on #13441 .
- Verify the background and text colors are correct.

| ![init](https://user-images.githubusercontent.com/1816888/76669964-a1d4f300-6553-11ea-92be-91dd3f15f125.png) | ![install](https://user-images.githubusercontent.com/1816888/76669967-a9949780-6553-11ea-9ff6-d6db36433a90.png) |
|--------|-------|

Hack:
- You can force show the `Don't have an account?` button if you don't want to actually install Jetpack. In `LoginEmailViewController:configureForWPComOnlyIfNeeded`, set `wpcomSignupButton?.isHidden = false`. The signup button will then always show on the email entry view. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
