### PR TITLE
Adds in-app appearance setting

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -67,6 +67,11 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
 
+        if #available(iOS 13.0, *) {
+            // Overrides the current user interface appearance
+            AppAppearance.overrideAppearance()
+        }
+
         // Start CrashLogging as soon as possible (in case a crash happens during startup)
         CrashLogging.start(withDataProvider: crashLoggingProvider)
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -33,6 +33,9 @@ import Foundation
     case editorPostSlugChanged
     case editorPostExcerptChanged
 
+    // App Settings
+    case appSettingsAppearanceChanged
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -85,6 +88,8 @@ import Foundation
             return "editor_post_slug_changed"
         case .editorPostExcerptChanged:
             return "editor_post_excerpt_changed"
+        case .appSettingsAppearanceChanged:
+            return "app_settings_appearance_changed"
         }
     }
 

--- a/WordPress/Classes/Utility/AppAppearance.swift
+++ b/WordPress/Classes/Utility/AppAppearance.swift
@@ -1,0 +1,48 @@
+import UIKit
+
+/// Encapsulates UIUserInterfaceStyle getting and setting for the app's
+/// main window. Allows users to override the interface style for the app.
+///
+@available(iOS 13.0, *)
+struct AppAppearance {
+    /// The default interface style if not overridden
+    static let `default`: UIUserInterfaceStyle = .unspecified
+
+    private static var currentWindow: UIWindow? {
+        return WordPressAppDelegate.shared?.window
+    }
+
+    /// The current user interface style used by the app
+    static var current: UIUserInterfaceStyle {
+        return currentWindow?.overrideUserInterfaceStyle ?? .unspecified
+    }
+
+    /// Overrides the app's current appeareance with the specified style
+    static func overrideAppearance(with style: UIUserInterfaceStyle) {
+        guard let window = currentWindow else {
+            return
+        }
+
+        window.overrideUserInterfaceStyle = style
+    }
+}
+
+@available(iOS 13.0, *)
+extension UIUserInterfaceStyle {
+    var appearanceDescription: String {
+        switch self {
+        case .light:
+            return NSLocalizedString("Light", comment: "Title for the app appearance setting for light mode")
+        case .dark:
+            return NSLocalizedString("Dark", comment: "Title for the app appearance setting for dark mode")
+        case .unspecified:
+            return NSLocalizedString("System default", comment: "Title for the app appearance setting (light / dark mode) that uses the system default value")
+        @unknown default:
+            return ""
+        }
+    }
+
+    static var allStyles: [UIUserInterfaceStyle] {
+        return [.light, .dark, .unspecified]
+    }
+}

--- a/WordPress/Classes/Utility/AppAppearance.swift
+++ b/WordPress/Classes/Utility/AppAppearance.swift
@@ -23,6 +23,8 @@ struct AppAppearance {
             return
         }
 
+        WPAnalytics.track(.appSettingsAppearanceChanged, properties: ["style": style.appearanceDescription])
+
         window.overrideUserInterfaceStyle = style
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */; };
 		17BD4A0820F76A4700975AC3 /* Routes+Banners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */; };
 		17BD4A192101D31B00975AC3 /* NavigationActionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BD4A182101D31B00975AC3 /* NavigationActionHelpers.swift */; };
+		17C64BD2248E26A200AF09D7 /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C64BD1248E26A200AF09D7 /* AppAppearance.swift */; };
 		17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */; };
 		17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */; };
 		17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */; };
@@ -2583,6 +2584,7 @@
 		17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewController.swift; sourceTree = "<group>"; };
 		17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Banners.swift"; sourceTree = "<group>"; };
 		17BD4A182101D31B00975AC3 /* NavigationActionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationActionHelpers.swift; sourceTree = "<group>"; };
+		17C64BD1248E26A200AF09D7 /* AppAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAppearance.swift; sourceTree = "<group>"; };
 		17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchService.swift; sourceTree = "<group>"; };
 		17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchViewController.swift; sourceTree = "<group>"; };
 		17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanComparisonViewController.swift; sourceTree = "<group>"; };
@@ -7650,6 +7652,7 @@
 				FFCB9F4A22A125BD0080A45F /* WPException.m */,
 				57C3D392235DFD8E00FE9CE6 /* ActionDispatcherFacade.swift */,
 				F582060123A85495005159A9 /* SiteDateFormatters.swift */,
+				17C64BD1248E26A200AF09D7 /* AppAppearance.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -12023,6 +12026,7 @@
 				9874767321963D330080967F /* SiteStatsInformation.swift in Sources */,
 				738B9A5821B85CF20005062B /* TitleSubtitleHeader.swift in Sources */,
 				43290CF4214F755400F6B398 /* FancyAlertViewController+QuickStart.swift in Sources */,
+				17C64BD2248E26A200AF09D7 /* AppAppearance.swift in Sources */,
 				3F09CCA82428FF3300D00A8C /* ReaderTabViewController.swift in Sources */,
 				7E4123CC20F418A500DF8486 /* ActivityActionsParser.swift in Sources */,
 				40F46B6B22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift in Sources */,


### PR DESCRIPTION
Implements #13122. This PR adds an in-app setting to change the current app theme independently of the current system dark mode setting.

![appearance-settings](https://user-images.githubusercontent.com/4780/84022917-0e0e9980-a97f-11ea-8279-27fa6172716c.png)

![appearance-1](https://user-images.githubusercontent.com/4780/84022927-12d34d80-a97f-11ea-905b-7f98a6dd13bb.gif)

**To test:**

* Build and run
* Navigate to Me (top right of My Site) > App Settings, and scroll to Appearance near the bottom
* Ensure that the default displayed value is 'system default'.
* Try changing the value to light and then dark and ensure that the UI appearance updates
* Quit the app and restart, and ensure that your preference is remembered – if you chose dark, the app should still be dark. Also check that the Settings menu still reflects your choice.
* As this feature involves overriding the style of the app's main window, do a smoke test of other areas of the app and ensure everything looks right. Most notably, Notices use their own window, however they appear to pick up the style from the app's main window.

cc @mattmiklic 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
