### PR TITLE
Add tag should be gray and disabled when there isn't text inside

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
@@ -100,4 +100,8 @@ typedef void (^SettingsAttributedTextChanged)(NSAttributedString * _Nonnull);
                                    placeholder:(NSString * __nullable)placeholder
                                           hint:(NSString * __nullable)hint;
 
+/// The method has been exposed for the testcase
+///
+- (BOOL)textPassesValidation;
+
 @end

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -124,7 +124,7 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     [super viewDidAppear:animated];
     [self.textField becomeFirstResponder];
     // Fire initial status
-    [self validateTextInput:_textField];
+    [self validateTextInput:self.textField];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -178,7 +178,7 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
 
 - (BOOL)textPassesValidation
 {
-    switch(self.mode){
+    switch (self.mode) {
         case SettingsTextModesEmail:
             return !self.validatesInput || self.textField.text.isValidEmail;
             break;
@@ -197,10 +197,7 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
 //TODO: This method should be stay in the WorpressShared project
 - (BOOL)isValidText:(NSString*)text
 {
-    NSString *regex = @"\\w+";
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF MATCHES %@" argumentArray:@[regex]];
-
-    return [predicate evaluateWithObject:text];
+    return [text length] > 0;
 }
 
 - (void)validateTextInput:(id)sender
@@ -212,12 +209,12 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
 - (void)evaluateActionButton
 {
     BOOL isValid = self.textPassesValidation;
-    if (isValid){
-        [_actionCell setUserInteractionEnabled: isValid];
-        _actionCell.textLabel.textColor = UIColor.murielText;
-    }else{
-        [_actionCell setUserInteractionEnabled: isValid];
-        _actionCell.textLabel.textColor = UIColor.murielTextSubtle;
+    if (isValid) {
+        [self.actionCell setUserInteractionEnabled: isValid];
+        self.actionCell.textLabel.textColor = UIColor.murielText;
+    } else {
+        [self.actionCell setUserInteractionEnabled: isValid];
+        self.actionCell.textLabel.textColor = UIColor.murielTextSubtle;
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -676,6 +676,7 @@
 		5D6C4B131B604190005E3C43 /* UITextView+RichTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6C4B101B604190005E3C43 /* UITextView+RichTextView.swift */; };
 		5D732F971AE84E3C00CD89E7 /* PostListFooterView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D732F961AE84E3C00CD89E7 /* PostListFooterView.m */; };
 		5D732F991AE84E5400CD89E7 /* PostListFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D732F981AE84E5400CD89E7 /* PostListFooterView.xib */; };
+		5D75ABAF247EEDF700C812A5 /* SettingsTextViewControllerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D75ABAE247EEDF700C812A5 /* SettingsTextViewControllerTest.swift */; };
 		5D7DEA2919D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7DEA2819D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift */; };
 		5D839AA8187F0D6B00811F4A /* PostFeaturedImageCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D839AA7187F0D6B00811F4A /* PostFeaturedImageCell.m */; };
 		5D839AAB187F0D8000811F4A /* PostGeolocationCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D839AAA187F0D8000811F4A /* PostGeolocationCell.m */; };
@@ -1593,10 +1594,10 @@
 		C81CCD83243BF7A600A83E27 /* TenorDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81CCD79243BF7A600A83E27 /* TenorDataLoader.swift */; };
 		C81CCD84243BF7A600A83E27 /* NoResultsTenorConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81CCD7A243BF7A600A83E27 /* NoResultsTenorConfiguration.swift */; };
 		C81CCD86243C00E000A83E27 /* TenorPageableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81CCD85243C00E000A83E27 /* TenorPageableTests.swift */; };
+		C856748F243EF177001A995E /* GutenbergTenorMediaPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C856748E243EF177001A995E /* GutenbergTenorMediaPicker.swift */; };
 		C8567492243F3751001A995E /* tenor-search-response.json in Resources */ = {isa = PBXBuildFile; fileRef = C8567491243F3751001A995E /* tenor-search-response.json */; };
 		C8567494243F388F001A995E /* tenor-invalid-search-reponse.json in Resources */ = {isa = PBXBuildFile; fileRef = C8567493243F388F001A995E /* tenor-invalid-search-reponse.json */; };
 		C8567496243F3D37001A995E /* TenorResultsPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8567495243F3D37001A995E /* TenorResultsPageTests.swift */; };
-		C856748F243EF177001A995E /* GutenbergTenorMediaPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C856748E243EF177001A995E /* GutenbergTenorMediaPicker.swift */; };
 		C8567498243F41CA001A995E /* MockTenorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8567497243F41CA001A995E /* MockTenorService.swift */; };
 		C856749A243F4292001A995E /* TenorMockDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8567499243F4292001A995E /* TenorMockDataHelper.swift */; };
 		CC19BE06223FECAC00CAB3E1 /* EditorPostSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC19BE05223FECAC00CAB3E1 /* EditorPostSettings.swift */; };
