### PR TITLE
Create Button Tracks Additions

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -5,6 +5,7 @@ import Foundation
     case mediaEditorShown
     case mediaEditorUsed
     case editorCreatedPage
+    case createSheetShown
 
     /// A String that represents the event
     var value: String {
@@ -15,6 +16,8 @@ import Foundation
             return "media_editor_used"
         case .editorCreatedPage:
             return "editor_page_created"
+        case .createSheetShown:
+            return "create_sheet_shown"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -4,6 +4,7 @@ import Foundation
 @objc enum WPAnalyticsEvent: Int {
     case mediaEditorShown
     case mediaEditorUsed
+    case editorCreatedPage
 
     /// A String that represents the event
     var value: String {
@@ -12,6 +13,8 @@ import Foundation
             return "media_editor_shown"
         case .mediaEditorUsed:
             return "media_editor_used"
+        case .editorCreatedPage:
+            return "editor_page_created"
         }
     }
 
@@ -74,6 +77,7 @@ extension WPAnalytics {
     @objc static func trackEvent(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any]) {
         var mergedProperties: [AnyHashable: Any] = event.defaultProperties ?? [:]
         mergedProperties.merge(properties) { (_, new) in new }
+
 
         WPAnalytics.trackString(event.value, withProperties: mergedProperties)
     }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -65,7 +65,9 @@ import Gridicons
     @objc private func showCreateSheet() {
         guard let viewController = viewController else { return }
         let actionSheetVC = actionSheetController(for: viewController.traitCollection)
-        viewController.present(actionSheetVC, animated: true, completion: nil)
+        viewController.present(actionSheetVC, animated: true, completion: {
+            WPAnalytics.track(.createSheetShown)
+        })
     }
 
     private func actionSheetController(for traitCollection: UITraitCollection) -> UIViewController {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -1,12 +1,12 @@
 extension WPTabBarController {
 
-    @objc func showPageTab(forBlog: Blog? = nil) {
-        showPageTab(blog: forBlog)
+    @objc func showPageEditor(forBlog: Blog? = nil) {
+        showPageEditor(blog: forBlog)
     }
 
     /// Show the page tab
     /// - Parameter inBlog: Blog to a add a page to. Uses the current or last blog if not provided
-    func showPageTab(blog inBlog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
+    func showPageEditor(blog inBlog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
 
         guard let blog = inBlog ?? self.currentOrLastBlog() else { return }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -1,20 +1,33 @@
 extension WPTabBarController {
 
-    @objc func showPageTab(forBlog blog: Blog) {
+    @objc func showPageTab(forBlog: Blog? = nil) {
+        showPageTab(blog: forBlog)
+    }
+
+    /// Show the page tab
+    /// - Parameter inBlog: Blog to a add a page to. Uses the current or last blog if not provided
+    func showPageTab(blog inBlog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
+
+        guard let blog = inBlog ?? self.currentOrLastBlog() else { return }
+
         let context = ContextManager.sharedInstance().mainContext
         let postService = PostService(managedObjectContext: context)
         let page = postService.createDraftPage(for: blog)
-        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "create_button"], with: blog)
+        page.postTitle = title
+        page.content = content
+
+        let blogID = blog.dotComID?.intValue ?? 0 as Any
+        WPAnalytics.track(WPAnalyticsEvent.editorCreatedPage, properties: ["tap_source": source, WPAppAnalyticsKeyBlogID: blogID])
 
         let editorFactory = EditorFactory()
 
-        let postViewController = editorFactory.instantiateEditor(
+        let pageViewController = editorFactory.instantiateEditor(
             for: page,
             replaceEditor: { [weak self] (editor, replacement) in
                 self?.replaceEditor(editor: editor, replacement: replacement)
         })
 
-        show(postViewController)
+        show(pageViewController)
     }
 
     private func replaceEditor(editor: EditorViewController, replacement: EditorViewController) {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -4,7 +4,7 @@ extension WPTabBarController {
         let context = ContextManager.sharedInstance().mainContext
         let postService = PostService(managedObjectContext: context)
         let page = postService.createDraftPage(for: blog)
-        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "tab_bar"], with: blog)
+        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "create_button"], with: blog)
 
         let editorFactory = EditorFactory()
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -76,4 +76,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 // will be removed when the new IA implementation completes
 - (void)showTabForIndex:(NSInteger)tabIndex;
 
+- (Blog *)currentOrLastBlog;
+
 @end

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -593,7 +593,11 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     editor.showImmediately = !animated;
     editor.openWithMediaPicker = openToMedia;
     editor.afterDismiss = afterDismiss;
-    [WPAppAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar"} withBlog:blog];
+    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
+        [WPAppAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"create_button"} withBlog:blog];
+    } else {
+        [WPAppAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": @"tab_bar"} withBlog:blog];
+    }
     [self presentViewController:editor animated:NO completion:nil];
     return;
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -464,7 +464,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
         } newPage:^{
             [weakSelf dismissViewControllerAnimated:true completion:nil];
             Blog *blog = [weakSelf currentOrLastBlog];
-            [weakSelf showPageTabForBlog:blog];
+            [weakSelf showPageEditorForBlog:blog];
         }];
     }
     


### PR DESCRIPTION
Pat of #13320 

- Sets "tap_source" to "create_button" when accessed from the button
- Code adjustments to be able to change "tap_source" when showing the page (for deep linking)
- Adds "create_sheet_shown" event
- General renaming

To test:
- Tap the Create Button and notice the new "create_sheet_shown" event
- Tap either option in the action sheet and notice that "tap_source" = "create_button"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
