### PR TITLE
Remove duplicate param in method

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -72,7 +72,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     [self trackString:eventPair.eventName withProperties:mergedProperties];
 }
 
-- (void)trackString:(NSString *)event:(NSString *)event
+- (void)trackString:(NSString *)event
 {
     [self trackString:event withProperties:nil];
 }


### PR DESCRIPTION
Fixes # n/a

To test:
- `rake dependencies`
- build & run

These warnings should disappear:
<img width="441" alt="Screen Shot 2020-03-13 at 4 37 03 PM" src="https://user-images.githubusercontent.com/1062444/76662009-d7c1a980-654a-11ea-8d19-a846e005d871.png">


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
