### PR TITLE
Tenor: correctly parse GIF date

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorAPI/TenorReponseParser.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorAPI/TenorReponseParser.swift
@@ -7,7 +7,7 @@ class TenorResponseParser<T> where T: Decodable {
 
     func parse(_ data: Data) throws {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .millisecondsSince1970
+        decoder.dateDecodingStrategy = .secondsSince1970
 
         let response = try decoder.decode(TenorResponse<[T]>.self, from: data)
 

--- a/WordPress/WordPressTest/MediaPicker/Tenor/TenorAPIResponseTests.swift
+++ b/WordPress/WordPressTest/MediaPicker/Tenor/TenorAPIResponseTests.swift
@@ -29,9 +29,10 @@ class TenorAPIResponseParserTests: XCTestCase {
         thumbnailGif = firstImage.media.first { $0.nanoGIF != nil }?.nanoGIF
     }
 
-    func testParserReturnsGIFImageWithCorrectIdAndTitle() {
+    func testParserReturnsGIFImageWithCorrectIdAndTitleAndCreatedDate() {
         XCTAssertEqual(firstImage.id, "5701246")
         XCTAssertEqual(firstImage.title, "My lovely cat")
+        XCTAssertEqual(firstImage.created, Date(timeIntervalSince1970: 1468938984.001052))
     }
 
     func testParserReturnsCorrectLargeGIFImage() {


### PR DESCRIPTION
This PR fixed the issue where the date value of Tenor picker mage's accessibility label was incorrect. This a part of #13803. 

**Test**
You will need the Accessibility Inspector tool running to inspect accessibility label: Right click on the Xcode icon at the macOS Dock, choose Open Developer Tool then select Accessibility Inspector.
- Go to Site -> Media Library
- Tap + button at the top right to access the media options menu
- Tap **Free GIF Library** to bring up the Tenor Picker
- Search for some images
- Tap the Locate button on the Accessibility Tool
![image](https://user-images.githubusercontent.com/17534738/79619214-9a56ca00-814f-11ea-9cf8-094c824939fd.png)
- Tap any image in the Tenor Picker, and notice the Label value in the Accessibility Tool shows a correct date
![image](https://user-images.githubusercontent.com/17534738/79619360-020d1500-8150-11ea-86b0-4de9dc069f5e.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
