### PR TITLE
Fixes reader more menu not appearing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 * [*] Fixed a bug where the "Publish a post" Quick Start tour didn't reflect the app's new information architecture 
 * [***] Free GIFs can now be added to the media library, posts, and pages.
 * [**] You can now set pages as your site's homepage or posts page directly from the Pages list.
+* [**] Reader: Fixed a bug where tapping on the more menu may not present the menu
 
 15.0
 -----

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailCoordinator.swift
@@ -185,7 +185,8 @@ class ReaderDetailCoordinator {
     /// Show a menu with options forthe current post's site
     ///
     private func showMenu(_ anchorView: UIView) {
-        guard let post = post else {
+        guard let post = post,
+            let context = post.managedObjectContext else {
             return
         }
 
@@ -194,10 +195,10 @@ class ReaderDetailCoordinator {
             return
         }
 
-        if let topic = topicService.findSiteTopic(withSiteID: post.siteID) {
-            ReaderPostMenu.showMenuForPost(post, topic: topic, fromView: anchorView, inViewController: viewController)
-            return
-        }
+        let service: ReaderTopicService = ReaderTopicService(managedObjectContext: context)
+        let siteTopic: ReaderSiteTopic? = service.findSiteTopic(withSiteID: post.siteID)
+
+        ReaderPostMenu.showMenuForPost(post, topic: siteTopic, fromView: anchorView, inViewController: viewController)
     }
 
     /// Show a list with posts contianing this tag

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1339,13 +1339,11 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             return
         }
 
-        let service = ReaderTopicService(managedObjectContext: context)
-        if let topic = service.findSiteTopic(withSiteID: post.siteID) {
-            ReaderPostMenu.showMenuForPost(post, topic: topic, fromView: menuButton, inViewController: self)
-            return
-        }
-    }
+        let service: ReaderTopicService = ReaderTopicService(managedObjectContext: context)
+        let siteTopic: ReaderSiteTopic? = service.findSiteTopic(withSiteID: post.siteID)
 
+        ReaderPostMenu.showMenuForPost(post, topic: siteTopic, fromView: menuButton, inViewController: self)
+    }
 
     @objc func didTapFeaturedImage(_ gesture: UITapGestureRecognizer) {
         guard gesture.state == .ended, let post = post else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
@@ -10,11 +10,10 @@ final class ReaderMenuAction {
             return
         }
 
-        let service = ReaderTopicService(managedObjectContext: context)
-        if let topic = service.findSiteTopic(withSiteID: post.siteID) {
-            showMenuForPost(post, context: context, topic: topic, readerTopic: readerTopic, fromView: anchor, vc: vc)
-            return
-        }
+        let service: ReaderTopicService = ReaderTopicService(managedObjectContext: context)
+        let siteTopic: ReaderSiteTopic? = service.findSiteTopic(withSiteID: post.siteID)
+
+        showMenuForPost(post, context: context, topic: siteTopic, readerTopic: readerTopic, fromView: anchor, vc: vc)
     }
 
     fileprivate func showMenuForPost(_ post: ReaderPost, context: NSManagedObjectContext, topic: ReaderSiteTopic? = nil, readerTopic: ReaderAbstractTopic?, fromView anchorView: UIView, vc: UIViewController) {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -95,7 +95,7 @@ extension ReaderTabItemsStore {
             dispatchGroup.leave()
         }, failure: { (error) in
             let actualError = error ?? ReaderTopicsConstants.remoteServiceError
-            DDLogError(ReaderTopicsConstants.remoteFetchError + actualError.localizedDescription)
+            DDLogError("Error syncing menu: \(String(describing: actualError))")
 
             dispatchGroup.leave()
         })
@@ -106,7 +106,7 @@ extension ReaderTabItemsStore {
             dispatchGroup.leave()
         }, failure: { (error) in
             let actualError = error ?? ReaderTopicsConstants.remoteServiceError
-            DDLogError(ReaderTopicsConstants.remoteFetchError + actualError.localizedDescription)
+            DDLogError("Could not sync sites: \(String(describing: actualError))")
 
             dispatchGroup.leave()
         })
