### PR TITLE
Login Epilogue: update content margins

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
@@ -102,7 +102,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
-                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        <inset key="separatorInset" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="BlogCell" rowHeight="58" id="jbC-9p-MD0" customClass="LoginEpilogueBlogCell" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="375" height="58"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qDW-L0-z8a">
-                                <rect key="frame" x="16" y="0.0" width="343" height="583"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
                                 <connections>
                                     <segue destination="UFO-Sm-cpW" kind="embed" id="rhb-gY-oAu"/>
                                 </connections>
@@ -41,7 +41,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="51h-er-sEL" customClass="FancyButton" customModule="WordPressUI">
-                                <rect key="frame" x="15.5" y="603" width="344" height="44"/>
+                                <rect key="frame" x="-0.5" y="603" width="376" height="44"/>
                                 <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="8TV-5o-H50"/>
@@ -68,10 +68,10 @@
                             <constraint firstItem="51h-er-sEL" firstAttribute="width" secondItem="qDW-L0-z8a" secondAttribute="width" constant="1" id="I7i-NQ-93d"/>
                             <constraint firstItem="51h-er-sEL" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" constant="20" id="M0r-84-tJ6"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="leading" secondItem="LF6-fg-TWa" secondAttribute="leading" id="ME9-0u-Vx1"/>
-                            <constraint firstItem="NNF-sA-UQ4" firstAttribute="trailing" secondItem="qDW-L0-z8a" secondAttribute="trailing" constant="16" id="au1-yD-v4h"/>
+                            <constraint firstItem="NNF-sA-UQ4" firstAttribute="trailing" secondItem="qDW-L0-z8a" secondAttribute="trailing" id="au1-yD-v4h"/>
                             <constraint firstItem="LF6-fg-TWa" firstAttribute="bottom" secondItem="CSv-1Z-yIA" secondAttribute="bottom" id="ePC-QY-FqS"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="bottom" secondItem="51h-er-sEL" secondAttribute="bottom" constant="20" id="jN3-1W-Vzo"/>
-                            <constraint firstItem="qDW-L0-z8a" firstAttribute="leading" secondItem="NNF-sA-UQ4" secondAttribute="leading" constant="16" id="pOP-pd-DMR"/>
+                            <constraint firstItem="qDW-L0-z8a" firstAttribute="leading" secondItem="NNF-sA-UQ4" secondAttribute="leading" id="pOP-pd-DMR"/>
                             <constraint firstItem="51h-er-sEL" firstAttribute="centerX" secondItem="qDW-L0-z8a" secondAttribute="centerX" id="wOQ-fM-hVH"/>
                             <constraint firstItem="qDW-L0-z8a" firstAttribute="top" secondItem="NNF-sA-UQ4" secondAttribute="top" id="yLi-rM-L1b"/>
                         </constraints>
@@ -97,33 +97,33 @@
             <objects>
                 <tableViewController id="UFO-Sm-cpW" customClass="LoginEpilogueTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="bES-Rc-GFi">
-                        <rect key="frame" x="0.0" y="0.0" width="343" height="583"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="BlogCell" rowHeight="58" id="jbC-9p-MD0" customClass="LoginEpilogueBlogCell" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="343" height="58"/>
+                                <rect key="frame" x="0.0" y="28" width="375" height="58"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="jbC-9p-MD0" id="WSD-zl-Z4K">
-                                    <rect key="frame" x="0.0" y="0.0" width="343" height="58"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="58"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="diS-LA-oFB">
-                                            <rect key="frame" x="0.0" y="10" width="40" height="38"/>
+                                            <rect key="frame" x="20" y="10" width="40" height="38"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="diS-LA-oFB" secondAttribute="height" multiplier="1:1" id="EDm-IG-hab"/>
                                                 <constraint firstAttribute="width" constant="40" id="jXu-be-bSL"/>
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Site Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sHR-j2-pY2">
-                                            <rect key="frame" x="50" y="10" width="293" height="18"/>
+                                            <rect key="frame" x="70" y="10" width="285" height="18"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="siteurl.wordpress.com" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w2L-7L-x21">
-                                            <rect key="frame" x="50" y="32" width="293" height="16"/>
+                                            <rect key="frame" x="70" y="32" width="285" height="16"/>
                                             <accessibility key="accessibilityConfiguration" identifier="siteUrl"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                             <nil key="textColor"/>
