### PR TITLE
Epilogues: fix status bar color

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -25,6 +25,8 @@ class WordPressAuthenticationManager: NSObject {
         // Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/12332#issuecomment-521994963
         let enableSignInWithApple = !(BuildConfiguration.current ~= [.a8cBranchTest, .a8cPrereleaseTesting])
 
+        let statusBarStyle: UIStatusBarStyle = FeatureFlag.unifiedAuth.enabled ? .default : .lightContent
+
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.client(),
                                                                 wpcomSecret: ApiCredentials.secret(),
                                                                 wpcomScheme: WPComScheme,
@@ -64,7 +66,7 @@ class WordPressAuthenticationManager: NSObject {
                                                 navBarBadgeColor: .accent(.shade20),
                                                 prologueBackgroundColor: .primary,
                                                 prologueTitleColor: .textInverted,
-                                                statusBarStyle: .lightContent)
+                                                statusBarStyle: statusBarStyle)
 
         WordPressAuthenticator.initialize(configuration: configuration,
                                           style: style)


### PR DESCRIPTION
Ref: #13939, #13413

This corrects the status bar color on the new Epilogues.

To test:

Note: The problem didn't always happen in simulators, so I suggest testing on a real device.

- Login or Signup. They use the same status bar setting, so either will suffice.
- On the epilogue, verify:
  - In light mode, the status bar text is dark.
  - In dark mode, the status bar text is light.

---

| Light | Dark |
|--------|-------|
| ![light_mode](https://user-images.githubusercontent.com/1816888/80660905-54044380-8a4a-11ea-9746-e0aef647ea97.jpeg) | ![dark_mode](https://user-images.githubusercontent.com/1816888/80660914-59618e00-8a4a-11ea-87bd-9699754f846f.jpeg) |

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
