### PR TITLE
Testing: Use Fastlane for CI test runs with retries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of the Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@1.0
+  ios: wordpress-mobile/ios@dev:add/store-test-bundles
   git: wordpress-mobile/git@1.0
   slack: circleci/slack@3.4.2
 
@@ -19,19 +19,6 @@ commands:
               echo "Manually added `/usr/local/bin` to the $PATH:"
               echo $PATH
             fi
-
-  save-xcresult:
-    steps:
-      - run:
-          name: Zip xcresult
-          command: |
-            mkdir testresults
-            zip -r testresults/xcresult.zip test-without-building.xcresult
-          when: on_fail # Zips the .xcresult file when tests fail, so it can be saved
-      - store_artifacts:
-          name: Save xcresult
-          path: testresults
-          destination: logs
 
 jobs:
   Build Tests:
@@ -52,6 +39,11 @@ jobs:
             - DerivedData/Build/Products
             - Pods/WordPressMocks
   Unit Tests:
+    parameters:
+      try-count:
+        description: Number of times to try unit tests
+        type: integer
+        default: 1
     executor:
       name: ios/default
       xcode-version: "11.2.1"
@@ -63,11 +55,10 @@ jobs:
       - attach_workspace:
           at: ./
       - ios/wait-for-simulator
-      - ios/xcodebuild:
-          command: test-without-building
-          arguments: -xctestrun DerivedData/Build/Products/WordPress_WordPressUnitTests_iphonesimulator13.2-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" -resultBundlePath test-without-building.xcresult
+      - run:
+          name: Run Unit Tests
+          command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUnitTests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:<< parameters.try-count >>
       - ios/save-xcodebuild-artifacts
-      - save-xcresult
   UI Tests:
     parameters:
       device:
@@ -76,6 +67,10 @@ jobs:
         description: Post to Slack when tests fail. SLACK_WEBHOOK ENV variable must be set.
         type: boolean
         default: false
+      try-count:
+        description: Number of times to try UI tests
+        type: integer
+        default: 1
     executor:
       name: ios/default
       xcode-version: "11.2.1"
@@ -91,11 +86,10 @@ jobs:
           command: ./Pods/WordPressMocks/scripts/start.sh 8282
           background: true
       - ios/wait-for-simulator
-      - ios/xcodebuild:
-          command: test-without-building
-          arguments: -xctestrun DerivedData/Build/Products/WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID" -resultBundlePath test-without-building.xcresult
+      - run:
+          name: Run UI Tests
+          command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:<< parameters.try-count >>
       - ios/save-xcodebuild-artifacts
-      - save-xcresult
       - when:
           condition: << parameters.post-to-slack >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
       xcode-version: "11.2.1"
     steps:
       - fix-path
+      - git/shallow-checkout
       - ios/boot-simulator:
           xcode-version: "11.2.1"
           device: iPhone 11
@@ -72,6 +73,7 @@ jobs:
       xcode-version: "11.2.1"
     steps:
       - fix-path
+      - git/shallow-checkout
       - ios/boot-simulator:
           xcode-version: "11.2.1"
           device: << parameters.device >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
           paths:
             - DerivedData/Build/Products
             - Pods/WordPressMocks
+            - vendor/bundle
   Unit Tests:
     executor:
       name: ios/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,6 @@ jobs:
             - DerivedData/Build/Products
             - Pods/WordPressMocks
   Unit Tests:
-    parameters:
-      try-count:
-        description: Number of times to try unit tests
-        type: integer
-        default: 1
     executor:
       name: ios/default
       xcode-version: "11.2.1"
@@ -57,7 +52,7 @@ jobs:
       - ios/wait-for-simulator
       - run:
           name: Run Unit Tests
-          command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUnitTests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:<< parameters.try-count >>
+          command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUnitTests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts
   UI Tests:
     parameters:
@@ -67,10 +62,6 @@ jobs:
         description: Post to Slack when tests fail. SLACK_WEBHOOK ENV variable must be set.
         type: boolean
         default: false
-      try-count:
-        description: Number of times to try UI tests
-        type: integer
-        default: 1
     executor:
       name: ios/default
       xcode-version: "11.2.1"
@@ -88,7 +79,7 @@ jobs:
       - ios/wait-for-simulator
       - run:
           name: Run UI Tests
-          command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:<< parameters.try-count >>
+          command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts
       - when:
           condition: << parameters.post-to-slack >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of the Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@dev:add/store-test-bundles
+  ios: wordpress-mobile/ios@1.0
   git: wordpress-mobile/git@1.0
   slack: circleci/slack@3.4.2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ jobs:
           device: iPhone 11
       - attach_workspace:
           at: ./
+      - run:
+          name: Prepare Bundle
+          command: bundle --path vendor/bundle
       - ios/wait-for-simulator
       - run:
           name: Run Unit Tests
@@ -74,6 +77,9 @@ jobs:
           device: << parameters.device >>
       - attach_workspace:
           at: ./
+      - run:
+          name: Prepare Bundle
+          command: bundle --path vendor/bundle
       - run:
           name: Run mocks
           command: ./Pods/WordPressMocks/scripts/start.sh 8282

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
       - ios/wait-for-simulator
       - run:
           name: Run Unit Tests
+          working_directory: Scripts
           command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUnitTests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts
   UI Tests:
@@ -79,6 +80,7 @@ jobs:
       - ios/wait-for-simulator
       - run:
           name: Run UI Tests
