### PR TITLE
Refactor Comment action method signature to be compatible with Xcode 11.4

### DIFF
--- a/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
@@ -18,8 +18,11 @@ class ApproveComment: DefaultNotificationActionCommand {
         return on ? .neutral(.shade30) : .primary
     }
 
-    override func execute<ObjectType: FormattableCommentContent>(context: ActionContext<ObjectType>) {
-        let block = context.block
+    override func execute<ObjectType: FormattableContent>(context: ActionContext<ObjectType>) {
+        guard let block = context.block as? FormattableCommentContent else {
+            super.execute(context: context)
+            return
+        }
         if on {
             unApprove(block: block)
         } else {

--- a/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
@@ -18,7 +18,7 @@ class ApproveComment: DefaultNotificationActionCommand {
         return on ? .neutral(.shade30) : .primary
     }
 
-    override func execute<ObjectType: FormattableCommentContent>(context: ActionContext<ObjectType>) {
+    func execute(context: ActionContext<FormattableCommentContent>) {
         let block = context.block
         if on {
             unApprove(block: block)

--- a/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
@@ -18,7 +18,7 @@ class ApproveComment: DefaultNotificationActionCommand {
         return on ? .neutral(.shade30) : .primary
     }
 
-    func execute(context: ActionContext<FormattableCommentContent>) {
+    override func execute<ObjectType: FormattableCommentContent>(context: ActionContext<ObjectType>) {
         let block = context.block
         if on {
             unApprove(block: block)

--- a/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
@@ -7,8 +7,11 @@ class EditComment: DefaultNotificationActionCommand {
         return EditComment.title
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
-        let block = context.block
+    override func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>) {
+        guard let block = context.block as? FormattableCommentContent else {
+            super.execute(context: context)
+            return
+        }
         let content = context.content
         actionsService?.updateCommentWithBlock(block, content: content, completion: { success in
             guard success else {

--- a/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
@@ -7,7 +7,7 @@ class EditComment: DefaultNotificationActionCommand {
         return EditComment.title
     }
 
-    func execute(context: ActionContext<FormattableCommentContent>) {
+    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
         let block = context.block
         let content = context.content
         actionsService?.updateCommentWithBlock(block, content: content, completion: { success in

--- a/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
@@ -7,7 +7,7 @@ class EditComment: DefaultNotificationActionCommand {
         return EditComment.title
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
+    func execute(context: ActionContext<FormattableCommentContent>) {
         let block = context.block
         let content = context.content
         actionsService?.updateCommentWithBlock(block, content: content, completion: { success in

--- a/WordPress/Classes/Models/Notifications/Actions/Follow.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/Follow.swift
@@ -13,7 +13,10 @@ final class Follow: DefaultNotificationActionCommand {
         return on ? .neutral(.shade30) : .primary
     }
 
-    override func execute<ContentType: FormattableUserContent>(context: ActionContext<ContentType>) {
-
+    override func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>) {
+        guard let _ = context.block as? FormattableUserContent else {
+            super.execute(context: context)
+            return
+        }
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/Follow.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/Follow.swift
@@ -13,7 +13,7 @@ final class Follow: DefaultNotificationActionCommand {
         return on ? .neutral(.shade30) : .primary
     }
 
-    override func execute<ContentType: FormattableUserContent>(context: ActionContext<ContentType>) {
+    func execute(context: ActionContext<FormattableUserContent>) {
 
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/Follow.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/Follow.swift
@@ -13,7 +13,7 @@ final class Follow: DefaultNotificationActionCommand {
         return on ? .neutral(.shade30) : .primary
     }
 
-    func execute(context: ActionContext<FormattableUserContent>) {
+    override func execute<ContentType: FormattableUserContent>(context: ActionContext<ContentType>) {
 
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
@@ -14,8 +14,11 @@ class LikeComment: DefaultNotificationActionCommand {
         return on ? TitleStrings.like : TitleStrings.unlike
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
-        let block = context.block
+    override func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>) {
+        guard let block = context.block as? FormattableCommentContent else {
+            super.execute(context: context)
+            return
+        }
         if on {
             removeLike(block: block)
         } else {

--- a/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
@@ -14,7 +14,7 @@ class LikeComment: DefaultNotificationActionCommand {
         return on ? TitleStrings.like : TitleStrings.unlike
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
+    func execute(context: ActionContext<FormattableCommentContent>) {
         let block = context.block
         if on {
             removeLike(block: block)

--- a/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
@@ -14,7 +14,7 @@ class LikeComment: DefaultNotificationActionCommand {
         return on ? TitleStrings.like : TitleStrings.unlike
     }
 
-    func execute(context: ActionContext<FormattableCommentContent>) {
+    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
         let block = context.block
         if on {
             removeLike(block: block)

--- a/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
@@ -4,7 +4,10 @@ final class LikePost: DefaultNotificationActionCommand {
         return NSLocalizedString("Like", comment: "Like a post.")
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
-
+    override func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>) {
+        guard let _ = context.block as? FormattableCommentContent else {
+            super.execute(context: context)
+            return
+        }
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
@@ -4,7 +4,7 @@ final class LikePost: DefaultNotificationActionCommand {
         return NSLocalizedString("Like", comment: "Like a post.")
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
+    func execute(context: ActionContext<FormattableCommentContent>) {
 
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
@@ -4,7 +4,7 @@ final class LikePost: DefaultNotificationActionCommand {
         return NSLocalizedString("Like", comment: "Like a post.")
     }
 
-    func execute(context: ActionContext<FormattableCommentContent>) {
+    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
 
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
@@ -7,9 +7,13 @@ class MarkAsSpam: DefaultNotificationActionCommand {
         return MarkAsSpam.title
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
+    override func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>) {
+        guard let block = context.block as? FormattableCommentContent else {
+            super.execute(context: context)
+            return
+        }
         let request = NotificationDeletionRequest(kind: .spamming, action: { [weak self] requestCompletion in
-            self?.actionsService?.spamCommentWithBlock(context.block) { (success) in
+            self?.actionsService?.spamCommentWithBlock(block) { (success) in
                 requestCompletion(success)
             }
         })

--- a/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
@@ -7,7 +7,7 @@ class MarkAsSpam: DefaultNotificationActionCommand {
         return MarkAsSpam.title
     }
 
-    func execute(context: ActionContext<FormattableCommentContent>) {
+    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
         let request = NotificationDeletionRequest(kind: .spamming, action: { [weak self] requestCompletion in
             self?.actionsService?.spamCommentWithBlock(context.block) { (success) in
                 requestCompletion(success)

--- a/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
@@ -7,7 +7,7 @@ class MarkAsSpam: DefaultNotificationActionCommand {
         return MarkAsSpam.title
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
+    func execute(context: ActionContext<FormattableCommentContent>) {
         let request = NotificationDeletionRequest(kind: .spamming, action: { [weak self] requestCompletion in
             self?.actionsService?.spamCommentWithBlock(context.block) { (success) in
                 requestCompletion(success)

--- a/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
@@ -7,8 +7,11 @@ class ReplyToComment: DefaultNotificationActionCommand {
         return ReplyToComment.title
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
-        let block = context.block
+    override func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>) {
+        guard let block = context.block as? FormattableCommentContent else {
+            super.execute(context: context)
+            return
+        }
         let content = context.content
         actionsService?.replyCommentWithBlock(block, content: content, completion: { success in
             guard success else {

--- a/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
@@ -7,7 +7,7 @@ class ReplyToComment: DefaultNotificationActionCommand {
         return ReplyToComment.title
     }
 
-    func execute(context: ActionContext<FormattableCommentContent>) {
+    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
         let block = context.block
         let content = context.content
         actionsService?.replyCommentWithBlock(block, content: content, completion: { success in

--- a/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
@@ -7,7 +7,7 @@ class ReplyToComment: DefaultNotificationActionCommand {
         return ReplyToComment.title
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
+    func execute(context: ActionContext<FormattableCommentContent>) {
         let block = context.block
         let content = context.content
         actionsService?.replyCommentWithBlock(block, content: content, completion: { success in

--- a/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
@@ -11,10 +11,14 @@ class TrashComment: DefaultNotificationActionCommand {
         return .error
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
+    override func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>) {
+        guard let block = context.block as? FormattableCommentContent else {
+            super.execute(context: context)
+            return
+        }
         ReachabilityUtils.onAvailableInternetConnectionDo {
             let request = NotificationDeletionRequest(kind: .deletion, action: { [weak self] requestCompletion in
-                self?.actionsService?.deleteCommentWithBlock(context.block, completion: { success in
+                self?.actionsService?.deleteCommentWithBlock(block, completion: { success in
                     requestCompletion(success)
                 })
             })

--- a/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
@@ -11,7 +11,7 @@ class TrashComment: DefaultNotificationActionCommand {
         return .error
     }
 
-    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
+    func execute(context: ActionContext<FormattableCommentContent>) {
         ReachabilityUtils.onAvailableInternetConnectionDo {
             let request = NotificationDeletionRequest(kind: .deletion, action: { [weak self] requestCompletion in
                 self?.actionsService?.deleteCommentWithBlock(context.block, completion: { success in

--- a/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
@@ -11,7 +11,7 @@ class TrashComment: DefaultNotificationActionCommand {
         return .error
     }
 
-    func execute(context: ActionContext<FormattableCommentContent>) {
+    override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {
         ReachabilityUtils.onAvailableInternetConnectionDo {
             let request = NotificationDeletionRequest(kind: .deletion, action: { [weak self] requestCompletion in
                 self?.actionsService?.deleteCommentWithBlock(context.block, completion: { success in


### PR DESCRIPTION
This PR fixes the build problems when using Xcode 11.4 to build the project

To test:
 - Check the notification area of the app
 - Try to mark notification with the multiple actions available: like, spams, reply, etc..

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
