### PR TITLE
[Gutenberg] Fix gutenberg web-view auth issues with Atomic sites

### DIFF
--- a/WordPress/Classes/Utility/Networking/GutenbergRequestAuthenticator.swift
+++ b/WordPress/Classes/Utility/Networking/GutenbergRequestAuthenticator.swift
@@ -1,0 +1,15 @@
+/// Small override of RequestAuthenticator to be able to authenticate with writting rights on Atomic sites.
+/// Needed to load the gutenberg web editor on a web view on Atomic public and private sites.
+class GutenbergRequestAuthenticator: RequestAuthenticator {
+    convenience init?(account: WPAccount, blog: Blog? = nil) {
+        guard
+            let username = account.username,
+            let token = account.authToken
+        else {
+            return nil
+        }
+
+        // To load gutenberg web editor (or wp-admin in general) we need regular authentication type.
+        self.init(credentials: .dotCom(username: username, authToken: token, authenticationType: .regular))
+    }
+}

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
@@ -12,7 +12,7 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
     private let progressView = WebProgressView()
 
     init(with post: AbstractPost, block: Block) throws {
-        authenticator = RequestAuthenticator(blog: post.blog)
+        authenticator = GutenbergRequestAuthenticator(blog: post.blog)
         let userId = "\(post.blog.userID ?? 1)"
 
         guard

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		1D36FCB53C05724865D41F7A /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1E0FF01E242BC572008DA898 /* GutenbergWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0FF01D242BC572008DA898 /* GutenbergWebViewController.swift */; };
+		1E485A90249B61440000A253 /* GutenbergRequestAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E485A8F249B61440000A253 /* GutenbergRequestAuthenticator.swift */; };
 		1E4F2E712458AF8500EB73E7 /* GutenbergWebNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4F2E702458AF8500EB73E7 /* GutenbergWebNavigationViewController.swift */; };
 		1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */; };
 		2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
@@ -2683,6 +2684,7 @@
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E0FF01D242BC572008DA898 /* GutenbergWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergWebViewController.swift; sourceTree = "<group>"; };
+		1E485A8F249B61440000A253 /* GutenbergRequestAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergRequestAuthenticator.swift; sourceTree = "<group>"; };
 		1E4F2E702458AF8500EB73E7 /* GutenbergWebNavigationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergWebNavigationViewController.swift; sourceTree = "<group>"; };
 		1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergRollout.swift; sourceTree = "<group>"; };
 		2262D835FA89938EBF63EADF /* Pods-WordPressShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
@@ -5540,6 +5542,7 @@
 			isa = PBXGroup;
 			children = (
 				F15272FE243B28B600C8DC7A /* RequestAuthenticator.swift */,
+				1E485A8F249B61440000A253 /* GutenbergRequestAuthenticator.swift */,
 				1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */,
 			);
 			path = Networking;
@@ -5554,7 +5557,7 @@
 			path = GutenbergWeb;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				98D31BBF239720E4009CFF43 /* MainInterface.storyboard */,
@@ -10905,7 +10908,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -12394,6 +12397,7 @@
 				B5C0CF3D204DA41000DB0362 /* NotificationReplyStore.swift in Sources */,
 				B53AD9BC1BE95687009AB87E /* SettingsTextViewController.m in Sources */,
 				E1389ADB1C59F7C200FB2466 /* PlanListViewController.swift in Sources */,
+				1E485A90249B61440000A253 /* GutenbergRequestAuthenticator.swift in Sources */,
 				8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */,
 				173BCE731CEB368A00AE8817 /* DomainsListViewController.swift in Sources */,
 				E1B912891BB01288003C25B9 /* PeopleViewController.swift in Sources */,


### PR DESCRIPTION
Fixes parts of https://github.com/wordpress-mobile/gutenberg-mobile/issues/2358

This PR overrides `RequestAuthenticator` for the specific Gutenberg web view use case, where we want to use the `regular` auth type also for Atomic sites.

To test:
- Setup an atomic site and test as public and private.
- Create a post with a block not yet supported on mobile.
- Test on a real device.
- Will need Metro server running (on gutenberg-mobile develop branch is enough)
- Log out from your wp account in the app to clean cookies.
- Uninstall the app from your device.
- Install building the app from this PR.
- Login and go directly to the Atomic site.
- Open the created post with unsupported block.
- Open the unsupported block on the web view.
- Check that gutenberg opens on the web view without asking for credentials 🙏 

@Guarani can I ask you for a review? Thanks!

Also cc @marecar3 @aerych 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
