### PR TITLE
Test PR to verify state of Danger integration

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,10 +11,11 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.16'
+    #pod 'WordPressShared', '~> 1.8.16'
 
     ## for development:
-    # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
+    #This should result in a build error from danger
+    pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''

--- a/Podfile
+++ b/Podfile
@@ -11,11 +11,10 @@ workspace 'WordPress.xcworkspace'
 ##
 def wordpress_shared
     ## for production:
-    #pod 'WordPressShared', '~> 1.8.16'
+    pod 'WordPressShared', '~> 1.8.16'
 
     ## for development:
-    #This should result in a build error from danger
-    pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
+    # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''

--- a/README.md
+++ b/README.md
@@ -110,3 +110,5 @@ If you have questions about getting setup or just want to say hi, join the [Word
 ## License
 
 WordPress for iOS is an Open Source project covered by the [GNU General Public License version 2](LICENSE).
+
+---


### PR DESCRIPTION
I'm opening this PR without a label and no changes compared to `develop`.
I'm expecting Danger to leave a comment regarding the missing label.

---

Update. Here's the comment:

<img width="962" alt="Screen Shot 2020-05-13 at 9 39 27 pm" src="https://user-images.githubusercontent.com/1218433/81807894-4084cc80-9562-11ea-9ac2-8c53bbae425e.png">

Next, I'll add a label and I expect the comment to disappear.

---

Update. [It worked](https://github.com/wordpress-mobile/WordPress-iOS/pull/14109/checks?check_run_id=670588803#step:7:14).

<img width="967" alt="Screen Shot 2020-05-13 at 9 50 09 pm" src="https://user-images.githubusercontent.com/1218433/81808876-bc334900-9563-11ea-8083-c225c8455175.png">


Interesting thing, though, it added some noise to the "Checks" view in the PR

<img width="951" alt="Screen Shot 2020-05-13 at 9 47 41 pm" src="https://user-images.githubusercontent.com/1218433/81808767-8aba7d80-9563-11ea-8a02-5f269fd445d1.png">

Those last two Danger checks have the "Details" pointing to http://danger.systems/js rather than a build 🤔 