### PR TITLE
Move FAB to Blog List Navigation Controller

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -100,12 +100,20 @@ import Gridicons
     }
 
     @objc func hideCreateButton() {
-        button.springAnimation(toShow: false)
+        if UIAccessibility.isReduceMotionEnabled {
+            button.isHidden = true
+        } else {
+            button.springAnimation(toShow: false)
+        }
     }
 
     @objc func showCreateButton() {
         button.setNeedsUpdateConstraints() // See `FloatingActionButton` implementation for more info on why this is needed.
-        button.springAnimation(toShow: true)
+        if UIAccessibility.isReduceMotionEnabled {
+            button.isHidden = false
+        } else {
+            button.springAnimation(toShow: true)
+        }
     }
 
     @objc func showNewPost() {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -112,10 +112,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
         [self setSelectedViewController:self.blogListSplitViewController];
         
-        if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
-            [self.createButtonCoordinator addTo:self.view trailingAnchor:((UIViewController *)self.blogListSplitViewController.viewControllers[0]).view.safeAreaLayoutGuide.trailingAnchor bottomAnchor:self.tabBar.topAnchor];
-        }
-
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(updateIconIndicators:)
                                                      name:NSNotification.ZendeskPushNotificationReceivedNotification
@@ -205,6 +201,10 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     Blog *blogToOpen = [blogService lastUsedOrFirstBlog];
     if (blogToOpen) {
         _blogListViewController.selectedBlog = blogToOpen;
+    }
+    
+    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
+        [self.createButtonCoordinator addTo:_blogListNavigationController.view trailingAnchor:_blogListNavigationController.view.safeAreaLayoutGuide.trailingAnchor bottomAnchor:_blogListNavigationController.view.safeAreaLayoutGuide.bottomAnchor];
     }
 
     return _blogListNavigationController;
@@ -425,10 +425,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     
     [self setViewControllers:[self tabViewControllers]];
     
-    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
-        [self.createButtonCoordinator addTo:self.view trailingAnchor:self.blogListSplitViewController.viewControllers[0].view.safeAreaLayoutGuide.trailingAnchor bottomAnchor:self.tabBar.topAnchor];
-    }
-
     // Reset the selectedIndex to the default MySites tab.
     self.selectedIndex = WPTabMySites;
 }


### PR DESCRIPTION
Fix #13633
Related to #13320 

This moves the Create Button to the Blog List's navigation controller. The animations will still occur when switching between screens in that navigation stack, but will not occur when switching tabs. The requirement to position the button next to the edge of the primary split view controller instead of the right hand side of the screen had made some of the constraints less than reliable. This change should resolve that since the view and its constraints are part of the same hierarchy.

This also removes animations when Reduced Motion is enabled.

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Not released.