+          working_directory: Scripts
           command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts
       - when:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     cocoapods-try (1.1.0)
     colored (1.2)
     colored2 (3.1.2)
+    colorize (0.8.1)
     commander-fastlane (4.4.6)
       highline (~> 1.7.2)
     commonmarker (0.20.1)
@@ -144,6 +145,12 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-appcenter (1.7.1)
     fastlane-plugin-sentry (1.6.0)
+    fastlane-plugin-test_center (3.10.1)
+      colorize
+      json
+      plist
+      xcodeproj
+      xctest_list (>= 1.1.8)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -270,6 +277,7 @@ GEM
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.0)
       xcpretty (~> 0.2, >= 0.0.7)
+    xctest_list (1.1.8)
 
 PLATFORMS
   ruby
@@ -281,6 +289,7 @@ DEPENDENCIES
   fastlane (= 2.143.0)!
   fastlane-plugin-appcenter (= 1.7.1)
   fastlane-plugin-sentry
+  fastlane-plugin-test_center
   fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)!
   rake!

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -15,19 +15,22 @@ def get_required_env(key)
   ENV[key]
 end
 
-before_all do
-  # Check that the env files exist
-  unless is_ci || File.file?(USER_ENV_FILE_PATH)
-    UI.user_error!("~/.wpios-env.default not found: Please copy env/user.env-example to #{USER_ENV_FILE_PATH} and fill in the values")
-  end
-  unless File.file?(PROJECT_ENV_FILE_PATH)
-    UI.user_error!("project.env not found: Make sure your configuration is up to date with `rake dependencies`")
-  end
+before_all do |lane|
+  # Skip these checks/steps for test lane (not needed for testing)
+  unless lane == :test_without_building
+    # Check that the env files exist
+    unless is_ci || File.file?(USER_ENV_FILE_PATH)
+      UI.user_error!("~/.wpios-env.default not found: Please copy env/user.env-example to #{USER_ENV_FILE_PATH} and fill in the values")
+    end
+    unless File.file?(PROJECT_ENV_FILE_PATH)
+      UI.user_error!("project.env not found: Make sure your configuration is up to date with `rake dependencies`")
+    end
 
-  # This allows code signing to work on CircleCI
-  # It is skipped if this isn't running on CI
-  # See https://circleci.com/docs/2.0/ios-codesigning/
-  setup_circle_ci
+    # This allows code signing to work on CircleCI
+    # It is skipped if this isn't running on CI
+    # See https://circleci.com/docs/2.0/ios-codesigning/
+    setup_circle_ci
+  end
 end
 
 platform :ios do

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -484,6 +484,35 @@ import "./ScreenshotFastfile"
   end
 
 ########################################################################
+# Test Lanes
+########################################################################
+  #####################################################################################
+  # test_without_building
+  # -----------------------------------------------------------------------------------
+  # This lane runs tests without building the app.
+  # It requires a prebuilt xctestrun file and simulator destination where the tests will be run.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane test_without_building [xctestrun:<Path to xctestrun file>] [destination:<Simulator>] [try_count:<Number of times to try tests>]
+  #
+  # Example:
+  # bundle exec fastlane test_without_building xctestrun:WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+  #####################################################################################
+  desc "Run tests without building"
+  lane :test_without_building do | options |
+    multi_scan(
+      workspace: "../WordPress.xcworkspace",
+      scheme: "WordPress",
+      test_without_building: true,
+      xctestrun: "../#{options[:xctestrun]}",
+      destination: options[:destination],
+      try_count: options[:try_count],
+      output_directory: "../build/results",
+      result_bundle: true
+    )
+  end
+
+########################################################################
 # Helper Lanes
 ########################################################################  
   desc "Get a list of pull request from `start_tag` to the current state"

--- a/Scripts/fastlane/Pluginfile
+++ b/Scripts/fastlane/Pluginfile
@@ -9,3 +9,4 @@ end
 gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.1'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.7.1'
+gem 'fastlane-plugin-test_center'


### PR DESCRIPTION
This PR switches CircleCI test runs to use Fastlane with the [test_center plugin](https://github.com/lyndsey-ferguson/fastlane-plugin-test_center), which supports various testing improvements including retries on failure. This change will retry failed tests (total of 3 test runs) before reporting failures, reducing CI failures due to flaky test results.

**This PR relies on:**

- [ ] https://github.com/wordpress-mobile/circleci-orbs/pull/56 (iOS orb reference in `config.yml` needs to be updated after that PR is merged.)

To test:

* Ensure unit and UI tests run as expected on CI, tests pass, and test output is saved.
* You can run the tests locally:
  * Build the app for testing. On the command line, you can run `xcodebuild build-for-testing -workspace 'WordPress.xcworkspace' -scheme 'WordPress' -configuration 'Debug' -sdk iphonesimulator -derivedDataPath DerivedData`.
  * Before running the UI tests, run `rake mocks` to start the mocks server.
  * From the `Scripts/` directory, run the fastlane command with this format: `bundle exec fastlane test_without_building xctestrun:<Path to xctestrun file> destination:<Simulator> try_count:<Number of times to try tests>`. (You can use a local simulator's ID as the destination, found under Xcode > Window > Devices & Simulators.)
  * If a test fails, confirm the tests rerun with a total number of test runs equal to the try_count value you selected. (You can force failures by not running the mocks server on UI tests or adding an impossible assertion to a test; note that you'll need to rebuild the app for testing if you make any test changes — and be sure not to commit those changes.)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
