### PR TITLE
Fix Media Editor track in Aztec

### DIFF
--- a/WordPress/Classes/Utility/WPMediaEditor.swift
+++ b/WordPress/Classes/Utility/WPMediaEditor.swift
@@ -16,6 +16,11 @@ class WPMediaEditor: MediaEditor {
         }
     }
 
+    /// The number of images in the Media Editor
+    private var numberOfImages: Int {
+        return max(asyncImages.count, images.count)
+    }
+
     override var styles: MediaEditorStyles {
         get {
             return [
@@ -41,7 +46,7 @@ class WPMediaEditor: MediaEditor {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        WPAnalytics.track(.mediaEditorShown)
+        WPAnalytics.track(.mediaEditorShown, properties: ["number_of_images": numberOfImages])
     }
 
     override func viewDidDisappear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2419,12 +2419,12 @@ extension AztecPostViewController {
         insert(exportableAsset: url as NSURL, source: .otherApps)
     }
 
-    fileprivate func insertImage(image: UIImage) {
-        insert(exportableAsset: image, source: .deviceLibrary)
+    fileprivate func insertImage(image: UIImage, source: MediaSource = .deviceLibrary) {
+        insert(exportableAsset: image, source: source)
     }
 
-    fileprivate func insertDeviceMedia(phAsset: PHAsset) {
-        insert(exportableAsset: phAsset, source: .deviceLibrary)
+    fileprivate func insertDeviceMedia(phAsset: PHAsset, source: MediaSource = .deviceLibrary) {
+        insert(exportableAsset: phAsset, source: source)
     }
 
     private func insertStockPhotosMedia(_ media: StockPhotosMedia) {
@@ -3528,9 +3528,9 @@ extension AztecPostViewController {
                               onFinishEditing: { [weak self] images, actions in
                                 images.forEach { mediaEditorImage in
                                     if let image = mediaEditorImage.editedImage {
-                                        self?.insertImage(image: image)
+                                        self?.insertImage(image: image, source: .mediaEditor)
                                     } else if let phAsset = mediaEditorImage as? PHAsset {
-                                        self?.insertDeviceMedia(phAsset: phAsset)
+                                        self?.insertDeviceMedia(phAsset: phAsset, source: .mediaEditor)
                                     }
                                 }
 


### PR DESCRIPTION
Fix the `source` when adding an image in Aztec through Media Editor and add a new property to check how many images are being shown in the Media Editor.

### To test

1. Create a new post in Aztec
2. Add an image
3. Edit the image using the Media Editor
4. Check that the property `wpios_editor_photo_added` has the property `via: media_editor`

### Gutenberg: Gallery

1. Add a Gallery block in Gutenberg
2. Tap "Add media" and then select "Choose from device"
3. Select multiple images from the device
4. Tap "Preview X" (at the left bottom corner)
5. Check that `media_editor_shown` is triggered with the correct `number_of_images`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
