### PR TITLE
Wrong calendar date when timezone differs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 14.5
 -----
 * Post Settings: Fix issue where the status of a post showed "Scheduled" instead of "Published" after scheduling before the current date.
+* Post Settings: Fix issue where the calendar selection may not match the selected date when site timezone differs from device timezone.
 * Dark Mode fixes:
   - Border color on Search bars.
   - Stats background color on wider screen sizes.

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -3,15 +3,17 @@ import JTAppleCalendar
 
 class CalendarCollectionView: JTACMonthView {
 
-    let calDataSource = CalendarDataSource()
+    let calDataSource: CalendarDataSource
 
-    override init() {
+    init(calendar: Calendar) {
+        calDataSource = CalendarDataSource(calendar: calendar)
         super.init()
 
         setup()
     }
 
     required init?(coder aDecoder: NSCoder) {
+        calDataSource = CalendarDataSource(calendar: Calendar.current)
         super.init(coder: aDecoder)
 
         setup()
@@ -38,10 +40,16 @@ class CalendarDataSource: JTACMonthViewDataSource {
     var didScroll: ((DateSegmentInfo) -> Void)?
     var didSelect: ((Date) -> Void)?
 
+    private let calendar: Calendar
+
+    init(calendar: Calendar) {
+        self.calendar = calendar
+    }
+
     func configureCalendar(_ calendar: JTACMonthView) -> ConfigurationParameters {
         let startDate = Date.farPastDate
         let endDate = Date.farFutureDate
-        return ConfigurationParameters(startDate: startDate, endDate: endDate)
+        return ConfigurationParameters(startDate: startDate, endDate: endDate, calendar: self.calendar)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift
@@ -22,10 +22,12 @@ class CalendarMonthView: UIView {
         }
     }
 
-    private let calendarCollectionView = CalendarCollectionView()
+    private let calendarCollectionView: CalendarCollectionView
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    init(calendar: Calendar) {
+        self.calendarCollectionView = CalendarCollectionView(calendar: calendar)
+        super.init(frame: .zero)
+
         setup()
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift
@@ -39,7 +39,7 @@ class CalendarMonthView: UIView {
 
     private func setup() {
         let weekdaysHeaderView = WeekdaysHeaderView(calendar: calendar)
-        let calendarHeaderView = CalendarHeaderView(next: (self, #selector(CalendarMonthView.nextMonth)), previous: (self, #selector(CalendarMonthView.previousMonth)))
+        let calendarHeaderView = CalendarHeaderView(calendar: calendar, next: (self, #selector(CalendarMonthView.nextMonth)), previous: (self, #selector(CalendarMonthView.previousMonth)))
 
         let stackView = UIStackView(arrangedSubviews: [
             calendarHeaderView,
@@ -56,9 +56,9 @@ class CalendarMonthView: UIView {
 
         pinSubviewToAllEdges(stackView)
 
-        calendarCollectionView.calDataSource.didScroll = { [weak calendarHeaderView, calendar] dateSegment in
+        calendarCollectionView.calDataSource.didScroll = { [weak calendarHeaderView] dateSegment in
             if let visibleDate = dateSegment.monthDates.first?.date {
-                calendarHeaderView?.set(date: visibleDate, withCalendar: calendar)
+                calendarHeaderView?.set(date: visibleDate)
             }
         }
         calendarCollectionView.calDataSource.didSelect = { [weak self] dateSegment in
@@ -122,45 +122,52 @@ class CalendarMonthView: UIView {
 /// A view containing two buttons to navigate forward and backward and a
 class CalendarHeaderView: UIStackView {
 
+    private enum Constants {
+        static let buttonSize = CGSize(width: 24, height: 24)
+        static let titeLabelColor: UIColor = .neutral(.shade60)
+        static let dateFormat = "MMMM, YYYY"
+    }
+
     typealias TargetSelector = (target: Any?, selector: Selector)
 
     /// A function to set the string of the title label to a given date
     /// - Parameter date: The date to set the `titleLabel`'s text to
-    func set(date: Date, withCalendar calendar: Calendar) {
-        let formatter = CalendarHeaderView.dateFormatter
-        formatter.calendar = calendar
-        formatter.timeZone = calendar.timeZone
-        titleLabel.text = formatter.string(from: date)
+    func set(date: Date) {
+        titleLabel.text = dateFormatter?.string(from: date)
     }
 
-    private let titleLabel: UILabel = {
+    let titleLabel: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
-        label.textColor = .neutral(.shade60)
+        label.textColor = Constants.titeLabelColor
         return label
     }()
 
-    private static var dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMMM, YYYY"
-        return formatter
-    }()
+    private var dateFormatter: DateFormatter? = nil
 
-    convenience init(next: TargetSelector, previous: TargetSelector) {
-        let previousButton = UIButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
+    convenience init(calendar: Calendar, next: TargetSelector, previous: TargetSelector) {
+        let previousButton = UIButton(frame: CGRect(origin: .zero, size: Constants.buttonSize))
         previousButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         previousButton.setImage(Gridicon.iconOfType(.chevronLeft).imageFlippedForRightToLeftLayoutDirection(), for: .normal)
 
-        let forwardButton = UIButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
+        let forwardButton = UIButton(frame: CGRect(origin: .zero, size: Constants.buttonSize))
         forwardButton.setImage(Gridicon.iconOfType(.chevronRight).imageFlippedForRightToLeftLayoutDirection(), for: .normal)
         forwardButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
 
         self.init()
+
         addArrangedSubviews([
             previousButton,
             titleLabel,
             forwardButton
         ])
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = Constants.dateFormat
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+
+        dateFormatter = formatter
 
         alignment = .center
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
@@ -31,7 +31,11 @@ class SchedulingCalendarViewController: UIViewController, DatePickerSheet, DateC
     let chosenValueRow = ChosenValueRow(frame: .zero)
 
     lazy var calendarMonthView: CalendarMonthView = {
-        let calendarMonthView = CalendarMonthView(frame: .zero)
+        var calendar = Calendar.current
+        if let timeZone = coordinator?.timeZone {
+            calendar.timeZone = timeZone
+        }
+        let calendarMonthView = CalendarMonthView(calendar: calendar)
         calendarMonthView.translatesAutoresizingMaskIntoConstraints = false
 
         let selectedDate = coordinator?.date ?? Date()
@@ -40,8 +44,12 @@ class SchedulingCalendarViewController: UIViewController, DatePickerSheet, DateC
             var newDate = date
 
             // Since the date from the calendar will not include hours and minutes, replace with the original date (either the current, or previously entered date)
-            let selectedComponents = Calendar.current.dateComponents([.hour, .minute], from: selectedDate)
-            newDate = Calendar.current.date(bySettingHour: selectedComponents.hour ?? 0, minute: selectedComponents.minute ?? 0, second: 0, of: newDate) ?? newDate
+            var calendar = Calendar.current
+            if let timeZone = self?.coordinator?.timeZone {
+                calendar.timeZone = timeZone
+            }
+            let selectedComponents = calendar.dateComponents([.hour, .minute], from: selectedDate)
+            newDate = calendar.date(bySettingHour: selectedComponents.hour ?? 0, minute: selectedComponents.minute ?? 0, second: 0, of: newDate) ?? newDate
 
             self?.coordinator?.date = newDate
             self?.chosenValueRow.detailLabel.text = self?.coordinator?.dateFormatter.string(from: date)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2057,6 +2057,8 @@
 		F59AAC10235E430F00385EE6 /* ChosenValueRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59AAC0F235E430E00385EE6 /* ChosenValueRow.swift */; };
 		F59AAC16235EA46D00385EE6 /* LightNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59AAC15235EA46D00385EE6 /* LightNavigationController.swift */; };
 		F5B8A60F23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B8A60E23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift */; };
+		F5C00EAE242179780047846F /* WeekdaysHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C00EAD242179780047846F /* WeekdaysHeaderViewTests.swift */; };
+		F5CFB8F524216DFC00E58B69 /* CalendarHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CFB8F424216DFC00E58B69 /* CalendarHeaderViewTests.swift */; };
 		F5D03DFF2370E28D0043F287 /* LightNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59AAC15235EA46D00385EE6 /* LightNavigationController.swift */; };
 		F5D03E002370E28E0043F287 /* LightNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F59AAC15235EA46D00385EE6 /* LightNavigationController.swift */; };
 		F5D0A64923C8FA1500B20D27 /* LinkBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D0A64823C8FA1500B20D27 /* LinkBehavior.swift */; };
@@ -4638,6 +4640,8 @@
 		F59AAC0F235E430E00385EE6 /* ChosenValueRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChosenValueRow.swift; sourceTree = "<group>"; };
 		F59AAC15235EA46D00385EE6 /* LightNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightNavigationController.swift; sourceTree = "<group>"; };
 		F5B8A60E23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDeviceSelectionViewController.swift; sourceTree = "<group>"; };
+		F5C00EAD242179780047846F /* WeekdaysHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekdaysHeaderViewTests.swift; sourceTree = "<group>"; };
+		F5CFB8F424216DFC00E58B69 /* CalendarHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarHeaderViewTests.swift; sourceTree = "<group>"; };
 		F5D0A64823C8FA1500B20D27 /* LinkBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkBehavior.swift; sourceTree = "<group>"; };
 		F5D0A64D23CC159400B20D27 /* PreviewWebKitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewWebKitViewController.swift; sourceTree = "<group>"; };
 		F5D0A64F23CC15A800B20D27 /* PreviewNonceHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewNonceHandler.swift; sourceTree = "<group>"; };
@@ -6229,6 +6233,8 @@
 			isa = PBXGroup;
 			children = (
 				57DF04C0231489A200CC93D6 /* PostCardStatusViewModelTests.swift */,
+				F5CFB8F424216DFC00E58B69 /* CalendarHeaderViewTests.swift */,
+				F5C00EAD242179780047846F /* WeekdaysHeaderViewTests.swift */,
 			);
 			name = Views;
 			path = ViewRelated/Post/Views;
@@ -13147,6 +13153,7 @@
 				D88A64A8208D9733008AE9BC /* ThumbnailCollectionTests.swift in Sources */,
 				572FB401223A806000933C76 /* NoticeStoreTests.swift in Sources */,
 				D816B8D12112D5960052CE4D /* DefaultNewsManagerTests.swift in Sources */,
+				F5CFB8F524216DFC00E58B69 /* CalendarHeaderViewTests.swift in Sources */,
 				748437EE1F1D4A7300E8DDAF /* RichContentFormatterTests.swift in Sources */,
 				8BE7C84123466927006EDE70 /* I18n.swift in Sources */,
 				D88A649E208D82D2008AE9BC /* XCTestCase+Wait.swift in Sources */,
@@ -13168,6 +13175,7 @@
 				931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */,
 				570265172298960B00F2214C /* PostListTableViewHandlerTests.swift in Sources */,
 				E1EBC3731C118ED200F638E0 /* ImmuTableTest.swift in Sources */,
+				F5C00EAE242179780047846F /* WeekdaysHeaderViewTests.swift in Sources */,
 				E1AB5A091E0BF31E00574B4E /* ArrayTests.swift in Sources */,
 				570B037722F1FFF6009D8411 /* PostCoordinatorFailedPostsFetcherTests.swift in Sources */,
 				4054F4592214E6FE00D261AB /* TagsCategoriesStatsRecordValueTests.swift in Sources */,

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/SchedulingCalendarViewControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/SchedulingCalendarViewControllerTests.swift
@@ -42,6 +42,29 @@ class SchedulingCalendarViewControllerTests: XCTestCase {
         let originalComponents = Calendar.current.dateComponents([.hour, .minute], from: dateValue)
 
         XCTAssertNotEqual(dateValue, coordinatorDate, "Dates should not be equal.")
-        XCTAssertEqual(newComponents, originalComponents, "Date should retain its minutes and seconds")
+        XCTAssertEqual(newComponents, originalComponents, "Date should retain its hours and minutes")
+    }
+
+    /// Tests that proper calendar is used based on site time zone insted of device time zone
+    func testVCCoordinatorCalendar() {
+
+        let currentDate = Date()
+        let dateValue = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: currentDate)!
+        let timeZone = TimeZone(secondsFromGMT: TimeZone.current.secondsFromGMT(for: currentDate) - 60 * 60)!
+
+        let coordinator = DateCoordinator(date: nil, timeZone: timeZone, dateFormatter: DateFormatter(), dateTimeFormatter: DateFormatter(), updated: { _ in })
+        calendarVC?.coordinator = coordinator
+        calendarVC?.calendarMonthView.updated?(dateValue)
+        calendarVC?.nextButtonPressed()
+
+        let coordinatorDate = calendarVC?.coordinator?.date
+
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+
+        let convertedComponents = calendar.dateComponents([.year, .month, .day], from: dateValue)
+        let coordinatorComponents = calendar.dateComponents([.year, .month, .day], from: coordinatorDate!)
+
+        XCTAssertEqual(coordinatorComponents, convertedComponents, "Date should be converted to proper day of time zone.")
     }
 }

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/CalendarHeaderViewTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/CalendarHeaderViewTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import WordPress
+
+class CalendarHeaderViewTests: XCTestCase {
+
+    func testDisplayedMonths() {
+        let gmtTimeZone = TimeZone(secondsFromGMT: 0)
+        var calendar = Calendar.current
+        calendar.timeZone = gmtTimeZone!
+
+        let dateComponents = DateComponents(calendar: calendar, timeZone: gmtTimeZone, year: 2020, month: 3, day: 1, hour: 0, minute: 0)
+
+        let headerView = CalendarHeaderView(calendar: calendar, next: (self, #selector(selectorForTest)), previous: (self, #selector(selectorForTest)))
+        if let date = dateComponents.date {
+            headerView.set(date: date)
+        }
+
+        XCTAssertEqual(headerView.titleLabel.text, "March, 2020", "Label should show appropriate month and year")
+    }
+
+    func selectorForTest() {
+
+    }
+}

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/WeekdaysHeaderViewTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/WeekdaysHeaderViewTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import WordPress
+
+class WeekdaysHeaderViewTests: XCTestCase {
+
+    func testDisplayedWeekdaysMonday() {
+        // A calendar with Monday as first weekday
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 2
+
+        let headerView = WeekdaysHeaderView(calendar: calendar)
+        let firstWeekday = headerView.subviews.first as? UILabel
+        let lastWeekday = headerView.subviews.last as? UILabel
+
+        XCTAssertEqual(firstWeekday?.text, "M", "Label should show Monday as first weekday")
+        XCTAssertEqual(lastWeekday?.text, "S", "Label should show Sunday as last weekday")
+    }
+
+    func testDisplayedWeekdaysSunday() {
+        // A calendar with Monday as first weekday
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 1
+
+        let headerView = WeekdaysHeaderView(calendar: calendar)
+        let firstWeekday = headerView.subviews.first as? UILabel
+        let lastWeekday = headerView.subviews.last as? UILabel
+
+        XCTAssertEqual(firstWeekday?.text, "S", "Label should show Sunday as first weekday")
+        XCTAssertEqual(lastWeekday?.text, "S", "Label should show Saturday as last weekday")
+    }
+}


### PR DESCRIPTION
Fixes #13651:

When the time zone of your site is after your device's time zone, the prior date is shown when selecting from the calendar.

To test:

- Set your time zone to one that is after that on your device (site: PST if device is in EST)

![2020-03-16 16-15-26 2020-03-16 16_17_03](https://user-images.githubusercontent.com/3250/76804341-9d057e80-67a1-11ea-99b7-1dfd3ba29938.gif)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
