### PR TITLE
Reader Comments: Fix Reply button color by ensuring image is tinted

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -121,7 +121,7 @@ class ReaderCommentCell: UITableViewCell {
     }
 
     @objc func setupReplyButton() {
-        let icon = UIImage.gridicon(.reply, size: Constants.buttonSize).rotate180Degrees()
+        let icon = UIImage.gridicon(.reply, size: Constants.buttonSize).rotate180Degrees()?.withRenderingMode(.alwaysTemplate)
         replyButton.setImage(icon, for: .normal)
         replyButton.setImage(icon, for: .highlighted)
 


### PR DESCRIPTION
This PR fixes an issue where the Reader comment reply button wasn't being tinted. I'm not sure why the original regression happened, but this fix ensures that the button image is tintable.

This image shows the issue:

<img width="180" alt="Screenshot 2020-05-11 at 15 27 25" src="https://user-images.githubusercontent.com/4780/81572507-35cc0b00-939b-11ea-94bc-28ecab309ab7.jpg">

And this is with the fix applied:

<img width="164" alt="Screenshot 2020-05-11 at 15 27 26" src="https://user-images.githubusercontent.com/4780/81573077-ee924a00-939b-11ea-9701-ad5ccf387eb1.png">

**To test:**

* Build and run
* From either a Reader post or a comment notification, access the comments of a post
* Ensure that the Reply button image is tinted the same as its title and the Like button

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
