### PR TITLE
Cleanup

### DIFF
--- a/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
+++ b/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
@@ -1,22 +1,14 @@
 import AutomatticTracks
 import Foundation
 
-/// Encapsulates all the authentication logic for web views.
+/// Authenticator for requests to self-hosted sites, wp.com sites, including private
+/// sites and atomic sites.
 ///
-/// This objects is in charge of deciding when a web view should be authenticated,
-/// and rewriting requests to do so.
+/// - Note: at some point I considered moving this module to the WordPressAuthenticator pod.
+///     Unfortunately the effort required for this makes it unfeasible for me to focus on it
+///     right now, as it involves also moving at least CookieJar, AuthenticationService and AtomicAuthenticationService over there as well. - @diegoreymendez
 ///
-/// Our current authentication system is based on posting to wp-login.php and
-/// taking advantage of the `redirect_to` parameter. In the specific case of
-/// WordPress.com, we sometimes want to pre-authenticate the user when visiting
-/// URLs that we're not sure if they are hosted there (e.g. mapped domains).
-///
-/// Since WordPress.com doesn't allow redirects to external URLs, we use a
-/// special WordPress.com URL that includes the target URL, and extract that on
-/// `interceptRedirect(request:)`. You should call that from your web view's
-/// delegate method, when deciding if a request or redirect should continue.
-///
-class WebViewAuthenticator: NSObject {
+class RequestAuthenticator: NSObject {
 
     enum Error: Swift.Error {
         case atomicSiteWithoutDotComID(blog: Blog)
@@ -118,7 +110,7 @@ class WebViewAuthenticator: NSObject {
         }
     }
 
-    func requestForWPCom(url: URL, cookieJar: CookieJar, username: String, authToken: String, authenticationType: DotComAuthenticationType, completion: @escaping (URLRequest) -> Void) {
+    private func requestForWPCom(url: URL, cookieJar: CookieJar, username: String, authToken: String, authenticationType: DotComAuthenticationType, completion: @escaping (URLRequest) -> Void) {
 
         switch authenticationType {
         case .regular:
@@ -211,15 +203,15 @@ class WebViewAuthenticator: NSObject {
     }
 }
 
-private extension WebViewAuthenticator {
+private extension RequestAuthenticator {
     static let wordPressComLoginUrl = URL(string: "https://wordpress.com/wp-login.php")!
 }
 
-extension WebViewAuthenticator {
+extension RequestAuthenticator {
     func isLogin(url: URL) -> Bool {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         components?.queryItems = nil
 
-        return components?.url == WebViewAuthenticator.wordPressComLoginUrl
+        return components?.url == RequestAuthenticator.wordPressComLoginUrl
     }
 }

--- a/WordPress/Classes/Utility/WPWebViewController.h
+++ b/WordPress/Classes/Utility/WPWebViewController.h
@@ -4,7 +4,7 @@
 @class Blog;
 @class WPAccount;
 @class WebViewControllerConfiguration;
-@class WebViewAuthenticator;
+@class RequestAuthenticator;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) BOOL addsHideMasterbarParameters;
 
-@property (nonatomic, strong, nullable) WebViewAuthenticator *authenticator;
+@property (nonatomic, strong, nullable) RequestAuthenticator *authenticator;
 
 /**
  *	@brief		Dismiss modal presentation

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -55,7 +55,7 @@ class WebKitViewController: UIViewController {
     @objc var customOptionsButton: UIBarButtonItem?
 
     @objc let url: URL?
-    @objc let authenticator: WebViewAuthenticator?
+    @objc let authenticator: RequestAuthenticator?
     @objc let navigationDelegate: WebNavigationDelegate?
     @objc var secureInteraction = false
     @objc var addsWPComReferrer = false

--- a/WordPress/Classes/Utility/WebViewControllerConfiguration.swift
+++ b/WordPress/Classes/Utility/WebViewControllerConfiguration.swift
@@ -14,7 +14,7 @@ class WebViewControllerConfiguration: NSObject {
     /// The behavior to use for allowing links to be loaded by the web view based
     var linkBehavior = LinkBehavior.all
     @objc var customTitle: String?
-    @objc var authenticator: WebViewAuthenticator?
+    @objc var authenticator: RequestAuthenticator?
     @objc weak var navigationDelegate: WebNavigationDelegate?
 
     @objc init(url: URL?) {
@@ -23,11 +23,11 @@ class WebViewControllerConfiguration: NSObject {
     }
 
     @objc func authenticate(blog: Blog) {
-        self.authenticator = WebViewAuthenticator(blog: blog)
+        self.authenticator = RequestAuthenticator(blog: blog)
     }
 
     @objc func authenticate(account: WPAccount) {
-        self.authenticator = WebViewAuthenticator(account: account)
+        self.authenticator = RequestAuthenticator(account: account)
     }
 
     @objc func authenticateWithDefaultAccount() {

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.swift
@@ -59,7 +59,7 @@ class SharingAuthorizationWebViewController: WPWebViewController {
 
         super.init(nibName: "WPWebViewController", bundle: nil)
 
-        self.authenticator = WebViewAuthenticator(blog: blog)
+        self.authenticator = RequestAuthenticator(blog: blog)
         self.secureInteraction = true
         self.url = url
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
@@ -261,7 +261,7 @@ private extension JetpackConnectionWebViewController {
     }
 
     func performSiteLogin(redirect: URL, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        guard let authenticator = WebViewAuthenticator(blog: blog) else {
+        guard let authenticator = RequestAuthenticator(blog: blog) else {
             decisionHandler(.allow)
             return
         }
@@ -285,7 +285,7 @@ private extension JetpackConnectionWebViewController {
     }
 
     func authenticateWithDotCom(username: String, token: String, redirect: URL) {
-        let authenticator = WebViewAuthenticator(credentials: .dotCom(username: username, authToken: token, authenticationType: .regular))
+        let authenticator = RequestAuthenticator(credentials: .dotCom(username: username, authToken: token, authenticationType: .regular))
 
         authenticator.request(url: redirect, cookieJar: webView.configuration.websiteDataStore.httpCookieStore, completion: { request in
             DDLogDebug("Performing WordPress.com login to \(String(describing: request.url))")

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
@@ -12,7 +12,7 @@ class PostPreviewGenerator: NSObject {
     @objc let post: AbstractPost
     @objc var previewURL: URL?
     @objc weak var delegate: PostPreviewGeneratorDelegate?
-    fileprivate let authenticator: WebViewAuthenticator?
+    fileprivate let authenticator: RequestAuthenticator?
 
     @objc convenience init(post: AbstractPost) {
         self.init(post: post, previewURL: nil)
@@ -21,7 +21,7 @@ class PostPreviewGenerator: NSObject {
     @objc init(post: AbstractPost, previewURL: URL? = nil) {
         self.post = post
         self.previewURL = previewURL
-        authenticator = WebViewAuthenticator(blog: post.blog)
+        authenticator = RequestAuthenticator(blog: post.blog)
         super.init()
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1853,7 +1853,7 @@
 		E185474E1DED8D8800D875D7 /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E185474D1DED8D8800D875D7 /* UserNotifications.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		E18549D9230EED73003C620E /* BlogService+Deduplicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18549D8230EED73003C620E /* BlogService+Deduplicate.swift */; };
 		E18549DB230FBFEF003C620E /* BlogServiceDeduplicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18549DA230FBFEF003C620E /* BlogServiceDeduplicationTests.swift */; };
-		E1928B2E1F8369F100E076C8 /* WebViewAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1928B2D1F8369F100E076C8 /* WebViewAuthenticatorTests.swift */; };
+		E1928B2E1F8369F100E076C8 /* RequestAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1928B2D1F8369F100E076C8 /* RequestAuthenticatorTests.swift */; };
 		E192E78C22EF453C008D725D /* WordPress-87-88.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E192E78B22EF453C008D725D /* WordPress-87-88.xcmappingmodel */; };
 		E19B17AE1E5C6944007517C6 /* BasePost.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B17AD1E5C6944007517C6 /* BasePost.swift */; };
 		E19B17B01E5C69A5007517C6 /* NSManagedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19B17AF1E5C69A5007517C6 /* NSManagedObject.swift */; };
