### PR TITLE
Login Epilogue: hide nav bar for social logins

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -56,13 +56,17 @@ class LoginEpilogueViewController: UIViewController {
             fatalError()
         }
 
-        navigationController?.setNavigationBarHidden(true, animated: false)
         view.backgroundColor = .basicBackground
         topLine.backgroundColor = .divider
         defaultTableViewMargin = tableViewLeadingConstraint.constant
         setTableViewMargins(forWidth: view.frame.width)
         refreshInterface(with: credentials)
         WordPressAuthenticator.track(.loginEpilogueViewed)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/issues/13413

In https://github.com/wordpress-mobile/WordPress-iOS/pull/14061 I moved `setNavigationBarHidden` to `viewDidLoad`. Turns out, that doesn't work for Google and Apple logins. This moves `setNavigationBarHidden` back to `viewWillAppear` so the nav bar is hidden when logging in with Google/Apple.

To test:
- Log in with Google and/or Apple.
- On the epilogue, verify the big blue nav bar is hidden.

| Before | After |
|--------|-------|
| ![broken](https://user-images.githubusercontent.com/1816888/81319455-eb6e2580-904c-11ea-8d00-5e57bbbe9e7f.png) | ![fixed](https://user-images.githubusercontent.com/1816888/81319565-18223d00-904d-11ea-9226-6b28e2eabba9.png) |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
