### PR TITLE
Adds Simplified Navigation News Card

### DIFF
--- a/WordPress/Classes/Models/NewsItem.swift
+++ b/WordPress/Classes/Models/NewsItem.swift
@@ -3,6 +3,7 @@ struct NewsItem {
     let title: String
     let content: String
     let extendedInfoURL: URL
+    let imageName: String
     let version: Decimal
 }
 
@@ -11,6 +12,7 @@ extension NewsItem {
         static let title = "Title"
         static let content = "Content"
         static let URL = "URL"
+        static let imageName = "ImageName"
         static let version = "version"
     }
 
@@ -19,12 +21,13 @@ extension NewsItem {
             let content = fileContent[FileKeys.content],
             let urlString = fileContent[FileKeys.URL],
             let url = URL(string: urlString),
+            let imageName = fileContent[FileKeys.imageName],
             let versionString = fileContent[FileKeys.version],
             let version = Decimal(string: versionString) else {
                 return nil
         }
 
-        self.init(title: title, content: content, extendedInfoURL: url, version: version)
+        self.init(title: title, content: content, extendedInfoURL: url, imageName: imageName, version: version)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
@@ -150,7 +150,7 @@ extension NewsCard: Accessible {
     }
 
     private func prepareReadMoreButtonForVoiceOver() {
-        readMore.accessibilityLabel = NSLocalizedString("Read More", comment: "Accessibility label for the Read More button on Reader's News Card")
+        readMore.accessibilityLabel = NSLocalizedString("Learn More", comment: "Accessibility label for the Learn More button on Reader's News Card")
         dismiss.accessibilityTraits = UIAccessibilityTraits.button
         dismiss.accessibilityHint = NSLocalizedString("Provides more information.", comment: "Accessibility hint for the Read More button on Reader's News Card")
     }

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
@@ -98,7 +98,7 @@ final class NewsCard: UIViewController {
 
     private func styleReadMoreButton() {
         readMore.naturalContentHorizontalAlignment = .leading
-        let title = NSLocalizedString("Read More", comment: "Button providing More information in the News Card")
+        let title = NSLocalizedString("Learn More", comment: "Button providing More information in the News Card")
         readMore.setTitle(title, for: .normal)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
@@ -46,7 +46,6 @@ final class NewsCard: UIViewController {
     private func setupUI() {
         setUpDismissButton()
         setUpReadMoreButton()
-        populateIllustration()
     }
 
     private func setUpDismissButton() {
@@ -57,8 +56,8 @@ final class NewsCard: UIViewController {
         readMore.addTarget(self, action: #selector(readMoreAction), for: .touchUpInside)
     }
 
-    private func populateIllustration() {
-        illustration.image = UIImage(named: "wp-illustration-notifications")?.imageFlippedForRightToLeftLayoutDirection()
+    private func populateIllustration(name: String) {
+        illustration.image = UIImage(named: name)?.imageFlippedForRightToLeftLayoutDirection()
     }
 
     @objc private func dismissAction() {
@@ -119,6 +118,8 @@ final class NewsCard: UIViewController {
 
         newsTitle.text = title
         newsSubtitle.text = content
+
+        populateIllustration(name: item.imageName)
 
         prepareTitleForVoiceOver(label: title)
         prepareSubtitleForVoiceOver(label: content)

--- a/WordPress/News.strings
+++ b/WordPress/News.strings
@@ -5,10 +5,10 @@
 "Content" = "Now there are fewer and better-organized tabs, posting shortcuts, and more, so you can find what you need fast.";
 
 /* News Card link. */
-"URL" = "https://en.blog.wordpress.com/2020/01/30/improved-offline-publishing/";
+"URL" = "https://en.blog.wordpress.com/2020/06/01/improved-navigation-in-the-wordpress-apps";
 
 /* News Card image name. */
-"ImageName" = "wp-illustration-notifications";
+"ImageName" = "wp-illustration-mobile-save-for-later";
 
 /* Build version this card applies to. */
 "version" = "14.9";

--- a/WordPress/News.strings
+++ b/WordPress/News.strings
@@ -1,11 +1,14 @@
 /* News Card title. */
-"Title" = "Offline Support";
+"Title" = "Streamlined navigation";
 
 /* News Card content. */
-"Content" = "Our mobile apps now support offline publishing and editing.";
+"Content" = "Now there are fewer and better-organized tabs, posting shortcuts, and more, so you can find what you need fast.";
 
 /* News Card link. */
 "URL" = "https://en.blog.wordpress.com/2020/01/30/improved-offline-publishing/";
 
+/* News Card image name. */
+"ImageName" = "wp-illustration-notifications";
+
 /* Build version this card applies to. */
-"version" = "14.1";
+"version" = "14.9";

--- a/WordPress/WordPressTest/DefaultNewsManagerTests.swift
+++ b/WordPress/WordPressTest/DefaultNewsManagerTests.swift
@@ -8,6 +8,7 @@ final class DefaultNewsManagerTests: XCTestCase {
         static let previousCardBuildNumber = "10.5"
         static let cardTitle = "Hello"
         static let cardContent = "How is your day going so far?"
+        static let cardImageName = "🦄"
         static let cardURL = URL(string: "http://wordpress.com")!
     }
 
@@ -15,7 +16,7 @@ final class DefaultNewsManagerTests: XCTestCase {
         func load(then completion: @escaping (Result<NewsItem, Error>) -> Void) {
             let newsItem = NewsItem(title: Constants.title,
                                     content: Constants.contextId,
-                                    extendedInfoURL: Constants.cardURL,
+                                    extendedInfoURL: Constants.cardURL, imageName: Constants.cardImageName,
                                     version: currentBuildVersion()!)
 
             let result: Result<NewsItem, Error> = .success(newsItem)

--- a/WordPress/WordPressTest/LocalNewsServiceTests.swift
+++ b/WordPress/WordPressTest/LocalNewsServiceTests.swift
@@ -5,6 +5,7 @@ final class LocalNewsServiceTests: XCTestCase {
     private struct Constants {
         static let title = "This is an awesome new feature!"
         static let content = "This is long form content. Here we explain why this feature is awesome"
+        static let imageName = "test-image-name"
         static let url = URL(string: "https://wordpress.com")!
     }
 
@@ -30,6 +31,9 @@ final class LocalNewsServiceTests: XCTestCase {
                 XCTFail()
             case .success(let newsItem):
                 XCTAssertEqual(newsItem.title, Constants.title)
+                XCTAssertEqual(newsItem.content, Constants.content)
+                XCTAssertEqual(newsItem.imageName, Constants.imageName)
+                XCTAssertEqual(newsItem.extendedInfoURL, Constants.url)
             }
         })
     }

--- a/WordPress/WordPressTest/NewsCardTests.swift
+++ b/WordPress/WordPressTest/NewsCardTests.swift
@@ -9,7 +9,7 @@ final class NewsCardTests: XCTestCase {
         static let content = "😳😳"
         static let url = URL(string: "http://wordpress.com")!
         static let version = Decimal(floatLiteral: 10.7)
-        static let readMore = NSLocalizedString("Read More", comment: "Read more")
+        static let readMore = NSLocalizedString("Learn More", comment: "Learn more")
         static let dismiss = NSLocalizedString("Dismiss", comment: "Dismiss")
     }
 
@@ -36,7 +36,7 @@ final class NewsCardTests: XCTestCase {
         }
 
         func load(then completion: @escaping (Result<NewsItem, Error>) -> Void) {
-            let newsItem = NewsItem(title: Constants.title, content: Constants.content, extendedInfoURL: Constants.url, version: Constants.version)
+            let newsItem = NewsItem(title: Constants.title, content: Constants.content, extendedInfoURL: Constants.url, imageName: "", version: Constants.version)
             let result: Result<NewsItem, Error> = .success(newsItem)
 
             completion(result)

--- a/WordPress/WordPressTest/NewsItemTests.swift
+++ b/WordPress/WordPressTest/NewsItemTests.swift
@@ -5,6 +5,7 @@ final class NewsItemTests: XCTestCase {
     private struct Constants {
         static let title = "🦄"
         static let content = "🦄"
+        static let imageName = "🦄"
         static let infoURL = URL(string: "https://wordpress.com")!
         static let version: Decimal = Decimal(floatLiteral: 10.7)
     }
@@ -13,7 +14,7 @@ final class NewsItemTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        subject = NewsItem(title: Constants.title, content: Constants.content, extendedInfoURL: Constants.infoURL, version: Constants.version)
+        subject = NewsItem(title: Constants.title, content: Constants.content, extendedInfoURL: Constants.infoURL, imageName: Constants.imageName, version: Constants.version)
     }
 
     override func tearDown() {

--- a/WordPress/WordPressTest/Test Data/News.strings
+++ b/WordPress/WordPressTest/Test Data/News.strings
@@ -7,5 +7,8 @@
 /* News Card link. */
 "URL" = "https://wordpress.com";
 
+/* News Card image name. */
+"ImageName" = "test-image-name";
+
 /* Build version this card applies to. */
 "version" = "10.8";


### PR DESCRIPTION
Closes #13789

<img width="418" alt="Screen Shot 2020-05-15 at 9 02 04 AM" src="https://user-images.githubusercontent.com/3250/82083308-c4e06800-96a6-11ea-840d-4fe8add4f13b.png">

#### Testing
- Change the version number to 14.9
- Visit the Reader tab with the Following filter tab selected
- Notice the header (news card) showing the simplified navigation
- The Learn More button should push the post preview (note that this URL doesn't work yet so you should get an error for that page).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
