### PR TITLE
ReaderDetailHeaderView: Reload gradients if interface style changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderDetailHeaderView.swift
@@ -110,6 +110,16 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
         reloadGradientColors()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if #available(iOS 13.0, *) {
+            if previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) == true {
+                reloadGradientColors()
+            }
+        }
+    }
+
     private func configureSiteImage() {
         let placeholder = UIImage(named: "post-blavatar-placeholder")
         blavatarImageView.image = placeholder


### PR DESCRIPTION
This PR fixes an issue where the gradient views at the edges of the Reader detail view header's byline didn't adapt to user interface style changes:

![reader-gradients](https://user-images.githubusercontent.com/4780/85563136-04df2700-b625-11ea-84e3-aa40ad5e9561.png)

When viewing the app in dark mode, for instance, the gradients remained using a light background color. This issue only affects the new webview-based Reader detail view.

**To test:**

* Build and run the app – ensure that the new Reader webview-based detail view is enabled.
* In Me > App Settings > Appearance, set the app to dark mode
* In Reader, visit the detail page for a post
* Ensure the gradients aren't visible at the sides of the byline
* You can also test this with the Appearance set to System default, and toggle dark mode on and off at the system level.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.