### PR TITLE
Domain Registration: Remove usage of NUX view controllers

### DIFF
--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import WordPressAuthenticator
 import WordPressEditor
 
-class RegisterDomainDetailsViewController: NUXTableViewController {
+class RegisterDomainDetailsViewController: UITableViewController {
 
     typealias Localized = RegisterDomainDetails.Localized
     typealias SectionIndex = RegisterDomainDetailsViewModel.SectionIndex

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WordPressAuthenticator
 
-class RegisterDomainSuggestionsViewController: NUXViewController, DomainSuggestionsButtonViewPresenter {
+class RegisterDomainSuggestionsViewController: UIViewController, DomainSuggestionsButtonViewPresenter {
 
     @IBOutlet weak var buttonContainerViewBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var buttonContainerViewHeightConstraint: NSLayoutConstraint!
@@ -69,9 +69,17 @@ class RegisterDomainSuggestionsViewController: NUXViewController, DomainSuggesti
         title = NSLocalizedString("Register domain",
                                   comment: "Register domain - Title for the Suggested domains screen")
         WPStyleGuide.configureColors(view: view, tableView: nil)
-        let backButton = UIBarButtonItem()
-        backButton.title = NSLocalizedString("Back", comment: "Back button title.")
-        navigationItem.backBarButtonItem = backButton
+
+        let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel,
+                                           target: self,
+                                           action: #selector(handleCancelButtonTapped))
+        navigationItem.leftBarButtonItem = cancelButton
+
+        let supportButton = UIBarButtonItem(title: NSLocalizedString("Help", comment: "Help button"),
+                                            style: .plain,
+                                            target: self,
+                                            action: #selector(handleSupportButtonTapped))
+        navigationItem.rightBarButtonItem = supportButton
     }
 
     // MARK: - Navigation
@@ -90,6 +98,18 @@ class RegisterDomainSuggestionsViewController: NUXViewController, DomainSuggesti
             domainsTableViewController = vc
         }
     }
+
+    // MARK: - Nav Bar Button Handling
+
+    @objc private func handleCancelButtonTapped(sender: UIBarButtonItem) {
+        dismiss(animated: true)
+    }
+
+    @objc private func handleSupportButtonTapped(sender: UIBarButtonItem) {
+        let supportVC = SupportTableViewController()
+        supportVC.showFromTabBar()
+    }
+
 }
 
 // MARK: - DomainSuggestionsTableViewControllerDelegate

--- a/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
@@ -11,7 +11,7 @@ protocol DomainSuggestionsTableViewControllerDelegate {
 /// This is intended to be an abstract base class that provides domain
 /// suggestions for the keyword that user searches.
 /// Subclasses should override the open variables to make customizations.
-class DomainSuggestionsTableViewController: NUXTableViewController {
+class DomainSuggestionsTableViewController: UITableViewController {
 
     // MARK: - Properties
 


### PR DESCRIPTION
Fixes #n/a
Ref https://github.com/orgs/wordpress-mobile/projects/60

This removes the usage of NUX view controllers in the Domain Registration views. It only affected the `RegisterDomainSuggestionsViewController`. The nav buttons are now added in that VC, instead of by `NUXViewController`.

---
To test:
- See below to manually enable domain registration.
- On site details, select `Register Domain`.
- Verify:
  - `Cancel` dismisses the view.
  - `Help` opens the `Support` view.

| ![reg](https://user-images.githubusercontent.com/1816888/81121419-f2c9ed80-8eeb-11ea-9b0a-5e144e3c284e.png) | ![support](https://user-images.githubusercontent.com/1816888/81121390-dcbc2d00-8eeb-11ea-8b62-bf96214ecf7f.png) |
|--------|-------|

---
To enable the Domain Registration option:
- In `BlogDetailsViewController:configureTableViewData`, disable the `DomainCreditEligibilityChecker` test, i.e.:

```
- (void)configureTableViewData
{
    NSMutableArray *marr = [NSMutableArray array];
//    if ([DomainCreditEligibilityChecker canRedeemDomainCreditWithBlog:self.blog]) {
//        if (!self.hasLoggedDomainCreditPromptShownEvent) {
//            [WPAnalytics track:WPAnalyticsStatDomainCreditPromptShown];
//            self.hasLoggedDomainCreditPromptShownEvent = YES;
//        }
        [marr addObject:[self domainCreditSectionViewModel]];
//    }
```

 ---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
