### PR TITLE
Change iPad Post Preview presentation to fullscreen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * Notifications: Fix layout on screens with a notch.
 * Post Commenting: fixed issue that prevented selecting an @ mention suggestion.
 * Site Creation: faster site creation, removed intermediate steps. Just select what kind of site you'd like, enter the domain name and the site will be created.
+* Post Preview: Increase Post and Page Preview size on iPads running iOS 13.
 
  
 14.5

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -478,7 +478,9 @@ fileprivate extension SearchManager {
         let controller = PreviewWebKitViewController(post: apost)
         controller.trackOpenEvent()
         let navWrapper = LightNavigationController(rootViewController: controller)
-        navWrapper.modalPresentationStyle = .fullScreen
+        if WPTabBarController.sharedInstance()?.traitCollection.userInterfaceIdiom == .pad {
+            navWrapper.modalPresentationStyle = .fullScreen
+        }
         WPTabBarController.sharedInstance().present(navWrapper, animated: true)
 
         openListView(for: apost)

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -478,6 +478,7 @@ fileprivate extension SearchManager {
         let controller = PreviewWebKitViewController(post: apost)
         controller.trackOpenEvent()
         let navWrapper = LightNavigationController(rootViewController: controller)
+        navWrapper.modalPresentationStyle = .fullScreen
         WPTabBarController.sharedInstance().present(navWrapper, animated: true)
 
         openListView(for: apost)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1541,7 +1541,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
 
     UIViewController *webViewController = [WebViewControllerFactory controllerWithUrl:targetURL blog:self.blog];
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
+    LightNavigationController *navController = [[LightNavigationController alloc] initWithRootViewController:webViewController];
+    if (self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+        navController.modalPresentationStyle = UIModalPresentationFullScreen;
+    }
     [self presentViewController:navController animated:YES completion:nil];
 
     [[QuickStartTourGuide find] visited:QuickStartTourElementViewSite];

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -946,6 +946,7 @@ class AbstractPostListViewController: UIViewController,
         // If the button title changes we should also update the title here.
         controller.navigationItem.title = NSLocalizedString("View", comment: "Verb. The screen title shown when viewing a post inside the app.")
         let navWrapper = LightNavigationController(rootViewController: controller)
+        navWrapper.modalPresentationStyle = .fullScreen
         navigationController?.present(navWrapper, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -946,7 +946,9 @@ class AbstractPostListViewController: UIViewController,
         // If the button title changes we should also update the title here.
         controller.navigationItem.title = NSLocalizedString("View", comment: "Verb. The screen title shown when viewing a post inside the app.")
         let navWrapper = LightNavigationController(rootViewController: controller)
-        navWrapper.modalPresentationStyle = .fullScreen
+        if navigationController?.traitCollection.userInterfaceIdiom == .pad {
+            navWrapper.modalPresentationStyle = .fullScreen
+        }
         navigationController?.present(navWrapper, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -239,7 +239,9 @@ class EditPostViewController: UIViewController {
         let controller = PreviewWebKitViewController(post: post)
         controller.trackOpenEvent()
         let navWrapper = LightNavigationController(rootViewController: controller)
-        navWrapper.modalPresentationStyle = .fullScreen
+        if postPost.traitCollection.userInterfaceIdiom == .pad {
+            navWrapper.modalPresentationStyle = .fullScreen
+        }
         postPost.present(navWrapper, animated: true) {}
     }
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -239,6 +239,7 @@ class EditPostViewController: UIViewController {
         let controller = PreviewWebKitViewController(post: post)
         controller.trackOpenEvent()
         let navWrapper = LightNavigationController(rootViewController: controller)
+        navWrapper.modalPresentationStyle = .fullScreen
         postPost.present(navWrapper, animated: true) {}
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -90,6 +90,7 @@ extension PostEditor where Self: UIViewController {
             }
             previewController.trackOpenEvent()
             let navWrapper = LightNavigationController(rootViewController: previewController)
+            navWrapper.modalPresentationStyle = .fullScreen
             self.navigationController?.present(navWrapper, animated: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -90,7 +90,9 @@ extension PostEditor where Self: UIViewController {
             }
             previewController.trackOpenEvent()
             let navWrapper = LightNavigationController(rootViewController: previewController)
-            navWrapper.modalPresentationStyle = .fullScreen
+            if self.navigationController?.traitCollection.userInterfaceIdiom == .pad {
+                navWrapper.modalPresentationStyle = .fullScreen
+            }
             self.navigationController?.present(navWrapper, animated: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeNavigationCoordinator.swift
@@ -27,8 +27,8 @@ class PostNoticeNavigationCoordinator {
         controller.trackOpenEvent()
         controller.navigationItem.title = NSLocalizedString("View", comment: "Verb. The screen title shown when viewing a post inside the app.")
 
-        let navigationController = UINavigationController(rootViewController: controller)
-        navigationController.modalPresentationStyle = .formSheet
+        let navigationController = LightNavigationController(rootViewController: controller)
+        navigationController.modalPresentationStyle = .fullScreen
         presenter.present(navigationController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeNavigationCoordinator.swift
@@ -28,7 +28,9 @@ class PostNoticeNavigationCoordinator {
         controller.navigationItem.title = NSLocalizedString("View", comment: "Verb. The screen title shown when viewing a post inside the app.")
 
         let navigationController = LightNavigationController(rootViewController: controller)
-        navigationController.modalPresentationStyle = .fullScreen
+        if presenter.traitCollection.userInterfaceIdiom == .pad {
+            navigationController.modalPresentationStyle = .fullScreen
+        }
         presenter.present(navigationController, animated: true)
     }
 


### PR DESCRIPTION
Sets the Post Preview to the `.fullScreen` modal presentation style. iOS 13 changes the default modal presentation style for iPads so that the view does not take up the entire screen. We want the full size of the preview to be shown on iPad.

| Before | After |
|--|--|
| <a href="https://user-images.githubusercontent.com/3250/78207730-c25fe100-745f-11ea-9ff5-18667ccf477b.png"><img src="https://user-images.githubusercontent.com/3250/78207730-c25fe100-745f-11ea-9ff5-18667ccf477b.png" width="350"></a> | <a href="https://user-images.githubusercontent.com/3250/78207753-cc81df80-745f-11ea-8b6d-dcbea1e5bfb2.png"><img src="https://user-images.githubusercontent.com/3250/78207753-cc81df80-745f-11ea-8b6d-dcbea1e5bfb2.png" width="350"></a> |



To test:
- Open a Post Preview from the Post List, the Post Published/Updated Notice, Settings inside the editor, or Spotlight
- Open a Page Preview from the Pages List, the Page Published/Updated Notice, Settings inside the editor, or Spotlight

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
