### PR TITLE
Add Saved Posts to the new Reader

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -34,7 +34,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .floatingCreateButton:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .newReaderNavigation:
-            return false
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -34,7 +34,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .floatingCreateButton:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .newReaderNavigation:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return false
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -6,7 +6,13 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
 
     var imageRequestAuthToken: String? = nil
     var isLoggedIn: Bool = false
-    private let visibleConfirmation: Bool
+    var visibleConfirmation: Bool {
+        didSet {
+            saveForLaterAction?.visibleConfirmation = visibleConfirmation
+        }
+    }
+
+    private weak var saveForLaterAction: ReaderSaveForLaterAction?
 
     // saved posts
     /// Posts that have been removed but not yet discarded
@@ -120,13 +126,11 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
 
     func toggleSavedForLater(for post: ReaderPost) {
         let actionOrigin: ReaderSaveForLaterOrigin
-        // TODO: - READERNAV - Remove this check once the old reader is removed
-        var presentSavedPostAlert = visibleConfirmation
+        // TODO: - READERNAV - Update this check once the old reader is removed
         if origin is ReaderSavedPostsViewController {
             actionOrigin = .savedStream
         } else if let origin = origin as? ReaderStreamViewController, origin.isSavedPostsController, FeatureFlag.newReaderNavigation.enabled {
             actionOrigin = .savedStream
-            presentSavedPostAlert = false
 
         } else {
             actionOrigin = .otherStream
@@ -138,7 +142,10 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
             }
         }
 
