### PR TITLE
Fixes Web Preview bug

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -70,6 +70,11 @@ extension PostEditor where Self: UIViewController {
             return
         }
 
+        guard post.remoteStatus != .pushing else {
+            displayPostIsUploadingAlert()
+            return
+        }
+
         savePostBeforePreview() { [weak self] previewURLString, error in
             guard let self = self else {
                 return

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -107,6 +107,12 @@ extension PostEditor where Self: UIViewController {
         }
     }
 
+    func displayPostIsUploadingAlert() {
+        let alertController = UIAlertController(title: PostUploadingAlert.title, message: PostUploadingAlert.message, preferredStyle: .alert)
+        alertController.addDefaultActionWithTitle(PostUploadingAlert.acceptTitle)
+        present(alertController, animated: true, completion: nil)
+    }
+
     func displayMediaIsUploadingAlert() {
         let alertController = UIAlertController(title: MediaUploadingAlert.title, message: MediaUploadingAlert.message, preferredStyle: .alert)
         alertController.addDefaultActionWithTitle(MediaUploadingAlert.acceptTitle)
@@ -495,6 +501,12 @@ struct PostEditorDebouncerConstants {
 private struct MediaUploadingAlert {
     static let title = NSLocalizedString("Uploading media", comment: "Title for alert when trying to save/exit a post before media upload process is complete.")
     static let message = NSLocalizedString("You are currently uploading media. Please wait until this completes.", comment: "This is a notification the user receives if they are trying to save a post (or exit) before the media upload process is complete.")
+    static let acceptTitle  = NSLocalizedString("OK", comment: "Accept Action")
+}
+
+private struct PostUploadingAlert {
+    static let title = NSLocalizedString("Uploading post", comment: "Title for alert when trying to preview a post before the uploading process is complete.")
+    static let message = NSLocalizedString("Your post is currently being uploaded. Please wait until this completes.", comment: "This is a notification the user receives if they are trying to preview a post before the upload process is complete.")
     static let acceptTitle  = NSLocalizedString("OK", comment: "Accept Action")
 }
 


### PR DESCRIPTION
Fixes #13437 

This fixes an issue where the web preview logic to upload a post could occur multiple times while the post is being uploaded to the server. It checks whether the post is currently being pushed before trying again and showing the web preview.

### Testing
- Create a new post
- Make a few changes to the content
- Throttle connection using Network Link Conditioner (or other tool). These were the settings I used:
<img width="366" alt="Screen Shot 2020-06-16 at 8 34 09 AM" src="https://user-images.githubusercontent.com/3250/84788243-29475d80-afac-11ea-9d8a-a0c7a1e801d8.png">

- Go to "Web Preview"
- While the Preview is being generated, tap "Web Preview" again and do this 2-3 times.
- Before the PR this should produce a Preview Unavailable message. Afterward, this should produce an alert about the post being uploaded.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