@@ -1884,7 +1884,6 @@
 		E1B9128B1BB0129C003C25B9 /* WPStyleGuide+People.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B9128A1BB0129C003C25B9 /* WPStyleGuide+People.swift */; };
 		E1B9128F1BB05B1D003C25B9 /* PeopleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B912841BB01266003C25B9 /* PeopleCell.swift */; };
 		E1B921BC1C0ED5A3003EA3CB /* MediaSizeSliderCellTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B921BB1C0ED5A3003EA3CB /* MediaSizeSliderCellTest.swift */; };
-		E1BB85981F82459800797050 /* WebViewAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BB85971F82459800797050 /* WebViewAuthenticator.swift */; };
 		E1BB92321FDAAFFA00F2D817 /* TextWithAccessoryButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BB92311FDAAFFA00F2D817 /* TextWithAccessoryButtonCell.swift */; };
 		E1BEEC631C4E35A8000B4FA0 /* Animator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BEEC621C4E35A8000B4FA0 /* Animator.swift */; };
 		E1BEEC651C4E3978000B4FA0 /* PaddedLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1BEEC641C4E3978000B4FA0 /* PaddedLabel.swift */; };
@@ -2043,6 +2042,7 @@
 		F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
 		F1DB8D292288C14400906E2F /* Uploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DB8D282288C14400906E2F /* Uploader.swift */; };
 		F1DB8D2B2288C24500906E2F /* UploadsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DB8D2A2288C24500906E2F /* UploadsManager.swift */; };
