### PR TITLE
Signup Epilogue: update User Info section

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -91,8 +91,7 @@ private extension EpilogueUserInfoCell {
 
     func configureColors() {
         gravatarAddIcon.tintColor = .primary
-        // TODO: update when table background updated.
-        gravatarAddIcon.backgroundColor = .listForeground
+        gravatarAddIcon.backgroundColor = .basicBackground
 
         fullNameLabel.textColor = .text
         fullNameLabel.font = fullNameFont()

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -30,8 +30,7 @@ class EpilogueUserInfoCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-
-        gravatarView.image = .gravatarPlaceholderImage
+        configureImages()
         configureColors()
     }
 
@@ -85,7 +84,16 @@ class EpilogueUserInfoCell: UITableViewCell {
 //
 private extension EpilogueUserInfoCell {
 
+    func configureImages() {
+        gravatarAddIcon.image = .gridicon(.add)
+        gravatarView.image = .gravatarPlaceholderImage
+    }
+
     func configureColors() {
+        gravatarAddIcon.tintColor = .primary
+        // TODO: update when table background updated.
+        gravatarAddIcon.backgroundColor = .listForeground
+
         fullNameLabel.textColor = .text
         fullNameLabel.font = fullNameFont()
 

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
@@ -51,7 +51,7 @@
                             <constraint firstAttribute="width" secondItem="2Ri-os-5ZW" secondAttribute="height" multiplier="1:1" id="Dlu-jo-OXt"/>
                         </constraints>
                     </activityIndicatorView>
-                    <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar-add-button" translatesAutoresizingMaskIntoConstraints="NO" id="GYR-3W-aku">
+                    <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar-add-button" translatesAutoresizingMaskIntoConstraints="NO" id="GYR-3W-aku" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                         <rect key="frame" x="50" y="11" width="26" height="26"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="26" id="gm6-03-VBa"/>

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
@@ -52,10 +52,10 @@
                         </constraints>
                     </activityIndicatorView>
                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar-add-button" translatesAutoresizingMaskIntoConstraints="NO" id="GYR-3W-aku" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="50" y="11" width="26" height="26"/>
+                        <rect key="frame" x="48" y="15" width="24" height="24"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="26" id="gm6-03-VBa"/>
-                            <constraint firstAttribute="height" constant="26" id="uxU-Ng-JTY"/>
+                            <constraint firstAttribute="width" constant="24" id="49J-ox-VuO"/>
+                            <constraint firstAttribute="width" secondItem="GYR-3W-aku" secondAttribute="height" multiplier="1:1" id="CCT-Ge-nHv"/>
                         </constraints>
                     </imageView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="11G-E4-8Jh">
@@ -72,7 +72,7 @@
                     <constraint firstItem="2Ri-os-5ZW" firstAttribute="width" secondItem="SqA-Tm-XVX" secondAttribute="width" multiplier="0.5" id="MZT-fb-8wR"/>
                     <constraint firstItem="xGK-LG-0cx" firstAttribute="centerX" secondItem="HfW-Dl-Z89" secondAttribute="centerX" id="Mwp-7z-bUJ"/>
                     <constraint firstItem="xGK-LG-0cx" firstAttribute="bottom" secondItem="89f-vg-HlI" secondAttribute="bottom" id="OBY-RQ-kRg"/>
-                    <constraint firstItem="GYR-3W-aku" firstAttribute="top" secondItem="SqA-Tm-XVX" secondAttribute="top" constant="-4" id="QV1-8T-K0y"/>
+                    <constraint firstItem="GYR-3W-aku" firstAttribute="top" secondItem="SqA-Tm-XVX" secondAttribute="top" id="QV1-8T-K0y"/>
                     <constraint firstItem="11G-E4-8Jh" firstAttribute="width" secondItem="SqA-Tm-XVX" secondAttribute="width" id="dBO-2f-cNz"/>
                     <constraint firstAttribute="trailing" secondItem="89f-vg-HlI" secondAttribute="trailing" id="fIW-sh-8b3"/>
                     <constraint firstAttribute="trailing" secondItem="MbK-Ns-TbF" secondAttribute="trailing" id="hBZ-XF-2Ok"/>
@@ -85,7 +85,7 @@
                     <constraint firstItem="MbK-Ns-TbF" firstAttribute="top" secondItem="SqA-Tm-XVX" secondAttribute="bottom" constant="15" id="tp1-hu-yDU"/>
                     <constraint firstItem="11G-E4-8Jh" firstAttribute="height" secondItem="SqA-Tm-XVX" secondAttribute="height" id="vjj-dA-RLw"/>
                     <constraint firstItem="MbK-Ns-TbF" firstAttribute="leading" secondItem="HfW-Dl-Z89" secondAttribute="leading" id="vv4-33-weD"/>
-                    <constraint firstItem="GYR-3W-aku" firstAttribute="trailing" secondItem="SqA-Tm-XVX" secondAttribute="trailing" constant="4" id="wL3-WH-8HH"/>
+                    <constraint firstItem="GYR-3W-aku" firstAttribute="trailing" secondItem="SqA-Tm-XVX" secondAttribute="trailing" id="wL3-WH-8HH"/>
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogue.storyboard
@@ -65,7 +65,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="egq-OL-lqe" userLabel="Table Container View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
+                                <rect key="frame" x="16" y="0.0" width="343" height="583"/>
                                 <connections>
                                     <segue destination="wAQ-AF-rOn" kind="embed" identifier="showEpilogueTable" id="PlO-Bm-BvC"/>
                                 </connections>
@@ -82,10 +82,10 @@
                         <constraints>
                             <constraint firstItem="240-cE-xSD" firstAttribute="top" secondItem="egq-OL-lqe" secondAttribute="bottom" id="6xk-4S-cWw"/>
                             <constraint firstItem="240-cE-xSD" firstAttribute="leading" secondItem="Zhy-FD-gA0" secondAttribute="leading" id="Jll-EX-f1p"/>
-                            <constraint firstItem="egq-OL-lqe" firstAttribute="leading" secondItem="Zhy-FD-gA0" secondAttribute="leading" id="Ke8-3y-IW1"/>
+                            <constraint firstItem="egq-OL-lqe" firstAttribute="leading" secondItem="Zhy-FD-gA0" secondAttribute="leading" constant="16" id="Ke8-3y-IW1"/>
                             <constraint firstItem="Zhy-FD-gA0" firstAttribute="top" secondItem="egq-OL-lqe" secondAttribute="top" id="VpG-I9-eZL"/>
                             <constraint firstItem="240-cE-xSD" firstAttribute="trailing" secondItem="Zhy-FD-gA0" secondAttribute="trailing" id="Yrw-fx-rz4"/>
-                            <constraint firstItem="Zhy-FD-gA0" firstAttribute="trailing" secondItem="egq-OL-lqe" secondAttribute="trailing" id="drs-fr-MgU"/>
+                            <constraint firstItem="Zhy-FD-gA0" firstAttribute="trailing" secondItem="egq-OL-lqe" secondAttribute="trailing" constant="16" id="drs-fr-MgU"/>
                             <constraint firstItem="240-cE-xSD" firstAttribute="bottom" secondItem="YP6-Jc-5Xa" secondAttribute="bottom" id="nht-aN-2J4"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Zhy-FD-gA0"/>
@@ -104,7 +104,7 @@
             <objects>
                 <tableViewController id="wAQ-AF-rOn" customClass="SignupEpilogueTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ACZ-Xu-JZ4">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
+                        <rect key="frame" x="0.0" y="0.0" width="343" height="583"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <connections>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogue.storyboard
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="e6u-CC-aMV">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="e6u-CC-aMV">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,11 +13,11 @@
             <objects>
                 <viewController storyboardIdentifier="usernames" id="CFB-8a-SBe" customClass="SignupUsernameViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="mFL-Rq-P6f">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tCm-cu-ulI">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="-20" width="375" height="667"/>
                                 <connections>
                                     <segue destination="QJL-0i-O1l" kind="embed" id="9tJ-oY-a4R"/>
                                 </connections>
@@ -68,7 +65,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="egq-OL-lqe" userLabel="Table Container View">
-                                <rect key="frame" x="0.0" y="20" width="375" height="563"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
                                 <connections>
                                     <segue destination="wAQ-AF-rOn" kind="embed" identifier="showEpilogueTable" id="PlO-Bm-BvC"/>
                                 </connections>
@@ -106,10 +103,9 @@
         <scene sceneID="GXq-Sg-B5O">
             <objects>
                 <tableViewController id="wAQ-AF-rOn" customClass="SignupEpilogueTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="ACZ-Xu-JZ4">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="563"/>
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ACZ-Xu-JZ4">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <connections>
                             <outlet property="dataSource" destination="wAQ-AF-rOn" id="Pe8-CE-a7F"/>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -154,7 +154,7 @@ class SignupEpilogueTableViewController: NUXTableViewController, EpilogueUserInf
             return
         }
 
-        cell.contentView.backgroundColor = .listForeground
+        cell.contentView.backgroundColor = .basicBackground
     }
 
     override func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -150,6 +150,7 @@ class SignupEpilogueTableViewController: NUXTableViewController, EpilogueUserInf
         return super.tableView(tableView, cellForRowAt: indexPath)
     }
 
+    // TODO: nix this when table background updated.
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         guard cell is EpilogueUserInfoCell else {
             return

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -90,15 +90,13 @@ class SignupEpilogueTableViewController: NUXTableViewController, EpilogueUserInf
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        var sectionTitle = ""
-        if section == TableSections.userInfo {
-            sectionTitle = NSLocalizedString("New Account", comment: "Header for user info, shown after account created.").localizedUppercase
+        // Don't show section header for User Info
+        guard section != TableSections.userInfo,
+        let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: CellIdentifiers.sectionHeaderFooter) as? EpilogueSectionHeaderFooter else {
+            return nil
         }
 
-        guard let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: CellIdentifiers.sectionHeaderFooter) as? EpilogueSectionHeaderFooter else {
-            fatalError("Failed to get a section header cell")
-        }
-        cell.titleLabel?.text = sectionTitle
+        cell.titleLabel?.text = ""
         cell.titleLabel?.accessibilityIdentifier = "New Account Header"
         return cell
     }
