### PR TITLE
Fix word count to ignore HTML tags/comments when doing analytics.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -811,7 +811,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func setHTML(_ html: String) {
-        editorView.setHTML(html)        
+        editorView.setHTML(html)
         if editorView.editingMode == .richText {
             processMediaAttachments()
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -80,6 +80,12 @@ class AztecPostViewController: UIViewController, PostEditor {
         self?.mapUIContentToPostAndSave(immediate: true)
     }
 
+    func getContentWordMetrics() -> (UInt, UInt)? {
+        let initialWordMetrics = self.initialWordMetrics ?? 0
+        let numberOfWords = richTextView.wordCount
+        return (initialWordMetrics, numberOfWords)
+    }
+
     // MARK: - Styling Options
 
     private lazy var optionsTablePresenter = OptionsTablePresenter(presentingViewController: self, presentingTextView: editorView.richTextView)
@@ -806,9 +812,13 @@ class AztecPostViewController: UIViewController, PostEditor {
         }
     }
 
+    fileprivate var initialWordMetrics: UInt?
+
     func setHTML(_ html: String) {
         editorView.setHTML(html)
-
+        if initialWordMetrics == nil {
+            initialWordMetrics = richTextView.wordCount
+        }
         if editorView.editingMode == .richText {
             processMediaAttachments()
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -80,7 +80,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         self?.mapUIContentToPostAndSave(immediate: true)
     }
 
-    var wordCount: UInt? {
+    var wordCount: UInt {
         return richTextView.wordCount
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -80,10 +80,8 @@ class AztecPostViewController: UIViewController, PostEditor {
         self?.mapUIContentToPostAndSave(immediate: true)
     }
 
-    func getContentWordMetrics() -> (UInt, UInt)? {
-        let initialWordMetrics = self.initialWordMetrics ?? 0
-        let numberOfWords = richTextView.wordCount
-        return (initialWordMetrics, numberOfWords)
+    var wordCount: UInt? {
+        return richTextView.wordCount
     }
 
     // MARK: - Styling Options
@@ -812,13 +810,8 @@ class AztecPostViewController: UIViewController, PostEditor {
         }
     }
 
-    fileprivate var initialWordMetrics: UInt?
-
     func setHTML(_ html: String) {
-        editorView.setHTML(html)
-        if initialWordMetrics == nil {
-            initialWordMetrics = richTextView.wordCount
-        }
+        editorView.setHTML(html)        
         if editorView.editingMode == .richText {
             processMediaAttachments()
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -642,7 +642,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         defer {
             isFirstGutenbergLayout = false
         }
-        if isFirstGutenbergLayout {            
+        if isFirstGutenbergLayout {
             insertPrePopulatedMedia()
             if isOpenedDirectlyForPhotoPost {
                 showMediaSelectionOnStart()

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -617,7 +617,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             self.html = html
             self.postTitle = title
         }
-        if (initialContentInfo == nil) {
+        if initialContentInfo == nil {
             initialContentInfo = contentInfo
         }
         self.contentInfo = contentInfo

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -15,7 +15,6 @@ class GutenbergViewController: UIViewController, PostEditor {
         case switchToAztec
         case switchBlog
         case autoSave
-        case initialLoad
     }
 
     private lazy var stockPhotos: GutenbergStockPhotos = {
@@ -236,12 +235,12 @@ class GutenbergViewController: UIViewController, PostEditor {
         self?.requestHTML(for: .autoSave)
     }
 
-    func getContentWordMetrics() -> (UInt, UInt)? {
-        guard let currentMetrics = contentInfo, let originalMetrics = initialContentInfo else {
+    var wordCount: UInt? {
+        guard let currentMetrics = contentInfo else {
             return nil
         }
 
-        return (UInt(originalMetrics.wordCount), UInt(currentMetrics.wordCount))
+        return UInt(currentMetrics.wordCount)
     }
 
     /// Media Library Data Source
@@ -280,7 +279,6 @@ class GutenbergViewController: UIViewController, PostEditor {
     private var themeSupportReceipt: Receipt? = nil
 
     internal private(set) var contentInfo: ContentInfo?
-    internal private(set) var initialContentInfo: ContentInfo?
 
     // MARK: - Initializers
     required init(
@@ -617,14 +615,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             self.html = html
             self.postTitle = title
         }
-        if initialContentInfo == nil {
-            initialContentInfo = contentInfo
-        }
         self.contentInfo = contentInfo
-        if let reason = requestHTMLReason, reason == .initialLoad {
-            requestHTMLReason = nil
-            return
-        }
         editorContentWasUpdated()
         mapUIContentToPostAndSave(immediate: true)
         if let reason = requestHTMLReason {
@@ -643,8 +634,6 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
                 blogPickerWasPressed()
             case .autoSave:
                 break
-            case .initialLoad:
-            break
             }
         }
     }
@@ -653,8 +642,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         defer {
             isFirstGutenbergLayout = false
         }
-        if isFirstGutenbergLayout {
-            requestHTML(for: .initialLoad)
+        if isFirstGutenbergLayout {            
             insertPrePopulatedMedia()
             if isOpenedDirectlyForPhotoPost {
                 showMediaSelectionOnStart()

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -235,9 +235,9 @@ class GutenbergViewController: UIViewController, PostEditor {
         self?.requestHTML(for: .autoSave)
     }
 
-    var wordCount: UInt? {
+    var wordCount: UInt {
         guard let currentMetrics = contentInfo else {
-            return nil
+            return 0
         }
 
         return UInt(currentMetrics.wordCount)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -182,17 +182,8 @@ extension PostEditor where Self: UIViewController {
             return
         }
 
-
-        var originalWordCount = post.original?.content?.wordCount() ?? 0
-        var wordCount = post.content?.wordCount() ?? 0
-        if let (original, current) = self.getContentWordMetrics() {
-            originalWordCount = original
-            wordCount = current
-        }
+        let wordCount = self.wordCount ?? 0        
         var properties: [String: Any] = ["word_count": wordCount, WPAppAnalyticsKeyEditorSource: analyticsEditorSource]
-        if post.hasRemote() {
-            properties["word_diff_count"] = originalWordCount
-        }
 
         properties[WPAppAnalyticsKeyPostType] = postTypeValue
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -182,8 +182,13 @@ extension PostEditor where Self: UIViewController {
             return
         }
 
-        let originalWordCount = post.original?.content?.wordCount() ?? 0
-        let wordCount = post.content?.wordCount() ?? 0
+
+        var originalWordCount = post.original?.content?.wordCount() ?? 0
+        var wordCount = post.content?.wordCount() ?? 0
+        if let (original, current) = self.getContentWordMetrics() {
+            originalWordCount = original
+            wordCount = current
+        }
         var properties: [String: Any] = ["word_count": wordCount, WPAppAnalyticsKeyEditorSource: analyticsEditorSource]
         if post.hasRemote() {
             properties["word_diff_count"] = originalWordCount

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -182,7 +182,7 @@ extension PostEditor where Self: UIViewController {
             return
         }
 
-        let wordCount = self.wordCount ?? 0
+        let wordCount = self.wordCount
         var properties: [String: Any] = ["word_count": wordCount, WPAppAnalyticsKeyEditorSource: analyticsEditorSource]
 
         properties[WPAppAnalyticsKeyPostType] = postTypeValue

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -182,7 +182,7 @@ extension PostEditor where Self: UIViewController {
             return
         }
 
-        let wordCount = self.wordCount ?? 0        
+        let wordCount = self.wordCount ?? 0
         var properties: [String: Any] = ["word_count": wordCount, WPAppAnalyticsKeyEditorSource: analyticsEditorSource]
 
         properties[WPAppAnalyticsKeyPostType] = postTypeValue

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -113,7 +113,7 @@ protocol PostEditor: class, UIViewControllerTransitioningDelegate {
     var postIsReblogged: Bool { get set }
 
     /// Returns the word counts of the content in the editor.
-    var wordCount: UInt? { get }
+    var wordCount: UInt { get }
 }
 
 extension PostEditor {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -111,6 +111,9 @@ protocol PostEditor: class, UIViewControllerTransitioningDelegate {
     var autosaver: Autosaver { get set }
     /// true if the post is the result of a reblog
     var postIsReblogged: Bool { get set }
+
+    /// Returns the word counts of the original post and current state of the post in the editor.
+    func getContentWordMetrics() -> (UInt, UInt)?
 }
 
 extension PostEditor {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -112,8 +112,8 @@ protocol PostEditor: class, UIViewControllerTransitioningDelegate {
     /// true if the post is the result of a reblog
     var postIsReblogged: Bool { get set }
 
-    /// Returns the word counts of the original post and current state of the post in the editor.
-    func getContentWordMetrics() -> (UInt, UInt)?
+    /// Returns the word counts of the content in the editor.
+    var wordCount: UInt? { get }
 }
 
 extension PostEditor {


### PR DESCRIPTION
Fixes #13618 

Added a new method to the PostEditor protocol to allow the editor
send the information about content metrics.
This allows them to use a more optimized way to calculate metrics
and match with the way they display content information in the editor.

@koke I think you may enjoy reviewing this one :)

I also have a question for you I notice that on `word_diff_count` prop for analytics we are sending the original number of words in the post, is this correct or should we send the actual difference of numbers words between the original post and new post content?

**Update (22-06-2020)**: After some discussion offline we decided to remove the `word_diff_count` property altogether.
The rationale is that we are not using it for any stats, and we also don't implement it in Android and web. 

To test:
 - Start the app
 - Edit a post
 - Add a breakpoint on this method: https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/13618_fix_word_count?expand=1#diff-ae677e43073df51ab2a9be66a47d74b0R189
 - Check that when you publish a post the metrics are correct.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
