### PR TITLE
Add support for Iterable deep links

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -458,7 +458,9 @@ extension WordPressAppDelegate {
                 return
         }
 
-        UniversalLinkRouter.shared.handle(url: url)
+        trackDeepLink(for: url) { url in
+            UniversalLinkRouter.shared.handle(url: url)
+        }
     }
 
     @objc func setupNetworkActivityIndicator() {
@@ -470,6 +472,31 @@ extension WordPressAppDelegate {
             Environment.replaceEnvironment(wordPressComApiBase: baseUrl)
         }
     }
+}
+
+// MARK: - Deep Link Handling
+
+extension WordPressAppDelegate {
+
+    private func trackDeepLink(for url: URL, completion: @escaping ((URL) -> Void)) {
+        guard isIterableDeepLink(url) else {
+            completion(url)
+            return
+        }
+
+        let task = URLSession.shared.dataTask(with: url) {(_, response, error) in
+            if let url = response?.url {
+                completion(url)
+            }
+        }
+        task.resume()
+    }
+
+    private func isIterableDeepLink(_ url: URL) -> Bool {
+        return url.absoluteString.contains(WordPressAppDelegate.iterableDomain)
+    }
+
+    private static let iterableDomain = "links.wp.a8cmail.com"
 }
 
 // MARK: - UIAppearance

--- a/WordPress/WordPress-Alpha.entitlements
+++ b/WordPress/WordPress-Alpha.entitlements
@@ -7,6 +7,7 @@
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
+		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/WordPress-Internal.entitlements
+++ b/WordPress/WordPress-Internal.entitlements
@@ -9,6 +9,7 @@
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
+		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/WordPress.entitlements
+++ b/WordPress/WordPress.entitlements
@@ -14,6 +14,7 @@
 		<string>applinks:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:public-api.wordpress.com</string>
+		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>


### PR DESCRIPTION
This PR adds preliminary support for Iterable deep links. The server side of things isn't set up yet, so we can't actually verify that the deep links work. But we can verify that existing links still work okay.

I've deviated a little from the [Iterable example code](https://support.iterable.com/hc/en-us/articles/115003909366-Handling-iOS-Deep-Links-Without-the-SDK-), as I can't see how thier way of detecting an Iterable deep link would work – they use a regex, which to me looks like it'll basically just match any URL? (`/a/[a-zA-Z0-9]+`) so instead, I'm checking for our Iterable domain.

**To test:**

* Build and run in the simulator
* Background the app
* In the Terminal, run: `xcrun simctl openurl booted https://wordpress.com/notifications` and verify that the app launches to the Notifications screen. If one of our normal deep links loads, the others should all be fine.
* Check the code to see how we'd detect and handle an Iterable deep link.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
