### PR TITLE
Fix: UNNotificationContent Crash

### DIFF
--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -39,8 +39,9 @@ class NotificationService: UNNotificationServiceExtension {
             let notificationType = notificationContent.type,
             let notificationKind = NotificationKind(rawValue: notificationType),
             token != nil else {
-            tracks.trackNotificationMalformed(properties: ["have_token": (token != nil) as AnyObject,
-                                                           "content": request.content])
+
+            let hasToken = token != nil
+            tracks.trackNotificationMalformed(hasToken: hasToken, notificationBody: request.content.body)
             contentHandler(request.content)
 
             return

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -60,7 +60,12 @@ extension Tracks {
     }
 
     /// Tracks the unsuccessful unwrapping of push notification payload data.
-    func trackNotificationMalformed(properties: [String: AnyObject]? = nil) {
+    func trackNotificationMalformed(hasToken: Bool, notificationBody: String) {
+        let properties: [String: AnyObject] = [
+            "have_token": hasToken as AnyObject,
+            "content": notificationBody as AnyObject
+        ]
+
         trackEvent(ServiceExtensionEvents.malformed, properties: properties)
     }
 


### PR DESCRIPTION
### Details:
In this PR we're fixing a crash in the NotificationServiceExtension, caused by JSON Encoding of an entity that's not encodeable.

Ref. #13412

cc @leandroalonso sir, may I bug you with this one? Thanks in advance!!

### To test:
Please DM me for instructions on how to send a Push Authentication Notification!

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
