### PR TITLE
Change to a Stack View for Notifications Header

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -32,10 +32,6 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     ///
     @IBOutlet var inlinePromptView: AppFeedbackPromptView!
 
-    /// Ensures the segmented control is below the feedback prompt
-    ///
-    @IBOutlet var inlinePromptSpaceConstraint: NSLayoutConstraint!
-
     /// TableView Handler: Our commander in chief!
     ///
     fileprivate var tableViewHandler: WPTableViewHandler!
@@ -110,17 +106,16 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableHeaderView.translatesAutoresizingMaskIntoConstraints = false
-
         setupNavigationBar()
         setupTableView()
         setupTableFooterView()
-        layoutHeaderIfNeeded()
-        setupConstraints()
         setupTableHandler()
         setupRefreshControl()
         setupNoResultsView()
         setupFilterBar()
+
+        tableView.tableHeaderView = tableHeaderView
+        setupConstraints()
 
         reloadTableViewPreservingSelection()
     }
@@ -174,6 +169,13 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         registerUserActivity()
 
         markWelcomeNotificationAsSeenIfNeeded()
+
+        if shouldShowPrimeForPush {
+            setupNotificationPrompt()
+        } else if AppRatingUtility.shared.shouldPromptForAppReview(section: InlinePrompt.section) {
+            setupAppRatings()
+            self.showInlinePrompt()
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -188,17 +190,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        layoutHeaderIfNeeded()
-    }
-
-    private func layoutHeaderIfNeeded() {
-        precondition(tableHeaderView != nil)
-        tableHeaderView.setNeedsLayout()
-        tableHeaderView.layoutIfNeeded()
-
-        // We reassign the tableHeaderView to force the UI to refresh. Yes, really.
-        tableView.tableHeaderView = tableHeaderView
-        tableView.setNeedsLayout()
+        tableView.layoutHeaderView()
     }
 
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
@@ -469,10 +461,7 @@ private extension NotificationsViewController {
     }
 
     func setupConstraints() {
-        precondition(inlinePromptSpaceConstraint != nil)
-
         // Inline prompt is initially hidden!
-        tableHeaderView.translatesAutoresizingMaskIntoConstraints = false
         inlinePromptView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
@@ -512,17 +501,7 @@ private extension NotificationsViewController {
 
         inlinePromptView.alpha = WPAlphaZero
 
-        // this allows the selector to move to the top
-        inlinePromptSpaceConstraint.isActive = false
-
-        if shouldShowPrimeForPush {
-            setupNotificationPrompt()
-        } else if AppRatingUtility.shared.shouldPromptForAppReview(section: InlinePrompt.section) {
-            setupAppRatings()
-            showInlinePrompt()
-        }
-
-        layoutHeaderIfNeeded()
+        inlinePromptView.isHidden = true
     }
 
     func setupRefreshControl() {
@@ -1305,26 +1284,24 @@ internal extension NotificationsViewController {
             return
         }
 
-        // allows the inline prompt to push the selector down
-        inlinePromptSpaceConstraint.isActive = true
+        UIView.animate(withDuration: WPAnimationDurationDefault, delay: 0, options: .curveEaseIn, animations: {
+            self.inlinePromptView.isHidden = false
+        })
 
-        // Layout immediately the TableHeaderView. Otherwise we'll see a seriously uncool Buttons Resizing animation.
-        tableHeaderView.layoutIfNeeded()
-
-        UIView.animate(withDuration: WPAnimationDurationDefault, delay: InlinePrompt.animationDelay, options: .curveEaseIn, animations: {
+        UIView.animate(withDuration: WPAnimationDurationDefault * 0.5, delay: WPAnimationDurationDefault * 0.75, options: .curveEaseIn, animations: {
             self.inlinePromptView.alpha = WPAlphaFull
-            self.layoutHeaderIfNeeded()
         })
 
         WPAnalytics.track(.appReviewsSawPrompt)
     }
 
     func hideInlinePrompt(delay: TimeInterval) {
-        inlinePromptSpaceConstraint.isActive = false
-
-        UIView.animate(withDuration: WPAnimationDurationDefault, delay: delay, animations: {
+        UIView.animate(withDuration: WPAnimationDurationDefault * 0.75, delay: delay, animations: {
             self.inlinePromptView.alpha = WPAlphaZero
-            self.layoutHeaderIfNeeded()
+        })
+
+        UIView.animate(withDuration: WPAnimationDurationDefault, delay: delay + WPAnimationDurationDefault * 0.5, animations: {
+            self.inlinePromptView.isHidden = true
         })
     }
 }
@@ -1645,6 +1622,5 @@ private extension NotificationsViewController {
 
     enum InlinePrompt {
         static let section = "notifications"
-        static let animationDelay = TimeInterval(0.5)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="doV-5W-Rtg">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="doV-5W-Rtg">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,54 +22,41 @@
                         </connections>
                     </tableView>
                     <connections>
-                        <outlet property="filterTabBar" destination="LBU-zb-iai" id="qqB-Tp-xXt"/>
-                        <outlet property="inlinePromptSpaceConstraint" destination="MBK-Ez-h7B" id="NJj-XL-4AG"/>
-                        <outlet property="inlinePromptView" destination="ZnY-3K-upT" id="lUG-fd-Stc"/>
-                        <outlet property="tableHeaderView" destination="Uvo-9e-l6I" id="dxx-mK-msp"/>
+                        <outlet property="filterTabBar" destination="p6x-Ny-2wu" id="Wui-ck-Vlw"/>
+                        <outlet property="inlinePromptView" destination="SZM-LE-bID" id="ovr-0R-gdo"/>
+                        <outlet property="tableHeaderView" destination="V09-JZ-6RQ" id="ga5-UG-6nB"/>
                         <segue destination="veA-Pg-QAw" kind="showDetail" identifier="NotificationDetailsViewController" id="qci-jy-59F"/>
                     </connections>
                 </tableViewController>
-                <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" id="Uvo-9e-l6I" userLabel="Header View">
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" id="V09-JZ-6RQ">
                     <rect key="frame" x="0.0" y="0.0" width="600" height="144"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZnY-3K-upT" userLabel="Ratings View" customClass="AppFeedbackPromptView" customModule="WordPress" customModuleProvider="target">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SZM-LE-bID" userLabel="Ratings View" customClass="AppFeedbackPromptView" customModule="WordPress" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="600" height="100"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="100" placeholder="YES" id="R1T-Iv-5Q8"/>
+                                <constraint firstAttribute="height" constant="100" placeholder="YES" id="bWv-aJ-fgb"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pEF-oN-cih" userLabel="Filters View">
+                        <view contentMode="scaleToFill" ambiguous="YES" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CJY-eS-kF1" userLabel="Filters View">
                             <rect key="frame" x="0.0" y="100" width="600" height="44"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LBU-zb-iai" customClass="FilterTabBar" customModule="WordPress" customModuleProvider="target">
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p6x-Ny-2wu" customClass="FilterTabBar" customModule="WordPress" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </view>
                             </subviews>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
-                                <constraint firstAttribute="bottom" secondItem="LBU-zb-iai" secondAttribute="bottom" id="6uy-tW-55g"/>
-                                <constraint firstItem="LBU-zb-iai" firstAttribute="leading" secondItem="pEF-oN-cih" secondAttribute="leading" priority="999" id="9sh-kF-RQv"/>
-                                <constraint firstItem="LBU-zb-iai" firstAttribute="top" secondItem="pEF-oN-cih" secondAttribute="top" id="Ib2-7V-nPZ"/>
-                                <constraint firstAttribute="trailing" secondItem="LBU-zb-iai" secondAttribute="trailing" priority="999" id="Zhl-Rn-WR6"/>
+                                <constraint firstItem="p6x-Ny-2wu" firstAttribute="leading" secondItem="CJY-eS-kF1" secondAttribute="leading" priority="999" id="AdC-UY-iyo"/>
+                                <constraint firstItem="p6x-Ny-2wu" firstAttribute="top" secondItem="CJY-eS-kF1" secondAttribute="top" id="Omd-d3-Vhm"/>
+                                <constraint firstAttribute="trailing" secondItem="p6x-Ny-2wu" secondAttribute="trailing" priority="999" id="ZrZ-W6-sPC"/>
+                                <constraint firstAttribute="bottom" secondItem="p6x-Ny-2wu" secondAttribute="bottom" id="wg2-sw-4xq"/>
                             </constraints>
                         </view>
                     </subviews>
-                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstItem="pEF-oN-cih" firstAttribute="leading" secondItem="Uvo-9e-l6I" secondAttribute="leading" priority="999" identifier="FiltersLeading" id="0TE-M7-WfE"/>
-                        <constraint firstAttribute="trailing" secondItem="pEF-oN-cih" secondAttribute="trailing" priority="999" identifier="FiltersTrailing" id="222-MX-igM"/>
-                        <constraint firstItem="ZnY-3K-upT" firstAttribute="leading" secondItem="Uvo-9e-l6I" secondAttribute="leading" priority="999" identifier="RatingsLeading" id="27p-cV-siE"/>
-                        <constraint firstItem="pEF-oN-cih" firstAttribute="top" secondItem="ZnY-3K-upT" secondAttribute="bottom" identifier="FiltersTop" id="MBK-Ez-h7B"/>
-                        <constraint firstItem="ZnY-3K-upT" firstAttribute="top" secondItem="Uvo-9e-l6I" secondAttribute="top" priority="750" identifier="RatingsTop" id="SJu-PU-nzt"/>
-                        <constraint firstAttribute="trailing" secondItem="ZnY-3K-upT" secondAttribute="trailing" priority="999" identifier="RatingsTrailing" id="b8L-0Q-JCB"/>
-                        <constraint firstItem="pEF-oN-cih" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Uvo-9e-l6I" secondAttribute="top" id="iOI-vG-EsO"/>
-                        <constraint firstItem="pEF-oN-cih" firstAttribute="centerX" secondItem="Uvo-9e-l6I" secondAttribute="centerX" identifier="FiltersCenter" id="rGu-9k-JxJ"/>
-                        <constraint firstAttribute="bottom" secondItem="pEF-oN-cih" secondAttribute="bottom" identifier="FiltersBottom" id="zwD-z0-d6i"/>
-                    </constraints>
-                </view>
+                </stackView>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="9wK-eg-RBm" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="700" y="-1061"/>
@@ -85,11 +70,11 @@
                         <viewControllerLayoutGuide type="bottom" id="6LW-NS-qSh"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="lvM-1n-Dgf">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="t2r-NP-ili">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                                 <subviews>
                                     <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Dcn-Il-AtN" customClass="IntrinsicTableView" customModule="WordPress">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>


### PR DESCRIPTION
🙏 @Gio2018 for pointing this out and noticing the layout loop.

- Use a UIStackView for the Notifications header so the view can just be hidden for collapse instead of manipulating a constraint.
- Remove the unnecessary layout calls
- Tweaks to the animations for hiding the prompt and showing the prompt

Fixes #13744 

| Before | After |
|--|--|
| <a href="https://user-images.githubusercontent.com/3250/77853965-8f3df900-71a4-11ea-9367-09d0d53fb6c1.gif"><img src="https://user-images.githubusercontent.com/3250/77853965-8f3df900-71a4-11ea-9367-09d0d53fb6c1.gif" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/77853972-995ff780-71a4-11ea-9255-6102911c2645.gif"><img src="https://user-images.githubusercontent.com/3250/77853972-995ff780-71a4-11ea-9255-6102911c2645.gif" width="300"></a> |

To test:
- Open Notifications tab and check animation of header
- Rotate while on (or after visiting) the tab to landscape and ensure you don't see the layout loop causing #13744

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ This has not shipped.
