### PR TITLE
Fix issue with notification header details comment preview not showing

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -625,7 +625,7 @@ private extension NotificationDetailsViewController {
         }
 
         cell.attributedHeaderTitle = formatter.render(content: gravatarBlock, with: HeaderContentStyles())
-        cell.attributedHeaderDetails = formatter.render(content: snippetBlock, with: SnippetsContentStyles())
+        cell.attributedHeaderDetails = formatter.render(content: snippetBlock, with: HeaderDetailsContentStyles())
 
         // Download the Gravatar
         let mediaURL = gravatarBlock.media.first?.mediaURL

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -618,7 +618,7 @@ private extension NotificationDetailsViewController {
 
         cell.attributedHeaderTitle = nil
         cell.attributedHeaderDetails = nil
-        
+
         guard let gravatarBlock: NotificationTextContent = blockGroup.blockOfKind(.image),
             let snippetBlock: NotificationTextContent = blockGroup.blockOfKind(.text) else {
                 return

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -616,15 +616,17 @@ private extension NotificationDetailsViewController {
         // -   UITableViewCell's taps don't require a Gestures Recognizer. No big deal, but less code!
         //
 
-        let snippetBlock: NotificationTextContent? = blockGroup.blockOfKind(.text)
-        cell.headerDetails = snippetBlock?.text
         cell.attributedHeaderTitle = nil
-
-        guard let gravatarBlock: NotificationTextContent = blockGroup.blockOfKind(.image) else {
-            return
+        cell.attributedHeaderDetails = nil
+        
+        guard let gravatarBlock: NotificationTextContent = blockGroup.blockOfKind(.image),
+            let snippetBlock: NotificationTextContent = blockGroup.blockOfKind(.text) else {
+                return
         }
 
         cell.attributedHeaderTitle = formatter.render(content: gravatarBlock, with: HeaderContentStyles())
+        cell.attributedHeaderDetails = formatter.render(content: snippetBlock, with: SnippetsContentStyles())
+
         // Download the Gravatar
         let mediaURL = gravatarBlock.media.first?.mediaURL
         cell.downloadAuthorAvatar(with: mediaURL)

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/HeaderDetailsContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/HeaderDetailsContentStyles.swift
@@ -1,8 +1,6 @@
-import WordPressShared
-
-class SnippetsContentStyles: FormattableContentStyles {
+class HeaderDetailsContentStyles: FormattableContentStyles {
     var attributes: [NSAttributedString.Key: Any] {
-        return WPStyleGuide.Notifications.snippetRegularStyle
+        return WPStyleGuide.Notifications.headerDetailsRegularStyle
     }
 
     var quoteStyles: [NSAttributedString.Key: Any]?
@@ -11,5 +9,5 @@ class SnippetsContentStyles: FormattableContentStyles {
 
     var linksColor: UIColor?
 
-    var key: String = "SnippetsContentStyles"
+    var key: String = "HeaderDetailsContentStyles"
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -314,7 +314,7 @@ extension WPStyleGuide {
         fileprivate static let snippetParagraph         = NSMutableParagraphStyle(
             minLineHeight: snippetLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
         )
-        fileprivate static let snippetHeaderParagraph         = NSMutableParagraphStyle(
+        fileprivate static let snippetHeaderParagraph   = NSMutableParagraphStyle(
             minLineHeight: snippetLineSize, lineBreakMode: .byTruncatingTail, alignment: .natural
         )
         fileprivate static let blockParagraph           = NSMutableParagraphStyle(

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -67,6 +67,13 @@ extension WPStyleGuide {
                     .foregroundColor: snippetColor ]
         }
 
+        public static var headerDetailsRegularStyle: [NSAttributedString.Key: Any] {
+            return  [.paragraphStyle: snippetHeaderParagraph,
+                     .font: headerDetailsRegularFont,
+                     .foregroundColor: headerDetailsColor
+            ]
+        }
+
         // MARK: - Styles used by NotificationDetailsViewController
         //
 
@@ -306,6 +313,9 @@ extension WPStyleGuide {
         )
         fileprivate static let snippetParagraph         = NSMutableParagraphStyle(
             minLineHeight: snippetLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
+        )
+        fileprivate static let snippetHeaderParagraph         = NSMutableParagraphStyle(
+            minLineHeight: snippetLineSize, lineBreakMode: .byTruncatingTail, alignment: .natural
         )
         fileprivate static let blockParagraph           = NSMutableParagraphStyle(
             minLineHeight: blockLineSize, lineBreakMode: .byWordWrapping, alignment: .natural

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.swift
@@ -43,6 +43,15 @@ class NoteBlockHeaderTableViewCell: NoteBlockTableViewCell {
         }
     }
 
+    @objc var attributedHeaderDetails: NSAttributedString? {
+        set {
+            headerDetailsLabel.attributedText  = newValue
+        }
+        get {
+            return headerDetailsLabel.attributedText
+        }
+    }
+
 
     // MARK: - Public Methods
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296890780FE971DC00770264 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296890770FE971DC00770264 /* Security.framework */; };
 		2F08ECFC2283A4FB000F8E11 /* PostService+UnattachedMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */; };
+		2F09D134245223D300956257 /* HeaderDetailsContentStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F09D133245223D300956257 /* HeaderDetailsContentStyles.swift */; };
 		2F161B0622CC2DC70066A5C5 /* LoadingStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F161B0522CC2DC70066A5C5 /* LoadingStatusView.swift */; };
 		2FA37B1A215724E900C80377 /* LongPressGestureLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA37B19215724E900C80377 /* LongPressGestureLabel.swift */; };
 		2FA6511721F26A24009AA935 /* ChangePasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA6511621F26A24009AA935 /* ChangePasswordViewController.swift */; };
@@ -2639,6 +2640,7 @@
 		292CECFF1027259000BD407D /* SFHFKeychainUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFHFKeychainUtils.m; sourceTree = "<group>"; };
 		296890770FE971DC00770264 /* Security.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+UnattachedMedia.swift"; sourceTree = "<group>"; };
+		2F09D133245223D300956257 /* HeaderDetailsContentStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderDetailsContentStyles.swift; sourceTree = "<group>"; };
 		2F161B0522CC2DC70066A5C5 /* LoadingStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingStatusView.swift; sourceTree = "<group>"; };
 		2F970F970DF929B8006BD934 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		2FA37B19215724E900C80377 /* LongPressGestureLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LongPressGestureLabel.swift; sourceTree = "<group>"; };
@@ -7051,6 +7053,7 @@
 				7E3E7A5C20E44DB00075D159 /* BadgeContentStyles.swift */,
 				7E3E7A5820E44D2F0075D159 /* FooterContentStyles.swift */,
 				7E3E7A5620E44D130075D159 /* HeaderContentStyles.swift */,
+				2F09D133245223D300956257 /* HeaderDetailsContentStyles.swift */,
 				7E3E7A5A20E44D950075D159 /* RichTextContentStyles.swift */,
 				7E3E7A5420E44B4B0075D159 /* SnippetsContentStyles.swift */,
 				7E3E7A5220E44B260075D159 /* SubjectContentStyles.swift */,
@@ -12641,6 +12644,7 @@
 				D8A3A5B5206A4C7800992576 /* StockPhotosPicker.swift in Sources */,
 				E60C2ED71DE5075100488630 /* ReaderCommentCell.swift in Sources */,
 				5DBCD9D518F35D7500B32229 /* ReaderTopicService.m in Sources */,
+				2F09D134245223D300956257 /* HeaderDetailsContentStyles.swift in Sources */,
 				403F57BC20E5CA6A004E889A /* RewindStatusRow.swift in Sources */,
 				F5D0A64923C8FA1500B20D27 /* LinkBehavior.swift in Sources */,
 				E6DE44671B90D251000FA7EF /* ReaderHelpers.swift in Sources */,


### PR DESCRIPTION
Fixes #13856 
Rendering notification details label (includes stripping new-line) instead of plain text. 

To test:
1. Go to notifications 
2. Tap on notification where someone replied or liked your comment 
3. see the comment details line 
(more information and screenshots in the issue)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
