### PR TITLE
ContextManager: Shared Derived Context API

### DIFF
--- a/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
+++ b/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
@@ -89,10 +89,23 @@ private extension ContextManager {
     }
 
     func reasonForIndividualError(_ error: NSError) -> String {
-        let entity = entityName(for: error) ?? "null"
-        let property = propertyName(for: error) ?? "null"
         let message = coreDataKnownErrorCodes[error.code] ?? "Unknown error (domain: \(error.domain) code: \(error.code), \(error.localizedDescription)"
-        return "\(message) on \(entity).\(property)"
+        var messageDetail = ""
+
+        if error.userInfo.keys.contains(NSValidationObjectErrorKey) {
+            let entity = entityName(for: error) ?? "null"
+            let property = propertyName(for: error) ?? "null"
+            messageDetail = "on \(entity).\(property)"
+
+        } else if error.code == NSManagedObjectMergeError,
+            let conflicts = error.userInfo["conflictList"] as? [NSMergeConflict],
+            let conflict = conflicts.first,
+            let name = conflict.sourceObject.entity.name {
+
+            messageDetail = "source entity: \(name)"
+        }
+
+        return "\(message) \(messageDetail)"
     }
 
     func entityName(for error: NSError) -> String? {

--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -48,6 +48,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSManagedObjectContext *const)newDerivedContext;
 
 /**
+ Returns a shared derived context, for background work, associated with a given kind.
+ The resulting instance is expected to always be the same for a given kind.
+
+ This is meant to allow the app to share the same DerivedContext across multiple LocalCoreDataService instances.
+
+ @return a MOC with NSPrivateQueueConcurrencyType,
+ with the parent context as the main context, and the flag `automaticallyMergesChangesFromParent` enabled.
+ */
+- (NSManagedObjectContext *const)sharedDerivedContextForKind:(Class)kind;
+
+/**
  For usage as a snapshot of the main context. This is useful when operations 
  should happen on the main queue (fetches) but not immedately reflect changes to
  the main context.

--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return a MOC with NSPrivateQueueConcurrencyType,
  with the parent context as the main context, and the flag `automaticallyMergesChangesFromParent` enabled.
  */
-- (NSManagedObjectContext *const)sharedDerivedContextForKind:(Class)kind;
+- (NSManagedObjectContext *const)derivedContextForKind:(Class)kind;
 
 /**
  For usage as a snapshot of the main context. This is useful when operations 

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -70,7 +70,7 @@ static ContextManager *_override;
     return [self newChildContextWithConcurrencyType:NSMainQueueConcurrencyType];
 }
 
-- (NSManagedObjectContext *const)sharedDerivedContextForKind:(Class)kind
+- (NSManagedObjectContext *const)derivedContextForKind:(Class)kind
 {
     NSAssert([NSThread isMainThread], @"This API is not threadsafe. Should only run on the main thread");
 

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -34,7 +34,7 @@ static ContextManager *_override;
 {
     self = [super init];
     if (self) {
-        _derivedContextMap = [NSMapTable strongToStrongObjectsMapTable];
+        self.derivedContextMap = [NSMapTable strongToStrongObjectsMapTable];
         [self startListeningToMainContextNotifications];
     }
 

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -22,6 +22,20 @@ class ContextManagerTests: XCTestCase {
         ContextManager.overrideSharedInstance(nil)
     }
 
+    func testSharedDerivedContextAlwaysReturnsSameContextForSomeEntityKind() {
+        let firstContext = contextManager.sharedDerivedContext(forKind: PostService.self)
+        let secondContext = contextManager.sharedDerivedContext(forKind: PostService.self)
+
+        XCTAssertEqual(firstContext, secondContext)
+    }
+
+    func testSharedDerivedContextReturnsDifferentContextsForDifferentEntityKinds() {
+        let firstContext = contextManager.sharedDerivedContext(forKind: PostService.self)
+        let secondContext = contextManager.sharedDerivedContext(forKind: BlogService.self)
+
+        XCTAssertNotEqual(firstContext, secondContext)
+    }
+
     func testIterativeMigration() {
         let model19Name = "WordPress 19"
 

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -30,8 +30,8 @@ class ContextManagerTests: XCTestCase {
     }
 
     func testSharedDerivedContextReturnsDifferentContextsForDifferentEntityKinds() {
-        let firstContext = contextManager.sharedDerivedContext(forKind: PostService.self)
-        let secondContext = contextManager.sharedDerivedContext(forKind: BlogService.self)
+        let firstContext = contextManager.derivedContext(forKind: PostService.self)
+        let secondContext = contextManager.derivedContext(forKind: BlogService.self)
 
         XCTAssertNotEqual(firstContext, secondContext)
     }

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -23,8 +23,8 @@ class ContextManagerTests: XCTestCase {
     }
 
     func testSharedDerivedContextAlwaysReturnsSameContextForSomeEntityKind() {
-        let firstContext = contextManager.sharedDerivedContext(forKind: PostService.self)
-        let secondContext = contextManager.sharedDerivedContext(forKind: PostService.self)
+        let firstContext = contextManager.derivedContext(forKind: PostService.self)
+        let secondContext = contextManager.derivedContext(forKind: PostService.self)
 
         XCTAssertEqual(firstContext, secondContext)
     }


### PR DESCRIPTION
### Details
In this PR we're implementing a new ContextManager API, meant to help us prevent multiple concurrent sync OP(s).

I'm also borrowing @aerych 's kung fu from #14068 (cherry picked a commit of your sir!).
#### Expected usage: Swift / ObjC
```
let context = ContextManager.sharedInstance().derivedContext(forKind: ReaderPostService.self)
let service = ReaderPostService(managedObjectContext: context)
```

```
NSManagedObjectContext *context = [[ContextManager sharedInstance] derivedContextForKind:[ReaderPostService class]]
ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context]

```

Refs #13867
Refs #13892

#### Next step:
Audit the top crasher services and implement this API when possible.

### To test:
- [ ] Verify the Unit Tests pass

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
