### PR TITLE
Fix bug w/ WPSplitView Rotation Logic

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 14.8
 -----
 * [internal] the "send magic link" screen has navigation changes that can cause regressions. See https://git.io/Jfqiz for testing details.
+* Fixes delayed split view resizing while rotating your device.
  
 14.7
 -----

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -40,15 +40,13 @@ class WPSplitViewController: UISplitViewController {
         case portrait = 230
         case landscape = 320
 
-        static func widthForInterfaceOrientation(_ orientation: UIInterfaceOrientation) -> CGFloat {
+        static func widthForSize(_ size: CGSize) -> CGFloat {
             // If the app is in multitasking (so isn't fullscreen), just use the narrow width
-            if let windowFrame = UIApplication.shared.keyWindow?.frame {
-                if windowFrame.width < UIScreen.main.bounds.width {
-                    return self.portrait.rawValue
-                }
+            if size.width < UIScreen.main.bounds.width {
+                return self.portrait.rawValue
             }
 
-            if orientation.isPortrait || WPDeviceIdentification.isUnzoomediPhonePlus() {
+            if size.width < size.height || WPDeviceIdentification.isUnzoomediPhonePlus() {
                 return self.portrait.rawValue
             } else {
                 return self.landscape.rawValue
@@ -56,21 +54,20 @@ class WPSplitViewController: UISplitViewController {
         }
     }
 
-    fileprivate func updateSplitViewForPrimaryColumnWidth() {
+    fileprivate func updateSplitViewForPrimaryColumnWidth(size: CGSize = UIScreen.main.bounds.size) {
         switch wpPrimaryColumnWidth {
         case .default:
             minimumPrimaryColumnWidth = UISplitViewController.automaticDimension
             maximumPrimaryColumnWidth = UISplitViewController.automaticDimension
             preferredPrimaryColumnWidthFraction = UISplitViewController.automaticDimension
         case .narrow:
-            let orientation = UIApplication.shared.statusBarOrientation
-            let columnWidth = WPSplitViewControllerNarrowPrimaryColumnWidth.widthForInterfaceOrientation(orientation)
+            let columnWidth = WPSplitViewControllerNarrowPrimaryColumnWidth.widthForSize(size)
 
             minimumPrimaryColumnWidth = columnWidth
             maximumPrimaryColumnWidth = columnWidth
-            preferredPrimaryColumnWidthFraction = UIScreen.main.bounds.width / columnWidth
+            preferredPrimaryColumnWidthFraction = size.width / columnWidth
         case .full:
-            maximumPrimaryColumnWidth = UIScreen.main.bounds.width
+            maximumPrimaryColumnWidth = size.width
             preferredPrimaryColumnWidthFraction = 1.0
         }
     }
@@ -159,8 +156,8 @@ class WPSplitViewController: UISplitViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
+        self.updateSplitViewForPrimaryColumnWidth(size: size)
         coordinator.animate(alongsideTransition: { context in
-            self.updateSplitViewForPrimaryColumnWidth()
             self.updateDimmingViewFrame()
         })
 

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -40,7 +40,7 @@ class WPSplitViewController: UISplitViewController {
         case portrait = 230
         case landscape = 320
 
-        static func widthForSize(_ size: CGSize) -> CGFloat {
+        static func width(for size: CGSize) -> CGFloat {
             // If the app is in multitasking (so isn't fullscreen), just use the narrow width
             if size.width < UIScreen.main.bounds.width {
                 return self.portrait.rawValue
@@ -61,7 +61,7 @@ class WPSplitViewController: UISplitViewController {
             maximumPrimaryColumnWidth = UISplitViewController.automaticDimension
             preferredPrimaryColumnWidthFraction = UISplitViewController.automaticDimension
         case .narrow:
-            let columnWidth = WPSplitViewControllerNarrowPrimaryColumnWidth.widthForSize(size)
+            let columnWidth = WPSplitViewControllerNarrowPrimaryColumnWidth.width(for: size)
 
             minimumPrimaryColumnWidth = columnWidth
             maximumPrimaryColumnWidth = columnWidth
@@ -156,7 +156,7 @@ class WPSplitViewController: UISplitViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        self.updateSplitViewForPrimaryColumnWidth(size: size)
+        updateSplitViewForPrimaryColumnWidth(size: size)
         coordinator.animate(alongsideTransition: { context in
             self.updateDimmingViewFrame()
         })


### PR DESCRIPTION
Fixes an issue where WPSplitViewController delays in updating its sizing.

I noticed these two issues with the split view controller:
- Frame settings of other views is delayed until the rotation animation is complete. (i.e. the frame of views in the primary view controller were wrong during transition because of the animation delay)
- Visual jitter occurs during rotation because the initial view sizing is based on the original property values before the animation

Notice the primary view controller's frame jump in the before gif:

| Before | After |
|--|--|
| ![Before 2020-04-29 16_44_44](https://user-images.githubusercontent.com/3250/80654111-d1bf5380-8a38-11ea-9999-54938a3a94b6.gif) | ![AfterChange 2020-04-29 16_42_56](https://user-images.githubusercontent.com/3250/80654122-d71c9e00-8a38-11ea-8108-07d2469b42af.gif) |

We don't need to change the column width properties alongside the transition animation because the spit view column properties will be smoothly animated anyway.

To test:
* Go to the My Sites Tab on a device which changes to the Regular horizontal size class on rotation (iPhone Pro Max, for example).
* Rotate the device and check the animation of the primary view controller.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
