### PR TITLE
Testing: Save test output with updated CircleCI Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
       - run:
           name: Zip test output
           working_directory: build/results
-          command: zip -r testoutput.zip *
+          command: zip -r testoutput.zip * || touch testoutput.zip
       - store_artifacts:
           name: Save test output
           path: build/results/testoutput.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of the Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@dev:add/store-test-bundles-take2
+  ios: wordpress-mobile/ios@1.0
   git: wordpress-mobile/git@1.0
   slack: circleci/slack@3.4.2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,16 @@ commands:
               echo "Manually added `/usr/local/bin` to the $PATH:"
               echo $PATH
             fi
+  save-test-output:
+    steps:
+      - run:
+          name: Zip test output
+          working_directory: build/results
+          command: zip -r testoutput.zip *
+      - store_artifacts:
+          name: Save test output
+          path: build/results/testoutput.zip
+          destination: testresults
 
 jobs:
   Build Tests:
@@ -60,6 +70,7 @@ jobs:
           working_directory: Scripts
           command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUnitTests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts
+      - save-test-output
   UI Tests:
     parameters:
       device:
@@ -92,6 +103,7 @@ jobs:
           working_directory: Scripts
           command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts
+      - save-test-output
       - when:
           condition: << parameters.post-to-slack >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of the Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@1.0
+  ios: wordpress-mobile/ios@dev:add/store-test-bundles-take2
   git: wordpress-mobile/git@1.0
   slack: circleci/slack@3.4.2
 
@@ -19,16 +19,6 @@ commands:
               echo "Manually added `/usr/local/bin` to the $PATH:"
               echo $PATH
             fi
-  save-test-output:
-    steps:
-      - run:
-          name: Zip test output
-          working_directory: build/results
-          command: zip -r testoutput.zip * || touch testoutput.zip
-      - store_artifacts:
-          name: Save test output
-          path: build/results/testoutput.zip
-          destination: testresults
 
 jobs:
   Build Tests:
@@ -69,8 +59,8 @@ jobs:
           name: Run Unit Tests
           working_directory: Scripts
           command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUnitTests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
-      - ios/save-xcodebuild-artifacts
-      - save-test-output
+      - ios/save-xcodebuild-artifacts:
+          result-bundle-path: build/results
   UI Tests:
     parameters:
       device:
@@ -102,8 +92,8 @@ jobs:
           name: Run UI Tests
           working_directory: Scripts
           command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
-      - ios/save-xcodebuild-artifacts
-      - save-test-output
+      - ios/save-xcodebuild-artifacts:
+          result-bundle-path: build/results
       - when:
           condition: << parameters.post-to-slack >>
           steps:


### PR DESCRIPTION
Followup to https://github.com/wordpress-mobile/WordPress-iOS/pull/13810

This updates our CI test runs to match changes to the iOS Orb, where the test output directory is set as a parameter on the `ios/save-xcodebuild-artifacts` step. In this case, `build/results` is the test output directory specified in our Fastlane setup.

Relies on this PR:
- [x] https://github.com/wordpress-mobile/circleci-orbs/pull/58

To test:

* Confirm unit and UI tests pass and test output is zipped and saved as a CircleCI artifact.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
