### PR TITLE
Add Gutenberg specific checks to Code Freeze

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -65,6 +65,7 @@ import "./ScreenshotFastfile"
   #####################################################################################
   desc "Creates a new release branch from the current develop"
   lane :code_freeze do | options |
+    gutenberg_dep_check()
     old_version = ios_codefreeze_prechecks(options)
     
     ios_bump_version_release()
@@ -490,4 +491,23 @@ import "./ScreenshotFastfile"
     get_prs_list(repository:GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/wpios_prs_list.txt")
   end
 
+  desc "Verifies that Gutenberg is referenced by release version and not by commit"
+  lane :gutenberg_dep_check do | options |
+    res = ''
+    
+    File.open '../../Podfile' do |file|
+      res = file.find { |line| line =~ /^(?!\s*#)(?=.*\bgutenberg\b).*(\bcommit|tag\b){1}.+/ }
+    end
+
+    UI.user_error!("Can't find any reference to Gutenberg!") unless (res.length != 0)
+    if res.include?("commit")
+      UI.user_error!("Gutenberg referenced by commit!\n#{res}") unless UI.interactive? 
+      
+      if (!UI.confirm("Gutenberg referenced by commit!\n#{res}\nDo you want to continue anyway?"))
+        UI.user_error!("Aborted by user request. Please fix Gutenberg reference and try again.")
+      end  
+    end
+    
+    UI.message("Gutenberg version: #{(res.scan(/'([^']*)'/))[0][0]}")
+  end
 end


### PR DESCRIPTION
This PR adds a step to the `code_freeze` lane that checks that mobile Gutenberg is referenced by version number and not by commit hash. 
If a reference by commit hash is found, the script fails on CI and ask the user if they want to continue or stop on local environments.

### To test:
1. Verify that Gutenberg is referenced by version in the `Podfile`.
2. Run `bundle exec fastlane code_freeze` and verify that the script shows a prompt with its proposal for the next version number. **Abort** the execution.
3. Edit the `Podfile` so that Gutenberg is referenced by commit hash.
4. Run `bundle exec fastlane code_freeze` and verify that the script shows a prompt about the Gutenberg reference and asks what to do. Agree to continue and verify that the script shows a prompt with its proposal for the next version number. **Abort** the execution.
5. Run `bundle exec fastlane code_freeze` and verify that the script shows a prompt about the Gutenberg reference and asks what to do. Respond `no` and verify that the script is aborted.

**Note:** I'm adding multiple reviewers to make sure this is reviewed and merged before the next code freeze. The script is simple and just one review should be enough. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
