### PR TITLE
Disable broken Danger to avoid noise for the dev team

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -34,14 +34,21 @@ jobs:
         # frozen-lockfile will make the build fail if the lockfile is not there
         run: yarn install --frozen-lockfile
 
-      - name: Validate Labels
-        run: |
-          yarn run danger ci \
-            --dangerfile Automattic/peril-settings/org/pr/label.ts \
-            --id pr_labels
+      # Disabled because of issues that look like outside of our control on the
+      # GitHub end.
+      #
+      # See:
+      # - https://github.com/wordpress-mobile/WordPress-iOS/pull/14110
+      # - https://github.com/wordpress-mobile/wordpress-ios/pull/14124
+      #
+      # - name: Validate Labels
+      #   run: |
+      #     yarn run danger ci \
+      #       --dangerfile Automattic/peril-settings/org/pr/label.ts \
+      #       --id pr_labels
 
-      - name: Consistency Checks
-        run: |
-          yarn run danger ci \
-            --dangerfile Automattic/peril-settings/org/pr/ios-macos.ts \
-            --id consistency_checks
+      # - name: Consistency Checks
+      #   run: |
+      #     yarn run danger ci \
+      #       --dangerfile Automattic/peril-settings/org/pr/ios-macos.ts \
+      #       --id consistency_checks


### PR DESCRIPTION
Builds have been starting to fail with a 404, but nothing has changed on our end. Something might have changed on the GitHub end.

While we sort this out, it's better to disable the integration so we don't disturb the devs' workflow.

See:

- https://github.com/wordpress-mobile/WordPress-iOS/pull/14124
- https://github.com/wordpress-mobile/WordPress-iOS/pull/14110


**To test**: If the GitHub action passes and no Danger step runs, then this works

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.