### PR TITLE
Prepublishing Nudges Tracks

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -8,7 +8,7 @@ import Foundation
     case createSheetShown
 
     // Prepublishing Nudges
-    case prepublishingTagsAdded
+    case editorPostPublishTap
 
     /// A String that represents the event
     var value: String {
@@ -21,8 +21,8 @@ import Foundation
             return "editor_page_created"
         case .createSheetShown:
             return "create_sheet_shown"
-        case .prepublishingTagsAdded:
-            return "prepublishing_tags_added"
+        case .editorPostPublishTap:
+            return "editor_post_publish_tapped"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -11,6 +11,7 @@ import Foundation
     case editorPostPublishTap
     case editorPostScheduled
     case editorPostVisibilityChanged
+    case editorPostTagsAdded
 
     /// A String that represents the event
     var value: String {
@@ -29,6 +30,8 @@ import Foundation
             return "editor_post_scheduled"
         case .editorPostVisibilityChanged:
             return "editor_post_visibility_changed"
+        case .editorPostTagsAdded:
+            return "editor_post_tags_added"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -10,6 +10,7 @@ import Foundation
     // Prepublishing Nudges
     case editorPostPublishTap
     case editorPostScheduled
+    case editorPostVisibilityChanged
 
     /// A String that represents the event
     var value: String {
@@ -26,6 +27,8 @@ import Foundation
             return "editor_post_publish_tapped"
         case .editorPostScheduled:
             return "editor_post_scheduled"
+        case .editorPostVisibilityChanged:
+            return "editor_post_visibility_changed"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -12,6 +12,7 @@ import Foundation
     case editorPostScheduled
     case editorPostVisibilityChanged
     case editorPostTagsAdded
+    case editorPostPublishNowTapped
 
     /// A String that represents the event
     var value: String {
@@ -32,6 +33,8 @@ import Foundation
             return "editor_post_visibility_changed"
         case .editorPostTagsAdded:
             return "editor_post_tags_added"
+        case .editorPostPublishNowTapped:
+            return "editor_post_publish_now_tapped"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -9,6 +9,7 @@ import Foundation
 
     // Prepublishing Nudges
     case editorPostPublishTap
+    case editorPostScheduled
 
     /// A String that represents the event
     var value: String {
@@ -23,6 +24,8 @@ import Foundation
             return "create_sheet_shown"
         case .editorPostPublishTap:
             return "editor_post_publish_tapped"
+        case .editorPostScheduled:
+            return "editor_post_scheduled"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -98,6 +98,8 @@ extension PostEditor where Self: UIViewController {
         if action.isAsync,
             let postStatus = self.post.original?.status ?? self.post.status,
             ![.publish, .publishPrivate].contains(postStatus) {
+            WPAnalytics.track(.editorPostPublishTap)
+
             // Only display confirmation alert for unpublished posts
             displayPublishConfirmationAlert(for: action, onPublish: publishBlock)
         } else {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1037,6 +1037,7 @@ FeaturedImageViewControllerDelegate>
     PostVisibilitySelectorViewController *vc = [[PostVisibilitySelectorViewController alloc] init:self.apost];
     __weak PostVisibilitySelectorViewController *weakVc = vc;
     vc.completion = ^(NSString *visibility) {
+        [WPAnalytics trackEvent:WPAnalyticsEventEditorPostVisibilityChanged properties:@{@"via": @"settings"}];
         [weakVc dismiss];
         [self.tableView reloadData];
     };

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1256,7 +1256,7 @@ FeaturedImageViewControllerDelegate>
 
     tagsPicker.onValueChanged = ^(NSString * _Nonnull value) {
         if (!value.isEmpty) {
-            [WPAnalytics track:WPAnalyticsStatPostSettingsTagsAdded];
+            [WPAnalytics trackEvent:WPAnalyticsEventEditorPostTagsAdded properties:@{@"via": @"settings"}];
         }
 
         self.post.tags = value;

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -194,6 +194,7 @@ class PrepublishingViewController: UITableViewController {
             sourceView: tableView.cellForRow(at: indexPath)?.contentView,
             viewModel: publishSettingsViewModel,
             updated: { [weak self] date in
+                WPAnalytics.track(.editorPostScheduled, properties: ["via": "prepublishing_nudges"])
                 self?.publishSettingsViewModel.setDate(date)
                 self?.reloadData()
                 self?.updatePublishButtonLabel()

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -170,6 +170,8 @@ class PrepublishingViewController: UITableViewController {
         visbilitySelectorViewController.completion = { [weak self] option in
             self?.reloadData()
 
+            WPAnalytics.track(.editorPostVisibilityChanged, properties: ["via": "prepublishing_nudges"])
+
             // If tue user selects password protected, prompt for a password
             if option == AbstractPost.passwordProtectedLabel {
                 self?.showPasswordAlert()

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -243,6 +243,7 @@ class PrepublishingViewController: UITableViewController {
 
     @objc func publish(_ sender: UIButton) {
         navigationController?.dismiss(animated: true) {
+            WPAnalytics.track(.editorPostPublishNowTapped)
             self.completion(self.post)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -148,7 +148,7 @@ class PrepublishingViewController: UITableViewController {
 
         tagPickerViewController.onValueChanged = { [weak self] tags in
             if !tags.isEmpty {
-                WPAnalytics.track(.editorPostTagsAdded, properties: ["via": "prepublishing_nudges"])
+                WPAnalytics.track(.editorPostTagsAdded, properties: Constants.analyticsDefaultProperty)
             }
 
             self?.post.tags = tags
@@ -170,7 +170,7 @@ class PrepublishingViewController: UITableViewController {
         visbilitySelectorViewController.completion = { [weak self] option in
             self?.reloadData()
 
-            WPAnalytics.track(.editorPostVisibilityChanged, properties: ["via": "prepublishing_nudges"])
+            WPAnalytics.track(.editorPostVisibilityChanged, properties: Constants.analyticsDefaultProperty)
 
             // If tue user selects password protected, prompt for a password
             if option == AbstractPost.passwordProtectedLabel {
@@ -196,7 +196,7 @@ class PrepublishingViewController: UITableViewController {
             sourceView: tableView.cellForRow(at: indexPath)?.contentView,
             viewModel: publishSettingsViewModel,
             updated: { [weak self] date in
-                WPAnalytics.track(.editorPostScheduled, properties: ["via": "prepublishing_nudges"])
+                WPAnalytics.track(.editorPostScheduled, properties: Constants.analyticsDefaultProperty)
                 self?.publishSettingsViewModel.setDate(date)
                 self?.reloadData()
                 self?.updatePublishButtonLabel()
@@ -298,6 +298,7 @@ class PrepublishingViewController: UITableViewController {
         static let publishNow = NSLocalizedString("Publish Now", comment: "Label for a button that publishes the post")
         static let scheduleNow = NSLocalizedString("Schedule Now", comment: "Label for the button that schedules the post")
         static let headerHeight: CGFloat = 70
+        static let analyticsDefaultProperty = ["via": "prepublishing_nudges"]
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -147,9 +147,9 @@ class PrepublishingViewController: UITableViewController {
         let tagPickerViewController = PostTagPickerViewController(tags: post.tags ?? "", blog: post.blog)
 
         tagPickerViewController.onValueChanged = { [weak self] tags in
-            if !tags.isEmpty {
-                WPAnalytics.track(.prepublishingTagsAdded)
-            }
+//            if !tags.isEmpty {
+//                WPAnalytics.track(.prepublishingTagsAdded)
+//            }
 
             self?.post.tags = tags
             self?.reloadData()

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -147,9 +147,9 @@ class PrepublishingViewController: UITableViewController {
         let tagPickerViewController = PostTagPickerViewController(tags: post.tags ?? "", blog: post.blog)
 
         tagPickerViewController.onValueChanged = { [weak self] tags in
-//            if !tags.isEmpty {
-//                WPAnalytics.track(.prepublishingTagsAdded)
-//            }
+            if !tags.isEmpty {
+                WPAnalytics.track(.editorPostTagsAdded, properties: ["via": "prepublishing_nudges"])
+            }
 
             self?.post.tags = tags
             self?.reloadData()

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -202,6 +202,7 @@ private struct DateAndTimeRow: ImmuTableRow {
                 dateFormatter: model.dateFormatter,
                 dateTimeFormatter: model.dateTimeFormatter,
                 updated: { [weak self] date in
+                    WPAnalytics.track(.editorPostScheduled, properties: ["via": "settings"])
                     self?.viewModel.setDate(date)
                     NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: ImmuTableViewController.modelChangedNotification), object: nil)
                 }


### PR DESCRIPTION
Fixes #13902

### To test

### Tap "Publish"

Check if `editor_post_publish_tapped` is fired.

### Schedule the post through the Nudges view

Check if `editor_post_scheduled` is fired with `via: prepublishing_nudges` property.

### Schedule the post through the Post Settings

Check if `editor_post_scheduled` is fired with `via: settings` property.

### Change post visibility through the Nudges view

Check if `editor_post_visibility_changed` is fired `via: prepublishing_nudges` property.

### Change post visibility through the Post Settings

Check if `editor_post_visibility_changed` is fired `via: settings` property.

### Change tags through the Nudges view

Check if `editor_post_tags_added` is fired `via: prepublishing_nudges` property.

### Change tags through the Post Settings

Check if `editor_post_tags_added` is fired `via: settings` property.

### Tap "Publish Now" or "Schedule Now"

Check if `editor_post_publish_now_tapped` is fired.