### PR TITLE
Epilogues: code cleanup

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -207,7 +207,7 @@ extension LoginEpilogueTableViewController {
     }
 }
 
-// MARK: - Private Methods
+// MARK: - Private Extension
 //
 private extension LoginEpilogueTableViewController {
 
@@ -244,6 +244,17 @@ private extension LoginEpilogueTableViewController {
         return blogDataSource.tableView(tableView, numberOfRowsInSection: section - 1)
     }
 
+    enum Sections {
+        static let userInfoSection = 0
+    }
+
+    enum Settings {
+        static let headerReuseIdentifier = "SectionHeader"
+        static let userCellReuseIdentifier = "userInfo"
+        static let profileRowHeight = CGFloat(180)
+        static let blogRowHeight = CGFloat(60)
+        static let headerHeight = CGFloat(50)
+    }
 }
 
 
@@ -270,7 +281,7 @@ private extension LoginEpilogueTableViewController {
 
     /// Loads the Blog for a given Username / XMLRPC, if any.
     ///
-    private func loadBlog(username: String, xmlrpc: String) -> Blog? {
+    func loadBlog(username: String, xmlrpc: String) -> Blog? {
         let context = ContextManager.sharedInstance().mainContext
         let service = BlogService(managedObjectContext: context)
 
@@ -279,7 +290,7 @@ private extension LoginEpilogueTableViewController {
 
     /// The self-hosted flow sets user info, if no user info is set, assume a wpcom flow and try the default wp account.
     ///
-    private func loadEpilogueForDotcom() -> LoginEpilogueUserInfo {
+    func loadEpilogueForDotcom() -> LoginEpilogueUserInfo {
         let context = ContextManager.sharedInstance().mainContext
         let service = AccountService(managedObjectContext: context)
         guard let account = service.defaultWordPressComAccount() else {
@@ -291,7 +302,7 @@ private extension LoginEpilogueTableViewController {
 
     /// Loads the EpilogueInfo for a SelfHosted site, with the specified credentials, at the given endpoint.
     ///
-    private func loadEpilogueForSelfhosted(username: String, password: String, xmlrpc: String, completion: @escaping (LoginEpilogueUserInfo?) -> ()) {
+    func loadEpilogueForSelfhosted(username: String, password: String, xmlrpc: String, completion: @escaping (LoginEpilogueUserInfo?) -> ()) {
         guard let service = UsersService(username: username, password: password, xmlrpc: xmlrpc) else {
             completion(nil)
             return
@@ -318,23 +329,5 @@ private extension LoginEpilogueTableViewController {
                 completion(epilogueInfo)
             }
         }
-    }
-}
-
-
-// MARK: - UITableViewDelegate methods
-//
-private extension LoginEpilogueTableViewController {
-
-    enum Sections {
-        static let userInfoSection = 0
-    }
-
-    enum Settings {
-        static let headerReuseIdentifier = "SectionHeader"
-        static let userCellReuseIdentifier = "userInfo"
-        static let profileRowHeight = CGFloat(180)
-        static let blogRowHeight = CGFloat(60)
-        static let headerHeight = CGFloat(50)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -56,6 +56,7 @@ class LoginEpilogueTableViewController: UITableViewController {
         tableView.tableFooterView = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 0, height: 1)))
 
         view.backgroundColor = .basicBackground
+        tableView.backgroundColor = .basicBackground
     }
 
     /// Initializes the EpilogueTableView so that data associated with the specified Endpoint is displayed.
@@ -205,25 +206,6 @@ extension LoginEpilogueTableViewController {
         onConnectSite?()
     }
 }
-
-// MARK: - UITableViewDelegate methods
-//
-extension LoginEpilogueTableViewController {
-
-    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        guard let headerView = view as? UITableViewHeaderFooterView else {
-            return
-        }
-
-        let backgroundView = UIView()
-        backgroundView.backgroundColor = .basicBackground
-        headerView.backgroundView = backgroundView
-
-        headerView.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
-        headerView.textLabel?.textColor = .neutral(.shade50)
-    }
-}
-
 
 // MARK: - Private Methods
 //

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -56,20 +56,12 @@ class LoginEpilogueViewController: UIViewController {
             fatalError()
         }
 
+        navigationController?.setNavigationBarHidden(true, animated: false)
         view.backgroundColor = .basicBackground
         topLine.backgroundColor = .divider
         defaultTableViewMargin = tableViewLeadingConstraint.constant
         setTableViewMargins(forWidth: view.frame.width)
         refreshInterface(with: credentials)
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: false)
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
         WordPressAuthenticator.track(.loginEpilogueViewed)
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -104,7 +104,7 @@ class LoginEpilogueViewController: UIViewController {
 
 }
 
-// MARK: - Configuration
+// MARK: - Private Extension
 //
 private extension LoginEpilogueViewController {
 
@@ -166,12 +166,7 @@ private extension LoginEpilogueViewController {
         static let ipadLandscape: CGFloat = 0.25
     }
 
-}
-
-
-// MARK: - Actions
-//
-extension LoginEpilogueViewController {
+    // MARK: - Actions
 
     @IBAction func dismissEpilogue() {
         onDismiss?()

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -115,66 +115,7 @@ class SignupEpilogueCell: UITableViewCell {
         cellField.backgroundColor = .basicBackground
     }
 
-    // MARK: - Private behavior
-
-    private func configureForPassword() {
-        let isPassword = (cellType == .password)
-        cellLabel.isHidden = isPassword
-
-        cellField.isSecureTextEntry = isPassword
-        cellField.showSecureTextEntryToggle = isPassword
-        cellField.textAlignment = isPassword ? .left : .right
-        cellField.textColor = isPassword ? .text : .textSubtle
-
-        cellFieldLeadingConstraintWithLabel.isActive = !isPassword
-        cellFieldLeadingConstraintWithoutLabel.isActive = isPassword
-        cellFieldTopConstraint.constant = isPassword ? passwordTopMargin : 0
-    }
-
-    private func configureAccessibility(for cellType: EpilogueCellType) {
-        if cellType == .username {
-            accessibilityTraits.insert(.button) // selection transitions to SignupUsernameViewController
-            isAccessibilityElement = true       // this assures double-tap properly captures cell selection
-        }
-
-        switch cellType {
-        case .displayName:
-            cellField.accessibilityIdentifier = "Display Name Field"
-        case .username:
-            cellField.accessibilityIdentifier = "Username Field"
-        case .password:
-            cellField.accessibilityIdentifier = "Password Field"
-            cellLabel.isAccessibilityElement = false
-        }
-    }
-
-    private func configureAccessoryType(for cellType: EpilogueCellType) {
-        if cellType == .username {
-            accessoryType = .disclosureIndicator
-            cellFieldTrailingConstraint.constant = cellFieldTrailingMarginDisclosure
-        } else {
-            accessoryType = .none
-            cellFieldTrailingConstraint.constant = cellFieldTrailingMarginDefault
-        }
-    }
-
-    private func configureTextContentTypeIfNeeded(for cellType: EpilogueCellType) {
-        guard #available(iOS 12, *) else {
-            return
-        }
-
-        switch cellType {
-        case .displayName:
-            cellField.textContentType = .name
-        case .username:
-            cellField.textContentType = .username
-        case .password:
-            cellField.textContentType = .newPassword
-        }
-    }
-
 }
-
 
 extension SignupEpilogueCell: UITextFieldDelegate {
 
@@ -207,4 +148,64 @@ extension SignupEpilogueCell: UITextFieldDelegate {
         cellField.endEditing(true)
         return true
     }
+}
+
+private extension SignupEpilogueCell {
+
+    func configureForPassword() {
+        let isPassword = (cellType == .password)
+        cellLabel.isHidden = isPassword
+
+        cellField.isSecureTextEntry = isPassword
+        cellField.showSecureTextEntryToggle = isPassword
+        cellField.textAlignment = isPassword ? .left : .right
+        cellField.textColor = isPassword ? .text : .textSubtle
+
+        cellFieldLeadingConstraintWithLabel.isActive = !isPassword
+        cellFieldLeadingConstraintWithoutLabel.isActive = isPassword
+        cellFieldTopConstraint.constant = isPassword ? passwordTopMargin : 0
+    }
+
+    func configureAccessibility(for cellType: EpilogueCellType) {
+        if cellType == .username {
+            accessibilityTraits.insert(.button) // selection transitions to SignupUsernameViewController
+            isAccessibilityElement = true       // this assures double-tap properly captures cell selection
+        }
+
+        switch cellType {
+        case .displayName:
+            cellField.accessibilityIdentifier = "Display Name Field"
+        case .username:
+            cellField.accessibilityIdentifier = "Username Field"
+        case .password:
+            cellField.accessibilityIdentifier = "Password Field"
+            cellLabel.isAccessibilityElement = false
+        }
+    }
+
+    func configureAccessoryType(for cellType: EpilogueCellType) {
+        if cellType == .username {
+            accessoryType = .disclosureIndicator
+            cellFieldTrailingConstraint.constant = cellFieldTrailingMarginDisclosure
+        } else {
+            accessoryType = .none
+            cellFieldTrailingConstraint.constant = cellFieldTrailingMarginDefault
+        }
+    }
+
+    func configureTextContentTypeIfNeeded(for cellType: EpilogueCellType) {
+        guard #available(iOS 12, *) else {
+            return
+        }
+
+        switch cellType {
+        case .displayName:
+            cellField.textContentType = .name
+        case .username:
+            cellField.textContentType = .username
+        case .password:
+            cellField.textContentType = .newPassword
+        }
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -120,8 +120,10 @@ class SignupEpilogueCell: UITableViewCell {
 extension SignupEpilogueCell: UITextFieldDelegate {
 
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if let cellType = cellType, cellType == .displayName || cellType == .password {
-            let updatedText = NSString(string: textField.text!).replacingCharacters(in: range, with: string)
+        if let cellType = cellType,
+            let originalText = textField.text,
+            cellType == .displayName || cellType == .password {
+            let updatedText = NSString(string: originalText).replacingCharacters(in: range, with: string)
             delegate?.changed(value: updatedText, forType: cellType)
         }
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -17,7 +17,7 @@ protocol SignupEpilogueTableViewControllerDataSource {
     var username: String? { get }
 }
 
-class SignupEpilogueTableViewController: NUXTableViewController, EpilogueUserInfoCellViewControllerProvider {
+class SignupEpilogueTableViewController: UITableViewController, EpilogueUserInfoCellViewControllerProvider {
 
     // MARK: - Properties
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -31,32 +31,6 @@ class SignupEpilogueTableViewController: UITableViewController, EpilogueUserInfo
     private var showPassword: Bool = true
     private var reloaded: Bool = false
 
-    private struct Constants {
-        static let numberOfSections = 2
-        static let userInfoRows = 1
-        static let noPasswordRows = 2
-        static let allAccountRows = 3
-        static let headerFooterHeight: CGFloat = 50
-        static let footerTrailingMargin: CGFloat = 16
-        static let footerTopMargin: CGFloat = 8
-    }
-
-    private struct TableSections {
-        static let userInfo = 0
-    }
-
-    private struct CellIdentifiers {
-        static let sectionHeaderFooter = "SectionHeaderFooter"
-        static let signupEpilogueCell = "SignupEpilogueCell"
-        static let epilogueUserInfoCell = "userInfo"
-    }
-
-    private struct CellNibNames {
-        static let sectionHeaderFooter = "EpilogueSectionHeaderFooter"
-        static let signupEpilogueCell = "SignupEpilogueCell"
-        static let epilogueUserInfoCell = "EpilogueUserInfoCell"
-    }
-
     // MARK: - View
 
     override func viewDidLoad() {
@@ -211,7 +185,7 @@ private extension SignupEpilogueTableViewController {
         epilogueUserInfo = userInfo
     }
 
-    private func generateDisplayName(from rawEmail: String) -> String {
+    func generateDisplayName(from rawEmail: String) -> String {
         // step 1: lower case
         let email = rawEmail.lowercased()
         // step 2: remove the @ and everything after
@@ -250,6 +224,31 @@ private extension SignupEpilogueTableViewController {
         return cell
     }
 
+    struct Constants {
+        static let numberOfSections = 2
+        static let userInfoRows = 1
+        static let noPasswordRows = 2
+        static let allAccountRows = 3
+        static let headerFooterHeight: CGFloat = 50
+        static let footerTrailingMargin: CGFloat = 16
+        static let footerTopMargin: CGFloat = 8
+    }
+
+    struct TableSections {
+        static let userInfo = 0
+    }
+
+    struct CellIdentifiers {
+        static let sectionHeaderFooter = "SectionHeaderFooter"
+        static let signupEpilogueCell = "SignupEpilogueCell"
+        static let epilogueUserInfoCell = "userInfo"
+    }
+
+    struct CellNibNames {
+        static let sectionHeaderFooter = "EpilogueSectionHeaderFooter"
+        static let signupEpilogueCell = "SignupEpilogueCell"
+        static let epilogueUserInfoCell = "EpilogueUserInfoCell"
+    }
 }
 
 // MARK: - SignupEpilogueCellDelegate

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -36,16 +36,12 @@ class SignupEpilogueViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        navigationController?.setNavigationBarHidden(true, animated: false)
+        view.backgroundColor = .basicBackground
         defaultTableViewMargin = tableViewLeadingConstraint.constant
         configureDoneButton()
         setTableViewMargins(forWidth: view.frame.width)
         WordPressAuthenticator.track(.signupEpilogueViewed, properties: tracksProperties())
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.setNavigationBarHidden(true, animated: false)
-        view.backgroundColor = .basicBackground
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -57,7 +57,7 @@ class SignupEpilogueViewController: UIViewController {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return UIDevice.isPad() ? .all : .portrait
     }
-    
+
     // MARK: - Navigation
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -79,23 +79,6 @@ class SignupEpilogueViewController: UIViewController {
         }
     }
 
-    // MARK: - analytics
-
-    private func tracksProperties() -> [AnyHashable: Any] {
-        let source: String = {
-            guard let service = socialService else {
-                return "email"
-            }
-            switch service {
-            case .google:
-                return "google"
-            case .apple:
-                return "apple"
-            }
-        }()
-
-        return ["source": source]
-    }
 }
 
 // MARK: - SignupEpilogueTableViewControllerDataSource
@@ -300,29 +283,32 @@ private extension SignupEpilogueViewController {
         })
     }
 
-    private func showPasswordError(_ error: Error? = nil) {
+    func showPasswordError(_ error: Error? = nil) {
         let errorMessage = error?.localizedDescription ?? HUDMessages.changePasswordGenericError
         SVProgressHUD.showError(withStatus: errorMessage)
+    }
+
+    func tracksProperties() -> [AnyHashable: Any] {
+        let source: String = {
+            guard let service = socialService else {
+                return "email"
+            }
+            switch service {
+            case .google:
+                return "google"
+            case .apple:
+                return "apple"
+            }
+        }()
+
+        return ["source": source]
     }
 
     enum TableViewMarginMultipliers {
         static let ipadPortrait: CGFloat = 0.1667
         static let ipadLandscape: CGFloat = 0.25
     }
-}
 
-extension SignupEpilogueViewController: SignupUsernameViewControllerDelegate {
-    func usernameSelected(_ username: String) {
-        if username.isEmpty || username == epilogueUserInfo?.username {
-            updatedUsername = nil
-        } else {
-            updatedUsername = username
-        }
-    }
-}
-
-
-private extension SignupEpilogueViewController {
     enum ButtonTitle {
         static let title = NSLocalizedString("Done", comment: "Button text on site creation epilogue page to proceed to My Sites.")
         // TODO: change UI Test when change this
@@ -334,6 +320,17 @@ private extension SignupEpilogueViewController {
         static let changingUsername = NSLocalizedString("Changing username", comment: "Shown while the app waits for the username changing web service to return.")
         static let changingPassword = NSLocalizedString("Changing password", comment: "Shown while the app waits for the password changing web service to return.")
         static let changePasswordGenericError = NSLocalizedString("There was an error changing the password", comment: "Text displayed when there is a failure changing the password.")
+    }
+
+}
+
+extension SignupEpilogueViewController: SignupUsernameViewControllerDelegate {
+    func usernameSelected(_ username: String) {
+        if username.isEmpty || username == epilogueUserInfo?.username {
+            updatedUsername = nil
+        } else {
+            updatedUsername = username
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -2,7 +2,7 @@ import SVProgressHUD
 import WordPressAuthenticator
 
 
-class SignupEpilogueViewController: NUXViewController {
+class SignupEpilogueViewController: UIViewController {
 
     // MARK: - Public Properties
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -36,12 +36,16 @@ class SignupEpilogueViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationController?.setNavigationBarHidden(true, animated: false)
         view.backgroundColor = .basicBackground
         defaultTableViewMargin = tableViewLeadingConstraint.constant
         configureDoneButton()
         setTableViewMargins(forWidth: view.frame.width)
         WordPressAuthenticator.track(.signupEpilogueViewed, properties: tracksProperties())
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -54,6 +54,10 @@ class SignupEpilogueViewController: UIViewController {
         setTableViewMargins(forWidth: view.frame.width)
     }
 
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return UIDevice.isPad() ? .all : .portrait
+    }
+    
     // MARK: - Navigation
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -2,7 +2,7 @@ import SVProgressHUD
 import WordPressAuthenticator
 
 
-class SignupUsernameTableViewController: NUXTableViewController, SearchTableViewCellDelegate {
+class SignupUsernameTableViewController: UITableViewController, SearchTableViewCellDelegate {
     open var currentUsername: String?
     open var displayName: String?
     open var delegate: SignupUsernameViewControllerDelegate?

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
@@ -7,7 +7,9 @@ protocol SignupUsernameViewControllerDelegate {
 }
 
 class SignupUsernameViewController: UIViewController {
+
     // MARK: - Properties
+
     open var currentUsername: String?
     open var displayName: String?
     open var delegate: SignupUsernameViewControllerDelegate?
@@ -19,23 +21,6 @@ class SignupUsernameViewController: UIViewController {
         super.viewDidLoad()
         configureView()
         navigationController?.setNavigationBarHidden(false, animated: false)
-    }
-
-    private func configureView() {
-        navigationItem.title = NSLocalizedString("Change Username", comment: "Change Username title.")
-        WPStyleGuide.configureColors(view: view, tableView: nil)
-
-        let supportButton = UIBarButtonItem(title: NSLocalizedString("Help", comment: "Help button"),
-                                            style: .plain,
-                                            target: self,
-                                            action: #selector(handleSupportButtonTapped))
-        navigationItem.rightBarButtonItem = supportButton
-    }
-
-    @objc private func handleSupportButtonTapped(sender: UIBarButtonItem) {
-        let supportVC = SupportTableViewController()
-        supportVC.sourceTag = .wpComCreateSiteUsername
-        supportVC.showFromTabBar()
     }
 
     // MARK: - Segue
@@ -50,6 +35,29 @@ class SignupUsernameViewController: UIViewController {
             vc.currentUsername = currentUsername
         }
     }
+}
+
+// MARK: - Private Extension
+
+private extension SignupUsernameViewController {
+
+    func configureView() {
+        navigationItem.title = NSLocalizedString("Change Username", comment: "Change Username title.")
+        WPStyleGuide.configureColors(view: view, tableView: nil)
+
+        let supportButton = UIBarButtonItem(title: NSLocalizedString("Help", comment: "Help button"),
+                                            style: .plain,
+                                            target: self,
+                                            action: #selector(handleSupportButtonTapped))
+        navigationItem.rightBarButtonItem = supportButton
+    }
+
+    @objc func handleSupportButtonTapped(sender: UIBarButtonItem) {
+        let supportVC = SupportTableViewController()
+        supportVC.sourceTag = .wpComCreateSiteUsername
+        supportVC.showFromTabBar()
+    }
+
 }
 
 // MARK: - SignupUsernameTableViewControllerDelegate

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
@@ -6,18 +6,11 @@ protocol SignupUsernameViewControllerDelegate {
     func usernameSelected(_ username: String)
 }
 
-class SignupUsernameViewController: NUXViewController {
+class SignupUsernameViewController: UIViewController {
     // MARK: - Properties
     open var currentUsername: String?
     open var displayName: String?
     open var delegate: SignupUsernameViewControllerDelegate?
-
-    override var sourceTag: WordPressSupportSourceTag {
-        get {
-            return .wpComCreateSiteUsername
-        }
-    }
-
     private var usernamesTableViewController: SignupUsernameTableViewController?
 
     // MARK: - View
@@ -29,9 +22,20 @@ class SignupUsernameViewController: NUXViewController {
     }
 
     private func configureView() {
-        _ = addHelpButtonToNavController()
         navigationItem.title = NSLocalizedString("Change Username", comment: "Change Username title.")
         WPStyleGuide.configureColors(view: view, tableView: nil)
+
+        let supportButton = UIBarButtonItem(title: NSLocalizedString("Help", comment: "Help button"),
+                                            style: .plain,
+                                            target: self,
+                                            action: #selector(handleSupportButtonTapped))
+        navigationItem.rightBarButtonItem = supportButton
+    }
+
+    @objc private func handleSupportButtonTapped(sender: UIBarButtonItem) {
+        let supportVC = SupportTableViewController()
+        supportVC.sourceTag = .wpComCreateSiteUsername
+        supportVC.showFromTabBar()
     }
 
     // MARK: - Segue


### PR DESCRIPTION
Ref #13413, #13939

This is just some code cleanup in the Signup and Login epilogues. Primarily:
- Remove usage of NUX view controllers.
- Cleanup private methods and properties.
- Remove some unnecessary code.

There should be no functional or visual changes.

---
To test:
- Login.
  - Verify the view appears as it should.
  - Verify the `Done` button dismisses the view.
  - Verify the `Connect another site` displays the site address view.
- Signup.
  - Verify the view appears as it should.
  - Verify the view does not rotate in iPhone landscape.
  - Select `Username`. Verify the `Help` nav bar button opens the `Support` view.
  - Go back to the epilogue. Verify the blue nav bar does not appear.

---
To show the Signup Epilogue without actually signing up:

- In WPiOS `Podfile`, point `WordPressAuthenticator` to your local Auth.
- In `LoginViewController`, change `showLoginEpilogue` to show the signup epilogue:

```
func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
    guard let navigationController = navigationController else {
        fatalError()
    }
    
    showSignupEpilogue(for: credentials)
    
//        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) { [weak self] in
//            self?.dismissBlock?(false)
//        }
}
```

- _Login_ with an existing account, and the _signup_ epilogue will be displayed.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
