### PR TITLE
Check sections count before accessing section 0

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
@@ -95,7 +95,8 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
         case .replace:
             tableView.reloadData()
         case .selective(let changedRows):
-            if tableView.numberOfRows(inSection: 0) == changedRows.count {
+            let tableViewSectionsCount = tableViewModel.sections.count
+            if tableViewSectionsCount > 0, tableView.numberOfRows(inSection: 0) == changedRows.count {
                 let indexPaths = changedRows.map { IndexPath(row: $0, section: 0) }
                 tableView.reloadRows(at: indexPaths, with: .none)
             } else {

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
@@ -96,7 +96,12 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
             tableView.reloadData()
         case .selective(let changedRows):
             let tableViewSectionsCount = tableViewModel.sections.count
-            if tableViewSectionsCount > 0, tableView.numberOfRows(inSection: 0) == changedRows.count {
+            guard tableViewSectionsCount > 0 else {
+                tableView.reloadData()
+                return
+            }
+
+            if tableView.numberOfRows(inSection: 0) == changedRows.count {
                 let indexPaths = changedRows.map { IndexPath(row: $0, section: 0) }
                 tableView.reloadRows(at: indexPaths, with: .none)
             } else {


### PR DESCRIPTION
Fixes #13891 

Attempt to fix the crash by adding a check for number of sections in tableViewModel > 0 before accessing a section

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
