### PR TITLE
Enable Me and Floating Create button for internal builds

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -30,9 +30,9 @@ enum FeatureFlag: Int, CaseIterable {
         case .quickActions:
             return true
         case .meMove:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .floatingCreateButton:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .newReaderNavigation:
             return false
         }


### PR DESCRIPTION
Enabling internal flag for #13320
Enabling internal flag for #13319

To test:
- Open app and notice removal of New Post and Me button from the tab bar
- Create FAB button should be visible in the bottom right when on the Blog Details screen
- Me button should be visible in the Navigation Bar when on the Blog Details screen

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Should this be added when we turn on for App Store or can we go ahead and add for internal testers?
