### PR TITLE
[Gutenberg] Cover block: Allow uploading video outside of editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 15.1
 -----
- 
+ * [**] Block Editor: Add support to upload videos to Cover Blocks after the editor has closed.
+
 15.0
 -----
 * [**] Block editor: Fix media upload progress when there's no connection.
@@ -38,7 +39,7 @@
 * Support the superscript and subscript HTML formatting on the Block Editor and Classic Editor.
 * [***] You can now draw on images to annotate them using the Edit image feature in the post editor.
 * [*] Fixed a bug on the editors where changing a featured image didn't trigger that the post/page changed.
- 
+
 14.8.1
 -----
 * Fix adding and removing of featured images to posts.
@@ -59,7 +60,7 @@
 * [internal] the "send magic link" screen has navigation changes that can cause regressions. See https://git.io/Jfqiz for testing details.
 * Updated UI for Login and Signup epilogues.
 * Fixes delayed split view resizing while rotating your device.
- 
+
 14.7
 -----
 * Classic Editor: Fixed action sheet position for additional Media sources picker on iPad
@@ -78,9 +79,9 @@
 * Updated site details screen title to My Site, to avoid duplicating the title of the current site which is displayed in the screen's header area.
 * You can now schedule your post, add tags or change the visibility before hitting "Publish Now" — and you don't have to go to the Post Settings for this!
 
-* Login Epilogue: fixed issue where account information never stopped loading for some self-hosted sites. 
-* Updated site details screen title to My Site, to avoid duplicating the title of the current site which is displayed in the screen's header area. 
- 
+* Login Epilogue: fixed issue where account information never stopped loading for some self-hosted sites.
+* Updated site details screen title to My Site, to avoid duplicating the title of the current site which is displayed in the screen's header area.
+
 14.6
 -----
 * [internal] the login flow with 2-factor authentication enabled has code changes that can cause regressions. See https://git.io/Jvdil for testing details.

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -321,6 +321,9 @@ class PostCoordinator: NSObject {
             let gutenbergVideoPostUploadProcessor = GutenbergVideoUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
             gutenbergProcessors.append(gutenbergVideoPostUploadProcessor)
 
+            let gutenbergCoverPostUploadProcessor = GutenbergCoverUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
+            gutenbergProcessors.append(gutenbergCoverPostUploadProcessor)
+
             let videoPostUploadProcessor = VideoUploadProcessor(mediaUploadID: mediaUploadID, remoteURLString: remoteURLStr, videoPressID: media.videopressGUID)
             aztecProcessors.append(videoPostUploadProcessor)
         } else if let remoteURL = URL(string: remoteURLStr) {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergCoverUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergCoverUploadProcessor.swift
@@ -8,12 +8,8 @@ class GutenbergCoverUploadProcessor: Processor {
         static let name = "wp:cover"
         static let id = "id"
         static let url = "url"
-    }
-
-    private struct HTMLKeys {
-        static let name = "div"
-        static let styleComponents = "style"
-        static let backgroundImage = "background-image:url"
+        static let backgroundType = "backgroundType"
+        static let videoType = "video"
     }
 
     let mediaUploadID: Int32
@@ -42,50 +38,13 @@ class GutenbergCoverUploadProcessor: Processor {
             block += jsonString
         }
 
+        let innerProcessor = self.isVideo(attributes) ? self.videoUploadProcessor : self.imgUploadProcessor
+
         block += " -->"
-        block += self.htmlUploadProcessor.process(coverBlock.content)
+        block += innerProcessor.process(coverBlock.content)
         block += "<!-- /\(CoverBlockKeys.name) -->"
         return block
     })
