### PR TITLE
Fix navigation bar title when scrolling

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -1227,7 +1227,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     }
 
     if ([Feature enabled:FeatureFlagReaderWebview]) {
-        post.content = remotePost.content;
+        post.content = [RichContentFormatter removeForbiddenTags:remotePost.content];
     } else {
         post.content = [RichContentFormatter formatContentString:remotePost.content isPrivateSite:remotePost.isBlogPrivate];
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -883,7 +883,7 @@ extension WordPressAppDelegate {
         let maximumPointSize = WPStyleGuide.maxFontSize
 
         UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white,
-                                                            NSAttributedString.Key.font: WPStyleGuide.fixedFont(for: UIFont.TextStyle.headline, weight: UIFont.Weight.bold)]
+                                                            NSAttributedString.Key.font: WPStyleGuide.fixedFont(for: UIFont.TextStyle.headline, weight: UIFont.Weight.semibold)]
 
         WPStyleGuide.configureSearchBarTextAppearance()
 

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// A struct that returns the Reader CSS URL
+/// If you need to fix an issue in the CSS, see pbArwn-GU-p2
 ///
 struct ReaderCSS {
     private let store: KeyValueDatabase

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailWebviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailWebviewViewController.swift
@@ -144,7 +144,9 @@ class ReaderDetailWebviewViewController: UIViewController, ReaderDetailView {
     /// - Parameter title: a optional String containing the title
     func show(title: String?) {
         let placeholder = NSLocalizedString("Post", comment: "Placeholder title for ReaderPostDetails.")
-        self.title = title ?? placeholder
+        let titleView = UILabel()
+        titleView.attributedText = NSAttributedString.init(string: title ?? placeholder, attributes: UINavigationBar.appearance().titleTextAttributes)
+        navigationItem.titleView = titleView
     }
 
     deinit {


### PR DESCRIPTION
This PR fixes the navigation bar title behavior when scrolling down/up in the Reader Detail.

It also makes sure that the Reader content doesn't have any `script` tag, preventing possible JavaScript injections.

### To test

#### Reader

1. Open a post in the Reader
2. Scroll down/up
3. Check that the navbar fades in or out depending on how much you scroll

#### In the app

Make sure the nav bar has the same font size / weight.