### PR TITLE
Show standard notice for network errors on the Media Library

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -595,6 +595,15 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
 
         updateViewState(for: pickerDataSource.numberOfAssets())
     }
+
+    func mediaPickerController(_ picker: WPMediaPickerViewController, handleError error: Error) -> Bool {
+        let nserror = error as NSError
+        if let mediaLibrary = self.blog.media, !mediaLibrary.isEmpty {
+            let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
+            WPError.showNetworkingNotice(title: title, error: nserror)
+        }
+        return true
+    }
 }
 
 // MARK: - State restoration


### PR DESCRIPTION
We are also disabling the default error message displayed by the
WPMediaPicker and not showing any message and use the no view screen
when media is empty.

Fixes #11320 
Fixes #10941 

To test:
 - Start the app
 - Navigate to a post where you never synced the media library before
 - Turn off the Internet Connection for the device
 - Open the Media Library
 - Check if the custom empty view shows a no extra alert is presented
 - Exit the Media Library
 - Turn on the internet connection
 - Renter the media library
 - Check that media assets shows
 - Turn off the connection again
 - Pull to refresh
 - See if a notice shows up with an easy to understand message.
 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