@@ -3080,6 +3081,7 @@
 		5D732F951AE84E3C00CD89E7 /* PostListFooterView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostListFooterView.h; sourceTree = "<group>"; };
 		5D732F961AE84E3C00CD89E7 /* PostListFooterView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PostListFooterView.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		5D732F981AE84E5400CD89E7 /* PostListFooterView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PostListFooterView.xib; sourceTree = "<group>"; };
+		5D75ABAE247EEDF700C812A5 /* SettingsTextViewControllerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTextViewControllerTest.swift; sourceTree = "<group>"; };
 		5D784E741A80430D005D7388 /* WordPress 27.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 27.xcdatamodel"; sourceTree = "<group>"; };
 		5D7DEA2819D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+ReaderComments.swift"; sourceTree = "<group>"; };
 		5D839AA6187F0D6B00811F4A /* PostFeaturedImageCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostFeaturedImageCell.h; sourceTree = "<group>"; };
@@ -4093,10 +4095,10 @@
 		C81CCD79243BF7A600A83E27 /* TenorDataLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TenorDataLoader.swift; sourceTree = "<group>"; };
 		C81CCD7A243BF7A600A83E27 /* NoResultsTenorConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoResultsTenorConfiguration.swift; sourceTree = "<group>"; };
 		C81CCD85243C00E000A83E27 /* TenorPageableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TenorPageableTests.swift; sourceTree = "<group>"; };
+		C856748E243EF177001A995E /* GutenbergTenorMediaPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergTenorMediaPicker.swift; sourceTree = "<group>"; };
 		C8567491243F3751001A995E /* tenor-search-response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tenor-search-response.json"; sourceTree = "<group>"; };
 		C8567493243F388F001A995E /* tenor-invalid-search-reponse.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "tenor-invalid-search-reponse.json"; sourceTree = "<group>"; };
 		C8567495243F3D37001A995E /* TenorResultsPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TenorResultsPageTests.swift; sourceTree = "<group>"; };
-		C856748E243EF177001A995E /* GutenbergTenorMediaPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergTenorMediaPicker.swift; sourceTree = "<group>"; };
 		C8567497243F41CA001A995E /* MockTenorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTenorService.swift; sourceTree = "<group>"; };
 		C8567499243F4292001A995E /* TenorMockDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TenorMockDataHelper.swift; sourceTree = "<group>"; };
 		C856749B243F462F001A995E /* TenorDataSouceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TenorDataSouceTests.swift; sourceTree = "<group>"; };
@@ -5530,7 +5532,7 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				98D31BBF239720E4009CFF43 /* MainInterface.storyboard */,
@@ -6588,6 +6590,14 @@
 				5D6C4B101B604190005E3C43 /* UITextView+RichTextView.swift */,
 			);
 			path = RichTextView;
