### PR TITLE
Testing: Disable tab bar navigation test due to unexpected failures

### DIFF
--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -22,6 +22,7 @@
       "skippedTests" : [
         "EditorTests\/testPlayground()",
         "LoginTests\/testEmailMagicLinkLogin()",
+        "MainNavigationTests\/testTabBarNavigation()",
         "SignupTests\/testEmailSignup()"
       ],
       "target" : {


### PR DESCRIPTION
We have started seeing the `testTabBarNavigation()` fail inconsistently in `develop` UI test runs, on the Reader step (opening Reader search with the keyboard up, instead of the Followed Sites screen).

This PR disables that test until we have time to thoroughly investigate and fix that failure.

To test:

* Confirm `testTabBarNavigation()` is disabled (isn't run with the UI tests).
* Confirm all other UI tests pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
