### PR TITLE
Login Epilogue: misc changes

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
@@ -9,22 +9,22 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="userInfo" rowHeight="180" id="uln-Hd-OJc" customClass="EpilogueUserInfoCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="383" height="180"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="userInfo" id="uln-Hd-OJc" customClass="EpilogueUserInfoCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="383" height="174"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uln-Hd-OJc" id="HfW-Dl-Z89">
-                <rect key="frame" x="0.0" y="0.0" width="383" height="180"/>
+                <rect key="frame" x="0.0" y="0.0" width="383" height="174"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SqA-Tm-XVX" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="16" y="20" width="72" height="72"/>
+                        <rect key="frame" x="16" y="15" width="72" height="72"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="72" id="9bQ-aU-GQb"/>
                             <constraint firstAttribute="height" constant="72" id="UTE-fR-kMZ"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full Name" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MbK-Ns-TbF">
-                        <rect key="frame" x="16" y="112" width="351" height="30"/>
+                        <rect key="frame" x="16" y="102" width="351" height="39"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="LJN-z2-A6L"/>
                         </constraints>
@@ -33,7 +33,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="89f-vg-HlI">
-                        <rect key="frame" x="16" y="142" width="351" height="18"/>
+                        <rect key="frame" x="16" y="141" width="351" height="18"/>
                         <accessibility key="accessibilityConfiguration" identifier="username"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="18" id="OMo-Z3-lLF"/>
@@ -43,23 +43,23 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="xGK-LG-0cx">
-                        <rect key="frame" x="181.5" y="140" width="20" height="20"/>
+                        <rect key="frame" x="181.5" y="139" width="20" height="20"/>
                     </activityIndicatorView>
                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="2Ri-os-5ZW">
-                        <rect key="frame" x="34" y="38" width="36" height="36"/>
+                        <rect key="frame" x="34" y="33" width="36" height="36"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="2Ri-os-5ZW" secondAttribute="height" multiplier="1:1" id="Dlu-jo-OXt"/>
                         </constraints>
                     </activityIndicatorView>
                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar-add-button" translatesAutoresizingMaskIntoConstraints="NO" id="GYR-3W-aku">
-                        <rect key="frame" x="66" y="16" width="26" height="26"/>
+                        <rect key="frame" x="66" y="11" width="26" height="26"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="26" id="gm6-03-VBa"/>
                             <constraint firstAttribute="height" constant="26" id="uxU-Ng-JTY"/>
                         </constraints>
                     </imageView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="11G-E4-8Jh">
-                        <rect key="frame" x="16" y="20" width="72" height="72"/>
+                        <rect key="frame" x="16" y="15" width="72" height="72"/>
                         <connections>
                             <action selector="gravatarTapped" destination="uln-Hd-OJc" eventType="touchUpInside" id="kQu-u7-vJd"/>
                         </connections>
@@ -78,11 +78,11 @@
                     <constraint firstAttribute="trailing" secondItem="MbK-Ns-TbF" secondAttribute="trailing" constant="16" id="hBZ-XF-2Ok"/>
                     <constraint firstItem="89f-vg-HlI" firstAttribute="top" secondItem="MbK-Ns-TbF" secondAttribute="bottom" id="hGl-uc-uSH"/>
                     <constraint firstItem="2Ri-os-5ZW" firstAttribute="centerY" secondItem="SqA-Tm-XVX" secondAttribute="centerY" id="jFZ-xH-4vw"/>
-                    <constraint firstItem="SqA-Tm-XVX" firstAttribute="top" secondItem="HfW-Dl-Z89" secondAttribute="top" constant="20" id="jnf-Zw-TmW"/>
+                    <constraint firstItem="SqA-Tm-XVX" firstAttribute="top" secondItem="HfW-Dl-Z89" secondAttribute="top" constant="15" id="jnf-Zw-TmW"/>
                     <constraint firstItem="SqA-Tm-XVX" firstAttribute="leading" secondItem="HfW-Dl-Z89" secondAttribute="leading" constant="16" id="l1U-Lm-Q7b"/>
-                    <constraint firstAttribute="bottom" secondItem="89f-vg-HlI" secondAttribute="bottom" constant="20" id="o6T-dK-g7J"/>
+                    <constraint firstAttribute="bottom" secondItem="89f-vg-HlI" secondAttribute="bottom" constant="15" id="o6T-dK-g7J"/>
                     <constraint firstItem="2Ri-os-5ZW" firstAttribute="centerX" secondItem="SqA-Tm-XVX" secondAttribute="centerX" id="tF0-R9-e3X"/>
