### PR TITLE
Issues/13867 null nulls

### DIFF
--- a/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
+++ b/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
@@ -89,10 +89,23 @@ private extension ContextManager {
     }
 
     func reasonForIndividualError(_ error: NSError) -> String {
-        let entity = entityName(for: error) ?? "null"
-        let property = propertyName(for: error) ?? "null"
         let message = coreDataKnownErrorCodes[error.code] ?? "Unknown error (domain: \(error.domain) code: \(error.code), \(error.localizedDescription)"
-        return "\(message) on \(entity).\(property)"
+        var messageDetail = ""
+
+        if error.userInfo.keys.contains(NSValidationObjectErrorKey) {
+            let entity = entityName(for: error) ?? "null"
+            let property = propertyName(for: error) ?? "null"
+            messageDetail = "on \(entity).\(property)"
+
+        } else if error.code == NSManagedObjectMergeError,
+            let conflicts = error.userInfo["conflictList"] as? [NSMergeConflict],
+            let conflict = conflicts.first,
+            let name = conflict.sourceObject.entity.name {
+
+            messageDetail = "source entity: \(name)"
+        }
+
+        return "\(message) \(messageDetail)"
     }
 
     func entityName(for error: NSError) -> String? {

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -21,7 +21,7 @@ static ContextManager *_override;
 @property (nonatomic, strong) NSManagedObjectContext *mainContext;
 @property (nonatomic, strong) NSManagedObjectContext *writerContext;
 @property (nonatomic, assign) BOOL migrationFailed;
-
+@property (nonatomic, strong) NSManagedObjectContext *derivedContext;
 @end
 
 
@@ -60,7 +60,10 @@ static ContextManager *_override;
 
 - (NSManagedObjectContext *const)newDerivedContext
 {
-    return [self newChildContextWithConcurrencyType:NSPrivateQueueConcurrencyType];
+    if (!self.derivedContext) {
+        self.derivedContext = [self newChildContextWithConcurrencyType:NSPrivateQueueConcurrencyType];
+    }
+    return self.derivedContext;
 }
 
 - (NSManagedObjectContext *const)newMainContextChildContext
@@ -99,6 +102,7 @@ static ContextManager *_override;
                                             initWithConcurrencyType:concurrencyType];
     childContext.parentContext = self.mainContext;
     childContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
+    childContext.automaticallyMergesChangesFromParent = true;
 
     return childContext;
 }


### PR DESCRIPTION
Refs #13867 
Refs #13892
This is a _very_ experimental patch that attempts to do two things:

1) Improve error messages logged when there is a Core Data merge error. Currently a merge error is appended with a message that reads "on null.null".  This isn't helpful as the message is intended to reference the object and property that caused the error, something that is not relevant for a merge conflict.  With this change, instead the source entity is logged so its at least easy to see which model is having the merge problem. 

2) We're theorizing a lot of the core data issues we're seeing is due to race conditions between saves happening across multiple derived contexts along with the main context. Somewhere a context is getting out of sync with the rest causing an error.  In this patch we're tweaking things to create one and only one derived context which will be used whenever a derived context is requested.  We're also setting all child contexts of the mainContext to auto merge changes from their parent.  This, in theory, should keep things from getting out of sync. 🤞 

To test:
Run tests. Make sure they all pass. 
Use the app. Like, seriously put it through the passes. Do things that are going to cause multiple background save operations in a short period of time. Monitor performance. Ensure the app performs as expected. Ensure there are no crashes.  Look particularly at media operations. 

Gonna ping lots of smart folks to help test this one because 😬 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
