### PR TITLE
[Testing] [Gutenberg] Link to existing content - RN UI implementation

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -147,7 +147,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => '1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7'
+    gutenberg :commit => 'e83db796ed935e7a7d8254f842c41d9d02021b3d'
 
     ## Third party libraries
     ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -287,7 +287,7 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
   - React-jsinspector (0.61.5)
-  - react-native-keyboard-aware-scroll-view (0.8.7):
+  - react-native-keyboard-aware-scroll-view (0.8.8):
     - React
   - react-native-linear-gradient (2.5.6):
     - React
@@ -295,11 +295,11 @@ PODS:
     - React
   - react-native-slider (2.0.7):
     - React
-  - react-native-video (4.4.1):
-    - React-Core
-    - react-native-video/Video (= 4.4.1)
-  - react-native-video/Video (4.4.1):
-    - React-Core
+  - react-native-video (5.0.2):
+    - React
+    - react-native-video/Video (= 5.0.2)
+  - react-native-video/Video (5.0.2):
+    - React
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
   - React-RCTAnimation (0.61.5):
@@ -429,15 +429,15 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.0.1)
-  - Gutenberg (from `../gutenberg-mobile`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `e83db796ed935e7a7d8254f842c41d9d02021b3d`)
   - JTAppleCalendar (~> 8.0.2)
   - MediaEditor (~> 1.1.0)
   - MRProgress (= 0.8.3)
