### PR TITLE
Change Media Picker label from "Preview %@" to "Edit %@"

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1859,6 +1859,7 @@ extension AztecPostViewController {
         picker.selectionActionTitle = Constants.mediaPickerInsertText
         picker.mediaPicker.options = options
         picker.delegate = self
+        picker.previewActionTitle = NSLocalizedString("Edit %@", comment: "Button that displays the media editor to the user")
         picker.modalPresentationStyle = .currentContext
         if let previousPicker = mediaPickerInputViewController?.mediaPicker {
             picker.mediaPicker.selectedAssets = previousPicker.selectedAssets

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -76,6 +76,7 @@ class GutenbergMediaPickerHelper: NSObject {
         mediaPickerOptions.allowMultipleSelection = allowMultipleSelection
         picker.mediaPicker.options = mediaPickerOptions
         picker.delegate = self
+        picker.previewActionTitle = NSLocalizedString("Edit %@", comment: "Button that displays the media editor to the user")
         picker.modalPresentationStyle = .currentContext
         context.present(picker, animated: true)
     }


### PR DESCRIPTION
This PR changes the bottom-left button's label in Media Picker. Instead of showing "Preview X" (where X is the number of images) we now say "Edit X".

<img src="https://user-images.githubusercontent.com/7040243/80027969-cc06c280-84ba-11ea-85b4-b6dae75d9c17.png" width="300px" />

This was discussed with @mbshakti and @malinajirka.

My intention was to point this PR to the release branch. But since this adds a new string (and the translation for the release branch has already started) I'm targeting `develop`. 

### To test

#### Gutenberg

1. Add a "Gallery Block"
2. Tap "Add Media"
3. Tap "Choose from Device"
4. Select one or more images and check that the label of the left button says "Edit X" (where X is the number of images you selected)

#### Aztec

1. Add a "+" at the action bar
2. Tap the image icon (right next to the WP logo)
3. Select one or more images and check that the label of the left button says "Edit X" (where X is the number of images you selected)