-        ReaderSaveForLaterAction(visibleConfirmation: presentSavedPostAlert).execute(with: post, context: context, origin: actionOrigin)
+        let saveAction = ReaderSaveForLaterAction(visibleConfirmation: visibleConfirmation)
+
+        saveAction.execute(with: post, context: context, origin: actionOrigin)
+        saveForLaterAction = saveAction
     }
 
     fileprivate func visitSiteForPost(_ post: ReaderPost) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -121,19 +121,24 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
     func toggleSavedForLater(for post: ReaderPost) {
         let actionOrigin: ReaderSaveForLaterOrigin
         // TODO: - READERNAV - Remove this check once the old reader is removed
+        var presentSavedPostAlert = visibleConfirmation
         if origin is ReaderSavedPostsViewController {
             actionOrigin = .savedStream
+        } else if let origin = origin as? ReaderStreamViewController, origin.isSavedPostsController, FeatureFlag.newReaderNavigation.enabled {
+            actionOrigin = .savedStream
+            presentSavedPostAlert = false
+
         } else {
             actionOrigin = .otherStream
         }
 
         if !post.isSavedForLater {
-            if let origin = origin as? UIViewController & UIViewControllerTransitioningDelegate {
+            if let origin = origin as? ReaderStreamViewController, !origin.isSavedPostsController {
                 FancyAlertViewController.presentReaderSavedPostsAlertControllerIfNecessary(from: origin)
             }
         }
 
-        ReaderSaveForLaterAction(visibleConfirmation: visibleConfirmation).execute(with: post, context: context, origin: actionOrigin)
+        ReaderSaveForLaterAction(visibleConfirmation: presentSavedPostAlert).execute(with: post, context: context, origin: actionOrigin)
     }
 
     fileprivate func visitSiteForPost(_ post: ReaderPost) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -213,10 +213,7 @@ extension ReaderPostCellActions {
     }
 
     func clearRemovedPosts() {
-        let allRemovedPosts = removedPosts.all()
-        for post in allRemovedPosts {
-            toggleSavedForLater(for: post)
-        }
+        removedPosts.all().forEach({ toggleSavedForLater(for: $0) })
         removedPosts = ReaderSaveForLaterRemovedPosts()
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -83,6 +83,10 @@ extension ReaderSavedPostsViewController {
 
 extension ReaderStreamViewController {
     func trackSavedPostNavigation() {
-        WPAppAnalytics.track(.readerSavedPostOpened, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.otherStream.openPostValue ])
+        if FeatureFlag.newReaderNavigation.enabled, isSavedPostsController {
+            WPAppAnalytics.track(.readerSavedPostOpened, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.savedStream.openPostValue ])
+        } else {
+            WPAppAnalytics.track(.readerSavedPostOpened, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.otherStream.openPostValue ])
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -6,7 +6,7 @@ enum ReaderSaveForLaterOrigin {
     case postDetail
     case readerMenu
 
-    fileprivate var saveActionValue: String {
+    var saveActionValue: String {
         switch self {
         case .savedStream:
             return "saved_post_list"
@@ -19,7 +19,7 @@ enum ReaderSaveForLaterOrigin {
         }
     }
 
-    fileprivate var openPostValue: String {
+    var openPostValue: String {
         switch self {
         case .savedStream:
             return "saved_post_list"
@@ -32,7 +32,7 @@ enum ReaderSaveForLaterOrigin {
         }
     }
 
-    fileprivate var viewAllPostsValue: String {
+    var viewAllPostsValue: String {
         switch self {
         case .savedStream:
             return "post_list_saved_post_notice"

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -6,7 +6,7 @@ enum ReaderSaveForLaterOrigin {
     case postDetail
     case readerMenu
 
-    var saveActionValue: String {
+    fileprivate var saveActionValue: String {
         switch self {
         case .savedStream:
             return "saved_post_list"
@@ -19,7 +19,7 @@ enum ReaderSaveForLaterOrigin {
         }
     }
 
-    var openPostValue: String {
+    fileprivate var openPostValue: String {
         switch self {
         case .savedStream:
             return "saved_post_list"
@@ -32,6 +32,7 @@ enum ReaderSaveForLaterOrigin {
         }
     }
 
+    // TODO: - READERNAV - Refactor this and ReaderStreamViewController+Helper once the old reader is removed
     var viewAllPostsValue: String {
         switch self {
         case .savedStream:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
@@ -11,7 +11,7 @@ final class ReaderSaveForLaterAction {
         static let removeFromSavedError = NSLocalizedString("Could not remove post from Saved for Later", comment: "Title of a prompt.")
     }
 
-    private let visibleConfirmation: Bool
+    var visibleConfirmation: Bool
 
     init(visibleConfirmation: Bool = false) {
         self.visibleConfirmation = visibleConfirmation

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -5,31 +5,11 @@ protocol ReaderSavedPostCellActionsDelegate: class {
 
 /// Specialises ReaderPostCellActions to provide specific overrides for the ReaderSavedPostsViewController
 final class ReaderSavedPostCellActions: ReaderPostCellActions {
-    /// Posts that have been removed but not yet discarded
-    private var removedPosts = ReaderSaveForLaterRemovedPosts()
-
-    weak var delegate: ReaderSavedPostCellActionsDelegate?
 
     override func readerCell(_ cell: ReaderPostCardCell, saveActionForProvider provider: ReaderPostContentProvider) {
         if let post = provider as? ReaderPost {
             removedPosts.add(post)
         }
-        delegate?.willRemove(cell)
-    }
-
-    func postIsRemoved(_ post: ReaderPost) -> Bool {
-        return removedPosts.contains(post)
-    }
-
-    func restoreUnsavedPost(_ post: ReaderPost) {
-        removedPosts.remove(post)
-    }
-
-    func clearRemovedPosts() {
-        let allRemovedPosts = removedPosts.all()
-        for post in allRemovedPosts {
-            toggleSavedForLater(for: post)
-        }
-        removedPosts = ReaderSaveForLaterRemovedPosts()
+        savedPostsDelegate?.willRemove(cell)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import Gridicons
 import WordPressShared
 import WordPressUI
-
+// TODO: - READERNAV - Remove this file once the new reader is released and stable
 final class ReaderSavedPostsViewController: UITableViewController {
     private enum Strings {
         static let title = NSLocalizedString("Saved Posts", comment: "Title for list of posts saved for later")
@@ -105,7 +105,7 @@ final class ReaderSavedPostsViewController: UITableViewController {
     @objc public func configurePostCardCell(_ cell: UITableViewCell, post: ReaderPost) {
         if postCellActions == nil {
             postCellActions = ReaderSavedPostCellActions(context: managedObjectContext(), origin: self, topic: post.topic, visibleConfirmation: false)
-            postCellActions?.delegate = self
+            postCellActions?.savedPostsDelegate = self
         }
 
         cellConfiguration.configurePostCardCell(cell,

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -131,5 +131,54 @@ extension ReaderStreamViewController {
             message: NSLocalizedString("No posts have been made recently", comment: "A default message shown whe the reader can find no post to display")
         )
     }
+}
 
+
+// MARK: - No Results for saved posts
+extension ReaderStreamViewController {
+    
+    func configureNoResultsViewForSavedPosts() {
+
+        let noResultsResponse = NoResultsResponse(title: NSLocalizedString("No Saved Posts",
+                                                                           comment: "Message displayed in Reader Saved Posts view if a user hasn't yet saved any posts."),
+                                                  message: NSLocalizedString("Tap [bookmark-outline] to save a post to your list.",
+                                                                             comment: "A hint displayed in the Saved Posts section of the Reader. The '[bookmark-outline]' placeholder will be replaced by an icon at runtime – please leave that string intact."))
+
+        var messageText = NSMutableAttributedString(string: noResultsResponse.message)
+
+        // Get attributed string styled for No Results so it gets the correct font attributes added to it.
+        // The font is used by the attributed string `replace(_:with:)` method below to correctly position the icon.
+        let styledText = resultsStatusView.applyMessageStyleTo(attributedString: messageText)
+        messageText = NSMutableAttributedString(attributedString: styledText)
+
+        let icon = UIImage.gridicon(.bookmarkOutline, size: CGSize(width: 18, height: 18))
+        messageText.replace("[bookmark-outline]", with: icon)
+
+        resultsStatusView.configure(title: noResultsResponse.title, attributedSubtitle: messageText)
+    }
+}
+
+
+// MARK: - Undo cell for saved posts
+extension ReaderStreamViewController {
+
+    private enum UndoCell {
+        static let nibName = "ReaderSavedPostUndoCell"
+        static let reuseIdentifier = "ReaderUndoCellReuseIdentifier"
+        static let height: CGFloat = 44
+    }
+
+    func setupUndoCell(_ tableView: UITableView) {
+        let nib = UINib(nibName: UndoCell.nibName, bundle: nil)
+        tableView.register(nib, forCellReuseIdentifier: UndoCell.reuseIdentifier)
+    }
+
+    func undoCell(_ tableView: UITableView) -> ReaderSavedPostUndoCell {
+        return tableView.dequeueReusableCell(withIdentifier: UndoCell.reuseIdentifier) as! ReaderSavedPostUndoCell
+    }
+
+    func configureUndoCell(_ cell: ReaderSavedPostUndoCell, with post: ReaderPost) {
+        cell.title.text = post.titleForDisplay()
+        cell.delegate = self
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -182,3 +182,11 @@ extension ReaderStreamViewController {
         cell.delegate = self
     }
 }
+
+
+// MARK: - Tracks
+extension ReaderStreamViewController {
+    func trackSavedListAccessed() {
+        WPAppAnalytics.track(.readerSavedListViewed, withProperties: ["source": ReaderSaveForLaterOrigin.readerMenu.viewAllPostsValue])
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -136,7 +136,7 @@ extension ReaderStreamViewController {
 
 // MARK: - No Results for saved posts
 extension ReaderStreamViewController {
-    
+
     func configureNoResultsViewForSavedPosts() {
 
         let noResultsResponse = NoResultsResponse(title: NSLocalizedString("No Saved Posts",

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -150,10 +150,8 @@ import WordPressFlux
             if isSavedPostsController {
                 configureControllerForTopic(synchronize: false)
                 trackSavedListAccessed()
-                postCellActions?.visibleConfirmation = false
-            } else {
-                postCellActions?.visibleConfirmation = true
             }
+            postCellActions?.visibleConfirmation = !isSavedPostsController
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -150,6 +150,9 @@ import WordPressFlux
             if isSavedPostsController {
                 configureControllerForTopic(synchronize: false)
                 trackSavedListAccessed()
+                postCellActions?.visibleConfirmation = false
+            } else {
+                postCellActions?.visibleConfirmation = true
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -519,6 +519,8 @@ import WordPressFlux
         updateAndPerformFetchRequest()
         if readerTopic != nil {
             configureStreamHeader()
+        } else {
+            tableView.tableHeaderView = nil
         }
         tableView.setContentOffset(CGPoint.zero, animated: false)
         content.refresh()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -141,11 +141,15 @@ import WordPressFlux
     }
 
     var isSavedPostsController: Bool = false {
-        didSet {
-            if !isSavedPostsController && oldValue {
+        willSet {
+            if isSavedPostsController && !newValue {
                 postCellActions?.clearRemovedPosts()
-            } else if isSavedPostsController {
+            }
+        }
+        didSet {
+            if isSavedPostsController {
                 configureControllerForTopic(synchronize: false)
+                trackSavedListAccessed()
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -185,6 +185,16 @@ extension ReaderTabView {
         }
     }
 
+    func switchToSavedPosts() {
+        guard let index = tabBar.items.firstIndex(where: {
+            $0.title == "Saved"
+        }) else {
+            return
+        }
+        tabBar.setSelectedIndex(index)
+        selectedTabDidChange(tabBar)
+    }
+
     /// Filter button
     @objc private func didTapFilterButton() {
         //TODO: - READERNAV - Remove. This test code is for UI prototyping only

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -26,10 +26,11 @@ class ReaderTabViewController: UIViewController {
     }
 }
 
-// MARK: - Actions
+// MARK: - Search
 extension ReaderTabViewController {
-    /// Search button
+
     @objc private func didTapSearchButton() {
-        viewModel.performSearch()
+        let searchController = ReaderSearchViewController.controller()
+        navigationController?.pushViewController(searchController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -34,3 +34,14 @@ extension ReaderTabViewController {
         navigationController?.pushViewController(searchController, animated: true)
     }
 }
+
+
+// MARK: - Tab Switching
+extension ReaderTabViewController {
+    @objc func navigateToSavedPosts() {
+        guard let readerTabView = view as? ReaderTabView else {
+            return
+        }
+        readerTabView.switchToSavedPosts()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -15,8 +15,6 @@ class ReaderTabViewModel {
     }
 
     // TODO: - READERNAV - Methods to be implemented. Signature will likely change
-    func performSearch() { }
-
     func presentFilter() { }
 
     func resetFilter() { }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -1,18 +1,17 @@
 
 class ReaderTabViewModel {
 
-    var tabSelectionCallback: ((ReaderAbstractTopic) -> Void)?
+    var tabSelectionCallback: ((ReaderAbstractTopic?) -> Void)?
 
     init() {
         addNotificationsObservers()
     }
 
     func showTab(for item: FilterTabBarItem) {
-        guard let readerItem = item as? ReaderTabItem,
-            let topic = readerItem.topic else {
-                return
+        guard let readerItem = item as? ReaderTabItem else {
+            return
         }
-        tabSelectionCallback?(topic)
+        tabSelectionCallback?(readerItem.topic)
     }
 
     // TODO: - READERNAV - Methods to be implemented. Signature will likely change
@@ -91,6 +90,7 @@ extension ReaderTabViewModel {
 
         self.tabSelectionCallback = { [weak controller] topic in
             controller?.setTopic(topic)
+            controller?.isSavedPostsController = topic == nil ? true : false
         }
         return controller
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -88,7 +88,7 @@ extension ReaderTabViewModel {
 
         self.tabSelectionCallback = { [weak controller] topic in
             controller?.setTopic(topic)
-            controller?.isSavedPostsController = topic == nil ? true : false
+            controller?.isSavedPostsController = (topic == nil)
         }
         return controller
     }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -923,6 +923,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
         [self.meNavigationController popToRootViewControllerAnimated:NO];
         [self.notificationsNavigationController popToRootViewControllerAnimated:NO];
     }
+    self.readerTabViewController = nil;
 }
 
 - (void)signinDidFinish:(NSNotification *)notification


### PR DESCRIPTION
#### Also adds the 'Search' on the top right

Ref #13580

To test:
##### Saved posts
- go to the Reader
- Save/unsave posts from any stream other than saved
- verify that the 'Saved' tab shows posts accordingly
- Verify that tapping one 'view all' on the toasts switches to the 'Saved' tab
- In the 'Saved' tab, tap on the 'save' icon, and verify that the undo cell appears and behaves as expected

##### Search
- tap on the 'search' button in the top right corner and verify that the search works same as the old reader.


PR submission checklist:

- [ ] ~~I have considered adding unit tests where possible.~~ will be added in a future PR
- [ ] ~~I have considered adding accessibility improvements for my changes.~~ will be handled in a future PR
- [ ] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~ Not released
