### PR TITLE
New Reader Detail: CSS fixes 

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -9,11 +9,13 @@ struct ReaderCSS {
 
     private let twoDays: Int = 60 * 60 * 24 * 2
 
+    private let updatedKey = "ReaderCSSLastUpdated"
+
     /// Returns the Reader CSS appending a timestamp
     /// We force it to update every 2 days
     ///
     var address: String {
-        guard let lastUpdated = store.object(forKey: "ReaderCSSLastUpdated") as? Int else {
+        guard let lastUpdated = store.object(forKey: updatedKey) as? Int else {
             saveCurrentDate()
             return url(appendingTimestamp: now)
         }
@@ -32,7 +34,7 @@ struct ReaderCSS {
     }
 
     private func saveCurrentDate() {
-        store.set(now, forKey: "ReaderCSSLastUpdated")
+        store.set(now, forKey: updatedKey)
     }
 
     private func url(appendingTimestamp appending: Int) -> String {

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -7,7 +7,11 @@ struct ReaderCSS {
 
     private let now: Int = Int(Date().timeIntervalSince1970)
 
-    private let twoDays: Int = 60 * 60 * 24 * 2
+    private let expirationDays: Int = 5
+
+    private var expirationDaysInMs: Int {
+        return expirationDays * 60 * 60 * 24
+    }
 
     private let updatedKey = "ReaderCSSLastUpdated"
 
@@ -16,7 +20,7 @@ struct ReaderCSS {
     ///
     var address: String {
         guard let lastUpdated = store.object(forKey: updatedKey) as? Int,
-                now - lastUpdated >= twoDays
+                now - lastUpdated >= expirationDaysInMs
                 && ReachabilityUtils.isInternetReachable() else {
             saveCurrentDate()
             return url(appendingTimestamp: now)

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// A struct that returns the Reader CSS URL
+///
+struct ReaderCSS {
+    private let store: KeyValueDatabase
+
+    private let now: Int = Int(Date().timeIntervalSince1970)
+
+    private let twoDays: Int = 60 * 60 * 24 * 2
+
+    /// Returns the Reader CSS appending a timestamp
+    /// We force it to update every 2 days
+    ///
+    var address: String {
+        guard let lastUpdated = store.object(forKey: "ReaderCSSLastUpdated") as? Int else {
+            saveCurrentDate()
+            return url(appendingTimestamp: now)
+        }
+
+        // If the last time we fetched the CSS was 2 days ago and the user is online, refresh it
+        if now - lastUpdated >= twoDays && ReachabilityUtils.isInternetReachable() {
+            saveCurrentDate()
+            return url(appendingTimestamp: now)
+        } else {
+            return url(appendingTimestamp: lastUpdated)
+        }
+    }
+
+    init(store: KeyValueDatabase = UserDefaults.standard) {
+        self.store = store
+    }
+
+    private func saveCurrentDate() {
+        store.set(now, forKey: "ReaderCSSLastUpdated")
+    }
+
+    private func url(appendingTimestamp appending: Int) -> String {
+        let timestamp = String(appending)
+        return "https://wordpress.com/calypso/reader-mobile.css?\(timestamp)"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -9,7 +9,7 @@ struct ReaderCSS {
 
     private let expirationDays: Int = 5
 
-    private var expirationDaysInMs: Int {
+    private var expirationDaysInSeconds: Int {
         return expirationDays * 60 * 60 * 24
     }
 
@@ -20,7 +20,7 @@ struct ReaderCSS {
     ///
     var address: String {
         guard let lastUpdated = store.object(forKey: updatedKey) as? Int,
-                now - lastUpdated >= expirationDaysInMs
+                now - lastUpdated >= expirationDaysInSeconds
                 && ReachabilityUtils.isInternetReachable() else {
             saveCurrentDate()
             return url(appendingTimestamp: now)

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -17,7 +17,7 @@ struct ReaderCSS {
     var address: String {
         guard let lastUpdated = store.object(forKey: updatedKey) as? Int,
                 now - lastUpdated >= twoDays
-                && ReachabilityUtils.isInternetReachable()else {
+                && ReachabilityUtils.isInternetReachable() else {
             saveCurrentDate()
             return url(appendingTimestamp: now)
         }

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -15,18 +15,15 @@ struct ReaderCSS {
     /// We force it to update every 2 days
     ///
     var address: String {
-        guard let lastUpdated = store.object(forKey: updatedKey) as? Int else {
+        guard let lastUpdated = store.object(forKey: updatedKey) as? Int,
+                now - lastUpdated >= twoDays
+                && ReachabilityUtils.isInternetReachable()else {
             saveCurrentDate()
             return url(appendingTimestamp: now)
         }
 
         // If the last time we fetched the CSS was 2 days ago and the user is online, refresh it
-        if now - lastUpdated >= twoDays && ReachabilityUtils.isInternetReachable() {
-            saveCurrentDate()
-            return url(appendingTimestamp: now)
-        } else {
-            return url(appendingTimestamp: lastUpdated)
-        }
+        return url(appendingTimestamp: lastUpdated)
     }
 
     init(store: KeyValueDatabase = UserDefaults.standard) {

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
@@ -68,6 +68,14 @@ class ReaderWebView: WKWebView {
 
             // Make all images tappable
             document.querySelectorAll('img').forEach((el) => { el.outerHTML = `<a href="${el.src}">${el.outerHTML}</a>` })
+
+            // Only display images after they have fully loaded, to have a native feel
+            document.querySelectorAll('img').forEach((el) => {
+                var img = new Image();
+                img.addEventListener('load', () => { el.style.opacity = "1" }, false);
+                img.src = el.currentSrc;
+                el.src = img.src;
+            })
         """, completionHandler: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
@@ -117,11 +117,15 @@ class ReaderWebView: WKWebView {
     @available(iOS 13, *)
     private func mappedCSSColors(_ style: UIUserInterfaceStyle) -> String {
         let trait = UITraitCollection(userInterfaceStyle: style)
+        UIColor(light: .muriel(color: .gray, .shade40),
+            dark: .muriel(color: .gray, .shade20)).color(for: trait).hexString()
         return """
             :root {
               --color-text: #\(UIColor.text.color(for: trait).hexString() ?? "");
               --color-neutral-70: #\(UIColor.text.color(for: trait).hexString() ?? "");
               --color-neutral-0: #\(UIColor.listForegroundUnread.color(for: trait).hexString() ?? "");
+              --color-neutral-40: #\(UIColor(light: .muriel(color: .gray, .shade40),
+              dark: .muriel(color: .gray, .shade20)).color(for: trait).hexString() ?? "");
               --color-neutral-50: #\(UIColor.textSubtle.color(for: trait).hexString() ?? "");
               --main-link-color: #\(UIColor.primary.color(for: trait).hexString() ?? "");
               --main-link-active-color: #\(UIColor.primaryDark.color(for: trait).hexString() ?? "");
@@ -137,6 +141,7 @@ class ReaderWebView: WKWebView {
               --color-text: #\(UIColor.text.hexString() ?? "");
               --color-neutral-70: #\(UIColor.text.hexString() ?? "");
               --color-neutral-0: #\(UIColor.listForegroundUnread.hexString() ?? "");
+              --color-neutral-40: #\(UIColor(color: .muriel(color: .gray, .shade40)).hexString() ?? "");
               --color-neutral-50: #\(UIColor.textSubtle.hexString() ?? "");
               --main-link-color: #\(UIColor.primary.hexString() ?? "");
               --main-link-active-color: #\(UIColor.primaryDark.hexString() ?? "");

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
@@ -34,7 +34,7 @@ class ReaderWebView: WKWebView {
         <!DOCTYPE html><html><head><meta charset='UTF-8' />
         <title>Reader Post</title>
         <meta name='viewport' content='initial-scale=1, maximum-scale=1.0, user-scalable=no'>
-        <link rel="stylesheet" type="text/css" href="https://wordpress.com/calypso/reader-mobile.css">
+        <link rel="stylesheet" type="text/css" href="\(ReaderCSS().address)">
         <style>
         \(cssColors())
         \(cssStyles())

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
@@ -129,7 +129,7 @@ class ReaderWebView: WKWebView {
     private func mappedCSSColors(_ style: UIUserInterfaceStyle) -> String {
         let trait = UITraitCollection(userInterfaceStyle: style)
         UIColor(light: .muriel(color: .gray, .shade40),
-            dark: .muriel(color: .gray, .shade20)).color(for: trait).hexString()
+                dark: .muriel(color: .gray, .shade20)).color(for: trait).hexString()
         return """
             :root {
               --color-text: #\(UIColor.text.color(for: trait).hexString() ?? "");

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/reader.css
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/reader.css
@@ -36,6 +36,10 @@ img {
     opacity: 0;
 }
 
+iframe {
+    max-width: 100%;
+}
+
 @media (max-width: 660px) {
     .alignleft img,
     .alignright img {

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/reader.css
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/reader.css
@@ -32,6 +32,10 @@ div.feedflare { display: none; }
 
 .sharedaddy, .jp-relatedposts, .mc4wp-form, .wpcnt, .OUTBRAIN, .adsbygoogle { display: none; }
 
+img {
+    opacity: 0;
+}
+
 @media (max-width: 660px) {
     .alignleft img,
     .alignright img {

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/reader.css
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/reader.css
@@ -32,6 +32,14 @@ div.feedflare { display: none; }
 
 .sharedaddy, .jp-relatedposts, .mc4wp-form, .wpcnt, .OUTBRAIN, .adsbygoogle { display: none; }
 
+@media (max-width: 660px) {
+    .alignleft img,
+    .alignright img {
+        display: block;
+        margin: 0 auto;
+    }
+}
+
 /* Safari overrides */
 
 figure {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.storyboard
@@ -16,19 +16,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9JA-VQ-zzw" customClass="ReaderScrollView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9JA-VQ-zzw" customClass="ReaderScrollView" customModule="WordPress" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xyq-y6-zPR">
-                                        <rect key="frame" x="0.0" y="0.0" width="446" height="48"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xyq-y6-zPR">
+                                        <rect key="frame" x="0.0" y="0.0" width="446" height="343"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
-                                    <wkWebView contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iSu-TI-yew" customClass="ReaderWebView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="128" width="414" height="100"/>
+                                    <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iSu-TI-yew" customClass="ReaderWebView" customModule="WordPress" customModuleProvider="target">
+                                        <rect key="frame" x="16" y="343" width="414" height="0.0"/>
                                         <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="414" placeholder="YES" id="akw-kl-dl7"/>
-                                            <constraint firstAttribute="height" constant="700" id="ywz-kG-xyW"/>
+                                            <constraint firstAttribute="height" id="ywz-kG-xyW"/>
                                         </constraints>
                                         <wkWebViewConfiguration key="configuration">
                                             <dataDetectorTypes key="dataDetectorTypes" none="YES"/>
@@ -36,8 +36,8 @@
                                             <wkPreferences key="preferences"/>
                                         </wkWebViewConfiguration>
                                     </wkWebView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="O4e-BA-8jp">
-                                        <rect key="frame" x="16" y="309" width="414" height="0.0"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="O4e-BA-8jp">
+                                        <rect key="frame" x="16" y="343" width="414" height="0.0"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TWq-e0-xZe">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="0.0"/>
@@ -59,6 +59,7 @@
                                     <constraint firstItem="Xyq-y6-zPR" firstAttribute="top" secondItem="9JA-VQ-zzw" secondAttribute="top" id="JZU-vN-GKO"/>
                                     <constraint firstItem="Xyq-y6-zPR" firstAttribute="centerX" secondItem="iSu-TI-yew" secondAttribute="centerX" id="RTC-cI-v2j"/>
                                     <constraint firstAttribute="bottom" secondItem="O4e-BA-8jp" secondAttribute="bottom" id="eFL-lL-cEF"/>
+                                    <constraint firstItem="eXr-4k-Adq" firstAttribute="bottom" secondItem="O4e-BA-8jp" secondAttribute="bottom" constant="509" placeholder="YES" id="pTD-l7-TPF"/>
                                     <constraint firstItem="Xyq-y6-zPR" firstAttribute="width" secondItem="iSu-TI-yew" secondAttribute="width" constant="32" id="xfj-7c-Lke"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="QF8-fp-xzq"/>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1094,6 +1094,7 @@
 		8BDA5A70247C36C100AB124C /* ReaderDetailViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8BDA5A6E247C308300AB124C /* ReaderDetailViewController.storyboard */; };
 		8BDA5A74247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5A73247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift */; };
 		8BDA5A75247C63F300AB124C /* ReaderDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5A71247C5E5800AB124C /* ReaderDetailCoordinator.swift */; };
+		8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */; };
 		8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BF0B607247D88EB009A7457 /* UITableViewCell+enableDisable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */; };
@@ -3556,6 +3557,7 @@
 		8BDA5A6E247C308300AB124C /* ReaderDetailViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ReaderDetailViewController.storyboard; sourceTree = "<group>"; };
 		8BDA5A71247C5E5800AB124C /* ReaderDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailCoordinator.swift; sourceTree = "<group>"; };
 		8BDA5A73247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailCoordinatorTests.swift; sourceTree = "<group>"; };
+		8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCSS.swift; sourceTree = "<group>"; };
 		8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrepublishingHeaderViewTests.swift; path = WordPressTest/PrepublishingHeaderViewTests.swift; sourceTree = SOURCE_ROOT; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+enableDisable.swift"; sourceTree = "<group>"; };
@@ -7772,6 +7774,7 @@
 				8BA77BCC248340CE00E1EBBF /* ReaderDetailToolbar.xib */,
 				8BA77BCE2483415400E1EBBF /* ReaderDetailToolbar.swift */,
 				8B11B6672489C0A4000F1A0F /* ReaderScrollView.swift */,
+				8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */,
 			);
 			path = DetailWebView;
 			sourceTree = "<group>";
@@ -12747,6 +12750,7 @@
 				43D74AC820F8D17A004AD934 /* DomainSuggestionsButtonViewPresenter.swift in Sources */,
 				F5E032E82408D537003AF350 /* BottomSheetPresentationController.swift in Sources */,
 				E1FD45E01C030B3800750F4C /* AccountSettingsService.swift in Sources */,
+				8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */,
 				E1D0D81616D3B86800E33F4C /* SafariActivity.m in Sources */,
 				E603C7701BC94AED00AD49D7 /* WordPress-37-38.xcmappingmodel in Sources */,
 				741E22461FC0CC55007967AB /* UploadOperation.swift in Sources */,


### PR DESCRIPTION
Review only after #14339 is merged.

This PR:

- Center images in small devices so they don't appear in the left if they're small
- Adds the color for the captions
- Adds a structure to refresh the CSS every two days if the user is online (won't affect offline)
- Only display images after they have been fully loaded, to simulate a native feel
- Do not display images broken, again, to have a native feel

To test

* Check this post, the image should be center-aligned: https://made4testing0318.blog/2020/04/17/another-image-block/
* In the same post, you can check the caption color
* Open a post full of images and check that they appear as a whole instead of slowly appearing
* Open a post with a broken image and check that the image doesn't appear, space it's there, but no broken images icons are displayed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
