### PR TITLE
Add support for developer device registration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: bd86b48c78d4463cb194272f24eaefaedf34d365
-  tag: 0.9.4
+  revision: 3ea2642938d9a79969024f9f7d5dfaa6771a0f59
+  branch: add/automated-device-registration
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.9.4)
+    fastlane-plugin-wpmreleasetoolkit (0.9.5)
       activesupport (~> 4)
       chroma (= 0.2.0)
       diffy (~> 3.3)

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -435,8 +435,60 @@ import "./ScreenshotFastfile"
     end
   end
 
+  #####################################################################################
+  # register_new_device
+  # -----------------------------------------------------------------------------------
+  # This lane helps a developer register a new device in the App Store Portal
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane register_new_device
+  #
+  # Example:
+  # bundle exec fastlane register_new_device 
+  #####################################################################################
+  desc "Registers a Device in the developer console"
+  lane :register_new_device do | options |
+
+    bundle_identifiers = [
+      "org.wordpress",
+      "org.wordpress.WordPressShare",
+      "org.wordpress.WordPressDraftAction",
+      "org.wordpress.WordPressTodayWidget",
+      "org.wordpress.WordPressNotificationServiceExtension",
+      "org.wordpress.WordPressNotificationContentExtension",
+      "org.wordpress.WordPressAllTimeWidget",
+      "org.wordpress.WordPressThisWeekWidget"
+    ]
+
+    device_name = UI.input("Device Name: ") unless options[:device_name] != nil
+    device_id = UI.input("Device ID: ") unless options[:device_id] != nil
+    UI.message "Registering #{device_name} with ID #{device_id} and registering it with any provisioning profiles associated with these bundle identifiers:"
+    bundle_identifiers.each { |identifier|
+      puts "\t#{identifier}"
+    }
+
+    # Register the user's device
+    register_device(
+      name: device_name,
+      udid: device_id,
+      team_id: get_required_env("EXT_EXPORT_TEAM_ID")
+    )
+
+    # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)
+    add_development_certificates_to_provisioning_profiles(
+      team_id: get_required_env("EXT_EXPORT_TEAM_ID"),
+      app_identifier: bundle_identifiers
+    )
+
+    # Add all devices to the provisioning profiles
+    add_all_devices_to_provisioning_profiles(
+      team_id: get_required_env("EXT_EXPORT_TEAM_ID"),
+      app_identifier: bundle_identifiers
+    )
+  end
+
 ########################################################################
-# Cnfigure Lanes
+# Configure Lanes
 ########################################################################
   #####################################################################################
   # update_certs_and_profiles

--- a/Scripts/fastlane/Pluginfile
+++ b/Scripts/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.9.4'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', branch: 'add/automated-device-registration'
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '1.8.0'
 gem 'fastlane-plugin-test_center'


### PR DESCRIPTION
Adds support for registering a device for Xcode debugging.

Additionally, this lane adds any orphaned developer certificates to all provisioning profiles – this is necessary in order for a developer to be able to use their signing certificate for local builds, so this seems like an appropriate time to add it if we're adding the device anyway. In the future we could do this work as part of other actions ([like the new `rake init:developer` lane](https://github.com/wordpress-mobile/WordPress-iOS/pull/14100)).

**To test:**
There are two potential ways to test this – either in isolation, or end-to-end. It can be difficult to test end-to-end if you don't have any unregistered devices laying around.

**End to end**
1. Checkout this branch
2. Connect a spare device to Xcode, and note its UDID
3. Run `bundle exec fastlane register_new_device` and enter the details there
4. Follow the associated prompts until the lane is complete
5. Run WPiOS in debug mode on the device (Xcode may prompt you to update your profiles – this is expected and should be done).

Additionally, how Xcode detects that a profile is out of date seems...odd. You can go to Preferences > Accounts, and choose "Download Manual Profiles" to force them to download. We might be able to automate this step away, but IMHO this would be a separate PR

**To Test in Isolation**
1. Remove a device from any WPiOS provisioning profile in the developer portal
2. Run `bundle exec fastlane register_new_device` and enter that device's details there (if you use a different name than the one the portal knows about, the name will be changed there – you can use that as a signal that the script works)
3. Follow the associated prompts until the lane is complete
4. Go back to the list of provisioning profiles in the developer portal, then click on the now-refresh profile. It will once again contain the relevant device.
5. Remove a certificate from any WPiOS provisioning profile in the developer portal. Do all the steps again, and note that the certificate was re-added. 

PR submission checklist:
- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
