### PR TITLE
Support Contact Email: Validate email when Return keyboard button pressed.

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -777,6 +777,7 @@ private extension ZendeskUtils {
             textField.placeholder = LocalizedText.emailPlaceholder
             textField.accessibilityLabel = LocalizedText.emailAccessibilityLabel
             textField.text = ZendeskUtils.sharedInstance.userEmail
+            textField.delegate = ZendeskUtils.sharedInstance
             textField.isEnabled = false
 
             textField.addTarget(self,
@@ -982,6 +983,15 @@ extension ZendeskUtils: UITextFieldDelegate {
 
         let newLength = text.count + string.count - range.length
         return newLength <= Constants.nameFieldCharacterLimit
+    }
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard textField != ZendeskUtils.sharedInstance.alertNameField,
+            let email = textField.text else {
+            return true
+        }
+
+        return EmailFormatValidator.validate(string: email)
     }
 
 }


### PR DESCRIPTION
Fixes #13473

To test:
- Go to Me > Help & Support.
- Tap `Contact Email`.
- Tap in the text field to bring up the keyboard.
- Enter a valid email address. Verify tapping `return` dismisses the alert.
  - You can tell it's valid because the `OK` button will be enabled.

![valid](https://user-images.githubusercontent.com/1816888/77484211-95705600-6def-11ea-9f45-0b5c9219c537.png)

- Enter an invalid email address. Verify tapping `return` does nothing.
  - You can tell it's invalid because the `OK` button will be disabled.

![invalid](https://user-images.githubusercontent.com/1816888/77484217-999c7380-6def-11ea-9b05-17f0a39b7dda.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
