### PR TITLE
Signup Epilogue: update content margins

### DIFF
--- a/WordPress/Classes/Extensions/UIView+Borders.swift
+++ b/WordPress/Classes/Extensions/UIView+Borders.swift
@@ -25,6 +25,19 @@ extension UIView {
         return borderView
     }
 
+    @discardableResult
+    func addBottomBorder(withColor bgColor: UIColor, leadingMargin: CGFloat) -> UIView {
+        let borderView = makeBorderView(withColor: bgColor)
+
+        NSLayoutConstraint.activate([
+            borderView.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
+            borderView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            borderView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: leadingMargin),
+            borderView.trailingAnchor.constraint(equalTo: trailingAnchor)
+            ])
+        return borderView
+    }
+
     private func makeBorderView(withColor: UIColor) -> UIView {
         let borderView = UIView()
         borderView.backgroundColor = withColor

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueSectionHeaderFooter.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueSectionHeaderFooter.swift
@@ -4,7 +4,6 @@ class EpilogueSectionHeaderFooter: UITableViewHeaderFooterView {
     static let identifier = "EpilogueSectionHeaderFooter"
 
     @IBOutlet weak var topConstraint: NSLayoutConstraint!
-    @IBOutlet weak var trailingConstraint: NSLayoutConstraint!
     @IBOutlet var titleLabel: UILabel?
 
     override func awakeFromNib() {

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueSectionHeaderFooter.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueSectionHeaderFooter.xib
@@ -15,7 +15,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LOGGED IN AS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h2s-FQ-khG">
-                    <rect key="frame" x="0.0" y="20" width="394" height="17"/>
+                    <rect key="frame" x="20" y="20" width="354" height="17"/>
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="16" id="bF1-fB-08e"/>
                     </constraints>
@@ -25,9 +25,9 @@
                 </label>
             </subviews>
             <constraints>
-                <constraint firstItem="h2s-FQ-khG" firstAttribute="leading" secondItem="21a-RX-ZhF" secondAttribute="leading" id="3Uz-6C-ppc"/>
+                <constraint firstItem="h2s-FQ-khG" firstAttribute="leading" secondItem="21a-RX-ZhF" secondAttribute="leading" constant="20" id="3Uz-6C-ppc"/>
                 <constraint firstItem="21a-RX-ZhF" firstAttribute="bottom" secondItem="h2s-FQ-khG" secondAttribute="bottom" constant="7" id="3bI-dr-T8V"/>
-                <constraint firstItem="21a-RX-ZhF" firstAttribute="trailing" secondItem="h2s-FQ-khG" secondAttribute="trailing" id="mUk-yi-bRz"/>
+                <constraint firstItem="21a-RX-ZhF" firstAttribute="trailing" secondItem="h2s-FQ-khG" secondAttribute="trailing" constant="20" id="mUk-yi-bRz"/>
                 <constraint firstItem="h2s-FQ-khG" firstAttribute="top" secondItem="21a-RX-ZhF" secondAttribute="top" constant="20" id="siM-Nd-UFb"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
@@ -35,7 +35,6 @@
             <connections>
                 <outlet property="titleLabel" destination="h2s-FQ-khG" id="xfc-xS-vwy"/>
                 <outlet property="topConstraint" destination="siM-Nd-UFb" id="u2G-qu-xyE"/>
-                <outlet property="trailingConstraint" destination="mUk-yi-bRz" id="Z49-C9-Que"/>
             </connections>
             <point key="canvasLocation" x="37" y="85"/>
         </view>

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
@@ -17,14 +17,14 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="SqA-Tm-XVX" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="32" width="72" height="72"/>
+                        <rect key="frame" x="20" y="32" width="72" height="72"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="72" id="9bQ-aU-GQb"/>
                             <constraint firstAttribute="height" constant="72" id="UTE-fR-kMZ"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full Name" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MbK-Ns-TbF">
-                        <rect key="frame" x="0.0" y="119" width="383" height="22"/>
+                        <rect key="frame" x="20" y="119" width="343" height="22"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="LJN-z2-A6L"/>
                         </constraints>
@@ -33,7 +33,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="89f-vg-HlI">
-                        <rect key="frame" x="0.0" y="141" width="383" height="18"/>
+                        <rect key="frame" x="20" y="141" width="343" height="18"/>
                         <accessibility key="accessibilityConfiguration" identifier="username"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="18" id="OMo-Z3-lLF"/>
@@ -46,20 +46,20 @@
                         <rect key="frame" x="181.5" y="139" width="20" height="20"/>
                     </activityIndicatorView>
                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="2Ri-os-5ZW">
-                        <rect key="frame" x="18" y="50" width="36" height="36"/>
+                        <rect key="frame" x="38" y="50" width="36" height="36"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="2Ri-os-5ZW" secondAttribute="height" multiplier="1:1" id="Dlu-jo-OXt"/>
                         </constraints>
                     </activityIndicatorView>
                     <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar-add-button" translatesAutoresizingMaskIntoConstraints="NO" id="GYR-3W-aku" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="48" y="32" width="24" height="24"/>
+                        <rect key="frame" x="68" y="32" width="24" height="24"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="24" id="49J-ox-VuO"/>
                             <constraint firstAttribute="width" secondItem="GYR-3W-aku" secondAttribute="height" multiplier="1:1" id="CCT-Ge-nHv"/>
                         </constraints>
                     </imageView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="11G-E4-8Jh">
-                        <rect key="frame" x="0.0" y="32" width="72" height="72"/>
+                        <rect key="frame" x="20" y="32" width="72" height="72"/>
                         <connections>
                             <action selector="gravatarTapped" destination="uln-Hd-OJc" eventType="touchUpInside" id="kQu-u7-vJd"/>
                         </connections>
@@ -68,23 +68,23 @@
                 <constraints>
                     <constraint firstItem="11G-E4-8Jh" firstAttribute="centerY" secondItem="SqA-Tm-XVX" secondAttribute="centerY" id="IxS-CJ-S1j"/>
                     <constraint firstItem="11G-E4-8Jh" firstAttribute="centerX" secondItem="SqA-Tm-XVX" secondAttribute="centerX" id="M29-uj-sGk"/>
-                    <constraint firstItem="89f-vg-HlI" firstAttribute="leading" secondItem="HfW-Dl-Z89" secondAttribute="leading" id="M44-Jk-uWN"/>
+                    <constraint firstItem="89f-vg-HlI" firstAttribute="leading" secondItem="HfW-Dl-Z89" secondAttribute="leading" constant="20" id="M44-Jk-uWN"/>
                     <constraint firstItem="2Ri-os-5ZW" firstAttribute="width" secondItem="SqA-Tm-XVX" secondAttribute="width" multiplier="0.5" id="MZT-fb-8wR"/>
                     <constraint firstItem="xGK-LG-0cx" firstAttribute="centerX" secondItem="HfW-Dl-Z89" secondAttribute="centerX" id="Mwp-7z-bUJ"/>
                     <constraint firstItem="xGK-LG-0cx" firstAttribute="bottom" secondItem="89f-vg-HlI" secondAttribute="bottom" id="OBY-RQ-kRg"/>
                     <constraint firstItem="GYR-3W-aku" firstAttribute="top" secondItem="SqA-Tm-XVX" secondAttribute="top" id="QV1-8T-K0y"/>
                     <constraint firstItem="11G-E4-8Jh" firstAttribute="width" secondItem="SqA-Tm-XVX" secondAttribute="width" id="dBO-2f-cNz"/>
-                    <constraint firstAttribute="trailing" secondItem="89f-vg-HlI" secondAttribute="trailing" id="fIW-sh-8b3"/>
-                    <constraint firstAttribute="trailing" secondItem="MbK-Ns-TbF" secondAttribute="trailing" id="hBZ-XF-2Ok"/>
+                    <constraint firstAttribute="trailing" secondItem="89f-vg-HlI" secondAttribute="trailing" constant="20" id="fIW-sh-8b3"/>
+                    <constraint firstAttribute="trailing" secondItem="MbK-Ns-TbF" secondAttribute="trailing" constant="20" id="hBZ-XF-2Ok"/>
                     <constraint firstItem="89f-vg-HlI" firstAttribute="top" secondItem="MbK-Ns-TbF" secondAttribute="bottom" id="hGl-uc-uSH"/>
                     <constraint firstItem="2Ri-os-5ZW" firstAttribute="centerY" secondItem="SqA-Tm-XVX" secondAttribute="centerY" id="jFZ-xH-4vw"/>
                     <constraint firstItem="SqA-Tm-XVX" firstAttribute="top" secondItem="HfW-Dl-Z89" secondAttribute="top" constant="32" id="jnf-Zw-TmW"/>
-                    <constraint firstItem="SqA-Tm-XVX" firstAttribute="leading" secondItem="HfW-Dl-Z89" secondAttribute="leading" id="l1U-Lm-Q7b"/>
+                    <constraint firstItem="SqA-Tm-XVX" firstAttribute="leading" secondItem="HfW-Dl-Z89" secondAttribute="leading" constant="20" id="l1U-Lm-Q7b"/>
                     <constraint firstAttribute="bottom" secondItem="89f-vg-HlI" secondAttribute="bottom" constant="15" id="o6T-dK-g7J"/>
                     <constraint firstItem="2Ri-os-5ZW" firstAttribute="centerX" secondItem="SqA-Tm-XVX" secondAttribute="centerX" id="tF0-R9-e3X"/>
                     <constraint firstItem="MbK-Ns-TbF" firstAttribute="top" secondItem="SqA-Tm-XVX" secondAttribute="bottom" constant="15" id="tp1-hu-yDU"/>
                     <constraint firstItem="11G-E4-8Jh" firstAttribute="height" secondItem="SqA-Tm-XVX" secondAttribute="height" id="vjj-dA-RLw"/>
-                    <constraint firstItem="MbK-Ns-TbF" firstAttribute="leading" secondItem="HfW-Dl-Z89" secondAttribute="leading" id="vv4-33-weD"/>
+                    <constraint firstItem="MbK-Ns-TbF" firstAttribute="leading" secondItem="HfW-Dl-Z89" secondAttribute="leading" constant="20" id="vv4-33-weD"/>
                     <constraint firstItem="GYR-3W-aku" firstAttribute="trailing" secondItem="SqA-Tm-XVX" secondAttribute="trailing" id="wL3-WH-8HH"/>
                 </constraints>
             </tableViewCellContentView>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogue.storyboard
@@ -65,7 +65,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="egq-OL-lqe" userLabel="Table Container View">
-                                <rect key="frame" x="16" y="0.0" width="359" height="583"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
                                 <connections>
                                     <segue destination="wAQ-AF-rOn" kind="embed" identifier="showEpilogueTable" id="PlO-Bm-BvC"/>
                                 </connections>
@@ -82,7 +82,7 @@
                         <constraints>
                             <constraint firstItem="240-cE-xSD" firstAttribute="top" secondItem="egq-OL-lqe" secondAttribute="bottom" id="6xk-4S-cWw"/>
                             <constraint firstItem="240-cE-xSD" firstAttribute="leading" secondItem="Zhy-FD-gA0" secondAttribute="leading" id="Jll-EX-f1p"/>
-                            <constraint firstItem="egq-OL-lqe" firstAttribute="leading" secondItem="Zhy-FD-gA0" secondAttribute="leading" constant="16" id="Ke8-3y-IW1"/>
+                            <constraint firstItem="egq-OL-lqe" firstAttribute="leading" secondItem="Zhy-FD-gA0" secondAttribute="leading" id="Ke8-3y-IW1"/>
                             <constraint firstItem="Zhy-FD-gA0" firstAttribute="top" secondItem="egq-OL-lqe" secondAttribute="top" id="VpG-I9-eZL"/>
                             <constraint firstItem="240-cE-xSD" firstAttribute="trailing" secondItem="Zhy-FD-gA0" secondAttribute="trailing" id="Yrw-fx-rz4"/>
                             <constraint firstItem="Zhy-FD-gA0" firstAttribute="trailing" secondItem="egq-OL-lqe" secondAttribute="trailing" id="drs-fr-MgU"/>
@@ -104,7 +104,7 @@
             <objects>
                 <tableViewController id="wAQ-AF-rOn" customClass="SignupEpilogueTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="ACZ-Xu-JZ4">
-                        <rect key="frame" x="0.0" y="0.0" width="359" height="583"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <connections>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -25,6 +25,11 @@ class SignupEpilogueCell: UITableViewCell {
     @IBOutlet var cellFieldLeadingConstraintWithLabel: NSLayoutConstraint!
     @IBOutlet var cellFieldLeadingConstraintWithoutLabel: NSLayoutConstraint!
 
+    // Used to layout cellField when disclosure icon is shown or hidden.
+    @IBOutlet var cellFieldTrailingConstraint: NSLayoutConstraint!
+    private var cellFieldTrailingMarginDefault: CGFloat = 0
+    private let cellFieldTrailingMarginDisclosure: CGFloat = 10
+
     // Used to apply a top margin to the Password field.
     @IBOutlet var cellFieldTopConstraint: NSLayoutConstraint!
     private let passwordTopMargin: CGFloat = 16
@@ -33,6 +38,11 @@ class SignupEpilogueCell: UITableViewCell {
     open var delegate: SignupEpilogueCellDelegate?
 
     // MARK: - UITableViewCell
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        cellFieldTrailingMarginDefault = cellFieldTrailingConstraint.constant
+    }
 
     override func prepareForReuse() {
         super.prepareForReuse()
@@ -137,8 +147,10 @@ class SignupEpilogueCell: UITableViewCell {
     private func configureAccessoryType(for cellType: EpilogueCellType) {
         if cellType == .username {
             accessoryType = .disclosureIndicator
+            cellFieldTrailingConstraint.constant = cellFieldTrailingMarginDisclosure
         } else {
             accessoryType = .none
+            cellFieldTrailingConstraint.constant = cellFieldTrailingMarginDefault
         }
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -30,6 +30,9 @@ class SignupEpilogueCell: UITableViewCell {
     private var cellFieldTrailingMarginDefault: CGFloat = 0
     private let cellFieldTrailingMarginDisclosure: CGFloat = 10
 
+    // Used to inset the separator lines.
+    @IBOutlet var cellLabelLeadingConstraint: NSLayoutConstraint!
+
     // Used to apply a top margin to the Password field.
     @IBOutlet var cellFieldTopConstraint: NSLayoutConstraint!
     private let passwordTopMargin: CGFloat = 16
@@ -103,7 +106,7 @@ class SignupEpilogueCell: UITableViewCell {
         configureTextContentTypeIfNeeded(for: newCellType)
         configureAccessibility(for: newCellType)
 
-        addBottomBorder(withColor: .divider)
+        addBottomBorder(withColor: .divider, leadingMargin: cellLabelLeadingConstraint.constant)
 
         // TODO: remove this when `WordPressAuthenticatorStyle:textFieldBackgroundColor` is updated.
         // This background color should be inherited from LoginTextField.

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.xib
@@ -58,6 +58,7 @@
                 <outlet property="cellFieldTopConstraint" destination="qjh-pQ-X5J" id="Fnd-0I-Qj1"/>
                 <outlet property="cellFieldTrailingConstraint" destination="nx1-DQ-7CM" id="07I-Dc-Ij6"/>
                 <outlet property="cellLabel" destination="IPK-b3-7Fi" id="zEA-to-D3Z"/>
+                <outlet property="cellLabelLeadingConstraint" destination="hj5-JA-DrQ" id="Owe-3a-Gi4"/>
             </connections>
             <point key="canvasLocation" x="-298.5" y="-176"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.xib
@@ -17,14 +17,14 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPK-b3-7Fi">
-                        <rect key="frame" x="0.0" y="0.0" width="42" height="44"/>
+                        <rect key="frame" x="20" y="0.0" width="42" height="44"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BeK-ke-PFi" customClass="LoginTextField" customModule="WordPressAuthenticator">
-                        <rect key="frame" x="42" y="0.0" width="317" height="44"/>
+                        <rect key="frame" x="62" y="0.0" width="293" height="44"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <accessibility key="accessibilityConfiguration" identifier="nuxEmailField"/>
                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -40,9 +40,9 @@
                     <constraint firstAttribute="bottom" secondItem="IPK-b3-7Fi" secondAttribute="bottom" id="OHt-cu-IFp"/>
                     <constraint firstAttribute="bottom" secondItem="BeK-ke-PFi" secondAttribute="bottom" id="al2-lo-1kk"/>
                     <constraint firstItem="IPK-b3-7Fi" firstAttribute="top" secondItem="BeK-ke-PFi" secondAttribute="top" id="edJ-SL-RYu"/>
-                    <constraint firstItem="BeK-ke-PFi" firstAttribute="leading" secondItem="j3X-VY-JUT" secondAttribute="leading" id="hbw-Vo-dIm"/>
-                    <constraint firstItem="IPK-b3-7Fi" firstAttribute="leading" secondItem="j3X-VY-JUT" secondAttribute="leading" id="hj5-JA-DrQ"/>
-                    <constraint firstAttribute="trailing" secondItem="BeK-ke-PFi" secondAttribute="trailing" constant="16" id="nx1-DQ-7CM"/>
+                    <constraint firstItem="BeK-ke-PFi" firstAttribute="leading" secondItem="j3X-VY-JUT" secondAttribute="leading" constant="12" id="hbw-Vo-dIm"/>
+                    <constraint firstItem="IPK-b3-7Fi" firstAttribute="leading" secondItem="j3X-VY-JUT" secondAttribute="leading" constant="20" id="hj5-JA-DrQ"/>
+                    <constraint firstAttribute="trailing" secondItem="BeK-ke-PFi" secondAttribute="trailing" constant="20" id="nx1-DQ-7CM"/>
                     <constraint firstItem="BeK-ke-PFi" firstAttribute="top" secondItem="j3X-VY-JUT" secondAttribute="top" id="qjh-pQ-X5J"/>
                 </constraints>
                 <variation key="default">
@@ -56,6 +56,7 @@
                 <outlet property="cellFieldLeadingConstraintWithLabel" destination="E6f-YY-zY1" id="Jul-fb-CwR"/>
                 <outlet property="cellFieldLeadingConstraintWithoutLabel" destination="hbw-Vo-dIm" id="G0A-xS-DO4"/>
                 <outlet property="cellFieldTopConstraint" destination="qjh-pQ-X5J" id="Fnd-0I-Qj1"/>
+                <outlet property="cellFieldTrailingConstraint" destination="nx1-DQ-7CM" id="07I-Dc-Ij6"/>
                 <outlet property="cellLabel" destination="IPK-b3-7Fi" id="zEA-to-D3Z"/>
             </connections>
             <point key="canvasLocation" x="-298.5" y="-176"/>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -114,7 +114,6 @@ class SignupEpilogueTableViewController: NUXTableViewController, EpilogueUserInf
         }
 
         cell.titleLabel?.numberOfLines = 0
-        cell.trailingConstraint.constant = Constants.footerTrailingMargin
         cell.topConstraint.constant = Constants.footerTopMargin
         cell.titleLabel?.text = NSLocalizedString("You can always log in with a magic link like the one you just used, but you can also set up a password if you prefer.", comment: "Information shown below the optional password field after new account creation.")
 


### PR DESCRIPTION
Ref #13939 

This updates the Signup Epilogue content margins to be 20pts leading and trailing. The margins have been added to the cells and removed from the table.

This allowed these issues to be resolved: (as discussed on https://github.com/wordpress-mobile/WordPress-iOS/pull/13973)
- The `Password (optional)` label now lines up with the other fields on the left.
- The `Username` disclosure icon now lines up with the other fields on the right.

**Note:** this change breaks the _Login_ epilogue alignment. I'll fix that in a follow up PR.

---
To test:
- Signup. (See below if you don't want to actually signup)
- On the epilogue, verify:
  - All the content has 20 pt leading and trailing margins.
  - The separator lines have 20 pt leading and 0 pt trailing margins.

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/80523579-867b4700-894b-11ea-8f15-7dab8a110aa6.png) | ![after](https://user-images.githubusercontent.com/1816888/80527050-fdffa500-8950-11ea-80ca-585ab46458c2.png) |

---
To show the Signup Epilogue without actually signing up:

- In WPiOS `Podfile`, point `WordPressAuthenticator` to your local Auth.
- In `LoginViewController`, change `showLoginEpilogue` to show the signup epilogue:

```
func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
    guard let navigationController = navigationController else {
        fatalError()
    }
    
    showSignupEpilogue(for: credentials)
    
//        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) { [weak self] in
//            self?.dismissBlock?(false)
//        }
}
```

- _Login_ with an existing WP account, and the _signup_ epilogue will be displayed.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
