### PR TITLE
Fixed post author not showing on drafted offline posts

### DIFF
--- a/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
+++ b/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
@@ -27,6 +27,7 @@
         }
 
         post.remoteStatus = .failed
+        post.author = post.blog.account?.displayName
 
         if !post.hasRemote() && post is Page {
             post.status = .draft


### PR DESCRIPTION
Fixes #12776

To test: Fixes a bug where the post author was not displayed for drafted posts made while offline, since the author info was obtained via networking. When the post is drafted while offline, the display name for the account associated with the blog is assigned as the author, so the user sees their name assigned to the post (rather than blank, as previously).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