+			sourceTree = "<group>";
+		};
+		5D75ABAD247EEDCF00C812A5 /* Tools */ = {
+			isa = PBXGroup;
+			children = (
+				5D75ABAE247EEDF700C812A5 /* SettingsTextViewControllerTest.swift */,
+			);
+			name = Tools;
 			sourceTree = "<group>";
 		};
 		5D7A577D1AFBFD7C0097C028 /* Models */ = {
@@ -9732,6 +9742,7 @@
 				D88A6490208D79F1008AE9BC /* Stock Photos */,
 				BEA0E4821BD8353B000AEE81 /* System */,
 				59B48B601B99E0B0008EBB84 /* TestUtilities */,
+				5D75ABAD247EEDCF00C812A5 /* Tools */,
 				852416D01A12ED2D0030700C /* Utility */,
 				BE20F5E11B2F738E0020694C /* ViewRelated */,
 				FF9839A71CD3960600E85258 /* WordPressAPI */,
@@ -10834,7 +10845,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -13513,6 +13524,7 @@
 				FF1B11E7238FE27A0038B93E /* GutenbergGalleryUploadProcessorTests.swift in Sources */,
 				8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */,
 				D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */,
+				5D75ABAF247EEDF700C812A5 /* SettingsTextViewControllerTest.swift in Sources */,
 				E135965D1E7152D1006C6606 /* RecentSitesServiceTests.swift in Sources */,
 				D88A64AC208D9B09008AE9BC /* StockPhotosPageableTests.swift in Sources */,
 				40C403F82215D88100E8C894 /* TopViewedStatsTests.swift in Sources */,

--- a/WordPress/WordPressTest/SettingsTextViewControllerTest.swift
+++ b/WordPress/WordPressTest/SettingsTextViewControllerTest.swift
@@ -1,0 +1,64 @@
+//
+//  SettingsTextViewControllerTest.swift
+//  WordPressTest
+//
+//  Created by Francesco Scalise on 27/05/2020.
+//  Copyright © 2020 WordPress. All rights reserved.
+//
+
+import XCTest
+@testable import WordPress
+
+class SettingsTextViewControllerTest: XCTestCase{
+    var settingsVC: SettingsTextViewController!
+    
+    override func setUp() {
+        super.setUp()
+        
+        settingsVC = SettingsTextViewController(text: nil, placeholder: "placeholder", hint: nil)
+    }
+    
+    func testWrongEmailValidation() {
+        settingsVC.mode = .email
+        settingsVC.text = "@email.com"
+        XCTAssertFalse(settingsVC.textPassesValidation())
+    }
+    
+    func testCorrectEmailValidation() {
+        settingsVC.mode = .email
+        settingsVC.text = "user@email.com"
+        XCTAssertTrue(settingsVC.textPassesValidation())
+    }
+    
+    func testWrongTextValidation() {
+        settingsVC.mode = .text
+        settingsVC.text = ""
+        XCTAssertFalse(settingsVC.textPassesValidation())
+    }
+    
+    func testTextValidation() {
+        settingsVC.mode = .text
+        settingsVC.text = "abc"
+        XCTAssertTrue(settingsVC.textPassesValidation())
+    }
+    
+    func testWrongLowerCaseTextValidation() {
+        settingsVC.mode = .lowerCaseText
+        settingsVC.text = ""
+        XCTAssertFalse(settingsVC.textPassesValidation())
+    }
+    
+    func testLowerCaseTextValidation() {
+        settingsVC.mode = .lowerCaseText
+        settingsVC.text = "abc"
+        XCTAssertTrue(settingsVC.textPassesValidation())
+    }
+    
+    // and so on..
+
+    override func tearDown() {
+        super.tearDown()
+        
+        settingsVC = nil
+    }
+}

--- a/WordPress/WordPressTest/SettingsTextViewControllerTest.swift
+++ b/WordPress/WordPressTest/SettingsTextViewControllerTest.swift
@@ -1,10 +1,3 @@
-//
-//  SettingsTextViewControllerTest.swift
-//  WordPressTest
-//
-//  Created by Francesco Scalise on 27/05/2020.
-//  Copyright © 2020 WordPress. All rights reserved.
-//
 
 import XCTest
 @testable import WordPress

--- a/WordPress/WordPressTest/SettingsTextViewControllerTest.swift
+++ b/WordPress/WordPressTest/SettingsTextViewControllerTest.swift
@@ -9,56 +9,55 @@
 import XCTest
 @testable import WordPress
 
-class SettingsTextViewControllerTest: XCTestCase{
+class SettingsTextViewControllerTest: XCTestCase {
     var settingsVC: SettingsTextViewController!
-    
+
     override func setUp() {
         super.setUp()
-        
+
         settingsVC = SettingsTextViewController(text: nil, placeholder: "placeholder", hint: nil)
     }
-    
+
     func testWrongEmailValidation() {
         settingsVC.mode = .email
         settingsVC.text = "@email.com"
         XCTAssertFalse(settingsVC.textPassesValidation())
     }
-    
+
     func testCorrectEmailValidation() {
         settingsVC.mode = .email
         settingsVC.text = "user@email.com"
         XCTAssertTrue(settingsVC.textPassesValidation())
     }
-    
+
     func testWrongTextValidation() {
         settingsVC.mode = .text
         settingsVC.text = ""
         XCTAssertFalse(settingsVC.textPassesValidation())
     }
-    
+
     func testTextValidation() {
         settingsVC.mode = .text
         settingsVC.text = "abc"
         XCTAssertTrue(settingsVC.textPassesValidation())
     }
-    
+
     func testWrongLowerCaseTextValidation() {
         settingsVC.mode = .lowerCaseText
         settingsVC.text = ""
         XCTAssertFalse(settingsVC.textPassesValidation())
     }
-    
+
     func testLowerCaseTextValidation() {
         settingsVC.mode = .lowerCaseText
         settingsVC.text = "abc"
         XCTAssertTrue(settingsVC.textPassesValidation())
     }
-    
-    // and so on..
 
+    // and so on..
     override func tearDown() {
         super.tearDown()
-        
+
         settingsVC = nil
     }
 }


### PR DESCRIPTION
Fixes #14119 
With this change, the ActionButton used to add a tag is disabled until at list a char is inserted. 
To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.