### PR TITLE
Reader Phase 2: Select Interests: Creates a custom UICollectionViewFlowLayout subclass

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -1,10 +1,13 @@
 import UIKit
 
 class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
-    @IBInspectable public var itemSpacing : CGFloat = 6
-    @IBInspectable public var cellHeight : CGFloat = 40
+    @IBInspectable public var itemSpacing: CGFloat = 6
+    @IBInspectable public var cellHeight: CGFloat = 40
 
     private var layoutAttributes: [UICollectionViewLayoutAttributes] = []
+    private var layoutDirection: UIUserInterfaceLayoutDirection {
+        return collectionView?.effectiveUserInterfaceLayoutDirection ?? .leftToRight
+    }
 
     // The content width minus the content insets used when calculating rows, and centering
     private var maxContentWidth: CGFloat {
@@ -20,7 +23,7 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
     /// The calculated content size for the view
     private var contentSize: CGSize = .zero
 
-    override open var collectionViewContentSize : CGSize {
+    override open var collectionViewContentSize: CGSize {
         return contentSize
     }
 
@@ -30,6 +33,7 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
         }
 
         let contentInsets = collectionView.contentInset
+        let isRTL = layoutDirection == .rightToLeft
 
         // The current row used to calculate the y position and the total content height
         var currentRow: CGFloat = 0
@@ -46,14 +50,19 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
             var frame: CGRect = CGRect(origin: .zero, size: itemSize)
 
             if item == 0 {
-                frame.origin = CGPoint(x: 0, y: contentInsets.top)
+                let minX: CGFloat = isRTL ? maxContentWidth - frame.width : 0
+                frame.origin = CGPoint(x: minX, y: contentInsets.top)
             } else {
-                                    frame.origin.x = previousFrame.maxX + itemSpacing
-
+                if isRTL {
+                    frame.origin.x = previousFrame.minX - itemSpacing - frame.width
+                } else {
+                    frame.origin.x = previousFrame.maxX + itemSpacing
+                }
 
                 // If the new X position will go off screen move it to the next row
-                if frame.maxX > maxContentWidth {
-                    frame.origin.x = 0
+                let needsNewRow = isRTL ? frame.origin.x < 0 : frame.maxX > maxContentWidth
+                if needsNewRow {
+                    frame.origin.x = isRTL ? (maxContentWidth - frame.width) : 0
                     currentRow += 1
                 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -92,12 +92,11 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
         guard
             let collectionView = collectionView,
             let delegate = collectionView.delegate as? UICollectionViewDelegateFlowLayout,
-            delegate.responds(to: #selector(delegate.collectionView(_:layout:sizeForItemAt:)))
+            let size = delegate.collectionView?(collectionView, layout: self, sizeForItemAt: indexPath)
         else {
             return CGSize(width: itemSize.width, height: cellHeight)
         }
 
-        let size = delegate.collectionView!(collectionView, layout: self, sizeForItemAt: indexPath)
         return CGSize(width: size.width, height: cellHeight)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -105,20 +105,14 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
             return centeredLayoutAttributesForElements(in: rect)
         }
 
-        var layoutAttributes = [UICollectionViewLayoutAttributes]()
-
-        for attribute in self.layoutAttributes {
-            if attribute.frame.intersects(rect) {
-                layoutAttributes.append(attribute)
-            }
+        return self.layoutAttributes.filter {
+            return $0.frame.intersects(rect)
         }
-
-        return layoutAttributes
     }
 
     private func centeredLayoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
         var rows = [Row]()
-        var rowY: CGFloat = CGFloat.greatestFiniteMagnitude
+        var rowY: CGFloat = .greatestFiniteMagnitude
 
         // Create an array of "rows" based on the y positions
         for attribute in layoutAttributes {

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -166,7 +166,7 @@ private class Row {
 
         var offset = isRightToLeft ? width - centerX : centerX
 
-        for attribute in layoutAttributes {
+        layoutAttributes.forEach { attribute in
             let itemWidth = attribute.frame.width + itemSpacing
 
             if isRightToLeft {
@@ -187,6 +187,6 @@ private class Row {
             return width + attribute.frame.width
         })
 
-        return width + itemSpacing * CGFloat(layoutAttributes.count-1)
+        return width + itemSpacing * CGFloat(layoutAttributes.count - 1)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -1,0 +1,115 @@
+import UIKit
+
+class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
+    @IBInspectable public var itemSpacing : CGFloat = 6
+    @IBInspectable public var cellHeight : CGFloat = 40
+
+    private var layoutAttributes: [UICollectionViewLayoutAttributes] = []
+
+    // The content width minus the content insets used when calculating rows, and centering
+    private var maxContentWidth: CGFloat {
+        guard let collectionView = collectionView else {
+            return 0
+        }
+
+        let contentInsets: UIEdgeInsets = collectionView.contentInset
+
+        return collectionView.bounds.width - (contentInsets.left + contentInsets.right)
+    }
+
+    /// The calculated content size for the view
+    private var contentSize: CGSize = .zero
+
+    override open var collectionViewContentSize : CGSize {
+        return contentSize
+    }
+
+    override func prepare() {
+        guard let collectionView = collectionView else {
+            return
+        }
+
+        let contentInsets = collectionView.contentInset
+
+        // The current row used to calculate the y position and the total content height
+        var currentRow: CGFloat = 0
+
+        // Keeps track of the previous items frame so we can properly calculate the current item's x position
+        var previousFrame: CGRect = .zero
+
+        let numberOfItems: Int = collectionView.numberOfItems(inSection: 0)
+
+        for item in 0 ..< numberOfItems {
+            let indexPath: IndexPath = IndexPath(row: item, section: 0)
+
+            let itemSize = sizeForItem(at: indexPath)
+            var frame: CGRect = CGRect(origin: .zero, size: itemSize)
+
+            if item == 0 {
+                frame.origin = CGPoint(x: 0, y: contentInsets.top)
+            } else {
+                                    frame.origin.x = previousFrame.maxX + itemSpacing
+
+
+                // If the new X position will go off screen move it to the next row
+                if frame.maxX > maxContentWidth {
+                    frame.origin.x = 0
+                    currentRow += 1
+                }
+
+                frame.origin.y = currentRow * (cellHeight + itemSpacing) + contentInsets.top
+            }
+
+            let attribute = UICollectionViewLayoutAttributes(forCellWith: indexPath)
+            attribute.frame = frame
+
+            layoutAttributes.append(attribute)
+
+            previousFrame = frame
+        }
+
+        // Update content size
+        contentSize.width = maxContentWidth
+        contentSize.height = currentRow * (cellHeight + itemSpacing) + contentInsets.top + contentInsets.bottom
+    }
+
+    override func invalidateLayout() {
+        contentSize = .zero
+        layoutAttributes = []
+
+        super.invalidateLayout()
+    }
+
+    /// Get the size for the given index path from the delegate, or the default item size
+    /// - Parameter indexPath: index path for the item
+    /// - Returns: The width for the cell either from the delegate or the itemSize property
+    private func sizeForItem(at indexPath: IndexPath) -> CGSize {
+        guard
+            let collectionView = collectionView,
+            let delegate = collectionView.delegate as? UICollectionViewDelegateFlowLayout,
+            delegate.responds(to: #selector(delegate.collectionView(_:layout:sizeForItemAt:)))
+            else {
+                return CGSize(width: itemSize.width, height: cellHeight)
+        }
+
+        let size = delegate.collectionView!(collectionView, layout: self, sizeForItemAt: indexPath)
+        return CGSize(width: size.width, height: cellHeight)
+    }
+
+    override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        var layoutAttributes = [UICollectionViewLayoutAttributes]()
+
+        for attribute in self.layoutAttributes {
+            if attribute.frame.intersects(rect) {
+                layoutAttributes.append(attribute)
+            }
+        }
+
+        return layoutAttributes
+    }
+
+    override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        return layoutAttributes[indexPath.row]
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		32C765BA23F715E4000A7F11 /* PostSignUpInterstitialCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F1A6CE23F7083500AB8CA9 /* PostSignUpInterstitialCoordinator.swift */; };
 		32C765BB23F7170C000A7F11 /* PostSignUpInterstitialCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F1A6D323F7111800AB8CA9 /* PostSignUpInterstitialCoordinatorTests.swift */; };
 		32CA6EC02390C61F00B51347 /* PostListEditorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CA6EBF2390C61F00B51347 /* PostListEditorPresenter.swift */; };
+		32E1BFDA24A66F2A007A08F0 /* ReaderInterestsCollectionViewFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E1BFD924A66F2A007A08F0 /* ReaderInterestsCollectionViewFlowLayout.swift */; };
 		37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 37022D901981BF9200F322B7 /* VerticallyStackedButton.m */; };
 		374CB16215B93C0800DD0EBC /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 374CB16115B93C0800DD0EBC /* AudioToolbox.framework */; };
 		37EAAF4D1A11799A006D6306 /* CircularImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EAAF4C1A11799A006D6306 /* CircularImageView.swift */; };
@@ -2742,6 +2743,7 @@
 		32A29A16236BC8BC009488C2 /* WordPress 93.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 93.xcdatamodel"; sourceTree = "<group>"; };
 		32C6CDDA23A1FF0D002556FF /* SiteCreationRotatingMessageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationRotatingMessageViewTests.swift; sourceTree = "<group>"; };
 		32CA6EBF2390C61F00B51347 /* PostListEditorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListEditorPresenter.swift; sourceTree = "<group>"; };
+		32E1BFD924A66F2A007A08F0 /* ReaderInterestsCollectionViewFlowLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderInterestsCollectionViewFlowLayout.swift; sourceTree = "<group>"; };
 		32F1A6CE23F7083500AB8CA9 /* PostSignUpInterstitialCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSignUpInterstitialCoordinator.swift; sourceTree = "<group>"; };
 		32F1A6D323F7111800AB8CA9 /* PostSignUpInterstitialCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSignUpInterstitialCoordinatorTests.swift; sourceTree = "<group>"; };
 		33D5016BDA00B45DFCAF3818 /* Pods-WordPressNotificationServiceExtension.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationServiceExtension.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationServiceExtension/Pods-WordPressNotificationServiceExtension.release-internal.xcconfig"; sourceTree = "<group>"; };
@@ -5854,6 +5856,14 @@
 				325D3B3C23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift */,
 			);
 			path = Controllers;
