### PR TITLE
Remove unused showNotificationsPrimerAlert from BlogDetailsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1581,36 +1581,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
-- (void)showNotificationPrimerAlert
-{
-    if ([[NSUserDefaults standardUserDefaults] notificationPrimerAlertWasDisplayed]) {
-        return;
-    }
-    NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:mainContext];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-    if (defaultAccount == nil) {
-        return;
-    }
-    [[PushNotificationsManager shared] loadAuthorizationStatusWithCompletion:^(UNAuthorizationStatus enabled) {
-        if (enabled == UNAuthorizationStatusNotDetermined) {
-            [NSUserDefaults standardUserDefaults].notificationPrimerAlertWasDisplayed = YES;
-
-            FancyAlertViewController *alert = [FancyAlertViewController makeNotificationPrimerAlertControllerWithApproveAction:^(FancyAlertViewController* controller) {
-                [[InteractiveNotificationsManager shared] requestAuthorizationWithCompletion:^() {
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [controller dismissViewControllerAnimated:true completion:^{}];
-                    });
-                }];
-            }];
-            alert.modalPresentationStyle = UIModalPresentationCustom;
-            alert.transitioningDelegate = self;
-
-            [self.tabBarController presentViewController:alert animated:YES completion:nil];
-        }
-    }];
-}
-
 #pragma mark - Remove Site
 
 - (void)showRemoveSiteAlert


### PR DESCRIPTION
Previously moved the method `showNotificationsPrimerAlert` from `BlogDetailsViewController+FancyAlerts` to `NotificationsViewController` in order to move the alert to the 'Notifications' tab, then noticed that there was another `showNotificationsPrimerAlert` in `BlogDetailsViewController` that is not called from anywhere.

Ref #14202

To test:

- verify that the app builds and runs
- optionally, fresh install, login, go to 'Notifications' and verify that the notification primer alert shows up.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
