### PR TITLE
Fix scheduling issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -114,7 +114,7 @@ public enum PostEditorAction {
         case .publish:
             return .saveAsDraft
         case .update:
-            return .publishNow
+            return .publish
         default:
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -27,7 +27,7 @@ struct PublishSettingsViewModel {
     let title: String?
 
     var detailString: String {
-        if let date = date {
+        if let date = date, post.hasFuturePublishDate() {
             return dateTimeFormatter.string(from: date)
         } else {
             return NSLocalizedString("Immediately", comment: "Undated post time label")

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -83,7 +83,11 @@ struct PublishSettingsViewModel {
             } else {
                 post.status = .publish
             }
-        } else {
+        } else if post.originalIsDraft() {
+            // If the original is a draft, keep the post as a draft
+            post.status = .draft
+            post.dateCreated = Date()
+        } else if post.hasFuturePublishDate() {
             post.publishImmediately()
         }
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -77,6 +77,7 @@ struct PublishSettingsViewModel {
 
     mutating func setDate(_ date: Date?) {
         if let date = date {
+            // If a date to schedule the post was given
             post.dateCreated = date
             if post.hasFuturePublishDate() {
                 post.status = .scheduled
@@ -88,6 +89,8 @@ struct PublishSettingsViewModel {
             post.status = .draft
             post.dateCreated = Date()
         } else if post.hasFuturePublishDate() {
+            // If the original is a already scheduled post, change it to publish immediately
+            // In this case the user had scheduled, but now wants to publish right away
             post.publishImmediately()
         }
 


### PR DESCRIPTION
Fixes #13983 and #13985

### To test

#### Customized date is ignored for previously saved drafts (#13983)

1. Go to My Site > Blog Posts > +.
1. Add a title and some content.
1. Tap More > Save as Draft. 
1. Tap More > Publish. 
1. Change the date to something in the future.
1. Tap the "Schedule Now" button.
1. The post should be scheduled

#### Stuck in publish loop after changing publish date to immediately (#13985)

For this one, I fixed two issues: we do not display a date in the past. If it's in the past, we show "Immediately". Also, if you schedule a draft and then remove the scheduling, the draft will behave as a draft (instead of "Publish" as it was before, you'll see "Update").

1. Go to the My site tab > Blog posts > Drafts.
2. Select a draft to open it in the editor.
3. Optional: make some changes to the post content.
4. Open the ellipsis menu and tap "Publish"
5. Notice that the publish date is set to "Immediately". Tap Publish > select Publish immediately.
6. Dismiss the bottom sheet.
7. Tap "X" to close the editor.
8. Notice the "You have unsaved changes" prompt appears. Select "Update Draft" to save the changes to the draft.