### PR TITLE
[Gutenberg] Unsupported fallback tracks

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -149,7 +149,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => 'b684e86f353cb0aad1f71d6ae4e2763d1616cd01'
+    gutenberg :commit => 'f3fc07d97cb3d21558b896992b8ea1c8af7159c7'
 
     ## Third party libraries
     ## =====================

--- a/Podfile
+++ b/Podfile
@@ -149,7 +149,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => '1d54a9fa3d79e95658557a825e1e08a9600fc842'
+    gutenberg :commit => 'b684e86f353cb0aad1f71d6ae4e2763d1616cd01'
 
     ## Third party libraries
     ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -439,14 +439,14 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/Folly.podspec.json`)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.0.1)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `1d54a9fa3d79e95658557a825e1e08a9600fc842`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `b684e86f353cb0aad1f71d6ae4e2763d1616cd01`)
   - JTAppleCalendar (~> 8.0.2)
   - MediaEditor (~> 1.2.0)
   - MRProgress (= 0.8.3)
@@ -456,36 +456,36 @@ DEPENDENCIES:
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-blur (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-blur.podspec.json`)
-  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-get-random-values.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `1d54a9fa3d79e95658557a825e1e08a9600fc842`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-blur (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-blur.podspec.json`)
+  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-get-random-values.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `b684e86f353cb0aad1f71d6ae4e2763d1616cd01`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -496,7 +496,7 @@ DEPENDENCIES:
   - WordPressShared (= 1.9.1-beta.1)
   - WordPressUI (~> 1.7.1)
   - WPMediaPicker (~> 1.7.0)
-  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -558,93 +558,93 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/FBLazyVector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/FBReactNativeSpec.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/FBReactNativeSpec.podspec.json
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/glog.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :commit: 1d54a9fa3d79e95658557a825e1e08a9600fc842
+    :commit: b684e86f353cb0aad1f71d6ae4e2763d1616cd01
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   RCTRequired:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/RCTRequired.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/RCTTypeSafety.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RCTTypeSafety.podspec.json
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-Core.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-Core.podspec.json
   React-CoreModules:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-CoreModules.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-CoreModules.podspec.json
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-cxxreact.podspec.json
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-jsi.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsinspector.podspec.json
   react-native-blur:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-blur.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-blur.podspec.json
   react-native-get-random-values:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-get-random-values.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-get-random-values.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-linear-gradient:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-linear-gradient.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-linear-gradient.podspec.json
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-slider:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-slider.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-slider.podspec.json
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/react-native-video.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTVibration.podspec.json
   ReactCommon:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/ReactCommon.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/ReactCommon.podspec.json
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/RNSVG.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :commit: 1d54a9fa3d79e95658557a825e1e08a9600fc842
+    :commit: b684e86f353cb0aad1f71d6ae4e2763d1616cd01
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   Yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/1d54a9fa3d79e95658557a825e1e08a9600fc842/third-party-podspecs/Yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :commit: 1d54a9fa3d79e95658557a825e1e08a9600fc842
+    :commit: b684e86f353cb0aad1f71d6ae4e2763d1616cd01
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   RNTAztecView:
-    :commit: 1d54a9fa3d79e95658557a825e1e08a9600fc842
+    :commit: b684e86f353cb0aad1f71d6ae4e2763d1616cd01
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
 
@@ -739,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: f273a3819fede9df81bc31fa720873366b2f67d8
+PODFILE CHECKSUM: 520b052d29a23e6429ade237fca67b4dca0a1584
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -439,14 +439,14 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/Folly.podspec.json`)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.0.1)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `b684e86f353cb0aad1f71d6ae4e2763d1616cd01`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `f3fc07d97cb3d21558b896992b8ea1c8af7159c7`)
   - JTAppleCalendar (~> 8.0.2)
   - MediaEditor (~> 1.2.0)
   - MRProgress (= 0.8.3)
@@ -456,36 +456,36 @@ DEPENDENCIES:
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-blur (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-blur.podspec.json`)
-  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-get-random-values.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `b684e86f353cb0aad1f71d6ae4e2763d1616cd01`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-blur (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-blur.podspec.json`)
+  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-get-random-values.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `f3fc07d97cb3d21558b896992b8ea1c8af7159c7`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -496,7 +496,7 @@ DEPENDENCIES:
   - WordPressShared (= 1.9.1-beta.1)
   - WordPressUI (~> 1.7.1)
   - WPMediaPicker (~> 1.7.0)
