### PR TITLE
Fixes the failing test

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderRelativeTimeFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderRelativeTimeFormatter.swift
@@ -5,7 +5,7 @@ class ReaderRelativeTimeFormatter: NSObject {
     private lazy var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
-        formatter.timeZone = .none
+        formatter.timeStyle = .none
         return formatter
     }()
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderRelativeTimeFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderRelativeTimeFormatter.swift
@@ -12,7 +12,7 @@ class ReaderRelativeTimeFormatter: NSObject {
     /// Date formatter used for dates older than a week but earlier than a year
     private lazy var recentDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.setLocalizedDateFormatFromTemplate("MMM dd")
         return formatter
     }()
 

--- a/WordPress/WordPressTest/ReaderRelativeTimeFormatterTests.swift
+++ b/WordPress/WordPressTest/ReaderRelativeTimeFormatterTests.swift
@@ -44,8 +44,8 @@ class ReaderRelativeTimeFormatterTests: XCTestCase {
 
     func testOlderThanAWeek() {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MMM dd"
-
+        dateFormatter.setLocalizedDateFormatFromTemplate("MMM dd")
+        
         let formatter = ReaderRelativeTimeFormatter(calendar: calendar)
         let date = Date(timeIntervalSinceNow: -(86400 * 14))
 
@@ -54,8 +54,9 @@ class ReaderRelativeTimeFormatterTests: XCTestCase {
 
     func testNotThisYear() {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MMM d, YYYY"
-
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .none
+        
         let formatter = ReaderRelativeTimeFormatter(calendar: calendar)
 
         guard let date = calendar.date(from: DateComponents(year: 2001, month: 01, day: 01)) else {

--- a/WordPress/WordPressTest/ReaderRelativeTimeFormatterTests.swift
+++ b/WordPress/WordPressTest/ReaderRelativeTimeFormatterTests.swift
@@ -45,7 +45,7 @@ class ReaderRelativeTimeFormatterTests: XCTestCase {
     func testOlderThanAWeek() {
         let dateFormatter = DateFormatter()
         dateFormatter.setLocalizedDateFormatFromTemplate("MMM dd")
-        
+
         let formatter = ReaderRelativeTimeFormatter(calendar: calendar)
         let date = Date(timeIntervalSinceNow: -(86400 * 14))
 
@@ -56,7 +56,7 @@ class ReaderRelativeTimeFormatterTests: XCTestCase {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .medium
         dateFormatter.timeStyle = .none
-        
+
         let formatter = ReaderRelativeTimeFormatter(calendar: calendar)
 
         guard let date = calendar.date(from: DateComponents(year: 2001, month: 01, day: 01)) else {


### PR DESCRIPTION
Fixes #14315

The test was failing because of a different in the date formats between the test and code. I updated the formats to match the code base. 

I also noticed the dateFormatter property was mistakenly setting the `timeZone` property and not the `timeStyle` property. I updated that as well.


## To test:
1. Run the unit tests for the ReaderRelativeTimeFormatterTests class

## PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
