### PR TITLE
Update the cross post table cell design to match the new reader card

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -3,15 +3,22 @@ import Foundation
 import AutomatticTracks
 import WordPressShared.WPStyleGuide
 
+private struct Constants {
+    static let imageBorderWidth: CGFloat = 1
+    static let blavatarPlaceholder: String = "post-blavatar-placeholder"
+    static let xPostTitlePrefix = "X-post: "
+    static let commentTemplate = "%@ left a comment on %@, cross-posted to %@"
+    static let siteTemplate = "%@ cross-posted from %@ to %@"
+}
+
 open class ReaderCrossPostCell: UITableViewCell {
     @IBOutlet fileprivate weak var blavatarImageView: UIImageView!
     @IBOutlet fileprivate weak var avatarImageView: UIImageView!
+    @IBOutlet fileprivate weak var titleLabel: UILabel!
     @IBOutlet fileprivate weak var label: UILabel!
+    @IBOutlet weak var borderView: UIView!
 
     @objc open weak var contentProvider: ReaderPostContentProvider?
-
-    @objc let blavatarPlaceholder = "post-blavatar-placeholder"
-    @objc let xPostTitlePrefix = "X-post: "
 
     // MARK: - Accessors
 
@@ -57,12 +64,15 @@ open class ReaderCrossPostCell: UITableViewCell {
 
     fileprivate func applyStyles() {
         contentView.backgroundColor = .listBackground
-        label?.backgroundColor = .listBackground
+        borderView?.backgroundColor = .listForeground
+        label?.backgroundColor = .listForeground
+        titleLabel?.backgroundColor = .listForeground
     }
 
     fileprivate func applyHighlightedEffect(_ highlighted: Bool, animated: Bool) {
         func updateBorder() {
             label.alpha = highlighted ? 0.50 : WPAlphaFull
+            titleLabel.alpha = highlighted ? 0.50 : WPAlphaFull
         }
         guard animated else {
             updateBorder()
@@ -80,6 +90,7 @@ open class ReaderCrossPostCell: UITableViewCell {
     @objc open func configureCell(_ contentProvider: ReaderPostContentProvider) {
         self.contentProvider = contentProvider
 
+        configureTitleLabel()
         configureLabel()
         configureBlavatarImage()
         configureAvatarImageView()
@@ -89,8 +100,7 @@ open class ReaderCrossPostCell: UITableViewCell {
         // Always reset
         blavatarImageView.image = nil
 
-        let placeholder = UIImage(named: blavatarPlaceholder)
-
+        let placeholder = UIImage(named: Constants.blavatarPlaceholder)
         let size = blavatarImageView.frame.size.width * UIScreen.main.scale
 
         guard let contentProvider = contentProvider,
@@ -116,7 +126,7 @@ open class ReaderCrossPostCell: UITableViewCell {
         // Always reset
         avatarImageView.image = nil
 
-        let placeholder = UIImage(named: blavatarPlaceholder)
+        let placeholder = UIImage(named: Constants.blavatarPlaceholder)
 
         let url = contentProvider?.avatarURLForDisplay()
         if url != nil {
@@ -126,21 +136,24 @@ open class ReaderCrossPostCell: UITableViewCell {
         }
     }
 
-    fileprivate func configureLabel() {
+    private func configureTitleLabel() {
+         if var title = contentProvider?.titleForDisplay(), !title.isEmpty() {
+            if let prefixRange = title.range(of: Constants.xPostTitlePrefix) {
+                title.removeSubrange(prefixRange)
+            }
 
-        // Compose the title.
-        var title = contentProvider!.titleForDisplay() ?? ""
-        if let prefixRange = title.range(of: xPostTitlePrefix) {
-            title.removeSubrange(prefixRange)
+            titleLabel.attributedText = NSAttributedString(string: title, attributes: readerCrossPostTitleAttributes)
+            titleLabel.isHidden = false
+        } else {
+            titleLabel.attributedText = nil
+            titleLabel.isHidden = true
         }
+    }
 
-        let attrText = NSMutableAttributedString(string: "\(title)\n", attributes: readerCrossPostTitleAttributes)
-
+    fileprivate func configureLabel() {
         // Compose the subtitle
         // These templates are deliberately not localized (for now) given the intended audience.
-        let commentTemplate = "%@ left a comment on %@, cross-posted to %@"
-        let siteTemplate = "%@ cross-posted from %@ to %@"
-        let template = contentProvider!.isCommentCrossPost() ? commentTemplate : siteTemplate
+        let template = contentProvider!.isCommentCrossPost() ? Constants.commentTemplate : Constants.siteTemplate
 
         let authorName: NSString = contentProvider!.authorForDisplay() as NSString
         let siteName = subDomainNameFromPath(contentProvider!.siteURLForDisplay())
@@ -148,18 +161,24 @@ open class ReaderCrossPostCell: UITableViewCell {
 
         let subtitle = NSString(format: template as NSString, authorName, originName, siteName) as String
         let attrSubtitle = NSMutableAttributedString(string: subtitle, attributes: readerCrossPostSubtitleAttributes)
+
         attrSubtitle.setAttributes(readerCrossPostBoldSubtitleAttributes, range: NSRange(location: 0, length: authorName.length))
 
-        // Add the subtitle to the attributed text
-        attrText.append(attrSubtitle)
+        if let siteRange = subtitle.nsRange(of: siteName) {
+            attrSubtitle.setAttributes(readerCrossPostBoldSubtitleAttributes, range: siteRange)
+        }
 
-        label.attributedText = attrText
+        if let originRange = subtitle.nsRange(of: originName) {
+            attrSubtitle.setAttributes(readerCrossPostBoldSubtitleAttributes, range: originRange)
+        }
+
+        label.attributedText = attrSubtitle
     }
 
     fileprivate func subDomainNameFromPath(_ path: String) -> String {
         if let url = URL(string: path), let host = url.host {
             let arr = host.components(separatedBy: ".")
-            return "+\(arr.first!)"
+            return arr.first!
         }
         return ""
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.xib
@@ -1,63 +1,100 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" id="l6Y-Fy-vps" customClass="ReaderCrossPostCell" customModule="WordPress">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="79"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" rowHeight="232" id="chZ-G6-vcS" customClass="ReaderCrossPostCell" customModule="WordPress">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="172"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="l6Y-Fy-vps" id="2sd-JP-syY">
-                <frame key="frameInset" width="320" height="78"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="chZ-G6-vcS" id="yQG-5S-y1g">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="172"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="Ap0-kK-cyS">
-                        <gestureRecognizers/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="32" id="0pN-Fl-k80"/>
-                            <constraint firstAttribute="height" constant="32" id="Wn7-hF-1D5"/>
-                        </constraints>
-                    </imageView>
-                    <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QNy-fU-VEf" customClass="ReaderPostCardContentLabel" customModule="WordPress" customModuleProvider="target">
-                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="4R4-gj-7Xa" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                        <gestureRecognizers/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="24" id="5A7-WD-dbE"/>
-                            <constraint firstAttribute="width" constant="24" id="cOW-bo-j4R"/>
-                        </constraints>
-                    </imageView>
+                    <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Phn-de-LXH" userLabel="Background View">
+                        <rect key="frame" x="-1" y="8" width="322" height="164"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </view>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="D38-SH-Xvw" userLabel="Content Stack View">
+                        <rect key="frame" x="16" y="20" width="288" height="140"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="4qr-gg-TCP">
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="113.5"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="31R-gx-fKg">
+                                        <rect key="frame" x="0.0" y="0.0" width="30" height="113.5"/>
+                                        <subviews>
+                                            <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" image="blavatar" translatesAutoresizingMaskIntoConstraints="NO" id="WUC-gY-tp6" userLabel="First" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="47" width="20" height="20"/>
+                                                <gestureRecognizers/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="20" id="HiT-Lq-HXe"/>
+                                                    <constraint firstAttribute="height" constant="20" id="ykn-4s-Ni8"/>
+                                                </constraints>
+                                            </imageView>
+                                            <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="blavatar" translatesAutoresizingMaskIntoConstraints="NO" id="JOq-VL-EJD" userLabel="Second" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="10" y="47" width="20" height="20"/>
+                                                <gestureRecognizers/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="20" id="Wly-6B-Yyx"/>
+                                                    <constraint firstAttribute="height" constant="20" id="jEX-wo-rhJ"/>
+                                                </constraints>
+                                            </imageView>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="WUC-gY-tp6" firstAttribute="centerY" secondItem="31R-gx-fKg" secondAttribute="centerY" id="2vK-eZ-fEe"/>
+                                            <constraint firstItem="JOq-VL-EJD" firstAttribute="centerY" secondItem="31R-gx-fKg" secondAttribute="centerY" id="CVJ-He-ikX"/>
+                                            <constraint firstItem="WUC-gY-tp6" firstAttribute="leading" secondItem="31R-gx-fKg" secondAttribute="leading" id="bTR-cF-WMZ"/>
+                                            <constraint firstAttribute="trailing" secondItem="JOq-VL-EJD" secondAttribute="trailing" id="nXv-EE-H7w"/>
+                                            <constraint firstItem="JOq-VL-EJD" firstAttribute="leading" secondItem="WUC-gY-tp6" secondAttribute="centerX" id="tdQ-IG-5vq"/>
+                                        </constraints>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="andrei cross-posted from designomatticp2 to teamxthings" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5MU-iV-oPy">
+                                        <rect key="frame" x="40" y="0.0" width="248" height="113.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <label userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lca-uT-huN" customClass="ReaderPostCardContentLabel" customModule="WordPress" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="119.5" width="288" height="20.5"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
                 </subviews>
-                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="calibratedWhite"/>
                 <constraints>
-                    <constraint firstItem="4R4-gj-7Xa" firstAttribute="centerY" secondItem="Ap0-kK-cyS" secondAttribute="centerY" constant="8" id="C6a-0B-phG"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="QNy-fU-VEf" secondAttribute="bottom" id="JUs-Mr-N5X"/>
-                    <constraint firstItem="QNy-fU-VEf" firstAttribute="top" secondItem="2sd-JP-syY" secondAttribute="topMargin" id="Tfd-If-a2D"/>
-                    <constraint firstItem="QNy-fU-VEf" firstAttribute="leading" secondItem="Ap0-kK-cyS" secondAttribute="trailing" constant="10" id="Z2v-H7-Gq7"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="QNy-fU-VEf" secondAttribute="trailing" id="gJd-ye-lPA"/>
-                    <constraint firstItem="Ap0-kK-cyS" firstAttribute="leading" secondItem="2sd-JP-syY" secondAttribute="leadingMargin" id="oA9-dv-qur"/>
-                    <constraint firstItem="4R4-gj-7Xa" firstAttribute="centerX" secondItem="Ap0-kK-cyS" secondAttribute="centerX" constant="8" id="xMu-69-G6W"/>
-                    <constraint firstItem="Ap0-kK-cyS" firstAttribute="top" secondItem="2sd-JP-syY" secondAttribute="topMargin" constant="1" id="yxj-Ou-gVT"/>
+                    <constraint firstItem="Phn-de-LXH" firstAttribute="leading" secondItem="yQG-5S-y1g" secondAttribute="leading" constant="-1" id="7Ep-5N-Qst"/>
+                    <constraint firstItem="Phn-de-LXH" firstAttribute="top" secondItem="yQG-5S-y1g" secondAttribute="top" constant="8" id="90n-YF-4D3"/>
+                    <constraint firstItem="D38-SH-Xvw" firstAttribute="top" secondItem="Phn-de-LXH" secondAttribute="top" constant="12" id="Kig-9E-kqG"/>
+                    <constraint firstItem="D38-SH-Xvw" firstAttribute="leading" secondItem="yQG-5S-y1g" secondAttribute="leading" constant="16" id="ML0-ur-kuZ"/>
+                    <constraint firstAttribute="bottom" secondItem="D38-SH-Xvw" secondAttribute="bottom" constant="12" id="cvY-j5-xr1"/>
+                    <constraint firstAttribute="trailing" secondItem="D38-SH-Xvw" secondAttribute="trailing" constant="16" id="iA4-0B-XeM"/>
+                    <constraint firstAttribute="bottom" secondItem="Phn-de-LXH" secondAttribute="bottom" id="rJ7-0T-oeM"/>
+                    <constraint firstAttribute="trailing" secondItem="Phn-de-LXH" secondAttribute="trailing" constant="-1" id="tsp-4A-wom"/>
                 </constraints>
-                <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
             </tableViewCellContentView>
             <connections>
-                <outlet property="avatarImageView" destination="4R4-gj-7Xa" id="noM-47-9Ga"/>
-                <outlet property="blavatarImageView" destination="Ap0-kK-cyS" id="IPR-Pi-AiK"/>
-                <outlet property="label" destination="QNy-fU-VEf" id="sbX-VU-jfS"/>
+                <outlet property="avatarImageView" destination="JOq-VL-EJD" id="qv3-Of-zZc"/>
+                <outlet property="blavatarImageView" destination="WUC-gY-tp6" id="U2a-iV-k1I"/>
+                <outlet property="borderView" destination="Phn-de-LXH" id="ZGz-sk-ljb"/>
+                <outlet property="label" destination="5MU-iV-oPy" id="9OI-1R-pcP"/>
+                <outlet property="titleLabel" destination="lca-uT-huN" id="cRk-nM-vEy"/>
             </connections>
-            <point key="canvasLocation" x="492" y="548.5"/>
+            <point key="canvasLocation" x="119" y="443"/>
         </tableViewCell>
     </objects>
     <resources>
-        <image name="post-blavatar-placeholder" width="32" height="32"/>
+        <image name="blavatar" width="40" height="40"/>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
@@ -89,9 +89,6 @@
                                         </connections>
                                     </button>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="40" id="SBj-Cn-PKj"/>
-                                </constraints>
                             </stackView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D4Q-6L-ZIL" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="16" y="64" width="288" height="162"/>

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -55,7 +55,7 @@ extension WPStyleGuide {
     // MARK: - Card Attributed Text Attributes
 
     @objc public class func readerCrossPostTitleAttributes() -> [NSAttributedString.Key: Any] {
-        let font = WPStyleGuide.notoBoldFontForTextStyle(Cards.titleTextStyle)
+        let font = WPStyleGuide.serifFontForTextStyle(Cards.crossPostTitleTextStyle)
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = Cards.crossPostLineSpacing
@@ -71,12 +71,10 @@ extension WPStyleGuide {
         let font = WPStyleGuide.fontForTextStyle(Cards.crossPostSubtitleTextStyle, symbolicTraits: .traitBold)
 
         let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = Cards.crossPostLineSpacing
-
         return [
             .paragraphStyle: paragraphStyle,
             .font: font,
-            .foregroundColor: UIColor.textSubtle
+            .foregroundColor: UIColor.neutral(.shade40)
         ]
     }
 
@@ -89,7 +87,7 @@ extension WPStyleGuide {
         return [
             .paragraphStyle: paragraphStyle,
             .font: font,
-            .foregroundColor: UIColor.textSubtle
+            .foregroundColor: UIColor.neutral(.shade40)
         ]
     }
 
@@ -516,7 +514,9 @@ extension WPStyleGuide {
         public static let buttonTextStyle: UIFont.TextStyle = .subheadline
         public static let subtextTextStyle: UIFont.TextStyle = .caption1
         public static let loadMoreButtonTextStyle: UIFont.TextStyle = .subheadline
-        public static let crossPostSubtitleTextStyle: UIFont.TextStyle = .footnote
+
+        public static let crossPostTitleTextStyle: UIFont.TextStyle = .body
+        public static let crossPostSubtitleTextStyle: UIFont.TextStyle = .caption1
         public static let crossPostLineSpacing: CGFloat = 2.0
 
         public static let actionButtonSize: CGSize = CGSize(width: 20, height: 20)


### PR DESCRIPTION
Fixes #14206

Updates the cross post cell design to match the new reader UI updates (https://github.com/wordpress-mobile/WordPress-iOS/pull/14185)

## Screenshots
### Light Mode
| Before | After |
|---|---|
| <img width="376" alt="Screen Shot 2020-05-27 at 5 22 20 PM" src="https://user-images.githubusercontent.com/793774/83084814-efcfa200-a03e-11ea-9607-4053498c7f9d.png"> | <img width="375" alt="Screen Shot 2020-05-27 at 5 25 45 PM" src="https://user-images.githubusercontent.com/793774/83084884-20afd700-a03f-11ea-98cb-b76fe978d66f.png"> |

### Dark Mode
| Before | After |
|---|---|
|<img width="371" alt="Screen Shot 2020-05-27 at 5 22 47 PM" src="https://user-images.githubusercontent.com/793774/83084830-f5c58300-a03e-11ea-89a1-9eabf18c1ed7.png"> | <img width="374" alt="Screen Shot 2020-05-27 at 5 25 40 PM" src="https://user-images.githubusercontent.com/793774/83084901-2d342f80-a03f-11ea-904b-fae72a061b9d.png"> |


## To test:
1. Open the app
2. Open the Reader
3. Tap on a team tab 
4. Locate a cross post
5. Verify it looks good in both dark and light modes

## PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
