### PR TITLE
Disable Homepage Settings feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -42,7 +42,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .swiftCoreData:
             return BuildConfiguration.current == .localDeveloper
         case .homepageSettings:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         }
     }
 }


### PR DESCRIPTION
I forgot to disable the Homepage Settings feature flag for the 15.0 test release! This PR fixes that.

**To test:**

* Build and run
* Ensure you can see Homepage Settings under Site Settings for a WordPress.com site.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
