### PR TITLE
Quick Start v2: adjust indicator for Reader

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] Block Editor: Display the animation of animated GIFs while editing image blocks.
 * [**] Block editor: Adds support for theme colors and gradients.
 * [*] Fix a bug where the Latest Post date on Insights Stats was being calculated incorrectly.
+* [*] Fixed a bug where "Follow another site" was using the wrong steps in the "Grow Your Audience" Quick Start tour. 
 
 15.0
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -49,7 +49,6 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementSharing = 8,
     QuickStartTourElementConnections = 9,
     QuickStartTourElementReaderTab = 10,
-    QuickStartTourElementReaderBack = 11,
     QuickStartTourElementReaderSearch = 12,
     QuickStartTourElementTourCompleted = 13,
     QuickStartTourElementCongratulations = 14,

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationSettings.swift
@@ -11,37 +11,13 @@ class QuickStartNavigationSettings: NSObject {
         case is BlogListViewController:
             tourGuide.visited(.noSuchElement)
             tourGuide.endCurrentTour()
-        case is ReaderMenuViewController:
-            tourGuide.visited(.readerBack)
-            removeReaderSpotlight()
-        case is ReaderSearchViewController, is ReaderStreamViewController, is ReaderSavedPostsViewController:
-            readerNav = navigationController
-            checkToSpotlightReader()
         default:
             break
         }
     }
-
-    func shouldSkipReaderBack() -> Bool {
-        guard let readerNav = readerNav else {
-            return false
-        }
-
-        return !readerNav.hasHorizontallyCompactView()
-    }
-
 }
 
 private extension QuickStartNavigationSettings {
-
-    func checkToSpotlightReader() {
-        guard let tourGuide = QuickStartTourGuide.find(),
-            tourGuide.isCurrentElement(.readerBack) else {
-            return
-        }
-
-        spotlightReaderBackButton()
-    }
 
     func spotlightReaderBackButton() {
         guard let readerNav = readerNav else {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -175,7 +175,7 @@ open class QuickStartTourGuide: NSObject {
         }
         if element != currentElement {
             let blogDetailEvents: [QuickStartTourElement] = [.blogDetailNavigation, .checklist, .themes, .viewSite, .sharing]
-            let readerElements: [QuickStartTourElement] = [.readerTab, .readerBack]
+            let readerElements: [QuickStartTourElement] = [.readerTab, .readerSearch, .readerBack]
 
             if blogDetailEvents.contains(element) {
                 endCurrentTour()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -175,7 +175,7 @@ open class QuickStartTourGuide: NSObject {
         }
         if element != currentElement {
             let blogDetailEvents: [QuickStartTourElement] = [.blogDetailNavigation, .checklist, .themes, .viewSite, .sharing]
-            let readerElements: [QuickStartTourElement] = [.readerTab, .readerSearch, .readerBack]
+            let readerElements: [QuickStartTourElement] = [.readerTab, .readerSearch]
 
             if blogDetailEvents.contains(element) {
                 endCurrentTour()
@@ -195,11 +195,6 @@ open class QuickStartTourGuide: NSObject {
             return
         }
         currentTourState = nextStep
-
-        if currentElement == .readerBack && navigationSettings.shouldSkipReaderBack() {
-            visited(.readerBack)
-            return
-        }
 
         showCurrentStep()
     }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -194,11 +194,7 @@ struct QuickStartFollowTour: QuickStartTour {
         let step2DescriptionTarget = NSLocalizedString("Search", comment: "The menu item to select during a guided tour.")
         let step2: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.search)))
 
-        let step3DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let step3DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
-        let step3: WayPoint = (element: .readerBack, description: step3DescriptionBase.highlighting(phrase: step3DescriptionTarget, icon: .gridicon(.chevronLeft)))
-
-        return [step1, step2, step3]
+        return [step1, step2]
     }()
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of following other sites.", comment: "This value is used to set the accessibility hint text for following the sites of other users.")

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -190,13 +190,13 @@ struct QuickStartFollowTour: QuickStartTour {
         let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .readerTab, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.reader)))
 
-        let step2DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let step2DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
-        let step2: WayPoint = (element: .readerBack, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.chevronLeft)))
+        let step2DescriptionBase = NSLocalizedString("Select %@ to look for sites with similar interests", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step2DescriptionTarget = NSLocalizedString("Search", comment: "The menu item to select during a guided tour.")
+        let step2: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.search)))
 
