### PR TITLE
Signup Epilogue: update secure text image color

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -185,9 +185,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.16.0-beta.3'
+    pod 'WordPressAuthenticator', '~> 1.16.0-beta.3'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/secure_image_color'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -185,9 +185,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.16.0-beta.2'
+    # pod 'WordPressAuthenticator', '~> 1.16.0-beta.3'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/secure_image_color'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -376,7 +376,7 @@ PODS:
   - WordPress-Aztec-iOS (1.18.0)
   - WordPress-Editor-iOS (1.18.0):
     - WordPress-Aztec-iOS (= 1.18.0)
-  - WordPressAuthenticator (1.16.0-beta.2):
+  - WordPressAuthenticator (1.16.0-beta.3):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -479,7 +479,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.18.0)
-  - WordPressAuthenticator (~> 1.16.0-beta.2)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/secure_image_color`)
   - WordPressKit (~> 4.8.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -527,7 +527,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -613,6 +612,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.27.0
+  WordPressAuthenticator:
+    :branch: issue/secure_image_color
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.27.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -626,6 +628,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.27.0
+  WordPressAuthenticator:
+    :commit: 4eb9fe54202f3b58d4c69109ee0602c6f4cb62e6
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -697,7 +702,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: fae5d158879dfd6f36c8d0ff0cc111a0b8e36790
   WordPress-Editor-iOS: f8217e10cacf138d374d868b1395ffcb41d434f9
-  WordPressAuthenticator: 26cf23fa8d2e573e342190dd698cfcea0f784760
+  WordPressAuthenticator: 0fa6e3c9072935e331571403ae7baf71a514b5f4
   WordPressKit: 84045e236949248632a2c644149e5657733011bb
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
@@ -714,6 +719,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 7a04c07ffa23154204dfe4e49c8c7a1c471cbf2f
+PODFILE CHECKSUM: db040312f9ecc6b3b3f1aa86e09666f198624939
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -479,7 +479,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.18.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/secure_image_color`)
+  - WordPressAuthenticator (~> 1.16.0-beta.3)
   - WordPressKit (~> 4.8.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -527,6 +527,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -612,9 +613,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.27.0
-  WordPressAuthenticator:
-    :branch: issue/secure_image_color
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.27.0/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -628,9 +626,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.27.0
-  WordPressAuthenticator:
-    :commit: 4eb9fe54202f3b58d4c69109ee0602c6f4cb62e6
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -719,6 +714,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: db040312f9ecc6b3b3f1aa86e09666f198624939
+PODFILE CHECKSUM: aa52d5b64c7bec88254c2f38ffc047192deaaae7
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Ref #13939 
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/269

This uses the Auth branch that updates the secure text image color on the Signup Epilogue password field.

---
To test:
- Sign up. (see below to work around signing up)
- On the epilogue, verify the password field icon matches the color in Zeplin or the images in #13939.

| <img width="432" alt="light" src="https://user-images.githubusercontent.com/1816888/81022685-766fd580-8e2b-11ea-8e94-2e92b8778b4d.png"> | <img width="432" alt="dark" src="https://user-images.githubusercontent.com/1816888/81022687-796ac600-8e2b-11ea-8915-f60142201774.png"> |
|--------|-------|

---
To show the Signup Epilogue without actually signing up:

- Check out the accompanying `WordPressAuthenticator` branch locally.
- In WPiOS `Podfile`, point `WordPressAuthenticator` to your local Auth.
- In `LoginViewController`, change `showLoginEpilogue` to show the signup epilogue:

```
func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
    guard let navigationController = navigationController else {
        fatalError()
    }
    
    showSignupEpilogue(for: credentials)
    
//        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) { [weak self] in
//            self?.dismissBlock?(false)
//        }
}
```

- _Login_ with an existing account, and the _signup_ epilogue will be displayed.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
