### PR TITLE
Login Epilogue: accessibility

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -117,7 +117,8 @@ private extension EpilogueUserInfoCell {
     }
 
     func configureLoginAccessibility() {
-        accessibilityLabel = String(format: "Account Information. %@. %@.", fullNameLabel.text ?? "", usernameLabel.text ?? "")
+        let accessibilityFormat = NSLocalizedString("Account Information. %@. %@.", comment: "Accessibility description for account information after logging in.")
+        accessibilityLabel = String(format: accessibilityFormat, fullNameLabel.text ?? "", usernameLabel.text ?? "")
         accessibilityTraits = .none
         fullNameLabel.isAccessibilityElement = false
         usernameLabel.isAccessibilityElement = false

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -32,13 +32,6 @@ class EpilogueUserInfoCell: UITableViewCell {
         super.awakeFromNib()
 
         gravatarView.image = .gravatarPlaceholderImage
-
-        let accessibilityDescription = NSLocalizedString("Add account image", comment: "Accessibility description for adding an image to a new user account. Tapping this initiates that flow.")
-        gravatarButton.accessibilityLabel = accessibilityDescription
-
-        let accessibilityHint = NSLocalizedString("Adds image, or avatar, to represent this new account.", comment: "Accessibility hint text for adding an image to a new user account.")
-        gravatarButton.accessibilityHint = accessibilityHint
-
         configureColors()
     }
 
@@ -52,9 +45,9 @@ class EpilogueUserInfoCell: UITableViewCell {
 
         usernameLabel.text = showEmail ? userInfo.email : "@\(userInfo.username)"
         usernameLabel.fadeInAnimation()
-        usernameLabel.accessibilityIdentifier = "login-epilogue-username-label"
 
         gravatarAddIcon.isHidden = !allowGravatarUploads
+        configureAccessibility()
 
         switch gravatarStatus {
         case .uploading(image: _):
@@ -62,10 +55,10 @@ class EpilogueUserInfoCell: UITableViewCell {
         case .finished:
             gravatarActivityIndicator.stopAnimating()
         case .idle:
-            let placeholder: UIImage = allowGravatarUploads ? .gravatarUploadablePlaceholderImage : .gravatarPlaceholderImage
             if let gravatarUrl = userInfo.gravatarUrl, let url = URL(string: gravatarUrl) {
                 gravatarView.downloadImage(from: url)
             } else {
+                let placeholder: UIImage = allowGravatarUploads ? .gravatarUploadablePlaceholderImage : .gravatarPlaceholderImage
                 gravatarView.downloadGravatarWithEmail(userInfo.email, rating: .x, placeholderImage: placeholder)
             }
         }
@@ -109,6 +102,28 @@ private extension EpilogueUserInfoCell {
 
         return UIFontMetrics.default.scaledFont(for: UIFont(descriptor: fontDescriptor, size: 0.0))
     }
+
+    func configureAccessibility() {
+        usernameLabel.accessibilityIdentifier = "login-epilogue-username-label"
+        gravatarAddIcon.isHidden ? configureLoginAccessibility() : configureSignupAccessibility()
+    }
+
+    func configureSignupAccessibility() {
+        let accessibilityDescription = NSLocalizedString("Add account image", comment: "Accessibility description for adding an image to a new user account. Tapping this initiates that flow.")
+        gravatarButton.accessibilityLabel = accessibilityDescription
+
+        let accessibilityHint = NSLocalizedString("Adds image, or avatar, to represent this new account.", comment: "Accessibility hint text for adding an image to a new user account.")
+        gravatarButton.accessibilityHint = accessibilityHint
+    }
+
+    func configureLoginAccessibility() {
+        accessibilityLabel = String(format: "Account Information. %@. %@.", fullNameLabel.text ?? "", usernameLabel.text ?? "")
+        accessibilityTraits = .none
+        fullNameLabel.isAccessibilityElement = false
+        usernameLabel.isAccessibilityElement = false
+        gravatarButton.isAccessibilityElement = false
+    }
+
 }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueConnectSiteCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueConnectSiteCell.swift
@@ -13,6 +13,7 @@ class LoginEpilogueConnectSiteCell: UITableViewCell, NibReusable {
         connectLabel.font = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .subheadline).pointSize, weight: .regular)
         connectLabel.textColor = .primary
         accessibilityIdentifier = "connectSite"
+        accessibilityTraits = .button
     }
 
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -159,7 +159,7 @@ extension LoginEpilogueTableViewController {
 
         cell.titleLabel?.text = title(for: section)
 
-        cell.accessibilityIdentifier = "loginUserInfoCell"
+        cell.accessibilityIdentifier = "siteListHeaderCell"
         cell.accessibilityLabel = cell.titleLabel?.text
         cell.accessibilityHint = NSLocalizedString("A list of sites on this account.", comment: "Accessibility hint for My Sites list.")
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -158,7 +158,8 @@ extension LoginEpilogueTableViewController {
         }
 
         cell.titleLabel?.text = title(for: section)
-        cell.accessibilityIdentifier = "Login Cell"
+        cell.accessibilityLabel = cell.titleLabel?.text
+        cell.accessibilityHint = NSLocalizedString("A list of sites on this account.", comment: "Accessibility hint for My Sites list.")
 
         return cell
     }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -158,6 +158,8 @@ extension LoginEpilogueTableViewController {
         }
 
         cell.titleLabel?.text = title(for: section)
+
+        cell.accessibilityIdentifier = "loginUserInfoCell"
         cell.accessibilityLabel = cell.titleLabel?.text
         cell.accessibilityHint = NSLocalizedString("A list of sites on this account.", comment: "Accessibility hint for My Sites list.")
 


### PR DESCRIPTION
Ref #13413 

This adds VoiceOver support to various Login Epilogue components.

To test:
- Login and enable VoiceOver. 
- Select the User Info block at the top.
  - VO should say `Account Information. <full name> <username>`.
  - The components inside the User Info block should not be accessible.
- Select the `My Sites` header.
  - VO should say `My Sites. Heading. A list of sites on this account.`.
- Select a site row.
  - VO should say `<site name> <site url>`. (To note, this has not changed, but just for verification.)
- Select the `Connect another site` button.
  - VO should say `Connect another site. Button`.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
