### PR TITLE
Signup & Login Epilogues: adjust gravatar top margin

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
@@ -17,14 +17,14 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SqA-Tm-XVX" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="15" width="72" height="72"/>
+                        <rect key="frame" x="0.0" y="32" width="72" height="72"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="72" id="9bQ-aU-GQb"/>
                             <constraint firstAttribute="height" constant="72" id="UTE-fR-kMZ"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full Name" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MbK-Ns-TbF">
-                        <rect key="frame" x="0.0" y="102" width="383" height="39"/>
+                        <rect key="frame" x="0.0" y="119" width="383" height="22"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="LJN-z2-A6L"/>
                         </constraints>
@@ -46,20 +46,20 @@
                         <rect key="frame" x="181.5" y="139" width="20" height="20"/>
                     </activityIndicatorView>
                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="2Ri-os-5ZW">
-                        <rect key="frame" x="18" y="33" width="36" height="36"/>
+                        <rect key="frame" x="18" y="50" width="36" height="36"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="2Ri-os-5ZW" secondAttribute="height" multiplier="1:1" id="Dlu-jo-OXt"/>
                         </constraints>
                     </activityIndicatorView>
                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar-add-button" translatesAutoresizingMaskIntoConstraints="NO" id="GYR-3W-aku" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="48" y="15" width="24" height="24"/>
+                        <rect key="frame" x="48" y="32" width="24" height="24"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="24" id="49J-ox-VuO"/>
                             <constraint firstAttribute="width" secondItem="GYR-3W-aku" secondAttribute="height" multiplier="1:1" id="CCT-Ge-nHv"/>
                         </constraints>
                     </imageView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="11G-E4-8Jh">
-                        <rect key="frame" x="0.0" y="15" width="72" height="72"/>
+                        <rect key="frame" x="0.0" y="32" width="72" height="72"/>
                         <connections>
                             <action selector="gravatarTapped" destination="uln-Hd-OJc" eventType="touchUpInside" id="kQu-u7-vJd"/>
                         </connections>
@@ -78,7 +78,7 @@
                     <constraint firstAttribute="trailing" secondItem="MbK-Ns-TbF" secondAttribute="trailing" id="hBZ-XF-2Ok"/>
                     <constraint firstItem="89f-vg-HlI" firstAttribute="top" secondItem="MbK-Ns-TbF" secondAttribute="bottom" id="hGl-uc-uSH"/>
                     <constraint firstItem="2Ri-os-5ZW" firstAttribute="centerY" secondItem="SqA-Tm-XVX" secondAttribute="centerY" id="jFZ-xH-4vw"/>
-                    <constraint firstItem="SqA-Tm-XVX" firstAttribute="top" secondItem="HfW-Dl-Z89" secondAttribute="top" constant="15" id="jnf-Zw-TmW"/>
+                    <constraint firstItem="SqA-Tm-XVX" firstAttribute="top" secondItem="HfW-Dl-Z89" secondAttribute="top" constant="32" id="jnf-Zw-TmW"/>
                     <constraint firstItem="SqA-Tm-XVX" firstAttribute="leading" secondItem="HfW-Dl-Z89" secondAttribute="leading" id="l1U-Lm-Q7b"/>
                     <constraint firstAttribute="bottom" secondItem="89f-vg-HlI" secondAttribute="bottom" constant="15" id="o6T-dK-g7J"/>
                     <constraint firstItem="2Ri-os-5ZW" firstAttribute="centerX" secondItem="SqA-Tm-XVX" secondAttribute="centerX" id="tF0-R9-e3X"/>


### PR DESCRIPTION
Ref: #13939, #13413

On the Signup and Login Epilogues, the gravatar's top margin is now 32pts.

To test:
- Login or Signup (they share the User Info view, so either will suffice).
- Verify the gravatar is now 32pts from the top of the view.

| Before | After |
|--------|-------|
| ![login_before](https://user-images.githubusercontent.com/1816888/80157707-fa040980-8583-11ea-8a83-b36bafbf5c4e.png) | ![login_after](https://user-images.githubusercontent.com/1816888/80157712-fd979080-8583-11ea-8719-c8e774ea7b13.png) |
| ![signup_before](https://user-images.githubusercontent.com/1816888/80157479-819d4880-8583-11ea-8bb2-1247042fd544.png) | ![signup_after](https://user-images.githubusercontent.com/1816888/80157483-85c96600-8583-11ea-9e93-34c3ab0e778d.png) |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
