### PR TITLE
Improve VoiceOver accessibility in Quick Start v2

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -37,8 +37,8 @@ struct QuickStartChecklistTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Tap %@ to see your checklist", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let descriptionTarget = NSLocalizedString("Quick Start", comment: "The menu item to tap during a guided tour.")
+        let descriptionBase = NSLocalizedString("Select %@ to see your checklist", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let descriptionTarget = NSLocalizedString("Quick Start", comment: "The menu item to select during a guided tour.")
         return [(element: .checklist, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: .gridicon(.listCheckmark)))]
     }()
 
@@ -85,8 +85,8 @@ struct QuickStartViewTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Tap %@ to preview", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let descriptionTarget = NSLocalizedString("View Site", comment: "The menu item to tap during a guided tour.")
+        let descriptionBase = NSLocalizedString("Select %@ to preview", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let descriptionTarget = NSLocalizedString("View Site", comment: "The menu item to select during a guided tour.")
         return [(element: .viewSite, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: .gridicon(.house)))]
     }()
 
@@ -103,8 +103,8 @@ struct QuickStartThemeTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Tap %@ to discover new themes", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let descriptionTarget = NSLocalizedString("Themes", comment: "The menu item to tap during a guided tour.")
+        let descriptionBase = NSLocalizedString("Select %@ to discover new themes", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let descriptionTarget = NSLocalizedString("Themes", comment: "The menu item to select during a guided tour.")
         return [(element: .themes, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: .gridicon(.themes)))]
     }()
 
@@ -121,12 +121,12 @@ struct QuickStartCustomizeTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let step1DescriptionBase = NSLocalizedString("Tap %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let step1DescriptionTarget = NSLocalizedString("Themes", comment: "The menu item to tap during a guided tour.")
+        let step1DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step1DescriptionTarget = NSLocalizedString("Themes", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .themes, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.themes)))
 
-        let step2DescriptionBase = NSLocalizedString("Tap %@ to start personalising your site", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let step2DescriptionTarget = NSLocalizedString("Customize", comment: "The menu item to tap during a guided tour.")
+        let step2DescriptionBase = NSLocalizedString("Select %@ to start personalising your site", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step2DescriptionTarget = NSLocalizedString("Customize", comment: "The menu item to select during a guided tour.")
         let step2: WayPoint = (element: .customize, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.themes)))
 
         return [step1, step2]
@@ -145,12 +145,12 @@ struct QuickStartShareTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let step1DescriptionBase = NSLocalizedString("Tap %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let step1DescriptionTarget = NSLocalizedString("Sharing", comment: "The menu item to tap during a guided tour.")
+        let step1DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step1DescriptionTarget = NSLocalizedString("Sharing", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .sharing, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.share)))
 
-        let step2DescriptionBase = NSLocalizedString("Tap the %@ to add your social media accounts", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let step2DescriptionTarget = NSLocalizedString("connections", comment: "The menu item to tap during a guided tour.")
+        let step2DescriptionBase = NSLocalizedString("Select the %@ to add your social media accounts", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step2DescriptionTarget = NSLocalizedString("connections", comment: "The menu item to select during a guided tour.")
         let step2: WayPoint = (element: .connections, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: nil))
 
         return [step1, step2]
@@ -169,7 +169,7 @@ struct QuickStartPublishTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Tap %@ to create a new post", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let descriptionBase = NSLocalizedString("Select %@ to create a new post", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         return [(element: .newpost, description: descriptionBase.highlighting(phrase: "", icon: .gridicon(.create)))]
     }()
 
@@ -186,16 +186,16 @@ struct QuickStartFollowTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let step1DescriptionBase = NSLocalizedString("Tap %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to tap during a guided tour.")
+        let step1DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .readerTab, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.reader)))
 
-        let step2DescriptionBase = NSLocalizedString("Tap %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let step2DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to tap during a guided tour.")
+        let step2DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step2DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
         let step2: WayPoint = (element: .readerBack, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.chevronLeft)))
 
