### PR TITLE
Signup Epilogue: accessibility

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -112,24 +112,27 @@ private extension EpilogueUserInfoCell {
 
     func configureAccessibility() {
         usernameLabel.accessibilityIdentifier = "login-epilogue-username-label"
-        gravatarAddIcon.isHidden ? configureLoginAccessibility() : configureSignupAccessibility()
-    }
+        accessibilityTraits = .none
 
-    func configureSignupAccessibility() {
-        let accessibilityDescription = NSLocalizedString("Add account image", comment: "Accessibility description for adding an image to a new user account. Tapping this initiates that flow.")
-        gravatarButton.accessibilityLabel = accessibilityDescription
-
-        let accessibilityHint = NSLocalizedString("Adds image, or avatar, to represent this new account.", comment: "Accessibility hint text for adding an image to a new user account.")
-        gravatarButton.accessibilityHint = accessibilityHint
-    }
-
-    func configureLoginAccessibility() {
         let accessibilityFormat = NSLocalizedString("Account Information. %@. %@.", comment: "Accessibility description for account information after logging in.")
         accessibilityLabel = String(format: accessibilityFormat, fullNameLabel.text ?? "", usernameLabel.text ?? "")
-        accessibilityTraits = .none
+
         fullNameLabel.isAccessibilityElement = false
         usernameLabel.isAccessibilityElement = false
         gravatarButton.isAccessibilityElement = false
+
+        if !gravatarAddIcon.isHidden {
+            configureSignupAccessibility()
+        }
+    }
+
+    func configureSignupAccessibility() {
+        gravatarButton.isAccessibilityElement = true
+        let accessibilityDescription = NSLocalizedString("Add account image.", comment: "Accessibility description for adding an image to a new user account. Tapping this initiates that flow.")
+        gravatarButton.accessibilityLabel = accessibilityDescription
+
+        let accessibilityHint = NSLocalizedString("Add image, or avatar, to represent this new account.", comment: "Accessibility hint text for adding an image to a new user account.")
+        gravatarButton.accessibilityHint = accessibilityHint
     }
 
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -144,6 +144,7 @@ class SignupEpilogueCell: UITableViewCell {
             cellField.accessibilityIdentifier = "Username Field"
         case .password:
             cellField.accessibilityIdentifier = "Password Field"
+            cellLabel.isAccessibilityElement = false
         }
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -98,9 +98,8 @@ class SignupEpilogueTableViewController: NUXTableViewController, EpilogueUserInf
         }
 
         cell.titleLabel?.text = NSLocalizedString("Account Details", comment: "Header for account details, shown after signing up.").localizedUppercase
-        cell.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
-        cell.textLabel?.textColor = .neutral(.shade50)
         cell.titleLabel?.accessibilityIdentifier = "New Account Header"
+        cell.accessibilityLabel = cell.titleLabel?.text
 
         return cell
     }
@@ -116,6 +115,7 @@ class SignupEpilogueTableViewController: NUXTableViewController, EpilogueUserInf
         cell.titleLabel?.numberOfLines = 0
         cell.topConstraint.constant = Constants.footerTopMargin
         cell.titleLabel?.text = NSLocalizedString("You can always log in with a magic link like the one you just used, but you can also set up a password if you prefer.", comment: "Information shown below the optional password field after new account creation.")
+        cell.accessibilityLabel = cell.titleLabel?.text
 
         return cell
     }


### PR DESCRIPTION
Ref #13939 

This adds VoiceOver support to various Signup Epilogue components.

---
To test:
- Signup and enable VoiceOver. 
- User Info:
  - Select the User Info block. VO should say `Account Information. <full name> <username>`.
  - Select the gravatar icon. VO should say `Add account image. Button. Add image, or avatar, to represent this new account.`
  - Fullname and username should not be accessible.
- Account Details:
  - Select the `Account Details` header. VO should say `Account details. Heading.`.
  - Select the Display Name row. VO should say `Display Name. <display name>.`.
  - Select the Display Name field. VO should say `<display name>. Text field. Double tap to edit`.
  - Select the Username row. VO should say `Username <username>. Button.`.
  - Select the Password row. VO should say `Password optional. Secure text field. Double tap to edit`.
  - Select the visibility icon.
    - If hidden, VO should say `Show password. Hidden. Button.`
    - If shown, VO should say `Show password. Shown. Button.`
- Table footer:
    - Select the password hint text. VO should read out the message.

---
To show the Signup Epilogue without actually signing up:

- Check out the accompanying `WordPressAuthenticator` branch locally.
- In WPiOS `Podfile`, point `WordPressAuthenticator` to your local Auth.
- In `LoginViewController`, change `showLoginEpilogue` to show the signup epilogue:

```
func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
    guard let navigationController = navigationController else {
        fatalError()
    }
    
    showSignupEpilogue(for: credentials)
    
//        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) { [weak self] in
//            self?.dismissBlock?(false)
//        }
}
```

- Login with an existing account, and the signup epilogue will be displayed.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
