### PR TITLE
Remove media deletion to prevent Core Data null.null errors

### DIFF
--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -249,14 +249,6 @@ class MediaFileManager: NSObject {
                         onCompletion()
                     }
                 }
-
-                // Update media objects local urls that were deleted to be updated to nil
-                let editedObjectsRequest = NSBatchUpdateRequest(entityName: Media.classNameWithoutNamespaces())
-                editedObjectsRequest.predicate = NSCompoundPredicate(notPredicateWithSubpredicate: predicate)
-                editedObjectsRequest.propertiesToUpdate = [localURLProperty: NSNull(), localThumbnailURLProperty: NSNull()]
-                editedObjectsRequest.resultType = .updatedObjectsCountResultType
-                try context.execute(editedObjectsRequest)
-                try context.save()
             } catch {
                 DDLogError("Error while attempting to clean local media: \(error.localizedDescription)")
                 if let onError = onError {
@@ -265,7 +257,6 @@ class MediaFileManager: NSObject {
                     }
                 }
             }
-
         }
     }
 


### PR DESCRIPTION
This PR aims to fix the `*** Terminating app due to uncaught exception 'Unresolved Core Data save error (Derived Context)', reason: 'Merge policy failed - unable to complete merging on null.null' crashes.

Please, keep in mind that this PR doesn't solve all of our Core Data errors, only this specific one.

### Context

This code reverted here was originally submitted to fix #12142. The removal of this part will probably cause a regression on the fix of this bug, but the impact it's nothing compared to the number of crashes we've seen.

### To test

#### Crash: Scenario 1

1. Create a draft post and add one or more images
2. Close the post and save as draft
3. Re-open the post
4. Background the app
5. Kill/relaunch: the app would re-open to that same post
6. Close the post: no crash should occur

#### Crash: Scenario 2

1. Upload gallery on an existing draft
1. quit the app (remove from background) before upload complete
1. launch the app -> blog posts and see the failed post
1. Hit "Retry" and quit the app before upload complete
1. Launch the app -> Blog posts see failed post
1. tap the post and remove the failed gallery
1. Quit the app
1. Relaunch the app, wait 5 seconds after splash screen and -> blog posts
1. See the post trying to upload media automatically
1. wait and see "Uploading media" changing briefly to "Local changes" and then "Uploading post"
1. No crash should occur