### PR TITLE
Signup Epilogue: don't update empty password

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -116,9 +116,7 @@ extension SignupEpilogueViewController: SignupEpilogueTableViewControllerDelegat
     }
 
     func passwordUpdated(newPassword: String) {
-        if !newPassword.isEmpty {
-            updatedPassword = newPassword
-        }
+        updatedPassword = newPassword.isEmpty ? nil : newPassword
     }
 
     func usernameTapped(userInfo: LoginEpilogueUserInfo?) {
@@ -177,7 +175,7 @@ private extension SignupEpilogueViewController {
                 self.updatedDisplayName = nil
                 self.saveChanges()
             }
-        } else if let newPassword = updatedPassword {
+        } else if let newPassword = updatedPassword, !newPassword.isEmpty {
             SVProgressHUD.show(withStatus: HUDMessages.changingPassword)
             changePassword(to: newPassword) { success, error in
                 if success {


### PR DESCRIPTION
Fixes #14067 

This fixes password validation on the Signup Epilogue. Specifically, if the password is blank, it will no longer attempt to update it.

---
To test:
- Sign up. (see below for a workaround)
- On the epilogue, enter a password.
- Delete the password.
- Tap Done.
- Verify:
  - You do not get the error noted on #14067 .
  - You do not see the `Changing password` HUD.

---
To show the Signup Epilogue without actually signing up:

- In WPiOS `Podfile`, point `WordPressAuthenticator` to your local Auth.
- In `LoginViewController`, change `showLoginEpilogue` to show the signup epilogue:

```
func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
    guard let navigationController = navigationController else {
        fatalError()
    }
    
    showSignupEpilogue(for: credentials)
    
//        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) { [weak self] in
//            self?.dismissBlock?(false)
//        }
}
```

- _Login_ with an existing account, and the _signup_ epilogue will be displayed.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