-                    <constraint firstItem="MbK-Ns-TbF" firstAttribute="top" secondItem="SqA-Tm-XVX" secondAttribute="bottom" constant="20" id="tp1-hu-yDU"/>
+                    <constraint firstItem="MbK-Ns-TbF" firstAttribute="top" secondItem="SqA-Tm-XVX" secondAttribute="bottom" constant="15" id="tp1-hu-yDU"/>
                     <constraint firstItem="11G-E4-8Jh" firstAttribute="height" secondItem="SqA-Tm-XVX" secondAttribute="height" id="vjj-dA-RLw"/>
                     <constraint firstItem="MbK-Ns-TbF" firstAttribute="leading" secondItem="HfW-Dl-Z89" secondAttribute="leading" constant="16" id="vv4-33-weD"/>
                     <constraint firstItem="GYR-3W-aku" firstAttribute="trailing" secondItem="SqA-Tm-XVX" secondAttribute="trailing" constant="4" id="wL3-WH-8HH"/>
@@ -98,7 +98,7 @@
                 <outlet property="gravatarView" destination="SqA-Tm-XVX" id="ag5-hS-Y5D"/>
                 <outlet property="usernameLabel" destination="89f-vg-HlI" id="u0g-9B-dLf"/>
             </connections>
-            <point key="canvasLocation" x="-207.19999999999999" y="-49.475262368815599"/>
+            <point key="canvasLocation" x="-207.19999999999999" y="-52.173913043478265"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -133,7 +133,7 @@ extension LoginEpilogueTableViewController {
         }
 
         // Site Rows
-        let wrappedPath = IndexPath(row: indexPath.row, section: indexPath.section-1)
+        let wrappedPath = IndexPath(row: indexPath.row, section: indexPath.section - 1)
         return blogDataSource.tableView(tableView, cellForRowAt: wrappedPath)
     }
 
@@ -142,6 +142,11 @@ extension LoginEpilogueTableViewController {
         // Don't show section header for User Info
         guard section != Sections.userInfoSection,
         let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: Settings.headerReuseIdentifier) as? EpilogueSectionHeaderFooter else {
+            return nil
+        }
+
+        // Don't show section header if there are no sites.
+        guard rowCount(forSection: section) > 0 else {
             return nil
         }
 
@@ -164,7 +169,17 @@ extension LoginEpilogueTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return section == Sections.userInfoSection ? 0 : UITableView.automaticDimension
+
+        if section == Sections.userInfoSection {
+            return 0
+        }
+
+        if rowCount(forSection: section) == 0 {
+            tableView.separatorStyle = .none
+            return 0
+        }
+
+        return UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
@@ -211,8 +226,7 @@ private extension LoginEpilogueTableViewController {
             return nil
         }
 
-        let rowCount = blogDataSource.tableView(tableView, numberOfRowsInSection: section - 1)
-        if rowCount > 1 {
+        if rowCount(forSection: section) > 1 {
             return NSLocalizedString("My Sites", comment: "Header for list of multiple sites, shown after logging in").localizedUppercase
         }
 
@@ -232,6 +246,10 @@ private extension LoginEpilogueTableViewController {
         let service = AccountService(managedObjectContext: context)
 
         return service.defaultWordPressComAccount()?.blogs.count ?? 0
+    }
+
+    func rowCount(forSection section: Int) -> Int {
+        return blogDataSource.tableView(tableView, numberOfRowsInSection: section - 1)
     }
 
 }
@@ -323,7 +341,7 @@ private extension LoginEpilogueTableViewController {
     enum Settings {
         static let headerReuseIdentifier = "SectionHeader"
         static let userCellReuseIdentifier = "userInfo"
-        static let profileRowHeight = CGFloat(140)
+        static let profileRowHeight = CGFloat(180)
         static let blogRowHeight = CGFloat(52)
         static let headerHeight = CGFloat(50)
     }


### PR DESCRIPTION
Ref #13413 

This addresses two issues from @mattmiklic 's PR reviews.

- My Sites list - If the user has no sites drop the "My Sites" header (https://github.com/wordpress-mobile/WordPress-iOS/pull/13561#pullrequestreview-371341140)
- User Info - adjust is the amount of extra space between the Gravatar and the display name (https://github.com/wordpress-mobile/WordPress-iOS/pull/13543#issuecomment-596603280)

To test:

---
**My Sites header:**
- Log in with an account that has no sites.
- Verify the `My Site` header no longer appears above `Connect a site`.

| iPhone | iPad |
|--------|-------|
| ![no_sites_iphone](https://user-images.githubusercontent.com/1816888/77211614-1ff04700-6aca-11ea-8bc5-5f2eff6842de.png) | ![no_sites_ipad](https://user-images.githubusercontent.com/1816888/77211622-254d9180-6aca-11ea-96b2-7ef9cf5c5368.png) |

---
**User Info spacing:**
- Verify the User Info section is less space-y. Specifically, these have been reduced from 20 to 15 pts:
  - Gravatar to top of User Info section.
  - Gravatar to Full Name.
  - Username to bottom of User Info section.

| Before | After |
|--------|-------|
| <img width="441" alt="before" src="https://user-images.githubusercontent.com/1816888/77353489-ae510c80-6d06-11ea-983d-8ee77693aaed.png"> | <img width="438" alt="after" src="https://user-images.githubusercontent.com/1816888/77353506-b6a94780-6d06-11ea-9b69-7ce7f8a9ae16.png"> |

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
