### PR TITLE
Signup Epilogue: remove Password table section

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -8,7 +8,7 @@ protocol SignupEpilogueCellDelegate {
     func usernameSelected()
 }
 
-enum EpilogueCellType {
+enum EpilogueCellType: Int {
     case displayName
     case username
     case password


### PR DESCRIPTION
Ref #13939 

This removes the table section just for the Password field, and adds the Password field to the same section as the other account fields.

To note, this is still a WIP, so table colors are still off. This change is just to move the Password field. 

---
To test:

- Sign up with Email. (If you don't want to actually sign up, see below for WPAuth hack tip.)
- On the epilogue, verify:
  - The password field is displayed below the Username field, in the same section.
  - The `You can always...` text is displayed below the Password field (in the section footer).
  
| Before | After |
|--------|-------|
| ![wp_before](https://user-images.githubusercontent.com/1816888/79923645-33f1d600-83f3-11ea-8575-82bda28aa1d8.png) | ![wp_after](https://user-images.githubusercontent.com/1816888/79923663-394f2080-83f3-11ea-880a-465b151a3622.png) |

---
- Sign up with a social account. (If you don't want to actually sign up, see below for WPAuth hack tip.)
- On the epilogue, verify the password field and footer text are not displayed.

| Before | After |
|--------|-------|
| ![social_before](https://user-images.githubusercontent.com/1816888/79923691-51bf3b00-83f3-11ea-9d51-2f93b56d7bd8.png) | ![social_after](https://user-images.githubusercontent.com/1816888/79923704-57b51c00-83f3-11ea-9e58-56dc4ebd4fcf.png) |

---
To show the Signup Epilogue without actually signing up:


- In WPiOS `Podfile`, point `WordPressAuthenticator` to your local Auth.
- In `LoginViewController`, change `showLoginEpilogue` to show the signup epilogue:

```
func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
    guard let navigationController = navigationController else {
        fatalError()
    }
    
    showSignupEpilogue(for: credentials)
    
//        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) { [weak self] in
//            self?.dismissBlock?(false)
//        }
}
```

- Login with an existing WP account to verify the Password field is shown.
- Login with a Google account to verify the Password field is not shown.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