@@ -447,34 +447,34 @@ DEPENDENCIES:
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - RCTRequired (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-slider (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `../gutenberg-mobile`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `e83db796ed935e7a7d8254f842c41d9d02021b3d`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -485,7 +485,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.7.0)
   - WPMediaPicker (~> 1.6.1)
-  - Yoga (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -545,79 +545,87 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json
   Folly:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :path: "../gutenberg-mobile"
+    :commit: e83db796ed935e7a7d8254f842c41d9d02021b3d
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RCTRequired:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json
   React:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json
   React-CoreModules:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json
   React-cxxreact:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json
   React-jsi:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-linear-gradient:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json
   react-native-safe-area:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-slider:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json
   react-native-video:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json
   ReactCommon:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json
   ReactNativeDarkMode:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNSVG:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :path: "../gutenberg-mobile"
+    :commit: e83db796ed935e7a7d8254f842c41d9d02021b3d
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   Yoga:
-    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json"
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/e83db796ed935e7a7d8254f842c41d9d02021b3d/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
+  Gutenberg:
+    :commit: e83db796ed935e7a7d8254f842c41d9d02021b3d
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  RNTAztecView:
+    :commit: e83db796ed935e7a7d8254f842c41d9d02021b3d
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -662,11 +670,11 @@ SPEC CHECKSUMS:
   React-jsi: 6d6afac4873e8a3433334378589a0a8190d58070
   React-jsiexecutor: 9dfdcd0db23042623894dcbc02d61a772da8e3c1
   React-jsinspector: 89927b9ec6d75759882949d2043ba704565edaec
-  react-native-keyboard-aware-scroll-view: 01c4b2303c4ef1c49c4d239c9c5856f0393104df
+  react-native-keyboard-aware-scroll-view: ffa9152671fec9a571197ed2d02e0fcb90206e60
   react-native-linear-gradient: 258ba8c61848324b1f2019bed5f460e6396137b7
   react-native-safe-area: e8230b0017d76c00de6b01e2412dcf86b127c6a3
   react-native-slider: b36527edad24d49d9f3b53f3078334f45558f97b
-  react-native-video: 9de661e89386bb7ab78cc68e61a146cbdf5ad4ad
+  react-native-video: d01ed7ff1e38fa7dcc6c15c94cf505e661b7bfd0
   React-RCTActionSheet: e8f642cfaa396b6b09fd38f53378506c2d63af35
   React-RCTAnimation: cec1abbcfb006978a288c5072e3d611d6ff76d4c
   React-RCTBlob: 7596eb2048150e429127a92a701e6cd40a8c0a74

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -287,7 +287,7 @@ PODS:
     - React-cxxreact (= 0.61.5)
     - React-jsi (= 0.61.5)
   - React-jsinspector (0.61.5)
-  - react-native-keyboard-aware-scroll-view (0.8.8):
+  - react-native-keyboard-aware-scroll-view (0.8.7):
     - React
   - react-native-linear-gradient (2.5.6):
     - React
@@ -295,11 +295,11 @@ PODS:
     - React
   - react-native-slider (2.0.7):
     - React
-  - react-native-video (5.0.2):
-    - React
-    - react-native-video/Video (= 5.0.2)
-  - react-native-video/Video (5.0.2):
-    - React
+  - react-native-video (4.4.1):
+    - React-Core
+    - react-native-video/Video (= 4.4.1)
+  - react-native-video/Video (4.4.1):
+    - React-Core
   - React-RCTActionSheet (0.61.5):
     - React-Core/RCTActionSheetHeaders (= 0.61.5)
   - React-RCTAnimation (0.61.5):
@@ -429,15 +429,15 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
+  - glog (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.0.1)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7`)
+  - Gutenberg (from `../gutenberg-mobile`)
   - JTAppleCalendar (~> 8.0.2)
   - MediaEditor (~> 1.1.0)
   - MRProgress (= 0.8.3)
@@ -447,34 +447,34 @@ DEPENDENCIES:
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7`)
+  - React (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-slider (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `../gutenberg-mobile`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -485,7 +485,7 @@ DEPENDENCIES:
   - WordPressShared (~> 1.8.16)
   - WordPressUI (~> 1.7.0)
   - WPMediaPicker (~> 1.6.1)
-  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -545,87 +545,79 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json"
   FBReactNativeSpec:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json"
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json"
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json"
   Gutenberg:
-    :commit: 1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :path: "../gutenberg-mobile"
   RCTRequired:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTRequired.podspec.json"
   RCTTypeSafety:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RCTTypeSafety.podspec.json"
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json"
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-Core.podspec.json"
   React-CoreModules:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-CoreModules.podspec.json"
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-cxxreact.podspec.json"
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsi.podspec.json"
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsiexecutor.podspec.json"
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-jsinspector.podspec.json"
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json"
   react-native-linear-gradient:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-linear-gradient.podspec.json"
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json"
   react-native-slider:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-slider.podspec.json"
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/react-native-video.podspec.json"
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTActionSheet.podspec.json"
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTAnimation.podspec.json"
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTBlob.podspec.json"
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTImage.podspec.json"
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTLinking.podspec.json"
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTNetwork.podspec.json"
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTSettings.podspec.json"
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTText.podspec.json"
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/React-RCTVibration.podspec.json"
   ReactCommon:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactCommon.podspec.json"
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/ReactNativeDarkMode.podspec.json"
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/RNSVG.podspec.json"
   RNTAztecView:
-    :commit: 1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :path: "../gutenberg-mobile"
   Yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
+    :podspec: "../gutenberg-mobile/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json"
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
-  Gutenberg:
-    :commit: 1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  RNTAztecView:
-    :commit: 1f5ee28cfd84a9a7fd962f0d63f560baeb777ba7
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -670,11 +662,11 @@ SPEC CHECKSUMS:
   React-jsi: 6d6afac4873e8a3433334378589a0a8190d58070
   React-jsiexecutor: 9dfdcd0db23042623894dcbc02d61a772da8e3c1
   React-jsinspector: 89927b9ec6d75759882949d2043ba704565edaec
-  react-native-keyboard-aware-scroll-view: ffa9152671fec9a571197ed2d02e0fcb90206e60
+  react-native-keyboard-aware-scroll-view: 01c4b2303c4ef1c49c4d239c9c5856f0393104df
   react-native-linear-gradient: 258ba8c61848324b1f2019bed5f460e6396137b7
   react-native-safe-area: e8230b0017d76c00de6b01e2412dcf86b127c6a3
   react-native-slider: b36527edad24d49d9f3b53f3078334f45558f97b
-  react-native-video: d01ed7ff1e38fa7dcc6c15c94cf505e661b7bfd0
+  react-native-video: 9de661e89386bb7ab78cc68e61a146cbdf5ad4ad
   React-RCTActionSheet: e8f642cfaa396b6b09fd38f53378506c2d63af35
   React-RCTAnimation: cec1abbcfb006978a288c5072e3d611d6ff76d4c
   React-RCTBlob: 7596eb2048150e429127a92a701e6cd40a8c0a74
@@ -714,6 +706,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: c7cd4e5f6e2a96a7ff3631ef6704512b53f9e88a
+PODFILE CHECKSUM: 3605c8e2ed61e2d3ab9a84e5b0e0fb57f70199bc
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -669,6 +669,15 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             self?.mentionShow(callback: callback)
         })
     }
+
+    func gutenbergDidRequestLinks(query: String, callback: @escaping RCTResponseSenderBlock) {
+        let fetchController = PostCoordinator.shared.posts(for: post.blog, wichTitleContains: query)
+        let links = (fetchController.fetchedObjects as! [Post]).map {[
+            "url": $0.permaLink,
+            "title": $0.postTitle
+        ]}
+        callback([links])
+    }
 }
 
 // MARK: - Mention implementation


### PR DESCRIPTION
This PR is for testing the iOS implementation of the link to existing content feature for the Gutenberg block editor. Related issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2194

To test:
tbd

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
