### PR TITLE
Quick Start: Dismiss Notices using clearWithTag

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -7,6 +7,7 @@ open class QuickStartTourGuide: NSObject {
     private var currentTourState: TourState?
     private var suggestionWorkItem: DispatchWorkItem?
     private weak var recentlyTouredBlog: Blog?
+    private let noticeTag: Notice.Tag = "QuickStartTour"
     static let notificationElementKey = "QuickStartElementKey"
 
     @objc static func find() -> QuickStartTourGuide? {
@@ -97,7 +98,8 @@ open class QuickStartTourGuide: NSObject {
                             message: tour.description,
                             style: noticeStyle,
                             actionTitle: tour.suggestionYesText,
-                            cancelTitle: tour.suggestionNoText) { [weak self] accepted in
+                            cancelTitle: tour.suggestionNoText,
+                            tag: noticeTag) { [weak self] accepted in
                                 self?.currentSuggestion = nil
 
                                 if accepted {
@@ -349,7 +351,7 @@ private extension QuickStartTourGuide {
 
     func showStepNotice(_ description: NSAttributedString) {
         let noticeStyle = QuickStartNoticeStyle(attributedMessage: description)
-        let notice = Notice(title: "Test Quick Start Notice", style: noticeStyle)
+        let notice = Notice(title: "Test Quick Start Notice", style: noticeStyle, tag: noticeTag)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
@@ -371,7 +373,7 @@ private extension QuickStartTourGuide {
         }
 
         currentSuggestion = nil
-        ActionDispatcher.dispatch(NoticeAction.dismiss)
+        ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeTag))
     }
 
     func getNextStep() -> TourState? {
@@ -389,7 +391,7 @@ private extension QuickStartTourGuide {
     }
 
     func dismissCurrentNotice() {
-        ActionDispatcher.dispatch(NoticeAction.dismiss)
+        ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeTag))
         ActionDispatcher.dispatch(NoticeAction.empty)
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.noSuchElement])
     }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -390,6 +390,7 @@ private extension QuickStartTourGuide {
         recentlyTouredBlog = nil
     }
 
+    // - TODO: Research if dispatching `NoticeAction.empty` is still necessary now that we use `.clearWithTag`.
     func dismissCurrentNotice() {
         ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeTag))
         ActionDispatcher.dispatch(NoticeAction.empty)


### PR DESCRIPTION
Fixes #11394 

This PR uses the recommended `.clearWithTag` behavior instead of `.dismiss` on the Quick Start tour guide.

### To test:
Walk through the "Customize Your Site" tour and "Grow Your Audience" tour. Ensure there are no regressions to the toasts and how they behave.

**Known issues:** the iA work has changed where our navigation is located, so now some steps are marked incorrectly in the Quick Start guide. See issues #14267 and #14268.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
