### PR TITLE
Remove formatterkit

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,6 @@ end
 def shared_with_all_pods
     wordpress_shared
     pod 'CocoaLumberjack', '3.5.2'
-    pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
     pod 'NSObject-SafeExpectations', '~> 0.0.4'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -436,7 +436,6 @@ DEPENDENCIES:
   - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.30.0/react-native-gutenberg-bridge/third-party-podspecs/FBLazyVector.podspec.json`)
   - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.30.0/react-native-gutenberg-bridge/third-party-podspecs/FBReactNativeSpec.podspec.json`)
   - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.30.0/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
-  - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
   - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.30.0/react-native-gutenberg-bridge/third-party-podspecs/glog.podspec.json`)
@@ -720,6 +719,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 4ac0a37cde410deeaf1167bb9e99229f15003f27
+PODFILE CHECKSUM: 2e276925bf677636db90f919b12af36cb8c32669
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -115,7 +115,6 @@
 
 // Pods
 #import <SVProgressHUD/SVProgressHUD.h>
-#import <FormatterKit/FormatterKit-umbrella.h>
 
 #import <WPMediaPicker/WPMediaPicker.h>
 


### PR DESCRIPTION
Running `bundle exec pod outdated` tells us that the `FormatterKit` pod is unused in the project.

Deleting it compiles and passes all tests, so I'd imagine it's safe to remove.

#14320 must be merged before opening this for review.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
