### PR TITLE
GIF search: correctly display partial page results.

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorPageable.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorPageable.swift
@@ -9,7 +9,16 @@ struct TenorPageable: Pageable {
     static let defaultPosition: String? = nil
 
     func next() -> Pageable? {
-        guard position != nil else {
+        guard let position = position,
+        let currentPosition = Int(position) else {
+            return nil
+        }
+
+        // If the last page is not full, there is no more to load (thus there is no next).
+        let totalPossibleResults = (currentPageIndex + 1) * itemsPerPage
+        let remainingPageSpace = totalPossibleResults - currentPosition
+
+        if remainingPageSpace < itemsPerPage {
             return nil
         }
 


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/issues/13803#issuecomment-626715437

This fixes the issue noted in the referenced comment: 
> Issue in the block editor where I saw search results appear briefly and then vanish. For some reason it happens for me every time with the search term 'blathers'.

The problem was `TenorService` was loading an additional page when it didn't need to because `TenorPageable` was telling it there was a next page. So, after correctly displaying the search results, the last fetch would return nothing, resulting in the no results message.

This change determines if the last page was partial or not. If it was, stop loading.

To test:
- Add media via Free GIF Library. (media library or page/post editors)
- Enter a search term that has few results. Specifically, less than 40. `blathers` or `hammerhead` should do it.
- Verify search results are displayed.

| ![blathers](https://user-images.githubusercontent.com/1816888/84327471-a30ac180-ab3c-11ea-9a9b-74dd2cee206d.png) | ![hammerhead](https://user-images.githubusercontent.com/1816888/84327492-adc55680-ab3c-11ea-8ad0-09177a3e0c9c.png) |
|--------|-------|


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
