### PR TITLE
Login Epilogue: fix iPad layout issues

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
@@ -3,7 +3,7 @@
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -80,9 +80,7 @@
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
                     <connections>
-                        <outlet property="buttonLeadingConstraint" destination="0rB-nq-HUv" id="nIt-rI-J1m"/>
                         <outlet property="buttonPanel" destination="LF6-fg-TWa" id="XBZ-Df-emN"/>
-                        <outlet property="buttonTrailingConstraint" destination="gKl-WT-Qzi" id="Qo8-3z-ogl"/>
                         <outlet property="doneButton" destination="51h-er-sEL" id="JUE-a3-f8p"/>
                         <outlet property="tableViewLeadingConstraint" destination="pOP-pd-DMR" id="Oat-2L-Iay"/>
                         <outlet property="tableViewTrailingConstraint" destination="au1-yD-v4h" id="jYm-53-dls"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -59,7 +59,7 @@ class LoginEpilogueViewController: UIViewController {
         view.backgroundColor = .basicBackground
         topLine.backgroundColor = .divider
         defaultTableViewMargin = tableViewLeadingConstraint.constant
-        setTableViewMargins()
+        setTableViewMargins(forWidth: view.frame.width)
         refreshInterface(with: credentials)
     }
 
@@ -102,12 +102,12 @@ class LoginEpilogueViewController: UIViewController {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        setTableViewMargins()
+        setTableViewMargins(forWidth: size.width)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        setTableViewMargins()
+        setTableViewMargins(forWidth: view.frame.width)
     }
 
 }
@@ -151,7 +151,7 @@ private extension LoginEpilogueViewController {
         }
     }
 
-    func setTableViewMargins() {
+    func setTableViewMargins(forWidth viewWidth: CGFloat) {
         guard traitCollection.horizontalSizeClass == .regular &&
             traitCollection.verticalSizeClass == .regular else {
                 tableViewLeadingConstraint.constant = defaultTableViewMargin
@@ -159,14 +159,10 @@ private extension LoginEpilogueViewController {
                 return
         }
 
-        let isLandscape = UIDevice.current.orientation.isLandscape
-        let marginMultiplier = isLandscape ?
+        let marginMultiplier = UIDevice.current.orientation.isLandscape ?
             TableViewMarginMultipliers.ipadLandscape :
             TableViewMarginMultipliers.ipadPortrait
 
-        let screenSizeMax = max(view.frame.width, view.frame.height)
-        let screenSizeMin = min(view.frame.width, view.frame.height)
-        let viewWidth = isLandscape ? screenSizeMax : screenSizeMin
         let margin = viewWidth * marginMultiplier
 
         tableViewLeadingConstraint.constant = margin

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -20,14 +20,11 @@ class LoginEpilogueViewController: UIViewController {
     ///
     @IBOutlet var doneButton: UIButton!
 
-    /// Constraints on the table view container and Done button.
+    /// Constraints on the table view container.
     /// Used to adjust the width on iPad.
     @IBOutlet var tableViewLeadingConstraint: NSLayoutConstraint!
     @IBOutlet var tableViewTrailingConstraint: NSLayoutConstraint!
     private var defaultTableViewMargin: CGFloat = 0
-    @IBOutlet var buttonLeadingConstraint: NSLayoutConstraint!
-    @IBOutlet var buttonTrailingConstraint: NSLayoutConstraint!
-    private var defaultButtonMargin: CGFloat = 0
 
     /// Links to the Epilogue TableViewController
     ///
@@ -62,7 +59,6 @@ class LoginEpilogueViewController: UIViewController {
         view.backgroundColor = .basicBackground
         topLine.backgroundColor = .divider
         defaultTableViewMargin = tableViewLeadingConstraint.constant
-        defaultButtonMargin = buttonLeadingConstraint.constant
         setTableViewMargins()
         refreshInterface(with: credentials)
     }
@@ -160,8 +156,6 @@ private extension LoginEpilogueViewController {
             traitCollection.verticalSizeClass == .regular else {
                 tableViewLeadingConstraint.constant = defaultTableViewMargin
                 tableViewTrailingConstraint.constant = defaultTableViewMargin
-                buttonLeadingConstraint.constant = defaultButtonMargin
-                buttonTrailingConstraint.constant = defaultButtonMargin
                 return
         }
 
@@ -177,9 +171,6 @@ private extension LoginEpilogueViewController {
 
         tableViewLeadingConstraint.constant = margin
         tableViewTrailingConstraint.constant = margin
-
-        buttonLeadingConstraint.constant = 0
-        buttonTrailingConstraint.constant = 0
     }
 
     enum TableViewMarginMultipliers {


### PR DESCRIPTION
Ref #13413 

This fixes two issues that @mattmiklic  discovered while testing the [Signup PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/14018):
- The Done button leading/trailing margins now match the table content margins.
- 50/50 split view on larger iPads should display properly now.

To test:

---
- Login.
- Verify the Done button margins are the same as the table content margins.

| ![ipad_portrait](https://user-images.githubusercontent.com/1816888/80657220-3fbb4900-8a40-11ea-99ec-494539775a6c.jpeg) | ![ipad_landscape](https://user-images.githubusercontent.com/1816888/80657228-45b12a00-8a40-11ea-8fa9-ab280e7236c6.jpeg) |
|--------|-------|

---
- Multitask on an iPad and change the view size. 
  - Especially 50/50 split view in landscape on a 12.9" iPad. 
  - Verify the table width is updated correctly.

| ![split1](https://user-images.githubusercontent.com/1816888/80657252-59f52700-8a40-11ea-945d-a2d6b2df38db.jpeg) | ![split2](https://user-images.githubusercontent.com/1816888/80657269-65485280-8a40-11ea-80d4-2e708c297340.jpeg) |
|--------|-------|

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
