### PR TITLE
Tell VoiceOver users that a quick start task has been completed

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
@@ -43,6 +43,12 @@ class QuickStartChecklistCell: UITableViewCell {
                                                                             .foregroundColor: UIColor.neutral(.shade30)])
                 descriptionLabel.textColor = .neutral(.shade30)
                 iconView?.tintColor = .neutral(.shade30)
+
+                // Overrides the existing accessibility hint in the tour property observer.
+                if let hint = tour?.accessibilityHintText, !hint.isEmpty {
+                    accessibilityHint = NSLocalizedString("Task completed.",
+                                                          comment: "Accessibility hint to let the user know they completed a quick site task.")
+                }
             } else {
                 titleLabel.textColor = .text
                 descriptionLabel.textColor = .textSubtle


### PR DESCRIPTION
Fixes #12128

This PR overrides the existing accessibility hint for the Quick Start tour items and tells the user that the task has been completed.

<a href="https://user-images.githubusercontent.com/1062444/84056227-8d9a6980-a97b-11ea-8d5f-1e4089fdb205.PNG"><img src="https://user-images.githubusercontent.com/1062444/84056227-8d9a6980-a97b-11ea-8d5f-1e4089fdb205.PNG" width="350" /></a>

VoiceOver reads, "Create your site. Get your site up and running (button). Task completed."

### To test:
1. Create a new site
2. Choose "Yes, Help Me" when the fancy alert is presented
3. Finish one of the tasks in the Quick Start tour
4. Turn on VoiceOver ("hey Siri turn on VoiceOver")
5. Navigate to the task list where you completed the task (either "Customize your site" or "Grow your audience")
6. Expand the Completed section.
7. Select the completed task. For example, in "Customize your site", the "Completed" section should have a cell that reads, "Create your site. Get your site up and running (button). Task completed."

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
