### PR TITLE
Move push notifications permission alert to Notifications tab

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -47,7 +47,6 @@ extension BlogDetailsViewController {
 
     private func showNoticeOrAlertAsNeeded() {
         guard let tourGuide = QuickStartTourGuide.find() else {
-            showNotificationPrimerAlert()
             return
         }
 
@@ -59,8 +58,6 @@ extension BlogDetailsViewController {
             tourGuide.didShowUpgradeToV2Notice(for: blog)
         } else if let tourToSuggest = tourGuide.tourToSuggest(for: blog) {
             tourGuide.suggest(tourToSuggest, for: blog)
-        } else {
-            showNotificationPrimerAlert()
         }
     }
 
@@ -117,42 +114,6 @@ extension BlogDetailsViewController {
         let section = BlogDetailsSection(title: sectionTitle, andRows: [customizeRow, growRow], category: .quickStart)
         section.showQuickStartMenu = true
         return section
-    }
-
-    private func showNotificationPrimerAlert() {
-        guard noPresentedViewControllers else {
-            return
-        }
-
-        guard !UserDefaults.standard.notificationPrimerAlertWasDisplayed else {
-            return
-        }
-
-        let mainContext = ContextManager.shared.mainContext
-        let accountService = AccountService(managedObjectContext: mainContext)
-
-        guard accountService.defaultWordPressComAccount() != nil else {
-            return
-        }
-
-        PushNotificationsManager.shared.loadAuthorizationStatus { [weak self] (enabled) in
-            guard enabled == .notDetermined else {
-                return
-            }
-
-            UserDefaults.standard.notificationPrimerAlertWasDisplayed = true
-
-            let alert = FancyAlertViewController.makeNotificationPrimerAlertController { (controller) in
-                InteractiveNotificationsManager.shared.requestAuthorization {
-                    DispatchQueue.main.async {
-                        controller.dismiss(animated: true)
-                    }
-                }
-            }
-            alert.modalPresentationStyle = .custom
-            alert.transitioningDelegate = self
-            self?.tabBarController?.present(alert, animated: true)
-        }
     }
 
     private func shouldShowCreateButtonAnnouncement() -> Bool {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1283,7 +1283,7 @@ extension NotificationsViewController: NoResultsViewControllerDelegate {
 //
 internal extension NotificationsViewController {
     func showInlinePrompt() {
-        guard inlinePromptView.alpha != WPAlphaFull else {
+        guard inlinePromptView.alpha != WPAlphaFull, UserDefaults.standard.notificationPrimerAlertWasDisplayed else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -176,9 +176,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
             setupAppRatings()
             self.showInlinePrompt()
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            self.showNotificationPrimerAlert()
-        }
+        showNotificationPrimerAlertIfNeeded()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -1638,11 +1636,17 @@ extension NotificationsViewController: UIViewControllerTransitioningDelegate {
         return FancyAlertPresentationController(presentedViewController: fancyAlertController, presenting: presenting)
     }
 
-    private func showNotificationPrimerAlert() {
-
+    private func showNotificationPrimerAlertIfNeeded() {
         guard !UserDefaults.standard.notificationPrimerAlertWasDisplayed else {
             return
         }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                self.showNotificationPrimerAlert()
+        }
+    }
+
+    private func showNotificationPrimerAlert() {
 
         let mainContext = ContextManager.shared.mainContext
         let accountService = AccountService(managedObjectContext: mainContext)
@@ -1650,7 +1654,6 @@ extension NotificationsViewController: UIViewControllerTransitioningDelegate {
         guard accountService.defaultWordPressComAccount() != nil else {
             return
         }
-
         PushNotificationsManager.shared.loadAuthorizationStatus { [weak self] (enabled) in
             guard enabled == .notDetermined else {
                 return


### PR DESCRIPTION
Ref #14202

To test:

- Build and run as fresh install
- Navigate to 'Notifications'
- Verify that the notifications permissions alert shows up
- verify that the buttons are actionable
- verify (on a real device) that tapping on 'allow notifications' presents the system screen to allow notifications

**Notes**
- The in-line prompt logic is yet to be updated. At this time, if users tap on 'not now', the in-line prompt will show up after navigating away and returning to the 'Notifications' tab
- To show the permission alert without deleting the app, pause the execution using the debugger and run the following command
```
e -l swift -- import WordPress; UserDefaults.standard.notificationPrimerAlertWasDisplayed = false
```

This will only work if the notifications permissions have not been set yet (that is, if you tap on 'not now' in the alert)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
