### PR TITLE
Fix localization warning

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteCreationRotatingMessageView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteCreationRotatingMessageView.swift
@@ -138,8 +138,7 @@ class SiteCreationRotatingMessageView: UIView {
     /// Updates the status label/accessiblity label with the provided text
     /// - Parameter message: The text to be displayed
     internal func updateStatus(message: String) {
-        statusLabel.text = NSLocalizedString(message,
-                                             comment: "User-facing string, presented to reflect that site assembly is underway.")
+        statusLabel.text = message
     }
 
     // MARK: - Private


### PR DESCRIPTION
This PR fixes a localisation warning in `SiteCreationRotatingMessageView` due to a variable being passed to `NSLocalizedString`.
As far I understand, `SiteCreationRotatingMessageView`  is instanced only in `SiteAssemblyContentView` and the strings in the _statusMessages_ array are already localised [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/6599f3ecd6787270fbac0bebda3401788d066daa/WordPress/Classes/ViewRelated/Site%20Creation/FinalAssembly/SiteAssemblyContentView.swift#L175), so I think that we can simply remove  the call to `NSLocalizedString`. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
