### PR TITLE
Hide Create FAB Tooltip after usage or # times

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -4,9 +4,10 @@ import WordPressFlux
 @objc class CreateButtonCoordinator: NSObject {
 
     private enum Constants {
-        static let padding: CGFloat = -16
-        static let heightWidth: CGFloat = 56
-        static let popoverOffset: CGFloat = -10
+        static let padding: CGFloat = -16 // Bottom and trailing padding to position the button along the bottom right corner
+        static let heightWidth: CGFloat = 56 // Height and width of the button
+        static let popoverOffset: CGFloat = -10 // The vertical offset of the iPad popover
+        static let maximumTooltipView = 5 // Caps the number of times the user can see the announcement tooltip
     }
 
     var button: FloatingActionButton = {
@@ -31,6 +32,15 @@ import WordPressFlux
         }
         return notice
     }()
+
+    // Once this reaches `maximumTooltipView` we won't show the tooltip again
+    private var shownTooltipCount = 0 {
+        didSet {
+            if shownTooltipCount >= Constants.maximumTooltipView {
+                didShowCreateTooltip = true
+            }
+        }
+    }
 
     private var didShowCreateTooltip: Bool {
         set {
@@ -140,6 +150,7 @@ import WordPressFlux
     }
 
     @objc func showCreateButton() {
+        shownTooltipCount += 1
         if !didShowCreateTooltip {
             noticeContainerView = noticeAnimator.present(notice: notice, in: viewController!.view, sourceView: button)
         }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -28,7 +28,9 @@ import WordPressFlux
     private lazy var notice: Notice = {
         let notice = Notice(title: NSLocalizedString("Create a post or page", comment: "The tooltip title for the Floating Create Button"),
                             message: "",
-                            style: ToolTipNoticeStyle()) { _ in
+                            style: ToolTipNoticeStyle()) { [weak self] _ in
+                self?.didDismissTooltip = true
+                self?.hideNotice()
         }
         return notice
     }()
@@ -37,12 +39,12 @@ import WordPressFlux
     private var shownTooltipCount = 0 {
         didSet {
             if shownTooltipCount >= Constants.maximumTooltipView {
-                didShowCreateTooltip = true
+                didDismissTooltip = true
             }
         }
     }
 
-    private var didShowCreateTooltip: Bool {
+    private var didDismissTooltip: Bool {
         set {
             UserDefaults.standard.createButtonTooltipWasDisplayed = newValue
         }
@@ -92,7 +94,7 @@ import WordPressFlux
     }
 
     @objc private func showCreateSheet() {
-        didShowCreateTooltip = true
+        didDismissTooltip = true
         hideNotice()
 
         guard let viewController = viewController else { return }
@@ -151,7 +153,7 @@ import WordPressFlux
 
     @objc func showCreateButton() {
         shownTooltipCount += 1
-        if !didShowCreateTooltip {
+        if !didDismissTooltip {
             noticeContainerView = noticeAnimator.present(notice: notice, in: viewController!.view, sourceView: button)
         }
         if UIAccessibility.isReduceMotionEnabled {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -38,7 +38,7 @@ import WordPressFlux
     // Once this reaches `maximumTooltipViews` we won't show the tooltip again
     private var shownTooltipCount: Int {
         set {
-            if shownTooltipCount >= Constants.maximumTooltipViews {
+            if newValue >= Constants.maximumTooltipViews {
                 didDismissTooltip = true
             } else {
                 UserDefaults.standard.createButtonTooltipDisplayCount = newValue

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -36,11 +36,16 @@ import WordPressFlux
     }()
 
     // Once this reaches `maximumTooltipView` we won't show the tooltip again
-    private var shownTooltipCount = 0 {
-        didSet {
+    private var shownTooltipCount: Int {
+        set {
             if shownTooltipCount >= Constants.maximumTooltipView {
                 didDismissTooltip = true
+            } else {
+                UserDefaults.standard.createButtonTooltipDisplayCount = newValue
             }
+        }
+        get {
+            return UserDefaults.standard.createButtonTooltipDisplayCount
         }
     }
 
@@ -197,6 +202,16 @@ extension CreateButtonCoordinator: UIViewControllerTransitioningDelegate {
 extension UserDefaults {
     private enum Keys: String {
         case createButtonTooltipWasDisplayed = "CreateButtonTooltipWasDisplayed"
+        case createButtonTooltipDisplayCount = "CreateButtonTooltipDisplayCount"
+    }
+
+    var createButtonTooltipDisplayCount: Int {
+        get {
+            return integer(forKey: Keys.createButtonTooltipDisplayCount.rawValue)
+        }
+        set {
+            set(newValue, forKey: Keys.createButtonTooltipDisplayCount.rawValue)
+        }
     }
 
     var createButtonTooltipWasDisplayed: Bool {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -7,7 +7,7 @@ import WordPressFlux
         static let padding: CGFloat = -16 // Bottom and trailing padding to position the button along the bottom right corner
         static let heightWidth: CGFloat = 56 // Height and width of the button
         static let popoverOffset: CGFloat = -10 // The vertical offset of the iPad popover
-        static let maximumTooltipView = 5 // Caps the number of times the user can see the announcement tooltip
+        static let maximumTooltipViews = 5 // Caps the number of times the user can see the announcement tooltip
     }
 
     var button: FloatingActionButton = {
@@ -35,10 +35,10 @@ import WordPressFlux
         return notice
     }()
 
-    // Once this reaches `maximumTooltipView` we won't show the tooltip again
+    // Once this reaches `maximumTooltipViews` we won't show the tooltip again
     private var shownTooltipCount: Int {
         set {
-            if shownTooltipCount >= Constants.maximumTooltipView {
+            if shownTooltipCount >= Constants.maximumTooltipViews {
                 didDismissTooltip = true
             } else {
                 UserDefaults.standard.createButtonTooltipDisplayCount = newValue
@@ -102,7 +102,9 @@ import WordPressFlux
         didDismissTooltip = true
         hideNotice()
 
-        guard let viewController = viewController else { return }
+        guard let viewController = viewController else {
+            return
+        }
         let actionSheetVC = actionSheetController(for: viewController.traitCollection)
         viewController.present(actionSheetVC, animated: true, completion: {
             WPAnalytics.track(.createSheetShown)
@@ -157,10 +159,11 @@ import WordPressFlux
     }
 
     @objc func showCreateButton() {
-        shownTooltipCount += 1
         if !didDismissTooltip {
             noticeContainerView = noticeAnimator.present(notice: notice, in: viewController!.view, sourceView: button)
+            shownTooltipCount += 1
         }
+
         if UIAccessibility.isReduceMotionEnabled {
             button.isHidden = false
         } else {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -32,13 +32,12 @@ import WordPressFlux
         return notice
     }()
 
-    private var shouldShowNotice: Bool {
+    private var didShowCreateTooltip: Bool {
         set {
-            //TODO: Set on persistent store
+            UserDefaults.standard.createButtonTooltipWasDisplayed = newValue
         }
         get {
-            //TODO: Fetch from persistent store
-            return true
+            return UserDefaults.standard.createButtonTooltipWasDisplayed
         }
     }
 
@@ -83,7 +82,7 @@ import WordPressFlux
     }
 
     @objc private func showCreateSheet() {
-        shouldShowNotice = false
+        didShowCreateTooltip = true
         hideNotice()
 
         guard let viewController = viewController else { return }
@@ -141,7 +140,9 @@ import WordPressFlux
     }
 
     @objc func showCreateButton() {
-        noticeContainerView = noticeAnimator.present(notice: notice, in: viewController!.view, sourceView: button)
+        if !didShowCreateTooltip {
+            noticeContainerView = noticeAnimator.present(notice: notice, in: viewController!.view, sourceView: button)
+        }
         if UIAccessibility.isReduceMotionEnabled {
             button.isHidden = false
         } else {
@@ -176,5 +177,21 @@ extension CreateButtonCoordinator: UIViewControllerTransitioningDelegate {
 
     public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         return (viewController?.presentedViewController?.presentationController as? BottomSheetPresentationController)?.interactionController
+    }
+}
+
+@objc
+extension UserDefaults {
+    private enum Keys: String {
+        case createButtonTooltipWasDisplayed = "CreateButtonTooltipWasDisplayed"
+    }
+
+    var createButtonTooltipWasDisplayed: Bool {
+        get {
+            return bool(forKey: Keys.createButtonTooltipWasDisplayed.rawValue)
+        }
+        set {
+            set(newValue, forKey: Keys.createButtonTooltipWasDisplayed.rawValue)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeStyle.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeStyle.swift
@@ -3,6 +3,12 @@ public enum NoticeAnimationStyle {
     case fade
 }
 
+/// A gesture which can be used to dismiss the notice.
+/// See `NoticeView.configurGestureRecognizer()` for more details.
+public enum NoticeDismissGesture {
+    case tap
+}
+
 public protocol NoticeStyle {
 
     // Text
@@ -25,6 +31,7 @@ public protocol NoticeStyle {
     // Misc
     var isDismissable: Bool { get }
     var animationStyle: NoticeAnimationStyle { get }
+    var dismissGesture: NoticeDismissGesture? { get }
 }
 
 public struct NormalNoticeStyle: NoticeStyle {
@@ -45,6 +52,8 @@ public struct NormalNoticeStyle: NoticeStyle {
     public let isDismissable = true
 
     public let animationStyle = NoticeAnimationStyle.moveIn
+
+    public let dismissGesture: NoticeDismissGesture? = nil
 }
 
 public struct QuickStartNoticeStyle: NoticeStyle {
@@ -65,6 +74,8 @@ public struct QuickStartNoticeStyle: NoticeStyle {
     public let isDismissable = false
 
     public let animationStyle = NoticeAnimationStyle.moveIn
+
+    public let dismissGesture: NoticeDismissGesture? = nil
 }
 
 public struct ToolTipNoticeStyle: NoticeStyle {
@@ -85,4 +96,6 @@ public struct ToolTipNoticeStyle: NoticeStyle {
     public let isDismissable = false
 
     public let animationStyle = NoticeAnimationStyle.fade
+
+    public let dismissGesture: NoticeDismissGesture? = NoticeDismissGesture.tap
 }

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -34,11 +34,22 @@ class NoticeView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    internal func configureGestureRecognizer() {
+        switch notice.style.dismissGesture {
+        case .tap:
+            let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(cancelButtonTapped))
+            addGestureRecognizer(tapRecognizer)
+        case .none:
+            ()
+        }
+    }
+
     /// configure the NoticeView for display
     internal func configure() {
         configureBackgroundViews()
         configureShadow()
         configureContentStackView()
+        configureGestureRecognizer()
         configureLabels()
         configureForNotice()
 
@@ -298,7 +309,7 @@ class NoticeView: UIView {
         dismissHandler?()
     }
 
-    private func cancelButtonTapped() {
+    @objc private func cancelButtonTapped() {
         notice.actionHandler?(false)
         dismissHandler?()
     }


### PR DESCRIPTION
* Persists tooltip state & display count via User Defaults
* Sets a maximum of 5 of times that tooltip will appear

## Testing

- Open the Blog Details screen
- Click on the Create button and ensure that the tooltip is no longer shown

Reset using these command in LLDB:
```
e -l swift -- import WordPress; UserDefaults.standard.createButtonTooltipWasDisplayed = false
e -l swift -- import WordPress; UserDefaults.standard.createButtonTooltipDisplayCount = 0
```

- Check that the tooltip is shown again
- Try switching to other screens (non-Blog Detail) and ensure that the tooltip is hidden after 5 times navigating away and back.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
