### PR TITLE
Fix the UI test failure on the Blog Details screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -283,7 +283,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self.view addSubview:self.tableView];
     [self.view pinSubviewToAllEdges:self.tableView];
 
-    self.view.accessibilityIdentifier = @"Blog Details Table";
+    self.tableView.accessibilityIdentifier = @"Blog Details Table";
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [WPStyleGuide configureAutomaticHeightRowsFor:self.tableView];


### PR DESCRIPTION
The "Blog Details Table" accessibility identifier was no longer on a table view so the query for a table with that identifier failed. This happened after a refactoring to make the table view a subview instead of the root view of this view controller.

### Testing
* Run UI tests
* Verify that tests succeed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
