### PR TITLE
Update notifications table colors

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -224,6 +224,22 @@ extension UIColor {
         return muriel(color: .gray, .shade0)
     }
 
+    static var ungroupedListBackground: UIColor {
+        if #available(iOS 13, *) {
+            return .systemBackground
+        }
+
+        return .white
+    }
+
+    static var ungroupedListUnread: UIColor {
+        if #available(iOS 13, *) {
+            return UIColor(light: .primary(.shade0), dark: muriel(color: .gray, .shade80))
+        }
+
+        return .primary(.shade0)
+    }
+
     /// For icons that are present in a table view, or similar list
     static var listIcon: UIColor {
         if #available(iOS 13, *) {

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -10,7 +10,7 @@ extension WPStyleGuide {
         //
 
         // NoteTableViewHeader
-        public static let sectionHeaderBackgroundColor = UIColor.listBackground
+        public static let sectionHeaderBackgroundColor = UIColor.ungroupedListBackground
 
         public static var sectionHeaderRegularStyle: [NSAttributedString.Key: Any] {
             return  [.paragraphStyle: sectionHeaderParagraph,
@@ -25,8 +25,8 @@ extension WPStyleGuide {
         public static let noticonUnreadColor        = UIColor.primary
         public static let noticonUnmoderatedColor   = UIColor.warning
 
-        public static let noteBackgroundReadColor   = UIColor.listForeground
-        public static let noteBackgroundUnreadColor = UIColor.listForegroundUnread
+        public static let noteBackgroundReadColor   = UIColor.ungroupedListBackground
+        public static let noteBackgroundUnreadColor = UIColor.ungroupedListUnread
 
         public static let noteSeparatorColor        = blockSeparatorColor
 


### PR DESCRIPTION
Fixes #13282 

To test:
- Check that the notifications section header, read and unread status look like the original specification on iOS < 13.
- Check that the notifications section header, read and unread status look like the original specification on iOS > 13, light and dark mode.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
