### PR TITLE
Improvements for Tenor picker to address comments in #13949

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
@@ -64,7 +64,6 @@ public struct MediaAnalyticsInfo {
     }
 
     // Old tracking events via WPShared
-    // Ref: https://iosp2.wordpress.com/2020/03/16/adding-tracks-forget-wordpress-shared/
     func wpsharedEventForMediaType(_ mediaType: MediaType) -> WPAnalyticsStat? {
         return origin.wpsharedEventForMediaType(mediaType)
     }
@@ -114,7 +113,6 @@ enum MediaUploadOrigin {
     case editor(MediaSource)
 
     // All new media tracking events will be added into WPAnalyticsEvent
-    // Ref: https://iosp2.wordpress.com/2020/03/16/adding-tracks-forget-wordpress-shared/
     func eventForMediaType(_ mediaType: MediaType) -> WPAnalyticsEvent? {
         switch (self, mediaType) {
         // Media Library
@@ -131,7 +129,6 @@ enum MediaUploadOrigin {
     }
 
     // This is for the previous events created within WordPressShared
-    // Ref: https://iosp2.wordpress.com/2020/03/16/adding-tracks-forget-wordpress-shared/
     func wpsharedEventForMediaType(_ mediaType: MediaType) -> WPAnalyticsStat? {
         switch (self, mediaType) {
         // Media Library

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -140,12 +140,7 @@ final class MediaLibraryMediaPickingCoordinator {
 
 extension MediaLibraryMediaPickingCoordinator: TenorPickerDelegate {
     func tenorPicker(_ picker: TenorPicker, didFinishPicking assets: [TenorMedia]) {
-        guard let delegate = self.delegate else {
-            tenor = nil
-            return
-        }
-
-        delegate.tenorPicker(picker, didFinishPicking: assets)
+        delegate?.tenorPicker(picker, didFinishPicking: assets)
         tenor = nil
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
@@ -97,12 +97,7 @@ final class AztecMediaPickingCoordinator {
 
 extension AztecMediaPickingCoordinator: TenorPickerDelegate {
     func tenorPicker(_ picker: TenorPicker, didFinishPicking assets: [TenorMedia]) {
-        guard let delegate = self.delegate else {
-            tenor = nil
-            return
-        }
-
-        delegate.tenorPicker(picker, didFinishPicking: assets)
+        delegate?.tenorPicker(picker, didFinishPicking: assets)
         tenor = nil
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
@@ -3,13 +3,16 @@ import WPMediaPicker
 
 /// Prepares the alert controller that will be presented when tapping the "more" button in Aztec's Format Bar
 final class AztecMediaPickingCoordinator {
+    typealias PickersDelegate = StockPhotosPickerDelegate & GiphyPickerDelegate & TenorPickerDelegate
+    private weak var delegate: PickersDelegate?
+    private var tenor: TenorPicker?
+
     private let giphy = GiphyPicker()
-    private let tenor = TenorPicker()
     private let stockPhotos = StockPhotosPicker()
 
-    init(delegate: StockPhotosPickerDelegate & GiphyPickerDelegate & TenorPickerDelegate) {
+    init(delegate: PickersDelegate) {
+        self.delegate = delegate
         giphy.delegate = delegate
-        tenor.delegate = delegate
         stockPhotos.delegate = delegate
     }
 
@@ -77,7 +80,10 @@ final class AztecMediaPickingCoordinator {
     }
 
     private func showTenor(origin: UIViewController, blog: Blog) {
-        tenor.presentPicker(origin: origin, blog: blog)
+        let picker = TenorPicker()
+        picker.delegate = self
+        picker.presentPicker(origin: origin, blog: blog)
+        tenor = picker
     }
 
     private func showDocumentPicker(origin: UIViewController & UIDocumentPickerDelegate, blog: Blog) {
@@ -86,5 +92,17 @@ final class AztecMediaPickingCoordinator {
         docPicker.delegate = origin
         docPicker.allowsMultipleSelection = true
         origin.present(docPicker, animated: true)
+    }
+}
+
+extension AztecMediaPickingCoordinator: TenorPickerDelegate {
+    func tenorPicker(_ picker: TenorPicker, didFinishPicking assets: [TenorMedia]) {
+        guard let delegate = self.delegate else {
+            tenor = nil
+            return
+        }
+
+        delegate.tenorPicker(picker, didFinishPicking: assets)
+        tenor = nil
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/Tenor/NoResultsTenorConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/NoResultsTenorConfiguration.swift
@@ -4,7 +4,7 @@ struct NoResultsTenorConfiguration {
     static func configureAsIntro(_ viewController: NoResultsViewController) {
         viewController.configure(title: .tenorPlaceholderTitle,
                                  image: Constants.imageName,
-                                 subtitleImage: "tenor-attribution")
+                                 subtitleImage: Constants.subtitleImageName)
 
         viewController.view.layoutIfNeeded()
     }
@@ -23,5 +23,6 @@ struct NoResultsTenorConfiguration {
 
     private enum Constants {
         static let imageName = "media-no-results"
+        static let subtitleImageName = "tenor-attribution"
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorAPI/TenorClient.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorAPI/TenorClient.swift
@@ -14,6 +14,14 @@ private struct SearchParams {
     static let searchString = "q"
     static let limit = "limit"
     static let position = "pos"
+    static let contentFilter = "contentfilter"
+}
+
+enum TenorContentFilter: String {
+    case off
+    case low
+    case medium
+    case high
 }
 
 // MARK: - TenorClient
@@ -43,8 +51,12 @@ struct TenorClient {
     ///   - query: a search string
     ///   - limit: return up to a specified number of results (max "limit" is 50 enforced by Tenor, default is 20 if unspecified)
     ///   - position: return results starting from "position" (use it's the last "position" of the previous search, for paging purpose)
+    ///   - contentFilter: specify the content safety filter level
     ///   - completion: the handler which will be called on completion
-    public func search(for query: String, limit: Int = 20, from position: String?, completion: @escaping TenorSearchResult) {
+    public func search(for query: String, limit: Int = 20,
+                       from position: String?,
+                       contentFilter: TenorContentFilter = .high,
+                       completion: @escaping TenorSearchResult) {
         assert(limit <= 50, "Tenor allows a maximum 50 images per search")
 
         guard let url = URL(string: EndPoints.search.rawValue) else {
@@ -56,6 +68,7 @@ struct TenorClient {
             SearchParams.searchString: query,
             SearchParams.limit: limit,
             SearchParams.position: position ?? "",
+            SearchParams.contentFilter: contentFilter.rawValue,
         ]
 
         Alamofire.request(url, method: .get, parameters: params).responseData { response in


### PR DESCRIPTION
This PR addresses comments from @frosty for #13949. 
What included?

1. Removed refs to P2 from the codebase
2. Added `contentFilter` param to Tenor API Client to allow us control the GIF safety filer level on Tenor
3. Converted some literal strings into Constants
4. Making sure a new Tenor picker instance being created each time and correctly release it when closing in Media Library and Aztec Editor

*Test*

1. Open a Post with Aztec Editor
2. Select Add media menu and choose Free GIF Library
3. Search with any term, close the picker
4. Select Add media menu again, and choose Free GIF Library
5. You will notice the Picker present a new instance without no previous search left

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
