### PR TITLE
Fixes some issues with GIF images in the reader.

### DIFF
--- a/WordPress/Classes/Utility/Media/GIFPlaybackStrategy.swift
+++ b/WordPress/Classes/Utility/Media/GIFPlaybackStrategy.swift
@@ -54,18 +54,18 @@ extension GIFPlaybackStrategy {
 
 class SmallGIFPlaybackStrategy: GIFPlaybackStrategy {
     var maxSize = 8_000_000  // in MB
-    var frameBufferCount = 25
+    var frameBufferCount = 50
     var gifStrategy: GIFStrategy = .smallGIFs
 }
 
 class MediumGIFPlaybackStrategy: GIFPlaybackStrategy {
     var maxSize = 20_000_000  // in MB
-    var frameBufferCount = 50
+    var frameBufferCount = 150
     var gifStrategy: GIFStrategy = .mediumGIFs
 }
 
 class LargeGIFPlaybackStrategy: GIFPlaybackStrategy {
     var maxSize = 50_000_000  // in MB
-    var frameBufferCount = 60
+    var frameBufferCount = 300
     var gifStrategy: GIFStrategy = .largeGIFs
 }

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -16,10 +16,6 @@ import WordPressShared
 ///
 class WPRichContentView: UITextView {
 
-    /// Used to keep references to image attachments.
-    ///
-    var mediaArray = [RichMedia]()
-
     /// Manages the layout and positioning of text attachments.
     ///
     @objc lazy var attachmentManager: WPTextAttachmentManager = {
@@ -339,29 +335,21 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
             attachment.maxSize = CGSize(width: finalSize.width, height: finalSize.height)
         }
 
-        let index = mediaArray.count
-        let indexPath = IndexPath(row: index, section: 1)
         weak var weakImage = image
 
-        image.loadImage(from: mediaHost, preferedSize: finalSize, indexPath: indexPath, onSuccess: { [weak self] indexPath in
-            guard
-                let richMedia = self?.mediaArray[indexPath.row],
-                let img = weakImage
-            else {
+        image.loadImage(from: mediaHost, preferedSize: finalSize, onSuccess: { [weak self] in
+            guard let img = weakImage else {
                 return
             }
 
-            richMedia.attachment.maxSize = img.contentSize()
+            attachment.maxSize = img.contentSize()
 
             if isUsingTemporaryLayoutDimensions {
                 self?.layoutAttachmentViews()
             }
-        }, onError: { (indexPath, error) in
+        }, onError: { (error) in
             DDLogError("\(String(describing: error))")
         })
-
-        let media = RichMedia(image: image, attachment: attachment)
-        mediaArray.append(media)
 
         return image
     }
@@ -415,12 +403,13 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
     /// - Returns: An NSRange optional.
     ///
     func attachmentRangeForRichTextImage(_ richTextImage: WPRichTextImage) -> NSRange? {
-        for item in mediaArray {
-            if item.image == richTextImage {
-                return rangeOfAttachment(item.attachment)
-            }
+        guard let match = attachmentManager.attachmentViews.first( where: { (_, value) -> Bool in
+            return value.view == richTextImage
+        }) else {
+            return nil
         }
-        return nil
+        
+        return rangeOfAttachment(match.key)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -408,7 +408,7 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
         }) else {
             return nil
         }
-        
+
         return rangeOfAttachment(match.key)
     }
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextImage.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextImage.swift
@@ -10,7 +10,7 @@ open class WPRichTextImage: UIControl, WPRichTextMediaAttachment {
     @objc fileprivate(set) var imageView: CachedAnimatedImageView
 
     fileprivate lazy var imageLoader: ImageLoader = {
-        let imageLoader = ImageLoader(imageView: imageView, gifStrategy: .smallGIFs)
+        let imageLoader = ImageLoader(imageView: imageView, gifStrategy: .largeGIFs)
         imageLoader.photonQuality = Constants.readerPhotonQuality
         return imageLoader
     }()
@@ -73,25 +73,23 @@ open class WPRichTextImage: UIControl, WPRichTextMediaAttachment {
     /// - Parameters:
     ///   - host: The host for the media.
     ///   - preferedSize: The prefered size of the image to load.
-    ///   - indexPath: The IndexPath where this view is located — returned as a param in success and error blocks.
     ///   - onSuccess: A closure to be called if the image was loaded successfully.
     ///   - onError: A closure to be called if there was an error loading the image.
     func loadImage(from host: MediaHost,
                    preferedSize size: CGSize = .zero,
-                   indexPath: IndexPath,
-                   onSuccess: ((IndexPath) -> Void)?,
-                   onError: ((IndexPath, Error?) -> Void)?) {
+                   onSuccess: (() -> Void)?,
+                   onError: ((Error?) -> Void)?) {
         guard let contentURL = self.contentURL else {
-            onError?(indexPath, nil)
+            onError?(nil)
             return
         }
 
         let successHandler: (() -> Void)? = {
-            onSuccess?(indexPath)
+            onSuccess?()
         }
 
         let errorHandler: ((Error?) -> Void)? = { error in
-            onError?(indexPath, error)
+            onError?(error)
         }
 
         imageLoader.loadImage(with: contentURL, from: host, preferredSize: size, placeholder: nil, success: successHandler, error: errorHandler)

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachmentManager.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachmentManager.swift
@@ -6,7 +6,7 @@ import UIKit
 ///
 @objc open class WPTextAttachmentManager: NSObject {
     @objc open var attachments = [WPTextAttachment]()
-    var attachmentViews = [String: WPTextAttachmentView]()
+    var attachmentViews = [WPTextAttachment: WPTextAttachmentView]()
     @objc open weak var delegate: WPTextAttachmentManagerDelegate?
     @objc fileprivate(set) open weak var textView: UITextView?
     @objc let layoutManager: NSLayoutManager
@@ -40,7 +40,7 @@ import UIKit
     /// - Returns: A UIView optional
     ///
     @objc open func viewForAttachment(_ attachment: WPTextAttachment) -> UIView? {
-        return attachmentViews[attachment.identifier]?.view
+        return attachmentViews[attachment]?.view
     }
 
 
@@ -88,7 +88,7 @@ import UIKit
         // Make sure attachments are correctly laid out.
         attachmentsAndRanges.forEach { (attachment, range) in
 
-            guard let attachmentView = attachmentViews[attachment.identifier] else {
+            guard let attachmentView = attachmentViews[attachment] else {
                 return
             }
 
@@ -125,7 +125,7 @@ import UIKit
                 self.attachments.append(attachment)
 
                 if let view = self.delegate?.attachmentManager(self, viewForAttachment: attachment) {
-                    self.attachmentViews[attachment.identifier] = WPTextAttachmentView(view: view, identifier: attachment.identifier, exclusionPath: nil)
+                    self.attachmentViews[attachment] = WPTextAttachmentView(view: view, identifier: attachment.identifier, exclusionPath: nil)
                     self.textView?.addSubview(view)
                 }
         })


### PR DESCRIPTION
Fixes #13895 (well kind of, read on).

The issue in #13895 is that the GIFs were really large, so we kept loading frames at all times.  This PR changes the amount of frames in the buffer to 300, which means there will be no more jumps when scrolling the reader **AFTER THE GIF IS DONE LOADING**.

There will still be some jumps before the GIFs finish loading, and fixing this IMHO is not great in terms of efforts vs benefit.

Additionally, an issue in the reader was causing attachments to be loaded twice, so these GIFs were animating twice.  This was caused by a strong reference to the images held by a the `mediaArray` we're removing.

## To test:

1. Load in the reader the post shown in p4a5px-2xT-p2.
2. Make sure that after the GIFs are done loading for good, scrolling is smooth in that post.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
