### PR TITLE
Add feature flag for reader improvements phase 2

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -14,6 +14,7 @@ enum FeatureFlag: Int, CaseIterable {
     case readerWebview
     case swiftCoreData
     case homepageSettings
+    case readerImprovementsPhase2
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -46,6 +47,8 @@ enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current == .localDeveloper
         case .homepageSettings:
             return true
+        case .readerImprovementsPhase2:
+            return false
         }
     }
 }
@@ -88,6 +91,8 @@ extension FeatureFlag: OverrideableFlag {
             return "Migrate Core Data Stack to Swift"
         case .homepageSettings:
             return "Homepage Settings"
+        case .readerImprovementsPhase2:
+            return "Reader Improvements Phase 2"
         }
     }
 


### PR DESCRIPTION
Main Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/14395

### To test:
1. Tap the My Sites tab
2. Tap your profile icon in the top corner
3. Tap the debug settings item
4. Verify there is a 'Reader Improvements Phase 2' item
5. And it's off

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
