### PR TITLE
Fix/post scheduling hotfix

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -420,7 +420,7 @@
 
 - (BOOL)shouldPublishImmediately
 {
-    return [self originalIsDraft] && ![self hasFuturePublishDate];
+    return [self originalIsDraft] && self.dateCreated == nil && ![self hasFuturePublishDate];
 }
 
 - (NSString *)authorNameForDisplay

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -420,7 +420,7 @@
 
 - (BOOL)shouldPublishImmediately
 {
-    return [self dateCreatedIsNilOrEqualToDateModified];
+    return [self originalIsDraft] && [self dateCreatedIsNilOrEqualToDateModified];
 }
 
 - (NSString *)authorNameForDisplay

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -420,7 +420,7 @@
 
 - (BOOL)shouldPublishImmediately
 {
-    return [self originalIsDraft] && self.dateCreated == nil && ![self hasFuturePublishDate];
+    return [self dateCreatedIsNilOrEqualToDateModified];
 }
 
 - (NSString *)authorNameForDisplay

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -111,7 +111,7 @@ extension PostEditor where Self: UIViewController {
             !UserDefaults.standard.asyncPromoWasDisplayed {
             promoBlock()
         } else if action.isAsync,
-            let postStatus = self.post.status,
+            let postStatus = self.post.original?.status ?? self.post.status,
             ![.publish, .publishPrivate].contains(postStatus) {
             // Only display confirmation alert for unpublished posts
             displayPublishConfirmationAlert(for: action, onPublish: publishBlock)

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -70,6 +70,11 @@ struct PublishSettingsViewModel {
     mutating func setDate(_ date: Date?) {
         if let date = date {
             post.dateCreated = date
+            if post.hasFuturePublishDate() {
+                post.status = .scheduled
+            } else {
+                post.status = .publish
+            }
         } else {
             post.publishImmediately()
         }

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/PublishSettingsControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/PublishSettingsControllerTests.swift
@@ -43,7 +43,7 @@ class PublishSettingsViewControllerTests: XCTestCase {
     func testViewModelDateImmediately() {
         let testDate = Date()
 
-        let post = PostBuilder(context).with(dateCreated: testDate).drafted().withRemote().build()
+        let post = PostBuilder(context).drafted().withRemote().build()
 
         var viewModel = PublishSettingsViewModel(post: post)
         XCTAssertNil(viewModel.date, "Date should not exist in view model")
@@ -51,10 +51,18 @@ class PublishSettingsViewControllerTests: XCTestCase {
         if case PublishSettingsViewModel.State.immediately = viewModel.state {
             // Success
         } else {
-            XCTFail("View model should be immediately")
+            XCTFail("View model should be immediately instead of \(viewModel.state)")
         }
 
         viewModel.setDate(testDate)
+
+        if case PublishSettingsViewModel.State.published(_) = viewModel.state {
+            // Success
+        } else {
+            XCTFail("View model should be published instead of \(viewModel.state)")
+        }
+
+        viewModel.setDate(nil)
 
         if case PublishSettingsViewModel.State.immediately = viewModel.state {
             // Success

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/PublishSettingsControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/PublishSettingsControllerTests.swift
@@ -61,14 +61,6 @@ class PublishSettingsViewControllerTests: XCTestCase {
         } else {
             XCTFail("View model should be published instead of \(viewModel.state)")
         }
-
-        viewModel.setDate(nil)
-
-        if case PublishSettingsViewModel.State.immediately = viewModel.state {
-            // Success
-        } else {
-            XCTFail("View model should be immediately instead of \(viewModel.state)")
-        }
     }
 
     func testViewModelDatePublished() {


### PR DESCRIPTION
Fixes #13655
Fixes #13654
Fixes #13710

Fixes the following issues:

* "Publish Immediately" logic being shown when Draft was back scheduled. (seems to be the same issue seen in #13710)
* Post button (in the upper right of the editor) displaying the wrong action after changing the publish date.
* Adds a simple confirmation dialog so it is extra clear when a Post moves from a non-published status to Published.

## To Test

### Back Scheduled Draft

A draft should be able to be scheduled in the past. Previously, "Immediately" was shown as the selected Date/Time. See https://github.com/wordpress-mobile/WordPress-iOS/issues/13710 for more details.

| Before | After |
|--|--|
| <a href="https://user-images.githubusercontent.com/3250/77583593-fa3ab780-6ea6-11ea-94b6-88c20563d2d7.gif"><img src="https://user-images.githubusercontent.com/3250/77583593-fa3ab780-6ea6-11ea-94b6-88c20563d2d7.gif" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/77567638-1598c900-6e8d-11ea-905f-53f346ef51e4.gif"><img src="https://user-images.githubusercontent.com/3250/77567638-1598c900-6e8d-11ea-905f-53f346ef51e4.gif" width="300"></a> |


### Confirmation Dialog

A confirmation dialog should show any time the post is Published from a non-published status. This is a temporary solution for https://github.com/wordpress-mobile/WordPress-iOS/issues/13654 to make it more obvious to users when a post will move to "Published". _Note that this happens _any time_ a post moves to Published from another status, not just when backdating a post._

<a href="https://user-images.githubusercontent.com/3250/77569847-77a6fd80-6e90-11ea-9815-bb8c86f3110c.gif"><img src="https://user-images.githubusercontent.com/3250/77569847-77a6fd80-6e90-11ea-9815-bb8c86f3110c.gif" width="300"></a>

### Move to Draft

Move an existing Published post to Draft. The Published date in Post Settings should be retained. See https://github.com/wordpress-mobile/WordPress-iOS/issues/13655 for more details.

## Known Issues

* "Publish Immediately" on an already published post changes the published date to the current date and time but does not show "Immediately".
* Scheduling a Post and then Publishing it seems to show the wrong "Action" button. Shouldn't the button say "Publish" since the status is changing from "Scheduled" to "Published"? The Publish confirmation is also not shown in this case.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