-
-    lazy var htmlUploadProcessor = HTMLProcessor(for: HTMLKeys.name, replacer: { (div) in
-
-        guard let styleAttributeValue = div.attributes[HTMLKeys.styleComponents]?.value,
-            case let .string(styleAttribute) = styleAttributeValue
-            else {
-                return nil
-        }
-
-        let range = styleAttribute.utf16NSRange(from: styleAttribute.startIndex ..< styleAttribute.endIndex)
-        let matches = self.localBackgroundImageRegex.matches(in: styleAttribute,
-                                                             options: [],
-                                                             range: range)
-        guard matches.count == 1 else {
-            return nil
-        }
-
-        let style = "\(HTMLKeys.backgroundImage)(\(self.remoteURLString))"
-        let updatedStyleAttribute = self.localBackgroundImageRegex.stringByReplacingMatches(in: styleAttribute,
-                                                                                            options: [],
-                                                                                            range: range,
-                                                                                            withTemplate: style)
-
-        var attributes = div.attributes
-        attributes.set(.string(updatedStyleAttribute), forKey: HTMLKeys.styleComponents)
-
-        let attributeSerializer = ShortcodeAttributeSerializer()
-        var html = "<\(HTMLKeys.name) "
-        html += attributeSerializer.serialize(attributes)
-        html += ">"
-        html += div.content ?? ""
-        html += "</\(HTMLKeys.name)>"
-        return html
-    })
-
-    private let localBackgroundImageRegex: NSRegularExpression = {
-        let pattern = "background-image:[ ]?url\\(file:\\/\\/\\/.*\\)"
-        return try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
-    }()
 
     func process(_ text: String) -> String {
         return coverBlockProcessor.process(text)
@@ -105,4 +64,74 @@ class GutenbergCoverUploadProcessor: Processor {
         block += "<!-- /wp:cover -->"
         return block
     }
+
+    // Image Support
+    private struct ImgHTMLKeys {
+        static let name = "div"
+        static let styleComponents = "style"
+        static let backgroundImage = "background-image:url"
+    }
+
+    lazy var imgUploadProcessor = HTMLProcessor(for: ImgHTMLKeys.name, replacer: { (div) in
+
+        guard let styleAttributeValue = div.attributes[ImgHTMLKeys.styleComponents]?.value,
+            case let .string(styleAttribute) = styleAttributeValue
+            else {
+                return nil
+        }
+
+        let range = styleAttribute.utf16NSRange(from: styleAttribute.startIndex ..< styleAttribute.endIndex)
+        let matches = self.localBackgroundImageRegex.matches(in: styleAttribute,
+                                                             options: [],
+                                                             range: range)
+        guard matches.count == 1 else {
+            return nil
+        }
+
+        let style = "\(ImgHTMLKeys.backgroundImage)(\(self.remoteURLString))"
+        let updatedStyleAttribute = self.localBackgroundImageRegex.stringByReplacingMatches(in: styleAttribute,
+                                                                                            options: [],
+                                                                                            range: range,
+                                                                                            withTemplate: style)
+
+        var attributes = div.attributes
+        attributes.set(.string(updatedStyleAttribute), forKey: ImgHTMLKeys.styleComponents)
+
+        let attributeSerializer = ShortcodeAttributeSerializer()
+        var html = "<\(ImgHTMLKeys.name) "
+        html += attributeSerializer.serialize(attributes)
+        html += ">"
+        html += div.content ?? ""
+        html += "</\(ImgHTMLKeys.name)>"
+        return html
+    })
+
+    private let localBackgroundImageRegex: NSRegularExpression = {
+        let pattern = "background-image:[ ]?url\\(file:\\/\\/\\/.*\\)"
+        return try! NSRegularExpression(pattern: pattern, options: .caseInsensitive)
+    }()
+
+    // Video Support
+    private struct VideoHTMLKeys {
+        static let name = "video"
+        static let source = "src"
+    }
+
+    private func isVideo(_ attributes: [String: Any]) -> Bool {
+        guard let backgroundType = attributes[CoverBlockKeys.backgroundType] as? String else { return false }
+        return backgroundType == CoverBlockKeys.videoType
+    }
+
+    lazy var videoUploadProcessor = HTMLProcessor(for: VideoHTMLKeys.name, replacer: { (video) in
+        var attributes = video.attributes
+        attributes.set(.string(self.remoteURLString), forKey: VideoHTMLKeys.source)
+
+        let attributeSerializer = ShortcodeAttributeSerializer()
+        var html = "<\(VideoHTMLKeys.name) "
+        html += attributeSerializer.serialize(attributes)
+        html += ">"
+        html += video.content ?? ""
+        html += "</\(VideoHTMLKeys.name)>"
+        return html
+    })
 }


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/1740

## To test:

- Close/Re-open post with an ongoing **video** upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/cover.md#tc010)
- Close post with an ongoing **video** upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/cover.md#tc011)
- Test the upload outside of the editor with a combination of Video cover blocks within Image cover blocks and vice versa. Also replacing the image of the outer cover block. 

### Image Testing (Validating there isn't a regression)
- Close/Re-open post with an ongoing **image** upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/cover.md#tc010)
- Close post with an ongoing **image** upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/cover.md#tc011)

## PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
