### PR TITLE
Ensure non-null Blog url before search

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Notifications: Fix layout on screens with a notch.
 * Post Commenting: fixed issue that prevented selecting an @ mention suggestion.
 * Site Creation: faster site creation, removed intermediate steps. Just select what kind of site you'd like, enter the domain name and the site will be created.
+* Fixed a crash when a blog's URL became `nil` from a Core Data operation.
 
  
 14.5

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -148,6 +148,7 @@ NSString * const OptionsKeyIsAtomic = @"is_wpcom_atomic";
 - (NSString *)displayURL
 {
     if (self.url == nil) {
+        DDLogInfo(@"Blog display URL is nil");
         return nil;
     }
     

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -147,6 +147,10 @@ NSString * const OptionsKeyIsAtomic = @"is_wpcom_atomic";
 // Used as a key to store passwords, if you change the algorithm, logins will break
 - (NSString *)displayURL
 {
+    if (self.url == nil) {
+        return nil;
+    }
+    
     NSError *error = nil;
     NSRegularExpression *protocol = [NSRegularExpression regularExpressionWithPattern:@"http(s?)://" options:NSRegularExpressionCaseInsensitive error:&error];
     NSString *result = [NSString stringWithFormat:@"%@", [protocol stringByReplacingMatchesInString:self.url options:0 range:NSMakeRange(0, [self.url length]) withTemplate:@""]];


### PR DESCRIPTION
Fixes #13742

To test:
- Ensure that the display URL is shown in the list of Blogs and Blog Details screens.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
