### PR TITLE
Changes the auth-proxy path.

### DIFF
--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -214,11 +214,12 @@ class MediaRequestAuthenticator {
             return
         }
 
-        let contentPath = components.path[wpContentRange.lowerBound ..< components.path.endIndex]
+        let contentPath = String(components.path[wpContentRange.lowerBound ..< components.path.endIndex])
 
         components.scheme = secureHttpScheme
         components.host = wpComApiHost
-        components.path = "/wpcom/v2/sites/\(siteID)/atomic-auth-proxy/file\(contentPath)"
+        components.path = "/wpcom/v2/sites/\(siteID)/atomic-auth-proxy/file"
+        components.queryItems = [URLQueryItem(name: "path", value: contentPath)]
 
         guard let finalURL = components.url else {
             fail(Error.cannotCreateAtomicProxyURL(components: components))


### PR DESCRIPTION
Fixes #13811 

The old proxy endpoint was:

`/sites/${ siteIdOrSlug }/atomic-auth-proxy/file${ mediaPath }`

The new one is:

`/sites/${ siteIdOrSlug }/atomic-auth-proxy/file?path=${ mediaPath }`

## To Test:

1. Create an Atomic Private Site following the instructions from p58i-8xH-p2
2. Remember to make sure the site is indeed, well, private 😄 
3. Publish a post with an image through the web, or set the site's icon.
4. Before running WPiOS place a breakpoint here: https://github.com/wordpress-mobile/WordPress-iOS/blob/665162286a4bd8a518934d8a90d511f37fe7b1d4/WordPress/Classes/Networking/MediaRequestAuthenticator.swift#L229
5. Run the App and make sure that breakpoint is hit for your image.  Check that the URL matches the new endpoint path described above.
6. Make sure the image is shown.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
