### PR TITLE
Fix reader crash for self hosted sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -14,12 +14,6 @@ class ReaderTabView: UIView {
 
     private let viewModel: ReaderTabViewModel
 
-    private var selectedItem: ReaderTabItem? {
-        guard !tabBar.items.isEmpty, tabBar.selectedIndex < tabBar.items.count else {
-            return nil
-        }
-        return tabBar.items[tabBar.selectedIndex] as? ReaderTabItem
-    }
 
     init(viewModel: ReaderTabViewModel) {
         mainStackView = UIStackView()
@@ -100,7 +94,7 @@ extension ReaderTabView {
     }
 
     private func configureTabBarElements() {
-        guard let tabItem = selectedItem else {
+        guard let tabItem = tabBar.currentlyCelectedItem as? ReaderTabItem else {
             return
         }
         buttonsStackView.isHidden = tabItem.shouldHideButtonsView
@@ -231,7 +225,7 @@ extension ReaderTabView {
     @objc private func didTapResetFilterButton() {
         setFilterButtonTitle(Appearance.defaultFilterButtonTitle)
         resetFilterButton.isHidden = true
-        guard let tabItem = selectedItem else {
+        guard let tabItem = tabBar.currentlyCelectedItem as? ReaderTabItem else {
             return
         }
         viewModel.resetFilter(selectedItem: tabItem)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -14,6 +14,13 @@ class ReaderTabView: UIView {
 
     private let viewModel: ReaderTabViewModel
 
+    private var selectedItem: ReaderTabItem? {
+        guard !tabBar.items.isEmpty, tabBar.selectedIndex < tabBar.items.count else {
+            return nil
+        }
+        return tabBar.items[tabBar.selectedIndex] as? ReaderTabItem
+    }
+
     init(viewModel: ReaderTabViewModel) {
         mainStackView = UIStackView()
         buttonsStackView = UIStackView()
@@ -93,7 +100,7 @@ extension ReaderTabView {
     }
 
     private func configureTabBarElements() {
-        guard let tabItem = tabBar.items[tabBar.selectedIndex] as? ReaderTabItem else {
+        guard let tabItem = selectedItem else {
             return
         }
         buttonsStackView.isHidden = tabItem.shouldHideButtonsView
@@ -224,7 +231,10 @@ extension ReaderTabView {
     @objc private func didTapResetFilterButton() {
         setFilterButtonTitle(Appearance.defaultFilterButtonTitle)
         resetFilterButton.isHidden = true
-        viewModel.resetFilter(selectedItem: tabBar.items[tabBar.selectedIndex])
+        guard let tabItem = selectedItem else {
+            return
+        }
+        viewModel.resetFilter(selectedItem: tabItem)
     }
 
     @objc private func didTapSettingsButton() {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -137,7 +137,7 @@ extension ReaderTabViewModel {
     /// Fetch request to extract reader menu topics from Core Data
     private var topicsFetchRequest: NSFetchRequest<NSFetchRequestResult> {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ReaderTopicsConstants.entityName)
-        fetchRequest.predicate = NSPredicate(format: ReaderTopicsConstants.predicateFormat)
+        fetchRequest.predicate = NSPredicate(format: ReaderTopicsConstants.predicateFormat, NSNumber(value: ReaderHelpers.isLoggedIn()))
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: ReaderTopicsConstants.sortByKey, ascending: true)]
         return fetchRequest
     }
@@ -172,7 +172,7 @@ extension ReaderTabViewModel {
     }
 
     private enum ReaderTopicsConstants {
-        static let predicateFormat = "following == YES AND showInMenu == YES AND type == 'default' OR type == 'list' OR type == 'team'"
+        static let predicateFormat = "type == 'default' OR type == 'team' OR (type == 'list' AND following == %@ AND showInMenu == YES)"
         static let entityName = "ReaderAbstractTopic"
         static let sortByKey = "type"
         static let fetchRequestError = "There was a problem fetching topics for the menu. "

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -137,7 +137,7 @@ extension ReaderTabViewModel {
     /// Fetch request to extract reader menu topics from Core Data
     private var topicsFetchRequest: NSFetchRequest<NSFetchRequestResult> {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ReaderTopicsConstants.entityName)
-        fetchRequest.predicate = NSPredicate(format: ReaderTopicsConstants.predicateFormat, NSNumber(value: ReaderHelpers.isLoggedIn()))
+        fetchRequest.predicate = NSPredicate(format: ReaderTopicsConstants.predicateFormat)
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: ReaderTopicsConstants.sortByKey, ascending: true)]
         return fetchRequest
     }
@@ -172,7 +172,7 @@ extension ReaderTabViewModel {
     }
 
     private enum ReaderTopicsConstants {
-        static let predicateFormat = "following == %@ AND showInMenu == YES AND type == 'default' OR type == 'list' OR type == 'team'"
+        static let predicateFormat = "following == YES AND showInMenu == YES AND type == 'default' OR type == 'list' OR type == 'team'"
         static let entityName = "ReaderAbstractTopic"
         static let sortByKey = "type"
         static let fetchRequestError = "There was a problem fetching topics for the menu. "

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -356,7 +356,19 @@ class FilterTabBar: UIControl {
         }
     }
 
+    var currentlyCelectedItem: FilterTabBarItem? {
+        guard !items.isEmpty, selectedIndex < items.count else {
+            return nil
+        }
+        return items[selectedIndex]
+    }
+
     func setSelectedIndex(_ index: Int, animated: Bool = true) {
+        guard index >= 0, index < items.count else {
+            DDLogError("FilterTabBar - Tried to set an invalid index")
+            return
+        }
+
         selectedIndex = index
 
         guard let tab = selectedTab else {


### PR DESCRIPTION
Fixes #13997

To test:
- log in with a self hosted site, go to the reader and verify that the tabs Discover and Saved show up, and no crash occurs

PR submission checklist:

- [x] ~~I have considered adding unit tests where possible.~~
- [x] ~~I have considered adding accessibility improvements for my changes.~~
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~
