### PR TITLE
Create Bottom Sheet

### DIFF
--- a/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
+++ b/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
@@ -1,0 +1,150 @@
+import UIKit
+
+class BottomSheetViewController: UIViewController {
+
+    private var isDeviceInLandscape: Bool {
+        return UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight
+    }
+
+    enum Constants {
+        static let gripHeight: CGFloat = 5
+        static let cornerRadius: CGFloat = 8
+        static let buttonSpacing: CGFloat = 8
+        static let additionalSafeAreaInsetsRegular: UIEdgeInsets = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
+        static let minimumWidth: CGFloat = 300
+
+        enum Header {
+            static let spacing: CGFloat = 16
+            static let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
+        }
+
+        enum Button {
+            static let height: CGFloat = 54
+            static let contentInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 35)
+            static let titleInsets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
+            static let imageTintColor: UIColor = .neutral(.shade30)
+            static let font: UIFont = .preferredFont(forTextStyle: .callout)
+            static let textColor: UIColor = .text
+        }
+
+        enum Stack {
+            static let insets: UIEdgeInsets = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
+        }
+    }
+
+    let headerTitle: String
+
+    private let childViewController: UIViewController
+
+    init(childViewController: UIViewController) {
+        self.headerTitle = "Foobar"
+        self.childViewController = childViewController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    func show(from presenting: UIViewController, sourceView: UIView? = nil) {
+        if UIDevice.isPad() {
+            modalPresentationStyle = .popover
+            popoverPresentationController?.sourceView = sourceView ?? UIView()
+            popoverPresentationController?.sourceRect = sourceView?.bounds ?? .zero
+        } else if isDeviceInLandscape {
+            if #available(iOS 13.0, *) {
+                modalPresentationStyle = .automatic
+            } else {
+                modalPresentationStyle = .pageSheet
+            }
+        } else {
+            transitioningDelegate = self
+            modalPresentationStyle = .custom
+        }
+
+        presenting.present(self, animated: true)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private var gripButton: UIButton = {
+        let button = GripButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)
+        return button
+    }()
+
+    @objc func buttonPressed() {
+        dismiss(animated: true, completion: nil)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.clipsToBounds = true
+        view.layer.cornerRadius = Constants.cornerRadius
+        view.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
+        view.backgroundColor = .basicBackground
+
+        NSLayoutConstraint.activate([
+            gripButton.heightAnchor.constraint(equalToConstant: Constants.gripHeight)
+        ])
+
+        addChild(childViewController)
+
+        let stackView = UIStackView(arrangedSubviews: [
+            gripButton,
+            childViewController.view
+        ])
+
+        stackView.setCustomSpacing(Constants.Header.spacing, after: gripButton)
+
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+
+        refreshForTraits()
+
+        view.addSubview(stackView)
+        view.pinSubviewToSafeArea(stackView, insets: Constants.Stack.insets)
+
+        childViewController.didMove(toParent: self)
+    }
+
+    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        refreshForTraits()
+    }
+
+    private func refreshForTraits() {
+        if presentingViewController?.traitCollection.horizontalSizeClass == .regular && presentingViewController?.traitCollection.verticalSizeClass != .compact {
+            gripButton.isHidden = true
+            additionalSafeAreaInsets = Constants.additionalSafeAreaInsetsRegular
+        } else {
+            gripButton.isHidden = false
+            additionalSafeAreaInsets = .zero
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        return preferredContentSize = CGSize(width: Constants.minimumWidth, height: view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height)
+    }
+}
+
+extension BottomSheetViewController: UIViewControllerTransitioningDelegate {
+    public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return BottomSheetAnimationController(transitionType: .presenting)
+    }
+
+    public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        return BottomSheetAnimationController(transitionType: .dismissing)
+    }
+
+    public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        let presentationController = BottomSheetPresentationController(presentedViewController: presented, presenting: presenting)
+        return presentationController
+    }
+
+    public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
+        return (self.presentedViewController?.presentationController as? BottomSheetPresentationController)?.interactionController
+    }
+}
+

--- a/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
+++ b/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
@@ -27,13 +27,10 @@ class BottomSheetViewController: UIViewController {
             static let insets: UIEdgeInsets = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
         }
     }
