### PR TITLE
Design improvements

### DIFF
--- a/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
+++ b/WordPress/Classes/Utility/Bottom Sheet/BottomSheetViewController.swift
@@ -121,6 +121,11 @@ class BottomSheetViewController: UIViewController {
         }
     }
 
+    override func accessibilityPerformEscape() -> Bool {
+        dismiss(animated: true, completion: nil)
+        return true
+    }
+
     private func refreshForTraits() {
         if presentingViewController?.traitCollection.horizontalSizeClass == .regular && presentingViewController?.traitCollection.verticalSizeClass != .compact {
             gripButton.isHidden = true

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -25,6 +25,7 @@ class PostTagPickerViewController: UIViewController {
     fileprivate let textView = UITextView()
     private let textViewContainer = UIView()
     fileprivate let tableView = UITableView(frame: .zero, style: .grouped)
+    private let descriptionLabel = UILabel()
     fileprivate var dataSource: PostTagPickerDataSource = LoadingDataSource() {
         didSet {
             tableView.dataSource = dataSource
@@ -67,17 +68,28 @@ class PostTagPickerViewController: UIViewController {
         textViewContainer.addSubview(textView)
         view.addSubview(textViewContainer)
 
+        descriptionLabel.text = NSLocalizedString("Tags help tell readers what a post is about. Separate different tags with commas.", comment: "Label explaining why users might want to add tags.")
+        descriptionLabel.numberOfLines = 0
+        WPStyleGuide.configureLabelForRegularFontStyle(descriptionLabel)
+        descriptionLabel.textColor = .textSubtle
+        view.addSubview(descriptionLabel)
+
         textView.translatesAutoresizingMaskIntoConstraints = false
         textViewContainer.translatesAutoresizingMaskIntoConstraints = false
         tableView.translatesAutoresizingMaskIntoConstraints = false
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
+            descriptionLabel.topAnchor.constraint(equalTo: view.readableContentGuide.topAnchor, constant: 10),
+            descriptionLabel.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
+            descriptionLabel.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
+
             textView.topAnchor.constraint(equalTo: textViewContainer.topAnchor),
             textView.bottomAnchor.constraint(equalTo: textViewContainer.bottomAnchor),
             textView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
             textView.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
 
-            textViewContainer.topAnchor.constraint(equalTo: view.topAnchor, constant: 35),
+            textViewContainer.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 10),
             textViewContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: -1),
             textViewContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 1),
             textViewContainer.bottomAnchor.constraint(equalTo: tableView.topAnchor),
@@ -93,6 +105,9 @@ class PostTagPickerViewController: UIViewController {
         textViewContainer.layer.masksToBounds = false
 
         keyboardObserver.tableView = tableView
+
+        let doneButton = UIBarButtonItem(title: NSLocalizedString("Done", comment: "Done button title"), style: .plain, target: self, action: #selector(doneButtonPressed))
+        navigationItem.setRightBarButton(doneButton, animated: false)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -125,6 +140,10 @@ class PostTagPickerViewController: UIViewController {
         if #available(iOS 13, *) {
             textViewContainer.layer.borderColor = UIColor.divider.cgColor
         }
+    }
+
+    @objc func doneButtonPressed() {
+        navigationController?.popViewController(animated: true)
     }
 
     fileprivate func reloadTableData() {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PasswordAlertController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PasswordAlertController.swift
@@ -63,7 +63,7 @@ class PasswordAlertController {
     private enum Constants {
         static let alertSubmit = NSLocalizedString("OK", comment: "Submit button on prompt for user information.")
         static let alertCancel = NSLocalizedString("Cancel", comment: "Cancel prompt for user information.")
-        static let postPassword = NSLocalizedString("Post Password", comment: "Placeholder of a field to type a password to protect the post.")
+        static let postPassword = NSLocalizedString("Enter password", comment: "Placeholder of a field to type a password to protect the post.")
         static let passwordMessage = NSLocalizedString("Enter a password to protect this post", comment: "Message explaining why the user might enter a password.")
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
@@ -42,6 +42,7 @@ class PrepublishingHeaderView: UIView, NibLoadable {
         configureBackButton()
         configurePublishingToLabel()
         configureBlogTitleLabel()
+        configureBlogImage()
         configureSeparator()
     }
 
@@ -61,6 +62,11 @@ class PrepublishingHeaderView: UIView, NibLoadable {
         publishingToLabel.textColor = WPStyleGuide.TableViewHeaderDetailView.titleColor
     }
 
+    private func configureBlogImage() {
+        blogImageView.layer.cornerRadius = Constants.imageRadius
+        blogImageView.clipsToBounds = true
+    }
+
     private func configureBlogTitleLabel() {
         WPStyleGuide.applyPostTitleStyle(blogTitleLabel)
     }
@@ -71,6 +77,7 @@ class PrepublishingHeaderView: UIView, NibLoadable {
 
     private enum Constants {
         static let backButtonSize = CGSize(width: 28, height: 28)
+        static let imageRadius: CGFloat = 4
         static let leftRightInset: CGFloat = 16
         static let title = NSLocalizedString("Publishing To", comment: "Label that describes in which blog the user is publishing to")
         static let close = NSLocalizedString("Close", comment: "Voiceover accessibility label informing the user that this button dismiss the current view")

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -31,7 +31,7 @@ class PrepublishingViewController: UITableViewController {
     private let completion: (AbstractPost) -> ()
 
     private let options: [PrepublishingOption] = [
-        PrepublishingOption(id: .schedule, title: NSLocalizedString("Publish", comment: "Label for Publish")),
+        PrepublishingOption(id: .schedule, title: Constants.publishLabel),
         PrepublishingOption(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility")),
         PrepublishingOption(id: .tags, title: NSLocalizedString("Tags", comment: "Label for Tags"))
     ]
@@ -186,6 +186,7 @@ class PrepublishingViewController: UITableViewController {
     // MARK: - Schedule
 
     func configureScheduleCell(_ cell: WPTableViewCell) {
+        cell.textLabel?.text = post.hasFuturePublishDate() ? Constants.scheduledLabel : Constants.publishLabel
         cell.detailTextLabel?.text = publishSettingsViewModel.detailString
     }
 
@@ -297,6 +298,8 @@ class PrepublishingViewController: UITableViewController {
         static let footerFrame = CGRect(x: 0, y: 0, width: 100, height: 80)
         static let publishNow = NSLocalizedString("Publish Now", comment: "Label for a button that publishes the post")
         static let scheduleNow = NSLocalizedString("Schedule Now", comment: "Label for the button that schedules the post")
+        static let publishLabel = NSLocalizedString("Publish", comment: "Label for Publish")
+        static let scheduledLabel = NSLocalizedString("Scheduled for", comment: "Scheduled for [date]")
         static let headerHeight: CGFloat = 70
         static let analyticsDefaultProperty = ["via": "prepublishing_nudges"]
     }


### PR DESCRIPTION
Fixes #13915

### To test

* Schedule the post for a future date and check that the cell label changes to "Scheduled for"
* Tap on "Tags" and check that there is a label informing why the user might want to add tags and a "Done" button at the right-top corner
* The blog image has 4pt radius
* The password placeholder has the text "Enter password"
* When using Voice Over, if you do an escape gesture (Z with two fingers) the bottom sheet is dismissed

### Additional info

I've testes other languages and RTL languages, it all work goods. Apparently the calendar doesn't support RTL languages, but I'd say this is out of our scope. I'll open an issue.