### PR TITLE
Remove the .showURLUsernamePassword segue and replace with navController

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -185,9 +185,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    #pod 'WordPressAuthenticator', '~> 1.13.0-beta.3'
+    pod 'WordPressAuthenticator', '~> 1.13.0-beta.3'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/239-remove-showURLUsernamePassword'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
 #    pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -185,9 +185,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.13.0-beta.1'
+    #pod 'WordPressAuthenticator', '~> 1.13.0-beta.3'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/239-remove-showURLUsernamePassword'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
      # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -479,7 +479,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.17.1)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/239-remove-showURLUsernamePassword`)
+  - WordPressAuthenticator (~> 1.13.0-beta.3)
   - WordPressKit (~> 4.7.1-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -527,6 +527,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -612,9 +613,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.25.0
-  WordPressAuthenticator:
-    :branch: issue/239-remove-showURLUsernamePassword
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.25.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -628,9 +626,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.25.0
-  WordPressAuthenticator:
-    :commit: 9a1cdfce612c96623bdf7680cc493d405f295e3a
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -719,6 +714,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 4573a5308667afd305404b2277ef0c2d7bd55613
+PODFILE CHECKSUM: 318b388b9de5b3025ac2de8fe4119edf6ce8a261
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -376,7 +376,7 @@ PODS:
   - WordPress-Aztec-iOS (1.17.1)
   - WordPress-Editor-iOS (1.17.1):
     - WordPress-Aztec-iOS (= 1.17.1)
-  - WordPressAuthenticator (1.13.0-beta.1):
+  - WordPressAuthenticator (1.13.0-beta.3):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -479,7 +479,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.17.1)
-  - WordPressAuthenticator (~> 1.13.0-beta.1)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/239-remove-showURLUsernamePassword`)
   - WordPressKit (~> 4.7.1-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -527,7 +527,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -613,6 +612,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.25.0
+  WordPressAuthenticator:
+    :branch: issue/239-remove-showURLUsernamePassword
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.25.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -626,6 +628,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.25.0
+  WordPressAuthenticator:
+    :commit: 9a1cdfce612c96623bdf7680cc493d405f295e3a
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -697,7 +702,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 319620514af963ca519bd83b96a2c0ebdf3a0f03
   WordPress-Editor-iOS: 497b55838ef0030cc6ca82eb92da84e661423521
-  WordPressAuthenticator: b64a15c023570a85ffa748766fd3e7469eac9449
+  WordPressAuthenticator: 6aa4deec9a328c354ea08a1d1a60f1ca19cb8279
   WordPressKit: dde0a214279fb70d7150b69ae90c7224c18fe2d0
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
@@ -714,6 +719,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 082f5addde6658b17532f09619ce370f79441e6b
+PODFILE CHECKSUM: 4573a5308667afd305404b2277ef0c2d7bd55613
 
 COCOAPODS: 1.8.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,9 @@
 14.7
 -----
-* [internal] the signup flow using email has code changes that can cause regressions. See https://git.io/JvALZ for testing details.
 * Classic Editor: Fixed action sheet position for additional Media sources picker on iPad
+* [internal] the signup flow using email has code changes that can cause regressions. See https://git.io/JvALZ for testing details.
 * [internal] Notifications tab should pop to the root of the navigation stack when tapping on the tab from within a notification detail screen. See https://git.io/Jvxka for testing details.
+* [internal] the login by email flow and the self-hosted login flow have code changes that can cause regressions. See https://git.io/JfeFN for testing details.
  
 14.6
 -----


### PR DESCRIPTION
Fixes # n/a

This PR removes the segue `.showURLUsernamePassword`, which sends the user to the `LoginSelfHostedViewController`. Now the user is navigated programmatically.

Ref. https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/240

### To test:
The object of the game is to reach the "username / password" screen 👇 from two different scenarios.

<img src="https://user-images.githubusercontent.com/1062444/79264265-e9ec7b80-7e59-11ea-8f87-2a57f7d084f4.png" width="350" />

Go through these flows:

#### Flow 1, Suspicious email. Login through self-hosted
**Devs:** not sure how to make an email address flagged as suspicious on purpose, so we'll do it manually.
**Testers:** you might have to skip testing this flow since I don't know how to manually make an email address get flagged as suspicious. 

1. Check out this branch AND check out the Authenticator branch. 
2. In the Authenticator code, go to the `LoginEmailViewController`. Remove the success code starting at L367. Replace it with failure code: 
```
                                        let error = NSError(domain:"", code: 401, userInfo:[WordPressComRestApi.ErrorKeyErrorCode: "email_login_not_allowed"])
                                        self?.showSelfHostedUsernamePasswordAndError(error as! Error)
```
Build the code.
3. Make the WPiOS podfile point to the local dev pod.
4. `rake dependencies`
5. Build and run WPiOS.
6. Log out if you're logged in.
7. Log in > Continue with WordPress.com > enter an email address > Next
8. **Expected:** an alert will appear. The wording isn't important, just the behavior. Tap Okay.
9. **Expected:** after the alert dismisses, you'll notice you are now on the self-hosted login flow. The address will say "wordpress.com" and the username / password fields are blank.
10. Log in with your username / password
11. **Expected:** you can log in successfully.

#### Flow 2, Self-hosted site login
1. Undo / discard any local changes made to Authenticator and WPiOS
2. `rake dependencies`
3. Build and run
4. Log out if you're logged in
5. Log in > entering your site address (text link) > site address > Next > username / password
6. **Expected:** you can log in successfully.

### Do not merge until:
2. The Authenticator PR has been merged: Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/240 ✔️
3. A new Authenticator release has been created ✔️
4. The release is published on Cocoapods trunk ✔️
5. This PR points to the new release  ✔️

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
