### PR TITLE
Fix spotlight on the reader tab icon when rotating devices

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -16,7 +16,7 @@ extension WPTabBarController {
             let newSpotlight = QuickStartSpotlightView()
             self?.view.addSubview(newSpotlight)
 
-            guard let tabButton = self?.getTabButton(at: 1) else {
+            guard let tabButton = self?.getTabButton(at: Int(WPTabType.reader.rawValue)) else {
                 return
             }
 
@@ -49,7 +49,7 @@ extension WPTabBarController {
     }
 
     private func getTabButton(at index: Int) -> UIView? {
-        var tabs = self.tabBar.subviews.compactMap { return $0 is UIControl ? $0 : nil }
+        var tabs = tabBar.subviews.compactMap { return $0 is UIControl ? $0 : nil }
         tabs.sort { $0.frame.origin.x < $1.frame.origin.x }
         return tabs[safe: index]
     }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -1,5 +1,4 @@
 private var spotlightView: QuickStartSpotlightView?
-private let spotlightViewOffset: CGFloat = -5.0
 private var quickStartObserver: NSObject?
 
 extension WPTabBarController {
@@ -10,17 +9,26 @@ extension WPTabBarController {
 
             guard let userInfo = notification.userInfo,
                 let element = userInfo[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement,
-                [.readerTab].contains(element),
-                let tabBar = self?.tabBar else {
+                [.readerTab].contains(element) else {
                     return
             }
 
             let newSpotlight = QuickStartSpotlightView()
-            tabBar.addSubview(newSpotlight)
+            self?.view.addSubview(newSpotlight)
 
-            let x = tabBar.bounds.size.width / 2.0
+            guard let tabButton = self?.getTabButton(at: 1) else {
+                return
+            }
 
-            newSpotlight.frame = CGRect(x: x, y: spotlightViewOffset, width: newSpotlight.frame.width, height: newSpotlight.frame.height)
+            newSpotlight.translatesAutoresizingMaskIntoConstraints = false
+
+            let newSpotlightCenterX = newSpotlight.centerXAnchor.constraint(equalTo: tabButton.centerXAnchor, constant: Constants.spotlightXOffset)
+            let newSpotlightCenterY = newSpotlight.centerYAnchor.constraint(equalTo: tabButton.centerYAnchor, constant: Constants.spotlightYOffset)
+            let newSpotlightWidth = newSpotlight.widthAnchor.constraint(equalToConstant: Constants.spotlightDiameter)
+            let newSpotlightHeight = newSpotlight.heightAnchor.constraint(equalToConstant: Constants.spotlightDiameter)
+
+            NSLayoutConstraint.activate([newSpotlightCenterX, newSpotlightCenterY, newSpotlightWidth, newSpotlightHeight])
+
             spotlightView = newSpotlight
         }
 
@@ -38,5 +46,17 @@ extension WPTabBarController {
     @objc func stopWatchingQuickTours() {
         NotificationCenter.default.removeObserver(quickStartObserver as Any)
         quickStartObserver = nil
+    }
+
+    private func getTabButton(at index: Int) -> UIView? {
+        var tabs = self.tabBar.subviews.compactMap { return $0 is UIControl ? $0 : nil }
+        tabs.sort { $0.frame.origin.x < $1.frame.origin.x }
+        return tabs[safe: index]
+    }
+
+    private enum Constants {
+        static let spotlightDiameter: CGFloat = 40
+        static let spotlightXOffset: CGFloat = 20
+        static let spotlightYOffset: CGFloat = -10
     }
 }


### PR DESCRIPTION
Fixes #14286

To test:

1. Create a new site
2. Yes, Help Me when prompted
3. Close the "Customize Your Site" modal view
4. Open "Grow Your Audience"
5. Choose "Follow other sites"
6. Rotate the device or sim and verify that the spotlight stays close to the reader icon tab

PR submission checklist:

- [x] ~~I have considered adding unit tests where possible.~~ no new functionalities were added
- [x] ~~I have considered adding accessibility improvements for my changes.~~ no changes in UI elements
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~ only fixes an issue, no user facing features changes or added