-
-    let headerTitle: String
-
+    
     private let childViewController: UIViewController
 
     init(childViewController: UIViewController) {
-        self.headerTitle = "Foobar"
         self.childViewController = childViewController
         super.init(nibName: nil, bundle: nil)
     }

--- a/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
+++ b/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
@@ -147,4 +147,3 @@ extension BottomSheetViewController: UIViewControllerTransitioningDelegate {
         return (self.presentedViewController?.presentationController as? BottomSheetPresentationController)?.interactionController
     }
 }
-

--- a/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
+++ b/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
@@ -27,7 +27,7 @@ class BottomSheetViewController: UIViewController {
             static let insets: UIEdgeInsets = UIEdgeInsets(top: 5, left: 0, bottom: 0, right: 0)
         }
     }
-    
+
     private let childViewController: UIViewController
 
     init(childViewController: UIViewController) {

--- a/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
+++ b/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
@@ -2,10 +2,6 @@ import UIKit
 
 class BottomSheetViewController: UIViewController {
 
-    private var isDeviceInLandscape: Bool {
-        return UIDevice.current.orientation == .landscapeLeft || UIDevice.current.orientation == .landscapeRight
-    }
-
     enum Constants {
         static let gripHeight: CGFloat = 5
         static let cornerRadius: CGFloat = 8
@@ -47,12 +43,6 @@ class BottomSheetViewController: UIViewController {
             modalPresentationStyle = .popover
             popoverPresentationController?.sourceView = sourceView ?? UIView()
             popoverPresentationController?.sourceRect = sourceView?.bounds ?? .zero
-        } else if isDeviceInLandscape {
-            if #available(iOS 13.0, *) {
-                modalPresentationStyle = .automatic
-            } else {
-                modalPresentationStyle = .pageSheet
-            }
         } else {
             transitioningDelegate = self
             modalPresentationStyle = .custom

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -33,6 +33,12 @@ extension PostEditor where Self: UIViewController {
         dismissWhenDone: Bool,
         analyticsStat: WPAnalyticsStat?) {
 
+        let prepublishing = PrepublishingViewController()
+        let bottomSheet = BottomSheetViewController(childViewController: prepublishing)
+        bottomSheet.show(from: self, sourceView: navigationBarManager.publishButton)
+
+        return
+
         mapUIContentToPostAndSave(immediate: true)
 
         // Cancel publishing if media is currently being uploaded

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+class PrepublishingViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -3,6 +3,8 @@ import UIKit
 class PrepublishingViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .red
+        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        view.translatesAutoresizingMaskIntoConstraints = false
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1063,6 +1063,7 @@
 		8BD36E062395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BF5F789242138A600BE49B7 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF5F788242138A600BE49B7 /* BottomSheetViewController.swift */; };
+		8BF5F78D2421677300BE49B7 /* BottomSheetViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF5F78C2421677300BE49B7 /* BottomSheetViewControllerTests.swift */; };
 		8BFE36FD230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */; };
 		8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */; };
 		91138455228373EB00FB02B7 /* GutenbergVideoUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91138454228373EB00FB02B7 /* GutenbergVideoUploadProcessor.swift */; };
@@ -3442,6 +3443,7 @@
 		8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaEditorOperation+DescriptionTests.swift"; sourceTree = "<group>"; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BF5F788242138A600BE49B7 /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
+		8BF5F78C2421677300BE49B7 /* BottomSheetViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewControllerTests.swift; sourceTree = "<group>"; };
 		8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLs.swift"; sourceTree = "<group>"; };
 		8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLsTests.swift"; sourceTree = "<group>"; };
 		8CE5BBD00FF1470AC4B88247 /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -7297,6 +7299,7 @@
 		852416D01A12ED2D0030700C /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				8BF5F78B2421676100BE49B7 /* Bottom Sheet */,
 				F93735F422D53C1800A3C312 /* Logging */,
 				93B853211B44165B0064FE72 /* Analytics */,
 				F198533B21ADAD0700DCDAE7 /* Editor */,
