### PR TITLE
Update GitHub Actions workflow running Danger to support milestone events

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v1
         with:
-          node_version: 10.x
+          node-version: 10.x
 
       - name: Install Yarn
         run: npm install -g yarn

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,5 +1,7 @@
 name: Run Checks with Danger
 on:
+  issues:
+    types: [milestoned, demilestoned]
   pull_request:
     # Because we have a rule that validates the PR labels, we want it to run
     # when the labels change, not only when a PR is opened/reopened or changes
@@ -14,6 +16,13 @@ jobs:
       # Till https://github.com/danger/danger-js/issues/1042 is fixed, we need
       # this workaround
       DANGER_GITHUB_API_BASE_URL: "https://api.github.com"
+    if:
+      # One of the Danger checks we run on PRs is for milestones, but the event
+      # that triggers it is for issues. PRs are special issues but, unlike
+      # labels, don't have a dedicated milestone event.   In order to run this
+      # workflow only for PRs, we need to check the context to see if this was
+      # triggered by a PR or a plain issue.
+      github.event.pull_request != null || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This is just a little refinement that makes sure that if the only change someone makes to a PR is adding or removing the milestone, our workflow will run and Danger will leave a comment, if appropriate.

### To test

Unfortunately, in order to test this, the code needs to be on the default branch already, see [the docs](https://help.github.com/en/actions/reference/events-that-trigger-workflows#issues-event-issues).

<img width="766" alt="Screen Shot 2020-06-17 at 9 01 46 pm" src="https://user-images.githubusercontent.com/1218433/84890780-2f3d5b80-b0de-11ea-9d2d-b80c77cc11a2.png">

(_The fact that the workflow needs to be on the default branch explains the behavior @jkmassel experienced with milestones [in this earlier PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/13556#discussion_r384676495)_)

You can play around with adding milestones to PRs and issues (to verify Danger doesn't run) on [this repo](https://github.com/mokagio/danger-github-actions-examples)

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.