-        let step3DescriptionBase = NSLocalizedString("Tap %@ to look for sites with similar interests", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let step3DescriptionTarget = NSLocalizedString("Search", comment: "The menu item to tap during a guided tour.")
+        let step3DescriptionBase = NSLocalizedString("Select %@ to look for sites with similar interests", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step3DescriptionTarget = NSLocalizedString("Search", comment: "The menu item to select during a guided tour.")
         let step3: WayPoint = (element: .readerSearch, description: step3DescriptionBase.highlighting(phrase: step3DescriptionTarget, icon: .gridicon(.search)))
 
         return [step1, step2, step3]
@@ -222,8 +222,8 @@ struct QuickStartSiteIconTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Tap %@ to upload a new one.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let descriptionTarget = NSLocalizedString("Your Site Icon", comment: "The item to tap during a guided tour.")
+        let descriptionBase = NSLocalizedString("Select %@ to upload a new one.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let descriptionTarget = NSLocalizedString("Your Site Icon", comment: "The item to select during a guided tour.")
         return [(element: .siteIcon, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: nil))]
     }()
 
@@ -240,10 +240,10 @@ struct QuickStartNewPageTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let pagesStepDesc = NSLocalizedString("Tap %@ to continue.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let pagesStepTarget = NSLocalizedString("Site Pages", comment: "The item to tap during a guided tour.")
+        let pagesStepDesc = NSLocalizedString("Select %@ to continue.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let pagesStepTarget = NSLocalizedString("Site Pages", comment: "The item to select during a guided tour.")
 
-        let newStepDesc = NSLocalizedString("Tap %@ to create a new page.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let newStepDesc = NSLocalizedString("Select %@ to create a new page.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
 
         return [
             (element: .pages, description: pagesStepDesc.highlighting(phrase: pagesStepTarget, icon: nil)),
@@ -264,8 +264,8 @@ struct QuickStartCheckStatsTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Tap %@ to see how your site is performing.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let descriptionTarget = NSLocalizedString("Stats", comment: "The item to tap during a guided tour.")
+        let descriptionBase = NSLocalizedString("Select %@ to see how your site is performing.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let descriptionTarget = NSLocalizedString("Stats", comment: "The item to select during a guided tour.")
         return [(element: .stats, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: .gridicon(.stats)))]
     }()
 
@@ -282,8 +282,8 @@ struct QuickStartExplorePlansTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Tap %@ to see your current plan and other available plans.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let descriptionTarget = NSLocalizedString("Plan", comment: "The item to tap during a guided tour.")
+        let descriptionBase = NSLocalizedString("Select %@ to see your current plan and other available plans.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let descriptionTarget = NSLocalizedString("Plan", comment: "The item to select during a guided tour.")
         return [(element: .plans, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: .gridicon(.plans)))]
     }()
 


### PR DESCRIPTION
Fixes #12129 

This PR changes the "tap" instruction text in the Quick Start tour notification to be more inclusive to our accessibility users and says "select" instead. Just like [we shouldn't say "click here"](https://www.smashingmagazine.com/2012/06/links-should-never-say-click-here/) for links, we should not say "tap". 

Once the user chooses the "Themes" item, it speaks the correct accessibility trait ("Themes. Button.")

### Screenshots
<a href="https://user-images.githubusercontent.com/1062444/84049993-c124c600-a972-11ea-9e60-c4c275764626.PNG"><img src="https://user-images.githubusercontent.com/1062444/84049993-c124c600-a972-11ea-9e60-c4c275764626.PNG" width="350" /></a>

<a href="https://user-images.githubusercontent.com/1062444/84050018-cc77f180-a972-11ea-9d1a-a6950eedcc21.PNG"><img src="https://user-images.githubusercontent.com/1062444/84050018-cc77f180-a972-11ea-9d1a-a6950eedcc21.PNG" width="350" /></a>

<a href="https://user-images.githubusercontent.com/1062444/84050045-d6015980-a972-11ea-8954-6fd7c907e53e.PNG"><img src="https://user-images.githubusercontent.com/1062444/84050045-d6015980-a972-11ea-8954-6fd7c907e53e.PNG" width="350" /></a>

#### Alternatives considered
1. The original issue suggested using "double tap" in the instruction text instead of "tap". The instruction text is displayed to all users and VoiceOver reads the text presented. We shouldn't segregate VoiceOver users and change their text to say "double tap", instead we should use more inclusive language, like "select", "find", or "choose". "double tap" works for VoiceOver users, but what happens when Apple introduces voice commands? Users might think it funny to hear "double tap X" when the action they take is speaking.
2. Accessibility hints are tied to UI elements. Adding an accessibility hint to the toast and using that hint to explain the element we want VoiceOver users to choose, is a mis-use of the accessibility hint. If a hint exists on the toast at all, it should describe how to dismiss the toast (not how to use the Theme button).  If we add the accessibility hint to the toast, it will end up sounding repetitive to VoiceOver users. "Tap Themes to discover new themes. Double-tap the Themes button to discover new themes." Not really necessary when the action is inferred the first time.

### To test:
1. Turn on VoiceOver
2. Navigate to the app
3. Create a new site
4. Choose "Yes, Help Me" to accept the guided tour
5. Find the "Choose a theme" row and select it
6. The toast should now read, "Select Themes to discover new themes"
7. Two finger swipe down will read the screen from top to buttom. The Themes row is correctly identified as "Themes (button)."

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
