### PR TITLE
Site creation domain search textField becomes first responder

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -17,14 +17,6 @@ final class SearchTextField: UITextField {
         static let textInset        = CGFloat(56)
     }
 
-    // MARK: Becoming First Responder
-
-    var allowFirstResponderStatus: Bool = true
-
-    override var canBecomeFirstResponder: Bool {
-        return allowFirstResponderStatus
-    }
-
     // MARK: UIView
 
     init() {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -124,13 +124,11 @@ final class WebAddressWizardContent: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         resignTextFieldResponderIfNeeded()
-        disallowTextFieldFirstResponder()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         restoreSearchIfNeeded()
-        allowTextFieldFirstResponder()
         postScreenChangedForVoiceOver()
     }
 
@@ -141,34 +139,12 @@ final class WebAddressWizardContent: UIViewController {
         clearContent()
     }
 
-    // MARK: Workaround: Text Field First Responder Issues
-
-    /// This method is uses as a workaround for what appears to be an SDK bug.
-    ///
-    /// There's an issue that's causing `textField.resignFirstResponder()` to be ignored when called from
-    /// within `viewDidDisappear(animated:)`.  This method makes it so that the text field just can't
-    /// have first responder whenever we don't want it to.
-    ///
-    /// Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/11702
-    ///
-    private func allowTextFieldFirstResponder() {
+    private func textFieldResignFirstResponder() {
         guard let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader else {
             return
         }
 
-        header.textField.allowFirstResponderStatus = true
-    }
-
-    /// This method makes it impossible for the text field to become first responder.
-    ///
-    /// Read the documentation of `allowTextFieldFirstResponder` for more details.
-    ///
-    private func disallowTextFieldFirstResponder() {
-        guard let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader else {
-            return
-        }
-
-        header.textField.allowFirstResponderStatus = false
+        header.textField.resignFirstResponder()
     }
 
     // MARK: Private behavior
@@ -304,7 +280,6 @@ final class WebAddressWizardContent: UIViewController {
 
         let textField = header.textField
         textField.resignFirstResponder()
-        textField.allowFirstResponderStatus = false
     }
 
     private func restoreSearchIfNeeded() {
@@ -316,14 +291,11 @@ final class WebAddressWizardContent: UIViewController {
     }
 
     private func prepareViewIfNeeded() {
-        guard WPDeviceIdentification.isiPhone(), let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader else {
+        guard let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader else {
             return
         }
 
         let textField = header.textField
-        guard let inputText = textField.text, !inputText.isEmpty else {
-            return
-        }
         textField.becomeFirstResponder()
     }
 


### PR DESCRIPTION
Fixes (same issue on android) https://github.com/wordpress-mobile/WordPress-Android/issues/12084

To test:
1. Create a site 
2. Choose segment
3. See that the keyboard is up immediately when domain search screen is visible 
4. Go back and forth, enter different values, remove tex.. check that everything works as expected

As part of this PR, I remove workaround code done to fix an issue with the textfield not resigning first responder. Since then we have shortened site creation steps so the only screen that has text input is domain search. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
