### PR TITLE
Show an alert when trying to preview while uploading media 

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -65,10 +65,11 @@ extension PostEditor where Self: UIViewController {
     }
 
     func displayPreview() {
-        if isUploadingMedia {
+        guard !isUploadingMedia else {
             displayMediaIsUploadingAlert()
             return
         }
+
         savePostBeforePreview() { [weak self] previewURLString, error in
             guard let self = self else {
                 return

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -65,7 +65,6 @@ extension PostEditor where Self: UIViewController {
     }
 
     func displayPreview() {
-        print("is uploading media: \(isUploadingMedia)")
         if isUploadingMedia {
             displayMediaIsUploadingAlert()
             return

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -65,6 +65,11 @@ extension PostEditor where Self: UIViewController {
     }
 
     func displayPreview() {
+        print("is uploading media: \(isUploadingMedia)")
+        if isUploadingMedia {
+            displayMediaIsUploadingAlert()
+            return
+        }
         savePostBeforePreview() { [weak self] previewURLString, error in
             guard let self = self else {
                 return

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -107,7 +107,7 @@ extension PostEditor where Self: UIViewController {
         }
     }
 
-    fileprivate func displayMediaIsUploadingAlert() {
+    func displayMediaIsUploadingAlert() {
         let alertController = UIAlertController(title: MediaUploadingAlert.title, message: MediaUploadingAlert.message, preferredStyle: .alert)
         alertController.addDefaultActionWithTitle(MediaUploadingAlert.acceptTitle)
         present(alertController, animated: true, completion: nil)


### PR DESCRIPTION
Fixes #13929 

To test (Classic and block editors - *Please test on device*):
1. Go to My Site -> Posts then select a Post to edit.
2. Add an Image / gallery block or classic
3. While the image being uploaded, Tap the ... menu at the top-right corner, select Preview
4. See the alert if image still uploading 
5. When Image done uploading, tap preview again
6. See preview with the image 

![IMG_5993](https://user-images.githubusercontent.com/1335657/80052594-e4cda300-84cf-11ea-940d-9caea364cffe.PNG)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
