### PR TITLE
[Testing] [Gutenberg] Link to existing content

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -149,7 +149,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => '1186db17990c7ffbd325f77ff7fe96401639e1d1'
+    gutenberg :commit => 'b29021cc60cc766a63a4fa1b39734c217aae1d58'
 
     ## Third party libraries
     ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -429,15 +429,15 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.0.1)
-  - Gutenberg (from `../gutenberg-mobile`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `b29021cc60cc766a63a4fa1b39734c217aae1d58`)
   - JTAppleCalendar (~> 8.0.2)
   - MediaEditor (~> 1.0.1)
   - MRProgress (= 0.8.3)
@@ -447,34 +447,34 @@ DEPENDENCIES:
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - RCTRequired (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-slider (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `../gutenberg-mobile`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `b29021cc60cc766a63a4fa1b39734c217aae1d58`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -485,7 +485,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.6.0)
   - WPMediaPicker (~> 1.6.1)
-  - Yoga (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -545,79 +545,87 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json
   Folly:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :path: "../gutenberg-mobile"
+    :commit: b29021cc60cc766a63a4fa1b39734c217aae1d58
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RCTRequired:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json
   React:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json
   React-CoreModules:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json
   React-cxxreact:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json
   React-jsi:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-linear-gradient:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json
   react-native-safe-area:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-slider:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json
   react-native-video:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json
   ReactCommon:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json
   ReactNativeDarkMode:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNSVG:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :path: "../gutenberg-mobile"
+    :commit: b29021cc60cc766a63a4fa1b39734c217aae1d58
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   Yoga:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b29021cc60cc766a63a4fa1b39734c217aae1d58/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  Gutenberg:
+    :commit: b29021cc60cc766a63a4fa1b39734c217aae1d58
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  RNTAztecView:
+    :commit: b29021cc60cc766a63a4fa1b39734c217aae1d58
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -67,7 +67,7 @@ PODS:
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.2)"
   - Gridicons (1.0.1)
   - GTMSessionFetcher/Core (1.4.0)
-  - Gutenberg (1.27.0):
+  - Gutenberg (1.27.1):
     - React (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -361,7 +361,7 @@ PODS:
     - React
   - RNSVG (9.13.6-gb):
     - React
-  - RNTAztecView (1.27.0):
+  - RNTAztecView (1.27.1):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.0)
   - Sentry (4.5.0):
@@ -429,15 +429,15 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
+  - glog (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.0.1)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `1186db17990c7ffbd325f77ff7fe96401639e1d1`)
+  - Gutenberg (from `../gutenberg-mobile`)
   - JTAppleCalendar (~> 8.0.2)
   - MediaEditor (~> 1.0.1)
   - MRProgress (= 0.8.3)
