### PR TITLE
Fix wrong analytics tracks when accessing notifications tab

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -2,11 +2,9 @@
 // MARK: - Tab Access Tracking
 
 extension WPTabBarController {
-    private static let tabIndexToStatMap: [WPTabType: WPAnalyticsStat] = [
-        .mySites: .mySitesTabAccessed,
-        .reader: .readerAccessed,
-        .me: .meTabAccessed
-    ]
+    private static let tabIndexToStatMap: [WPTabType: WPAnalyticsStat] = FeatureFlag.meMove.enabled ?
+        [.mySites: .mySitesTabAccessed, .reader: .readerAccessed] :
+        [.mySites: .mySitesTabAccessed, .reader: .readerAccessed, .me: .meTabAccessed]
 
     private struct AssociatedKeys {
         static var shouldTrackTabAccessOnViewDidAppear = 0

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -2,7 +2,7 @@
 
 extern NSString * const WPNewPostURLParamContentKey;
 extern NSString * const WPNewPostURLParamTagsKey;
-
+//TODO: Remove WPTabMe and WPTabNewPost when the new Me page and FAB are released
 typedef NS_ENUM(NSUInteger, WPTabType) {
     WPTabMySites,
     WPTabReader,


### PR DESCRIPTION
##### Access to the `Me` tab was wrongly tracked when accessing the `Notifications` tab
Fixes #NA

To test:
- build/run
- verify that when tapping the `Notification` tab bar icon, analytics do not track `me_tab_accessed`

##### Note: after the new `Me` scene is shipped and we remove the feature flag, the track name will be changed to `me_scene_accessed`. We keep `me_tab_accessed` until the old `Me` tab is still in the code.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
