### PR TITLE
Fix publish label in Prepublishing Nudges

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -169,6 +169,7 @@ class PrepublishingViewController: UITableViewController {
 
         visbilitySelectorViewController.completion = { [weak self] option in
             self?.reloadData()
+            self?.updatePublishButtonLabel()
 
             WPAnalytics.track(.editorPostVisibilityChanged, properties: Constants.analyticsDefaultProperty)
 


### PR DESCRIPTION
Fixes #14250

### To test

1. Create a new post.
2. Enter a title and/or content.
3. Tap `Publish`.
4. Change the publish date to a past or future date.
5. Change the visibility to `Private`.

Result: The publish date is set to `Immediately` and the button says "Publish Now".