### PR TITLE
13581: Reader Filter Sheet

### DIFF
--- a/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
+++ b/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
@@ -5,7 +5,7 @@ class BottomSheetViewController: UIViewController {
         static let gripHeight: CGFloat = 5
         static let cornerRadius: CGFloat = 8
         static let buttonSpacing: CGFloat = 8
-        static let additionalSafeAreaInsetsRegular: UIEdgeInsets = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
+        static let additionalSafeAreaInsetsRegular: UIEdgeInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
         static let minimumWidth: CGFloat = 300
 
         enum Header {
@@ -34,9 +34,10 @@ class BottomSheetViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
     }
 
-    func show(from presenting: UIViewController, sourceView: UIView? = nil) {
+    func show(from presenting: UIViewController, sourceView: UIView? = nil, arrowDirections: UIPopoverArrowDirection = .any) {
         if UIDevice.isPad() {
             modalPresentationStyle = .popover
+            popoverPresentationController?.permittedArrowDirections = arrowDirections
             popoverPresentationController?.sourceView = sourceView ?? UIView()
             popoverPresentationController?.sourceRect = sourceView?.bounds ?? .zero
         } else {
@@ -105,6 +106,15 @@ class BottomSheetViewController: UIViewController {
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         refreshForTraits()
+    }
+
+    override var preferredContentSize: CGSize {
+        set {
+            childViewController?.preferredContentSize = newValue
+        }
+        get {
+            return childViewController?.preferredContentSize ?? super.preferredContentSize
+        }
     }
 
     private func refreshForTraits() {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -31,7 +31,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .floatingCreateButton:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .newReaderNavigation:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return false
         }
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -34,7 +34,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .floatingCreateButton:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .newReaderNavigation:
-            return false
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -103,7 +103,7 @@ extension ReaderSiteTopic {
         let siteService = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
 
         siteService.fetchFollowedSites(success: {
-            completion(.success(siteService.allSiteTopics()))
+            completion(.success(siteService.allSiteTopics().filter { !$0.isExternal }))
         }, failure: { error in
             let unknownRestAPIError = NSError(domain: WordPressComRestApiErrorDomain, code: -1, userInfo: nil)
             completion(.failure(error ?? unknownRestAPIError))

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -1,0 +1,165 @@
+import WordPressFlux
+
+class FilterProvider: Observable, FilterTabBarItem {
+
+    enum State {
+        case loading
+        case ready([TableDataItem])
+        case error(Error)
+
+        var isReady: Bool {
+            switch self {
+            case .ready:
+                return true
+            case .error, .loading:
+                return false
+            }
+        }
+    }
+
+    var title: String {
+        return titleFunc(state)
+    }
+
+    var state: State = .loading {
+        didSet {
+            emitChange()
+        }
+    }
+
+    var items: [TableDataItem] {
+        switch state {
+        case .loading, .error:
+            return []
+        case .ready(let items):
+            return items
+        }
+    }
+
+    let accessibilityIdentifier: String
+
+    let cellClass: UITableViewCell.Type
+    let reuseIdentifier: String
+
+    private let titleFunc: (State?) -> String
+
+    let changeDispatcher = Dispatcher<Void>()
+
+    init(title: @escaping (State?) -> String,
+         accessibilityIdentifier: String,
+         cellClass: UITableViewCell.Type,
+         reuseIdentifier: String,
+         provider: (@escaping (Result<[TableDataItem], Error>) -> Void) -> Void) {
+
+        titleFunc = title
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.cellClass = cellClass
+        self.reuseIdentifier = reuseIdentifier
+
+        provider() { [weak self] result in
+            switch result {
+            case .success(let items):
+                self?.state = .ready(items)
+            case .failure(let error):
+                self?.state = .error(error)
+            }
+        }
+    }
+}
+
+extension ReaderSiteTopic {
+
+    static func filterProvider() -> FilterProvider {
+        let titleFunction: (FilterProvider.State?) -> String = { state in
+            switch state {
+            case .loading, .error, .none:
+                return NSLocalizedString("Sites", comment: "Sites Filter Tab Title")
+            case .ready(let items):
+                return String(format: NSLocalizedString("Sites (%lu)", comment: "Sites Filter Tab Title with Count"), items.count)
+            }
+        }
+        return FilterProvider(title: titleFunction,
+                              accessibilityIdentifier: "SitesFilterTab",
+                              cellClass: SiteTableViewCell.self,
+                              reuseIdentifier: "Sites",
+                              provider: tableProvider)
+    }
+
+    private static func tableProvider(completion: @escaping (Result<[TableDataItem], Error>) -> Void) {
+        fetchFollowedSites(completion: { result in
+            let itemResult = result.map { sites in
+                sites.map { topic in
+                    return TableDataItem(topic: topic, configure: { cell in
+                        cell.textLabel?.text = topic.title
+                        cell.detailTextLabel?.text = topic.siteURL
+                    })
+                }
+            }
+            completion(itemResult)
+        })
+    }
+
+    private static func fetchFollowedSites(completion: @escaping (Result<[ReaderSiteTopic], Error>) -> Void) {
+        let siteService = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+
+        siteService.fetchFollowedSites(success: {
+            completion(.success(siteService.allSiteTopics()))
+        }, failure: { error in
+            let unknownRestAPIError = NSError(domain: WordPressComRestApiErrorDomain, code: -1, userInfo: nil)
+            completion(.failure(error ?? unknownRestAPIError))
+            DDLogError("Could not sync sites: \(String(describing: error))")
+        })
+    }
+}
+
+extension ReaderTagTopic {
+
+    static func filterProvider() -> FilterProvider {
+        let titleFunction: (FilterProvider.State?) -> String = { state in
+            switch state {
+            case .loading, .error, .none:
+                return NSLocalizedString("Tags", comment: "Tags Filter Tab Title")
+            case .ready(let items):
+                return String(format: NSLocalizedString("Tags (%lu)", comment: "Tags Filter Tab Title with Count"), items.count)
+            }
+        }
+        return FilterProvider(title: titleFunction,
+                              accessibilityIdentifier: "TagsFilterTab",
+                              cellClass: UITableViewCell.self,
+                              reuseIdentifier: "Tags",
+                              provider: tableProvider)
+    }
+
+    private static func tableProvider(completion: @escaping (Result<[TableDataItem], Error>) -> Void) {
+        fetchFollowedTags(completion: { result in
+            let itemResult = result.map { tags in
+                tags.map { topic in
+                    return TableDataItem(topic: topic, configure: { (cell) in
+                        cell.textLabel?.text = topic.slug
+                    })
+                }
+            }
+            completion(itemResult)
+        })
+    }
+
+    private static var tagsFetchRequest: NSFetchRequest<NSFetchRequestResult> {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ReaderTagTopic")
+        fetchRequest.predicate = NSPredicate(format: "following == %@ AND showInMenu == YES AND type == 'tag'",
+                                             NSNumber(value: ReaderHelpers.isLoggedIn()))
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "title", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare))]
+        return fetchRequest
+    }
+
+    private static func fetchFollowedTags(completion: @escaping (Result<[ReaderTagTopic], Error>) -> Void) {
+        do {
+            guard let topics = try ContextManager.sharedInstance().mainContext.fetch(tagsFetchRequest) as? [ReaderTagTopic] else {
+                return
+            }
+            completion(.success(topics))
+        } catch {
+            DDLogError("There was a problem fetching followed tags." + error.localizedDescription)
+            completion(.failure(error))
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
@@ -1,0 +1,143 @@
+import WordPressFlux
+
+class FilterSheetView: UIView {
+
+    enum Constants {
+        enum Header {
+            static let spacing: CGFloat = 16
+            static let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
+            static let title = NSLocalizedString("Following", comment: "Title for Reader Filter Sheet")
+            static let font = WPStyleGuide.fontForTextStyle(.headline)
+        }
+    }
+
+    // MARK: View Setup
+
+    lazy var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.tableFooterView = UIView() // To hide the separators for empty cells
+        tableView.delegate = self
+        return tableView
+    }()
+
+    lazy var ghostableTableView: UITableView = {
+        let ghostTV = UITableView()
+        ghostTV.isScrollEnabled = false
+        return ghostTV
+    }()
+
+    lazy var filterTabBar: FilterTabBar = {
+        let tabBar = FilterTabBar()
+        WPStyleGuide.configureFilterTabBar(tabBar)
+        tabBar.tabSizingStyle = .equalWidths
+        tabBar.addTarget(self, action: #selector(FilterSheetView.changedTab(_:)), for: .valueChanged)
+        return tabBar
+    }()
+
+    lazy var headerLabelView: UIView = {
+        let labelView = UIView()
+        let label = UILabel()
+        label.font = Constants.Header.font
+        label.text = Constants.Header.title
+        label.translatesAutoresizingMaskIntoConstraints = false
+        labelView.addSubview(label)
+        labelView.pinSubviewToAllEdges(label, insets: Constants.Header.insets)
+        return labelView
+    }()
+
+    lazy var stackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [
+            headerLabelView,
+            filterTabBar,
+            tableView,
+            ghostableTableView
+        ])
+
+        stack.setCustomSpacing(Constants.Header.spacing, after: headerLabelView)
+        stack.axis = .vertical
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+
+    // MARK: Properties
+
+    private var subscriptions: [Receipt]?
+    private var changedFilter: (ReaderAbstractTopic) -> Void
+    private var dataSource: FilterTableViewDataSource? {
+        didSet {
+            tableView.dataSource = dataSource
+            tableView.reloadData()
+        }
+    }
+
+    private var selectedFilter: FilterProvider? {
+        set {
+            if let filter = newValue {
+                dataSource = FilterTableViewDataSource(data: filter.items, reuseIdentifier: filter.reuseIdentifier)
+                if filter.state.isReady == false {
+                    tableView.isHidden = true
+                    updateGhostableTableViewOptions(cellClass: filter.cellClass, identifier: filter.reuseIdentifier)
+                } else {
+                    ghostableTableView.stopGhostAnimation()
+                    ghostableTableView.isHidden = true
+                    tableView.isHidden = false
+                }
+            }
+        }
+        get {
+            return filterTabBar.items[filterTabBar.selectedIndex] as? FilterProvider
+        }
+    }
+
+    // MARK: Methods
+
+    init(filters: [FilterProvider], changedFilter: @escaping (ReaderAbstractTopic) -> Void) {
+        self.changedFilter = changedFilter
+        super.init(frame: .zero)
+
+        filterTabBar.items = filters
+        filters.forEach { filter in
+            tableView.register(filter.cellClass, forCellReuseIdentifier: filter.reuseIdentifier)
+        }
+        selectedFilter = filters.first
+
+        addSubview(stackView)
+        pinSubviewToAllEdges(stackView)
+
+        subscriptions = filters.map() { filter in
+            filter.onChange() { [weak self] in
+                if self?.selectedFilter?.accessibilityIdentifier == filter.accessibilityIdentifier {
+                    self?.selectedFilter = filter
+                }
+                self?.filterTabBar.items = filters
+            }
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func updateGhostableTableViewOptions(cellClass: UITableViewCell.Type, identifier: String) {
+        ghostableTableView.register(cellClass, forCellReuseIdentifier: identifier)
+        let ghostOptions = GhostOptions(displaysSectionHeader: false, reuseIdentifier: identifier, rowsPerSection: [15])
+        let style = GhostStyle(beatDuration: GhostStyle.Defaults.beatDuration,
+                               beatStartColor: .placeholderElement,
+                               beatEndColor: .placeholderElementFaded)
+        ghostableTableView.removeGhostContent()
+        ghostableTableView.isHidden = false
+        ghostableTableView.displayGhostContent(options: ghostOptions, style: style)
+    }
+
+    @objc func changedTab(_ sender: FilterTabBar) {
+        selectedFilter = filterTabBar.items[sender.selectedIndex] as? FilterProvider
+    }
+}
+
+extension FilterSheetView: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if let topic = dataSource?.data[indexPath.row].topic {
+            changedFilter(topic)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
@@ -16,6 +16,7 @@ class FilterSheetView: UIView {
     lazy var tableView: UITableView = {
         let tableView = UITableView()
         tableView.tableFooterView = UIView() // To hide the separators for empty cells
+        tableView.separatorStyle = .none
         tableView.delegate = self
         return tableView
     }()

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
@@ -22,9 +22,10 @@ class FilterSheetView: UIView {
     }()
 
     lazy var ghostableTableView: UITableView = {
-        let ghostTV = UITableView()
-        ghostTV.isScrollEnabled = false
-        return ghostTV
+        let tableView = UITableView()
+        tableView.isScrollEnabled = false
+        tableView.separatorStyle = .none
+        return tableView
     }()
 
     lazy var filterTabBar: FilterTabBar = {

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
@@ -23,6 +23,7 @@ class FilterSheetView: UIView {
 
     lazy var ghostableTableView: UITableView = {
         let tableView = UITableView()
+        tableView.allowsSelection = false
         tableView.isScrollEnabled = false
         tableView.separatorStyle = .none
         return tableView

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
@@ -1,0 +1,26 @@
+class FilterSheetViewController: UIViewController {
+
+    private let filters: [FilterProvider]
+    private let changedFilter: (ReaderAbstractTopic) -> Void
+
+    //TODO: Make changedFilter generic
+    init(filters: [FilterProvider], changedFilter: @escaping (ReaderAbstractTopic) -> Void) {
+        self.filters = filters
+        self.changedFilter = changedFilter
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = FilterSheetView(filters: filters, changedFilter: changedFilter)
+    }
+}
+
+extension FilterSheetViewController: DrawerPresentable {
+    var scrollableView: UIScrollView? {
+        return (view as? FilterSheetView)?.tableView
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
@@ -23,4 +23,12 @@ extension FilterSheetViewController: DrawerPresentable {
     var scrollableView: UIScrollView? {
         return (view as? FilterSheetView)?.tableView
     }
+
+    var collapsedHeight: DrawerHeight {
+        if traitCollection.verticalSizeClass == .compact {
+            return .maxHeight
+        } else {
+            return .contentHeight(0)
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterTableData.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterTableData.swift
@@ -29,6 +29,11 @@ class FilterTableViewDataSource: NSObject, UITableViewDataSource {
 
 class SiteTableViewCell: UITableViewCell, GhostableView {
 
+    enum Constants {
+        static let textLabelCharacterWidth = 40 // Number of characters in text label
+        static let detailLabelCharacterWidth = 80 // Number of characters in detail label
+    }
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
         detailTextLabel?.textColor = UIColor.systemGray
@@ -42,9 +47,9 @@ class SiteTableViewCell: UITableViewCell, GhostableView {
         contentView.subviews.forEach { view in
             view.isGhostableDisabled = true
         }
-        textLabel?.text = "TEST LABEL Text Label"
+        textLabel?.text = String(repeating: " ", count: Constants.textLabelCharacterWidth)
         textLabel?.isGhostableDisabled = false
-        detailTextLabel?.text = "TEST LABEL sdflsjlwe lsdfjsldjsl sidjflsidj"
+        detailTextLabel?.text = String(repeating: " ", count: Constants.detailLabelCharacterWidth)
         detailTextLabel?.isGhostableDisabled = false
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterTableData.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterTableData.swift
@@ -1,0 +1,50 @@
+struct TableDataItem {
+    let topic: ReaderAbstractTopic
+    let configure: (UITableViewCell) -> Void
+}
+
+class FilterTableViewDataSource: NSObject, UITableViewDataSource {
+
+    let data: [TableDataItem]
+    private let reuseIdentifier: String
+
+    init(data: [TableDataItem], reuseIdentifier: String) {
+        self.data = data
+        self.reuseIdentifier = reuseIdentifier
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return data.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let item = data[indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
+
+        item.configure(cell)
+
+        return cell
+    }
+}
+
+class SiteTableViewCell: UITableViewCell, GhostableView {
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+        detailTextLabel?.textColor = UIColor.systemGray
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func ghostAnimationWillStart() {
+        contentView.subviews.forEach { view in
+            view.isGhostableDisabled = true
+        }
+        textLabel?.text = "TEST LABEL Text Label"
+        textLabel?.isGhostableDisabled = false
+        detailTextLabel?.text = "TEST LABEL sdflsjlwe lsdfjsldjsl sidjflsidj"
+        detailTextLabel?.isGhostableDisabled = false
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -208,7 +208,8 @@ extension ReaderTabView {
 
     /// Filter button
     @objc private func didTapFilterButton() {
-        viewModel.presentFilter(from: filterButton) { [weak self] title in
+        /// Present from the image view to align to the left hand side
+        viewModel.presentFilter(from: filterButton.imageView ?? filterButton) { [weak self] title in
             if let title = title {
                 self?.resetFilterButton.isHidden = false
                 self?.setFilterButtonTitle(title)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -187,11 +187,10 @@ extension ReaderTabView {
 
     /// Filter button
     @objc private func didTapFilterButton() {
-        viewModel.presentFilter(from: filterButton) { [weak self] topic in
-            if let topic = topic {
+        viewModel.presentFilter(from: filterButton) { [weak self] title in
+            if let title = title {
                 self?.resetFilterButton.isHidden = false
-                self?.setFilterButtonTitle(topic.title)
-                self?.viewModel.tabSelectionCallback?(topic)
+                self?.setFilterButtonTitle(title)
             }
         }
     }
@@ -207,7 +206,6 @@ extension ReaderTabView {
         viewModel.presentSettings()
     }
 }
-
 
 // MARK: - Appearance
 extension ReaderTabView {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -187,10 +187,6 @@ extension ReaderTabView {
 
     /// Filter button
     @objc private func didTapFilterButton() {
-        //TODO: - READERNAV - Remove. This test code is for UI prototyping only
-        guard filterButton.titleLabel?.text == "Filter" else {
-            return
-        }
         viewModel.presentFilter(from: filterButton) { [weak self] topic in
             if let topic = topic {
                 self?.resetFilterButton.isHidden = false

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -97,8 +97,6 @@ extension ReaderTabView {
         buttonsStackView.alignment = .fill
         buttonsStackView.addArrangedSubview(filterButton)
         buttonsStackView.addArrangedSubview(resetFilterButton)
-        let spacer = UIView()
-        buttonsStackView.addArrangedSubview(spacer)
         buttonsStackView.addArrangedSubview(verticalDivider)
         buttonsStackView.addArrangedSubview(settingsButton)
     }
@@ -108,6 +106,7 @@ extension ReaderTabView {
         filterButton.contentEdgeInsets = Appearance.filterButtonInsets
         filterButton.imageEdgeInsets = Appearance.filterButtonimageInsets
         filterButton.titleEdgeInsets = Appearance.filterButtonTitleInsets
+        filterButton.contentHorizontalAlignment = .leading
 
         filterButton.titleLabel?.font = Appearance.filterButtonFont
         WPStyleGuide.applyReaderFilterButtonStyle(filterButton)
@@ -229,9 +228,9 @@ extension ReaderTabView {
 
         static let defaultFilterButtonTitle = NSLocalizedString("Filter", comment: "Title of the filter button in the Reader")
         static let filterButtonMaxFontSize: CGFloat = 28.0
-        static let filterButtonFont = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
+        static let filterButtonFont = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .regular)
         static let filterButtonInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
-        static let filterButtonimageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        static let filterButtonimageInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
         static let filterButtonTitleInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
 
         static let resetButtonWidth: CGFloat = 32

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -191,16 +191,20 @@ extension ReaderTabView {
         guard filterButton.titleLabel?.text == "Filter" else {
             return
         }
-        setFilterButtonTitle("Phoebe's Photos")
-        resetFilterButton.isHidden = false
-        viewModel.presentFilter()
+        viewModel.presentFilter() { [weak self] topic in
+            if let topic = topic {
+                self?.resetFilterButton.isHidden = false
+                self?.setFilterButtonTitle(topic.title)
+                self?.viewModel.tabSelectionCallback?(topic)
+            }
+        }
     }
 
     /// Reset filter button
     @objc private func didTapResetFilterButton() {
         setFilterButtonTitle(Appearance.defaultFilterButtonTitle)
         resetFilterButton.isHidden = true
-        viewModel.resetFilter()
+        viewModel.resetFilter(selectedItem: tabBar.items[tabBar.selectedIndex])
     }
 
     @objc private func didTapSettingsButton() {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -51,8 +51,8 @@ extension ReaderTabView {
         setupButtonsView()
         setupFilterButton()
         setupResetFilterButton()
-        setupDivider(verticalDivider)
-        setupDivider(horizontalDivider)
+        setupVerticalDivider(verticalDivider)
+        setupHorizontalDivider(horizontalDivider)
         setupSettingsButton()
         activateConstraints()
     }
@@ -94,7 +94,7 @@ extension ReaderTabView {
         buttonsStackView.translatesAutoresizingMaskIntoConstraints = false
         buttonsStackView.isLayoutMarginsRelativeArrangement = true
         buttonsStackView.axis = .horizontal
-        buttonsStackView.alignment = .center
+        buttonsStackView.alignment = .fill
         buttonsStackView.addArrangedSubview(filterButton)
         buttonsStackView.addArrangedSubview(resetFilterButton)
         let spacer = UIView()
@@ -123,7 +123,21 @@ extension ReaderTabView {
         resetFilterButton.isHidden = true
     }
 
-    private func setupDivider(_ divider: UIView) {
+    private func setupVerticalDivider(_ divider: UIView) {
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        let dividerView = UIView()
+        dividerView.translatesAutoresizingMaskIntoConstraints = false
+        dividerView.backgroundColor = Appearance.dividerColor
+        divider.addSubview(dividerView)
+        NSLayoutConstraint.activate([
+            dividerView.centerYAnchor.constraint(equalTo: divider.centerYAnchor),
+            dividerView.heightAnchor.constraint(equalTo: divider.heightAnchor, multiplier: Appearance.verticalDividerHeightMultiplier),
+            dividerView.leadingAnchor.constraint(equalTo: divider.leadingAnchor),
+            dividerView.trailingAnchor.constraint(equalTo: divider.trailingAnchor)
+        ])
+    }
+
+    private func setupHorizontalDivider(_ divider: UIView) {
         divider.translatesAutoresizingMaskIntoConstraints = false
         divider.backgroundColor = Appearance.dividerColor
     }
@@ -157,8 +171,6 @@ extension ReaderTabView {
             buttonsStackView.heightAnchor.constraint(equalToConstant: Appearance.barHeight),
             resetFilterButton.widthAnchor.constraint(equalToConstant: Appearance.resetButtonWidth),
             verticalDivider.widthAnchor.constraint(equalToConstant: Appearance.dividerWidth),
-            verticalDivider.heightAnchor.constraint(equalTo: buttonsStackView.heightAnchor,
-                                                    multiplier: Appearance.verticalDividerHeightMultiplier),
             horizontalDivider.heightAnchor.constraint(equalToConstant: Appearance.dividerWidth),
             horizontalDivider.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
             settingsButton.widthAnchor.constraint(equalToConstant: Appearance.settingsButtonWidth)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -191,7 +191,7 @@ extension ReaderTabView {
         guard filterButton.titleLabel?.text == "Filter" else {
             return
         }
-        viewModel.presentFilter() { [weak self] topic in
+        viewModel.presentFilter(from: filterButton) { [weak self] topic in
             if let topic = topic {
                 self?.resetFilterButton.isHidden = false
                 self?.setFilterButtonTitle(topic.title)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -7,14 +7,14 @@ class ReaderTabViewController: UIViewController {
     init(viewModel: ReaderTabViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        self.viewModel.filterTapped = { [weak self] completion in
+        self.viewModel.filterTapped = { [weak self] (fromView, completion) in
             guard let self = self else { return }
             let viewController = FilterSheetViewController(filters: [ReaderSiteTopic.filterProvider(), ReaderTagTopic.filterProvider()], changedFilter: { [weak self] topic in
                 completion(topic)
                 self?.dismiss(animated: true, completion: nil)
             })
             let bottomSheet = BottomSheetViewController(childViewController: viewController)
-            bottomSheet.show(from: self, sourceView: self.view)
+            bottomSheet.show(from: self, sourceView: fromView, arrowDirections: .up)
         }
         self.title = NSLocalizedString("Reader", comment: "The default title of the Reader")
         setupSearchButton()

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -9,14 +9,12 @@ class ReaderTabViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         self.viewModel.filterTapped = { [weak self] (fromView, completion) in
             guard let self = self else { return }
-            let viewController = FilterSheetViewController(filters: [ReaderSiteTopic.filterProvider(), ReaderTagTopic.filterProvider()], changedFilter: { [weak self] topic in
-                completion(topic)
+            self.viewModel.presentFilter(from: self, sourceView: fromView, completion: { [weak self] title in
                 self?.dismiss(animated: true, completion: nil)
+                completion(title)
             })
-            let bottomSheet = BottomSheetViewController(childViewController: viewController)
-            bottomSheet.show(from: self, sourceView: fromView, arrowDirections: .up)
         }
-        self.title = NSLocalizedString("Reader", comment: "The default title of the Reader")
+        title = NSLocalizedString("Reader", comment: "The default title of the Reader")
         setupSearchButton()
     }
 
@@ -31,7 +29,7 @@ class ReaderTabViewController: UIViewController {
     }
 
     override func loadView() {
-        self.view = ReaderTabView(viewModel: viewModel)
+        view = ReaderTabView(viewModel: viewModel)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -7,6 +7,15 @@ class ReaderTabViewController: UIViewController {
     init(viewModel: ReaderTabViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
+        self.viewModel.filterTapped = { [weak self] completion in
+            guard let self = self else { return }
+            let viewController = FilterSheetViewController(filters: [ReaderSiteTopic.filterProvider(), ReaderTagTopic.filterProvider()], changedFilter: { [weak self] topic in
+                completion(topic)
+                self?.dismiss(animated: true, completion: nil)
+            })
+            let bottomSheet = BottomSheetViewController(childViewController: viewController)
+            bottomSheet.show(from: self, sourceView: self.view)
+        }
         self.title = NSLocalizedString("Reader", comment: "The default title of the Reader")
         setupSearchButton()
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -1,7 +1,7 @@
 
 class ReaderTabViewModel {
 
-    var tabSelectionCallback: ((ReaderAbstractTopic) -> Void)?
+    var tabSelectionCallback: ((ReaderAbstractTopic?) -> Void)?
     var selectedFilter: ReaderAbstractTopic?
     var filterTapped: ((UIView, @escaping (ReaderAbstractTopic?) -> Void) -> Void)?
 
@@ -11,12 +11,13 @@ class ReaderTabViewModel {
 
     func showTab(for item: FilterTabBarItem) {
 
-        guard let readerItem = item as? ReaderTabItem,
-            let topic = readerItem.topic else {
-                return
+        guard let readerItem = item as? ReaderTabItem else {
+            return
         }
 
-        let selectedTopic: ReaderAbstractTopic
+        let topic = readerItem.topic
+
+        let selectedTopic: ReaderAbstractTopic?
         if readerItem.shouldHideButtonsView == false {
             selectedTopic = selectedFilter ?? topic
         } else {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -2,7 +2,7 @@
 class ReaderTabViewModel {
 
     var tabSelectionCallback: ((ReaderAbstractTopic) -> Void)?
-    var filterTapped: ((@escaping (ReaderAbstractTopic?) -> Void) -> Void)?
+    var filterTapped: ((UIView, @escaping (ReaderAbstractTopic?) -> Void) -> Void)?
 
     init() {
         addNotificationsObservers()
@@ -19,8 +19,8 @@ class ReaderTabViewModel {
     // TODO: - READERNAV - Methods to be implemented. Signature will likely change
     func performSearch() { }
 
-    func presentFilter(completion: @escaping (ReaderAbstractTopic?) -> Void) {
-        filterTapped?(completion)
+    func presentFilter(from: UIView, completion: @escaping (ReaderAbstractTopic?) -> Void) {
+        filterTapped?(from, completion)
     }
 
     func resetFilter(selectedItem: FilterTabBarItem) {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -2,6 +2,7 @@
 class ReaderTabViewModel {
 
     var tabSelectionCallback: ((ReaderAbstractTopic) -> Void)?
+    var selectedFilter: ReaderAbstractTopic?
     var filterTapped: ((UIView, @escaping (ReaderAbstractTopic?) -> Void) -> Void)?
 
     init() {
@@ -9,21 +10,34 @@ class ReaderTabViewModel {
     }
 
     func showTab(for item: FilterTabBarItem) {
+
         guard let readerItem = item as? ReaderTabItem,
             let topic = readerItem.topic else {
                 return
         }
-        tabSelectionCallback?(topic)
+
+        let selectedTopic: ReaderAbstractTopic
+        if readerItem.shouldHideButtonsView == false {
+            selectedTopic = selectedFilter ?? topic
+        } else {
+            selectedTopic = topic
+        }
+
+        tabSelectionCallback?(selectedTopic)
     }
 
     // TODO: - READERNAV - Methods to be implemented. Signature will likely change
     func performSearch() { }
 
     func presentFilter(from: UIView, completion: @escaping (ReaderAbstractTopic?) -> Void) {
-        filterTapped?(from, completion)
+        filterTapped?(from, { [weak self] topic in
+            self?.selectedFilter = topic
+            completion(topic)
+        })
     }
 
     func resetFilter(selectedItem: FilterTabBarItem) {
+        selectedFilter = nil
         if let topic = (selectedItem as? ReaderTabItem)?.topic {
             tabSelectionCallback?(topic)
         }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -29,10 +29,19 @@ class ReaderTabViewModel {
     // TODO: - READERNAV - Methods to be implemented. Signature will likely change
     func performSearch() { }
 
-    func presentFilter(from: UIView, completion: @escaping (ReaderAbstractTopic?) -> Void) {
+    func presentFilter(from: UIViewController, sourceView: UIView, completion: @escaping (ReaderAbstractTopic?) -> Void) {
+        let viewController = makeFilterSheetViewController(completion: completion)
+        let bottomSheet = BottomSheetViewController(childViewController: viewController)
+        bottomSheet.show(from: from, sourceView: sourceView, arrowDirections: .up)
+    }
+
+    func presentFilter(from: UIView, completion: @escaping (String?) -> Void) {
         filterTapped?(from, { [weak self] topic in
             self?.selectedFilter = topic
-            completion(topic)
+            if let topic = topic {
+                self?.tabSelectionCallback?(topic)
+            }
+            completion(topic?.title)
         })
     }
 
@@ -44,6 +53,17 @@ class ReaderTabViewModel {
     }
 
     func presentSettings() { }
+}
+
+// MARK: - Bottom Sheet
+
+extension ReaderTabViewModel {
+    private func makeFilterSheetViewController(completion: @escaping (ReaderAbstractTopic) -> Void) -> FilterSheetViewController {
+        return FilterSheetViewController(filters:
+            [ReaderSiteTopic.filterProvider(),
+             ReaderTagTopic.filterProvider()],
+            changedFilter: completion)
+    }
 }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -2,6 +2,7 @@
 class ReaderTabViewModel {
 
     var tabSelectionCallback: ((ReaderAbstractTopic) -> Void)?
+    var filterTapped: ((@escaping (ReaderAbstractTopic?) -> Void) -> Void)?
 
     init() {
         addNotificationsObservers()
@@ -18,9 +19,15 @@ class ReaderTabViewModel {
     // TODO: - READERNAV - Methods to be implemented. Signature will likely change
     func performSearch() { }
 
-    func presentFilter() { }
+    func presentFilter(completion: @escaping (ReaderAbstractTopic?) -> Void) {
+        filterTapped?(completion)
+    }
 
-    func resetFilter() { }
+    func resetFilter(selectedItem: FilterTabBarItem) {
+        if let topic = (selectedItem as? ReaderTabItem)?.topic {
+            tabSelectionCallback?(topic)
+        }
+    }
 
     func presentSettings() { }
 }

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/DrawerPresentationController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/DrawerPresentationController.swift
@@ -13,7 +13,7 @@ public enum DrawerHeight {
     // Height is based on the specified margin from the top of the screen
     case topMargin(CGFloat)
 
-    // Height will be equal to the the content height value
+    // Height will be equal to the the content height value. A height of 0 will use the calculated height.
     case contentHeight(CGFloat)
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1026,9 +1026,7 @@
 		83418AAA11C9FA6E00ACF00C /* Comment.m in Sources */ = {isa = PBXBuildFile; fileRef = 83418AA911C9FA6E00ACF00C /* Comment.m */; };
 		834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7331256D0DE0046A4A3 /* CFNetwork.framework */; };
 		8350E49611D2C71E00A7B073 /* Media.m in Sources */ = {isa = PBXBuildFile; fileRef = 8350E49511D2C71E00A7B073 /* Media.m */; };
-		8355D67E11D13EAD00A61362 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D67D11D13EAD00A61362 /* MobileCoreServices.framework */; };
 		8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D7D811D260AA00A61362 /* CoreData.framework */; };
-		835E2403126E66E50085940B /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 835E2402126E66E50085940B /* AssetsLibrary.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8370D10911FA499A009D650F /* WPTableViewActivityCell.m */; };
 		83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
 		83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E2D211276371004CD686 /* CoreLocation.framework */; };
@@ -2078,6 +2076,10 @@
 		F5E032E82408D537003AF350 /* BottomSheetPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E032E52408D537003AF350 /* BottomSheetPresentationController.swift */; };
 		F5E032EA2409C291003AF350 /* BottomSheetAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E032E92409C291003AF350 /* BottomSheetAnimationController.swift */; };
 		F5E032EC240D49FF003AF350 /* ActionSheetComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E032EB240D49FF003AF350 /* ActionSheetComponent.swift */; };
+		F5E29036243E4F5F00C19CA5 /* FilterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E29035243E4F5F00C19CA5 /* FilterProvider.swift */; };
+		F5E29038243FAB0300C19CA5 /* FilterTableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E29037243FAB0300C19CA5 /* FilterTableData.swift */; };
+		F5E63129243BC8190088229D /* FilterSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E63128243BC8190088229D /* FilterSheetView.swift */; };
+		F5E6312B243BC83E0088229D /* FilterSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E6312A243BC83E0088229D /* FilterSheetViewController.swift */; };
 		F5EF481723ABCAD8004C3532 /* MainShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74337EDC20054D5500777997 /* MainShareViewController.swift */; };
 		F5EF481823ABCAE0004C3532 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 740C7C4E202F4CD6001C31B0 /* MainInterface.storyboard */; };
 		F928EDA3226140620030D451 /* WPCrashLoggingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F928EDA2226140620030D451 /* WPCrashLoggingProvider.swift */; };
@@ -4668,6 +4670,10 @@
 		F5E032E52408D537003AF350 /* BottomSheetPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomSheetPresentationController.swift; sourceTree = "<group>"; };
 		F5E032E92409C291003AF350 /* BottomSheetAnimationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetAnimationController.swift; sourceTree = "<group>"; };
 		F5E032EB240D49FF003AF350 /* ActionSheetComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionSheetComponent.swift; sourceTree = "<group>"; };
+		F5E29035243E4F5F00C19CA5 /* FilterProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterProvider.swift; sourceTree = "<group>"; };
+		F5E29037243FAB0300C19CA5 /* FilterTableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTableData.swift; sourceTree = "<group>"; };
+		F5E63128243BC8190088229D /* FilterSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSheetView.swift; sourceTree = "<group>"; };
+		F5E6312A243BC83E0088229D /* FilterSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSheetViewController.swift; sourceTree = "<group>"; };
 		F7E3CC306AECBBCB71D2E19C /* Pods_WordPressDraftActionExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressDraftActionExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F928EDA2226140620030D451 /* WPCrashLoggingProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPCrashLoggingProvider.swift; sourceTree = "<group>"; };
 		F93735F022D534FE00A3C312 /* LoggingURLRedactor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoggingURLRedactor.swift; sourceTree = "<group>"; };
@@ -4798,7 +4804,6 @@
 				FF75933B1BE2423800814D3B /* Photos.framework in Frameworks */,
 				93E5285619A77BAC003A1A9C /* NotificationCenter.framework in Frameworks */,
 				93A3F7DE1843F6F00082FEEA /* CoreTelephony.framework in Frameworks */,
-				8355D67E11D13EAD00A61362 /* MobileCoreServices.framework in Frameworks */,
 				A01C542E0E24E88400D411F2 /* SystemConfiguration.framework in Frameworks */,
 				374CB16215B93C0800DD0EBC /* AudioToolbox.framework in Frameworks */,
 				E10B3655158F2D7800419A93 /* CoreGraphics.framework in Frameworks */,
@@ -4813,7 +4818,6 @@
 				83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */,
 				8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */,
 				834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */,
-				835E2403126E66E50085940B /* AssetsLibrary.framework in Frameworks */,
 				83043E55126FA31400EC9953 /* MessageUI.framework in Frameworks */,
 				FD3D6D2C1349F5D30061136A /* ImageIO.framework in Frameworks */,
 				B5AA54D51A8E7510003BDD12 /* WebKit.framework in Frameworks */,
@@ -9300,6 +9304,7 @@
 		CCB3A03814C8DD5100D43C3F /* Reader */ = {
 			isa = PBXGroup;
 			children = (
+				F597768C243E1E140062BAD1 /* Filter */,
 				5D1D04731B7A50B100CDE646 /* Reader.storyboard */,
 				5D5A6E901B613C1800DAF819 /* Cards */,
 				5D08B8FD19647C0800D5B381 /* Controllers */,
@@ -10083,6 +10088,17 @@
 				F57402A6235FF9C300374346 /* SchedulingDate+Helpers.swift */,
 			);
 			path = Scheduling;
+			sourceTree = "<group>";
+		};
+		F597768C243E1E140062BAD1 /* Filter */ = {
+			isa = PBXGroup;
+			children = (
+				F5E63128243BC8190088229D /* FilterSheetView.swift */,
+				F5E6312A243BC83E0088229D /* FilterSheetViewController.swift */,
+				F5E29035243E4F5F00C19CA5 /* FilterProvider.swift */,
+				F5E29037243FAB0300C19CA5 /* FilterTableData.swift */,
+			);
+			path = Filter;
 			sourceTree = "<group>";
 		};
 		F5D0A64C23CC157100B20D27 /* Preview */ = {
@@ -11825,6 +11841,7 @@
 				313AE4A019E3F20400AAFABE /* CommentViewController.m in Sources */,
 				7E3E7A6620E44F200075D159 /* HeaderContentGroup.swift in Sources */,
 				B5015C581D4FDBB300C9449E /* NotificationActionsService.swift in Sources */,
+				F5E63129243BC8190088229D /* FilterSheetView.swift in Sources */,
 				A0E293F10E21027E00C6919C /* WPAddPostCategoryViewController.m in Sources */,
 				E6BDEA731CE4824300682885 /* ReaderSearchTopic.swift in Sources */,
 				9A8ECE132254A3260043C8DA /* JetpackInstallError+Blocking.swift in Sources */,
@@ -12064,6 +12081,7 @@
 				E166FA1B1BB0656B00374B5B /* PeopleCellViewModel.swift in Sources */,
 				73CE3E0E21F7F9D3007C9C85 /* TableViewOffsetCoordinator.swift in Sources */,
 				436D56292117312700CEAA33 /* RegisterDomainDetailsViewController.swift in Sources */,
+				F5E29036243E4F5F00C19CA5 /* FilterProvider.swift in Sources */,
 				027AC51D227896540033E56E /* DomainCreditEligibilityChecker.swift in Sources */,
 				83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */,
 				91DCE84421A6A7840062F134 /* PostEditor+BlogPicker.swift in Sources */,
@@ -12084,6 +12102,7 @@
 				74EFB5C8208674250070BD4E /* BlogListViewController+Activity.swift in Sources */,
 				738B9A5721B85CF20005062B /* TableDataCoordinator.swift in Sources */,
 				B541276B1C0F7D610015CA80 /* SettingsMultiTextViewController.m in Sources */,
+				F5E6312B243BC83E0088229D /* FilterSheetViewController.swift in Sources */,
 				E6F2788021BC1A4A008B4DB5 /* Plan.swift in Sources */,
 				B5AC00681BE3C4E100F8E7C3 /* DiscussionSettingsViewController.swift in Sources */,
 				D816C1F620E0896F00C4D82F /* TrashComment.swift in Sources */,
@@ -12414,6 +12433,7 @@
 				E6A2158E1D10627500DE5270 /* ReaderMenuViewModel.swift in Sources */,
 				73C8F06021BEED9100DDDF7E /* SiteAssemblyStep.swift in Sources */,
 				82C420761FE44BD900CFB15B /* SiteSettingsViewController+Swift.swift in Sources */,
+				F5E29038243FAB0300C19CA5 /* FilterTableData.swift in Sources */,
 				E6A3384C1BB08E3F00371587 /* ReaderGapMarker.m in Sources */,
 				D8281CF1212AB34C00D09098 /* NewsStats.swift in Sources */,
 				E1CFC1571E0AC8FF001DF9E9 /* Pattern.swift in Sources */,


### PR DESCRIPTION
#13581 This adds the Filter Sheet control for filtering the Reader stream.

### Testing

- Open to the Reader screen and select the "Filter" button

### Known Issues

* No Empty Sites or Tags views. I'll add these in a follow up PR.
* No Unit tests. I will also add these in a follow up PR (maybe the same with the empty views)

### UX Questions

@osullivanchris I have a few questions about some things I noticed that we might want to add/change:

- I think we may want to update the designs to show the site's icon to match what the current app is doing. I can do this in a follow up PR.
- Should we show a checkmark next to the currently selected site / tag in the filter table?
- On Landscape iPhone, the bottom sheet starts out "collapsed" (half way down the screen) this doesn't leave much room for scrolling (see the first iPhone landscape screenshot below). Should we transition to an expanded height in that orientation?

### Summary

A bottom sheet modal appears half way up the screen on iPhone and can be swiped up to enlarge:

<a href="https://user-images.githubusercontent.com/3250/79028384-08e2c900-7b4d-11ea-9aa6-f23233495701.gif"><img src="https://user-images.githubusercontent.com/3250/79028384-08e2c900-7b4d-11ea-9aa6-f23233495701.gif" width="300"></a>

On iPad, a popover is used:

<a href="https://user-images.githubusercontent.com/3250/79028389-0c765000-7b4d-11ea-8bc4-eb73c2311773.gif"><img src="https://user-images.githubusercontent.com/3250/79028389-0c765000-7b4d-11ea-8bc4-eb73c2311773.gif" width="400"></a>

<details>
  <summary>Screenshots</summary>
<img width="1142" alt="Screen Shot 2020-04-10 at 4 58 36 PM" src="https://user-images.githubusercontent.com/3250/79028488-5fe89e00-7b4d-11ea-9ea6-0244404f1fac.png">
<img width="1142" alt="Screen Shot 2020-04-10 at 4 58 44 PM" src="https://user-images.githubusercontent.com/3250/79028489-624af800-7b4d-11ea-8662-58f7fd457896.png">
<img width="739" alt="Screen Shot 2020-04-10 at 4 52 16 PM" src="https://user-images.githubusercontent.com/3250/79028376-fcf70700-7b4c-11ea-89d6-4860378fa5f3.png">
</details>

PR submission checklist:

- [x] ~I have considered adding unit tests where possible.~ These will be added in a follow up PR
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Unreleased
