### PR TITLE
Changes grip button margin

### DIFF
--- a/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
+++ b/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
@@ -27,10 +27,14 @@ class BottomSheetViewController: UIViewController {
         }
     }
 
+    private var customHeaderSpacing: CGFloat?
+
     private weak var childViewController: DrawerPresentableViewController?
 
-    init(childViewController: DrawerPresentableViewController) {
+    init(childViewController: DrawerPresentableViewController,
+         customHeaderSpacing: CGFloat? = nil) {
         self.childViewController = childViewController
+        self.customHeaderSpacing = customHeaderSpacing
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -58,6 +62,8 @@ class BottomSheetViewController: UIViewController {
         return button
     }()
 
+    private var stackView: UIStackView!
+
     @objc func buttonPressed() {
         dismiss(animated: true, completion: nil)
     }
@@ -84,12 +90,12 @@ class BottomSheetViewController: UIViewController {
 
         addChild(childViewController)
 
-        let stackView = UIStackView(arrangedSubviews: [
+        stackView = UIStackView(arrangedSubviews: [
             gripButton,
             childViewController.view
         ])
 
-        stackView.setCustomSpacing(Constants.Header.spacing, after: gripButton)
+        stackView.setCustomSpacing(customHeaderSpacing ?? Constants.Header.spacing, after: gripButton)
 
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
@@ -147,6 +153,10 @@ extension BottomSheetViewController: UIViewControllerTransitioningDelegate {
 
 // MARK: - DrawerDelegate
 extension BottomSheetViewController: DrawerPresentable {
+    var allowsUserTransition: Bool {
+        return childViewController?.allowsUserTransition ?? true
+    }
+
     var compactWidth: DrawerWidth {
         childViewController?.compactWidth ?? .percentage(0.66)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -136,7 +136,7 @@ extension PostEditor where Self: UIViewController {
             publishAction()
         }
         let prepublishingNavigationController = PrepublishingNavigationController(rootViewController: prepublishing)
-        let bottomSheet = BottomSheetViewController(childViewController: prepublishingNavigationController)
+        let bottomSheet = BottomSheetViewController(childViewController: prepublishingNavigationController, customHeaderSpacing: 0)
         bottomSheet.show(from: self, sourceView: navigationBarManager.publishButton)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
@@ -22,7 +22,7 @@ extension PrepublishingNavigationController: DrawerPresentable {
     var allowsUserTransition: Bool {
         return false
     }
-    
+
     var expandedHeight: DrawerHeight {
         return .topMargin(20)
     }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
@@ -19,6 +19,10 @@ class PrepublishingNavigationController: LightNavigationController {
 // MARK: - DrawerPresentable
 
 extension PrepublishingNavigationController: DrawerPresentable {
+    var allowsUserTransition: Bool {
+        return false
+    }
+    
     var expandedHeight: DrawerHeight {
         return .topMargin(20)
     }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -63,8 +63,6 @@ class PrepublishingViewController: UITableViewController {
         setupPublishButton()
 
         announcePublishButton()
-
-        tableView.isScrollEnabled = false
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Depends on #13853

Fixes #13876

This PR reduces the space below the grip button and disable gestures to increase the Nudges view height.

### To test

1. Tap "Publish..."
2. Tap "Tags"
3. Check that the space between the navigation bar and the grip is zero
