### PR TITLE
Testing: Make UI tests optional on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   # Using 1.0 of the Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
   ios: wordpress-mobile/ios@1.0
   git: wordpress-mobile/git@1.0
+  slack: circleci/slack@3.4.2
 
 commands:
   fix-path:
@@ -71,6 +72,10 @@ jobs:
     parameters:
       device:
         type: string
+      post-to-slack:
+        description: Post to Slack when tests fail. SLACK_WEBHOOK ENV variable must be set.
+        type: boolean
+        default: false
     executor:
       name: ios/default
       xcode-version: "11.2.1"
@@ -91,6 +96,19 @@ jobs:
           arguments: -xctestrun DerivedData/Build/Products/WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" -resultBundlePath test-without-building.xcresult
       - ios/save-xcodebuild-artifacts
       - save-xcresult
+      - when:
+          condition: << parameters.post-to-slack >>
+          steps:
+            - run:
+                name: Prepare Slack message
+                when: always
+                command: |
+                  # Get the name of the device that is running. Using "<< parameters.device >>" can cause slack formatting errors.
+                  DEVICE_NAME=$(xcrun simctl list -j | jq -r --arg UDID $SIMULATOR_UDID '.devices[] | .[] | select(.udid == "\($UDID)") | .name')
+                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: WordPress iOS UI tests failed on ${DEVICE_NAME} in \`${CIRCLE_BRANCH}\` branch by ${CIRCLE_USERNAME}.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'" >> $BASH_ENV
+            - slack/status:
+                fail_only: true
+                failure_message: '${SLACK_FAILURE_MESSAGE}'
   Installable Build:
     executor:
       name: ios/default
@@ -149,6 +167,39 @@ workflows:
       - Build Tests
       - Unit Tests:
           requires: [ "Build Tests" ]
+      # Always run UI tests on develop and release branches
+      - UI Tests:
+          name: UI Tests (iPhone 11)
+          device: iPhone 11
+          post-to-slack: true
+          requires: [ "Build Tests" ]
+          filters:
+            branches:
+              only:
+                - develop
+                - /^release.*/
+      - UI Tests:
+          name: UI Tests (iPad Air 3rd generation)
+          device: iPad Air \\(3rd generation\\)
+          post-to-slack: true
+          requires: [ "Build Tests" ]
+          filters:
+            branches:
+              only:
+                - develop
+                - /^release.*/
+  Optional Tests:
+    #Optionally run UI tests on PRs
+    jobs:
+      - Hold:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - develop
+                - /^release.*/
+      - Build Tests:
+          requires: [Hold]
       - UI Tests:
           name: UI Tests (iPhone 11)
           device: iPhone 11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,26 +188,23 @@ workflows:
               only:
                 - develop
                 - /^release.*/
-  Optional Tests:
-    #Optionally run UI tests on PRs
-    jobs:
-      - Hold:
+      #Optionally run UI tests on PRs
+      - Optional Tests:
           type: approval
+          requires: [ "Build Tests" ]
           filters:
             branches:
               ignore:
                 - develop
                 - /^release.*/
-      - Build Tests:
-          requires: [Hold]
       - UI Tests:
           name: UI Tests (iPhone 11)
           device: iPhone 11
-          requires: [ "Build Tests" ]
+          requires: [ "Optional Tests" ]
       - UI Tests:
           name: UI Tests (iPad Air 3rd generation)
           device: iPad Air \\(3rd generation\\)
-          requires: [ "Build Tests" ]
+          requires: [ "Optional Tests" ]
   Installable Build:
     jobs:
       - Hold:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,8 @@ jobs:
                   echo "export SLACK_FAILURE_MESSAGE=':red_circle: WordPress iOS UI tests failed on ${DEVICE_NAME} in \`${CIRCLE_BRANCH}\` branch by ${CIRCLE_USERNAME}.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'" >> $BASH_ENV
             - slack/status:
                 fail_only: true
+                include_job_number_field: false
+                include_project_field: false
                 failure_message: '${SLACK_FAILURE_MESSAGE}'
   Installable Build:
     executor:


### PR DESCRIPTION
This change sets up a CircleCI workflow to optionally run UI tests on PRs. This is the iOS equivalent of these Android changes:

* https://github.com/wordpress-mobile/WordPress-Android/pull/11495
* https://github.com/wordpress-mobile/WordPress-Android/pull/11535
* https://github.com/wordpress-mobile/WordPress-Android/pull/11575

Here's an overview of the changes:
* UI tests continue to run automatically on the `develop` and `release/*` branches. When a test fails on one of these branches, a Slack notification will be posted in `#ios-osx-dev` similar to this:
<img width="453" alt="Screenshot 2020-04-01 17 53 45" src="https://user-images.githubusercontent.com/8658164/78165588-72732100-7443-11ea-964b-07a84589f7a7.png">

* On PRs, UI tests will only run on PRs when the `Optional Tests` job is manually approved on CircleCI. (Peril will be set up to force the `Optional Tests` check to have a `success` status on the PR, so you can ignore it if you don't want to run the tests.)
* Peril comments on the PR with a link to the workflow on CircleCI. To run the tests, you can approve the `Optional Tests` job on CircleCI and the UI test results will be posted on the PR.
* Any new commits to the PR will trigger the Peril comment to be updated with the current link to run the UI tests.

To test:

* Confirm the Slack notification message and config look ok.
* Confirm you see a `ci/circleci: wordpress_ios/Optional Tests` check on this PR with a `success` status.
* Confirm you see a Peril comment on this PR that says, "You can trigger optional UI/connected tests for these changes by visiting CircleCI here."
* Confirm the text "here" is a link to the workflow with an `Optional Tests` job on hold on CircleCI. On CircleCI, confirm you can manually approve it to start the UI tests.
* Confirm that when the UI tests finish, the test results are posted as additional checks on the PR.

**Note:** The equivalent changes on Android also added automatic retries for failed test runs. I haven't added those here, since the setup isn't as straightforward. We'll add retries in a followup PR.