### PR TITLE
Disable editing GIFs in the classic editor.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2786,6 +2786,7 @@ extension AztecPostViewController {
         let title: String = MediaAttachmentActionSheet.title
         var message: String?
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
+
         let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (action) in
             if attachment == self.currentSelectedAttachment {
                 self.currentSelectedAttachment = nil
@@ -2814,6 +2815,7 @@ extension AztecPostViewController {
                     self.richTextView.remove(attachmentID: attachmentID)
             })
         }
+
         if let mediaUploadID = attachment.uploadID,
            let media = mediaCoordinator.media(withObjectID: mediaUploadID),
            let error = media.error {
@@ -2849,7 +2851,7 @@ extension AztecPostViewController {
                                                                                         self.displayDetails(forAttachment: imageAttachment)
                 })
 
-                if imageAttachment.isLoaded {
+                if imageAttachment.isLoaded && imageAttachment.mediaURL?.isGif == false {
                     alertController.addActionWithTitle(MediaAttachmentActionSheet.editActionTitle,
                                                                                          style: .default,
                                                                                          handler: { (action) in


### PR DESCRIPTION
Ref #https://github.com/wordpress-mobile/WordPress-iOS/issues/13803#issuecomment-626715437

This removes the ability to edit a GIF when added to a post/page via the classic editor. The block editor will be updated with https://github.com/WordPress/gutenberg/issues/23036.

To test:
- Create a new post or page.
- Switch to the classic editor.
- Insert media, and select `Free GIF Library`.
- Select a GIF. Wait for it to finish loading.
- Tap on the GIF. 
- Verify `Edit` does _not_ appear in the options list.

| GIF options | Image options |
|--------|-------|
| ![gif_options](https://user-images.githubusercontent.com/1816888/84185253-f3562680-aa4b-11ea-9417-b31e3b36ab8b.png) | ![image_options](https://user-images.githubusercontent.com/1816888/84185264-f8b37100-aa4b-11ea-97bc-e6075dae093b.png) |


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
