### PR TITLE
Do not change the date of published posts when changing it to private

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostVisibilitySelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostVisibilitySelectorViewController.swift
@@ -35,8 +35,10 @@ import UIKit
             }
 
             if visibility == AbstractPost.privateLabel {
-                // Make sure the post is not scheduled anymore. The user can't schedule a private post
-                post.publishImmediately()
+                if post.isScheduled() {
+                    // Make sure the post is not scheduled anymore. The user can't schedule a private post
+                    post.publishImmediately()
+                }
                 post.status = .publishPrivate
                 post.password = nil
             } else {


### PR DESCRIPTION
Fixes #13996

This PR makes sure that published posts' original date isn't changed when changing its status to private.

cc @jd-alexander 

### To test

Change a published post to private and make sure that the original date is not changed.