-  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -558,93 +558,93 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/FBLazyVector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/FBReactNativeSpec.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/FBReactNativeSpec.podspec.json
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/glog.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :commit: b684e86f353cb0aad1f71d6ae4e2763d1616cd01
+    :commit: f3fc07d97cb3d21558b896992b8ea1c8af7159c7
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   RCTRequired:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RCTRequired.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RCTTypeSafety.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/RCTTypeSafety.podspec.json
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-Core.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-Core.podspec.json
   React-CoreModules:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-CoreModules.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-CoreModules.podspec.json
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-cxxreact.podspec.json
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsi.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-jsinspector.podspec.json
   react-native-blur:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-blur.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-blur.podspec.json
   react-native-get-random-values:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-get-random-values.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-get-random-values.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-linear-gradient:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-linear-gradient.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-linear-gradient.podspec.json
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-slider:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-slider.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-slider.podspec.json
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/react-native-video.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/React-RCTVibration.podspec.json
   ReactCommon:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/ReactCommon.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/ReactCommon.podspec.json
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/RNSVG.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :commit: b684e86f353cb0aad1f71d6ae4e2763d1616cd01
+    :commit: f3fc07d97cb3d21558b896992b8ea1c8af7159c7
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   Yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b684e86f353cb0aad1f71d6ae4e2763d1616cd01/third-party-podspecs/Yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f3fc07d97cb3d21558b896992b8ea1c8af7159c7/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :commit: b684e86f353cb0aad1f71d6ae4e2763d1616cd01
+    :commit: f3fc07d97cb3d21558b896992b8ea1c8af7159c7
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   RNTAztecView:
-    :commit: b684e86f353cb0aad1f71d6ae4e2763d1616cd01
+    :commit: f3fc07d97cb3d21558b896992b8ea1c8af7159c7
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
 
@@ -739,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 520b052d29a23e6429ade237fca67b4dca0a1584
+PODFILE CHECKSUM: a3cf08ba348fcc04b340899797d66dffca3faa14
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -37,6 +37,10 @@ import Foundation
     // App Settings
     case appSettingsAppearanceChanged
 
+    // Gutenberg Features
+    case gutenbergUnsupportedBlockWebViewShown
+    case gutenbergUnsupportedBlockWebViewClosed
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -93,8 +97,12 @@ import Foundation
             return "editor_post_site_changed"
         case .appSettingsAppearanceChanged:
             return "app_settings_appearance_changed"
-        }
+        case .gutenbergUnsupportedBlockWebViewShown:
+            return "gutenberg_unsupported_block_webview_shown"
+        case .gutenbergUnsupportedBlockWebViewClosed:
+            return "gutenberg_unsupported_block_webview_closed"
     }
+}
 
     /**
      The default properties of the event

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebNavigationViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebNavigationViewController.swift
@@ -41,10 +41,12 @@ class GutenbergWebNavigationController: UINavigationController {
 extension GutenbergWebNavigationController: GutenbergWebDelegate {
     func webController(controller: GutenbergWebSingleBlockViewController, didPressSave block: Block) {
         onSave?(block)
+        WPAnalytics.track(.gutenbergUnsupportedBlockWebViewClosed, properties: ["action": "save"])
         dismiss(webController: controller)
     }
 
     func webControllerDidPressClose(controller: GutenbergWebSingleBlockViewController) {
+        WPAnalytics.track(.gutenbergUnsupportedBlockWebViewClosed, properties: ["action": "dismiss"])
         dismiss(webController: controller)
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
@@ -38,11 +38,6 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
         startObservingWebView()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        WPAnalytics.track(.gutenbergUnsupportedBlockWebViewShown)
-    }
-
     deinit {
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
@@ -38,6 +38,11 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
         startObservingWebView()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        WPAnalytics.track(.gutenbergUnsupportedBlockWebViewShown)
+    }
+
     deinit {
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
     }


### PR DESCRIPTION
This PR replaces https://github.com/wordpress-mobile/WordPress-iOS/pull/14353
Fixes parts of https://github.com/wordpress-mobile/gutenberg-mobile/issues/2358

Implements changes from: https://github.com/WordPress/gutenberg/pull/23450
`gutenberg-mobile` ref: https://github.com/wordpress-mobile/gutenberg-mobile/pull/2449

We are adding:
- `gutenberg_unsupported_block_webview_shown`
  - params: `"block": "{block_internal_name}"`
- `gutenberg_unsupported_block_webview_closed` 
  - params: `"action": "save" / "dismiss"` accordingly.


cc @marecar3 

To test:

- Run Metro server on https://github.com/wordpress-mobile/gutenberg-mobile/pull/2449  to activate the webview option on unsupported blocks ensuring that the required JS code is running.
- Open the unsupported block web view
  - Check that `gutenberg_unsupported_block_webview_shown` is triggered.
- Close the web view by dismissing and by saving
  - Check that `gutenberg_unsupported_block_webview_closed` is triggered with the corresponding property.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
