### PR TITLE
[Gutenberg] Adding tracking to gutenberg webview usage

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -148,7 +148,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => '41f12f65649bb86ffa3de2ebb0046a96065e18ee'
+    gutenberg :commit => 'eebdfa016fbe89ccebc852f4fee9074d0d2619db'
 
     ## Third party libraries
     ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ PODS:
   - GTMSessionFetcher/Core (1.4.0)
   - GTMSessionFetcher/Full (1.4.0):
     - GTMSessionFetcher/Core (= 1.4.0)
-  - Gutenberg (1.31.0):
+  - Gutenberg (1.30.0):
     - React (= 0.61.5)
     - React-CoreModules (= 0.61.5)
     - React-RCTImage (= 0.61.5)
@@ -368,7 +368,7 @@ PODS:
     - React
   - RNSVG (9.13.6-gb):
     - React
-  - RNTAztecView (1.31.0):
+  - RNTAztecView (1.30.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.2)
   - Sentry (4.5.0):
@@ -437,14 +437,14 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/Folly.podspec.json`)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.0.1)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `41f12f65649bb86ffa3de2ebb0046a96065e18ee`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `eebdfa016fbe89ccebc852f4fee9074d0d2619db`)
   - JTAppleCalendar (~> 8.0.2)
   - MediaEditor (~> 1.1.0)
   - MRProgress (= 0.8.3)
@@ -454,35 +454,35 @@ DEPENDENCIES:
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-get-random-values.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `41f12f65649bb86ffa3de2ebb0046a96065e18ee`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-get-random-values.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `eebdfa016fbe89ccebc852f4fee9074d0d2619db`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -493,7 +493,7 @@ DEPENDENCIES:
   - WordPressShared (= 1.9.0)
   - WordPressUI (~> 1.7.1)
   - WPMediaPicker (~> 1.7.0)
-  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -555,91 +555,91 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/FBLazyVector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/FBReactNativeSpec.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/FBReactNativeSpec.podspec.json
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/glog.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :commit: 41f12f65649bb86ffa3de2ebb0046a96065e18ee
+    :commit: eebdfa016fbe89ccebc852f4fee9074d0d2619db
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   RCTRequired:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/RCTRequired.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/RCTTypeSafety.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/RCTTypeSafety.podspec.json
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-Core.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-Core.podspec.json
   React-CoreModules:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-CoreModules.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-CoreModules.podspec.json
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-cxxreact.podspec.json
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-jsi.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-jsinspector.podspec.json
   react-native-get-random-values:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-get-random-values.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-get-random-values.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-linear-gradient:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-linear-gradient.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-linear-gradient.podspec.json
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-slider:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-slider.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-slider.podspec.json
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/react-native-video.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/React-RCTVibration.podspec.json
   ReactCommon:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/ReactCommon.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/ReactCommon.podspec.json
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/RNSVG.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :commit: 41f12f65649bb86ffa3de2ebb0046a96065e18ee
+    :commit: eebdfa016fbe89ccebc852f4fee9074d0d2619db
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   Yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/41f12f65649bb86ffa3de2ebb0046a96065e18ee/third-party-podspecs/Yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/eebdfa016fbe89ccebc852f4fee9074d0d2619db/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :commit: 41f12f65649bb86ffa3de2ebb0046a96065e18ee
+    :commit: eebdfa016fbe89ccebc852f4fee9074d0d2619db
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   RNTAztecView:
-    :commit: 41f12f65649bb86ffa3de2ebb0046a96065e18ee
+    :commit: eebdfa016fbe89ccebc852f4fee9074d0d2619db
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
 
@@ -668,7 +668,7 @@ SPEC CHECKSUMS:
   Gridicons: 8e19276b20bb15d1fda1d4d0db96d066d170135b
   GTMAppAuth: 4deac854479704f348309e7b66189e604cf5e01e
   GTMSessionFetcher: 6f5c8abbab8a9bce4bb3f057e317728ec6182b10
-  Gutenberg: 65c3fbb5589a29231721f59fc113a0f1fd19ef70
+  Gutenberg: 9d8727bcc2ce2521f72d3cb59d9575ed87614e06
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   lottie-ios: 85ce835dd8c53e02509f20729fc7d6a4e6645a0a
   MediaEditor: a1838320ae55bf92af0fd938c6767c68265a9351
@@ -706,7 +706,7 @@ SPEC CHECKSUMS:
   ReactCommon: 48926fc48fcd7c8a629860049ffba9c23b4005dc
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
   RNSVG: 68a534a5db06dcbdaebfd5079349191598caef7b
-  RNTAztecView: a722a86cacd99d983ef3377c1ceb3fb31967a245
+  RNTAztecView: 8dcf335ba4b305681b11a2f0ce9e22ab19f041e4
   Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
   SimulatorStatusMagic: 28d4a9d1a500ac7cea0b2b5a43c1c6ddb40ba56c
   Sodium: 63c0ca312a932e6da481689537d4b35568841bdc
@@ -733,6 +733,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 2c789d1b70eae40c75502de7a3e4ce7acb93c779
+PODFILE CHECKSUM: cb20c13db7a87cf2e64395736ca237182983c721
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -37,6 +37,10 @@ import Foundation
     // App Settings
     case appSettingsAppearanceChanged
 
+    // Gutenberg Features
+    case gutenbergUnsupportedBlockWebViewShown
+    case gutenbergUnsupportedBlockWebViewClosed
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -93,8 +97,12 @@ import Foundation
             return "editor_post_site_changed"
         case .appSettingsAppearanceChanged:
             return "app_settings_appearance_changed"
-        }
+        case .gutenbergUnsupportedBlockWebViewShown:
+            return "gutenberg_unsupported_block_webview_shown"
+        case .gutenbergUnsupportedBlockWebViewClosed:
+            return "gutenberg_unsupported_block_webview_closed"
     }
+}
 
     /**
      The default properties of the event

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebNavigationViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebNavigationViewController.swift
@@ -41,10 +41,12 @@ class GutenbergWebNavigationController: UINavigationController {
 extension GutenbergWebNavigationController: GutenbergWebDelegate {
     func webController(controller: GutenbergWebSingleBlockViewController, didPressSave block: Block) {
         onSave?(block)
+        WPAnalytics.track(.gutenbergUnsupportedBlockWebViewClosed, properties: ["action": "save"])
         dismiss(webController: controller)
     }
 
     func webControllerDidPressClose(controller: GutenbergWebSingleBlockViewController) {
+        WPAnalytics.track(.gutenbergUnsupportedBlockWebViewClosed, properties: ["action": "dismiss"])
         dismiss(webController: controller)
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
@@ -38,11 +38,6 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
         startObservingWebView()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        WPAnalytics.track(.gutenbergUnsupportedBlockWebViewShown)
-    }
-
     deinit {
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
@@ -38,6 +38,11 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
         startObservingWebView()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        WPAnalytics.track(.gutenbergUnsupportedBlockWebViewShown)
+    }
+
     deinit {
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
     }


### PR DESCRIPTION
Fixes parts of https://github.com/wordpress-mobile/gutenberg-mobile/issues/2358

We are adding:
- `gutenberg_unsupported_block_webview_shown`
  - params: `"block": "{block_internal_name}"`
- `gutenberg_unsupported_block_webview_closed` 
  - params: `"action": "save" / "dismiss"` accordingly.


On a second step we want to add the internal block name as param to `gutenberg_unsupported_block_webview_shown` to know what block wanted to be edited. Let's do this after the monorepo is merged since it will need changes on JS side.

cc @marecar3 

To test:

- Run Metro server to activate the webview option on unsupported blocks.
- Open the unsupported block web view
  - Check that `gutenberg_unsupported_block_webview_shown` is triggered.
- Close the web view by dismissing and by saving
  - Check that `gutenberg_unsupported_block_webview_closed` is triggered with the corresponding property.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
