### PR TITLE
Testing: Fix and enable MainNavigationTests - TestTabBarNavigation

### DIFF
--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -82,4 +82,8 @@ class MySiteScreen: BaseScreen {
         createButton.tap()
         return ActionSheetComponent()
     }
+    
+    static func isLoaded() -> Bool {
+        return XCUIApplication().tables[ElementStringIDs.blogTable].exists
+    }
 }

--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -82,7 +82,7 @@ class MySiteScreen: BaseScreen {
         createButton.tap()
         return ActionSheetComponent()
     }
-    
+
     static func isLoaded() -> Bool {
         return XCUIApplication().tables[ElementStringIDs.blogTable].exists
     }

--- a/WordPress/WordPressUITests/Screens/ReaderScreen.swift
+++ b/WordPress/WordPressUITests/Screens/ReaderScreen.swift
@@ -10,4 +10,8 @@ class ReaderScreen: BaseScreen {
 
         super.init(element: readerTable)
     }
+    
+    static func isLoaded() -> Bool {
+        return XCUIApplication().tables["Reader"].exists
+    }
 }

--- a/WordPress/WordPressUITests/Screens/ReaderScreen.swift
+++ b/WordPress/WordPressUITests/Screens/ReaderScreen.swift
@@ -10,7 +10,7 @@ class ReaderScreen: BaseScreen {
 
         super.init(element: readerTable)
     }
-    
+
     static func isLoaded() -> Bool {
         return XCUIApplication().tables["Reader"].exists
     }

--- a/WordPress/WordPressUITests/Screens/ReaderScreen.swift
+++ b/WordPress/WordPressUITests/Screens/ReaderScreen.swift
@@ -1,17 +1,21 @@
 import Foundation
 import XCTest
 
+private struct ElementStringIDs {
+    static let readerTable = "Reader"
+}
+
 class ReaderScreen: BaseScreen {
     let tabBar: TabNavComponent
 
     init() {
-        let readerTable = XCUIApplication().tables["Reader"]
+        let readerTable = XCUIApplication().tables[ElementStringIDs.readerTable]
         tabBar = TabNavComponent()
 
         super.init(element: readerTable)
     }
 
     static func isLoaded() -> Bool {
-        return XCUIApplication().tables["Reader"].exists
+        return XCUIApplication().tables[ElementStringIDs.readerTable].exists
     }
 }

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -7,9 +7,8 @@ class MainNavigationTests: XCTestCase {
         setUpTestSuite()
 
         _ = LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, username: WPUITestCredentials.testWPcomUsername, password: WPUITestCredentials.testWPcomPassword)
-        mySiteScreen = EditorFlow
-            .toggleBlockEditor(to: .on)
-            .goBackToMySite()
+        mySiteScreen = TabNavComponent()
+         .gotoMySiteScreen()
     }
 
     override func tearDown() {
@@ -19,13 +18,14 @@ class MainNavigationTests: XCTestCase {
     }
 
     func testTabBarNavigation() {
-        mySiteScreen
-            .tabBar.gotoMySitesScreen()
-            .tabBar.gotoBlockEditorScreen()
-            .closeEditor()
+        XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
 
         _ = mySiteScreen
             .tabBar.gotoReaderScreen()
+        
+        XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
+        
+        _ = mySiteScreen
             .tabBar.gotoNotificationsScreen()
 
         XCTContext.runActivity(named: "Confirm Notifications screen and main navigation bar are loaded.") { (activity) in

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -22,9 +22,9 @@ class MainNavigationTests: XCTestCase {
 
         _ = mySiteScreen
             .tabBar.gotoReaderScreen()
-        
+
         XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
-        
+
         _ = mySiteScreen
             .tabBar.gotoNotificationsScreen()
 

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -22,7 +22,6 @@
       "skippedTests" : [
         "EditorTests\/testPlayground()",
         "LoginTests\/testEmailMagicLinkLogin()",
-        "MainNavigationTests\/testTabBarNavigation()",
         "SignupTests\/testEmailSignup()"
       ],
       "target" : {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/13825

This test case was [disabled](https://github.com/wordpress-mobile/WordPress-iOS/pull/13824) because it was failing inconsistently. This PR enables it again and also addresses suggestions to improve it from the issue:

> We should ensure the test checks that the correct Reader screen is opened (not just any Reader screen).

Now it will check the Reader screen has loaded.

> We should update the test to only navigate through the tabs in the bottom nav bar. (The test still opens the block editor, but that's no longer part of the bottom nav bar. The editor is exercised as part of the editor tests, so it shouldn't be required here.)

It removes opening the block editor and just navigates throughout the navigation bar.

To test:

MainNavigationTests > testTabBarNavigation should pass in the UI Tests.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
