### PR TITLE
Constraint Quick Actions Max Width

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -125,9 +125,11 @@ class NewBlogDetailHeaderView: UIView {
 
         let edgeConstraints = [
             leadingSafeAreaConstraint,
-            stackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            stackView.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
             stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: Constants.minimumSideSpacing),
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.interSectionSpacing),
+            stackView.centerXAnchor.constraint(equalTo: layoutMarginsGuide.centerXAnchor),
+            stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 500),
             buttonsStackView.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.interSectionSpacing),
             buttonsStackView.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
             bottomConstraint

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -113,20 +113,18 @@ class NewBlogDetailHeaderView: UIView {
         let bottomConstraint = buttonsStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.buttonsBottomPadding)
         bottomConstraint.priority = UILayoutPriority(999) // Allow to break so encapsulated height (on initial table view load) doesn't spew warnings
 
-        /// If we are able to attach to the safe area's leading edge, we should, otherwise it can break
-        let leadingSafeAreaConstraint = stackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor)
-        leadingSafeAreaConstraint.priority = .defaultHigh
+        let widthConstraint = buttonsStackView.widthAnchor.constraint(equalToConstant: 320)
+        widthConstraint.priority = .defaultHigh
 
         let edgeConstraints = [
-            leadingSafeAreaConstraint,
             stackView.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
             stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: Constants.minimumSideSpacing),
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.interSectionSpacing),
             stackView.centerXAnchor.constraint(equalTo: layoutMarginsGuide.centerXAnchor),
-            buttonsStackView.widthAnchor.constraint(equalToConstant: 320),
             buttonsStackView.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.interSectionSpacing),
             buttonsStackView.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
-            bottomConstraint
+            bottomConstraint,
+            widthConstraint
         ]
 
         NSLayoutConstraint.activate(minimumPaddingSideConstraints + edgeConstraints)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -104,12 +104,6 @@ class NewBlogDetailHeaderView: UIView {
         stackView.setCustomSpacing(Constants.spacingBelowIcon, after: siteIconView)
         stackView.setCustomSpacing(Constants.spacingBelowTitle, after: titleLabel)
 
-        /// Constraints for larger widths with extra padding (iPhone portrait)
-        let extraPaddingSideConstraints = [
-            buttonsStackView.trailingAnchor.constraint(greaterThanOrEqualTo: stackView.trailingAnchor, constant: -Constants.buttonsSidePadding),
-            buttonsStackView.leadingAnchor.constraint(lessThanOrEqualTo: stackView.leadingAnchor, constant: Constants.buttonsSidePadding)
-        ]
-
         /// Constraints for constrained widths (iPad portrait)
         let minimumPaddingSideConstraints = [
             buttonsStackView.leadingAnchor.constraint(greaterThanOrEqualTo: stackView.leadingAnchor, constant: 0),
@@ -129,13 +123,13 @@ class NewBlogDetailHeaderView: UIView {
             stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: Constants.minimumSideSpacing),
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.interSectionSpacing),
             stackView.centerXAnchor.constraint(equalTo: layoutMarginsGuide.centerXAnchor),
-            stackView.widthAnchor.constraint(lessThanOrEqualToConstant: 500),
+            buttonsStackView.widthAnchor.constraint(equalToConstant: 320),
             buttonsStackView.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.interSectionSpacing),
             buttonsStackView.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
             bottomConstraint
         ]
 
-        NSLayoutConstraint.activate(extraPaddingSideConstraints + minimumPaddingSideConstraints + edgeConstraints)
+        NSLayoutConstraint.activate(minimumPaddingSideConstraints + edgeConstraints)
     }
 
     override init(frame: CGRect) {


### PR DESCRIPTION
Sets the Quick Actions maximum width to 500 points based on feedback to reduce spacing from @osullivanchris and to avoid running into the FAB.

### Before

![Screen Shot 2020-04-10 at 1 04 32 PM](https://user-images.githubusercontent.com/3250/79016348-fad08080-7b2b-11ea-8841-66ca9a95ef05.png)


### After
![Screen Shot 2020-04-10 at 12 42 36 PM](https://user-images.githubusercontent.com/3250/79016098-623a0080-7b2b-11ea-8e19-005dba8292c2.png)


## To Test

- Visit the Blog Details Page
- Check the Quick Actions Buttons in Portrait and Landscape

## Screenshots

<details>
  <summary><strong>iPhone 11 Pro</strong></summary>

![Screen Shot 2020-04-10 at 12 42 46 PM](https://user-images.githubusercontent.com/3250/79015742-a547a400-7b2a-11ea-8a4e-22cddba63e1d.png)

![Screen Shot 2020-04-10 at 12 42 36 PM](https://user-images.githubusercontent.com/3250/79015756-ae387580-7b2a-11ea-823f-10ae84db54ed.png)
</details>

<details>
  <summary><strong>iPhone 11 Pro Max</strong></summary>

![Screen Shot 2020-04-10 at 12 48 06 PM](https://user-images.githubusercontent.com/3250/79015760-b1cbfc80-7b2a-11ea-93de-adf9939ace78.png)

![Screen Shot 2020-04-10 at 12 48 25 PM](https://user-images.githubusercontent.com/3250/79015774-b55f8380-7b2a-11ea-9eed-9e5397294f91.png)
</details>

<details>
  <summary><strong>iPad Pro 11"</strong></summary>

![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2020-04-10 at 12 44](https://user-images.githubusercontent.com/3250/79015780-b8f30a80-7b2a-11ea-8a48-0a41d0c6ccb8.png)

![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2020-04-10 at 12 45](https://user-images.githubusercontent.com/3250/79015784-bb556480-7b2a-11ea-91ac-032e84a2c6ae.png)
</details>

## PR submission checklist

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