@@ -7527,6 +7530,14 @@
 			isa = PBXGroup;
 			children = (
 				8BF5F788242138A600BE49B7 /* BottomSheetViewController.swift */,
+			);
+			path = "Bottom Sheet";
+			sourceTree = "<group>";
+		};
+		8BF5F78B2421676100BE49B7 /* Bottom Sheet */ = {
+			isa = PBXGroup;
+			children = (
+				8BF5F78C2421677300BE49B7 /* BottomSheetViewControllerTests.swift */,
 			);
 			path = "Bottom Sheet";
 			sourceTree = "<group>";
@@ -13166,6 +13177,7 @@
 				748437EE1F1D4A7300E8DDAF /* RichContentFormatterTests.swift in Sources */,
 				8BE7C84123466927006EDE70 /* I18n.swift in Sources */,
 				D88A649E208D82D2008AE9BC /* XCTestCase+Wait.swift in Sources */,
+				8BF5F78D2421677300BE49B7 /* BottomSheetViewControllerTests.swift in Sources */,
 				E18549DB230FBFEF003C620E /* BlogServiceDeduplicationTests.swift in Sources */,
 				400A2C8F2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift in Sources */,
 				7320C8BD2190C9FC0082FED5 /* UITextView+SummaryTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1062,6 +1062,7 @@
 		8BD36E022395CAEA00EFFF1C /* MediaEditorOperation+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36E012395CAEA00EFFF1C /* MediaEditorOperation+Description.swift */; };
 		8BD36E062395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
+		8BF5F789242138A600BE49B7 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF5F788242138A600BE49B7 /* BottomSheetViewController.swift */; };
 		8BFE36FD230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */; };
 		8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */; };
 		91138455228373EB00FB02B7 /* GutenbergVideoUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91138454228373EB00FB02B7 /* GutenbergVideoUploadProcessor.swift */; };
@@ -3440,6 +3441,7 @@
 		8BD36E012395CAEA00EFFF1C /* MediaEditorOperation+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaEditorOperation+Description.swift"; sourceTree = "<group>"; };
 		8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaEditorOperation+DescriptionTests.swift"; sourceTree = "<group>"; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
+		8BF5F788242138A600BE49B7 /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
 		8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLs.swift"; sourceTree = "<group>"; };
 		8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLsTests.swift"; sourceTree = "<group>"; };
 		8CE5BBD00FF1470AC4B88247 /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -7360,6 +7362,7 @@
 		8584FDB4192437160019C02E /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				8BF5F7872421388F00BE49B7 /* Bottom Sheet */,
 				1A433B1B2254CBC300AE7910 /* Networking */,
 				40247E002120FE2300AE1C3C /* Automated Transfer */,
 				F198533821ADAA4E00DCDAE7 /* Editor */,
@@ -7518,6 +7521,14 @@
 				8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */,
 			);
 			name = Aztec;
+			sourceTree = "<group>";
+		};
+		8BF5F7872421388F00BE49B7 /* Bottom Sheet */ = {
+			isa = PBXGroup;
+			children = (
+				8BF5F788242138A600BE49B7 /* BottomSheetViewController.swift */,
+			);
+			path = "Bottom Sheet";
 			sourceTree = "<group>";
 		};
 		931D26FB19EDA0D000114F17 /* ALIterativeMigrator */ = {
@@ -12179,6 +12190,7 @@
 				E137B1661F8B77D4006AC7FC /* WebNavigationDelegate.swift in Sources */,
 				937D9A0F19F83812007B9D5F /* WordPress-22-23.xcmappingmodel in Sources */,
 				9A1A67A622B2AD4E00FF8422 /* CountriesMap.swift in Sources */,
+				8BF5F789242138A600BE49B7 /* BottomSheetViewController.swift in Sources */,
 				439F4F3A219B715300F8D0C7 /* RevisionsNavigationController.swift in Sources */,
 				40F46B6A22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift in Sources */,
 				17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1052,6 +1052,7 @@
 		8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */; };
 		8B93856E22DC08060010BF02 /* PageListSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */; };
 		8B939F4323832E5D00ACCB0F /* PostListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B939F4223832E5D00ACCB0F /* PostListViewControllerTests.swift */; };
