### PR TITLE
Don't log sentry error for cancelled Site Icon downloads

### DIFF
--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -88,7 +88,18 @@ extension UIImageView {
 
                 self.removePlaceholderBorder()
             case .failure(let error):
-                CrashLogging.logError(error)
+
+                // Do not log intentionally cancelled requests as errors.                
+                let shouldLog: Bool
+                if case .requestCancelled = (error as? AFIError) {
+                    shouldLog = false
+                } else {
+                    shouldLog = true
+                }
+
+                if shouldLog {
+                    CrashLogging.logError(error)
+                }
             }
         }
     }

--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -88,16 +88,9 @@ extension UIImageView {
 
                 self.removePlaceholderBorder()
             case .failure(let error):
-
-                // Do not log intentionally cancelled requests as errors.                
-                let shouldLog: Bool
                 if case .requestCancelled = (error as? AFIError) {
-                    shouldLog = false
+                    // Do not log intentionally cancelled requests as errors.
                 } else {
-                    shouldLog = true
-                }
-
-                if shouldLog {
                     CrashLogging.logError(error)
                 }
             }


### PR DESCRIPTION
Fixes #14051

To test:
- Set a breakpoint on UIImageView+SiteIcon lines 93 and 101.
- Search for a site using the Reader search page .
- When rapidly switching between searches (quick enough so that some site icons do not finish loading), you should NOT see the error handler (line 101) called when the `AFIError.requestCancelled` error occurs.

Throttling the network connection with Charles or Link Conditioner should help make it easier to switch between searches.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Not user facing.
