### PR TITLE
Fix to update labels correctly when scheduling or publishing immediately 

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -186,7 +186,7 @@ class PrepublishingViewController: UITableViewController {
     // MARK: - Schedule
 
     func configureScheduleCell(_ cell: WPTableViewCell) {
-        cell.textLabel?.text = post.hasFuturePublishDate() ? Constants.scheduledLabel : Constants.publishDateLabel
+        cell.textLabel?.text = post.shouldPublishImmediately() ? Constants.publishDateLabel : Constants.scheduledLabel
         cell.detailTextLabel?.text = publishSettingsViewModel.detailString
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -27,7 +27,7 @@ struct PublishSettingsViewModel {
     let title: String?
 
     var detailString: String {
-        if let date = date, post.hasFuturePublishDate() {
+        if let date = date, !post.shouldPublishImmediately() {
             return dateTimeFormatter.string(from: date)
         } else {
             return NSLocalizedString("Immediately", comment: "Undated post time label")
@@ -79,15 +79,15 @@ struct PublishSettingsViewModel {
         if let date = date {
             // If a date to schedule the post was given
             post.dateCreated = date
-            if post.hasFuturePublishDate() {
-                post.status = .scheduled
-            } else {
+            if post.shouldPublishImmediately() {
                 post.status = .publish
+            } else {
+                post.status = .scheduled
             }
         } else if post.originalIsDraft() {
             // If the original is a draft, keep the post as a draft
             post.status = .draft
-            post.dateCreated = Date()
+            post.publishImmediately()
         } else if post.hasFuturePublishDate() {
             // If the original is a already scheduled post, change it to publish immediately
             // In this case the user had scheduled, but now wants to publish right away


### PR DESCRIPTION
Fixes #14113 

To test:

1.
1.1 Create a post
1.2. hit publish 
1.3. schedule the post (to past date or future date - test both)
1.4. go to post settings
1.5. see that the date and all labels are correct  

2.
2.1 Create a post
2.2. go to post settings  
2.3. schedule the post (to past date or future date - test both)
2.4. back to editor
2.5 hit schedule 
2.5. see that the date and all labels are correct 

** Please test Switching between scheduling and publish Immediately to see all labels and dates are updated correctly on both post settings and bottom sheet**

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
