### PR TITLE
Auth: Use atomic cookie auth only if atomic and private.

### DIFF
--- a/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
+++ b/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
@@ -16,7 +16,7 @@ class RequestAuthenticator: NSObject {
 
     enum DotComAuthenticationType {
         case regular
-        case atomic(blogID: Int)
+        case privateAtomic(blogID: Int)
     }
 
     enum Credentials {
@@ -46,6 +46,7 @@ class RequestAuthenticator: NSObject {
         let authenticationType: DotComAuthenticationType
 
         if let blog = blog,
+            blog.isPrivate(),
             blog.isAtomic() {
 
             guard let blogID = blog.dotComID as? Int else {
@@ -53,7 +54,7 @@ class RequestAuthenticator: NSObject {
                 return nil
             }
 
-            authenticationType = .atomic(blogID: blogID)
+            authenticationType = .privateAtomic(blogID: blogID)
         } else {
             authenticationType = .regular
         }
@@ -120,7 +121,7 @@ class RequestAuthenticator: NSObject {
                 username: username,
                 authToken: authToken,
                 completion: completion)
-        case .atomic(let siteID):
+        case .privateAtomic(let siteID):
             requestForAtomicWPCom(
                 url: url,
                 cookieJar: cookieJar,


### PR DESCRIPTION
Refs #13953 

This fixes an issue where the app would attempt to fetch auth cookies for atomic sites that were not private.  The endpoint in question assumes that it will only be used with a private atomic site and returns a 500 error in other cases. 

To test:
Use a private atomic site, set to coming soon or not, and confirm you can successfully get auth cookies, view the site's media, and preview a draft post
Repeat the test with a public atomic site and confirm auth cookies are not fetched and not needed to preview posts or view media.

@etoledom Could I trouble you with this one?

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
