### PR TITLE
Revert swift core data feature flag to local developer only

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -43,7 +43,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .readerWebview:
             return false
         case .swiftCoreData:
-            return true
+            return BuildConfiguration.current == .localDeveloper
         case .homepageSettings:
             return true
         }


### PR DESCRIPTION
Fixes #NA

To test:
- Make sure the app builds and runs
- Additionally, try to draft/publish some posts, access the Reader, add saved posts, etc

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