@@ -122,7 +122,6 @@ extension ReaderTabItemsStore {
         static let entityName = "ReaderAbstractTopic"
         static let sortByKey = "type"
         static let fetchRequestError = "There was a problem fetching topics for the menu. "
-        static let remoteFetchError = "Error syncing menu: "
         static let objectTypeError = NSError(domain: "ReaderTabItemsStoreDomain", code: -1, userInfo: nil)
         static let remoteServiceError = NSError(domain: WordPressComRestApiErrorDomain, code: -1, userInfo: nil)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -94,7 +94,7 @@ extension ReaderTabItemsStore {
         service.fetchReaderMenu(success: {
             dispatchGroup.leave()
         }, failure: { (error) in
-            let actualError = error ?? NSError(domain: WordPressComRestApiErrorDomain, code: -1, userInfo: nil)
+            let actualError = error ?? ReaderTopicsConstants.remoteServiceError
             DDLogError(ReaderTopicsConstants.remoteFetchError + actualError.localizedDescription)
 
             dispatchGroup.leave()
@@ -105,7 +105,7 @@ extension ReaderTabItemsStore {
         service.fetchFollowedSites(success: {
             dispatchGroup.leave()
         }, failure: { (error) in
-            let actualError = error ?? NSError(domain: WordPressComRestApiErrorDomain, code: -1, userInfo: nil)
+            let actualError = error ?? ReaderTopicsConstants.remoteServiceError
             DDLogError(ReaderTopicsConstants.remoteFetchError + actualError.localizedDescription)
 
             dispatchGroup.leave()


### PR DESCRIPTION
**Fixes** #14190

## Bug description
When a user taps the more menu the event looks for a `ReaderSiteTopic` for the `ReaderPost`'s site, and if the site topic doesn't exist for some reason the the event would be ignored and nothing will happen. 

```
let service = ReaderTopicService(managedObjectContext: context)
--> if let topic = service.findSiteTopic(withSiteID: post.siteID) { <-- if this is nil, nothing happens
    showMenuForPost(post, context: context, topic: topic, readerTopic: readerTopic, fromView: anchor, vc: vc)
    return
}
```

### Why would the site topic be nil?
Prior to 14.7 the `ReaderMenuViewController` called the [`syncTopics`](https://github.com/wordpress-mobile/WordPress-iOS/blob/14.6/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift#L253) method which sync'd both the reader more menu and the followed sites.

The `fetchFollowedSites` method creates a `ReaderSiteTopic` object for each of the users followed sites.

When the new reader tab navigation was introduced this file is no longer used and the followed sites network request is triggered asynchronously when the user taps the tab bar filter button, then the followed sites tab. This means that `ReaderSiteTopic` objects aren't created until then which causes the `service.findSiteTopic(withSiteID:)` method to return nil

### The fix
#### Part 1: Sync the followed sites at the same time we pull down the reader more menu
When the reader tab is loaded we'll pull down both the reader more menu and the followed sites to mimic how it used to work before the new tab bar change in 14.7. 

#### Part 2: Remove the `ReaderSiteTopic` requirement from the show menu action
The  `ReaderPostMenu.showMenuForPost` method already supports passing an optional for the site topic. I updated the instances where this is called to ignore the requirement to have a site topic before displaying. 

This is a fallback just in case the topic doesn't exist for the user. It presents all options except the `Turn on/off site notifications` item. 

## To test:
1. Delete the app, this resets your database
2. Reinstall the app
3. Tap on the Reader tab
4. Tap on the more button (`⋮`, vertical ellipsis) on a post in the reader
5. Verify the more menu appears with the following options:
```
- Turn on/off site notifications
- Unfollow site
- Visit
- Share
```
6. Verify each of the options work as intended

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
