### PR TITLE
Refactor the fix for comments crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -49,8 +49,6 @@ class ReaderCommentCell: UITableViewCell {
 
     @objc var comment: Comment?
 
-    @objc var blog: Blog?
-
     @objc var attributedString: NSAttributedString?
 
     @objc var showReply: Bool {
@@ -146,9 +144,8 @@ class ReaderCommentCell: UITableViewCell {
     // MARK: - Configuration
 
 
-    @objc func configureCell(comment: Comment, blog: Blog?, attributedString: NSAttributedString) {
+    @objc func configureCell(comment: Comment, attributedString: NSAttributedString) {
         self.comment = comment
-        self.blog = blog
         self.attributedString = attributedString
 
         configureAvatar()
@@ -205,16 +202,14 @@ class ReaderCommentCell: UITableViewCell {
 
 
     @objc func configureText() {
-        if let blog = blog {
-            textView.mediaHost = MediaHost(with: blog, failure: { error in
-                // We'll log the error, so we know it's there, but we won't halt execution.
-                CrashLogging.logError(error)
-            })
-        }
-
-        guard let attributedString = attributedString else {
+        guard let comment = comment, let attributedString = attributedString else {
             return
         }
+
+        textView.mediaHost = MediaHost(with: comment.blog, failure: { error in
+            // We'll log the error, so we know it's there, but we won't halt execution.
+            CrashLogging.logError(error)
+        })
 
         // Use `content` vs `contentForDisplay`. Hierarchcial comments are already
         // correctly formatted during the sync process.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -203,7 +203,7 @@ class ReaderCommentCell: UITableViewCell {
 
     @objc func configureText() {
         textView.mediaHost = mediaHost()
-        
+
         guard let attributedString = attributedString else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -246,12 +246,12 @@ class ReaderCommentCell: UITableViewCell {
     /// Returns the media host for the current comment
     private func mediaHost() -> MediaHost {
         if let blog = comment?.blog {
-            textView.mediaHost = MediaHost(with: blog, failure: { error in
+            return MediaHost(with: blog, failure: { error in
                 // We'll log the error, so we know it's there, but we won't halt execution.
                 CrashLogging.logError(error)
             })
         } else if let post = comment?.post as? ReaderPost, post.isPrivate() {
-            textView.mediaHost = MediaHost(with: post, failure: { error in
+            return MediaHost(with: post, failure: { error in
                 // We'll log the error, so we know it's there, but we won't halt execution.
                 CrashLogging.logError(error)
             })

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -211,6 +211,11 @@ class ReaderCommentCell: UITableViewCell {
                 // We'll log the error, so we know it's there, but we won't halt execution.
                 CrashLogging.logError(error)
             })
+        }  else if let post = comment.post as? ReaderPost, post.isPrivate() {
+            textView.mediaHost = MediaHost(with: post, failure: { error in
+                // We'll log the error, so we know it's there, but we won't halt execution.
+                CrashLogging.logError(error)
+            })
         }
 
         // Use `content` vs `contentForDisplay`. Hierarchcial comments are already

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -206,10 +206,12 @@ class ReaderCommentCell: UITableViewCell {
             return
         }
 
-        textView.mediaHost = MediaHost(with: comment.blog, failure: { error in
-            // We'll log the error, so we know it's there, but we won't halt execution.
-            CrashLogging.logError(error)
-        })
+        if let blog = comment.blog {
+            textView.mediaHost = MediaHost(with: blog, failure: { error in
+                // We'll log the error, so we know it's there, but we won't halt execution.
+                CrashLogging.logError(error)
+            })
+        }
 
         // Use `content` vs `contentForDisplay`. Hierarchcial comments are already
         // correctly formatted during the sync process.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -202,27 +202,16 @@ class ReaderCommentCell: UITableViewCell {
 
 
     @objc func configureText() {
-        guard let comment = comment, let attributedString = attributedString else {
+        textView.mediaHost = mediaHost()
+        
+        guard let attributedString = attributedString else {
             return
-        }
-
-        if let blog = comment.blog {
-            textView.mediaHost = MediaHost(with: blog, failure: { error in
-                // We'll log the error, so we know it's there, but we won't halt execution.
-                CrashLogging.logError(error)
-            })
-        }  else if let post = comment.post as? ReaderPost, post.isPrivate() {
-            textView.mediaHost = MediaHost(with: post, failure: { error in
-                // We'll log the error, so we know it's there, but we won't halt execution.
-                CrashLogging.logError(error)
-            })
         }
 
         // Use `content` vs `contentForDisplay`. Hierarchcial comments are already
         // correctly formatted during the sync process.
         textView.attributedText = attributedString
     }
-
 
     @objc func configureActionBar() {
         guard let comment = comment else {
@@ -254,6 +243,22 @@ class ReaderCommentCell: UITableViewCell {
         textView.updateLayoutForAttachments()
     }
 
+    /// Returns the media host for the current comment
+    private func mediaHost() -> MediaHost {
+        if let blog = comment?.blog {
+            textView.mediaHost = MediaHost(with: blog, failure: { error in
+                // We'll log the error, so we know it's there, but we won't halt execution.
+                CrashLogging.logError(error)
+            })
+        } else if let post = comment?.post as? ReaderPost, post.isPrivate() {
+            textView.mediaHost = MediaHost(with: post, failure: { error in
+                // We'll log the error, so we know it's there, but we won't halt execution.
+                CrashLogging.logError(error)
+            })
+        }
+
+        return .publicSite
+    }
 
     // MARK: - Actions
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -35,7 +35,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
                                             SuggestionsTableViewDelegate>
 
 @property (nonatomic, strong, readwrite) ReaderPost *post;
-@property (nonatomic, strong) Blog *blog;
 @property (nonatomic, strong) NSNumber *postSiteID;
 @property (nonatomic, strong) UIGestureRecognizer *tapOffKeyboardGesture;
 @property (nonatomic, strong) UIActivityIndicatorView *activityFooter;
@@ -71,7 +70,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     ReaderCommentsViewController *controller = [[self alloc] init];
     controller.post = post;
-    [controller setupBlogWithSiteID:post.siteID];
     return controller;
 }
 
@@ -79,7 +77,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     ReaderCommentsViewController *controller = [[self alloc] init];
     [controller setupWithPostID:postID siteID:siteID];
-    [controller setupBlogWithSiteID:siteID];
     return controller;
 }
 
@@ -871,14 +868,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     }];
 }
 
-#pragma mark - Blog Helper
-
-- (void)setupBlogWithSiteID:(NSNumber *)siteID
-{
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-    self.blog = [blogService blogByBlogId:siteID];
-}
 
 #pragma mark - UITableView Delegate Methods
 
@@ -933,7 +922,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     }
 
     NSAttributedString *attrStr = [self cacheContentForComment:comment];
-    [cell configureCellWithComment:comment blog:self.blog attributedString:attrStr];
+    [cell configureCellWithComment:comment attributedString:attrStr];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
Fixes #13950

After talking to @aerych we can simplify the fix for the comments section crash while keeping Reader unaware of `BlogService`.

### To test

1. Navigate to the Notifications tab
2. Tap a notification (for example, a notification about a new post)
3. Tap the "comments" icon at the bottom right
4. The app navigates to the list of comments, and should not crash