### PR TITLE
Privacy settings: add a crash reporting option

### DIFF
--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -24,3 +24,16 @@ class WPCrashLoggingProvider: CrashLoggingDataProvider {
         return TracksUser(userID: account.userID.stringValue, email: account.email, username: account.username)
     }
 }
+
+// MARK: - Static Property
+extension WPCrashLoggingProvider {
+
+    static var userHasOptedOut: Bool {
+        get {
+            return UserDefaults.standard.bool(forKey: UserOptedOutKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserOptedOutKey)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
@@ -22,7 +22,7 @@ class PrivacySettingsViewController: UITableViewController {
         super.viewDidLoad()
 
         ImmuTable.registerRows([
-            InfoRow.self,
+            PaddedInfoRow.self,
             SwitchRow.self,
             PaddedLinkRow.self
             ], tableView: self.tableView)
@@ -59,9 +59,8 @@ class PrivacySettingsViewController: UITableViewController {
             onChange: usageTrackingChanged()
         )
 
-        let shareInfoText = InfoRow(
-            title: NSLocalizedString("Share information with our analytics tool about your use of services while logged in to your WordPress.com account.", comment: "Informational text for Collect Information setting"),
-            icon: .gridicon(.info)
+        let shareInfoText = PaddedInfoRow(
+            title: NSLocalizedString("Share information with our analytics tool about your use of services while logged in to your WordPress.com account.", comment: "Informational text for Collect Information setting")
         )
 
         let shareInfoLink = PaddedLinkRow(
@@ -69,9 +68,8 @@ class PrivacySettingsViewController: UITableViewController {
             action: openCookiePolicy()
         )
 
-        let privacyText = InfoRow(
-            title: NSLocalizedString("This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.", comment: "Informational text for the privacy policy link"),
-            icon: .gridicon(.userCircle)
+        let privacyText = PaddedInfoRow(
+            title: NSLocalizedString("This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.", comment: "Informational text for the privacy policy link")
         )
 
         let privacyLink = PaddedLinkRow(
@@ -79,9 +77,8 @@ class PrivacySettingsViewController: UITableViewController {
             action: openPrivacyPolicy()
         )
 
-        let otherTracking = InfoRow(
-            title: NSLocalizedString("We use other tracking tools, including some from third parties. Read about these and how to control them.", comment: "Informational text about link to other tracking tools"),
-            icon: .gridicon(.briefcase)
+        let otherTracking = PaddedInfoRow(
+            title: NSLocalizedString("We use other tracking tools, including some from third parties. Read about these and how to control them.", comment: "Informational text about link to other tracking tools")
         )
 
         let otherTrackingLink = PaddedLinkRow(
@@ -89,21 +86,32 @@ class PrivacySettingsViewController: UITableViewController {
             action: openCookiePolicy()
         )
 
+        let reportCrashes = SwitchRow(
+            title: NSLocalizedString("Crash reports", comment: "Label for switch to turn on/off sending crashes info"),
+            value: !WPCrashLoggingProvider.userHasOptedOut,
+            icon: .gridicon(.bug),
+            onChange: crashReportingChanged()
+        )
+
+        let reportCrashesInfoText = PaddedInfoRow(
+            title: NSLocalizedString("To help us improve the app’s performance and fix the occasional bug, enable automatic crash reports.", comment: "Informational text for Report Crashes setting")
+        )
+
         return ImmuTable(sections: [
             ImmuTableSection(rows: [
                 collectInformation,
                 shareInfoText,
-                shareInfoLink
-                ]),
-            ImmuTableSection(rows: [
+                shareInfoLink,
                 privacyText,
-                privacyLink
-                ]),
-            ImmuTableSection(rows: [
+                privacyLink,
                 otherTracking,
                 otherTrackingLink
-                ])
+                ]),
+            ImmuTableSection(rows: [
+                reportCrashes,
+                reportCrashesInfoText
             ])
+        ])
     }
 
     func usageTrackingChanged() -> (Bool) -> Void {
@@ -113,8 +121,6 @@ class PrivacySettingsViewController: UITableViewController {
 
             let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
             AccountSettingsHelper(accountService: accountService).updateTracksOptOutSetting(!enabled)
-
-            CrashLogging.setNeedsDataRefresh()
         }
     }
 
@@ -139,6 +145,13 @@ class PrivacySettingsViewController: UITableViewController {
         present(navigation, animated: true)
     }
 
+    func crashReportingChanged() -> (Bool) -> Void {
+        return { enabled in
+            WPCrashLoggingProvider.userHasOptedOut = !enabled
+
+            CrashLogging.setNeedsDataRefresh()
+        }
+    }
 }
 
 private class InfoCell: WPTableViewCellDefault {
@@ -180,17 +193,16 @@ private class InfoCell: WPTableViewCellDefault {
     }
 }
 
-private struct InfoRow: ImmuTableRow {
+private struct PaddedInfoRow: ImmuTableRow {
     static let cell = ImmuTableCell.class(InfoCell.self)
 
     let title: String
-    let icon: UIImage
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
         cell.textLabel?.text = title
         cell.textLabel?.numberOfLines = 10
-        cell.imageView?.image = icon
+        cell.imageView?.image = UIImage(color: .clear, havingSize: Gridicon.defaultSize)
         cell.selectionStyle = .none
 
         WPStyleGuide.configureTableViewCell(cell)
@@ -208,5 +220,6 @@ private struct PaddedLinkRow: ImmuTableRow {
         cell.imageView?.image = UIImage(color: .clear, havingSize: Gridicon.defaultSize)
 
         WPStyleGuide.configureTableViewActionCell(cell)
+        cell.textLabel?.textColor = .primary
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
@@ -56,7 +56,7 @@ class PrivacySettingsViewController: UITableViewController {
             title: NSLocalizedString("Collect information", comment: "Label for switch to turn on/off sending app usage data"),
             value: !WPAppAnalytics.userHasOptedOut(),
             icon: .gridicon(.stats),
-            onChange: usageTrackingChanged()
+            onChange: usageTrackingChanged
         )
 
         let shareInfoText = PaddedInfoRow(
@@ -90,7 +90,7 @@ class PrivacySettingsViewController: UITableViewController {
             title: NSLocalizedString("Crash reports", comment: "Label for switch to turn on/off sending crashes info"),
             value: !WPCrashLoggingProvider.userHasOptedOut,
             icon: .gridicon(.bug),
-            onChange: crashReportingChanged()
+            onChange: crashReportingChanged
         )
 
         let reportCrashesInfoText = PaddedInfoRow(
@@ -114,14 +114,12 @@ class PrivacySettingsViewController: UITableViewController {
         ])
     }
 
-    func usageTrackingChanged() -> (Bool) -> Void {
-        return { enabled in
-            let appAnalytics = WordPressAppDelegate.shared?.analytics
-            appAnalytics?.setUserHasOptedOut(!enabled)
+    func usageTrackingChanged(_ enabled: Bool) {
+        let appAnalytics = WordPressAppDelegate.shared?.analytics
+        appAnalytics?.setUserHasOptedOut(!enabled)
 
-            let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-            AccountSettingsHelper(accountService: accountService).updateTracksOptOutSetting(!enabled)
-        }
+        let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        AccountSettingsHelper(accountService: accountService).updateTracksOptOutSetting(!enabled)
     }
 
     func openCookiePolicy() -> ImmuTableAction {
@@ -145,13 +143,11 @@ class PrivacySettingsViewController: UITableViewController {
         present(navigation, animated: true)
     }
 
-    func crashReportingChanged() -> (Bool) -> Void {
-        return { enabled in
-            WPCrashLoggingProvider.userHasOptedOut = !enabled
-
-            CrashLogging.setNeedsDataRefresh()
-        }
+    func crashReportingChanged(_ enabled: Bool) {
+      WPCrashLoggingProvider.userHasOptedOut = !enabled
+      CrashLogging.setNeedsDataRefresh()
     }
+
 }
 
 private class InfoCell: WPTableViewCellDefault {


### PR DESCRIPTION
Fixes #10344 

To test:
- Launch the app and verify that the privacy section looks like expected.
- Turn the crash reporting setting on and off and verify that crash reporting reacts accordingly.

| Before | After |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone X - 2020-06-04 at 13 27 43](https://user-images.githubusercontent.com/5558824/83802416-19ad4800-a681-11ea-9cc2-f880cbfb0bf7.png)  | ![Simulator Screen Shot - iPhone X - 2020-06-04 at 15 47 40](https://user-images.githubusercontent.com/5558824/83802425-1ca83880-a681-11ea-8d49-40911e97122b.png)  |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
