### PR TITLE
Fix editor button from being truncated

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -206,6 +206,7 @@ class PostEditorNavigationBarManager {
 
     func reloadPublishButton() {
         publishButton.setTitle(delegate?.publishButtonText ?? "", for: .normal)
+        publishButton.sizeToFit()
         publishButton.isEnabled = delegate?.isPublishButtonEnabled ?? true
     }
 


### PR DESCRIPTION
Fixes #13966

### To test

1. Create a new post
2. Tap Publish
3. Schedule the post
4. Check if the top-right button is not truncated and displays the whole word