@@ -447,34 +447,34 @@ DEPENDENCIES:
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `1186db17990c7ffbd325f77ff7fe96401639e1d1`)
+  - React (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-slider (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `../gutenberg-mobile`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -485,7 +485,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.6.0)
   - WPMediaPicker (~> 1.6.1)
-  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -545,87 +545,79 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json"
   FBReactNativeSpec:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json"
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json"
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json"
   Gutenberg:
-    :commit: 1186db17990c7ffbd325f77ff7fe96401639e1d1
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :path: "../gutenberg-mobile"
   RCTRequired:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json"
   RCTTypeSafety:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json"
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json"
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json"
   React-CoreModules:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json"
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json"
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json"
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json"
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json"
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json"
   react-native-linear-gradient:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json"
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json"
   react-native-slider:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json"
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json"
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json"
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json"
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json"
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json"
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json"
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json"
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json"
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json"
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json"
   ReactCommon:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json"
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json"
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json"
   RNTAztecView:
-    :commit: 1186db17990c7ffbd325f77ff7fe96401639e1d1
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :path: "../gutenberg-mobile"
   Yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1186db17990c7ffbd325f77ff7fe96401639e1d1/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json"
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
-  Gutenberg:
-    :commit: 1186db17990c7ffbd325f77ff7fe96401639e1d1
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  RNTAztecView:
-    :commit: 1186db17990c7ffbd325f77ff7fe96401639e1d1
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -650,7 +642,7 @@ SPEC CHECKSUMS:
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
   Gridicons: 8e19276b20bb15d1fda1d4d0db96d066d170135b
   GTMSessionFetcher: 6f5c8abbab8a9bce4bb3f057e317728ec6182b10
-  Gutenberg: aa041019bf81d30c7b9c7de0f313a2d55561cc4a
+  Gutenberg: 13cbcc0422333b06532bbcbcbea95514fc5a05b5
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   lottie-ios: 85ce835dd8c53e02509f20729fc7d6a4e6645a0a
   MediaEditor: 7296cd01d7a0548fb2bc909aa72153b376a56a61
@@ -687,7 +679,7 @@ SPEC CHECKSUMS:
   ReactCommon: 48926fc48fcd7c8a629860049ffba9c23b4005dc
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
   RNSVG: 68a534a5db06dcbdaebfd5079349191598caef7b
-  RNTAztecView: dc2364760fad53f52defde7c01be765e77b9ba19
+  RNTAztecView: 4c248fd117fe7101b1cbd0fbfcbd3923c7dc3c23
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   SimulatorStatusMagic: 28d4a9d1a500ac7cea0b2b5a43c1c6ddb40ba56c
   Sodium: 63c0ca312a932e6da481689537d4b35568841bdc
@@ -714,6 +706,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: b26343300a0042f307cc89ed647712e2fe546029
+PODFILE CHECKSUM: f3a71507a8f0a5a40ee8aff966a81d7c051e30dc
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
@@ -151,8 +151,11 @@ class LinkSettingsViewController: UITableViewController {
         guard let blog = blog else {
             return
         }
-        let selectPostViewController = SelectPostViewController(blog: blog, selectedLink: linkSettings.url, callback: { [weak self] (url, title) in
+        let selectPostViewController = SelectPostViewController(blog: blog, selectedLink: linkSettings.url, callback: { [weak self] (url, title, cancelled) in
             guard let strongSelf = self else {
+                return
+            }
+            if cancelled {
                 return
             }
             strongSelf.linkSettings.url = url

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
@@ -50,7 +50,7 @@ class SelectPostViewController: UITableViewController {
         searchController.dismiss(animated: false, completion: nil)
         invokeJSCallbackIfNecessary()
     }
-    
+
     func invokeJSCallbackIfNecessary() {
         if !wasCallbackInvoked {
             callback?("", "", true)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -363,6 +363,25 @@ extension GutenbergViewController {
 // MARK: - GutenbergBridgeDelegate
 
 extension GutenbergViewController: GutenbergBridgeDelegate {
+    func gutenbergDidRequestLinkToExistingContent(selectedLink: String, with callback: @escaping LinkToExistingContentCallback) {
+        navigationController?.definesPresentationContext = true
+
+        let controller = SelectPostViewController(blog: post.blog, selectedLink: selectedLink, callback: { [weak self] (url, title, cancelled) in
+            guard let strongSelf = self else {
+                callback(nil)
+                return
+            }
+            if cancelled {
+                callback(nil)
+                return
+            }
+            strongSelf.navigationController?.popViewController(animated: true)
+            callback(ContentLink(url: url, title: title))
+        })
+        controller.title = NSLocalizedString("Link to existing content", comment: "Action. Label for navigate and display links to other posts on the site")
+        navigationController?.pushViewController(controller, animated: true)
+    }
+    
 
     func gutenbergDidRequestFetch(path: String, completion: @escaping (Result<Any, NSError>) -> Void) {
         GutenbergNetworkRequest(path: path, blog: post.blog).request(completion: completion)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -381,7 +381,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         controller.title = NSLocalizedString("Link to existing content", comment: "Action. Label for navigate and display links to other posts on the site")
         navigationController?.pushViewController(controller, animated: true)
     }
-    
+
 
     func gutenbergDidRequestFetch(path: String, completion: @escaping (Result<Any, NSError>) -> Void) {
         GutenbergNetworkRequest(path: path, blog: post.blog).request(completion: completion)


### PR DESCRIPTION
This PR is for testing the iOS implementation of the link to existing content feature for the Gutenberg block editor. Related issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2194

To test:
tbd

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
