### PR TITLE
Comment mentions: move NRV behind suggestions table

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [internal] the login and signup Magic Link flows have code changes that could cause regressions. See https://git.io/Jvy4P for testing details.
 * Notifications: Fix layout on screens with a notch.
+* Post Commenting: fixed issue that prevented selecting an @ mention suggestion.
 
  
 14.5

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -700,7 +700,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     [self.noResultsViewController hideImageView:hideImageView];
     [self.noResultsViewController.view setBackgroundColor:[UIColor clearColor]];
     [self addChildViewController:self.noResultsViewController];
-    [self.view addSubviewWithFadeAnimation:self.noResultsViewController.view];
+    [self.view insertSubview:self.noResultsViewController.view belowSubview:self.suggestionsTableView];
     self.noResultsViewController.view.frame = self.tableView.frame;
     [self.noResultsViewController didMoveToParentViewController:self];
 }


### PR DESCRIPTION
Fixes #13577 

The issue was caused by the no results view being added to the top of the view stack, causing it to cover the suggestions table, blocking selection. This change inserts the NRV below the suggestions table.

To test:
- Go to the Reader.
- Find a post with no comments.
- Tap the comments icon.
- The no results view will display `Be the first to leave a comment.`
- Tap in the reply text view.
- Type `@` to display @ suggestions.
- Verify:
  - The no results message appears behind the suggestion list.
  - You can select a suggestion.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
