### PR TITLE
Fixes wrong site title showing in quick start tour

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -237,12 +237,12 @@ struct QuickStartSiteTitleTour: QuickStartTour {
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
 
-    var waypoints: [WayPoint] = {
+    var waypoints: [WayPoint] {
         let descriptionBase = NSLocalizedString("Select %@ to set a new title.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let placeholder = NSLocalizedString("Site Title", comment: "The item to select during a guided tour.")
         let descriptionTarget = WPTabBarController.sharedInstance()?.currentOrLastBlog()?.title ?? placeholder
         return [(element: .siteTitle, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: nil))]
-    }()
+    }
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of setting a title for your site.", comment: "This value is used to set the accessibility hint text for setting the site title.")
 }


### PR DESCRIPTION
Fixes #14411

To test:

1. With an existing account, create a new site and when prompted "Want a little help getting started" tap on "Yes, help me". 
2. Select "Set your site title" and verify that the notice says "Select Site Title to set a new title"
3. Set a custom title
3. From "My Site", tap on the "Customize my site" in the "Next Steps Section", and from the "Completed" section, select "~~Set your Site Title~~"
4. Verify that the notice now reports the custom title that you previously set
1. Log out.
1. Log in with a new account and create a new site. Follow the same steps as 1
1. Select "Yes, Help Me" when prompted.
1. Go to Quick Start > Site Title.
1. Checkthe notice says "Select Site Title to set a new title" and does not contain names from the previously logged accounts

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
