### PR TITLE
Push Notifications Permissions - In-line Prompt After 5 Visits

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -170,6 +170,10 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
         markWelcomeNotificationAsSeenIfNeeded()
 
+        if userDefaults.notificationsTabAccessCount < Constants.inlineTabAccessCount {
+            userDefaults.notificationsTabAccessCount += 1
+        }
+
         if shouldShowPrimeForPush {
             setupNotificationPrompt()
         } else if AppRatingUtility.shared.shouldPromptForAppReview(section: InlinePrompt.section) {
@@ -1281,7 +1285,9 @@ extension NotificationsViewController: NoResultsViewControllerDelegate {
 //
 internal extension NotificationsViewController {
     func showInlinePrompt() {
-        guard inlinePromptView.alpha != WPAlphaFull, UserDefaults.standard.notificationPrimerAlertWasDisplayed else {
+        guard inlinePromptView.alpha != WPAlphaFull,
+            userDefaults.notificationPrimerAlertWasDisplayed,
+            userDefaults.notificationsTabAccessCount >= Constants.inlineTabAccessCount else {
             return
         }
 
@@ -1637,11 +1643,12 @@ extension NotificationsViewController: UIViewControllerTransitioningDelegate {
     }
 
     private func showNotificationPrimerAlertIfNeeded() {
-        guard !UserDefaults.standard.notificationPrimerAlertWasDisplayed else {
+
+        guard !userDefaults.notificationPrimerAlertWasDisplayed else {
             return
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.displayAlertDelay) {
                 self.showNotificationPrimerAlert()
         }
     }
@@ -1672,5 +1679,10 @@ extension NotificationsViewController: UIViewControllerTransitioningDelegate {
             alert.transitioningDelegate = self
             self?.tabBarController?.present(alert, animated: true)
         }
+    }
+
+    private enum Constants {
+        static let inlineTabAccessCount = 5
+        static let displayAlertDelay = 0.2
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1682,7 +1682,7 @@ extension NotificationsViewController: UIViewControllerTransitioningDelegate {
     }
 
     private enum Constants {
-        static let inlineTabAccessCount = 5
+        static let inlineTabAccessCount = 6
         static let displayAlertDelay = 0.2
     }
 }

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+NotificationPrimer.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+NotificationPrimer.swift
@@ -53,14 +53,25 @@ extension FancyAlertViewController {
 extension UserDefaults {
     private enum Keys: String {
         case notificationPrimerAlertWasDisplayed = "NotificationPrimerAlertWasDisplayed"
+        case notificationsTabAccessCount = "NotificationsTabAccessCount"
     }
 
     var notificationPrimerAlertWasDisplayed: Bool {
         get {
-            return bool(forKey: Keys.notificationPrimerAlertWasDisplayed.rawValue)
+            bool(forKey: Keys.notificationPrimerAlertWasDisplayed.rawValue)
         }
         set {
             set(newValue, forKey: Keys.notificationPrimerAlertWasDisplayed.rawValue)
+        }
+    }
+
+    var notificationsTabAccessCount: Int {
+        get {
+            integer(forKey: Keys.notificationsTabAccessCount.rawValue)
+        }
+
+        set {
+            set(newValue, forKey: Keys.notificationsTabAccessCount.rawValue)
         }
     }
 }


### PR DESCRIPTION
Ref #14202 14202

To test:

- perform a fresh install and login or signup
- go to 'Notifications' tab
- When the alert shows, tab 'Not Now'
- Go to another tab and back to 'Notifications' four more times
- Verify that the in-line prompt shows up

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
