### PR TITLE
Prepublishing Nudges Accessibility Improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -146,7 +146,7 @@ extension PostEditor where Self: UIViewController {
     fileprivate func displayPublishConfirmationAlert(for action: PostEditorAction, onPublish publishAction: @escaping () -> ()) {
         // End editing to avoid issues with accessibility
         view.endEditing(true)
-        
+
         let prepublishing = PrepublishingViewController(post: post as! Post) { _ in
             publishAction()
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -144,6 +144,9 @@ extension PostEditor where Self: UIViewController {
     ///     - dismissWhenDone: if `true`, the VC will be dismissed if the user picks "Publish".
     ///
     fileprivate func displayPublishConfirmationAlert(for action: PostEditorAction, onPublish publishAction: @escaping () -> ()) {
+        // End editing to avoid issues with accessibility
+        view.endEditing(true)
+        
         let prepublishing = PrepublishingViewController(post: post as! Post) { _ in
             publishAction()
         }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
@@ -24,17 +24,10 @@ class PrepublishingHeaderView: UIView, NibLoadable {
 
     // MARK: - Close button
 
-    func hideCloseButton() {
-        closeButtonView.layer.opacity = 0
-        closeButtonView.isHidden = true
-        leadingConstraint.constant = Constants.leftRightInset
-        layoutIfNeeded()
-    }
-
-    func showCloseButton() {
-        closeButtonView.layer.opacity = 1
-        closeButtonView.isHidden = false
-        leadingConstraint.constant = 0
+    func toggleCloseButton(visible: Bool) {
+        closeButtonView.layer.opacity = visible ? 1 : 0
+        closeButtonView.isHidden = visible ? false : true
+        leadingConstraint.constant = visible ? 0 : Constants.leftRightInset
         layoutIfNeeded()
     }
 
@@ -59,7 +52,7 @@ class PrepublishingHeaderView: UIView, NibLoadable {
         closeButton.accessibilityHint = Constants.doubleTapToDismiss
 
         // Only show close button for accessibility purposes
-        UIAccessibility.isVoiceOverRunning ? showCloseButton() : hideCloseButton()
+        toggleCloseButton(visible: UIAccessibility.isVoiceOverRunning)
     }
 
     private func configurePublishingToLabel() {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
@@ -2,7 +2,7 @@ import UIKit
 import Gridicons
 
 protocol PrepublishingHeaderViewDelegate: class {
-    func backButtonTapped()
+    func closeButtonTapped()
 }
 
 class PrepublishingHeaderView: UIView, NibLoadable {
@@ -10,9 +10,9 @@ class PrepublishingHeaderView: UIView, NibLoadable {
     @IBOutlet weak var blogImageView: UIImageView!
     @IBOutlet weak var publishingToLabel: UILabel!
     @IBOutlet weak var blogTitleLabel: UILabel!
-    @IBOutlet weak var backButtonView: UIView!
+    @IBOutlet weak var closeButtonView: UIView!
     @IBOutlet weak var leadingConstraint: NSLayoutConstraint!
-    @IBOutlet weak var backButton: UIButton!
+    @IBOutlet weak var closeButton: UIButton!
     @IBOutlet weak var separator: UIView!
 
     weak var delegate: PrepublishingHeaderViewDelegate?
@@ -22,24 +22,24 @@ class PrepublishingHeaderView: UIView, NibLoadable {
         blogTitleLabel.text = blog.title
     }
 
-    // MARK: - Back button
+    // MARK: - Close button
 
-    func hideBackButton() {
-        backButtonView.layer.opacity = 0
-        backButtonView.isHidden = true
+    func hideCloseButton() {
+        closeButtonView.layer.opacity = 0
+        closeButtonView.isHidden = true
         leadingConstraint.constant = Constants.leftRightInset
         layoutIfNeeded()
     }
 
-    func showBackButton() {
-        backButtonView.layer.opacity = 1
-        backButtonView.isHidden = false
+    func showCloseButton() {
+        closeButtonView.layer.opacity = 1
+        closeButtonView.isHidden = false
         leadingConstraint.constant = 0
         layoutIfNeeded()
     }
 
-    @IBAction func backButtonTapped(_ sender: Any) {
-        delegate?.backButtonTapped()
+    @IBAction func closeButtonTapped(_ sender: Any) {
+        delegate?.closeButtonTapped()
     }
 
     // MARK: - Style
@@ -53,8 +53,12 @@ class PrepublishingHeaderView: UIView, NibLoadable {
     }
 
     private func configureBackButton() {
-        backButtonView.isHidden = true
-        backButton.setImage(.gridicon(.chevronLeft, size: Constants.backButtonSize), for: .normal)
+        closeButtonView.isHidden = true
+        closeButton.setImage(.gridicon(.cross, size: Constants.backButtonSize), for: .normal)
+        closeButton.accessibilityHint = Constants.doubleTapToDismiss
+
+        // Only show close button for accessibility purposes
+        UIAccessibility.isVoiceOverRunning ? showCloseButton() : hideCloseButton()
     }
 
     private func configurePublishingToLabel() {
@@ -75,5 +79,6 @@ class PrepublishingHeaderView: UIView, NibLoadable {
         static let backButtonSize = CGSize(width: 28, height: 28)
         static let leftRightInset: CGFloat = 20
         static let title = NSLocalizedString("Publishing To", comment: "Label that describes in which blog the user is publishing to")
+        static let doubleTapToDismiss = NSLocalizedString("Double tap to dismiss", comment: "Voiceover accessibility hint informing the user they can double tap a modal alert to dismiss it")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
@@ -55,6 +55,7 @@ class PrepublishingHeaderView: UIView, NibLoadable {
     private func configureBackButton() {
         closeButtonView.isHidden = true
         closeButton.setImage(.gridicon(.cross, size: Constants.backButtonSize), for: .normal)
+        closeButton.accessibilityLabel = Constants.close
         closeButton.accessibilityHint = Constants.doubleTapToDismiss
 
         // Only show close button for accessibility purposes
@@ -79,6 +80,7 @@ class PrepublishingHeaderView: UIView, NibLoadable {
         static let backButtonSize = CGSize(width: 28, height: 28)
         static let leftRightInset: CGFloat = 20
         static let title = NSLocalizedString("Publishing To", comment: "Label that describes in which blog the user is publishing to")
+        static let close = NSLocalizedString("Close", comment: "Voiceover accessibility label informing the user that this button dismiss the current view")
         static let doubleTapToDismiss = NSLocalizedString("Double tap to dismiss", comment: "Voiceover accessibility hint informing the user they can double tap a modal alert to dismiss it")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.xib
@@ -26,9 +26,9 @@
                                         <constraint firstAttribute="width" constant="44" id="Hzn-wu-Giy"/>
                                         <constraint firstAttribute="height" constant="44" id="nMd-Hh-E65"/>
                                     </constraints>
-                                    <state key="normal" image="icon-post-actionbar-back"/>
+                                    <state key="normal" image="gridicons-cross"/>
                                     <connections>
-                                        <action selector="backButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="MTX-wi-cBI"/>
+                                        <action selector="closeButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="MTX-wi-cBI"/>
                                     </connections>
                                 </button>
                             </subviews>
@@ -108,10 +108,10 @@
             <nil key="simulatedTopBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="backButton" destination="nQB-ct-GJB" id="iVs-bk-h0W"/>
-                <outlet property="backButtonView" destination="Lqd-3Z-R2I" id="SxC-Uc-zrp"/>
                 <outlet property="blogImageView" destination="7Pf-bk-gek" id="eLY-zs-ARs"/>
                 <outlet property="blogTitleLabel" destination="fYs-yz-ucu" id="sA7-6P-XAg"/>
+                <outlet property="closeButton" destination="nQB-ct-GJB" id="iVs-bk-h0W"/>
+                <outlet property="closeButtonView" destination="Lqd-3Z-R2I" id="SxC-Uc-zrp"/>
                 <outlet property="leadingConstraint" destination="tyj-l1-rNT" id="Qlz-fc-hJn"/>
                 <outlet property="publishingToLabel" destination="ZFo-FV-nl8" id="bSu-i4-xEU"/>
                 <outlet property="separator" destination="FfF-E5-Fym" id="63L-2I-pWd"/>
@@ -120,7 +120,7 @@
         </view>
     </objects>
     <resources>
-        <image name="icon-post-actionbar-back" width="18" height="18"/>
+        <image name="gridicons-cross" width="24" height="24"/>
         <namedColor name="Gray30">
             <color red="0.55686274509803924" green="0.56862745098039214" blue="0.58823529411764708" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -58,8 +58,13 @@ class PrepublishingViewController: UITableViewController {
 
         title = ""
 
+        header.delegate = self
         header.configure(post.blog)
         setupPublishButton()
+
+        announcePublishButton()
+
+        tableView.isScrollEnabled = false
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -181,7 +186,7 @@ class PrepublishingViewController: UITableViewController {
     }
 
     func didTapSchedule(_ indexPath: IndexPath) {
-        presentedVC?.transition(to: .hidden)
+        transitionIfVoiceOverDisabled(to: .hidden)
         SchedulingCalendarViewController.present(
             from: self,
             sourceView: tableView.cellForRow(at: indexPath)?.contentView,
@@ -193,7 +198,7 @@ class PrepublishingViewController: UITableViewController {
             },
             onDismiss: { [weak self] in
                 self?.reloadData()
-                self?.presentedVC?.transition(to: .collapsed)
+                self?.transitionIfVoiceOverDisabled(to: .collapsed)
             }
         )
     }
@@ -244,6 +249,24 @@ class PrepublishingViewController: UITableViewController {
         reloadData()
     }
 
+    // MARK: - Accessibility
+
+    private func announcePublishButton() {
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
+            UIAccessibility.post(notification: .screenChanged, argument: self.publishButton)
+        }
+    }
+
+    /// Only perform a transition if Voice Over is disabled
+    /// This avoids some unresponsiveness
+    private func transitionIfVoiceOverDisabled(to position: DrawerPosition) {
+        guard !UIAccessibility.isVoiceOverRunning else {
+            return
+        }
+
+        presentedVC?.transition(to: position)
+    }
+
     private enum Constants {
         static let reuseIdentifier = "wpTableViewCell"
         static let nuxButtonInsets = UIEdgeInsets(top: 20, left: 15, bottom: 20, right: 15)
@@ -251,5 +274,11 @@ class PrepublishingViewController: UITableViewController {
         static let publishNow = NSLocalizedString("Publish Now", comment: "Label for a button that publishes the post")
         static let scheduleNow = NSLocalizedString("Schedule Now", comment: "Label for the button that schedules the post")
         static let headerHeight: CGFloat = 80
+    }
+}
+
+extension PrepublishingViewController: PrepublishingHeaderViewDelegate {
+    func closeButtonTapped() {
+        dismiss(animated: true)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1052,7 +1052,6 @@
 		8B05D29323AA572A0063B9AA /* GutenbergMediaEditorImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B05D29223AA572A0063B9AA /* GutenbergMediaEditorImage.swift */; };
 		8B0732E7242B9C5200E7FBD3 /* PrepublishingHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8B0732E6242B9C5200E7FBD3 /* PrepublishingHeaderView.xib */; };
 		8B0732E9242BA1F000E7FBD3 /* PrepublishingHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0732E8242BA1F000E7FBD3 /* PrepublishingHeaderView.swift */; };
-		8B0732ED242BEF8500E7FBD3 /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0732EC242BEF8500E7FBD3 /* PrepublishingHeaderViewTests.swift */; };
 		8B0732F0242BF7E800E7FBD3 /* Blog+Title.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0732EE242BF6EA00E7FBD3 /* Blog+Title.swift */; };
 		8B0732F3242BF99B00E7FBD3 /* PrepublishingNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0732F1242BF97B00E7FBD3 /* PrepublishingNavigationController.swift */; };
 		8B158B2A243CF07F00C66823 /* BottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B158B29243CF07F00C66823 /* BottomSheetViewController.swift */; };
@@ -1077,6 +1076,7 @@
 		8BC6020D2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */; };
 		8BD36E022395CAEA00EFFF1C /* MediaEditorOperation+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36E012395CAEA00EFFF1C /* MediaEditorOperation+Description.swift */; };
 		8BD36E062395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */; };
+		8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BF5F78D2421677300BE49B7 /* BottomSheetViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF5F78C2421677300BE49B7 /* BottomSheetViewControllerTests.swift */; };
 		8BFE36FD230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */; };
@@ -3451,7 +3451,6 @@
 		8B05D29223AA572A0063B9AA /* GutenbergMediaEditorImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergMediaEditorImage.swift; sourceTree = "<group>"; };
 		8B0732E6242B9C5200E7FBD3 /* PrepublishingHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PrepublishingHeaderView.xib; sourceTree = "<group>"; };
 		8B0732E8242BA1F000E7FBD3 /* PrepublishingHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingHeaderView.swift; sourceTree = "<group>"; };
-		8B0732EC242BEF8500E7FBD3 /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingHeaderViewTests.swift; sourceTree = "<group>"; };
 		8B0732EE242BF6EA00E7FBD3 /* Blog+Title.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Title.swift"; sourceTree = "<group>"; };
 		8B0732F1242BF97B00E7FBD3 /* PrepublishingNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingNavigationController.swift; sourceTree = "<group>"; };
 		8B158B29243CF07F00C66823 /* BottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewController.swift; sourceTree = "<group>"; };
@@ -3476,6 +3475,7 @@
 		8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullBlogPropertySanitizerTests.swift; sourceTree = "<group>"; };
 		8BD36E012395CAEA00EFFF1C /* MediaEditorOperation+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaEditorOperation+Description.swift"; sourceTree = "<group>"; };
 		8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MediaEditorOperation+DescriptionTests.swift"; sourceTree = "<group>"; };
+		8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrepublishingHeaderViewTests.swift; path = WordPressTest/PrepublishingHeaderViewTests.swift; sourceTree = SOURCE_ROOT; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BF5F78C2421677300BE49B7 /* BottomSheetViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetViewControllerTests.swift; sourceTree = "<group>"; };
 		8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLs.swift"; sourceTree = "<group>"; };
@@ -6339,7 +6339,7 @@
 		59ECF8791CB705EB00E68F25 /* Posts */ = {
 			isa = PBXGroup;
 			children = (
-				8B0732EB242BEF6F00E7FBD3 /* Prepublishing Nudges */,
+				8BE69514243E676C00FF492F /* Prepublishing Nudges */,
 				59ECF87A1CB7061D00E68F25 /* PostSharingControllerTests.swift */,
 				F18B43771F849F580089B817 /* PostAttachmentTests.swift */,
 				8B6BD54F24293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift */,
@@ -7581,14 +7581,6 @@
 			path = "Prepublishing Nudge";
 			sourceTree = "<group>";
 		};
-		8B0732EB242BEF6F00E7FBD3 /* Prepublishing Nudges */ = {
-			isa = PBXGroup;
-			children = (
-				8B0732EC242BEF8500E7FBD3 /* PrepublishingHeaderViewTests.swift */,
-			);
-			name = "Prepublishing Nudges";
-			sourceTree = "<unknown>";
-		};
 		8B158B28243CF05900C66823 /* Bottom Sheet */ = {
 			isa = PBXGroup;
 			children = (
@@ -7619,6 +7611,14 @@
 				8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */,
 			);
 			name = Aztec;
+			sourceTree = "<group>";
+		};
+		8BE69514243E676C00FF492F /* Prepublishing Nudges */ = {
+			isa = PBXGroup;
+			children = (
+				8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */,
+			);
+			name = "Prepublishing Nudges";
 			sourceTree = "<group>";
 		};
 		8BF5F78B2421676100BE49B7 /* Bottom Sheet */ = {
@@ -13365,6 +13365,7 @@
 				730354BA21C867E500CD18C2 /* SiteCreatorTests.swift in Sources */,
 				B566EC751B83867800278395 /* NSMutableAttributedStringTests.swift in Sources */,
 				E6B9B8AF1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift in Sources */,
+				8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */,
 				40F50B82221310F000CBBB73 /* StatsTestCase.swift in Sources */,
 				02BE5CC02281B53F00E351BA /* RegisterDomainDetailsViewModelLoadingStateTests.swift in Sources */,
 				40EE948222132F5800CD264F /* PublicizeConectionStatsRecordValueTests.swift in Sources */,
@@ -13389,7 +13390,6 @@
 				8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */,
 				D88A64B0208DA093008AE9BC /* StockPhotosResultsPageTests.swift in Sources */,
 				0879FC161E9301DD00E1EFC8 /* MediaTests.swift in Sources */,
-				8B0732ED242BEF8500E7FBD3 /* PrepublishingHeaderViewTests.swift in Sources */,
 				B556EFCB1DCA374200728F93 /* DictionaryHelpersTests.swift in Sources */,
 				8B6BD55024293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift in Sources */,
 				8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */,

--- a/WordPress/WordPressTest/PrepublishingHeaderViewTests.swift
+++ b/WordPress/WordPressTest/PrepublishingHeaderViewTests.swift
@@ -10,17 +10,17 @@ class PrepublishingHeaderViewTests: XCTestCase {
         let delegateMock = PrepublishingHeaderViewDelegateMock()
         prepublishingHeaderView.delegate = delegateMock
 
-        prepublishingHeaderView.backButton.sendActions(for: .touchUpInside)
+        prepublishingHeaderView.closeButton.sendActions(for: .touchUpInside)
 
-        expect(delegateMock.didCallBackButtonTapped).to(beTrue())
+        expect(delegateMock.didCallCloseButtonTapped).to(beTrue())
     }
 
 }
 
 class PrepublishingHeaderViewDelegateMock: PrepublishingHeaderViewDelegate {
-    var didCallBackButtonTapped = false
+    var didCallCloseButtonTapped = false
 
-    func backButtonTapped() {
-        didCallBackButtonTapped = true
+    func closeButtonTapped() {
+        didCallCloseButtonTapped = true
     }
 }


### PR DESCRIPTION
Fixes #13849

This PR:

- Makes sure the Voice Over focus move to Prepublishing Nudges when it appears
- That all the options are accessible and the user can return to the main screen
- That the bottom sheet is dismissable

### To test

You will need a real device.

1. Enable Voice Over
2. Create a new post
3. Tap Publish
4. Navigate through the Prepublishing Nudges and try to find a dead-end
