### PR TITLE
ULS: Display navigation bar large titles

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -186,9 +186,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.18.0'
+    #pod 'WordPressAuthenticator', '~> 1.19.0-beta.3'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/182-large_nav_titles'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -381,7 +381,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.2)
   - WordPress-Editor-iOS (1.19.2):
     - WordPress-Aztec-iOS (= 1.19.2)
-  - WordPressAuthenticator (1.18.0):
+  - WordPressAuthenticator (1.19.0-beta.3):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -484,7 +484,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.2)
-  - WordPressAuthenticator (~> 1.18.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/182-large_nav_titles`)
   - WordPressKit (= 4.11.0-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.0)
@@ -534,7 +534,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -620,6 +619,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 031a963546be4a41125082ede53a470696aa96e9
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :branch: feature/182-large_nav_titles
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/031a963546be4a41125082ede53a470696aa96e9/react-native-gutenberg-bridge/third-party-podspecs/Yoga.podspec.json
 
@@ -633,6 +635,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 031a963546be4a41125082ede53a470696aa96e9
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressAuthenticator:
+    :commit: 83c242d77131c0f2e9e65a5a1bf035d3250d9d25
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -706,7 +711,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: d01bf0c5e150ae6a046f06ba63b7cc2762061c0b
   WordPress-Editor-iOS: 5b726489e5ae07b7281a2862d69aba2d5c83f140
-  WordPressAuthenticator: 7c7f442088af2022f7ee5d7baa6bd73d87df9e25
+  WordPressAuthenticator: 6d6b085a895ce00bd616c2132d58e59cd1f26745
   WordPressKit: cf04f034a376fe54a44edff62c3bd0ece5ef13a6
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b887b17aa949e4b142a1421fd479de495db9a054
@@ -723,6 +728,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: f53b628ab432951703d42cbcd81825b2e1f79f60
+PODFILE CHECKSUM: 2040a8d9985a359e0532c19b8b3428a8253b5fbb
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/182
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/307

This uses the Auth branch to display Large Titles in the navigation bar. 

As noted in the Auth PR, displaying the large titles in the email login flow is for testing purposes only, and will be removed before the PRs are merged.

To test:

---
- Run the app. Log out if necessary.
- `Log In` > `Continue with WordPress.com`.
- Verify:
  - The back button label is 'Back'.
  - `Log In` is displayed in the nav bar.

![login_email](https://user-images.githubusercontent.com/1816888/84959210-2471cf00-b0bc-11ea-8520-aa0ba64385fb.png)

---
- Enter an email address and `Next`.
- Verify:
  - The back button label is 'Back'.
  - `Log In` is displayed in the nav bar.

![login_magic_link](https://user-images.githubusercontent.com/1816888/84959497-aa8e1580-b0bc-11ea-97dd-f94a08efb50d.png)

---
- Select `Enter your password instead.`
- Verify:
  - The back button label is 'Back'.
  - There is no large title displayed in the nav bar.

![login_password](https://user-images.githubusercontent.com/1816888/84959509-afeb6000-b0bc-11ea-8a3d-6abaf5d0dca7.png)

---
- Go into any other login or signup flow.
- Verify large titles are not displayed in the nav bar.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
