### PR TITLE
Change showPageTab to showPageEditor

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -178,7 +178,7 @@ import AutomatticTracks
         // Should more formats be accepted be accepted in the future, this line would have to be expanded to accomodate it.
         let contentEscaped = contentRaw.escapeHtmlNamedEntities()
 
-        WPTabBarController.sharedInstance()?.showPageTab(blog: blog, title: title, content: contentEscaped, source: "url_scheme")
+        WPTabBarController.sharedInstance()?.showPageEditor(blog: blog, title: title, content: contentEscaped, source: "url_scheme")
 
         return true
     }

--- a/WordPress/Classes/Utility/Universal Links/Route+Page.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route+Page.swift
@@ -13,9 +13,9 @@ struct NewPageForSiteRoute: Route {
 struct NewPageNavigationAction: NavigationAction {
     func perform(_ values: [String: String], source: UIViewController? = nil) {
         if let blog = blog(from: values) {
-            WPTabBarController.sharedInstance()?.showPageTab(forBlog: blog)
+            WPTabBarController.sharedInstance()?.showPageEditor(forBlog: blog)
         } else {
-            WPTabBarController.sharedInstance()?.showPageTab()
+            WPTabBarController.sharedInstance()?.showPageEditor()
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -11,7 +11,7 @@ extension WPTabBarController {
         // If we are already showing a view controller, dismiss and show the editor afterward
         guard presentedViewController == nil else {
             dismiss(animated: true) { [weak self] in
-                self?.showPageTab(blog: inBlog, title: title, content: content, source: source)
+                self?.showPageEditor(blog: inBlog, title: title, content: content, source: source)
             }
             return
         }


### PR DESCRIPTION
Fixes bad merge. `showPageTab` changed to `showPageEditor`.

To test:
- Compile

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
