### PR TITLE
Reader detail: fix background colors when switching appearance

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * Site Creation: faster site creation, removed intermediate steps. Just select what kind of site you'd like, enter the domain name and the site will be created.
 * Fixed a crash when a blog's URL became `nil` from a Core Data operation.
 * Period Stats: fix colors when switching between light and dark modes.
+* Reader post detail: fix colors when switching between light and dark modes.
 
  
 14.5

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -9,7 +9,7 @@ import MobileCoreServices
 class ReaderPlaceholderAttachment: NSTextAttachment {
     init() {
         // Initialize with default image data to prevent placeholder graphics appearing on iOS 13.
-        super.init(data: UIImage(color: .basicBackground).pngData(), ofType: kUTTypePNG as String)
+        super.init(data: UIImage(color: .clear).pngData(), ofType: kUTTypePNG as String)
     }
 
     required init?(coder: NSCoder) {
@@ -71,7 +71,6 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     // Header realated Views
     @IBOutlet fileprivate weak var headerView: UIView!
-    @IBOutlet fileprivate weak var headerViewBackground: UIView!
     @IBOutlet fileprivate weak var blavatarImageView: UIImageView!
     @IBOutlet fileprivate weak var blogNameButton: UIButton!
     @IBOutlet fileprivate weak var blogURLLabel: UILabel!


### PR DESCRIPTION
Fixes #13763 

To test:
- Go to Reader.
- Select a post.
- Switch between light & dark modes.
- Verify the area around the image (or title if there is no image) is updated accordingly.

| Before | After |
|--------|-------|
| ![broken](https://user-images.githubusercontent.com/1816888/78305795-0d7d0100-74ff-11ea-8459-627adbbdc3f4.png) | ![fixed](https://user-images.githubusercontent.com/1816888/78305867-39988200-74ff-11ea-8ff8-ee6cf7e08ac6.png) |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
