### PR TITLE
Label changed from post settings to page settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3385,7 +3385,7 @@ extension AztecPostViewController {
         static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
         static let historyTitle = NSLocalizedString("History", comment: "Displays the History screen from the editor's alert sheet")
-        static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
+        static let postSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1251,8 +1251,14 @@ private extension AztecPostViewController {
             }
         }
 
-        alert.addDefaultActionWithTitle(MoreSheetAlert.postSettingsTitle) { [unowned self] _ in
-            self.displayPostSettings()
+        if let _ = post as? Post {
+            alert.addDefaultActionWithTitle(MoreSheetAlert.postSettingsTitle) { [weak self] _ in
+                self?.displayPostSettings()
+            }
+        } else if let _ = post as? Page {
+            alert.addDefaultActionWithTitle(MoreSheetAlert.pageSettingsTitle) { [weak self] _ in
+                self?.displayPostSettings()
+            }
         }
 
         alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
@@ -3385,7 +3391,8 @@ extension AztecPostViewController {
         static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
         static let historyTitle = NSLocalizedString("History", comment: "Displays the History screen from the editor's alert sheet")
-        static let postSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
+        static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
+        static let pageSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -102,7 +102,7 @@ extension GutenbergViewController {
         static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
         static let historyTitle = NSLocalizedString("History", comment: "Displays the History screen from the editor's alert sheet")
-        static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
+        static let postSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -53,11 +53,17 @@ extension GutenbergViewController {
                 self?.displayHistory()
             }
         }
-
-        alert.addDefaultActionWithTitle(MoreSheetAlert.postSettingsTitle) { [weak self] _ in
-            self?.displayPostSettings()
+        
+        if let _ = post as? Post {
+            alert.addDefaultActionWithTitle(MoreSheetAlert.postSettingsTitle) { [weak self] _ in
+                self?.displayPostSettings()
+            }
+        } else if let _ = post as? Page {
+            alert.addDefaultActionWithTitle(MoreSheetAlert.pageSettingsTitle) { [weak self] _ in
+                self?.displayPostSettings()
+            }
         }
-
+        
         alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
 
         alert.popoverPresentationController?.barButtonItem = navigationBarManager.moreBarButtonItem
@@ -102,7 +108,8 @@ extension GutenbergViewController {
         static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
         static let historyTitle = NSLocalizedString("History", comment: "Displays the History screen from the editor's alert sheet")
-        static let postSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
+        static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
+        static let pageSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -130,7 +130,7 @@ FeaturedImageViewControllerDelegate>
 {
     [super viewDidLoad];
     
-    self.title = NSLocalizedString(@"Post Settings", @"The title of the Post Settings screen.");
+    self.title = NSLocalizedString(@"Page Settings", @"The title of the Page Settings screen.");
 
     DDLogInfo(@"%@ %@", self, NSStringFromSelector(_cmd));
 


### PR DESCRIPTION
Fixes #12374 

To test:
1. open posts in My Site
2. edit some post
3. select more button
4. last alert action's title should be "Page Settings"
5.  click this action
6. navigation bar title should be "Page Settings"



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
