### PR TITLE
Fix WebViews Auth on WPCom after login in.

### DIFF
--- a/WordPress/Classes/Services/AuthenticationService.swift
+++ b/WordPress/Classes/Services/AuthenticationService.swift
@@ -94,7 +94,9 @@ class AuthenticationService {
                     // so that the user sees a reasonable error situation on screen.
                     // We could opt to create a special screen but for now I'd rather users report
                     // the issue when it happens.
-                    failure(error)
+                    DispatchQueue.main.async {
+                        failure(error)
+                    }
                 }
         }
     }
@@ -141,6 +143,7 @@ class AuthenticationService {
         headers.forEach { (key, value) in
             request.setValue(value, forHTTPHeaderField: key)
         }
+        request.setValue(WPUserAgent.wordPress(), forHTTPHeaderField: "User-Agent")
 
         let task = session.dataTask(with: request) { data, response, error in
             if let error = error {

--- a/WordPress/Classes/Services/AuthenticationService.swift
+++ b/WordPress/Classes/Services/AuthenticationService.swift
@@ -94,9 +94,7 @@ class AuthenticationService {
                     // so that the user sees a reasonable error situation on screen.
                     // We could opt to create a special screen but for now I'd rather users report
                     // the issue when it happens.
-                    DispatchQueue.main.async {
-                        failure(error)
-                    }
+                    failure(error)
                 }
         }
     }
@@ -147,7 +145,9 @@ class AuthenticationService {
 
         let task = session.dataTask(with: request) { data, response, error in
             if let error = error {
-                failure(error)
+                DispatchQueue.main.async {
+                    failure(error)
+                }
                 return
             }
 
@@ -162,7 +162,9 @@ class AuthenticationService {
             // and compare the session cookies.
             let responseCookies = self.cookies(from: response, loginURL: url)
             let cookies = (session.configuration.httpCookieStorage?.cookies ?? [HTTPCookie]()) + responseCookies
-            success(cookies)
+            DispatchQueue.main.async {
+                success(cookies)
+            }
         }
 
         task.resume()

--- a/WordPress/Classes/Utility/CookieJar.swift
+++ b/WordPress/Classes/Utility/CookieJar.swift
@@ -156,23 +156,13 @@ extension WKHTTPCookieStore: CookieJarSharedImplementation {
     }
 
     func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
-        guard !cookies.isEmpty else {
+        guard let cookie = cookies.last else {
             return completion()
         }
 
-        var completionCount = 0
-
-        func completionIncrement() {
-            completionCount += 1
-
-            if completionCount >= cookies.count {
-                completion()
-            }
-        }
-
-        for cookie in cookies {
-            DispatchQueue.main.async {
-                self.setCookie(cookie, completionHandler: completionIncrement)
+        DispatchQueue.main.async {
+            self.setCookie(cookie) { [weak self] in
+                self?.setCookies(cookies.dropLast(), completion: completion)
             }
         }
     }

--- a/WordPress/Classes/Utility/CookieJar.swift
+++ b/WordPress/Classes/Utility/CookieJar.swift
@@ -156,6 +156,10 @@ extension WKHTTPCookieStore: CookieJarSharedImplementation {
     }
 
     func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+        guard !cookies.isEmpty else {
+            return completion()
+        }
+
         var completionCount = 0
 
         func completionIncrement() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderRelativeTimeFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderRelativeTimeFormatter.swift
@@ -5,14 +5,14 @@ class ReaderRelativeTimeFormatter: NSObject {
     private lazy var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
-        formatter.timeZone = .none
+        formatter.timeStyle = .none
         return formatter
     }()
 
     /// Date formatter used for dates older than a week but earlier than a year
     private lazy var recentDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        formatter.setLocalizedDateFormatFromTemplate("MMM dd")
         return formatter
     }()
 

--- a/WordPress/WordPressTest/ReaderRelativeTimeFormatterTests.swift
+++ b/WordPress/WordPressTest/ReaderRelativeTimeFormatterTests.swift
@@ -44,7 +44,7 @@ class ReaderRelativeTimeFormatterTests: XCTestCase {
 
     func testOlderThanAWeek() {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MMM dd"
+        dateFormatter.setLocalizedDateFormatFromTemplate("MMM dd")
 
         let formatter = ReaderRelativeTimeFormatter(calendar: calendar)
         let date = Date(timeIntervalSinceNow: -(86400 * 14))
@@ -54,7 +54,8 @@ class ReaderRelativeTimeFormatterTests: XCTestCase {
 
     func testNotThisYear() {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "MMM d, YYYY"
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .none
 
         let formatter = ReaderRelativeTimeFormatter(calendar: calendar)
 


### PR DESCRIPTION
This PR fixes an auth issue on Previews due to changes in the backend.
We are not setting the WordPress User Agent to the auth cookies request to avoid being blocked.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2411

To test:
- Clean install the WordPress app.
- Login to a WPCom account.
- Create a new post on a blog that's not private Atomic.
- Write something and choose to preview (without publishing).
- Check that the preview works.

**Note:** This PR was initially intended to fix an auth issue on Gutenberg Web-View for the unsupported block fallback project. So this also fixes parts of https://github.com/wordpress-mobile/gutenberg-mobile/issues/2358

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @marecar3 @aerych 
