### PR TITLE
Use correct analytics event for save draft action

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -306,7 +306,13 @@ extension PostEditor where Self: UIViewController {
 
             // The post is a local or remote draft
             alertController.addDefaultActionWithTitle(title) { _ in
-                self.publishPost(action: self.editorAction(), dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
+
+                let action = self.editorAction()
+                if action == .saveAsDraft {
+                    self.postEditorStateContext.action = .save
+                }
+
+                self.publishPost(action: action, dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
             }
         }
 


### PR DESCRIPTION
`PostEditorStateContext`'s `action` property was not holding the correct value for a save draft operation. I've updated it to be `.save` instead of `.publish`.

Fixes #13729

### Testing steps
Taken from main issue:
1. Create a new Page or Post
2. Make a few edits Set title and content
3. Select "X" in the top left-hand corner
Expect: To see a dialog with "You have unsaved changes." and "Save Draft"
4. Select Save
5. The editor should fire the analytics event `editor_draft_saved`


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
