### PR TITLE
Blog: Deletes the old, obsolete, custom icon setter.

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -126,24 +126,6 @@ NSString * const OptionsKeyIsAtomic = @"is_wpcom_atomic";
     return [value boolValue];
 }
 
-- (NSString *)icon
-{
-    [self willAccessValueForKey:@"icon"];
-    NSString *icon = [self primitiveValueForKey:@"icon"];
-    [self didAccessValueForKey:@"icon"];
-
-    if (icon) {
-        return icon;
-    }
-
-    // if the icon is not set we can use the host url to construct it
-    NSString *hostUrl = [[NSURL URLWithString:self.xmlrpc] host];
-    if (hostUrl == nil) {
-        hostUrl = self.xmlrpc;
-    }
-    return hostUrl;
-}
-
 // Used as a key to store passwords, if you change the algorithm, logins will break
 - (NSString *)displayURL
 {


### PR DESCRIPTION
Fixes #14052 

This PR is removing a custom setter implemented back in https://github.com/wordpress-mobile/WordPress-iOS/pull/3806 as it is no longer needed -- we're not building blavatars for sites anymore. As written the code returns the site URL's host rather than an icon. This leads to errors attempting to load the non-nil icon. 
All props to @oguzkocer for the investigation into the cause of the errors.

To test:
Confirm the app builds.
Confirm unit tests pass.
Load the site list. Confirm there are no sentry errors logged and that any site with a site icon continues to display its site icon. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
