### PR TITLE
Added CCPA notice to PrivacySettingsViewController

### DIFF
--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -13,6 +13,7 @@ extern NSString *const WPMobileReaderDetailURL;
 extern NSString *const WPAutomatticMainURL;
 extern NSString *const WPAutomatticTermsOfServiceURL;
 extern NSString *const WPAutomatticPrivacyURL;
+extern NSString *const WPAutomatticCCPAPrivacyNoticeURL;
 extern NSString *const WPAutomatticCookiesURL;
 extern NSString *const WPAutomatticAppsBlogURL;
 extern NSString *const WPGithubMainURL;

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -13,6 +13,7 @@ NSString *const WPMobileReaderDetailURL                             = @"https://
 NSString *const WPAutomatticMainURL                                 = @"https://automattic.com/";
 NSString *const WPAutomatticTermsOfServiceURL                       = @"https://wordpress.com/tos/";
 NSString *const WPAutomatticPrivacyURL                              = @"https://automattic.com/privacy/";
+NSString *const WPAutomatticCCPAPrivacyNoticeURL                    = @"https://automattic.com/privacy/#california-consumer-privacy-act-ccpa";
 NSString *const WPAutomatticCookiesURL                              = @"https://automattic.com/cookies/";
 NSString *const WPAutomatticAppsBlogURL                             = @"https://blog.wordpress.com";
 NSString *const WPGithubMainURL                                     = @"https://github.com/wordpress-mobile/WordPress-iOS/";

--- a/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
@@ -77,6 +77,11 @@ class PrivacySettingsViewController: UITableViewController {
             action: openPrivacyPolicy()
         )
 
+        let ccpaLink = PaddedLinkRow(
+            title: NSLocalizedString("Privacy notice for California users", comment: "Link to the CCPA privacy notice for residents of California."),
+            action: openCCPANotice()
+        )
+
         let otherTracking = PaddedInfoRow(
             title: NSLocalizedString("We use other tracking tools, including some from third parties. Read about these and how to control them.", comment: "Informational text about link to other tracking tools")
         )
@@ -104,6 +109,7 @@ class PrivacySettingsViewController: UITableViewController {
                 shareInfoLink,
                 privacyText,
                 privacyLink,
+                ccpaLink,
                 otherTracking,
                 otherTrackingLink
                 ]),
@@ -124,13 +130,22 @@ class PrivacySettingsViewController: UITableViewController {
 
     func openCookiePolicy() -> ImmuTableAction {
         return { [weak self] _ in
+            self?.tableView.deselectSelectedRowWithAnimation(true)
             self?.displayWebView(WPAutomatticCookiesURL)
         }
     }
 
     func openPrivacyPolicy() -> ImmuTableAction {
         return { [weak self] _ in
+            self?.tableView.deselectSelectedRowWithAnimation(true)
             self?.displayWebView(WPAutomatticPrivacyURL)
+        }
+    }
+
+    func openCCPANotice() -> ImmuTableAction {
+        return { [weak self] _ in
+            self?.tableView.deselectSelectedRowWithAnimation(true)
+            self?.displayWebView(WPAutomatticCCPAPrivacyNoticeURL)
         }
     }
 


### PR DESCRIPTION
This PR adds the [CCPA privacy notice](https://automattic.com/privacy/#california-consumer-privacy-act-ccpa) link to `PrivacySettingsViewController`. Additionally, it fixes a small nit where rows were not getting deselected on this screen..

![3](https://user-images.githubusercontent.com/154014/84279330-7e422a00-aafb-11ea-8b8e-de538c9f3936.png)![13](https://user-images.githubusercontent.com/154014/84279340-826e4780-aafb-11ea-99f0-3c230b1cdd97.png)

@frosty or @yaelirub — would y'all mind giving this a quick look?

/cc @mattmiklic

### To test:
1. Navigate to App Settings → Privacy Settings
2. Tap on `Privacy notice for California users`
3. Verify [this link](https://automattic.com/privacy/#california-consumer-privacy-act-ccpa) is displayed in the web view.
4. Dismiss the the web view, verify the row is deselected (try this on the other links as well)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