+		8BAD272C241FEF3300E9D105 /* PrepublishingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */; };
 		8BAD53D6241922B900230F4B /* WPAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD53D5241922B900230F4B /* WPAnalyticsEvent.swift */; };
 		8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */; };
 		8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */; };
@@ -3429,6 +3430,7 @@
 		8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadMessages.swift; sourceTree = "<group>"; };
 		8B93856D22DC08060010BF02 /* PageListSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListSectionHeaderView.swift; sourceTree = "<group>"; };
 		8B939F4223832E5D00ACCB0F /* PostListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListViewControllerTests.swift; sourceTree = "<group>"; };
+		8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingViewController.swift; sourceTree = "<group>"; };
 		8BAD53D5241922B900230F4B /* WPAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAnalyticsEvent.swift; sourceTree = "<group>"; };
 		8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorTests.swift; sourceTree = "<group>"; };
 		8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeeded.swift"; sourceTree = "<group>"; };
@@ -8305,6 +8307,7 @@
 				FFEECFFB2084DE2B009B8CDB /* PostSettingsViewController+FeaturedImageUpload.swift */,
 				593F26601CAB00CA00F14073 /* PostSharingController.swift */,
 				E155EC711E9B7DCE009D7F63 /* PostTagPickerViewController.swift */,
+				8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */,
 				5D17F0BC1A1D4C5F0087CCB8 /* PrivateSiteURLProtocol.h */,
 				5D17F0BD1A1D4C5F0087CCB8 /* PrivateSiteURLProtocol.m */,
 				5903AE1C19B60AB9009D5354 /* WPButtonForNavigationBar.h */,
@@ -12057,6 +12060,7 @@
 				08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */,
 				9A4E216021F87AE200EFF212 /* QuickStartChecklistHeader.swift in Sources */,
 				98B52AE121F7AF4A006FF6B4 /* StatsDataHelper.swift in Sources */,
+				8BAD272C241FEF3300E9D105 /* PrepublishingViewController.swift in Sources */,
 				9A22D9C0214A6BCA00BAEAF2 /* PageListTableViewHandler.swift in Sources */,
 				74729CA62056FE6000D1394D /* SearchableItemConvertable.swift in Sources */,
 				FFE3B2C71B2E651400E9F1E0 /* WPAndDeviceMediaLibraryDataSource.m in Sources */,

--- a/WordPress/WordPressTest/Bottom Sheet/BottomSheetViewControllerTests.swift
+++ b/WordPress/WordPressTest/Bottom Sheet/BottomSheetViewControllerTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import Nimble
+
+@testable import WordPress
+
+class BottomSheetViewControllerTests: XCTestCase {
+
+    /// - Add the given ViewController as a child View Controller
+    ///
+    func testAddTheGivenViewControllerAsAChildViewController() {
+        let viewController = UIViewController()
+        let bottomSheet = BottomSheetViewController(childViewController: viewController)
+
+        bottomSheet.viewDidLoad()
+
+        expect(bottomSheet.children).to(contain(viewController))
+    }
+
+    /// - Add the given ViewController view to the subviews of the Bottom Sheet
+    ///
+    func testAddGivenVCViewToTheBottomSheetSubviews() {
+        let viewController = UIViewController()
+        let bottomSheet = BottomSheetViewController(childViewController: viewController)
+
+        bottomSheet.viewDidLoad()
+
+        expect(bottomSheet.view.subviews.flatMap { $0.subviews }).to(contain(viewController.view))
+    }
+}


### PR DESCRIPTION
Fixes #13659

This PR creates the Bottom Sheet to be used for Prepublishing Nudges.

Most of the code is basically a copy-and-paste of the work @bjtitus has been doing with a few changes:

* The `BottomSheetViewController` needs another `UIViewController`
* The `view` of this `UIViewController` is what will be displayed in the Bottom Sheet

### To test

1. Create a new post
2. Tap "Publish"
3. Check that the Bottom Sheet appears

If you're using iPad, the sheet should behave as a popover and appear from the "Publish" button.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes — will be done in a future task
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
