### PR TITLE
Correct the whitespace for a translation string

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -183,10 +183,10 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0'
 
-    #pod 'WordPressAuthenticator', '~> 1.11.2'
+    # pod 'WordPressAuthenticator', '~> 1.11.2'
     # While in PR
     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/220-remove-spaces'
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+    #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '646575636e44a5b2225ceec63f8462fee620fc56'
     #pod 'WordPressAuthenticator', :path => ''
 
     pod 'MediaEditor', '~> 1.0.1'

--- a/Podfile
+++ b/Podfile
@@ -183,10 +183,10 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0'
 
-    # pod 'WordPressAuthenticator', '~> 1.11.2'
+    pod 'WordPressAuthenticator', '~> 1.11.2'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/220-remove-spaces'
-    #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '646575636e44a5b2225ceec63f8462fee620fc56'
+    #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     #pod 'WordPressAuthenticator', :path => ''
 
     pod 'MediaEditor', '~> 1.0.1'

--- a/Podfile
+++ b/Podfile
@@ -183,9 +183,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0'
 
-    pod 'WordPressAuthenticator', '~> 1.11.1'
+    #pod 'WordPressAuthenticator', '~> 1.11.2'
     # While in PR
-    #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/220-remove-spaces'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     #pod 'WordPressAuthenticator', :path => ''
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -476,7 +476,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.17.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/220-remove-spaces`)
+  - WordPressAuthenticator (~> 1.11.2)
   - WordPressKit (~> 4.6.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -523,6 +523,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -608,9 +609,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.24.0
-  WordPressAuthenticator:
-    :branch: fix/220-remove-spaces
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.24.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -624,9 +622,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.24.0
-  WordPressAuthenticator:
-    :commit: 646575636e44a5b2225ceec63f8462fee620fc56
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -714,6 +709,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 3bd20d335e0810b3e846fd7c7d91c6a4de66a38f
+PODFILE CHECKSUM: e7d499c6dc80679f513bcf15603aaf3ae1e00541
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -625,7 +625,7 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.24.0
   WordPressAuthenticator:
-    :commit: 1d3bdc54ae011a53a5d4d21c0b8f3470f55cfe53
+    :commit: 646575636e44a5b2225ceec63f8462fee620fc56
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -714,6 +714,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 26e752b472bc4ac1596794b4e0bf9447c844605a
+PODFILE CHECKSUM: 3bd20d335e0810b3e846fd7c7d91c6a4de66a38f
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -374,7 +374,7 @@ PODS:
   - WordPress-Aztec-iOS (1.17.0)
   - WordPress-Editor-iOS (1.17.0):
     - WordPress-Aztec-iOS (= 1.17.0)
-  - WordPressAuthenticator (1.11.1):
+  - WordPressAuthenticator (1.11.2):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -476,7 +476,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.17.0)
-  - WordPressAuthenticator (~> 1.11.1)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/220-remove-spaces`)
   - WordPressKit (~> 4.6.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -523,7 +523,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -609,6 +608,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.24.0
+  WordPressAuthenticator:
+    :branch: fix/220-remove-spaces
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.24.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -622,6 +624,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.24.0
+  WordPressAuthenticator:
+    :commit: 1d3bdc54ae011a53a5d4d21c0b8f3470f55cfe53
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -692,7 +697,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 2a9fb6c2a23284f53d6d69ada43c50b5fddc7c3b
   WordPress-Editor-iOS: 9f236b27b068120af37d6d02e82037e122187804
-  WordPressAuthenticator: 5711680069ca4b4f7614bad8d57cc453e7663b54
+  WordPressAuthenticator: 1c9f97c2776e997270adfe07ccfd464ecc647810
   WordPressKit: 767cc17ae08894f73f08c852fe124c865a62fb3d
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
@@ -709,6 +714,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: b7eed931b549247bbe3288435d9f43e02458b8a0
+PODFILE CHECKSUM: 26e752b472bc4ac1596794b4e0bf9447c844605a
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
First reviewer wins 🏆 

Fixes # n/a

Ref. https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/223

### To test: 
1. Check out this branch
2. `rake dependencies`
3. Build and run
4. Select the Log in button
5. Verify the "Continue with Google" and "Continue with Apple" buttons have a logo and the spacing is correct.
6. Select the carousel to dismiss the Log in button view
7. Select "Sign up for WordPress.com" and verify the Google and Apple buttons are correctly spaced.
8. Select "Sign up with Email" and verify the NUX button has the correct insets (the hotfix was accidentally reverted).

### Do not merge until
1. The Authenticator PR has been merged: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/223
2. The Authenticator changes have been released
3. The release has been published to CocoaPods trunk
4. This branch points to the release version

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

iPhone 11 Pro, 13.3
<img src="https://user-images.githubusercontent.com/1062444/77557037-437b0f00-6e87-11ea-9229-7067e59de3ce.png" width="350" />
<img src="https://user-images.githubusercontent.com/1062444/77557051-4970f000-6e87-11ea-8a15-d0126b551f0a.png" width="350" />
<img src="https://user-images.githubusercontent.com/1062444/77557057-4bd34a00-6e87-11ea-9a54-b9f7c7d5af85.png" width="350" />