### PR TITLE
Change how the interactionControllerForDismissal gets the interactionController

### DIFF
--- a/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
+++ b/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
@@ -191,6 +191,7 @@ extension BottomSheetViewController: UIViewControllerTransitioningDelegate {
     }
 
     public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
-        return (self.presentedViewController?.presentationController as? BottomSheetPresentationController)?.interactionController
+
+        return (self.presentationController as? BottomSheetPresentationController)?.interactionController
     }
 }


### PR DESCRIPTION
Fixes #13721 

**To test:**

1. Create a new blog post
2. Tap the publish button
3. Tap the drag handler and slide down to begin dismissing
3.a. Flick down to dismiss quickly
3.b Slowly drag down to dismiss interactively 

Expected Result:
- While dragging you are able to slide the view up/down
- When flicking the view dismisses

**Demo**
<img src="https://user-images.githubusercontent.com/793774/77463787-6ba13a00-6dc3-11ea-9708-24d3d0c4f488.gif" width="50%" />

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
