### PR TITLE
ULS: Use Google signup flow

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -184,9 +184,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.18.0-beta.6'
+    # pod 'WordPressAuthenticator', '~> 1.18.0-beta.8'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/282-google_signup_create_account'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -380,7 +380,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.2)
   - WordPress-Editor-iOS (1.19.2):
     - WordPress-Aztec-iOS (= 1.19.2)
-  - WordPressAuthenticator (1.18.0-beta.6):
+  - WordPressAuthenticator (1.18.0-beta.8):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -483,7 +483,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.2)
-  - WordPressAuthenticator (~> 1.18.0-beta.6)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/282-google_signup_create_account`)
   - WordPressKit (~> 4.9.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.8.16)
@@ -532,7 +532,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -618,6 +617,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: a3a155d0053c75985960ae7ac8ecfaa2e3732efa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :branch: feature/282-google_signup_create_account
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/a3a155d0053c75985960ae7ac8ecfaa2e3732efa/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -631,6 +633,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: a3a155d0053c75985960ae7ac8ecfaa2e3732efa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :commit: 00af4e392685de296c96dd1eea94515cb38581f2
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -703,7 +708,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: d01bf0c5e150ae6a046f06ba63b7cc2762061c0b
   WordPress-Editor-iOS: 5b726489e5ae07b7281a2862d69aba2d5c83f140
-  WordPressAuthenticator: 2b69a6755a8b578e2d5dfd1a9be2e3a894f6650b
+  WordPressAuthenticator: aa122f955529beecdb49bf7932ed9431c2ea5c97
   WordPressKit: 2e707edd1b28e8dd0f74a40469ca6e7be7b20a70
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 1bc316ed162f42af4e0fa2869437e9e28b532b01
@@ -720,6 +725,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: fc7232ad47fd9b9a9d3156e232076e0d7a0ebb6f
+PODFILE CHECKSUM: 487033b05e00e2b5e265856ee441252169ed7561
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -27,11 +27,11 @@ enum FeatureFlag: Int, CaseIterable {
         case .debugMenu:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .unifiedAuth:
-            return BuildConfiguration.current == .localDeveloper
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .unifiedSiteAddress:
             return false
         case .unifiedGoogle:
-            return false
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .meMove:
             return true
         case .floatingCreateButton:


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/282
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/300

This uses the Auth changes to create a Google account. Also, the `unifiedGoogle` Feature Flag is now enabled for dev.

To test:

Prerequisites:
- Sorry - you're going to need 3 unused Google accounts for this, one for each test case.
- You'll need another instance of WP (not using these changes) for the existing account tests.

---
New Google account:
- Select either Log in or Sign up > Continue with Google.
- Walk through the Google auth process, selecting an unused Google account.
- Press `Next` on the signup confirmation view.
- While the account is being created, the `Processing Account` HUD is displayed.
- When the account is created, the Signup Epilogue is displayed. 

---
Existing account:
- Select either Log in or Sign up > Continue with Google.
- Walk through the Google auth process, selecting an unused Google account.
- _Stop! Leave this view showing._
- On another device, create a WP account with this Google account.
- Come back, and press `Next` on the signup confirmation view.
- Verify the account is logged in, and the Login Epilogue is displayed.

---
Existing 2FA account: 
- Select either Log in or Sign up > Continue with Google.
- Walk through the Google auth process, selecting an unused Google account.
- _Stop! Leave this view showing._
- On another device, create a WP account with this Google account.
- On the web, enable 2FA on the WP account.
- Come back, and press `Next` on the signup confirmation view.
- Verify an error alert is displayed.

<img width="500" alt="fail" src="https://user-images.githubusercontent.com/1816888/83929560-0b2e6180-a751-11ea-8225-3f3ed4aad790.png">

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
