### PR TITLE
Update Auth to fix the nav bar's normal title color.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -188,9 +188,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.19.0'
+    # pod 'WordPressAuthenticator', '~> 1.19.1'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/nav_bar_title_color'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -188,9 +188,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.19.1'
+    pod 'WordPressAuthenticator', '~> 1.19.1'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/nav_bar_title_color'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -487,7 +487,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.2)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/nav_bar_title_color`)
+  - WordPressAuthenticator (~> 1.19.1)
   - WordPressKit (= 4.11.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.1)
@@ -537,6 +537,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -626,9 +627,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.31.0
-  WordPressAuthenticator:
-    :branch: fix/nav_bar_title_color
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.31.0/third-party-podspecs/Yoga.podspec.json
 
@@ -644,9 +642,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.31.0
-  WordPressAuthenticator:
-    :commit: ce5b479a96d565a85ed09825bb4797d0beb553b8
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -738,6 +733,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 8f22d185816b507d8b8c811a69eafb31c0e967b7
+PODFILE CHECKSUM: 2b806df98b918d8c96fb4fe232f6c896d6bc2ba3
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -383,7 +383,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.2)
   - WordPress-Editor-iOS (1.19.2):
     - WordPress-Aztec-iOS (= 1.19.2)
-  - WordPressAuthenticator (1.19.0):
+  - WordPressAuthenticator (1.19.1):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -487,7 +487,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.2)
-  - WordPressAuthenticator (~> 1.19.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/nav_bar_title_color`)
   - WordPressKit (= 4.11.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.1)
@@ -537,7 +537,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -627,6 +626,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.31.0
+  WordPressAuthenticator:
+    :branch: fix/nav_bar_title_color
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.31.0/third-party-podspecs/Yoga.podspec.json
 
@@ -642,6 +644,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.31.0
+  WordPressAuthenticator:
+    :commit: ce5b479a96d565a85ed09825bb4797d0beb553b8
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -716,7 +721,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: d01bf0c5e150ae6a046f06ba63b7cc2762061c0b
   WordPress-Editor-iOS: 5b726489e5ae07b7281a2862d69aba2d5c83f140
-  WordPressAuthenticator: bdabe18e108929acbee76f2ac7253d540638977c
+  WordPressAuthenticator: d49ff4d406fd60831c7ca30893760fb97a1058b2
   WordPressKit: 67f8bf4e86961f46052c2e124016956019c0ffed
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 423779c24b1f8f2ee06d1068d30c7d2ea51ca813
@@ -733,6 +738,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: f79e683dc01fa79fbad6aa8c7de10c6961e5ea92
+PODFILE CHECKSUM: 8f22d185816b507d8b8c811a69eafb31c0e967b7
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Fixes #14404 
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/314

This uses the Auth changes to correctly set the navigation bar's title text color.

To test:

- Run the app on a device with iOS 13.5.1. (Per the comment on the [bug](https://github.com/wordpress-mobile/WordPress-iOS/issues/14404): "I'm only seeing this on iOS 13.5.1. On iOS simulators with iOS 13.5 I don't see the issue.")
- Log in.
  - NOTE: The only way I could reproduce the bug was to log in with a social account that didn't require any WP information, i.e. a Google or Apple account that does not prompt for WP password or 2FA code, and goes directly to the login epilogue.
- Verify the nav title text color is white.

![nav_title_text_color](https://user-images.githubusercontent.com/1816888/86635631-8ec9b100-bf90-11ea-9c73-ab697fad438a.jpeg)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
