### PR TITLE
Track Settings Options usage + fix Media Editor tracking

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -20,6 +20,7 @@ import Foundation
     case editorPostStickyChanged
     case editorPostLocationChanged
     case editorPostSlugChanged
+    case editorPostExcerptChanged
 
     /// A String that represents the event
     var value: String {
@@ -56,6 +57,8 @@ import Foundation
             return "editor_post_location_changed"
         case .editorPostSlugChanged:
             return "editor_post_slug_changed"
+        case .editorPostExcerptChanged:
+            return "editor_post_excerpt_changed"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -13,6 +13,8 @@ import Foundation
     case editorPostVisibilityChanged
     case editorPostTagsAdded
     case editorPostPublishNowTapped
+    case editorPostCategoryChanged
+    case editorPostStatusChanged
 
     /// A String that represents the event
     var value: String {
@@ -35,6 +37,10 @@ import Foundation
             return "editor_post_tags_added"
         case .editorPostPublishNowTapped:
             return "editor_post_publish_now_tapped"
+        case .editorPostCategoryChanged:
+            return "editor_post_category_changed"
+        case .editorPostStatusChanged:
+            return "editor_post_status_changed"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -17,6 +17,7 @@ import Foundation
     case editorPostStatusChanged
     case editorPostFormatChanged
     case editorPostFeaturedImageChanged
+    case editorPostStickyChanged
 
     /// A String that represents the event
     var value: String {
@@ -47,6 +48,8 @@ import Foundation
             return "editor_post_format_changed"
         case .editorPostFeaturedImageChanged:
             return "editor_post_featured_image_changed"
+        case .editorPostStickyChanged:
+            return "editor_post_sticky_changed"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -15,6 +15,7 @@ import Foundation
     case editorPostPublishNowTapped
     case editorPostCategoryChanged
     case editorPostStatusChanged
+    case editorPostFormatChanged
 
     /// A String that represents the event
     var value: String {
@@ -41,6 +42,8 @@ import Foundation
             return "editor_post_category_changed"
         case .editorPostStatusChanged:
             return "editor_post_status_changed"
+        case .editorPostFormatChanged:
+            return "editor_post_format_changed"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -18,6 +18,7 @@ import Foundation
     case editorPostFormatChanged
     case editorPostFeaturedImageChanged
     case editorPostStickyChanged
+    case editorPostLocationChanged
 
     /// A String that represents the event
     var value: String {
@@ -50,6 +51,8 @@ import Foundation
             return "editor_post_featured_image_changed"
         case .editorPostStickyChanged:
             return "editor_post_sticky_changed"
+        case .editorPostLocationChanged:
+            return "editor_post_location_changed"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -7,7 +7,7 @@ import Foundation
     case editorCreatedPage
     case createSheetShown
 
-    // Prepublishing Nudges
+    // Settings and Prepublishing Nudges
     case editorPostPublishTap
     case editorPostScheduled
     case editorPostVisibilityChanged

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -19,6 +19,7 @@ import Foundation
     case editorPostFeaturedImageChanged
     case editorPostStickyChanged
     case editorPostLocationChanged
+    case editorPostSlugChanged
 
     /// A String that represents the event
     var value: String {
@@ -53,6 +54,8 @@ import Foundation
             return "editor_post_sticky_changed"
         case .editorPostLocationChanged:
             return "editor_post_location_changed"
+        case .editorPostSlugChanged:
+            return "editor_post_slug_changed"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -16,6 +16,7 @@ import Foundation
     case editorPostCategoryChanged
     case editorPostStatusChanged
     case editorPostFormatChanged
+    case editorPostFeaturedImageChanged
 
     /// A String that represents the event
     var value: String {
@@ -44,6 +45,8 @@ import Foundation
             return "editor_post_status_changed"
         case .editorPostFormatChanged:
             return "editor_post_format_changed"
+        case .editorPostFeaturedImageChanged:
+            return "editor_post_featured_image_changed"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3522,9 +3522,9 @@ extension AztecPostViewController {
                               onFinishEditing: { [weak self] images, actions in
                                 images.forEach { mediaEditorImage in
                                     if let image = mediaEditorImage.editedImage {
-                                        self?.insertImage(image: image, source: .mediaEditor)
+                                        self?.insertImage(image: image)
                                     } else if let phAsset = mediaEditorImage as? PHAsset {
-                                        self?.insertDeviceMedia(phAsset: phAsset, source: .mediaEditor)
+                                        self?.insertDeviceMedia(phAsset: phAsset)
                                     }
                                 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -97,8 +97,8 @@ class GutenbergMediaInserterHelper: NSObject {
         callback([MediaInfo(id: mediaUploadID, url: url.absoluteString, type: media.mediaTypeString)])
     }
 
-    func insertFromImage(image: UIImage, callback: @escaping MediaPickerDidPickMediaCallback) {
-        guard let media = insert(exportableAsset: image, source: .mediaEditor) else {
+    func insertFromImage(image: UIImage, callback: @escaping MediaPickerDidPickMediaCallback, source: MediaSource = .deviceLibrary) {
+        guard let media = insert(exportableAsset: image, source: source) else {
             callback([])
             return
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -460,7 +460,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
                                     return
                                 }
 
-                                self?.mediaInserterHelper.insertFromImage(image: image, callback: callback)
+                                self?.mediaInserterHelper.insertFromImage(image: image, callback: callback, source: .mediaEditor)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Geolocation/PostGeolocationViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Geolocation/PostGeolocationViewController.m
@@ -161,12 +161,14 @@ typedef NS_ENUM(NSInteger, SearchResultsSection) {
 
 - (void)removeGeolocation
 {
+    [WPAnalytics trackEvent:WPAnalyticsEventEditorPostLocationChanged properties:@{@"via": @"settings", @"action": @"removed"}];
     self.post.geolocation = nil;
     [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 }
 
 - (void)confirmGeolocation
 {
+    [WPAnalytics trackEvent:WPAnalyticsEventEditorPostLocationChanged properties:@{@"via": @"settings", @"action": @"added"}];
     self.post.geolocation = self.geoView.coordinate;
     [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1376,6 +1376,8 @@ FeaturedImageViewControllerDelegate>
     [self unregisterChangeObserver];
     [self.mediaDataSource searchCancelled];
 
+    [WPAnalytics trackEvent:WPAnalyticsEventEditorPostFeaturedImageChanged properties:@{@"via": @"settings", @"action": @"added"}];
+
     if ([[assets firstObject] isKindOfClass:[PHAsset class]]){
         PHAsset *asset = [assets firstObject];
         self.isUploadingMedia = YES;
@@ -1450,6 +1452,7 @@ FeaturedImageViewControllerDelegate>
 
 - (void)FeaturedImageViewControllerOnRemoveImageButtonPressed:(FeaturedImageViewController *)controller
 {
+    [WPAnalytics trackEvent:WPAnalyticsEventEditorPostFeaturedImageChanged properties:@{@"via": @"settings", @"action": @"removed"}];
     self.featuredImage = nil;
     self.animatedFeaturedImageData = nil;
     [self.apost setFeaturedImage:nil];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1075,6 +1075,7 @@ FeaturedImageViewControllerDelegate>
     vc.onItemSelected = ^(NSString *status) {
         // Check if the object passed is indeed an NSString, otherwise we don't want to try to set it as the post format
         if ([status isKindOfClass:[NSString class]]) {
+            [WPAnalytics trackEvent:WPAnalyticsEventEditorPostFormatChanged properties:@{@"via": @"settings"}];
             post.postFormatText = status;
             [weakVc dismiss];
             [self.tableView reloadData];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1199,6 +1199,7 @@ FeaturedImageViewControllerDelegate>
     vc.title = NSLocalizedString(@"Slug", @"Label for the slug field. Should be the same as WP core.");
     vc.autocapitalizationType = UITextAutocapitalizationTypeNone;
     vc.onValueChanged = ^(NSString *value) {
+        [WPAnalytics trackEvent:WPAnalyticsEventEditorPostSlugChanged properties:@{@"via": @"settings"}];
         self.apost.wp_slug = value;
         [self.tableView reloadData];
     };

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1214,6 +1214,10 @@ FeaturedImageViewControllerDelegate>
                                                                                      isPassword:NO];
     vc.title = NSLocalizedString(@"Excerpt", @"Label for the excerpt field. Should be the same as WP core.");
     vc.onValueChanged = ^(NSString *value) {
+        if (self.apost.mt_excerpt != value) {
+            [WPAnalytics trackEvent:WPAnalyticsEventEditorPostExcerptChanged properties:@{@"via": @"settings"}];
+        }
+
         self.apost.mt_excerpt = value;
         [self.tableView reloadData];
     };

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -767,6 +767,7 @@ FeaturedImageViewControllerDelegate>
     cell.name = NSLocalizedString(@"Stick post to the front page", @"This is the cell title.");
     cell.on = self.post.isStickyPost;
     cell.onChange = ^(BOOL newValue) {
+        [WPAnalytics trackEvent:WPAnalyticsEventEditorPostStickyChanged properties:@{@"via": @"settings"}];
         weakSelf.post.isStickyPost = newValue;
     };
     return cell;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1025,6 +1025,7 @@ FeaturedImageViewControllerDelegate>
     SettingsSelectionViewController *vc = [[SettingsSelectionViewController alloc] initWithDictionary:statusDict];
     __weak SettingsSelectionViewController *weakVc = vc;
     vc.onItemSelected = ^(NSString *status) {
+        [WPAnalytics trackEvent:WPAnalyticsEventEditorPostStatusChanged properties:@{@"via": @"settings"}];
         self.apost.status = status;
         [weakVc dismiss];
         [self.tableView reloadData];
@@ -1401,6 +1402,8 @@ FeaturedImageViewControllerDelegate>
 
 - (void)postCategoriesViewController:(PostCategoriesViewController *)controller didUpdateSelectedCategories:(NSSet *)categories
 {
+    [WPAnalytics trackEvent:WPAnalyticsEventEditorPostCategoryChanged properties:@{@"via": @"settings"}];
+
     // Save changes.
     self.post.categories = [categories mutableCopy];
     [self.post save];


### PR DESCRIPTION
Fixes #14036

### To test

#### Post Settings

1. Create a new post
2. Go to post settings
3. Change each setting and check the console output for the events triggered

#### Media Editing

After talking with @malinajirka we decided to change how the property `via: media_editor` should be fired for `photo_added`. Now, this only happens if the user edits an already uploaded image, otherwise, the original source will be kept.