### PR TITLE
Fix crash when rendering comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -49,6 +49,8 @@ class ReaderCommentCell: UITableViewCell {
 
     @objc var comment: Comment?
 
+    @objc var blog: Blog?
+
     @objc var attributedString: NSAttributedString?
 
     @objc var showReply: Bool {
@@ -144,8 +146,9 @@ class ReaderCommentCell: UITableViewCell {
     // MARK: - Configuration
 
 
-    @objc func configureCell(comment: Comment, attributedString: NSAttributedString) {
+    @objc func configureCell(comment: Comment, blog: Blog?, attributedString: NSAttributedString) {
         self.comment = comment
+        self.blog = blog
         self.attributedString = attributedString
 
         configureAvatar()
@@ -202,14 +205,16 @@ class ReaderCommentCell: UITableViewCell {
 
 
     @objc func configureText() {
-        guard let comment = comment, let attributedString = attributedString else {
-            return
+        if let blog = blog {
+            textView.mediaHost = MediaHost(with: blog, failure: { error in
+                // We'll log the error, so we know it's there, but we won't halt execution.
+                CrashLogging.logError(error)
+            })
         }
 
-        textView.mediaHost = MediaHost(with: comment.blog, failure: { error in
-            // We'll log the error, so we know it's there, but we won't halt execution.
-            CrashLogging.logError(error)
-        })
+        guard let attributedString = attributedString else {
+            return
+        }
 
         // Use `content` vs `contentForDisplay`. Hierarchcial comments are already
         // correctly formatted during the sync process.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -35,6 +35,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
                                             SuggestionsTableViewDelegate>
 
 @property (nonatomic, strong, readwrite) ReaderPost *post;
+@property (nonatomic, strong) Blog *blog;
 @property (nonatomic, strong) NSNumber *postSiteID;
 @property (nonatomic, strong) UIGestureRecognizer *tapOffKeyboardGesture;
 @property (nonatomic, strong) UIActivityIndicatorView *activityFooter;
@@ -70,6 +71,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     ReaderCommentsViewController *controller = [[self alloc] init];
     controller.post = post;
+    [controller setupBlogWithSiteID:post.siteID];
     return controller;
 }
 
@@ -77,6 +79,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     ReaderCommentsViewController *controller = [[self alloc] init];
     [controller setupWithPostID:postID siteID:siteID];
+    [controller setupBlogWithSiteID:siteID];
     return controller;
 }
 
@@ -868,6 +871,14 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     }];
 }
 
+#pragma mark - Blog Helper
+
+- (void)setupBlogWithSiteID:(NSNumber *)siteID
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+    self.blog = [blogService blogByBlogId:siteID];
+}
 
 #pragma mark - UITableView Delegate Methods
 
@@ -922,7 +933,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     }
 
     NSAttributedString *attrStr = [self cacheContentForComment:comment];
-    [cell configureCellWithComment:comment attributedString:attrStr];
+    [cell configureCellWithComment:comment blog:self.blog attributedString:attrStr];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
Fixes #13950

This PR fixes the crash when loading the list of comments.

### To test

1. Navigate to the Notifications tab
2. Tap a notification (for example, a notification about a new post)
3. Tap the "comments" icon at the bottom right
4. The app navigates to the list of comments, and should not crash

### Additional info

From my tests, all `comment`'s entities had a `nil` `blog` property. What I did was to change the way the comments and cell is configured. Given a post or siteID/blogID I try to load the `Blog` associated with these params.

Then, this value is given to the cell, who uses it to configure the `MediaHost`. This fixes both the crash while maintains the logic to load images from a private Atomic site.