### PR TITLE
Update Auth to use Google signup refactor.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -185,9 +185,9 @@ target 'WordPress' do
     pod 'Gridicons', '~> 1.0.1'
 
 
-    # pod 'WordPressAuthenticator', '~> 1.17.0-beta.8'
+    pod 'WordPressAuthenticator', '~> 1.17.0-beta.8'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/282-refactor_google_signup'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -185,9 +185,9 @@ target 'WordPress' do
     pod 'Gridicons', '~> 1.0.1'
 
 
-    pod 'WordPressAuthenticator', '~> 1.17.0-beta.7'
+    # pod 'WordPressAuthenticator', '~> 1.17.0-beta.8'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/282-refactor_google_signup'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -483,7 +483,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.1)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/282-refactor_google_signup`)
+  - WordPressAuthenticator (~> 1.17.0-beta.8)
   - WordPressKit (~> 4.9.0-beta.2)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -532,6 +532,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -616,9 +617,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 59220b0adb795557639a017b065af270d284c9bf
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressAuthenticator:
-    :branch: feature/282-refactor_google_signup
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WPMediaPicker:
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
     :tag: 1.7.0-beta.2
@@ -635,9 +633,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 59220b0adb795557639a017b065af270d284c9bf
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressAuthenticator:
-    :commit: 5ca4b5af4775383831db15c0423d8f3a85c92995
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WPMediaPicker:
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
     :tag: 1.7.0-beta.2
@@ -730,6 +725,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 1fcc96125eaec10fb88e3098aa850c8c0f11f9c7
+PODFILE CHECKSUM: 13cb64ba681cefe81f81e67dd8ef5c467907ea65
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -380,7 +380,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.1)
   - WordPress-Editor-iOS (1.19.1):
     - WordPress-Aztec-iOS (= 1.19.1)
-  - WordPressAuthenticator (1.17.0-beta.7):
+  - WordPressAuthenticator (1.17.0-beta.8):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -483,7 +483,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.1)
-  - WordPressAuthenticator (~> 1.17.0-beta.7)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/282-refactor_google_signup`)
   - WordPressKit (~> 4.9.0-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -532,7 +532,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -617,6 +616,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 59220b0adb795557639a017b065af270d284c9bf
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :branch: feature/282-refactor_google_signup
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WPMediaPicker:
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
     :tag: 1.7.0-beta.2
@@ -633,6 +635,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 59220b0adb795557639a017b065af270d284c9bf
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :commit: c990694d9ef8516474dd17a122a0552706ea7d5e
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WPMediaPicker:
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
     :tag: 1.7.0-beta.2
@@ -708,7 +713,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: 25a9cbe204a22dd6d540d66d90b8a889421e0b42
   WordPress-Editor-iOS: 9f3d720086b90fd8b73f8eccd744c15abbdb7607
-  WordPressAuthenticator: aa6c0a219c17cdfdb19fe6c2a1859b2577857cd5
+  WordPressAuthenticator: 4fe95997e179d447e19b24e26c872b18e6dc9903
   WordPressKit: e8aab0ace717c9b9be307ccfdda08821f31b655c
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
@@ -725,6 +730,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 163eb7f9c122cdb34d0147af94628a7bb40f62d8
+PODFILE CHECKSUM: 42f28342afba5ce28464d6b97509ad5ec0125585
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -636,7 +636,7 @@ CHECKOUT OPTIONS:
     :commit: 59220b0adb795557639a017b065af270d284c9bf
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressAuthenticator:
-    :commit: c990694d9ef8516474dd17a122a0552706ea7d5e
+    :commit: 5ca4b5af4775383831db15c0423d8f3a85c92995
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WPMediaPicker:
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [**] Block editor: Fix media upload progress when there's no connection.
 * [*] Fix a bug where taking a photo for your user gravatar got you blocked in the crop screen.
 * [internal] Logging in via 'Continue with Google' has changes that can cause regressions. See https://git.io/Jf2LF for full testing details.
+* [internal] Signing up via 'Continue with Google' has changes that can cause regressions. See https://git.io/JfwjX for full testing details.
 
 14.9
 -----


### PR DESCRIPTION
Ref #https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/282
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/287

This uses the Auth branch to utilize the Google signup refactor.  To note, there should be _no_ functional or visible changes. Testing is to verify nothing is broken.

To test:

---
**Error Handling:**

Different settings on an existing WP account result in different errors. I _think_ these scenarios cover them. But the gist here is that if Signup fails when selecting an existing account, a popup is displayed with an API error message. i.e. the _handling_ of these errors is no different, just the messages may differ.

Pro tip: To check if your WP account is connected to Google, go to wordpress.com > Account > Security > Social Login. You can also connect/disconnect Google from here. 

<img width="730" alt="social_connection" src="https://user-images.githubusercontent.com/1816888/83063783-ea159480-a01d-11ea-9122-2d10736eb8d0.png">


**Scenario 1: WP account is _not_ connected to Google.**
- Sign up with Google. 
- Select an email already used on a WP account.
- Error alert - email is already used.

![already_in_use](https://user-images.githubusercontent.com/1816888/83063997-4e385880-a01e-11ea-8ce4-7a99f6118fc6.png)

**Scenario 2: WP account _is_ connected to Google, and WP 2FA _is_ enabled.**
- Sign up with Google. 
- Select an email already used on a WP account.
- Error alert - WP account with 2fa enabled.

![wp_2fa](https://user-images.githubusercontent.com/1816888/83064135-90619a00-a01e-11ea-9c65-91327b0d4878.png)

---
**Redirect to Login:**

This is the only scenario I found where selecting an existing account actually redirects to login.

**WP account _is_ connected to Google, and WP 2FA is _not_ enabled.**
- Sign up with Google. 
- Select an email already used on a WP account.
- The account is logged in and the login epilogue is displayed.

<kbd>![login_epilogue](https://user-images.githubusercontent.com/1816888/83064459-0b2ab500-a01f-11ea-92c4-81f0d15a43d7.png)</kbd>

---
**Successful Signup:**

No existing WP account for Google account:
- Sign up with Google. 
- Select an email not used on a WP account.
- The account is created and the signup epilogue is displayed. Rejoice.

| ![hud_message](https://user-images.githubusercontent.com/1816888/83064762-8f7d3800-a01f-11ea-90d5-ace50b2c9b6f.png) | ![signup_epilogue](https://user-images.githubusercontent.com/1816888/83064818-ac197000-a01f-11ea-8cc8-a460eed86161.png) |
|--------|-------|


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
