### PR TITLE
Fix crash on Bottom Sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Action Sheet/DrawerPresentationController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/DrawerPresentationController.swift
@@ -422,11 +422,12 @@ private extension DrawerPresentationController {
         guard
             let scrollView = presentableViewController?.scrollableView,
             !scrollView.isScrolling,
-            let presentedView = self.presentedView
+            let presentedView = self.presentedView,
+            let presentingView = presentingViewController.view
             else { return }
 
 
-        let bottom = presentingViewController.view.safeAreaLayoutGuide.layoutFrame.origin.y
+        let bottom = presentingView.safeAreaLayoutGuide.layoutFrame.origin.y
         let margin = presentedView.frame.origin.y + bottom
 
         scrollView.contentInset.bottom = margin


### PR DESCRIPTION
Fixes #13879

### What was the issue

The method `configureScrollViewInsets` was crashing due to a `nil` property only on devices.

### What was fixed

We just check if `presentingViewController.view` exists before moving on.

### To test

Using a DEVICE (the crash doesn't happen on Simulator):

* Tap "Publish..." to show the Nudges view
* Tap "Publish" option to schedule
* Dismiss the calendar
* Dismiss the Nudges view
* Tap "Publish..." to show the Nudges view again
* Tap "Tags"
* Tags show be displayed