### PR TITLE
Fix new tab selection logic in WPTabBar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 14.7
 -----
+* [internal] Notifications tab should pop to the root of the navigation stack when tapping on the tab from within a notification detail screen. See https://git.io/Jvxka for testing details.
  
 14.6
 -----

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -824,9 +824,9 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (BOOL)tabBarController:(UITabBarController *)tabBarController shouldSelectViewController:(UIViewController *)viewController
 {
-    NSUInteger newIndex = [tabBarController.viewControllers indexOfObject:viewController];
+    NSUInteger selectedIndex = [tabBarController.viewControllers indexOfObject:viewController];
 
-    newIndex = [self adjustedTabIndex:newIndex toTabType:false];
+    NSUInteger newIndex = [self adjustedTabIndex:selectedIndex toTabType:false];
 
     if (newIndex == WPTabNewPost) {
         [self showPostTab];
@@ -834,7 +834,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     }
 
     // If we're selecting a new tab...
-    if (newIndex != tabBarController.selectedIndex) {
+    if (selectedIndex != tabBarController.selectedIndex) {
         switch (newIndex) {
             case WPTabMySites: {
                 [self bypassBlogListViewControllerIfNecessary];


### PR DESCRIPTION
Fixes an issue reported in Mobile Requests (p4a5px-2xL-p2) with navigating to the root of Notifications by tapping the tab bar icon.

To test:
- Enter the Notifications tab
- Tap on one of the Notifications
- Tap again on the Notifications tab
- You should be popped to the root of the Notifications navigation stack (prior to this PR, this was not working)

PR submission checklist:

- [x] ~I have considered adding unit tests where possible.~ Could add a UI test but I'm not sure if this is critical enough functionality.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Wasn't released but I added a line for internal testing.
