### PR TITLE
Tenor search: call prepForReuse on overlay view.

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorPicker.swift
@@ -157,6 +157,7 @@ extension TenorPicker: WPMediaPickerViewControllerDelegate {
             return
         }
 
+        animatedImageView.prepForReuse()
         animatedImageView.gifStrategy = .tinyGIFs
         animatedImageView.contentMode = .scaleAspectFill
         animatedImageView.clipsToBounds = true


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/issues/13803#issuecomment-641234677

This calls `animatedImageView.prepForReuse()` when searching Tenor GIFs to ensure old content is not displayed.

To test:
- Perform a GIF search via Tenor.
- Verify the cells don't display old content.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
