### PR TITLE
Track site changes inside the editor

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -32,6 +32,7 @@ import Foundation
     case editorPostLocationChanged
     case editorPostSlugChanged
     case editorPostExcerptChanged
+    case editorPostSiteChanged
 
     // App Settings
     case appSettingsAppearanceChanged
@@ -88,6 +89,8 @@ import Foundation
             return "editor_post_slug_changed"
         case .editorPostExcerptChanged:
             return "editor_post_excerpt_changed"
+        case .editorPostSiteChanged:
+            return "editor_post_site_changed"
         case .appSettingsAppearanceChanged:
             return "app_settings_appearance_changed"
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
@@ -21,6 +21,7 @@ extension PostEditor where Self: UIViewController {
         // Setup Handlers
         let successHandler: BlogSelectorSuccessHandler = { selectedObjectID in
             self.dismiss(animated: true)
+            WPAnalytics.track(.editorPostSiteChanged)
 
             guard let blog = self.mainContext.object(with: selectedObjectID) as? Blog else {
                 return


### PR DESCRIPTION
Fixes #13041

To test:

For both editors, for pages and posts, check that when switching the site the entry belongs to the new event is fired, and that is not fired when canceling the site switching.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
