### PR TITLE
Wrong analytics image source for Stock Photo in Gutenberg Editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergStockPhotos.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergStockPhotos.swift
@@ -61,7 +61,7 @@ extension GutenbergStockPhotos: StockPhotosPickerDelegate {
         }
 
         let mediaInfo = assets.compactMap({ (asset) -> MediaInfo? in
-            guard let media = self.mediaInserter.insert(exportableAsset: asset, source: .giphy) else {
+            guard let media = self.mediaInserter.insert(exportableAsset: asset, source: .stockPhotos) else {
                 return nil
             }
             let mediaUploadID = media.gutenbergUploadID
@@ -75,7 +75,7 @@ extension GutenbergStockPhotos: StockPhotosPickerDelegate {
     /// - Parameter assets: Stock Media objects to append.
     func appendOnNewBlocks(assets: ArraySlice<StockPhotosMedia>) {
         assets.forEach {
-            if let media = self.mediaInserter.insert(exportableAsset: $0, source: .giphy) {
+            if let media = self.mediaInserter.insert(exportableAsset: $0, source: .stockPhotos) {
                 self.gutenberg.appendMedia(id: media.gutenbergUploadID, url: $0.URL, type: .image)
             }
         }


### PR DESCRIPTION
This PR fixes an issue where the analytics source of stock photo images being sent as Giphy within Gutenberg Editor. The issue's found when I were working on #13803.

**To test**

1. Go to Site -> Posts, open a Post to edit with **Block Editor** (you may need to switch if your default editor is the classic one)
2. Add an image block, tap **ADD IMAGE** then choose **Free Photo Library**
3. Search and select an image, then tap **Add** button at the bottom right.
4. Notice the message `🔵 Tracked: editor_photo_added <blog_id: 174512392, bytes: 815818752, ext: jpeg, media_origin: not_identified, megapixels: 1, mime: image/jpeg, via: stock_photos>` where the `via` is correctly pointed to `stock_photos` source.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