@@ -164,7 +162,7 @@ class SignupEpilogueTableViewController: NUXTableViewController, EpilogueUserInf
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableView.automaticDimension
+        return section == TableSections.userInfo ? 0 : UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {


### PR DESCRIPTION
Ref #13939 

This updates the Signup Epilogue's User Info section to the new design. Specifically:
- 'New Account' section header removed.
- Blue 'add' gridicon is now used for the add gravatar button.
- Top and bottom separator lines removed.
- Background color updated (light and dark modes).

Please note the table itself hasn't been updated, so the table colors are still off (i.e. the area around the User Info section). This change only applies to the User Info section itself. I'll request Design review once the table is updated and it looks more final.

---
To test:
- Signup.
  - If you don't want to actually sign up, see below for WPAuth hack tip.
- On the Signup Epilogue, verify the User Info section looks like that on #13939 or the designs in Zeplin.

| Before | After |
|--------|-------|
| <img width="455" alt="before_light" src="https://user-images.githubusercontent.com/1816888/79912274-00a54c00-83df-11ea-8535-062c9d2c2720.png"> | <img width="458" alt="after_light" src="https://user-images.githubusercontent.com/1816888/79912291-06029680-83df-11ea-91d5-d0e4f7ec4c5b.png"> |
| <img width="455" alt="before_dark" src="https://user-images.githubusercontent.com/1816888/79912304-0e5ad180-83df-11ea-83fe-dac92e6bbb52.png"> | <img width="455" alt="after_dark" src="https://user-images.githubusercontent.com/1816888/79912320-13b81c00-83df-11ea-9473-49b192af8296.png"> |

---
Want to see the signup epilogue without actually signing up? Well you came to the right place!
- In WPiOS `Podfile`, point `WordPressAuthenticator` to your local Auth.
- In `LoginViewController`, change `showLoginEpilogue` to show the signup epilogue:

```
func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
    guard let navigationController = navigationController else {
        fatalError()
    }
    
    showSignupEpilogue(for: credentials)
    
//        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) { [weak self] in
//            self?.dismissBlock?(false)
//        }
}
```
- Then _login_ with an existing account, and the _signup_ epilogue will display. 🎉 

---
PR submission checklist:
- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
