### PR TITLE
Fixing Push Authentication

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -504,7 +504,7 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
         //  -   Nuke `PushNotificationsManager`
         //
         //
-        PushNotificationsManager.shared.handleNotification(userInfo) { _ in
+        PushNotificationsManager.shared.handleNotification(userInfo, userInteraction: true) { _ in
             completionHandler()
         }
     }

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -157,9 +157,10 @@ final public class PushNotificationsManager: NSObject {
     ///
     /// - Parameters:
     ///     - userInfo: The Notification's Payload
+    ///     - userInteraction: Indicates if the user interacted with the Push Notification
     ///     - completionHandler: A callback, to be executed on completion
     ///
-    @objc func handleNotification(_ userInfo: NSDictionary, completionHandler: ((UIBackgroundFetchResult) -> Void)?) {
+    @objc func handleNotification(_ userInfo: NSDictionary, userInteraction: Bool = false, completionHandler: ((UIBackgroundFetchResult) -> Void)?) {
         DDLogVerbose("Received push notification:\nPayload: \(userInfo)\n")
         DDLogVerbose("Current Application state: \(applicationState.rawValue)")
 
@@ -184,7 +185,7 @@ final public class PushNotificationsManager: NSObject {
                         handleQuickStartLocalNotification]
 
         for handler in handlers {
-            if handler(userInfo, completionHandler) {
+            if handler(userInfo, userInteraction, completionHandler) {
                 break
             }
         }
@@ -230,7 +231,7 @@ extension PushNotificationsManager {
     ///
     /// - Returns: True when handled. False otherwise
     ///
-    @objc func handleSupportNotification(_ userInfo: NSDictionary, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
+    @objc func handleSupportNotification(_ userInfo: NSDictionary, userInteraction: Bool, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
 
         guard let type = userInfo.string(forKey: ZendeskUtils.PushNotificationIdentifiers.key),
             type == ZendeskUtils.PushNotificationIdentifiers.type else {
@@ -263,7 +264,7 @@ extension PushNotificationsManager {
     ///
     /// - Returns: True when handled. False otherwise
     ///
-    @objc func handleAuthenticationNotification(_ userInfo: NSDictionary, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
+    @objc func handleAuthenticationNotification(_ userInfo: NSDictionary, userInteraction: Bool, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
         // WordPress.com Push Authentication Notification
         // Due to the Background Notifications entitlement, any given Push Notification's userInfo might be received
         // while the app is in BG, and when it's about to become active. In order to prevent UI glitches, let's skip
@@ -274,7 +275,17 @@ extension PushNotificationsManager {
             return false
         }
 
-        if applicationState != .background {
+        /// This is a (hopefully temporary) workaround. A Push Authentication must be dealt with whenever:
+        ///
+        ///     1.  When the user interacts with a Push Notification
+        ///     2.  When the App is in Foreground
+        ///
+        /// As per iOS 13 there are certain scenarios in which the `applicationState` may be `.background` when the user pressed over the Alert.
+        /// By means of the `userInteraction` flag, we're just working around the new SDK behavior.
+        ///
+        /// Proper fix involves a full refactor, and definitely stop checking on `applicationState`, since it's not reliable anymore.
+        ///
+        if applicationState != .background || userInteraction {
             authenticationManager.handleAuthenticationNotification(userInfo)
         }
 
@@ -295,7 +306,7 @@ extension PushNotificationsManager {
     ///
     /// - Returns: True when handled. False otherwise
     ///
-    @objc func handleInactiveNotification(_ userInfo: NSDictionary, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
+    @objc func handleInactiveNotification(_ userInfo: NSDictionary, userInteraction: Bool, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
         guard applicationState == .inactive else {
             return false
         }
@@ -322,7 +333,7 @@ extension PushNotificationsManager {
     ///
     /// - Returns: True when handled. False otherwise
     ///
-    @objc func handleBackgroundNotification(_ userInfo: NSDictionary, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
+    @objc func handleBackgroundNotification(_ userInfo: NSDictionary, userInteraction: Bool, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
         guard userInfo.number(forKey: Notification.identifierKey)?.stringValue != nil else {
             return false
         }
@@ -389,7 +400,7 @@ extension PushNotificationsManager {
     ///     - completionHandler: A callback, to be executed on completion
     ///
     /// - Returns: True when handled. False otherwise
-    @objc func handleQuickStartLocalNotification(_ userInfo: NSDictionary, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
+    @objc func handleQuickStartLocalNotification(_ userInfo: NSDictionary, userInteraction: Bool, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
         guard let type = userInfo.string(forKey: Notification.typeKey),
             type == Notification.local else {
                 return false

--- a/WordPress/WordPressTest/PushNotificationsManagerTests.m
+++ b/WordPress/WordPressTest/PushNotificationsManagerTests.m
@@ -60,7 +60,7 @@
     [OCMStub([mockManager sharedApplication]) andReturn:mockApplication];
     [OCMStub([mockManager applicationState]) andReturnValue:OCMOCK_VALUE(UIApplicationStateActive)];
     
-    [mockManager handleNotification:userInfo completionHandler:nil];
+    [mockManager handleNotification:userInfo userInteraction:NO completionHandler:nil];
     OCMVerify(mockManager);
 }
 
@@ -72,14 +72,14 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-result"
-    [[mockManager reject] handleAuthenticationNotification:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-    [[mockManager reject] handleSupportNotification:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-    [[mockManager reject] handleInactiveNotification:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-    [[mockManager reject] handleBackgroundNotification:OCMOCK_ANY completionHandler:OCMOCK_ANY];
-    [[mockManager reject] handleQuickStartLocalNotification:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+    [[mockManager reject] handleAuthenticationNotification:OCMOCK_ANY userInteraction:NO completionHandler:OCMOCK_ANY];
+    [[mockManager reject] handleSupportNotification:OCMOCK_ANY userInteraction:NO completionHandler:OCMOCK_ANY];
+    [[mockManager reject] handleInactiveNotification:OCMOCK_ANY userInteraction:NO completionHandler:OCMOCK_ANY];
+    [[mockManager reject] handleBackgroundNotification:OCMOCK_ANY userInteraction:NO completionHandler:OCMOCK_ANY];
+    [[mockManager reject] handleQuickStartLocalNotification:OCMOCK_ANY userInteraction:NO completionHandler:OCMOCK_ANY];
 #pragma clang diagnostic pop
     
-    [mockManager handleNotification:userInfo completionHandler:nil];
+    [mockManager handleNotification:userInfo userInteraction:NO completionHandler:nil];
     OCMVerify(mockManager);
 }
 
@@ -89,14 +89,14 @@
     PushNotificationsManager *manager = [PushNotificationsManager new];
     id mockManager = OCMPartialMock(manager);
     
-    XCTAssertTrue([mockManager handleSupportNotification:userInfo completionHandler:nil], @"Error handling Zendesk");
-    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Zendesk");
-    XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Zendesk");
-    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Zendesk");
-    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo completionHandler:nil], @"Error handling Zendesk");
+    XCTAssertTrue([mockManager handleSupportNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Zendesk");
+    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Zendesk");
+    XCTAssertFalse([mockManager handleInactiveNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Zendesk");
+    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Zendesk");
+    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Zendesk");
 
-    OCMExpect([manager handleSupportNotification:userInfo completionHandler:nil]);
-    [mockManager handleNotification:userInfo completionHandler:nil];
+    OCMExpect([manager handleSupportNotification:userInfo userInteraction:NO completionHandler:nil]);
+    [mockManager handleNotification:userInfo userInteraction:NO completionHandler:nil];
     OCMVerify(mockManager);
 }
 
@@ -106,14 +106,14 @@
     PushNotificationsManager *manager = [PushNotificationsManager new];
     id mockManager = OCMPartialMock(manager);
     
-    XCTAssertTrue([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling PushAuth");
-    XCTAssertFalse([mockManager handleSupportNotification:userInfo completionHandler:nil], @"Error handling PushAuth");
-    XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling PushAuth");
-    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling PushAuth");
-    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo completionHandler:nil], @"Error handling PushAuth");
+    XCTAssertTrue([mockManager handleAuthenticationNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling PushAuth");
+    XCTAssertFalse([mockManager handleSupportNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling PushAuth");
+    XCTAssertFalse([mockManager handleInactiveNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling PushAuth");
+    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling PushAuth");
+    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling PushAuth");
 
-    OCMExpect([manager handleAuthenticationNotification:userInfo completionHandler:nil]);
-    [mockManager handleNotification:userInfo completionHandler:nil];
+    OCMExpect([manager handleAuthenticationNotification:userInfo userInteraction:NO completionHandler:nil]);
+    [mockManager handleNotification:userInfo userInteraction:NO completionHandler:nil];
     OCMVerify(mockManager);
 }
 
@@ -129,14 +129,14 @@
     [OCMStub([mockManager sharedApplication]) andReturn:mockApplication];
 
     XCTAssert([mockManager applicationState] == UIApplicationStateInactive);
-    XCTAssertTrue([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Note");
-    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Note");
-    XCTAssertFalse([mockManager handleSupportNotification:userInfo completionHandler:nil], @"Error handling Note");
-    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Note");
-    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo completionHandler:nil], @"Error handling Note");
+    XCTAssertTrue([mockManager handleInactiveNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Note");
+    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Note");
+    XCTAssertFalse([mockManager handleSupportNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Note");
+    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Note");
+    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Note");
 
-    OCMExpect([manager handleInactiveNotification:userInfo completionHandler:nil]);
-    [mockManager handleNotification:userInfo completionHandler:nil];
+    OCMExpect([manager handleInactiveNotification:userInfo userInteraction:NO completionHandler:nil]);
+    [mockManager handleNotification:userInfo userInteraction:NO completionHandler:nil];
     OCMVerify(mockManager);
 }
 
@@ -153,14 +153,14 @@
     
     XCTAssert([mockManager applicationState] == UIApplicationStateBackground);
     
-    XCTAssertTrue([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Note");
-    XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Note");
-    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Note");
-    XCTAssertFalse([mockManager handleSupportNotification:userInfo completionHandler:nil], @"Error handling Note");
-    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo completionHandler:nil], @"Error handling Note");
+    XCTAssertTrue([mockManager handleBackgroundNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Note");
+    XCTAssertFalse([mockManager handleInactiveNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Note");
+    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Note");
+    XCTAssertFalse([mockManager handleSupportNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Note");
+    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Note");
 
-    OCMExpect([manager handleBackgroundNotification:userInfo completionHandler:nil]);
-    [mockManager handleNotification:userInfo completionHandler:nil];
+    OCMExpect([manager handleBackgroundNotification:userInfo userInteraction:NO completionHandler:nil]);
+    [mockManager handleNotification:userInfo userInteraction:NO completionHandler:nil];
     OCMVerify(mockManager);
 }
 
@@ -177,14 +177,14 @@
     
     XCTAssert([mockManager applicationState] == UIApplicationStateBackground);
     
-    XCTAssertTrue([mockManager handleQuickStartLocalNotification:userInfo completionHandler:nil], @"Error handling Quick Start");
-    XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Quick Start");
-    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Quick Start");
-    XCTAssertFalse([mockManager handleSupportNotification:userInfo completionHandler:nil], @"Error handling Quick Start");
-    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Quick Start");
+    XCTAssertTrue([mockManager handleQuickStartLocalNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Quick Start");
+    XCTAssertFalse([mockManager handleInactiveNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Quick Start");
+    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Quick Start");
+    XCTAssertFalse([mockManager handleSupportNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Quick Start");
+    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo userInteraction:NO completionHandler:nil], @"Error handling Quick Start");
     
-    OCMExpect([manager handleBackgroundNotification:userInfo completionHandler:nil]);
-    [mockManager handleNotification:userInfo completionHandler:nil];
+    OCMExpect([manager handleBackgroundNotification:userInfo userInteraction:NO completionHandler:nil]);
+    [mockManager handleNotification:userInfo userInteraction:NO completionHandler:nil];
     OCMVerify(mockManager);
 }
 


### PR DESCRIPTION
### Details:
In this PR we're introducing a workaround, expected to fix scenarios in which the Push Authentication alert would not be presented.

cc @leandroalonso sir, may I bug you with this one?
cc @yaelirub @bummytime Ladies and gentlmene, **quick and easy workaround**

Fixes #13412

### Details:
Before time was invented, the way to determine if the user interacted (pressed) a Push Notification alert was to check the `applicationState`. Anything but `.background` signaled that the Alert was presented, and the user pressed on it.

Since iOS 10, `UNUserNotificationCenter` has become the preferred way to determine User Interaction over Pushes.

Proper solution involves a cleaner refactor of `PushAuthenticationManager` / `InteractiveNotificationsManager`. In the aims of fixing this bug ASAP, we're introducing a low footprint workaround.


### Testing
1. Leave WPiOS in the foreground. Reader or My Sites work
2. Lock your phone
3. Receive a Push Auth Notification (DM me to force this on develop builds please!)
4. Wait ~4 seconds
5. Press over the Push Auth notification.
5.1. On FaceID capable phones, make sure to keep your face away from the sensor
5.2. On TouchID phones, press with an unregistered finger (so that the phone doesnt unlock immediately)
6. Wait for the "FaceID to Unlock"
7. Perform FaceID to unlock!

- [ ] Verify the Push Authentication Alert shows up onscreen

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
