### PR TITLE
Save as draft problem

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3381,6 +3381,7 @@ extension AztecPostViewController {
             "Switch to block editor",
             comment: "Switches from the classic editor to block editor."
         )
+        static let saveAsDraft = NSLocalizedString("Save As Draft", comment: "Title of button allowing users to change the status of the post they are currently editing to Draft.")
         static let htmlTitle = NSLocalizedString("Switch to HTML Mode", comment: "Switches the Editor to HTML Mode")
         static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -19,13 +19,14 @@ extension GutenbergViewController {
 
             alert.title = textCounterTitle
         }*/
-
-        if postEditorStateContext.isSecondaryPublishButtonShown,
-            let buttonTitle = postEditorStateContext.secondaryPublishButtonText {
-
-            alert.addDefaultActionWithTitle(buttonTitle) { _ in
-                self.secondaryPublishButtonTapped()
-            }
+        
+        let action: PostEditorAction = .saveAsDraft
+        alert.addDefaultActionWithTitle(MoreSheetAlert.saveAsDraft) { [weak self] _ in
+            guard let self = self else {return}
+            self.publishPost(
+                action: action,
+                dismissWhenDone: action.dismissesEditor,
+            analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
         }
 
         alert.addDefaultActionWithTitle(MoreSheetAlert.classicTitle) { [unowned self] _ in
@@ -39,7 +40,7 @@ extension GutenbergViewController {
                 return MoreSheetAlert.richTitle
             }
         }()
-
+        
         alert.addDefaultActionWithTitle(toggleModeTitle) { [unowned self] _ in
             self.toggleEditingMode()
         }
@@ -98,6 +99,7 @@ extension GutenbergViewController {
             "Switch to classic editor",
             comment: "Switches from Gutenberg mobile to the classic editor"
         )
+        static let saveAsDraft = NSLocalizedString("Save As Draft", comment: "Title of button allowing users to change the status of the post they are currently editing to Draft.")
         static let htmlTitle = NSLocalizedString("Switch to HTML Mode", comment: "Switches the Editor to HTML Mode")
         static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -281,7 +281,7 @@ extension PostEditor where Self: UIViewController {
         let updatePostTitle = NSLocalizedString("Update Post", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already published post.")
         let updatePageTitle = NSLocalizedString("Update Page", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already published page.")
         let discardTitle = NSLocalizedString("Discard", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
-
+        let scheduleItTitle = NSLocalizedString("Schedule It", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already published page And if publish date is future.")
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
         alertController.view.accessibilityIdentifier = "post-has-changes-alert"
 
@@ -297,7 +297,9 @@ extension PostEditor where Self: UIViewController {
                     } else {
                         return updateTitle
                     }
-                } else if post is Page {
+                }else if post.status == .scheduled{
+                    return scheduleItTitle
+                }else if post is Page {
                     return updatePageTitle
                 } else {
                     return updatePostTitle


### PR DESCRIPTION
Fixes #14251

To test:
1. create post
2. click more
3. click post settings
4. check publish date (not today)
5. than back to post
6. click more sheet
7. there will be option to save as draft and when you click that it saved as draft
8. also if you click X button there must be "Schedule It"  text , not "Update it" (because post is from future)

PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
