### PR TITLE
Add Share action into post "more" button in the Posts list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * Fixed an issue that could have caused the app to crash when accessing Site Pages.
 * Site Creation: faster site creation, removed intermediate steps. Just select what kind of site you'd like, enter the domain name and the site will be created.
 * Fixed a crash when a blog's URL became `nil` from a Core Data operation.
+* Added Share action to the more menu in the Posts list
 
  
 14.5

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -10,4 +10,5 @@ import Foundation
     func draft(_ post: AbstractPost)
     func retry(_ post: AbstractPost)
     func cancelAutoUpload(_ post: AbstractPost)
+    func share(_ post: AbstractPost, fromView view: UIView)
 }

--- a/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
@@ -68,6 +68,10 @@ class PostActionSheet {
                     actionSheetController.addDefaultActionWithTitle(Titles.edit) { [weak self] _ in
                         self?.interactivePostViewDelegate?.edit(post)
                     }
+                case .share:
+                    actionSheetController.addDefaultActionWithTitle(Titles.share) { [weak self] _ in
+                        self?.interactivePostViewDelegate?.share(post, fromView: view)
+                    }
                 case .more:
                     CrashLogging.logMessage("Cannot handle unexpected button for post action sheet: \(button). This is a configuration error.", level: .error)
                 }
@@ -93,5 +97,6 @@ class PostActionSheet {
         static let view = NSLocalizedString("View", comment: "Label for the view post button. Tapping displays the post as it appears on the web.")
         static let retry = NSLocalizedString("Retry", comment: "Retry uploading the post.")
         static let edit = NSLocalizedString("Edit", comment: "Edit the post.")
+        static let share = NSLocalizedString("Share", comment: "Share the post.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -16,6 +16,7 @@ class PostCardStatusViewModel: NSObject {
         case moveToDraft
         case trash
         case cancelAutoUpload
+        case share
     }
 
     struct ButtonGroups: Equatable {
@@ -177,6 +178,7 @@ class PostCardStatusViewModel: NSObject {
 
             if post.status == .publish && post.hasRemote() {
                 buttons.append(.stats)
+                buttons.append(.share)
             }
 
             if post.status != .draft {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -662,6 +662,15 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         PostCoordinator.shared.cancelAutoUploadOf(post)
     }
 
+    func share(_ apost: AbstractPost, fromView view: UIView) {
+        guard let post = apost as? Post else {
+            return
+        }
+
+        let shareController = PostSharingController()
+        shareController.sharePost(post, fromView: view, inViewController: self)
+    }
+
     // MARK: - Searching
 
     override func updateForLocalPostsMatchingSearchText() {

--- a/WordPress/WordPressTest/PostActionSheetTests.swift
+++ b/WordPress/WordPressTest/PostActionSheetTests.swift
@@ -25,7 +25,7 @@ class PostActionSheetTests: XCTestCase {
         postActionSheet.show(for: viewModel, from: view)
 
         let options = viewControllerMock.viewControllerPresented?.actions.compactMap { $0.title }
-        XCTAssertEqual(["Cancel", "Stats", "Move to Draft", "Move to Trash"], options)
+        XCTAssertEqual(["Cancel", "Stats", "Share", "Move to Draft", "Move to Trash"], options)
     }
 
     func testLocallyPublishedPostShowsCancelAutoUploadOption() {
@@ -70,7 +70,7 @@ class PostActionSheetTests: XCTestCase {
         postActionSheet.show(for: viewModel, from: view, isCompactOrSearching: true)
 
         let options = viewControllerMock.viewControllerPresented?.actions.compactMap { $0.title }
-        XCTAssertEqual(["Cancel", "View", "Stats", "Move to Draft", "Move to Trash"], options)
+        XCTAssertEqual(["Cancel", "View", "Stats", "Share", "Move to Draft", "Move to Trash"], options)
     }
 
     func testCallDelegateWhenStatsTapped() {
@@ -80,6 +80,15 @@ class PostActionSheetTests: XCTestCase {
         tap("Stats", in: viewControllerMock.viewControllerPresented)
 
         XCTAssertTrue(interactivePostViewDelegateMock.didCallHandleStats)
+    }
+
+    func testCallDelegateWhenShareTapped() {
+        let viewModel = PostCardStatusViewModel(post: PostBuilder().published().withRemote().build())
+
+        postActionSheet.show(for: viewModel, from: view)
+        tap("Share", in: viewControllerMock.viewControllerPresented)
+
+        XCTAssertTrue(interactivePostViewDelegateMock.didCallShare)
     }
 
     func testCallDelegateWhenMoveToDraftTapped() {
@@ -168,6 +177,7 @@ class InteractivePostViewDelegateMock: InteractivePostViewDelegate {
     private(set) var didCallView = false
     private(set) var didCallRetry = false
     private(set) var didCallCancelAutoUpload = false
+    private(set) var didCallShare = false
 
     func stats(for post: AbstractPost) {
         didCallHandleStats = true
@@ -203,5 +213,9 @@ class InteractivePostViewDelegateMock: InteractivePostViewDelegate {
 
     func cancelAutoUpload(_ post: AbstractPost) {
         didCallCancelAutoUpload = true
+    }
+
+    func share(_ post: AbstractPost, fromView view: UIView) {
+        didCallShare = true
     }
 }

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -57,12 +57,12 @@ class PostCardStatusViewModelTests: XCTestCase {
             (
                 "Published post",
                 PostBuilder(context).published().withRemote().build(),
-                ButtonGroups(primary: [.edit, .view, .more], secondary: [.stats, .moveToDraft, .trash])
+                ButtonGroups(primary: [.edit, .view, .more], secondary: [.stats, .share, .moveToDraft, .trash])
             ),
             (
                 "Published post with local confirmed changes",
                 PostBuilder(context).published().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build(),
-                ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.stats, .moveToDraft, .trash])
+                ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.stats, .share, .moveToDraft, .trash])
             ),
             (
                 "Post with the max number of auto uploades retry reached",


### PR DESCRIPTION
This PR implements the feature as described in #12314 

To test:

1. Go to Posts -> Published tab
2. Tap *more* button, then select Share
3. The Share activity dialog should show and allow user to share the published Post.
iPhone:
![Simulator Screen Shot - iPhone 11 - 2020-04-02 at 14 19 11](https://user-images.githubusercontent.com/17534738/78207634-f97cd380-74ed-11ea-905b-388bdc0166d8.png)

iPad:
![Simulator Screen Shot - iPad Air (3rd generation) - 2020-04-02 at 14 29 04](https://user-images.githubusercontent.com/17534738/78207783-63957880-74ee-11ea-9313-b581c5542f03.png)
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
