### PR TITLE
Animating GIFs in Tenor Picker

### DIFF
--- a/WordPress/Classes/Utility/Media/GIFPlaybackStrategy.swift
+++ b/WordPress/Classes/Utility/Media/GIFPlaybackStrategy.swift
@@ -2,6 +2,7 @@ import Foundation
 
 @objc
 public enum GIFStrategy: Int {
+    case tinyGIFs
     case smallGIFs
     case mediumGIFs
     case largeGIFs
@@ -10,6 +11,8 @@ public enum GIFStrategy: Int {
     ///
     var playbackStrategy: GIFPlaybackStrategy {
         switch self {
+        case .tinyGIFs:
+            return TinyGIFPlaybackStrategy()
         case .smallGIFs:
             return SmallGIFPlaybackStrategy()
         case .mediumGIFs:
@@ -50,6 +53,12 @@ extension GIFPlaybackStrategy {
         }
         return true
     }
+}
+// This is good for thumbnail GIFs used in a collection view
+class TinyGIFPlaybackStrategy: GIFPlaybackStrategy {
+    var maxSize = 2_000_000  // in MB
+    var frameBufferCount = 5
+    var gifStrategy: GIFStrategy = .tinyGIFs
 }
 
 class SmallGIFPlaybackStrategy: GIFPlaybackStrategy {

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorMedia.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorMedia.swift
@@ -52,26 +52,13 @@ extension TenorMedia {
 
 extension TenorMedia: WPMediaAsset {
     func image(with size: CGSize, completionHandler: @escaping WPMediaImageBlock) -> WPMediaRequestID {
-        let url = imageURL(with: size)
-
-        DispatchQueue.global().async {
-            do {
-                let data = try Data(contentsOf: url)
-                let image = UIImage(data: data)
-                completionHandler(image, nil)
-            } catch {
-                completionHandler(nil, error)
-            }
-        }
-
-        return (id as NSString).intValue
+        // We don't need to download any image here, leave it for the overlay to handle
+        return 0
     }
 
-    private func imageURL(with size: CGSize) -> URL {
-        return size == .zero ? images.previewURL : images.staticThumbnailURL
+    func cancelImageRequest(_ requestID: WPMediaRequestID) {
+        // Nothing to do
     }
-
-    func cancelImageRequest(_ requestID: WPMediaRequestID) {}
 
     func videoAsset(completionHandler: @escaping WPMediaAssetBlock) -> WPMediaRequestID {
         return 0
@@ -124,5 +111,13 @@ extension TenorMedia: MediaExternalAsset {
 
     var caption: String {
         return ""
+    }
+}
+
+// Overlay
+extension TenorMedia {
+    // Return the smallest GIF size for previewing
+    var previewURL: URL {
+        return images.staticThumbnailURL
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorPicker.swift
@@ -156,6 +156,7 @@ extension TenorPicker: WPMediaPickerViewControllerDelegate {
             return
         }
 
+        animatedImageView.gifStrategy = .tinyGIFs
         animatedImageView.contentMode = .scaleAspectFill
         animatedImageView.clipsToBounds = true
         animatedImageView.setAnimatedImage(URLRequest(url: tenorMedia.previewURL),

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorPicker.swift
@@ -54,6 +54,7 @@ final class TenorPicker: NSObject {
         picker.showGroupSelector = false
         picker.dataSource = dataSource
         picker.cancelButtonTitle = .closePicker
+        picker.mediaPicker.registerClass(forReusableCellOverlayViews: CachedAnimatedImageView.self)
         return picker
     }()
 
@@ -137,6 +138,30 @@ extension TenorPicker: WPMediaPickerViewControllerDelegate {
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, didDeselect asset: WPMediaAsset) {
         hideKeyboard(from: picker.searchBar)
+    }
+
+    func mediaPickerController(_ picker: WPMediaPickerViewController, shouldShowOverlayViewForCellFor asset: WPMediaAsset) -> Bool {
+        return true
+    }
+
+    func mediaPickerController(_ picker: WPMediaPickerViewController,
+                               willShowOverlayView overlayView: UIView,
+                               forCellFor asset: WPMediaAsset) {
+        guard let animatedImageView = overlayView as? CachedAnimatedImageView else {
+            return
+        }
+
+        guard let tenorMedia = asset as? TenorMedia else {
+            assertionFailure("asset should be of type `TenorMedia`")
+            return
+        }
+
+        animatedImageView.contentMode = .scaleAspectFill
+        animatedImageView.clipsToBounds = true
+        animatedImageView.setAnimatedImage(URLRequest(url: tenorMedia.previewURL),
+                                           placeholderImage: nil,
+                                           success: nil,
+                                           failure: nil)
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, previewViewControllerFor assets: [WPMediaAsset], selectedIndex selected: Int) -> UIViewController? {


### PR DESCRIPTION
This PR adds support for animating GIF in the Tenor Picker as an enhancement for #13803. It is a follow up after my post [here](https://wp.me/pbMoDN-hD).

**To test:**
Tenor GIF picker can be found in Media Library, Aztec Editor & Block Editor. However, they use the same Tenor Picker instance, so you can verify in any where which is convenient, of course it's best to verify all of those places.

Steps to verify animated GIF support in Tenor Picker trigged from Media Library
1. Go to Site -> Media Library, tap the + button at the top right corner
2. Select Free GIF Library
3. Search for any GIF, verify they are being animated in the picker ;-)
![tenor-picker-small](https://user-images.githubusercontent.com/17534738/79628818-da39a380-8187-11ea-969d-20d9e90d9c6f.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
