### PR TITLE
Gutenberg - Media Inserter - Check for internet connection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 15.0
 -----
- 
+* [**] Block editor: Fix media upload progress when there's no connection.
+
 14.9
 -----
 * Streamlined navigation: now there are fewer and better organized tabs, posting shortcuts and more, so you can find what you need fast.

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -240,6 +240,11 @@ class GutenbergMediaInserterHelper: NSObject {
         case .processing:
             gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .uploading, progress: 0, url: nil, serverID: nil)
         case .thumbnailReady(let url):
+            guard ReachabilityUtils.isInternetReachable() else {
+                gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .failed, progress: 0, url: url, serverID: nil)
+                return
+            }
+            
             gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .uploading, progress: 0.20, url: url, serverID: nil)
             break
         case .uploading:

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -244,7 +244,6 @@ class GutenbergMediaInserterHelper: NSObject {
                 gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .failed, progress: 0, url: url, serverID: nil)
                 return
             }
-            
             gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .uploading, progress: 0.20, url: url, serverID: nil)
             break
         case .uploading:


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2106

When uploading media from the block editor without **internet connection**, the placeholder will hang instead of showing the retry message. This affects any block that handles media upload, `Image`, `Video`, `Media & Text`, and `Cover`.

This PR adds an internet connection check in the `thumbnailReady` state to avoid showing the progress bar when it is not uploading anything and display the retry message instead.

For a bit more insight, when uploading media from the media library outside the editor it won't let the user upload anything without an internet connection. In this case, we do want to start the upload process but let the user know if it failed by having no connection.

### To test
- Open the app.
- Open the editor.
- Add one of these blocks: `Image`, `Video`, `Media & Text` or `Cover`.
- Turn on Airplane mode or disable any internet connection from the device.
- Tap on the block and upload a file from the device.
- **Expect** the block to display a retry message.
- Turn on the internet connection.
- Tap on the block and retry the upload.
- **Expect** the media to be uploaded successfully.

| Before | After |
|     :---:      |     :---:      |
| <img src="https://user-images.githubusercontent.com/4885740/82328192-d647ae00-99df-11ea-8a7f-4af59416f010.gif" width=250 /> | <img src="https://user-images.githubusercontent.com/4885740/82328343-08f1a680-99e0-11ea-95a0-e7af49e44e7a.gif" width=250 />  |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
