### PR TITLE
Update My Sites tab title to My Site

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * [internal] the login by email flow and the self-hosted login flow have code changes that can cause regressions. See https://git.io/JfeFN for testing details.
 * Updated the appearance of the login and signup buttons to make signup more prominent.
 * [internal] the navigation to the "login by site address" flow has code changes that can cause regressions. See https://git.io/JfvP9 for testing details.
+* Updated site details screen title to My Site, to avoid duplicating the title of the current site which is displayed in the screen's header area. 
  
 14.6
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -350,7 +350,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         self.restorableSelectedIndexPath = nil;
     }
     
-    self.navigationItem.title = self.blog.settings.name;
+    self.navigationItem.title = NSLocalizedString(@"My Site", @"Title of My Site tab");
 
     [self.headerView setBlog:self.blog];
 
@@ -1644,7 +1644,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     NSSet *updatedObjects = note.userInfo[NSUpdatedObjectsKey];
     if ([updatedObjects containsObject:self.blog] || [updatedObjects containsObject:self.blog.settings]) {
-        self.navigationItem.title = self.blog.settings.name;
         [self configureTableViewData];
         BOOL isQuickStartSectionShownAfter = [self findSectionIndexWithSections:self.tableSections category:BlogDetailsSectionCategoryQuickStart] != NSNotFound;
         

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -193,9 +193,9 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     _blogListNavigationController.tabBarItem.image = mySitesTabBarImage;
     _blogListNavigationController.tabBarItem.selectedImage = mySitesTabBarImage;
     _blogListNavigationController.restorationIdentifier = WPBlogListNavigationRestorationID;
-    _blogListNavigationController.tabBarItem.accessibilityLabel = NSLocalizedString(@"My Sites", @"The accessibility value of the my sites tab.");
+    _blogListNavigationController.tabBarItem.accessibilityLabel = NSLocalizedString(@"My Site", @"The accessibility value of the my site tab.");
     _blogListNavigationController.tabBarItem.accessibilityIdentifier = @"mySitesTabButton";
-    _blogListNavigationController.tabBarItem.title = NSLocalizedString(@"My Sites", @"The accessibility value of the my sites tab.");
+    _blogListNavigationController.tabBarItem.title = NSLocalizedString(@"My Site", @"The accessibility value of the my site tab.");
 
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
@@ -1016,7 +1016,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
     return @[
              [UIKeyCommand keyCommandWithInput:@"N" modifierFlags:UIKeyModifierCommand action:@selector(showPostTab) discoverabilityTitle:NSLocalizedString(@"New Post", @"The accessibility value of the post tab.")],
-             [UIKeyCommand keyCommandWithInput:@"1" modifierFlags:UIKeyModifierCommand action:@selector(showMySitesTab) discoverabilityTitle:NSLocalizedString(@"My Sites", @"The accessibility value of the my sites tab.")],
+             [UIKeyCommand keyCommandWithInput:@"1" modifierFlags:UIKeyModifierCommand action:@selector(showMySitesTab) discoverabilityTitle:NSLocalizedString(@"My Site", @"The accessibility value of the my site tab.")],
              [UIKeyCommand keyCommandWithInput:@"2" modifierFlags:UIKeyModifierCommand action:@selector(showReaderTab) discoverabilityTitle:NSLocalizedString(@"Reader", @"The accessibility value of the reader tab.")],
              // will be removed when the new IA implementation completes
              [UIKeyCommand keyCommandWithInput:@"3" modifierFlags:UIKeyModifierCommand action:@selector(showMeTab) discoverabilityTitle:NSLocalizedString(@"Me", @"The accessibility value of the me tab.")],


### PR DESCRIPTION
This PR is a small tweak the title of the Blog Detail screen to always read "My Site" instead of duplicating the site name, which is shown in the screen header anyway.

I've chosen not to update all the code references to "My Sites" at this stage, as we may do a further refactoring to the actual hierarchy of the sites list -> site detail screens.

![my-site-title-ios](https://user-images.githubusercontent.com/4780/79572643-37185980-80b5-11ea-92d3-08f3e3962ff5.png)

To test:

* Build and run, and check the leftmost tab bar item is titled "My Site"
* Select a site and ensure the header title is "My Site"
* Select a different site and ensure the header title stays as "My Site"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