-        let step3DescriptionBase = NSLocalizedString("Select %@ to look for sites with similar interests", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let step3DescriptionTarget = NSLocalizedString("Search", comment: "The menu item to select during a guided tour.")
-        let step3: WayPoint = (element: .readerSearch, description: step3DescriptionBase.highlighting(phrase: step3DescriptionTarget, icon: .gridicon(.search)))
+        let step3DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step3DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
+        let step3: WayPoint = (element: .readerBack, description: step3DescriptionBase.highlighting(phrase: step3DescriptionTarget, icon: .gridicon(.chevronLeft)))
 
         return [step1, step2, step3]
     }()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -147,6 +147,8 @@ import Gridicons
         if didBumpStats {
             return
         }
+
+        QuickStartTourGuide.find()?.visited(.readerSearch)
         WPAppAnalytics.track(.readerSearchLoaded)
         didBumpStats = true
     }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -10,7 +10,7 @@ extension WPTabBarController {
 
             guard let userInfo = notification.userInfo,
                 let element = userInfo[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement,
-                [.newpost, .readerTab].contains(element),
+                [.readerTab].contains(element),
                 let tabBar = self?.tabBar else {
                     return
             }
@@ -18,21 +18,13 @@ extension WPTabBarController {
             let newSpotlight = QuickStartSpotlightView()
             tabBar.addSubview(newSpotlight)
 
-            let x: CGFloat
-            if element == .readerTab {
-                x = tabBar.bounds.size.width / 2.0
-            } else {
-                x = tabBar.bounds.size.width * 0.40 - newSpotlight.frame.size.width
-            }
+            let x = tabBar.bounds.size.width / 2.0
+
             newSpotlight.frame = CGRect(x: x, y: spotlightViewOffset, width: newSpotlight.frame.width, height: newSpotlight.frame.height)
             spotlightView = newSpotlight
         }
 
         quickStartObserver = observer as? NSObject
-    }
-
-    @objc func alertQuickStartThatWriteWasTapped() {
-        tourGuide.visited(.newpost)
     }
 
     @objc func alertQuickStartThatReaderWasTapped() {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -19,7 +19,7 @@ extension WPTabBarController {
             tabBar.addSubview(newSpotlight)
 
             let x: CGFloat
-            if element == .newpost {
+            if element == .readerTab {
                 x = tabBar.bounds.size.width / 2.0
             } else {
                 x = tabBar.bounds.size.width * 0.40 - newSpotlight.frame.size.width

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -27,6 +27,10 @@ extension WPTabBarController {
         quickStartObserver = observer as? NSObject
     }
 
+    @objc func alertQuickStartThatWriteWasTapped() {
+        tourGuide.visited(.newpost)
+    }
+
     @objc func alertQuickStartThatReaderWasTapped() {
         tourGuide.visited(.readerTab)
     }


### PR DESCRIPTION
Fixes #14268 

This PR adjusts the "Follow another site" steps in the "Grow Your Audience" guided tour. The indicator for the Reader points to the correct location on the tab bar. The second step telling users to tap the back button has been removed. Now the second step tells the user to tap on the search button in the nav bar. Tapping the search button dismisses the toast.

| Before | After |
| --- | --- |
| <a href="https://user-images.githubusercontent.com/1062444/84073001-aadc3180-a995-11ea-8aca-77a17f59da37.PNG"><img src="https://user-images.githubusercontent.com/1062444/84073001-aadc3180-a995-11ea-8aca-77a17f59da37.PNG" width="350" /></a> | <a href="https://user-images.githubusercontent.com/1062444/84177451-80977c00-aa48-11ea-9061-5797ca63baf1.png"><img src="https://user-images.githubusercontent.com/1062444/84177451-80977c00-aa48-11ea-9061-5797ca63baf1.png" width="350" /></a> |
| <a href="https://user-images.githubusercontent.com/1062444/84073044-b7f92080-a995-11ea-9dc7-cb8852b2054a.PNG"><img src="https://user-images.githubusercontent.com/1062444/84073044-b7f92080-a995-11ea-9dc7-cb8852b2054a.PNG" width="350" /></a> | <a href="https://user-images.githubusercontent.com/1062444/84177530-9c028700-aa48-11ea-96e3-9898ccf3d581.png"><img src="https://user-images.githubusercontent.com/1062444/84177530-9c028700-aa48-11ea-96e3-9898ccf3d581.png" width="350" /></a> |

### To test:
1. Navigate to My Sites > + button > Create WordPress.com site
2. Name your site > Create > Done
3. When the fancy alert appears, choose Yes, Help Me.
4. Close the "Customize Your Site" tour guide.
5. Choose "Grow Your Audience" tour guide.
6. Choose "Follow other sites" from the list.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
