### PR TITLE
Save for later: basic offline support

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/OfflineReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/OfflineReaderWebView.swift
@@ -4,9 +4,19 @@ import Foundation
 /// The mechanism is quite simple: open the post in a hidden webview so the images are cached
 ///
 class OfflineReaderWebView: ReaderWebView {
-    func saveForLater(_ string: String) {
+    func saveForLater(_ post: ReaderPost, viewController: UIViewController) {
         navigationDelegate = self
 
+        frame = CGRect(x: 0, y: 0, width: viewController.view.frame.width, height: viewController.view.frame.height)
+
+        isHidden = true
+
+        viewController.view.addSubview(self)
+
+        load(post.contentForDisplay())
+    }
+
+    private func load(_ string: String) {
         // Remove all srcset from the images, only the URL in the src tag will be cached
         let content = super.formattedContent(string, additionalJavaScript: """
             document.querySelectorAll('img').forEach((el) => {el.removeAttribute('srcset')})

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/OfflineReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/OfflineReaderWebView.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// A WKWebView used to save post content to be available when offline
+/// The mechanism is quite simple: open the post in a hidden webview so the images are cached
+///
+class OfflineReaderWebView: ReaderWebView {
+    func saveForLater(_ string: String) {
+        navigationDelegate = self
+
+        // Remove all srcset from the images, only the URL in the src tag will be cached
+        let content = super.formattedContent(string, additionalJavaScript: """
+            document.querySelectorAll('img').forEach((el) => {el.removeAttribute('srcset')})
+        """)
+
+        super.loadHTMLString(content, baseURL: Bundle.wordPressSharedBundle.bundleURL)
+    }
+}
+
+extension OfflineReaderWebView: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // We wait 5 secs before removing the WebView to give it time to be rendered
+        // If its removed before it was rendered, the images won't be cached
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+            self.removeFromSuperview()
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/OfflineReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/OfflineReaderWebView.swift
@@ -5,6 +5,10 @@ import Foundation
 ///
 class OfflineReaderWebView: ReaderWebView {
     func saveForLater(_ post: ReaderPost, viewController: UIViewController) {
+        guard let contentForDisplay = post.contentForDisplay() else {
+            return
+        }
+
         navigationDelegate = self
 
         frame = CGRect(x: 0, y: 0, width: viewController.view.frame.width, height: viewController.view.frame.height)
@@ -13,7 +17,7 @@ class OfflineReaderWebView: ReaderWebView {
 
         viewController.view.addSubview(self)
 
-        load(post.contentForDisplay())
+        load(contentForDisplay)
     }
 
     private func load(_ string: String) {

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/OfflineReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/OfflineReaderWebView.swift
@@ -22,9 +22,7 @@ class OfflineReaderWebView: ReaderWebView {
 
     private func load(_ string: String) {
         // Remove all srcset from the images, only the URL in the src tag will be cached
-        let content = super.formattedContent(string, additionalJavaScript: """
-            document.querySelectorAll('img').forEach((el) => {el.removeAttribute('srcset')})
-        """)
+        let content = super.formattedContent(string, additionalJavaScript: jsToRemoveSrcSet)
 
         super.loadHTMLString(content, baseURL: Bundle.wordPressSharedBundle.bundleURL)
     }

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderDetailToolbar.swift
@@ -64,7 +64,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             FancyAlertViewController.presentReaderSavedPostsAlertControllerIfNecessary(from: viewController)
         }
 
-        ReaderSaveForLaterAction().execute(with: readerPost, context: context, origin: .postDetail) { [weak self] in
+        ReaderSaveForLaterAction().execute(with: readerPost, context: context, origin: .postDetail, viewController: viewController) { [weak self] in
             self?.saveForLaterButton.isSelected = readerPost.isSavedForLater
             self?.prepareActionButtonsForVoiceOver()
         }

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
@@ -16,9 +16,21 @@ class ReaderWebView: WKWebView {
 
     /// Loads a HTML content into the webview and apply styles
     ///
-    @discardableResult
-    override func loadHTMLString(_ string: String, baseURL: URL?) -> WKNavigation? {
-        let content = """
+    func loadHTMLString(_ string: String) {
+        // If the user is offline, we remove the srcset from all images
+        // This is because only the image inside the src tag is previously saved
+        let additionalJavaScript = ReachabilityUtils.isInternetReachable() ? "" : "document.querySelectorAll('img-placeholder').forEach((el) => {el.removeAttribute('srcset')})"
+
+        let content = formattedContent(addPlaceholder(string), additionalJavaScript: additionalJavaScript)
+
+        super.loadHTMLString(content, baseURL: Bundle.wordPressSharedBundle.bundleURL)
+    }
+
+    /// Given a HTML content, returns it formatted.
+    /// Ie.: Including tags, CSS, JS, etc.
+    ///
+    func formattedContent(_ content: String, additionalJavaScript: String = "") -> String {
+        return """
         <!DOCTYPE html><html><head><meta charset='UTF-8' />
         <title>Reader Post</title>
         <meta name='viewport' content='initial-scale=1, maximum-scale=1.0, user-scalable=no'>
@@ -28,18 +40,17 @@ class ReaderWebView: WKWebView {
         \(cssStyles())
         </style>
         </head><body class="reader-full-post reader-full-post__story-content">
-        \(addPlaceholder(string))
+        \(content)
         </body>
         <script>
             document.addEventListener('DOMContentLoaded', function(event) {
+                \(additionalJavaScript)
                 // Remove autoplay to avoid media autoplaying
                 document.querySelectorAll('video-placeholder, audio-placeholder').forEach((el) => {el.removeAttribute('autoplay')})
             })
         </script>
         </html>
         """
-
-        return super.loadHTMLString(content, baseURL: Bundle.wordPressSharedBundle.bundleURL)
     }
 
     /// Tell the webview to load all media

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
@@ -8,6 +8,8 @@ class ReaderWebView: WKWebView {
     /// From: https://www.w3schools.com/tags/att_src.asp
     private let elements = ["audio", "embed", "iframe", "img", "input", "script", "source", "track", "video"]
 
+    let jsToRemoveSrcSet = "document.querySelectorAll('img-placeholder').forEach((el) => {el.removeAttribute('srcset')})"
+
     /// Make the webview transparent
     ///
     override func awakeFromNib() {
@@ -20,7 +22,7 @@ class ReaderWebView: WKWebView {
     func loadHTMLString(_ string: String) {
         // If the user is offline, we remove the srcset from all images
         // This is because only the image inside the src tag is previously saved
-        let additionalJavaScript = ReachabilityUtils.isInternetReachable() ? "" : "document.querySelectorAll('img-placeholder').forEach((el) => {el.removeAttribute('srcset')})"
+        let additionalJavaScript = ReachabilityUtils.isInternetReachable() ? "" : jsToRemoveSrcSet
 
         let content = formattedContent(addPlaceholder(string), additionalJavaScript: additionalJavaScript)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1254,7 +1254,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             FancyAlertViewController.presentReaderSavedPostsAlertControllerIfNecessary(from: self)
         }
 
-        ReaderSaveForLaterAction().execute(with: readerPost, context: context, origin: .postDetail) { [weak self] in
+        ReaderSaveForLaterAction().execute(with: readerPost, context: context, origin: .postDetail, viewController: self) { [weak self] in
             self?.saveForLaterButton.isSelected = readerPost.isSavedForLater
             self?.prepareActionButtonsForVoiceOver()
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailWebviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailWebviewViewController.swift
@@ -111,7 +111,7 @@ class ReaderDetailWebviewViewController: UIViewController, ReaderDetailView {
         configureDiscoverAttribution(post)
         toolbar.configure(for: post, in: self)
         header.configure(for: post)
-        webView.loadHTMLString(post.contentForDisplay(), baseURL: nil)
+        webView.loadHTMLString(post.contentForDisplay())
     }
 
     /// Show ghost cells indicating the content is loading

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -137,7 +137,7 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
 
         let saveAction = ReaderSaveForLaterAction(visibleConfirmation: visibleConfirmation)
 
-        saveAction.execute(with: post, context: context, origin: actionOrigin)
+        saveAction.execute(with: post, context: context, origin: actionOrigin, viewController: origin)
         saveForLaterAction = saveAction
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
@@ -17,7 +17,13 @@ final class ReaderSaveForLaterAction {
         self.visibleConfirmation = visibleConfirmation
     }
 
-    func execute(with post: ReaderPost, context: NSManagedObjectContext, origin: ReaderSaveForLaterOrigin, completion: (() -> Void)? = nil) {
+    func execute(with post: ReaderPost, context: NSManagedObjectContext, origin: ReaderSaveForLaterOrigin, viewController: UIViewController?, completion: (() -> Void)? = nil) {
+        /// Preload the post
+        if let viewController = viewController, !post.isSavedForLater, FeatureFlag.readerWebview.enabled {
+            let offlineReaderWebView = OfflineReaderWebView()
+            offlineReaderWebView.saveForLater(post, viewController: viewController)
+        }
+
         trackSaveAction(for: post, origin: origin)
         toggleSavedForLater(post, context: context, origin: origin, completion: completion)
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1063,6 +1063,7 @@
 		8B11B6682489C0A4000F1A0F /* ReaderScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B11B6672489C0A4000F1A0F /* ReaderScrollView.swift */; };
 		8B1CF00F2433902700578582 /* PasswordAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1CF00E2433902700578582 /* PasswordAlertController.swift */; };
 		8B1CF0112433E61C00578582 /* AbstractPost+TitleForVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1CF0102433E61C00578582 /* AbstractPost+TitleForVisibility.swift */; };
+		8B24C4E3249A4C3E0005E8A5 /* OfflineReaderWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B24C4E2249A4C3E0005E8A5 /* OfflineReaderWebView.swift */; };
 		8B260D7E2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
@@ -3523,6 +3524,7 @@
 		8B11B6672489C0A4000F1A0F /* ReaderScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderScrollView.swift; sourceTree = "<group>"; };
 		8B1CF00E2433902700578582 /* PasswordAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordAlertController.swift; sourceTree = "<group>"; };
 		8B1CF0102433E61C00578582 /* AbstractPost+TitleForVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+TitleForVisibility.swift"; sourceTree = "<group>"; };
+		8B24C4E2249A4C3E0005E8A5 /* OfflineReaderWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineReaderWebView.swift; sourceTree = "<group>"; };
 		8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostVisibilitySelectorViewController.swift; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
@@ -7763,6 +7765,7 @@
 			children = (
 				8B64B4B1247EC3A2009A1229 /* reader.css */,
 				8BADF16424801BCE005AD038 /* ReaderWebView.swift */,
+				8B24C4E2249A4C3E0005E8A5 /* OfflineReaderWebView.swift */,
 				8B0CE7D02481CFE8004C4799 /* ReaderDetailHeaderView.swift */,
 				8B0CE7D22481CFF8004C4799 /* ReaderDetailHeaderView.xib */,
 				8BA77BCA2482C52A00E1EBBF /* ReaderCardDiscoverAttributionView.xib */,
@@ -12506,6 +12509,7 @@
 				D8A3A5AF206A442800992576 /* StockPhotosDataSource.swift in Sources */,
 				F53FF3A323EA3E45001AD596 /* BlogDetailsViewController+Header.swift in Sources */,
 				E6F058021C1A122B008000F9 /* ReaderPostMenu.swift in Sources */,
+				8B24C4E3249A4C3E0005E8A5 /* OfflineReaderWebView.swift in Sources */,
 				9A5C854822B3E42800BEE7A3 /* CountriesMapCell.swift in Sources */,
 				B5B410B61B1772B000CFCF8D /* NavigationTitleView.swift in Sources */,
 				8BAD53D6241922B900230F4B /* WPAnalyticsEvent.swift in Sources */,


### PR DESCRIPTION
Fixes #14337

Review only after #14328 is merged

This PR adds basic support to offline when saving a post for later in the Reader.

Why *basic* support? What we do is:

1. We open a hidden webview to preload the post, so when offline must of the resources (mainly images) will be there
2. Why not all of them? Because the WebView respects the cache from the server. If an image comes from a server that disables caching its resources, this will not work (but it will work with WP.com)

### To test

**Make sure that you have overridden the new reader Feature Flag and it's not using the older Reader (Me -> App Settings -> Debug -> "Reader content displayed in a webview" should be ON)**

1. Open the Reader
2. Save a few posts for later
3. Close the app
4. Go offline
5. Open the app
6. Open the saved posts, most of the images should be there

You can use this snippet to make sure the webview content is erased:

```swift
let websiteDataTypes = NSSet(array: [WKWebsiteDataTypeDiskCache, WKWebsiteDataTypeMemoryCache])
let date = Date(timeIntervalSince1970: 0)
WKWebsiteDataStore.default().removeData(ofTypes: websiteDataTypes as! Set<String>, modifiedSince: date, completionHandler:{ })
```

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