+		F1E746E7242E459400C74D8A /* RequestAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E746E6242E459400C74D8A /* RequestAuthenticator.swift */; };
 		F1F083F6241FFE930056D3B1 /* AtomicAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F083F5241FFE930056D3B1 /* AtomicAuthenticationServiceTests.swift */; };
 		F511F8A42356A4F400895E73 /* PublishSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F511F8A32356A4F400895E73 /* PublishSettingsViewController.swift */; };
 		F53FF3A123E2377E001AD596 /* NewBlogDetailHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A023E2377E001AD596 /* NewBlogDetailHeaderView.swift */; };
@@ -4355,7 +4355,7 @@
 		E1874BFE161C5DBC0058BDC4 /* WordPress 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 7.xcdatamodel"; sourceTree = "<group>"; };
 		E18D8AE21397C51A00000861 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		E18D8AE41397C54E00000861 /* nb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nb; path = nb.lproj/Localizable.strings; sourceTree = "<group>"; };
-		E1928B2D1F8369F100E076C8 /* WebViewAuthenticatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewAuthenticatorTests.swift; sourceTree = "<group>"; };
+		E1928B2D1F8369F100E076C8 /* RequestAuthenticatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAuthenticatorTests.swift; sourceTree = "<group>"; };
 		E192E78B22EF453C008D725D /* WordPress-87-88.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-87-88.xcmappingmodel"; sourceTree = "<group>"; };
 		E1939C671B15B4D2001AFEF7 /* WordPress 30.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 30.xcdatamodel"; sourceTree = "<group>"; };
 		E19853331755E461001CC6D5 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -4397,7 +4397,6 @@
 		E1B912881BB01288003C25B9 /* PeopleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeopleViewController.swift; sourceTree = "<group>"; };
 		E1B9128A1BB0129C003C25B9 /* WPStyleGuide+People.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+People.swift"; sourceTree = "<group>"; };
 		E1B921BB1C0ED5A3003EA3CB /* MediaSizeSliderCellTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaSizeSliderCellTest.swift; sourceTree = "<group>"; };
-		E1BB85971F82459800797050 /* WebViewAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewAuthenticator.swift; sourceTree = "<group>"; };
 		E1BB92311FDAAFFA00F2D817 /* TextWithAccessoryButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextWithAccessoryButtonCell.swift; sourceTree = "<group>"; };
 		E1BCFBC51C0626C5004BDADF /* WordPress 43.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 43.xcdatamodel"; sourceTree = "<group>"; };
 		E1BEEC621C4E35A8000B4FA0 /* Animator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animator.swift; sourceTree = "<group>"; };
@@ -4633,6 +4632,7 @@
 		F1D690151F828FF000200E30 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		F1DB8D282288C14400906E2F /* Uploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Uploader.swift; sourceTree = "<group>"; };
 		F1DB8D2A2288C24500906E2F /* UploadsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadsManager.swift; sourceTree = "<group>"; };
+		F1E746E6242E459400C74D8A /* RequestAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestAuthenticator.swift; sourceTree = "<group>"; };
 		F1F083F5241FFE930056D3B1 /* AtomicAuthenticationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicAuthenticationServiceTests.swift; sourceTree = "<group>"; };
 		F262DFCA1F94418CE76D1D78 /* Pods-WordPressNotificationContentExtension.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationContentExtension.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationContentExtension/Pods-WordPressNotificationContentExtension.release-internal.xcconfig"; sourceTree = "<group>"; };
 		F373612EEEEF10E500093FF3 /* Pods-WordPress.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -5418,6 +5418,7 @@
 		1A433B1B2254CBC300AE7910 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				F1E746E6242E459400C74D8A /* RequestAuthenticator.swift */,
 				1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */,
 			);
 			path = Networking;
