### PR TITLE
Notifications: change subject font to semibold

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SubjectContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SubjectContentStyles.swift
@@ -11,9 +11,9 @@ class SubjectContentStyles: FormattableContentStyles {
 
     var rangeStylesMap: [FormattableRangeKind: [NSAttributedString.Key: Any]]? {
         return [
-            .user: WPStyleGuide.Notifications.subjectBoldStyle,
-            .post: WPStyleGuide.Notifications.subjectBoldStyle,
-            .comment: WPStyleGuide.Notifications.subjectBoldStyle,
+            .user: WPStyleGuide.Notifications.subjectSemiBoldStyle,
+            .post: WPStyleGuide.Notifications.subjectSemiBoldStyle,
+            .comment: WPStyleGuide.Notifications.subjectSemiBoldStyle,
             .blockquote: WPStyleGuide.Notifications.subjectQuotedStyle,
             .noticon: WPStyleGuide.Notifications.subjectNoticonStyle
         ]

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -42,9 +42,9 @@ extension WPStyleGuide {
                      .foregroundColor: subjectTextColor ]
         }
 
-        public static var subjectBoldStyle: [NSAttributedString.Key: Any] {
+        public static var subjectSemiBoldStyle: [NSAttributedString.Key: Any] {
             return [.paragraphStyle: subjectParagraph,
-                    .font: subjectBoldFont ]
+                    .font: subjectSemiBoldFont ]
         }
 
         public static var subjectItalicsStyle: [NSAttributedString.Key: Any] {
@@ -333,8 +333,8 @@ extension WPStyleGuide {
         fileprivate static var subjectRegularFont: UIFont {
             return WPStyleGuide.fontForTextStyle(.subheadline)
         }
-        fileprivate static var subjectBoldFont: UIFont {
-            return WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .bold)
+        fileprivate static var subjectSemiBoldFont: UIFont {
+            return WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
         }
         fileprivate static var subjectItalicsFont: UIFont {
             return  WPStyleGuide.fontForTextStyle(.subheadline, symbolicTraits: .traitItalic)


### PR DESCRIPTION
Fixes #13340 

To test:
- Go to Notifications.
- Verify the bold text is now semibold.

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/77695582-9e893080-6f71-11ea-9fe4-567590d9178d.png) | ![after](https://user-images.githubusercontent.com/1816888/77695600-a47f1180-6f71-11ea-9e80-26a7307b54c5.png) |


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
