### PR TITLE
Core Data: Tweaks thrown errors to include more context about what went wrong

### DIFF
--- a/WordPress/Classes/Utility/Migrator/CoreDataIterativeMigrator.swift
+++ b/WordPress/Classes/Utility/Migrator/CoreDataIterativeMigrator.swift
@@ -30,7 +30,7 @@ class CoreDataIterativeMigrator: NSObject {
 
         // Get the persistent store's metadata.  The metadata is used to
         // get information about the store's managed object model.
-        // If metadataForPersistentStore throws an error that error is propigated, not replaced by the throw
+        // If metadataForPersistentStore throws an error that error is propagated, not replaced by the throw
         // in the guard's else clause.  If metadataForPersistentStore returns nil then an error is thrown.
         guard let sourceMetadata = try metadataForPersistentStore(storeType: storeType, at: sourceStore) else {
             throw error(with: .failedRetrievingMetadata, description: "The source metadata was nil.")
@@ -252,7 +252,8 @@ private extension CoreDataIterativeMigrator {
 
     static func metadataForPersistentStore(storeType: String, at url: URL) throws -> [String: Any]? {
         do {
-            return try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: url, options: nil)
+            let metadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: url, options: nil)
+            return metadata
         } catch {
             let originalDescription: String = (error as NSError).userInfo[NSLocalizedDescriptionKey] as? String ?? ""
             let description = "Failed to find source metadata for store: \(url). Original Description: \(originalDescription)"

--- a/WordPress/Classes/Utility/Migrator/CoreDataIterativeMigrator.swift
+++ b/WordPress/Classes/Utility/Migrator/CoreDataIterativeMigrator.swift
@@ -5,6 +5,10 @@ import CoreData
 ///
 class CoreDataIterativeMigrator: NSObject {
 
+    private static func error(with code: IterativeMigratorErrorCodes, description: String) -> NSError {
+        return NSError(domain: "IterativeMigrator", code: code.rawValue, userInfo: [NSLocalizedDescriptionKey: description])
+    }
+
     /// Migrates a store to a particular model using the list of models to do it iteratively, if required.
     ///
     /// - Parameters:
@@ -26,8 +30,10 @@ class CoreDataIterativeMigrator: NSObject {
 
         // Get the persistent store's metadata.  The metadata is used to
         // get information about the store's managed object model.
+        // If metadataForPersistentStore throws an error that error is propigated, not replaced by the throw
+        // in the guard's else clause.  If metadataForPersistentStore returns nil then an error is thrown.
         guard let sourceMetadata = try metadataForPersistentStore(storeType: storeType, at: sourceStore) else {
-            throw MigrationError.migrationFailed
+            throw error(with: .failedRetrievingMetadata, description: "The source metadata was nil.")
         }
 
         // Check whether the final model is already compatible with the store.
@@ -75,6 +81,15 @@ class CoreDataIterativeMigrator: NSObject {
             modelsToMigrate = modelsToMigrate.reversed()
         }
 
+        // Nested function for retrieving a model's version name.
+        // Used to give more context to errors.
+        func versionNameForModel(model: NSManagedObjectModel) -> String {
+            guard let index = objectModels.firstIndex(of: model) else {
+                return "Unknown"
+            }
+            return modelNames[index]
+        }
+
         // Migrate between each model. Count - 2 because of zero-based index and we want
         // to stop at the last pair (you can't migrate the last model to nothingness).
         let upperBound = modelsToMigrate.count - 2
@@ -82,17 +97,33 @@ class CoreDataIterativeMigrator: NSObject {
             let modelFrom = modelsToMigrate[index]
             let modelTo = modelsToMigrate[index + 1]
 
+            let migrateWithModel: NSMappingModel
             // Check whether a custom mapping model exists.
-            guard let migrateWithModel = NSMappingModel(from: nil, forSourceModel: modelFrom, destinationModel: modelTo) ??
-                (try? NSMappingModel.inferredMappingModel(forSourceModel: modelFrom, destinationModel: modelTo)) else {
-                    throw MigrationError.migrationFailed
+            if let customModel = NSMappingModel(from: nil, forSourceModel: modelFrom, destinationModel: modelTo) {
+                migrateWithModel = customModel
+            } else {
+                // No custom model, so use an inferred model.
+                do {
+                    let inferredModel = try NSMappingModel.inferredMappingModel(forSourceModel: modelFrom, destinationModel: modelTo)
+                    migrateWithModel = inferredModel
+                } catch {
+                    let versionFrom = versionNameForModel(model: modelFrom)
+                    let versionTo = versionNameForModel(model: modelTo)
+                    var description = "Mapping model could not be inferred, and no custom mapping model found."
+                    description = description + "Version From \(versionFrom), To \(versionTo)."
+                    description = description + " Original Error: \(error)"
+                    throw CoreDataIterativeMigrator.error(with: IterativeMigratorErrorCodes.failedOnCustomMappingModel, description: description)
+                }
+
             }
 
             // Migrate the model to the next step
             DDLogWarn("⚠️ Attempting migration from \(modelNames[index]) to \(modelNames[index + 1])")
 
             guard migrateStore(at: sourceStore, storeType: storeType, fromModel: modelFrom, toModel: modelTo, with: migrateWithModel) == true else {
-                throw MigrationError.migrationFailed
+                let versionFrom = versionNameForModel(model: modelFrom)
+                let versionTo = versionNameForModel(model: modelTo)
+                throw error(with: .failedMigratingStore, description: "Failed migrating store from version \(versionFrom) to version \(versionTo).")
             }
         }
     }
@@ -218,20 +249,20 @@ private extension CoreDataIterativeMigrator {
     }
 
     static func metadataForPersistentStore(storeType: String, at url: URL) throws -> [String: Any]? {
-
-        guard let sourceMetadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: url, options: nil) else {
-            let description = "Failed to find source metadata for store: \(url)"
-            throw NSError(domain: "IterativeMigrator", code: 102, userInfo: [NSLocalizedDescriptionKey: description])
+        do {
+            return try NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: storeType, at: url, options: nil)
+        } catch {
+            let originalDescription: String = (error as NSError).userInfo[NSLocalizedDescriptionKey] as? String ?? ""
+            let description = "Failed to find source metadata for store: \(url). Original Description: \(originalDescription)"
+            throw CoreDataIterativeMigrator.error(with: IterativeMigratorErrorCodes.noMetadataForStore, description: description)
         }
-
-        return sourceMetadata
     }
 
     static func model(for metadata: [String: Any]) throws -> NSManagedObjectModel? {
         let bundle = Bundle(for: ContextManager.self)
         guard let sourceModel = NSManagedObjectModel.mergedModel(from: [bundle], forStoreMetadata: metadata) else {
             let description = "Failed to find source model for metadata: \(metadata)"
-            throw NSError(domain: "IterativeMigrator", code: 100, userInfo: [NSLocalizedDescriptionKey: description])
+            throw error(with: .noSourceModelForMetadata, description: description)
         }
 
         return sourceModel
@@ -242,7 +273,7 @@ private extension CoreDataIterativeMigrator {
             guard let url = urlForModel(name: name, in: nil),
                 let model = NSManagedObjectModel(contentsOf: url) else {
                     let description = "No model found for \(name)"
-                    throw NSError(domain: "IterativeMigrator", code: 110, userInfo: [NSLocalizedDescriptionKey: description])
+                    throw error(with: .noModelFound, description: description)
             }
 
             return model
@@ -271,6 +302,12 @@ private extension CoreDataIterativeMigrator {
     }
 }
 
-enum MigrationError: Error {
-    case migrationFailed
+enum IterativeMigratorErrorCodes: Int {
+    case noSourceModelForMetadata = 100
+    case noMetadataForStore = 102
+    case noModelFound = 110
+
+    case failedRetrievingMetadata = 120
+    case failedOnCustomMappingModel = 130
+    case failedMigratingStore = 140
 }


### PR DESCRIPTION
A quick PR to add some extra information to errors that can be thrown during a core data migration to help better understand what went wrong.  Changes include:
- Including the to and from version involved when something goes 💥 
- Including information from an original error (if one exists) as part of our thrown error description.
- A slight refactor in a couple of places where a thrown error could be out right ignored.

Xcode was complaining in a few places about the newly added `error(with:description)` method so there is a bit of a mix-match with its usage. I prefer not having to include the class as part of the usage so I've only done that where necessary. Not sure why this is happening tho.

To test:
Run the branch and make sure it builds. 
Try migrating from a previous version and make sure there are no errors. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@Gio2018 and @leandroalonso, hoping y'all could both take a peek (when it comes to our core data stack the more eyes the better!)