### PR TITLE
Editors: show warning alert when editing a GIF.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3554,6 +3554,36 @@ extension AztecPostViewController {
     }
 
     private func edit(_ imageAttachment: ImageAttachment) {
+
+        guard imageAttachment.mediaURL?.isGif == false else {
+            confirmEditingGIF(imageAttachment)
+            return
+        }
+
+        editAttachment(imageAttachment)
+    }
+
+    private func confirmEditingGIF(_ imageAttachment: ImageAttachment) {
+        let alertController = UIAlertController(title: GIFAlertStrings.title,
+                                                message: GIFAlertStrings.message,
+                                                preferredStyle: .alert)
+
+        alertController.addCancelActionWithTitle(GIFAlertStrings.cancel) { _ in
+            if imageAttachment == self.currentSelectedAttachment {
+                self.currentSelectedAttachment = nil
+                self.resetMediaAttachmentOverlay(imageAttachment)
+                self.richTextView.refresh(imageAttachment)
+            }
+        }
+
+        alertController.addDefaultActionWithTitle(GIFAlertStrings.continue) { _ in
+            self.editAttachment(imageAttachment)
+        }
+
+        present(alertController, animated: true)
+    }
+
+    private func editAttachment(_ imageAttachment: ImageAttachment) {
         guard let image = imageAttachment.image else {
             return
         }
@@ -3562,13 +3592,13 @@ extension AztecPostViewController {
         mediaEditor.editingAlreadyPublishedImage = true
 
         mediaEditor.edit(from: self,
-                              onFinishEditing: { [weak self] images, actions in
-                                guard !actions.isEmpty, let image = images.first as? UIImage else {
-                                    // If the image wasn't edited, do nothing
-                                    return
-                                }
+                         onFinishEditing: { [weak self] images, actions in
+                            guard !actions.isEmpty, let image = images.first as? UIImage else {
+                                // If the image wasn't edited, do nothing
+                                return
+                            }
 
-                                self?.replace(attachment: imageAttachment, with: image, actions: actions)
+                            self?.replace(attachment: imageAttachment, with: image, actions: actions)
         })
     }
 
@@ -3584,4 +3614,5 @@ extension AztecPostViewController {
         }
         attachment.uploadID = media.uploadID
     }
+
 }

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorStrings.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorStrings.swift
@@ -23,4 +23,12 @@ extension String {
     static var tenorSearchLoading: String {
         return NSLocalizedString("Loading GIFs...", comment: "Phrase to show when the user has searched for GIFs and they are being loaded.")
     }
+
+}
+
+enum GIFAlertStrings {
+    static let title = NSLocalizedString("Warning", comment: "Editing GIF alert title.")
+    static let message = NSLocalizedString("Editing a GIF will remove its animation.", comment: "Editing GIF alert message.")
+    static let cancel = NSLocalizedString("Cancel", comment: "Editing GIF alert Cancel button.")
+    static let `continue` = NSLocalizedString("Continue", comment: "Editing GIF alert Continue button.")
 }


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/issues/13803#issuecomment-626715437

When attempting to edit a GIF in the post/page editor, an alert is displayed warning the user the animations will be lost of they proceed.

To test:

---
Block Editor:
- Create/edit a post/page.
- Add an Image block.
- Select `ADD IMAGE` > `Free GIF Library`.
- Search for and select a GIF.
- After it finished loading, tap on the edit button, and select `Edit`.
- Verify the warning alert appears.

| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-09 at 17 49 40](https://user-images.githubusercontent.com/1816888/84211889-ae48e900-aa79-11ea-802a-72b6f3bc456b.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-09 at 17 49 45](https://user-images.githubusercontent.com/1816888/84211902-b3a63380-aa79-11ea-99a5-512826e688af.png) |
|--------|-------|

---
Classic Editor:
- Create/edit a post/page.
- Switch to the classic editor.
- Go to media insert > `Free GIF Library`.
- Search for and select a GIF.
- After it finished loading, tap on the GIF, and select `Edit`.
- Verify the warning alert appears.

| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-09 at 17 52 29](https://user-images.githubusercontent.com/1816888/84212074-17306100-aa7a-11ea-9ae6-9caa2d3e460b.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-06-09 at 17 52 52](https://user-images.githubusercontent.com/1816888/84212086-1d264200-aa7a-11ea-8f8a-84f6fca24664.png) |
|--------|-------|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