@@ -7345,7 +7346,7 @@
 				93A379EB19FFBF7900415023 /* KeychainTest.m */,
 				1759F1711FE017F20003EC81 /* QueueTests.swift */,
 				1797373620EBAA4100377B4E /* RouteMatcherTests.swift */,
-				E1928B2D1F8369F100E076C8 /* WebViewAuthenticatorTests.swift */,
+				E1928B2D1F8369F100E076C8 /* RequestAuthenticatorTests.swift */,
 				5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */,
 				E1E4CE0C177439D100430844 /* WPAvatarSourceTest.m */,
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
@@ -8468,7 +8469,6 @@
 				E16FB7E21F8B61030004DD9F /* WebKitViewController.swift */,
 				F5D0A64823C8FA1500B20D27 /* LinkBehavior.swift */,
 				E1222B621F877FD700D23173 /* WebProgressView.swift */,
-				E1BB85971F82459800797050 /* WebViewAuthenticator.swift */,
 				E16FB7E01F8B5D7D0004DD9F /* WebViewControllerConfiguration.swift */,
 				E1222B661F878E4700D23173 /* WebViewControllerFactory.swift */,
 				B526DC271B1E47FC002A8C5F /* WPStyleGuide+WebView.h */,
@@ -11740,6 +11740,7 @@
 				F580C3C123D22E2D0038E243 /* PreviewDeviceLabel.swift in Sources */,
 				5D7DEA2919D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift in Sources */,
 				40C403F62215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift in Sources */,
+				F1E746E7242E459400C74D8A /* RequestAuthenticator.swift in Sources */,
 				82FC61251FA8ADAD00A1757E /* ActivityListViewController.swift in Sources */,
 				E66E2A651FE4311300788F22 /* SettingsTitleSubtitleController.swift in Sources */,
 				E1222B671F878E4700D23173 /* WebViewControllerFactory.swift in Sources */,
@@ -12263,7 +12264,6 @@
 				85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */,
 				B50C0C5E1EF42A4A00372C65 /* AztecAttachmentViewController.swift in Sources */,
 				F53FF3A123E2377E001AD596 /* NewBlogDetailHeaderView.swift in Sources */,
-				E1BB85981F82459800797050 /* WebViewAuthenticator.swift in Sources */,
 				43FB3F411EBD215C00FC8A62 /* LoginEpilogueBlogCell.swift in Sources */,
 				57D66B9A234BB206005A2D74 /* PostServiceRemoteFactory.swift in Sources */,
 				98EB126A20D2DC2500D2D5B5 /* NoResultsViewController+Model.swift in Sources */,
