### PR TITLE
Stats Period: light/dark mode ghost colors 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * Fixed an issue that could have caused the app to crash when accessing Site Pages.
 * Site Creation: faster site creation, removed intermediate steps. Just select what kind of site you'd like, enter the domain name and the site will be created.
 * Fixed a crash when a blog's URL became `nil` from a Core Data operation.
+* Period Stats: fix colors when switching between light and dark modes.
 
  
 14.5

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -68,6 +68,12 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
         applyStyles()
     }
 
+    override func tintColorDidChange() {
+        super.tintColorDidChange()
+        // Restart animation when toggling light/dark mode so colors are updated.
+        restartGhostAnimation(style: GhostCellStyle.muriel)
+    }
+
     func configure(date: Date?,
                    period: StatsPeriodUnit?,
                    delegate: SiteStatsTableHeaderDelegate,

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostCells.swift
@@ -9,6 +9,12 @@ class StatsGhostBaseCell: UITableViewCell {
         setupBorders()
     }
 
+    override func tintColorDidChange() {
+        super.tintColorDidChange()
+        // Restart animation when toggling light/dark mode so colors are updated.
+        restartGhostAnimation(style: GhostCellStyle.muriel)
+    }
+
     override func prepareForReuse() {
         super.prepareForReuse()
         stopGhostAnimation()


### PR DESCRIPTION
Fixes #13781 

This updates the stats period chart, date bar, and stats ghost cells to re-animate when the appearance changes so the ghost colors are updated.

To test:
- On a slow network, go to Stats > any period (Days, Weeks, Months, Years).
- While the ghost animation is displayed, toggle light/dark modes.
- Verify these ghost colors update accordingly.
  - Date bar. 
  - Chart.
  - Stats rows.


| Before | After |
|--------|-------|
| ![broken](https://user-images.githubusercontent.com/1816888/78191344-08528000-7433-11ea-9aaa-78e8581b5e58.gif) | ![fixed](https://user-images.githubusercontent.com/1816888/78191305-f7a20a00-7432-11ea-80f0-e6154272b8f0.gif) |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
