### PR TITLE
Issue/14141 detect change of featured image

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 * [internal] the "enter your password" screen has navigation changes that can cause regressions. See https://git.io/Jfl1C for full testing details.
 * Support the superscript and subscript HTML formatting on the Block Editor and Classic Editor.
 * [***] You can now draw on images to annotate them using the Edit image feature in the post editor.
+* [*] Fixed a bug on the editors where changing a featured image didn't trigger that the post/page changed.
  
 14.8.1
 -----

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -572,8 +572,8 @@
         return YES;
     }
 
-    if ( (self.featuredImage == NULL && self.original.featuredImage != NULL) ||
-        ![self.featuredImage.objectID isEqual: original.featuredImage.objectID] ) {
+    if ( ((self.featuredImage != nil) && ![self.featuredImage.objectID isEqual: original.featuredImage.objectID]) ||
+        (self.featuredImage == nil && self.original.featuredImage != nil) ) {
         return YES;
     }
 

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -572,6 +572,11 @@
         return YES;
     }
 
+    if ( (self.featuredImage == NULL && self.original.featuredImage != NULL) ||
+        ![self.featuredImage.objectID isEqual: original.featuredImage.objectID] ) {
+        return YES;
+    }
+
     return NO;
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -278,6 +278,12 @@ class GutenbergViewController: UIViewController, PostEditor {
         verificationPromptHelper?.updateVerificationStatus()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // Handles refreshing controls with state context after options screen is dismissed
+        editorContentWasUpdated()
+    }
+
     // MARK: - Functions
 
     private func configureNavigationBar() {

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -489,4 +489,34 @@ class PostTests: XCTestCase {
         XCTAssertNil(post.statusAfterSync)
         XCTAssertNil(post.statusAfterSyncString)
     }
+
+    /// When removing the featured image hasLocalChanges returns true
+    func testLocalChangesWhenfeaturedImageIsRemoved() {
+        let post = newTestPost()
+        post.featuredImage = Media.makeMedia(in: context)
+        let revision = post.createRevision()
+        revision.featuredImage = nil
+
+        XCTAssertTrue(revision.hasLocalChanges())
+    }
+
+    /// When adding a featured image hasLocalChanges returns true
+    func testLocalChangesWhenfeaturedImageIsAdded() {
+        let post = newTestPost()
+        let revision = post.createRevision()
+        revision.featuredImage = Media.makeMedia(in: context)
+
+        XCTAssertTrue(revision.hasLocalChanges())
+    }
+
+    /// When keeping the featured image hasLocalChanges returns false
+    func testLocalChangesWhenFeaturedImageIsTheSame() {
+        let post = newTestPost()
+        let media = Media.makeMedia(in: context)
+        post.featuredImage = media
+        let revision = post.createRevision()
+        revision.featuredImage = media
+
+        XCTAssertFalse(revision.hasLocalChanges())
+    }
 }


### PR DESCRIPTION
Fixes #14141

This PR adds checks for feature image changes to the method `hasLocalChanges` of `AbstractPost`.

It also updates the `GutenbergViewController` code to refresh the navigation bar every time it comes back from `PostSettings`.

To test:
 - Please test the steps bellow with Aztec and Gutenberg editor, and with **post** and **pages**.

 - Create a new post and publish it.
 - Open the same post
 - Open post settings and add a featured image
 - Close Post settings
 - Check that the Update on the top right is active.
 - Update the post
 - Exit the post and open it again
 - Open Post settings
 - Tap on the Featured Image
 - Remove it
 - Close Post Settings
 - Check that the update on the top right is active.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
