### PR TITLE
Applies new reader card UI design feedback

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
@@ -113,7 +113,6 @@ private enum ReaderCardDiscoverAttribution: Int {
         let str = stringForPostAttribution(contentProvider.sourceAuthorNameForDisplay(),
                                             blogName: contentProvider.sourceBlogNameForDisplay())
         let attributes = originalAttributionParagraphAttributes
-        WPStyleGuide.applyReaderCardAttributionLabelStyle(textLabel)
         textLabel.attributedText = NSAttributedString(string: str, attributes: attributes)
         attributionAction = .none
     }
@@ -136,7 +135,6 @@ private enum ReaderCardDiscoverAttribution: Int {
         attributedString.addAttribute(.font, value: font, range: range)
         textLabel.textColor = .primary
         textLabel.highlightedTextColor = .primary
-        WPStyleGuide.applyReaderCardAttributionLabelStyle(textLabel)
         textLabel.attributedText = attributedString
         attributionAction = .visitSite
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -63,6 +63,7 @@ open class ReaderCrossPostCell: UITableViewCell {
     // MARK: - Appearance
 
     fileprivate func applyStyles() {
+        backgroundColor = .clear
         contentView.backgroundColor = .listBackground
         borderView?.backgroundColor = .listForeground
         label?.backgroundColor = .listForeground

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -4,7 +4,6 @@ import AutomatticTracks
 import WordPressShared.WPStyleGuide
 
 private struct Constants {
-    static let imageBorderWidth: CGFloat = 1
     static let blavatarPlaceholder: String = "post-blavatar-placeholder"
     static let xPostTitlePrefix = "X-post: "
     static let commentTemplate = "%@ left a comment on %@, cross-posted to %@"

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.xib
@@ -24,21 +24,21 @@
                         <rect key="frame" x="0.0" y="8" width="320" height="106"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="4qr-gg-TCP">
-                                <rect key="frame" x="16" y="16" width="288" height="52.5"/>
+                                <rect key="frame" x="16" y="12" width="288" height="56.5"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="31R-gx-fKg">
-                                        <rect key="frame" x="0.0" y="0.0" width="30" height="52.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="30" height="56.5"/>
                                         <subviews>
-                                            <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" image="blavatar" translatesAutoresizingMaskIntoConstraints="NO" id="WUC-gY-tp6" userLabel="First" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="16.5" width="20" height="20"/>
+                                            <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="WUC-gY-tp6" userLabel="First" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="18.5" width="20" height="20"/>
                                                 <gestureRecognizers/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="20" id="HiT-Lq-HXe"/>
                                                     <constraint firstAttribute="height" constant="20" id="ykn-4s-Ni8"/>
                                                 </constraints>
                                             </imageView>
-                                            <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="blavatar" translatesAutoresizingMaskIntoConstraints="NO" id="JOq-VL-EJD" userLabel="Second" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="10" y="16.5" width="20" height="20"/>
+                                            <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="JOq-VL-EJD" userLabel="Second" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                                <rect key="frame" x="10" y="18.5" width="20" height="20"/>
                                                 <gestureRecognizers/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="20" id="Wly-6B-Yyx"/>
@@ -55,14 +55,14 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="andrei cross-posted from designomatticp2 to teamxthings" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5MU-iV-oPy">
-                                        <rect key="frame" x="40" y="0.0" width="248" height="52.5"/>
+                                        <rect key="frame" x="40" y="0.0" width="248" height="56.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                             </stackView>
-                            <label userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lca-uT-huN" customClass="ReaderPostCardContentLabel" customModule="WordPress" customModuleProvider="target">
+                            <label userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lca-uT-huN" customClass="ReaderPostCardContentLabel" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="16" y="74.5" width="288" height="20.5"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -70,7 +70,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <edgeInsets key="layoutMargins" top="16" left="16" bottom="6" right="16"/>
+                        <edgeInsets key="layoutMargins" top="12" left="16" bottom="8" right="16"/>
                     </stackView>
                 </subviews>
                 <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="calibratedWhite"/>
@@ -92,10 +92,7 @@
                 <outlet property="label" destination="5MU-iV-oPy" id="9OI-1R-pcP"/>
                 <outlet property="titleLabel" destination="lca-uT-huN" id="cRk-nM-vEy"/>
             </connections>
-            <point key="canvasLocation" x="887" y="471"/>
+            <point key="canvasLocation" x="535" y="470"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <image name="blavatar" width="40" height="40"/>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.xib
@@ -9,28 +9,28 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" rowHeight="232" id="chZ-G6-vcS" customClass="ReaderCrossPostCell" customModule="WordPress">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="172"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" rowHeight="174" id="chZ-G6-vcS" customClass="ReaderCrossPostCell" customModule="WordPress">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="114"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="chZ-G6-vcS" id="yQG-5S-y1g">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="172"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="114"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Phn-de-LXH" userLabel="Background View">
-                        <rect key="frame" x="-1" y="8" width="322" height="164"/>
+                        <rect key="frame" x="-1" y="8" width="322" height="106"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="D38-SH-Xvw" userLabel="Content Stack View">
-                        <rect key="frame" x="16" y="20" width="288" height="140"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="D38-SH-Xvw" userLabel="Content Stack View">
+                        <rect key="frame" x="0.0" y="8" width="320" height="106"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="4qr-gg-TCP">
-                                <rect key="frame" x="0.0" y="0.0" width="288" height="113.5"/>
+                                <rect key="frame" x="16" y="16" width="288" height="52.5"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="31R-gx-fKg">
-                                        <rect key="frame" x="0.0" y="0.0" width="30" height="113.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="30" height="52.5"/>
                                         <subviews>
                                             <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" image="blavatar" translatesAutoresizingMaskIntoConstraints="NO" id="WUC-gY-tp6" userLabel="First" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="47" width="20" height="20"/>
+                                                <rect key="frame" x="0.0" y="16.5" width="20" height="20"/>
                                                 <gestureRecognizers/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="20" id="HiT-Lq-HXe"/>
@@ -38,7 +38,7 @@
                                                 </constraints>
                                             </imageView>
                                             <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="blavatar" translatesAutoresizingMaskIntoConstraints="NO" id="JOq-VL-EJD" userLabel="Second" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="10" y="47" width="20" height="20"/>
+                                                <rect key="frame" x="10" y="16.5" width="20" height="20"/>
                                                 <gestureRecognizers/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="20" id="Wly-6B-Yyx"/>
@@ -55,7 +55,7 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="andrei cross-posted from designomatticp2 to teamxthings" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5MU-iV-oPy">
-                                        <rect key="frame" x="40" y="0.0" width="248" height="113.5"/>
+                                        <rect key="frame" x="40" y="0.0" width="248" height="52.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -63,23 +63,24 @@
                                 </subviews>
                             </stackView>
                             <label userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="750" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lca-uT-huN" customClass="ReaderPostCardContentLabel" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="119.5" width="288" height="20.5"/>
+                                <rect key="frame" x="16" y="74.5" width="288" height="20.5"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
+                        <edgeInsets key="layoutMargins" top="16" left="16" bottom="6" right="16"/>
                     </stackView>
                 </subviews>
                 <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="calibratedWhite"/>
                 <constraints>
                     <constraint firstItem="Phn-de-LXH" firstAttribute="leading" secondItem="yQG-5S-y1g" secondAttribute="leading" constant="-1" id="7Ep-5N-Qst"/>
                     <constraint firstItem="Phn-de-LXH" firstAttribute="top" secondItem="yQG-5S-y1g" secondAttribute="top" constant="8" id="90n-YF-4D3"/>
-                    <constraint firstItem="D38-SH-Xvw" firstAttribute="top" secondItem="Phn-de-LXH" secondAttribute="top" constant="12" id="Kig-9E-kqG"/>
-                    <constraint firstItem="D38-SH-Xvw" firstAttribute="leading" secondItem="yQG-5S-y1g" secondAttribute="leading" constant="16" id="ML0-ur-kuZ"/>
-                    <constraint firstAttribute="bottom" secondItem="D38-SH-Xvw" secondAttribute="bottom" constant="12" id="cvY-j5-xr1"/>
-                    <constraint firstAttribute="trailing" secondItem="D38-SH-Xvw" secondAttribute="trailing" constant="16" id="iA4-0B-XeM"/>
+                    <constraint firstItem="D38-SH-Xvw" firstAttribute="top" secondItem="Phn-de-LXH" secondAttribute="top" id="Kig-9E-kqG"/>
+                    <constraint firstItem="D38-SH-Xvw" firstAttribute="leading" secondItem="yQG-5S-y1g" secondAttribute="leading" id="ML0-ur-kuZ"/>
+                    <constraint firstAttribute="bottom" secondItem="D38-SH-Xvw" secondAttribute="bottom" id="cvY-j5-xr1"/>
+                    <constraint firstAttribute="trailing" secondItem="D38-SH-Xvw" secondAttribute="trailing" id="iA4-0B-XeM"/>
                     <constraint firstAttribute="bottom" secondItem="Phn-de-LXH" secondAttribute="bottom" id="rJ7-0T-oeM"/>
                     <constraint firstAttribute="trailing" secondItem="Phn-de-LXH" secondAttribute="trailing" constant="-1" id="tsp-4A-wom"/>
                 </constraints>
@@ -91,7 +92,7 @@
                 <outlet property="label" destination="5MU-iV-oPy" id="9OI-1R-pcP"/>
                 <outlet property="titleLabel" destination="lca-uT-huN" id="cRk-nM-vEy"/>
             </connections>
-            <point key="canvasLocation" x="119" y="443"/>
+            <point key="canvasLocation" x="887" y="471"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -145,7 +145,7 @@ private struct Constants {
 
         // Update colors
         applyStyles()
-
+        setupMenuButton()
         configureFeaturedImageView()
         configureAvatarImageView()
     }
@@ -172,8 +172,14 @@ private struct Constants {
             return
         }
 
-        let tintedIcon = icon.imageWithTintColor(.neutral(.shade50))
-        let highlightIcon = icon.imageWithTintColor(.neutral)
+        let tintColor = UIColor(light: .muriel(color: .gray, .shade50),
+                                dark: .textSubtle)
+
+        let highlightColor = UIColor(light: .muriel(color: .gray, .shade10),
+                                     dark: .textQuaternary)
+
+        let tintedIcon = icon.imageWithTintColor(tintColor)
+        let highlightIcon = icon.imageWithTintColor(highlightColor)
 
         menuButton.setImage(tintedIcon, for: .normal)
         menuButton.setImage(highlightIcon, for: .highlighted)

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -270,10 +270,10 @@ extension WPStyleGuide {
     // MARK: - Button Styles and Text
     class func applyReaderStreamActionButtonStyle(_ button: UIButton) {
         let tintColor = UIColor(light: .muriel(color: .gray, .shade50),
-                                dark: .muriel(color: .gray, .shade10))
+                                dark: .textSubtle)
 
         let disabledColor = UIColor(light: .muriel(color: .gray, .shade10),
-                                    dark: .muriel(color: .gray, .shade60))
+                                    dark: .textQuaternary)
 
         return applyReaderActionButtonStyle(button,
                                             titleColor: tintColor,

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -281,7 +281,11 @@ extension WPStyleGuide {
                                             disabledColor: disabledColor)
     }
 
-    class func applyReaderActionButtonStyle(_ button: UIButton, titleColor: UIColor = .listIcon, imageColor: UIColor = .listIcon, disabledColor: UIColor = .neutral(.shade10)) {
+
+    class func applyReaderActionButtonStyle(_ button: UIButton,
+                                            titleColor: UIColor = .listIcon,
+                                            imageColor: UIColor = .listIcon,
+                                            disabledColor: UIColor = .neutral(.shade10)) {
         button.tintColor = imageColor
         let highlightedColor: UIColor = .neutral
         let selectedColor: UIColor = .primary(.shade40)
@@ -354,6 +358,7 @@ extension WPStyleGuide {
         button.setImage(selectedIcon, for: .selected)
         button.setImage(selectedIcon, for: .highlighted)
         button.setImage(selectedIcon, for: [.highlighted, .selected])
+        button.setImage(icon, for: .disabled)
 
         applyReaderStreamActionButtonStyle(button)
     }
@@ -374,6 +379,7 @@ extension WPStyleGuide {
         button.setImage(resizedSelectedIcon, for: .selected)
         button.setImage(resizedSelectedIcon, for: .highlighted)
         button.setImage(resizedSelectedIcon, for: [.highlighted, .selected])
+        button.setImage(resizedIcon, for: .disabled)
 
         applyReaderStreamActionButtonStyle(button)
     }
@@ -387,6 +393,7 @@ extension WPStyleGuide {
         button.setImage(selectedIcon, for: .selected)
         button.setImage(selectedIcon, for: .highlighted)
         button.setImage(selectedIcon, for: [.highlighted, .selected])
+        button.setImage(icon, for: .disabled)
 
         applyReaderStreamActionButtonStyle(button)
     }
@@ -411,6 +418,10 @@ extension WPStyleGuide {
         let icon = UIImage.gridicon(.reblog, size: size)
 
         button.setImage(icon, for: .normal)
+        button.setImage(icon, for: .selected)
+        button.setImage(icon, for: .highlighted)
+        button.setImage(icon, for: [.highlighted, .selected])
+        button.setImage(icon, for: .disabled)
 
         applyReaderStreamActionButtonStyle(button)
     }

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -28,7 +28,8 @@ extension WPStyleGuide {
     // MARK: - Reader Card Styles
 
     @objc public class func readerCardBlogNameLabelTextColor() -> UIColor {
-        return .neutral(.shade90)
+        return UIColor(light: .muriel(color: .gray, .shade90),
+                       dark: .muriel(color: .gray, .shade0))
     }
 
     @objc public class func readerCardBlogNameLabelDisabledTextColor() -> UIColor {
@@ -220,7 +221,7 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderCardSummaryLabelStyle(_ label: UILabel) {
-        label.textColor = UIColor(light: .gray(.shade80), dark: .textSubtle)
+        label.textColor = UIColor(light: .gray(.shade80), dark: .muriel(color: .gray, .shade0))
     }
 
     public class func applyReaderCardAttributionLabelStyle(_ label: UILabel) {

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -44,7 +44,7 @@ extension WPStyleGuide {
         return .neutral(.shade10)
     }
 
-    @objc public class func readerCardBlogIconBorderColor() -> UIColor {
+    public class func readerCardBlogIconBorderColor() -> UIColor {
         if #available(iOS 13.0, *) {
             return UIColor(light: .gray(.shade0), dark: .systemGray5)
         } else {
@@ -52,7 +52,7 @@ extension WPStyleGuide {
         }
     }
 
-    @objc public class func readerCardFeaturedMediaBorderColor() -> UIColor {
+    public class func readerCardFeaturedMediaBorderColor() -> UIColor {
         return readerCardBlogIconBorderColor()
     }
 
@@ -223,7 +223,7 @@ extension WPStyleGuide {
         label.textColor = UIColor(light: .gray(.shade80), dark: .textSubtle)
     }
 
-    @objc public class func applyReaderCardAttributionLabelStyle(_ label: UILabel) {
+    public class func applyReaderCardAttributionLabelStyle(_ label: UILabel) {
         label.textColor = UIColor(light: .gray(.shade80), dark: .textSubtle)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -74,7 +74,7 @@ extension WPStyleGuide {
         return [
             .paragraphStyle: paragraphStyle,
             .font: font,
-            .foregroundColor: UIColor.neutral(.shade40)
+            .foregroundColor: UIColor(light: .gray(.shade40), dark: .systemGray)
         ]
     }
 
@@ -87,7 +87,7 @@ extension WPStyleGuide {
         return [
             .paragraphStyle: paragraphStyle,
             .font: font,
-            .foregroundColor: UIColor.neutral(.shade40)
+            .foregroundColor: UIColor(light: .gray(.shade40), dark: .systemGray)
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -535,7 +535,7 @@ extension WPStyleGuide {
         public static let defaultLineSpacing: CGFloat = WPDeviceIdentification.isiPad() ? 6.0 : 3.0
         public static let titleTextStyle: UIFont.TextStyle = WPDeviceIdentification.isiPad() ? .title2 : .title3
         public static let titleLineSpacing: CGFloat = WPDeviceIdentification.isiPad() ? 0.0 : 0.0
-        public static let summaryTextStyle: UIFont.TextStyle = .footnote
+        public static let summaryTextStyle: UIFont.TextStyle = .subheadline
         public static let contentTextStyle: UIFont.TextStyle = .footnote
         public static let contentLineSpacing: CGFloat = 4
         public static let buttonTextStyle: UIFont.TextStyle = .subheadline

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -96,9 +96,10 @@ extension WPStyleGuide {
     }
 
     /// Returns a the system serif font (New York) for iOS 13+ but defaults to noto for older devices
-    private class func serifFontForTextStyle(_ style: UIFont.TextStyle) -> UIFont {
+    private class func serifFontForTextStyle(_ style: UIFont.TextStyle,
+                                             fontWeight weight: UIFont.Weight = .regular) -> UIFont {
         guard #available(iOS 13, *),
-            let fontDescriptor = WPStyleGuide.fontForTextStyle(style).fontDescriptor.withDesign(.serif)
+            let fontDescriptor = WPStyleGuide.fontForTextStyle(style, fontWeight: weight).fontDescriptor.withDesign(.serif)
         else {
             return WPStyleGuide.notoFontForTextStyle(style)
         }
@@ -112,7 +113,7 @@ extension WPStyleGuide {
 
         return [
             .paragraphStyle: paragraphStyle,
-            .font: serifFontForTextStyle(Cards.titleTextStyle)
+            .font: serifFontForTextStyle(Cards.titleTextStyle, fontWeight: .semibold)
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -45,11 +45,15 @@ extension WPStyleGuide {
     }
 
     @objc public class func readerCardBlogIconBorderColor() -> UIColor {
-        return .neutral(.shade0)
+        if #available(iOS 13.0, *) {
+            return UIColor(light: .gray(.shade0), dark: .systemGray5)
+        } else {
+            return .neutral(.shade0)
+        }
     }
 
     @objc public class func readerCardFeaturedMediaBorderColor() -> UIColor {
-        return .neutral(.shade0)
+        return readerCardBlogIconBorderColor()
     }
 
     // MARK: - Card Attributed Text Attributes

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -213,23 +213,19 @@ extension WPStyleGuide {
         WPStyleGuide.configureLabel(label, textStyle: Cards.subtextTextStyle)
         label.textColor = UIColor(light: .muriel(color: .gray, .shade40),
                                   dark: .muriel(color: .gray, .shade20))
-
     }
 
     @objc public class func applyReaderCardTitleLabelStyle(_ label: UILabel) {
-        label.textColor = .neutral(.shade90)
+        label.textColor = UIColor(light: .gray(.shade90), dark: .text)
     }
 
     @objc public class func applyReaderCardSummaryLabelStyle(_ label: UILabel) {
-        label.textColor = UIColor(light: .muriel(color: .gray, .shade40),
-                                  dark: .muriel(color: .gray, .shade20))
+        label.textColor = UIColor(light: .gray(.shade80), dark: .textSubtle)
     }
 
     @objc public class func applyReaderCardAttributionLabelStyle(_ label: UILabel) {
-        label.textColor = UIColor(light: .muriel(color: .gray, .shade40),
-                                  dark: .muriel(color: .gray, .shade20))
+        label.textColor = UIColor(light: .gray(.shade80), dark: .textSubtle)
     }
-
 
     @objc public class func applyReaderCardTagButtonStyle(_ button: UIButton) {
         WPStyleGuide.configureLabel(button.titleLabel!, textStyle: Cards.subtextTextStyle)


### PR DESCRIPTION
Fixes #14253

Applies the following feedback:

### Dark Mode
- [x] Use `.systemGray` for the cross-post header text color
- [x] Use the elevated background color for the postcard 
- [x] The stroke of the thumbnail image/site icon should be `.systemGray5`
- [x] Match the dark mode colors from the design image (see issue)

### Postcard font sizes
- [x] Change post title font weight to `.semibold`
- [x] Change excerpt/summary label font size to `.subhead`
- [x] Change excerpt/summary label font color to `.darkGray`

### iPad
- [x] Fix a bug with the cross posted cell not adhering to the readable width

## Screenshots

### Card
#### Light Mode
| Before | After |
|---|---|
|![01 - discover - light - before](https://user-images.githubusercontent.com/793774/83925393-e4196500-a73b-11ea-8f62-7c8934afdd0e.png)|![01 - discover - light - after](https://user-images.githubusercontent.com/793774/83925381-e085de00-a73b-11ea-8876-8367335841cd.png)|

#### Dark Mode
| Before | After |
|---|---|
|![02 - discover - dark - before](https://user-images.githubusercontent.com/793774/83925428-fc897f80-a73b-11ea-8bd1-6c2a557447e1.png)|![02 - discover - dark - after](https://user-images.githubusercontent.com/793774/83925417-f85d6200-a73b-11ea-84e7-480cb1c4511b.png)|

### Cross Post
#### Light Mode
| Before | After |
|---|---|
|<img width="406" alt="03 - 01 - crosspost - light - before" src="https://user-images.githubusercontent.com/793774/83925581-5c802600-a73c-11ea-91a2-8239f92c9852.png">|<img width="381" alt="03 - 02 - crosspost - light - after" src="https://user-images.githubusercontent.com/793774/83925585-5db15300-a73c-11ea-9318-bbb574f3cb82.png">|

#### Dark Mode
| Before | After |
|---|---|
|<img width="383" alt="03 - 01 - crosspost - dark - before" src="https://user-images.githubusercontent.com/793774/83925578-5be78f80-a73c-11ea-806d-a5b0626c4705.png">|<img width="384" alt="03 - 02 - crosspost - dark - after" src="https://user-images.githubusercontent.com/793774/83925582-5d18bc80-a73c-11ea-89ba-acfdab34e6b5.png">|

### iPad
| Before | After |
|---|---|
|<img width="864" alt="04 - 01 - ipad xpost - before" src="https://user-images.githubusercontent.com/793774/83925707-af59dd80-a73c-11ea-847b-e5624b8e04e5.png">|<img width="852" alt="04 - 02 - ipad xpost - after" src="https://user-images.githubusercontent.com/793774/83925710-b08b0a80-a73c-11ea-8e0f-5197745de366.png">|

## To test:
1. Launch the app
2. Tap on the reader tab
3. Tap on the Discover tab
4. Make sure the app colors look good in both dark and light modes
5. Make sure the fonts are correct
6. Launch the app on the iPad
7. Tap the reader tab
8. Tap the team tab
9. Locate a cross post
10. Make sure the crosspost margins match the post card

## PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
