### PR TITLE
Change options order and fix label and scroll issue

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -648,7 +648,7 @@ FeaturedImageViewControllerDelegate>
             
             cell.detailTextLabel.text = [self.postDateFormatter stringFromDate:self.apost.dateCreated];
         } else {
-            cell.textLabel.text = NSLocalizedString(@"Publish", @"Label for the publish (verb) button. Tapping publishes a draft post.");
+            cell.textLabel.text = NSLocalizedString(@"Publish Date", @"Label for the publish date button.");
             cell.detailTextLabel.text = NSLocalizedString(@"Immediately", @"");
         }
         cell.tag = PostSettingsRowPublishDate;

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
@@ -33,7 +33,7 @@ extension PrepublishingNavigationController: DrawerPresentable {
     }
 
     var scrollableView: UIScrollView? {
-        let scroll = visibleViewController?.view as? UIScrollView
+        let scroll = topViewController?.view as? UIScrollView
 
         return scroll
     }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -32,7 +32,7 @@ class PrepublishingViewController: UITableViewController {
 
     private let options: [PrepublishingOption] = [
         PrepublishingOption(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility")),
-        PrepublishingOption(id: .schedule, title: Constants.publishLabel),
+        PrepublishingOption(id: .schedule, title: Constants.publishDateLabel),
         PrepublishingOption(id: .tags, title: NSLocalizedString("Tags", comment: "Label for Tags"))
     ]
 
@@ -186,7 +186,7 @@ class PrepublishingViewController: UITableViewController {
     // MARK: - Schedule
 
     func configureScheduleCell(_ cell: WPTableViewCell) {
-        cell.textLabel?.text = post.hasFuturePublishDate() ? Constants.scheduledLabel : Constants.publishLabel
+        cell.textLabel?.text = post.hasFuturePublishDate() ? Constants.scheduledLabel : Constants.publishDateLabel
         cell.detailTextLabel?.text = publishSettingsViewModel.detailString
     }
 
@@ -298,7 +298,7 @@ class PrepublishingViewController: UITableViewController {
         static let footerFrame = CGRect(x: 0, y: 0, width: 100, height: 80)
         static let publishNow = NSLocalizedString("Publish Now", comment: "Label for a button that publishes the post")
         static let scheduleNow = NSLocalizedString("Schedule Now", comment: "Label for the button that schedules the post")
-        static let publishLabel = NSLocalizedString("Publish", comment: "Label for Publish")
+        static let publishDateLabel = NSLocalizedString("Publish Date", comment: "Label for Publish date")
         static let scheduledLabel = NSLocalizedString("Scheduled for", comment: "Scheduled for [date]")
         static let headerHeight: CGFloat = 70
         static let analyticsDefaultProperty = ["via": "prepublishing_nudges"]

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -31,8 +31,8 @@ class PrepublishingViewController: UITableViewController {
     private let completion: (AbstractPost) -> ()
 
     private let options: [PrepublishingOption] = [
-        PrepublishingOption(id: .schedule, title: Constants.publishLabel),
         PrepublishingOption(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility")),
+        PrepublishingOption(id: .schedule, title: Constants.publishLabel),
         PrepublishingOption(id: .tags, title: NSLocalizedString("Tags", comment: "Label for Tags"))
     ]
 


### PR DESCRIPTION
Fixes #14020, #14021, #13986 (phew!)

### To test

#### Order (#14021)

1. Create a post
2. Tap Publish
3. Check that the order in the Nudges view is: Visibility, Publish Date and Tags

#### Label (#14020)

1. Create a post
2. Tap Publish
3. Check that the option that schedules a post now reads "Publish Date"

#### Scroll (#13986)

1. Create a post
2. Tap Publish
3. Tap "Publish Date"
4. Dismiss the calendar
5. Scroll the Nudges view and check that there's no additional empty scroll area
