### PR TITLE
ULS: set unified views background color

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -184,9 +184,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.18.0-beta.4'
+    # pod 'WordPressAuthenticator', '~> 1.18.0-beta.5'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/182-unified_style'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -184,9 +184,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.18.0-beta.5'
+    pod 'WordPressAuthenticator', '~> 1.18.0-beta.5'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/182-unified_style'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -380,7 +380,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.2)
   - WordPress-Editor-iOS (1.19.2):
     - WordPress-Aztec-iOS (= 1.19.2)
-  - WordPressAuthenticator (1.18.0-beta.4):
+  - WordPressAuthenticator (1.18.0-beta.5):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -483,7 +483,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.2)
-  - WordPressAuthenticator (~> 1.18.0-beta.4)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/182-unified_style`)
   - WordPressKit (~> 4.9.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -532,7 +532,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -618,6 +617,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: a3a155d0053c75985960ae7ac8ecfaa2e3732efa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :branch: feature/182-unified_style
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/a3a155d0053c75985960ae7ac8ecfaa2e3732efa/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -631,6 +633,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: a3a155d0053c75985960ae7ac8ecfaa2e3732efa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :commit: 7c915d3639702e45a01e65cc57aec02244ca8cea
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -703,7 +708,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: d01bf0c5e150ae6a046f06ba63b7cc2762061c0b
   WordPress-Editor-iOS: 5b726489e5ae07b7281a2862d69aba2d5c83f140
-  WordPressAuthenticator: 5459031b7834a55072307a40e060d501c2db1c90
+  WordPressAuthenticator: b9fff706c7900c8f58843e839ddd7f6d8d021db9
   WordPressKit: 2e707edd1b28e8dd0f74a40469ca6e7be7b20a70
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
@@ -720,6 +725,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 2bc3eb3ac69e02d017a5a63f1c82bd0f779a26d7
+PODFILE CHECKSUM: c517e2812f6fdd0538a5fb2685bcf1ac73ce10e1
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -483,7 +483,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.2)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/182-unified_style`)
+  - WordPressAuthenticator (~> 1.18.0-beta.5)
   - WordPressKit (~> 4.9.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -532,6 +532,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -617,9 +618,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: a3a155d0053c75985960ae7ac8ecfaa2e3732efa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressAuthenticator:
-    :branch: feature/182-unified_style
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/a3a155d0053c75985960ae7ac8ecfaa2e3732efa/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -633,9 +631,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: a3a155d0053c75985960ae7ac8ecfaa2e3732efa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressAuthenticator:
-    :commit: 7c915d3639702e45a01e65cc57aec02244ca8cea
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -725,6 +720,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: c517e2812f6fdd0538a5fb2685bcf1ac73ce10e1
+PODFILE CHECKSUM: 70ce23efd403fdcd56794720c66be9f3d3d22077
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -69,7 +69,7 @@ class WordPressAuthenticationManager: NSObject {
                                                 statusBarStyle: .lightContent)
 
         let unifiedStyle = WordPressAuthenticatorUnifiedStyle(viewControllerBackgroundColor: .basicBackground)
-        
+
         WordPressAuthenticator.initialize(configuration: configuration,
                                           style: style,
                                           unifiedStyle: unifiedStyle)

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -59,7 +59,7 @@ class WordPressAuthenticationManager: NSObject {
                                                 instructionColor: .text,
                                                 subheadlineColor: .textSubtle,
                                                 placeholderColor: .textPlaceholder,
-                                                viewControllerBackgroundColor: FeatureFlag.unifiedSiteAddress.enabled ? .white : .listBackground,
+                                                viewControllerBackgroundColor: .listBackground,
                                                 textFieldBackgroundColor: .listForeground,
                                                 buttonViewBackgroundColor: .authButtonViewBackground,
                                                 navBarImage: .gridicon(.mySites),
@@ -68,8 +68,11 @@ class WordPressAuthenticationManager: NSObject {
                                                 prologueTitleColor: .textInverted,
                                                 statusBarStyle: .lightContent)
 
+        let unifiedStyle = WordPressAuthenticatorUnifiedStyle(viewControllerBackgroundColor: .basicBackground)
+        
         WordPressAuthenticator.initialize(configuration: configuration,
-                                          style: style)
+                                          style: style,
+                                          unifiedStyle: unifiedStyle)
     }
 }
 


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/182
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/297

This change:
1. Updates the unified `viewControllerBackgroundColor` to work in light and dark modes (i.e white and black).
2. Uses the Auth changes to set background color via `WordPressAuthenticatorUnifiedStyle`.

To test:
- Enable the `unifiedSiteAddress` feature flag.
- Run the app.
- Log out if necessary.
- Go to Log In > Site Address.
- Verify the background is white.
- Enable dark mode.
- Verify the background is black.


| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-03 at 18 23 22](https://user-images.githubusercontent.com/1816888/83703140-de047680-a5cb-11ea-92a2-ecb42f3fe67d.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-03 at 18 23 26](https://user-images.githubusercontent.com/1816888/83703149-e361c100-a5cb-11ea-88fe-caf143d3de2a.png) |
|--------|-------|


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
