### PR TITLE
[IA] Updates blog post URL used in IA announcement alert

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -168,7 +168,7 @@ extension BlogDetailsViewController {
 
         let alert = FancyAlertViewController.makeCreateButtonAnnouncementAlertController { [weak self] (controller) in
             controller.dismiss(animated: true)
-            if let url = URL(string: "https://wordpress.com/blog/") {
+            if let url = URL(string: "https://wordpress.com/blog/2020/06/01/improved-navigation-in-the-wordpress-apps/") {
                 let webViewController = WebViewControllerFactory.controller(url: url)
                 let navController = LightNavigationController(rootViewController: webViewController)
                 self?.tabBarController?.present(navController, animated: true)


### PR DESCRIPTION
This PR simply updates the blog post URL used in the IA announcement model to what we expect the published post URL to be.

**To test**

As the post isn't live yet, you can't really test this one functionally. Just check the URL looks okay!

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
