### PR TITLE
[FIX] Gutenberg - use allowMultipleSelection flag from JS in the GutenbergStockPhotosPicker

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergStockPhotos.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergStockPhotos.swift
@@ -15,8 +15,7 @@ class GutenbergStockPhotos {
     func presentPicker(origin: UIViewController, post: AbstractPost, multipleSelection: Bool, callback: @escaping MediaPickerDidPickMediaCallback) {
         let picker = StockPhotosPicker()
         stockPhotos = picker
-        // Forcing multiple selection while multipleSelection == false in JS side.
-        picker.allowMultipleSelection = true //multipleSelection
+        picker.allowMultipleSelection = multipleSelection
         picker.delegate = self
         mediaPickerCallback = callback
         picker.presentPicker(origin: origin, blog: post.blog)


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/953#issuecomment-627709554
In this PR I removed the hardcoded value of `allowMultipleSelection` in StockPhotosPicker and used flag passed from JS side instead.

To test:
- Run app
- Open Gutenberg editor
- Add the cover block and choose "Free photo library"
- You should be able to select only one media

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
