### PR TITLE
Added Tappable Sites to Login Epilogue

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
@@ -71,9 +71,9 @@ private struct LoggedInDataSourceMapper: BlogListDataSourceMapper {
 }
 
 class BlogListDataSource: NSObject {
-    
+
     //Create array of urls
-    var siteURLS = [NSString]()
+    var siteURLS = [String]()
 
     override init() {
         super.init()
@@ -322,9 +322,10 @@ extension BlogListDataSource: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: WPBlogTableViewCell.reuseIdentifier()) as? WPBlogTableViewCell else {
             fatalError("Failed to get a blog cell")
         }
-        
+
         let displayURL = blog.displayURL as String? ?? ""
-        siteURLS.append(blog.displayURL!)
+
+        siteURLS.append(displayURL)
         if let name = blog.settings?.name?.nonEmptyString() {
             cell.textLabel?.text = name
             cell.detailTextLabel?.text = displayURL

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
@@ -3,6 +3,8 @@ import Foundation
 import UIKit
 import WordPressShared
 
+
+
 private protocol BlogListDataSourceMapper {
     func map(_ data: [Blog]) -> [[Blog]]
 }
@@ -69,6 +71,10 @@ private struct LoggedInDataSourceMapper: BlogListDataSourceMapper {
 }
 
 class BlogListDataSource: NSObject {
+    
+    //Create array of urls
+    var siteURLS = [NSString]()
+
     override init() {
         super.init()
         // We can't decide if we're using recent sites until the results controller
@@ -316,7 +322,9 @@ extension BlogListDataSource: UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: WPBlogTableViewCell.reuseIdentifier()) as? WPBlogTableViewCell else {
             fatalError("Failed to get a blog cell")
         }
+        
         let displayURL = blog.displayURL as String? ?? ""
+        siteURLS.append(blog.displayURL!)
         if let name = blog.settings?.name?.nonEmptyString() {
             cell.textLabel?.text = name
             cell.detailTextLabel?.text = displayURL

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -137,7 +137,7 @@ extension LoginEpilogueTableViewController {
         // Site Rows
         let wrappedPath = IndexPath(row: indexPath.row, section: indexPath.section - 1)
         let cell = blogDataSource.tableView(tableView, cellForRowAt: wrappedPath)
-        
+
         guard let loginCell = cell as? LoginEpilogueBlogCell else {
             return cell
         }
@@ -150,8 +150,8 @@ extension LoginEpilogueTableViewController {
 
         // Don't show section header for User Info
         guard section != Sections.userInfoSection,
-        let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: Settings.headerReuseIdentifier) as? EpilogueSectionHeaderFooter else {
-            return nil
+            let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: Settings.headerReuseIdentifier) as? EpilogueSectionHeaderFooter else {
+                return nil
         }
 
         // Don't show section header if there are no sites.
@@ -199,25 +199,26 @@ extension LoginEpilogueTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard indexPath.section != Sections.userInfoSection,
-            indexPath.row == lastRowInSection(indexPath.section) else {
-                
-                //checks if section is the same section as the sites
-                if indexPath.section != 1 {
-                    return
-                }
-                //pulls the URL from the URL array created in the blogListDataSource and displays it
-                var siteURLString = String(blogDataSource.siteURLS[indexPath.row])
-                siteURLString = siteURLString.hasPrefix("https://") ? siteURLString : "https://" + siteURLString
-                let siteURL = URL(string: siteURLString)
-
-                let vc = SFSafariViewController(url: siteURL!)
-                self.present(vc, animated: true, completion: nil)
-            
-                return
+        guard indexPath.section != Sections.userInfoSection else {
+            return
         }
-        
-        onConnectSite?()
+
+        //checks if section is the same section as the connect site button
+        if indexPath.row == lastRowInSection(indexPath.section) {
+            onConnectSite?()
+        }
+        else {
+            //pulls the URL from the URL array created in the blogListDataSource and displays it
+            var siteURLString = blogDataSource.siteURLS[indexPath.row]
+            siteURLString = siteURLString.hasPrefix("https://") ?
+                siteURLString : "https://" + siteURLString
+            guard let siteURL = URL(string: siteURLString) else {
+                return
+            }
+
+            let vc = SFSafariViewController(url: siteURL)
+            self.present(vc, animated: true, completion: nil)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import WordPressShared
 import WordPressAuthenticator
+import SafariServices
 
 
 // MARK: - LoginEpilogueTableViewController
@@ -136,7 +137,7 @@ extension LoginEpilogueTableViewController {
         // Site Rows
         let wrappedPath = IndexPath(row: indexPath.row, section: indexPath.section - 1)
         let cell = blogDataSource.tableView(tableView, cellForRowAt: wrappedPath)
-
+        
         guard let loginCell = cell as? LoginEpilogueBlogCell else {
             return cell
         }
@@ -200,9 +201,22 @@ extension LoginEpilogueTableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard indexPath.section != Sections.userInfoSection,
             indexPath.row == lastRowInSection(indexPath.section) else {
-            return
-        }
+                
+                //checks if section is the same section as the sites
+                if indexPath.section != 1 {
+                    return
+                }
+                //pulls the URL from the URL array created in the blogListDataSource and displays it
+                var siteURLString = String(blogDataSource.siteURLS[indexPath.row])
+                siteURLString = siteURLString.hasPrefix("https://") ? siteURLString : "https://" + siteURLString
+                let siteURL = URL(string: siteURLString)
 
+                let vc = SFSafariViewController(url: siteURL!)
+                self.present(vc, animated: true, completion: nil)
+            
+                return
+        }
+        
         onConnectSite?()
     }
 }


### PR DESCRIPTION
Fixes #13933 

![tappablesites](https://user-images.githubusercontent.com/55606409/84320131-ff161b80-ab25-11ea-8aa1-774f6bcfc320.gif)

To test:
When logging in and login epilogue is shown, try clicking on one site. It should open a Safari view controller that displays the website

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
