### PR TITLE
Reload all data instead of section only.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1463,7 +1463,7 @@ FeaturedImageViewControllerDelegate>
     self.animatedFeaturedImageData = nil;
     [self.apost setFeaturedImage:nil];
     [self dismissViewControllerAnimated:YES completion:nil];
-    [self.tableView reloadSections:[NSIndexSet indexSetWithIndex:PostSettingsSectionFeaturedImage]  withRowAnimation:UITableViewRowAnimationNone];
+    [self.tableView reloadData];
 }
 
 @end


### PR DESCRIPTION
On pages the featured image while has the same tag is
not on the same position so reloading the section make
the code to crash.

Fixes #14098 

To test:
  - Start the app
  - Create a **page** 
  - Open page settings and add a featured image to it.
  - Tap on the featured image
 - Tap on remove
 - Check that it doesn't crash.

 - Repeat the steps above but now using a **post** and see if all is ok there too.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
