### PR TITLE
Signup Epilogue: Remove showUsernames segue name

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -185,9 +185,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.16.0-beta.2'
+    pod 'WordPressAuthenticator', '~> 1.16.0-beta.2'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/257-remove_showUsernames'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -185,9 +185,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.15.0'
+    # pod 'WordPressAuthenticator', '~> 1.16.0-beta.2'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/use-wpui-1-6-0'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/257-remove_showUsernames'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -376,7 +376,7 @@ PODS:
   - WordPress-Aztec-iOS (1.18.0)
   - WordPress-Editor-iOS (1.18.0):
     - WordPress-Aztec-iOS (= 1.18.0)
-  - WordPressAuthenticator (1.15.0):
+  - WordPressAuthenticator (1.16.0-beta.2):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -479,7 +479,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.18.0)
-  - WordPressAuthenticator (~> 1.15.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/257-remove_showUsernames`)
   - WordPressKit (~> 4.8.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -527,7 +527,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -613,6 +612,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.27.0
+  WordPressAuthenticator:
+    :branch: issue/257-remove_showUsernames
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.27.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -626,6 +628,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.27.0
+  WordPressAuthenticator:
+    :commit: 994b7b6f3d6fa12ea106a86f240c31f0ff1b3c8b
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -697,7 +702,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: fae5d158879dfd6f36c8d0ff0cc111a0b8e36790
   WordPress-Editor-iOS: f8217e10cacf138d374d868b1395ffcb41d434f9
-  WordPressAuthenticator: 17e102eabef6f43959bd24e6da3aa5ba531daa38
+  WordPressAuthenticator: 26cf23fa8d2e573e342190dd698cfcea0f784760
   WordPressKit: 84045e236949248632a2c644149e5657733011bb
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
@@ -714,6 +719,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 3420424f199ee2b575947e0510871c9733d79c7e
+PODFILE CHECKSUM: 0488e66bb70e43c3dd7f2daeb6b5e2f1320714db
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -479,7 +479,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.18.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/257-remove_showUsernames`)
+  - WordPressAuthenticator (~> 1.16.0-beta.2)
   - WordPressKit (~> 4.8.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -527,6 +527,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -612,9 +613,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.27.0
-  WordPressAuthenticator:
-    :branch: issue/257-remove_showUsernames
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.27.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -628,9 +626,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.27.0
-  WordPressAuthenticator:
-    :commit: 994b7b6f3d6fa12ea106a86f240c31f0ff1b3c8b
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -719,6 +714,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 0488e66bb70e43c3dd7f2daeb6b5e2f1320714db
+PODFILE CHECKSUM: 7a04c07ffa23154204dfe4e49c8c7a1c471cbf2f
 
 COCOAPODS: 1.8.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 14.9
 -----
+* [internal] the navigation to "Change Username" on the Signup Epilogue screen has navigation changes that can cause regressions. See https://git.io/JfGnv for testing details.
  
 14.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 14.9
 -----
-* [internal] the navigation to "Change Username" on the Signup Epilogue screen has navigation changes that can cause regressions. See https://git.io/JfGnv for testing details.
+* [internal] the "Change Username" on the Signup Epilogue screen has navigation changes that can cause regressions. See https://git.io/JfGnv for testing details.
  
 14.8
 -----

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogue.storyboard
@@ -108,7 +108,7 @@
                         <outlet property="doneButton" destination="atb-5g-t4d" id="JdZ-x9-aXK"/>
                         <outlet property="tableViewLeadingConstraint" destination="Ke8-3y-IW1" id="gra-zm-3j4"/>
                         <outlet property="tableViewTrailingConstraint" destination="drs-fr-MgU" id="1WO-CG-vgL"/>
-                        <segue destination="CFB-8a-SBe" kind="show" identifier="showUsernames" id="39l-r4-qyx"/>
+                        <segue destination="CFB-8a-SBe" kind="show" identifier="SignupUsernameViewController" id="39l-r4-qyx"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jgc-gi-57Y" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -136,7 +136,7 @@ extension SignupEpilogueViewController: SignupEpilogueTableViewControllerDelegat
 
     func usernameTapped(userInfo: LoginEpilogueUserInfo?) {
         epilogueUserInfo = userInfo
-        performSegue(withIdentifier: .showUsernames, sender: self)
+        performSegue(withIdentifier: SignupUsernameViewController.classNameWithoutNamespaces(), sender: self)
         WordPressAuthenticator.track(.signupEpilogueUsernameTapped, properties: self.tracksProperties())
     }
 }


### PR DESCRIPTION
Ref #https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/257
WPAuth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/268

---
To test:
- Sign up. (see below to avoid actually signing up)
- On the epilogue, select `Username`.
- Verify the `Change Username` view is displayed.

| ![epilogue](https://user-images.githubusercontent.com/1816888/81007061-c6d83a80-8e0d-11ea-86cc-ddf411614eca.png) | ![username](https://user-images.githubusercontent.com/1816888/81007072-cb9cee80-8e0d-11ea-929f-f3853027b0b8.png) |
|--------|-------|

---
To show the Signup Epilogue without actually signing up:

- Check out the accompanying `WordPressAuthenticator` branch locally.
- In WPiOS `Podfile`, point `WordPressAuthenticator` to your local Auth.
- In `LoginViewController`, change `showLoginEpilogue` to show the signup epilogue:

```
func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
    guard let navigationController = navigationController else {
        fatalError()
    }
    
    showSignupEpilogue(for: credentials)
    
//        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) { [weak self] in
//            self?.dismissBlock?(false)
//        }
}
```

- _Login_ with an existing account, and the _signup_ epilogue will be displayed.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