@@ -13403,7 +13403,7 @@
 				D821C81B21003AE9002ED995 /* FormattableContentGroupTests.swift in Sources */,
 				93D86B981C691E71003D8E3E /* LocalCoreDataServiceTests.m in Sources */,
 				400A2C932217B463000A8A59 /* ReferrerStatsRecordValueTests.swift in Sources */,
-				E1928B2E1F8369F100E076C8 /* WebViewAuthenticatorTests.swift in Sources */,
+				E1928B2E1F8369F100E076C8 /* RequestAuthenticatorTests.swift in Sources */,
 				73178C2921BEE09300E37C9A /* SiteSegmentsStepTests.swift in Sources */,
 				08F8CD311EBD2A960049D0C0 /* MediaImageExporterTests.swift in Sources */,
 				400A2C912217B308000A8A59 /* CountryStatsRecordValueTests.swift in Sources */,

--- a/WordPress/WordPressTest/RequestAuthenticatorTests.swift
+++ b/WordPress/WordPressTest/RequestAuthenticatorTests.swift
@@ -9,7 +9,7 @@ private extension URLRequest {
     }
 }
 
-class WebViewAuthenticatorTests: XCTestCase {
+class RequestAuthenticatorTests: XCTestCase {
     let dotComLoginURL = URL(string: "https://wordpress.com/wp-login.php")!
     let dotComUser = "comuser"
     let dotComToken = "comtoken"
@@ -23,12 +23,12 @@ class WebViewAuthenticatorTests: XCTestCase {
     let selfHostedAuthCookies = "wordpress_test_cookie=WP+Cookie+check; path=/; secure, wordpress_sec_ef1631b592f07561aae70fbd1ee1e768=siteuser%7C1586285558%7CTLyGwaryk81cmBFnizrj2uQju5Y9K7Y4gVTc4M4N21F%7C6b4639402efdc086cefdb23c022645bf5d6860c658bd5795014fcd47e0dac6ad; expires=Wed, 08 Apr 3020 06:52:38 GMT;secure; HttpOnly; path=/wp-content/plugins; SameSite=None, wordpress_sec_ef1631b592f07561aae70fbd1ee1e768=siteuser%7C1586285558%7CTLyGwaryk81cmBFnizrj2uQju5Y9K7Y4gVTc4M4N21F%7C6b4639402efdc086cefdb23c022645bf5d6860c658bd5795014fcd47e0dac6ad; expires=Wed, 08 Apr 3020 06:52:38 GMT;secure; HttpOnly; path=/wp-admin; SameSite=None, wordpress_logged_in_ef1631b592f07561aae70fbd1ee1e768=siteuser%7C1586285558%7CTLyGwaryk81cmBFnizrj2uQju5Y9K7Y4gVTc4M4N21F%7Cb7afb00b8d8400e841c6dca1ea0a70d083c1365698da93756fce705d17d3ce71; expires=Wed, 08 Apr 3020 06:52:38 GMT;secure; HttpOnly; path=/; SameSite=None"
     let wpComAuthCookies = "wordpress_test_cookie=WP+Cookie+check; path=/; domain=.wordpress.com; secure, recognized_logins=uNdWIS9WV3eDx26Krcur2-7FL3rT-yChl0fovl6JYznIoqxe2P6uelkXWmsdzeMmHd4Nxg22nsFbh00MDVj1; expires=Sat, 23-Sep-2023 07:58:01 GMT; Max-Age=110376000; path=/; domain=wordpress.com; secure; HttpOnly, wordpress=comuser%7C1679587881%7CZ6LgnUJJBPfwh7Tjszh7FbgQ1Klr70r2sIDfGQLMlMY%7C976df5f2b2edbabf7c0d098f6a1764c7f8ea948e39c747e673822fefed09a431; expires=Fri, 24 Mar 2023 19:58:01 GMT;path=/wp-content/plugins; domain=.wordpress.com; HttpOnly, wordpress=comuser%7C1679587881%7CZ6LgnvJJbPmwh8Tjszh7Fbg1aKlr70r2sIDfGQLMlMY%7C976df5f2b0eddebf7c0d098f6a1764c7f8ea948e39c747e673822fefed09a431; expires=Fri, 24 Mar 2023 19:58:01 GMT;path=/wp-admin; domain=.wordpress.com; HttpOnly, wordpress_logged_in=comuser%7C1679587881%uCz6LgnUJJvpmwh8Tjszh7FbgQ1Klr70r2sIDfGQLo0MY%7Ce8a22bb97b915bdefab8be0ab63ec4fe6f82d88c34b47c1a62bd9510c89b0073; expires=Fri, 24 Mar 2023 19:58:01 GMT;path=/; domain=.wordpress.com; HttpOnly, wordpress=comuser%7C1679587881%7CZ6LgnUjJBPmwh8Tjszh7FbgQ1Klr70o0sIDfGQLMlMY%7C976df5f2b0edbabf7c0d098f6a1764c7f8ea948e39c747e673822fefed09a431; expires=Fri, 24 Mar 2023 19:58:01 GMT;path=/wp-content/plugins; domain=.wordpress.com; secure; HttpOnly, wordpress=comuser%7C1679597881%7CZ6LgnUJJBPmwh8Tjszh7FbgQ1Klr71Y2sIDfGQLMlMY%7C976df5f2b0edbabf7c0d098f6a1764c7f8ea948e39c747e673822fefed09a431; expires=Fri, 24 Mar 2023 19:58:01 GMT;path=/wp-admin; domain=.wordpress.com; secure; HttpOnly, wordpress_logged_in=comuser%7C1679587881%7CZ6LgnUJJBPmwh8TjshY7FbgQ1Klr70r2sIDfGQLMlMY%7Ce8a22bb97b915bdefab8be0ab63ec4fe6f82d88c34b47c1a62bd9510c89b0073; expires=Fri, 24 Mar 2023 19:58:01 GMT;path=/; domain=.wordpress.com; secure; HttpOnly, wordpress_sec=comuser%7C1679587881%7CZ6LgnUJJBPmwh8Tjszh7F00Q1Klr70r2sIDfGQLMlMY%7Cc5577c02994f8e5ed884548e6ff344b7a0147607959598ab0adf7128272780c6; expires=Fri, 24 Mar 2023 19:58:01 GMT;path=/wp-content/plugins; domain=.wordpress.com; secure; HttpOnly, wordpress_sec=comuser%7C1679587881%7CZ6LgnUJJBPmwh8TjZSh7FbgQ1Klr70r2sIDfGQLMlMY%7Cc5577c02994f8e5ed884548e6ff344b7a0147607959598ab0adf7128272780c6; expires=Fri, 24 Mar 2023 19:58:01 GMT;path=/wp-admin; domain=.wordpress.com; secure; HttpOnly"
 
-    var dotComAuthenticator: WebViewAuthenticator {
-        return WebViewAuthenticator(credentials: .dotCom(username: dotComUser, authToken: dotComToken, authenticationType: .regular))
+    var dotComAuthenticator: RequestAuthenticator {
+        return RequestAuthenticator(credentials: .dotCom(username: dotComUser, authToken: dotComToken, authenticationType: .regular))
     }
 
-    var siteAuthenticator: WebViewAuthenticator {
-        return WebViewAuthenticator(
+    var siteAuthenticator: RequestAuthenticator {
+        return RequestAuthenticator(
             credentials: .siteLogin(loginURL: siteLoginURL, username: siteUser, password: sitePassword))
     }
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/wordpress-mobile/WordPress-iOS/pull/13712
It moves forward #13571 

It renames the class to a more fitting name (since it's no longer specific to web views).  It also updates the documentation which was outdated.

## Testing:

There's no need to test as there haven't been changes to the code, but the test scenarios from the PR linked above would be good for validation.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
