### PR TITLE
Make Post Stats chart difference value grey for current day

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -69,8 +69,8 @@ struct OverviewTabData: FilterTabBarItem {
             StatsPeriodHelper().dateAvailableAfterDate(date, period: period) == false {
             return .neutral(.shade40)
         }
-        return WPStyleGuide.grey()
-        //return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor
+
+        return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor
     }
 
     var title: String {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -69,8 +69,8 @@ struct OverviewTabData: FilterTabBarItem {
             StatsPeriodHelper().dateAvailableAfterDate(date, period: period) == false {
             return .neutral(.shade40)
         }
-
-        return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor
+        return WPStyleGuide.grey()
+        //return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor
     }
 
     var title: String {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -128,8 +128,8 @@ private extension PostStatsViewModel {
                                            tabData: dayData.viewCount,
                                            difference: dayData.difference,
                                            differencePercent: dayData.percentage,
-                                           date: self.selectedDate,
-            period: .day
+                                           date: selectedDate,
+                                           period: .day
         )
 
         let chart = PostChart(postViews: lastTwoWeeks)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -127,7 +127,10 @@ private extension PostStatsViewModel {
         let overviewData = OverviewTabData(tabTitle: StatSection.periodOverviewViews.tabTitle,
                                            tabData: dayData.viewCount,
                                            difference: dayData.difference,
-                                           differencePercent: dayData.percentage)
+                                           differencePercent: dayData.percentage,
+                                           date: self.selectedDate,
+            period: .day
+        )
 
         let chart = PostChart(postViews: lastTwoWeeks)
 


### PR DESCRIPTION
Fixes #12156

To test:
Go to Period > Posts and Pages > select a post.
Go to Insights > Latest Post Summary > View more.
Note that the differenceLabel color is now grey
![image](https://user-images.githubusercontent.com/1892674/78207798-44d6b800-74d5-11ea-9d09-7924646c5af1.png)

PR submission checklist:

- [x ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
