### PR TITLE
Update WordPressUI to 1.5.4-beta.3

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -34,12 +34,12 @@ end
 
 def wordpress_ui
     ## for production:
-    #pod 'WordPressUI', '~> 1.5.4-beta.2'
+    pod 'WordPressUI', '~> 1.5.4-beta.3'
 
     ## for development:
     #pod 'WordPressUI', :path => '../WordPressUI-iOS'
     ## while PR is in review:
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :branch => 'fancybutton-public-isprimary'
+    #pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :branch => 'fancybutton-public-isprimary'
     #pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :commit => '05d82b280a4b65e084f34e282ec392cb80afdec1'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -483,7 +483,7 @@ DEPENDENCIES:
   - WordPressKit (~> 4.8.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
-  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS`, branch `fancybutton-public-isprimary`)
+  - WordPressUI (~> 1.5.4-beta.3)
   - WPMediaPicker (~> 1.6.1)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/6906be56ace31186ded1df0b65b9ea34fe2aaf34/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
@@ -531,6 +531,7 @@ SPEC REPOS:
     - WordPressKit
     - WordPressMocks
     - WordPressShared
+    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskCommonUISDK
@@ -612,9 +613,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 6906be56ace31186ded1df0b65b9ea34fe2aaf34
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressUI:
-    :branch: fancybutton-public-isprimary
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/6906be56ace31186ded1df0b65b9ea34fe2aaf34/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -628,9 +626,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 6906be56ace31186ded1df0b65b9ea34fe2aaf34
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressUI:
-    :commit: ab417cb9738f4db96f19801537153cebebbc8005
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -719,6 +714,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 1d245d068a1b60e4f03202a8a1f5d85615becab0
+PODFILE CHECKSUM: 8471ff7f40023516c5d1f4d2d1127bf55dd761f4
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Forgot to change the referenced WordPressUI version from the branch to the released version.

## Testing

You can verify this works if the pods install and the Filter Sheet Popover on iPad does not collapse.

PR submission checklist:

- [x] ~I have considered adding unit tests where possible.~
- [x] ~I have considered adding accessibility improvements for my changes.~
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~