@@ -133,15 +133,15 @@
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstItem="diS-LA-oFB" firstAttribute="centerY" secondItem="WSD-zl-Z4K" secondAttribute="centerY" id="0PF-9R-ocT"/>
-                                        <constraint firstItem="diS-LA-oFB" firstAttribute="leading" secondItem="WSD-zl-Z4K" secondAttribute="leading" id="2hH-m8-OhI"/>
+                                        <constraint firstItem="diS-LA-oFB" firstAttribute="leading" secondItem="WSD-zl-Z4K" secondAttribute="leading" constant="20" id="2hH-m8-OhI"/>
                                         <constraint firstItem="sHR-j2-pY2" firstAttribute="centerY" secondItem="diS-LA-oFB" secondAttribute="centerY" id="CgY-JP-zlk"/>
                                         <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="diS-LA-oFB" secondAttribute="bottom" constant="10" id="EI4-C6-JZL"/>
                                         <constraint firstItem="diS-LA-oFB" firstAttribute="top" relation="greaterThanOrEqual" secondItem="WSD-zl-Z4K" secondAttribute="top" constant="10" id="FIZ-Oq-Edg"/>
-                                        <constraint firstAttribute="trailing" secondItem="w2L-7L-x21" secondAttribute="trailing" id="Jga-aE-6wc"/>
+                                        <constraint firstAttribute="trailing" secondItem="w2L-7L-x21" secondAttribute="trailing" constant="20" id="Jga-aE-6wc"/>
                                         <constraint firstItem="sHR-j2-pY2" firstAttribute="top" relation="greaterThanOrEqual" secondItem="WSD-zl-Z4K" secondAttribute="top" constant="10" id="NRK-5z-MD7"/>
                                         <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="w2L-7L-x21" secondAttribute="bottom" constant="10" id="NxC-la-3Ir"/>
                                         <constraint firstItem="sHR-j2-pY2" firstAttribute="leading" secondItem="diS-LA-oFB" secondAttribute="trailing" constant="10" id="On8-Kk-6Od"/>
-                                        <constraint firstAttribute="trailing" secondItem="sHR-j2-pY2" secondAttribute="trailing" id="QcF-DX-Fd5"/>
+                                        <constraint firstAttribute="trailing" secondItem="sHR-j2-pY2" secondAttribute="trailing" constant="20" id="QcF-DX-Fd5"/>
                                         <constraint firstItem="w2L-7L-x21" firstAttribute="leading" secondItem="diS-LA-oFB" secondAttribute="trailing" constant="10" id="hC5-KQ-cuE"/>
                                         <constraint firstItem="w2L-7L-x21" firstAttribute="top" secondItem="sHR-j2-pY2" secondAttribute="bottom" constant="4" id="kxP-qc-0Hr"/>
                                     </constraints>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
@@ -41,7 +41,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="51h-er-sEL" customClass="FancyButton" customModule="WordPressUI">
-                                <rect key="frame" x="-0.5" y="603" width="376" height="44"/>
+                                <rect key="frame" x="20" y="603" width="335" height="44"/>
                                 <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="8TV-5o-H50"/>
@@ -63,16 +63,16 @@
                             </button>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="51h-er-sEL" firstAttribute="leading" secondItem="qDW-L0-z8a" secondAttribute="leading" constant="20" id="0rB-nq-HUv"/>
                             <constraint firstItem="LF6-fg-TWa" firstAttribute="top" secondItem="qDW-L0-z8a" secondAttribute="bottom" id="3xo-Xc-gY6"/>
                             <constraint firstItem="LF6-fg-TWa" firstAttribute="trailing" secondItem="NNF-sA-UQ4" secondAttribute="trailing" id="980-CW-Iwa"/>
-                            <constraint firstItem="51h-er-sEL" firstAttribute="width" secondItem="qDW-L0-z8a" secondAttribute="width" constant="1" id="I7i-NQ-93d"/>
                             <constraint firstItem="51h-er-sEL" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" constant="20" id="M0r-84-tJ6"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="leading" secondItem="LF6-fg-TWa" secondAttribute="leading" id="ME9-0u-Vx1"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="trailing" secondItem="qDW-L0-z8a" secondAttribute="trailing" id="au1-yD-v4h"/>
                             <constraint firstItem="LF6-fg-TWa" firstAttribute="bottom" secondItem="CSv-1Z-yIA" secondAttribute="bottom" id="ePC-QY-FqS"/>
+                            <constraint firstItem="qDW-L0-z8a" firstAttribute="trailing" secondItem="51h-er-sEL" secondAttribute="trailing" constant="20" id="gKl-WT-Qzi"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="bottom" secondItem="51h-er-sEL" secondAttribute="bottom" constant="20" id="jN3-1W-Vzo"/>
                             <constraint firstItem="qDW-L0-z8a" firstAttribute="leading" secondItem="NNF-sA-UQ4" secondAttribute="leading" id="pOP-pd-DMR"/>
-                            <constraint firstItem="51h-er-sEL" firstAttribute="centerX" secondItem="qDW-L0-z8a" secondAttribute="centerX" id="wOQ-fM-hVH"/>
                             <constraint firstItem="qDW-L0-z8a" firstAttribute="top" secondItem="NNF-sA-UQ4" secondAttribute="top" id="yLi-rM-L1b"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="NNF-sA-UQ4"/>
