### PR TITLE
Hotfix for featured image bugs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,10 @@
 14.9
 -----
  
+14.8.1
+-----
+* Fix adding and removing of featured images to posts.
+
 14.8
 -----
 * Block editor: Prefill caption for image blocks when available on the Media library

--- a/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
+++ b/WordPress/Classes/Networking/MediaRequestAuthenticator.swift
@@ -52,7 +52,7 @@ class MediaRequestAuthenticator {
 
         // We want to make sure we're never sending credentials
         // to a URL that's not safe.
-        guard url.isHostedAtWPCom || url.isPhoton() else {
+        guard !url.isFileURL || url.isHostedAtWPCom || url.isPhoton() else {
             let request = URLRequest(url: url)
             provide(request)
             return

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -64,7 +64,9 @@ import AutomatticTracks
     ///   - size: The preferred size of the image to load.
     ///
     func loadImage(with url: URL, from host: MediaHost, preferredSize size: CGSize = .zero) {
-        if url.isGif {
+        if url.isFileURL {
+            downloadImage(from: url)
+        } else if url.isGif {
             loadGif(with: url, from: host, preferredSize: size)
         } else {
             imageView.clean()

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1463,6 +1463,7 @@ FeaturedImageViewControllerDelegate>
     self.animatedFeaturedImageData = nil;
     [self.apost setFeaturedImage:nil];
     [self dismissViewControllerAnimated:YES completion:nil];
+    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:PostSettingsSectionFeaturedImage]  withRowAnimation:UITableViewRowAnimationNone];
 }
 
 @end


### PR DESCRIPTION
Fixes #14098 

To test:
 - Start a new post
 - Add some content
 - Access the Post Settings
 - Set a Featured image ( use an image from the local device)
 - Wait for the upload to finish
 - Check if the featured image shows correctly
 - Exit Post Settings
 - Enter Post SEttings again
 - Check if the featured image shows
 - Tap on the feature image.
 - Tap Remove
 - Check if the Post Settings reload and the image is not show any longer.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
