### PR TITLE
Fix State Restoration issue + feature flag check

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -257,7 +257,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (id)initWithMeScenePresenter:(id<ScenePresenter>)meScenePresenter
 {
-    self = [super init];
+    self = [self init];
     self.meScenePresenter = meScenePresenter;
     return self;
 }
@@ -377,7 +377,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    if ([self.tabBarController isKindOfClass:[WPTabBarController class]]) {
+    if ([self.tabBarController isKindOfClass:[WPTabBarController class]] && [Feature enabled:FeatureFlagFloatingCreateButton]) {
         [self.createButtonCoordinator showCreateButton];
     }
     [self createUserActivity];

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -83,8 +83,10 @@ import WordPressFlux
         }
     }
 
+    /// Button must be manually shown _after_ adding using `showCreateButton`
     @objc func add(to view: UIView, trailingAnchor: NSLayoutXAxisAnchor, bottomAnchor: NSLayoutYAxisAnchor) {
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.isHidden = true
 
         view.addSubview(button)
 


### PR DESCRIPTION
Fixes #14150 

This fixes an issue where state restoration would fail on Blog Details View Controller (and view controllers below it in the navigation stack) because the restoration properties were not set.

There are two additional preventative changes.

### Changes

- Calls the proper initializer in `BlogDetailsViewController` so that `restorationClass` and restorationIdentifier` are set.
- Defaults to hiding the create button instead of leaving it shown.
- Also adds a check for the CreateButton feature flag to prevent a possible crash if that feature flag is disabled.

### Testing 

#### State Restoration
- Navigate to the Blog Details or Stats Screens inside the My Sites Screen
- Send the app to the background
- Kill the app in Xcode to trigger state restoration
- Notice that the Stats Screen is restored (this _does not_ happen in current the 14.9 branch)

#### `floatingCreateButton` Feature Flag
- Disable the `floatingCreateButton` feature flag. The app should no longer crash when launching to the Blog Details screen. It would previously as it tries to add the tooltip to a button which is not on screen.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