@@ -80,7 +80,9 @@
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
                     <connections>
+                        <outlet property="buttonLeadingConstraint" destination="0rB-nq-HUv" id="nIt-rI-J1m"/>
                         <outlet property="buttonPanel" destination="LF6-fg-TWa" id="XBZ-Df-emN"/>
+                        <outlet property="buttonTrailingConstraint" destination="gKl-WT-Qzi" id="Qo8-3z-ogl"/>
                         <outlet property="doneButton" destination="51h-er-sEL" id="JUE-a3-f8p"/>
                         <outlet property="tableViewLeadingConstraint" destination="pOP-pd-DMR" id="Oat-2L-Iay"/>
                         <outlet property="tableViewTrailingConstraint" destination="au1-yD-v4h" id="jYm-53-dls"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueConnectSiteCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueConnectSiteCell.xib
@@ -19,7 +19,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Connect another site" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m0A-Ir-2z5">
-                        <rect key="frame" x="0.0" y="20" width="320" height="34"/>
+                        <rect key="frame" x="20" y="20" width="280" height="34"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                         <color key="textColor" name="Blue50"/>
                         <nil key="highlightedColor"/>
@@ -28,8 +28,8 @@
                 <constraints>
                     <constraint firstItem="m0A-Ir-2z5" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" id="07B-oB-DOY"/>
                     <constraint firstAttribute="bottom" secondItem="m0A-Ir-2z5" secondAttribute="bottom" constant="20" id="1vQ-bJ-0PK"/>
-                    <constraint firstItem="m0A-Ir-2z5" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="5Ah-mj-O4E"/>
-                    <constraint firstAttribute="trailing" secondItem="m0A-Ir-2z5" secondAttribute="trailing" id="jVN-cL-ZFs"/>
+                    <constraint firstItem="m0A-Ir-2z5" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="5Ah-mj-O4E"/>
+                    <constraint firstAttribute="trailing" secondItem="m0A-Ir-2z5" secondAttribute="trailing" constant="20" id="jVN-cL-ZFs"/>
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -20,11 +20,14 @@ class LoginEpilogueViewController: UIViewController {
     ///
     @IBOutlet var doneButton: UIButton!
 
-    /// Constraints on the table view container.
-    /// Used to adjust the table width on iPad.
+    /// Constraints on the table view container and Done button.
+    /// Used to adjust the width on iPad.
     @IBOutlet var tableViewLeadingConstraint: NSLayoutConstraint!
     @IBOutlet var tableViewTrailingConstraint: NSLayoutConstraint!
     private var defaultTableViewMargin: CGFloat = 0
+    @IBOutlet var buttonLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet var buttonTrailingConstraint: NSLayoutConstraint!
+    private var defaultButtonMargin: CGFloat = 0
 
     /// Links to the Epilogue TableViewController
     ///
@@ -59,6 +62,7 @@ class LoginEpilogueViewController: UIViewController {
         view.backgroundColor = .basicBackground
         topLine.backgroundColor = .divider
         defaultTableViewMargin = tableViewLeadingConstraint.constant
+        defaultButtonMargin = buttonLeadingConstraint.constant
         setTableViewMargins()
         refreshInterface(with: credentials)
     }
@@ -156,6 +160,8 @@ private extension LoginEpilogueViewController {
             traitCollection.verticalSizeClass == .regular else {
                 tableViewLeadingConstraint.constant = defaultTableViewMargin
                 tableViewTrailingConstraint.constant = defaultTableViewMargin
+                buttonLeadingConstraint.constant = defaultButtonMargin
+                buttonTrailingConstraint.constant = defaultButtonMargin
                 return
         }
 
@@ -171,6 +177,9 @@ private extension LoginEpilogueViewController {
 
         tableViewLeadingConstraint.constant = margin
         tableViewTrailingConstraint.constant = margin
+
+        buttonLeadingConstraint.constant = 0
+        buttonTrailingConstraint.constant = 0
     }
 
     enum TableViewMarginMultipliers {


### PR DESCRIPTION
Ref #13413 

This updates the Login Epilogue content margins to be 20pts leading and trailing. The margins have been added to the cells and removed from the table.

---
To test:
- Login.
- On the epilogue, verify:
  - All the content has 20 pt leading and trailing margins.
  - The separator lines have 20 pt leading and 0 pt trailing margins.
  - On iPhone, the Done button as 20 pt leading and trailing margins.
  - On iPad, the Done button has 0 leading and trailing margins (i.e. is the same width as the table).

| iPhone | iPad |
|--------|-------|
| ![iphone](https://user-images.githubusercontent.com/1816888/80542609-8c345500-896a-11ea-9eb3-0172bca31da5.png) | ![ipad](https://user-images.githubusercontent.com/1816888/80542622-922a3600-896a-11ea-8905-b6e9c4896b2b.png) |

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