+			sourceTree = "<group>";
+		};
+		32E1BFD824A66801007A08F0 /* Select Interests */ = {
+			isa = PBXGroup;
+			children = (
+				32E1BFD924A66F2A007A08F0 /* ReaderInterestsCollectionViewFlowLayout.swift */,
+			);
+			path = "Select Interests";
 			sourceTree = "<group>";
 		};
 		32F1A6D123F710A300AB8CA9 /* NUX */ = {
@@ -9583,6 +9593,7 @@
 		CCB3A03814C8DD5100D43C3F /* Reader */ = {
 			isa = PBXGroup;
 			children = (
+				32E1BFD824A66801007A08F0 /* Select Interests */,
 				F5A738C1244DF92300EDE065 /* Manage */,
 				F597768C243E1E140062BAD1 /* Filter */,
 				5D1D04731B7A50B100CDE646 /* Reader.storyboard */,
@@ -12315,6 +12326,7 @@
 				D82253DF2199418B0014D0E2 /* WebAddressWizardContent.swift in Sources */,
 				400A2C782217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift in Sources */,
 				D853723C21952DC90076F461 /* SiteSegmentsStep.swift in Sources */,
+				32E1BFDA24A66F2A007A08F0 /* ReaderInterestsCollectionViewFlowLayout.swift in Sources */,
 				FF70A3221FD5840500BC270D /* PHAsset+Metadata.swift in Sources */,
 				5DA5BF4418E32DCF005F11F9 /* Theme.m in Sources */,
 				D8A3A5B1206A49A100992576 /* StockPhotosMediaGroup.swift in Sources */,


### PR DESCRIPTION
Creates a `UICollectionViewFlowLayout` class to be used on the Reader Phase 2 Select Interests view.

The flow layout supports:
- [x] Left to Right
- [x] Right to Left
- [x] Centering for larger size classes
- [x] Custom row height
- [x] Custom item spacing

### Demo Screenshots
| Left to Right | Right to Left | Centered LTR | Centered RTL |
|---|---|---|---|
| ![00 - LTR](https://user-images.githubusercontent.com/793774/85890189-ba36e980-b7a1-11ea-852f-2cd3ddada390.png) | ![01 - RTL](https://user-images.githubusercontent.com/793774/85890192-bacf8000-b7a1-11ea-933c-77575d28cad4.png) | ![02 - Centered LTR](https://user-images.githubusercontent.com/793774/85890194-bacf8000-b7a1-11ea-83cc-b90a1e00385f.png) | ![03 - Centered RTL](https://user-images.githubusercontent.com/793774/85890196-bb681680-b7a1-11ea-8bd1-acfd6d124ab8.png)|

### To test:
There are no user facing changes to test right now. 

### PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
