### PR TITLE
Add deep link for Page editor

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -137,7 +137,7 @@ import AutomatticTracks
             return false
         }
 
-        // Should more formats be accepted be accepted in the future, this line would have to be expanded to accomodate it.
+        // Should more formats be accepted in the future, this line would have to be expanded to accomodate it.
         let contentEscaped = contentRaw.escapeHtmlNamedEntities()
 
         let post = PostService(managedObjectContext: context).createDraftPost(for: blog)

--- a/WordPress/Classes/Utility/Universal Links/Route+Page.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route+Page.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct NewPageRoute: Route {
+    let path = "/page"
+    let action: NavigationAction = NewPageNavigationAction()
+}
+
+struct NewPageForSiteRoute: Route {
+    let path = "/page/:domain"
+    let action: NavigationAction = NewPageNavigationAction()
+}
+
+struct NewPageNavigationAction: NavigationAction {
+    func perform(_ values: [String: String], source: UIViewController? = nil) {
+        if let blog = blog(from: values) {
+            WPTabBarController.sharedInstance()?.showPageTab(forBlog: blog)
+        } else {
+            WPTabBarController.sharedInstance()?.showPageTab()
+        }
+    }
+}

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -21,6 +21,7 @@ struct UniversalLinkRouter {
         redirects +
         meRoutes +
         newPostRoutes +
+        newPageRoutes +
         notificationsRoutes +
         readerRoutes +
         statsRoutes +
@@ -36,6 +37,11 @@ struct UniversalLinkRouter {
     static let newPostRoutes: [Route] = [
         NewPostRoute(),
         NewPostForSiteRoute()
+    ]
+
+    static let newPageRoutes: [Route] = [
+        NewPageRoute(),
+        NewPageForSiteRoute()
     ]
 
     static let notificationsRoutes: [Route] = [

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -8,6 +8,12 @@ extension WPTabBarController {
     /// - Parameter inBlog: Blog to a add a page to. Uses the current or last blog if not provided
     func showPageTab(blog inBlog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
 
+        if presentedViewController != nil {
+            dismiss(animated: true) { [weak self] in
+                self?.showPageTab(blog: inBlog, title: title, content: content, source: source)
+            }
+        }
+
         guard let blog = inBlog ?? self.currentOrLastBlog() else { return }
 
         let context = ContextManager.sharedInstance().mainContext

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -8,10 +8,12 @@ extension WPTabBarController {
     /// - Parameter inBlog: Blog to a add a page to. Uses the current or last blog if not provided
     func showPageTab(blog inBlog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
 
-        if presentedViewController != nil {
+        // If we are already showing a view controller, dismiss and show the editor afterward
+        guard presentedViewController == nil else {
             dismiss(animated: true) { [weak self] in
                 self?.showPageTab(blog: inBlog, title: title, content: content, source: source)
             }
+            return
         }
 
         guard let blog = inBlog ?? self.currentOrLastBlog() else { return }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2053,6 +2053,7 @@
 		F5660D07235D114500020B1E /* CalendarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D06235D114500020B1E /* CalendarCollectionView.swift */; };
 		F5660D09235D1CDD00020B1E /* CalendarMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D08235D1CDD00020B1E /* CalendarMonthView.swift */; };
 		F57402A7235FF9C300374346 /* SchedulingDate+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57402A6235FF9C300374346 /* SchedulingDate+Helpers.swift */; };
+		F574416E242569CA00E150A8 /* Route+Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = F574416C2425697D00E150A8 /* Route+Page.swift */; };
 		F580C3C123D22E2D0038E243 /* PreviewDeviceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F580C3C023D22E2D0038E243 /* PreviewDeviceLabel.swift */; };
 		F580C3CB23D8F9B40038E243 /* AbstractPost+Dates.swift in Sources */ = {isa = PBXBuildFile; fileRef = F580C3CA23D8F9B40038E243 /* AbstractPost+Dates.swift */; };
 		F582060223A85495005159A9 /* SiteDateFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = F582060123A85495005159A9 /* SiteDateFormatters.swift */; };
@@ -4640,6 +4641,7 @@
 		F5660D06235D114500020B1E /* CalendarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionView.swift; sourceTree = "<group>"; };
 		F5660D08235D1CDD00020B1E /* CalendarMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthView.swift; sourceTree = "<group>"; };
 		F57402A6235FF9C300374346 /* SchedulingDate+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SchedulingDate+Helpers.swift"; sourceTree = "<group>"; };
+		F574416C2425697D00E150A8 /* Route+Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route+Page.swift"; sourceTree = "<group>"; };
 		F580C3C023D22E2D0038E243 /* PreviewDeviceLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDeviceLabel.swift; sourceTree = "<group>"; };
 		F580C3CA23D8F9B40038E243 /* AbstractPost+Dates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+Dates.swift"; sourceTree = "<group>"; };
 		F582060123A85495005159A9 /* SiteDateFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDateFormatters.swift; sourceTree = "<group>"; };
@@ -5203,6 +5205,7 @@
 				17E24F5320FCF1D900BD70A3 /* Routes+MySites.swift */,
 				17B7C8C020EE2A870042E260 /* Routes+Notifications.swift */,
 				1703D04B20ECD93800D292E9 /* Routes+Post.swift */,
+				F574416C2425697D00E150A8 /* Route+Page.swift */,
 				17A4A36820EE51870071C2CA /* Routes+Reader.swift */,
 				1715179120F4B2EB002C4A38 /* Routes+Stats.swift */,
 				17BD4A182101D31B00975AC3 /* NavigationActionHelpers.swift */,
@@ -12487,6 +12490,7 @@
 				98F537A722496CF300B334F9 /* SiteStatsTableHeaderView.swift in Sources */,
 				E14977181C0DC0770057CD60 /* MediaSizeSliderCell.swift in Sources */,
 				7E987F562108017B00CAFB88 /* NotificationContentRouter.swift in Sources */,
+				F574416E242569CA00E150A8 /* Route+Page.swift in Sources */,
 				177076211EA206C000705A4A /* PlayIconView.swift in Sources */,
 				57BAD50C225CCE1A006139EC /* WPTabBarController+Swift.swift in Sources */,
 				E1468DE71E794A4D0044D80F /* LanguageSelectorViewController.swift in Sources */,


### PR DESCRIPTION
Adds the following Deep Link routes:

`wordpress://newpage` following the same URL query parameters as the `newpost` URL but without`tags`:
* `content` at minimum
* `title`

`https://apps.wordpress.com/get#/page`
`https:/apps.wordpress.com/get#/page/<domain>`

Part of #13320

## To test
- Open `https://apps.wordpress.com/get#/page` as a link (I used Messages to send myself the link and open the app. All other copies of the app must be uninstalled since I believe it is random which copy of the app is chosen to open the URL)
- Open `wpdebug://newpage?content=test` as a link (also used Messages for this one after configuring the app to register for the wordpress scheme)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Unreleased, although this could theoretically be released without enabling the Create button.
