### PR TITLE
Extract post visibility selection

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1034,59 +1034,10 @@ FeaturedImageViewControllerDelegate>
 
 - (void)showPostVisibilitySelector
 {
-    NSArray *titles = @[
-                        NSLocalizedString(@"Public", @"Privacy setting for posts set to 'Public' (default). Should be the same as in core WP."),
-                        NSLocalizedString(@"Password protected", @"Privacy setting for posts set to 'Password protected'. Should be the same as in core WP."),
-                        NSLocalizedString(@"Private", @"Privacy setting for posts set to 'Private'. Should be the same as in core WP.")
-                        ];
-    NSDictionary *visiblityDict = @{
-                                    @"DefaultValue": NSLocalizedString(@"Public", @"Privacy setting for posts set to 'Public' (default). Should be the same as in core WP."),
-                                    @"Title" : NSLocalizedString(@"Visibility", nil),
-                                    @"Titles" : titles,
-                                    @"Values" : titles,
-                                    @"CurrentValue" : [self titleForVisibility]};
-    SettingsSelectionViewController *vc = [[SettingsSelectionViewController alloc] initWithDictionary:visiblityDict];
-    __weak SettingsSelectionViewController *weakVc = vc;
-    vc.onItemSelected = ^(NSString *visibility) {
+    PostVisibilitySelectorViewController *vc = [[PostVisibilitySelectorViewController alloc] init:self.apost];
+    __weak PostVisibilitySelectorViewController *weakVc = vc;
+    vc.completion = ^{
         [weakVc dismiss];
-        
-        NSAssert(self.apost != nil, @"The post should not be nil here.");
-        NSAssert(!self.apost.isFault, @"The post should not be a fault here here.");
-        NSAssert(self.apost.managedObjectContext != nil, @"The post's MOC should not be nil here.");
-
-        if ([visibility isEqualToString:NSLocalizedString(@"Private", @"Post privacy status in the Post Editor/Settings area (compare with WP core translations).")]) {
-            self.apost.status = PostStatusPrivate;
-            self.apost.password = nil;
-        } else {
-            if ([self.apost.status isEqualToString:PostStatusPrivate]) {
-                if ([self.apost.original.status isEqualToString:PostStatusPrivate]) {
-                    self.apost.status = PostStatusPublish;
-                } else {
-                    // restore the original status
-                    self.apost.status = self.apost.original.status;
-                }
-            }
-            if ([visibility isEqualToString:NSLocalizedString(@"Password protected", @"Post password protection in the Post Editor/Settings area (compare with WP core translations).")]) {
-                
-                NSString *password = @"";
-                
-                NSAssert(self.apost.original != nil,
-                         @"We're expecting to have a reference to the original post here.");
-                NSAssert(!self.apost.original.isFault,
-                         @"The original post should not be a fault here here.");
-                NSAssert(self.apost.original.managedObjectContext != nil,
-                         @"The original post's MOC should not be nil here.");
-                
-                if (self.apost.original.password) {
-                    // restore the original password
-                    password = self.apost.original.password;
-                }
-                self.apost.password = password;
-            } else {
-                self.apost.password = nil;
-            }
-        }
-
         [self.tableView reloadData];
     };
     [self.navigationController pushViewController:vc animated:YES];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -671,7 +671,7 @@ FeaturedImageViewControllerDelegate>
         // Visibility
         cell = [self getWPTableViewDisclosureCell];
         cell.textLabel.text = NSLocalizedString(@"Visibility", @"The visibility settings of the post. Should be the same as in core WP.");
-        cell.detailTextLabel.text = [self titleForVisibility];
+        cell.detailTextLabel.text = [self.apost titleForVisibility];
         cell.tag = PostSettingsRowVisibility;
         cell.accessibilityIdentifier = @"Visibility";
 
@@ -1279,17 +1279,6 @@ FeaturedImageViewControllerDelegate>
     DDLogError(@"Error loading featured image: %@", error);
     UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
     cell.textLabel.text = NSLocalizedString(@"Featured Image did not load", @"");
-}
-
-- (NSString *)titleForVisibility
-{
-    if (self.apost.password) {
-        return NSLocalizedString(@"Password protected", @"Privacy setting for posts set to 'Password protected'. Should be the same as in core WP.");
-    } else if ([self.apost.status isEqualToString:PostStatusPrivate]) {
-        return NSLocalizedString(@"Private", @"Privacy setting for posts set to 'Private'. Should be the same as in core WP.");
-    }
-
-    return NSLocalizedString(@"Public", @"Privacy setting for posts set to 'Public' (default). Should be the same as in core WP.");
 }
 
 - (NoResultsViewController *)noResultsView

--- a/WordPress/Classes/ViewRelated/Post/PostVisibilitySelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostVisibilitySelectorViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 
         let visiblityDict: [AnyHashable: Any] = [
             "DefaultValue": NSLocalizedString("Public", comment: "Privacy setting for posts set to 'Public' (default). Should be the same as in core WP."),
-            "Title": NSLocalizedString("Visibility", comment: ""),
+            "Title": NSLocalizedString("Visibility", comment: "Visibility label"),
             "Titles": titles,
             "Values": titles,
             "CurrentValue": post.titleForVisibility
@@ -75,7 +75,7 @@ import UIKit
         fatalError("init(coder:) has not been implemented")
     }
 
-    override init!(style: UITableView.Style, andDictionary dictionary: [AnyHashable : Any]!) {
+    override init!(style: UITableView.Style, andDictionary dictionary: [AnyHashable: Any]!) {
         super.init(style: style, andDictionary: dictionary)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostVisibilitySelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostVisibilitySelectorViewController.swift
@@ -86,12 +86,12 @@ import UIKit
 
 // MARK: - Abstract Post private extension
 
-private extension AbstractPost {
+extension AbstractPost {
     static let passwordProtectedLabel = NSLocalizedString("Password protected", comment: "Privacy setting for posts set to 'Password protected'. Should be the same as in core WP.")
     static let privateLabel = NSLocalizedString("Private", comment: "Privacy setting for posts set to 'Private'. Should be the same as in core WP.")
     static let publicLabel = NSLocalizedString("Public", comment: "Privacy setting for posts set to 'Public' (default). Should be the same as in core WP.")
 
-    var titleForVisibility: String {
+    @objc var titleForVisibility: String {
         if password != nil {
             return AbstractPost.passwordProtectedLabel
         } else if status == .publishPrivate {

--- a/WordPress/Classes/ViewRelated/Post/PostVisibilitySelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostVisibilitySelectorViewController.swift
@@ -1,0 +1,103 @@
+import UIKit
+
+@objc class PostVisibilitySelectorViewController: SettingsSelectionViewController {
+    /// The post to change the visibility
+    private var post: AbstractPost!
+
+    /// A completion block that is called after the user select an option
+    @objc var completion: (() -> Void)?
+
+    // MARK: - Constructors
+
+    @objc init(_ post: AbstractPost) {
+        self.post = post
+
+        let titles: NSArray = [
+            NSLocalizedString("Public", comment: "Privacy setting for posts set to 'Public' (default). Should be the same as in core WP."),
+            NSLocalizedString("Password protected", comment: "Privacy setting for posts set to 'Password protected'. Should be the same as in core WP."),
+            NSLocalizedString("Private", comment: "Privacy setting for posts set to 'Private'. Should be the same as in core WP.")
+        ]
+
+        let visiblityDict: [AnyHashable: Any] = [
+            "DefaultValue": NSLocalizedString("Public", comment: "Privacy setting for posts set to 'Public' (default). Should be the same as in core WP."),
+            "Title": NSLocalizedString("Visibility", comment: ""),
+            "Titles": titles,
+            "Values": titles,
+            "CurrentValue": post.titleForVisibility
+        ]
+
+        super.init(dictionary: visiblityDict)
+
+        onItemSelected = { visibility in
+            guard let visibility = visibility as? String,
+                !post.isFault, post.managedObjectContext != nil else {
+                return
+            }
+
+            if visibility == AbstractPost.privateLabel {
+                post.status = .publishPrivate
+                post.password = nil
+            } else {
+                if post.status == .publishPrivate {
+                    if post.original?.status == .publishPrivate {
+                        post.status = .publish
+                    } else {
+                        // restore the original status
+                        post.status = post.original?.status
+                    }
+                }
+
+                if visibility == AbstractPost.passwordProtectedLabel {
+                    var password = ""
+
+                    assert(post.original != nil,
+                           "We're expecting to have a reference to the original post here.")
+                    assert(!post.original!.isFault,
+                           "We're expecting to have a reference to the original post here.")
+                    assert(post.original!.managedObjectContext != nil,
+                           "The original post's MOC should not be nil here.")
+
+                    if let originalPassword = post.original?.password {
+                        password = originalPassword
+                    }
+                    post.password = password
+                } else {
+                    post.password = nil
+                }
+            }
+
+            self.completion?()
+
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override init!(style: UITableView.Style, andDictionary dictionary: [AnyHashable : Any]!) {
+        super.init(style: style, andDictionary: dictionary)
+    }
+
+    override init(style: UITableView.Style) {
+        super.init(style: style)
+    }
+}
+
+// MARK: - Abstract Post private extension
+
+private extension AbstractPost {
+    static let passwordProtectedLabel = NSLocalizedString("Password protected", comment: "Privacy setting for posts set to 'Password protected'. Should be the same as in core WP.")
+    static let privateLabel = NSLocalizedString("Private", comment: "Privacy setting for posts set to 'Private'. Should be the same as in core WP.")
+    static let publicLabel = NSLocalizedString("Public", comment: "Privacy setting for posts set to 'Public' (default). Should be the same as in core WP.")
+
+    var titleForVisibility: String {
+        if password != nil {
+            return AbstractPost.passwordProtectedLabel
+        } else if status == .publishPrivate {
+            return AbstractPost.privateLabel
+        }
+
+        return AbstractPost.publicLabel
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
@@ -65,7 +65,7 @@ class PrepublishingHeaderView: UIView, NibLoadable {
 
     private func configureBackButton() {
         backButtonView.isHidden = true
-        backButton.setImage(Gridicon.iconOfType(.chevronLeft, withSize: Constants.backButtonSize), for: .normal)
+        backButton.setImage(.gridicon(.chevronLeft, size: Constants.backButtonSize), for: .normal)
     }
 
     private func configurePublishingToLabel() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1064,6 +1064,7 @@
 		8B939F4323832E5D00ACCB0F /* PostListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B939F4223832E5D00ACCB0F /* PostListViewControllerTests.swift */; };
 		8BAD272C241FEF3300E9D105 /* PrepublishingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */; };
 		8BAD53D6241922B900230F4B /* WPAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD53D5241922B900230F4B /* WPAnalyticsEvent.swift */; };
+		8BB2768424323A94002D2BEC /* PostVisibilitySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB2768324323A94002D2BEC /* PostVisibilitySelectorViewController.swift */; };
 		8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */; };
 		8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */; };
 		8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */; };
@@ -3462,6 +3463,7 @@
 		8B939F4223832E5D00ACCB0F /* PostListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListViewControllerTests.swift; sourceTree = "<group>"; };
 		8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingViewController.swift; sourceTree = "<group>"; };
 		8BAD53D5241922B900230F4B /* WPAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAnalyticsEvent.swift; sourceTree = "<group>"; };
+		8BB2768324323A94002D2BEC /* PostVisibilitySelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostVisibilitySelectorViewController.swift; sourceTree = "<group>"; };
 		8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorTests.swift; sourceTree = "<group>"; };
 		8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeeded.swift"; sourceTree = "<group>"; };
 		8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeededTests.swift"; sourceTree = "<group>"; };
@@ -8404,6 +8406,7 @@
 				FFEECFFB2084DE2B009B8CDB /* PostSettingsViewController+FeaturedImageUpload.swift */,
 				593F26601CAB00CA00F14073 /* PostSharingController.swift */,
 				E155EC711E9B7DCE009D7F63 /* PostTagPickerViewController.swift */,
+				8BB2768324323A94002D2BEC /* PostVisibilitySelectorViewController.swift */,
 				8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */,
 				5D17F0BC1A1D4C5F0087CCB8 /* PrivateSiteURLProtocol.h */,
 				5D17F0BD1A1D4C5F0087CCB8 /* PrivateSiteURLProtocol.m */,
@@ -12815,6 +12818,7 @@
 				988AC37522F10DD900BC1433 /* FileDownloadsStatsRecordValue+CoreDataProperties.swift in Sources */,
 				E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */,
 				436D55DF210F866900CEAA33 /* StoryboardLoadable.swift in Sources */,
+				8BB2768424323A94002D2BEC /* PostVisibilitySelectorViewController.swift in Sources */,
 				D8212CC320AA7F57008E8AE8 /* ReaderBlockSiteAction.swift in Sources */,
 				5D44EB381986D8BA008B7175 /* ReaderSiteService.m in Sources */,
 				B518E1651CCAA19200ADFE75 /* Blog+Capabilities.swift in Sources */,


### PR DESCRIPTION
This is a refactor to allow the Post Visibility selection View Controller to be used in other parts (Nudges View, I'm looking at you).

### To test

1. Create a new post
2. Go to Settings
3. Change the visibility

The post should be published with the visibility you specified.
