### PR TITLE
Categories: Makes fields scalar non optional. Adjusts order of execution

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -8,7 +8,7 @@ data model as well as any custom migrations.
 @aerych 2020-06-17
 
 - All stats entities were reviewed for consistency of Optional settings for strings and dates and default values for scalar numerical fields.
-
+- Categories entity updated to make numeric fields scalar and non-optional.
 
 ## WordPress 94
 

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -155,10 +155,11 @@ NS_ASSUME_NONNULL_BEGIN
                            }
                            PostCategory *newCategory = [self newCategoryForBlog:blog];
                            newCategory.categoryID = receivedCategory.categoryID;
+                           BOOL needsSync = NO;
                            if ([remote isKindOfClass:[TaxonomyServiceRemoteXMLRPC class]]) {
                                // XML-RPC only returns ID, let's fetch the new category as
                                // filters might change the content
-                               [self syncCategoriesForBlog:blog success:nil failure:nil];
+                               needsSync = YES;
                                newCategory.categoryName = remoteCategory.name;
                                newCategory.parentID = remoteCategory.parentID;
                            } else {
@@ -168,10 +169,14 @@ NS_ASSUME_NONNULL_BEGIN
                            if (newCategory.parentID == nil) {
                                newCategory.parentID = @0;
                            }
-                           [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-                           if (success) {
-                               success(newCategory);
-                           }
+                           [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
+                               if (success) {
+                                   success(newCategory);
+                               }
+                               if (needsSync) {
+                                   [self syncCategoriesForBlog:blog success:nil failure:nil];
+                               }
+                           }];
                        }];
                    } failure:failure];
 }
@@ -187,7 +192,6 @@ NS_ASSUME_NONNULL_BEGIN
         NSSet *blogCategories = [blog.categories copy];
         for (PostCategory *category in blogCategories) {
             if ([toDelete containsObject:category.categoryID]) {
-                category.blog = nil;
                 [self.managedObjectContext deleteObject:category];
             }
         }
@@ -207,11 +211,11 @@ NS_ASSUME_NONNULL_BEGIN
         [categories addObject:category];
     }
 
-    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-
-    if (completion) {
-        completion(categories);
-    }
+    [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
+        if (completion) {
+            completion(categories);
+        }
+    }];
 }
 
 - (nullable Blog *)blogWithObjectID:(nullable NSManagedObjectID *)objectID

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 97.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 97.xcdatamodel/contents
@@ -213,9 +213,9 @@
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="settings" inverseEntity="Blog" syncable="YES"/>
     </entity>
     <entity name="Category" representedClassName="PostCategory">
-        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO"/>
+        <attribute name="categoryID" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="YES"/>
         <attribute name="categoryName" attributeType="String"/>
-        <attribute name="parentID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
+        <attribute name="parentID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="categories" inverseEntity="Blog" indexed="YES"/>
         <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Post" inverseName="categories" inverseEntity="Post" indexed="YES"/>
         <userInfo/>
@@ -780,7 +780,7 @@
         <element name="Blog" positionX="315.19921875" positionY="-178.44921875" width="188.421875" height="328"/>
         <element name="BlogAuthor" positionX="564.83203125" positionY="-385.12109375" width="128" height="165"/>
         <element name="BlogSettings" positionX="1056.86328125" positionY="236.3984375" width="128" height="855"/>
-        <element name="Category" positionX="-472.19921875" positionY="-178.47265625" width="128" height="120"/>
+        <element name="Category" positionX="-472.19921875" positionY="-178.47265625" width="128" height="118"/>
         <element name="ClicksStatsRecordValue" positionX="493.99609375" positionY="1741.6171875" width="128" height="133"/>
         <element name="Comment" positionX="-897.9921875" positionY="-561.09375" width="128" height="343"/>
         <element name="CountryStatsRecordValue" positionX="321.078125" positionY="2037.06640625" width="128" height="88"/>


### PR DESCRIPTION
Refs #12028 

This PR attempts to address some core data save errors where `Category.parentID` is `nil`, or where `Category.blog` is `nil`.  The exact circumstance that leads to the error remains unknown so the changes here are a best guess about what could contribute to the error. 

Changes:
- I've removed where Category.blog was explicitly set to `nil` when deleting a Category. The Category entity is already configured to nullify the `blog` relation when deleted so this should have been unnecessary and it's not clear why it [was added](https://github.com/wordpress-mobile/WordPress-iOS/pull/6451/files).
- The data model is updated so numeric fields are scalar and non optional. This should result in there always being a default value as opposed to nil when saving.
- I've modified code in PostCategoryService so `success` is called _after_ the context is saved. The same for where Categories are synced for self-hosted sites when creating a new category.  The reason for this is work is done asychronously across multiple `performBlock` calls. The way things were, a success block was called before the managed object context was saved.  Same for a call to sync categories (tho this was unlikely to finish before the context was saved).  Taken together this presented a scant window of time where inflight changes were assumed to be complete, even tho they weren't, and it may be the case this contributes to the core data crashes.  It's hard to say for sure.

Note that the model version was already bumped to 97 in a previous PR for this release cycle so I have not bumped it again. Expect to be logged out when launching the app since there is not a migration for the changes in this PR.

To test:
Perform the following smoke tests and confirm the app does not crash and categories function as expected.

### Scenario 1 - Try this with both a wpcom and self-hosted site.
- Launch the branch and browse to the Categories feature under post settings. 
- Add some new categories.
- Tap back to post settings. 
- Delete some categories via the web.
- Back in the app return to the list of categories and confirm that the list updates to remove the categories you deleted.

### Scenario 2 
- Browse to the Menus feature and add try to add a new menu item. 
- Select a category menu item
- Confirm the list of categories appears as expected.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
