### PR TITLE
Support dark mode on pre-blocks in post history

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -341,9 +341,9 @@ extension UIColor {
 
         return .white
     }
-    
+
     // MARK: - Others
-    
+
     static var preformattedBackground: UIColor {
         if #available(iOS 13, *) {
             return .systemGray6

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -341,6 +341,16 @@ extension UIColor {
 
         return .white
     }
+    
+    // MARK: - Others
+    
+    static var preformattedBackground: UIColor {
+        if #available(iOS 13, *) {
+            return .systemGray6
+        } else {
+            return UIColor.black.withAlphaComponent(0.05)
+        }
+    }
 }
 
 extension UIColor {

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
@@ -60,6 +60,7 @@ private extension RevisionPreviewViewController {
     private func setupAztec() {
         textView.load(WordPressPlugin())
         textView.textAttachmentDelegate = textViewManager
+        textView.preBackgroundColor = .neutral(.shade5)
 
         let providers: [TextViewAttachmentImageProvider] = [
             SpecialTagAttachmentRenderer(),

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
@@ -60,7 +60,7 @@ private extension RevisionPreviewViewController {
     private func setupAztec() {
         textView.load(WordPressPlugin())
         textView.textAttachmentDelegate = textViewManager
-        textView.preBackgroundColor = .neutral(.shade5)
+        textView.preBackgroundColor = .preformattedBackground
 
         let providers: [TextViewAttachmentImageProvider] = [
             SpecialTagAttachmentRenderer(),


### PR DESCRIPTION
Fixes #14241

When viewing the Visual Preview of a post revision, any verse or preformatted blocks used by the post did not adapt to Dark Mode.

### Visual changes

Preformatted blocks now support Dark Mode on this Visual Preview screen. Here's how it looks now for both Light and Dark mode, as well as iOS 12 (which does not support Dark Mode).

| Light Mode | Dark Mode | Light Mode (iOS 12) |
| -- | -- | -- |
| <img src="https://user-images.githubusercontent.com/1898325/85896077-d2b8fb00-b7c5-11ea-9115-11d388b70e54.png"> | <img src="https://user-images.githubusercontent.com/1898325/85896080-d3519180-b7c5-11ea-857e-09f9cd0f4069.png"> | <img src="https://user-images.githubusercontent.com/1898325/85896074-d187ce00-b7c5-11ea-81d7-20750705f875.png"> |

### How was it fixed?
This is fixed by setting the `preBackgroundColor` of the Aztec instance that powers this screen. Previously it was `rgb(243, 246, 248)`, which did not adapt to Dark Mode.


### How to test
Repeat the steps found in https://github.com/wordpress-mobile/WordPress-iOS/issues/14241#issue-630178763.
Expected result: With Dark Mode enabled, the content of pre-based blocks (verse and preformatted) should be readable on the Visual Previews screen (i.e. light text on a dark background).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
