### PR TITLE
Add guard around self-hosted site generation to help limit the risk o…

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 15.2
 ----
 * [**] Block editor: Display content metrics information (blocks, words, characters count).
+* [*] Fixed a crash that results in navigating to the block editor quickly after logging out and immediately back in.
 
 -----
  

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -30,7 +30,6 @@ private func makeCookieNonceAuthenticator(blog: Blog) -> Authenticator? {
 
 private func apiBase(blog: Blog) -> URL? {
     precondition(blog.account == nil, ".com support has not been implemented yet")
-    guard blog.xmlrpc != nil else { return nil }
     return try? blog.url(withPath: "wp-json/").asURL()
 }
 

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -30,6 +30,7 @@ private func makeCookieNonceAuthenticator(blog: Blog) -> Authenticator? {
 
 private func apiBase(blog: Blog) -> URL? {
     precondition(blog.account == nil, ".com support has not been implemented yet")
+    guard blog.xmlrpc != nil else { return nil }
     return try? blog.url(withPath: "wp-json/").asURL()
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -341,14 +341,14 @@ class GutenbergViewController: UIViewController, PostEditor {
     private var previousFirstResponder: UIView?
 
     private func setupKeyboardObservers() {
-        keyboardShowObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: .main) { (notification) in
-            if let keyboardRect = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+        keyboardShowObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: .main) { [weak self] (notification) in
+            if let self = self, let keyboardRect = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
                 self.keyboardFrame = keyboardRect
                 self.updateConstraintsToAvoidKeyboard(frame: keyboardRect)
             }
         }
-        keyboardHideObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: .main) { (notification) in
-            if let keyboardRect = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
+        keyboardHideObserver = NotificationCenter.default.addObserver(forName: UIResponder.keyboardDidShowNotification, object: nil, queue: .main) { [weak self] (notification) in
+            if let self = self, let keyboardRect = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
                 self.keyboardFrame = keyboardRect
                 self.updateConstraintsToAvoidKeyboard(frame: keyboardRect)
             }


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-iOS/issues/14354

The exception reported in the ticket was a result of the xmlrpc path not being populated yet. The code attempts to [catch](https://github.com/wordpress-mobile/WordPress-iOS/blob/ea2bf8d5d942f6c735a9ee66c374c31f773823b8/WordPress/Classes/Networking/WordPressOrgRestApi%2BWordPress.swift#L34) possible errors however there seems to be an interesting difference between how errors are thrown from Objective-C and how swift manages them.

> Although Swift error handling resembles exception handling in Objective-C, it is entirely separate functionality. If an Objective-C method throws an exception during runtime, Swift triggers a runtime error. There is no way to recover from Objective-C exceptions directly in Swift. Any exception handling behavior must be implemented in Objective-C code used by Swift.
Excerpt From: Apple Inc. “Using Swift with Cocoa and Objective-C (Swift 2.1).” iBooks.
https://stackoverflow.com/a/35141887/1350218

As a result, I added a guard around this point to return nil which would have followed the logic if this catch was working as expected.

## To test:

- Open Gutenberg on a blog (tested on a Premium wpcom site)
- Logout from the app
- Log back in right away
- The app should show the same blog as before
- Go to Posts
- Open a post
## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
