### PR TITLE
ULS: Update large title font

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -189,9 +189,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.20.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.20.0-beta'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/315-large_title_font'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -189,9 +189,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.19.0'
+    # pod 'WordPressAuthenticator', '~> 1.20.0-beta'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/315-large_title_font'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.2)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/315-large_title_font`)
+  - WordPressAuthenticator (~> 1.20.0-beta)
   - WordPressKit (= 4.12.0-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.1)
@@ -540,6 +540,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -631,9 +632,6 @@ EXTERNAL SOURCES:
     :commit: b435ab26c0cf5a8af78e7d6fefc694aef7c1a8e0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
-  WordPressAuthenticator:
-    :branch: feature/315-large_title_font
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b435ab26c0cf5a8af78e7d6fefc694aef7c1a8e0/third-party-podspecs/Yoga.podspec.json
 
@@ -649,9 +647,6 @@ CHECKOUT OPTIONS:
     :commit: b435ab26c0cf5a8af78e7d6fefc694aef7c1a8e0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
-  WordPressAuthenticator:
-    :commit: d81317ec15d5f8e4d0ff49704110d798e33756f3
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -744,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 78482f66fff3e529e2319a624107f09fea388dda
+PODFILE CHECKSUM: 414ab2a9a546d62fed0d5bd90e1d352a9d85ac62
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.2)
   - WordPress-Editor-iOS (1.19.2):
     - WordPress-Aztec-iOS (= 1.19.2)
-  - WordPressAuthenticator (1.19.0):
+  - WordPressAuthenticator (1.20.0-beta.1):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -395,7 +395,7 @@ PODS:
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (= 2.2.5)
     - WordPressKit (~> 4.0-beta.0)
-    - WordPressShared (~> 1.0-beta.0)
+    - WordPressShared (~> 1.9-beta)
     - WordPressUI (~> 1.7.0)
   - WordPressKit (4.11.0):
     - Alamofire (~> 4.8.0)
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.2)
-  - WordPressAuthenticator (~> 1.19.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/315-large_title_font`)
   - WordPressKit (= 4.11.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.1)
@@ -540,7 +540,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -632,6 +631,9 @@ EXTERNAL SOURCES:
     :commit: b435ab26c0cf5a8af78e7d6fefc694aef7c1a8e0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :branch: feature/315-large_title_font
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/b435ab26c0cf5a8af78e7d6fefc694aef7c1a8e0/third-party-podspecs/Yoga.podspec.json
 
@@ -647,6 +649,9 @@ CHECKOUT OPTIONS:
     :commit: b435ab26c0cf5a8af78e7d6fefc694aef7c1a8e0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :commit: d81317ec15d5f8e4d0ff49704110d798e33756f3
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -722,7 +727,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: d01bf0c5e150ae6a046f06ba63b7cc2762061c0b
   WordPress-Editor-iOS: 5b726489e5ae07b7281a2862d69aba2d5c83f140
-  WordPressAuthenticator: bdabe18e108929acbee76f2ac7253d540638977c
+  WordPressAuthenticator: 2bbfc66cf060ca89f92d8ee46bbf22a7c776f39b
   WordPressKit: 67f8bf4e86961f46052c2e124016956019c0ffed
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 423779c24b1f8f2ee06d1068d30c7d2ea51ca813
@@ -739,6 +744,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: e2b8bb3867624fbf7306b59efaaae3515f7ca383
+PODFILE CHECKSUM: 5ff321ba354ccffa0c57723cd0a9b8e2cb9df0ff
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -28,16 +28,6 @@ class EpilogueUserInfoCell: UITableViewCell {
     private var gravatarStatus: GravatarUploaderStatus = .idle
     private var email: String?
 
-    private var fullNameFont: UIFont {
-        // Use New York font for full name.
-        guard #available(iOS 13, *),
-            let fontDescriptor = UIFont.systemFont(ofSize: 34.0, weight: .medium).fontDescriptor.withDesign(.serif) else {
-                return WPStyleGuide.mediumWeightFont(forStyle: .largeTitle)
-        }
-
-        return UIFontMetrics.default.scaledFont(for: UIFont(descriptor: fontDescriptor, size: 0.0))
-    }
-
     override func awakeFromNib() {
         super.awakeFromNib()
         configureImages()
@@ -104,7 +94,7 @@ private extension EpilogueUserInfoCell {
         gravatarAddIcon.backgroundColor = .basicBackground
 
         fullNameLabel.textColor = .text
-        fullNameLabel.font = fullNameFont
+        fullNameLabel.font = WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .semibold)
 
         usernameLabel.textColor = .textSubtle
         usernameLabel.font = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .headline).pointSize, weight: .regular)


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/315
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/316

This updates the large title font weight in the Login and Signup Epilogues. It also uses the Auth changes to show the updated nav bar in the Site Address view.

To test:
- Enable the `unifiedSiteAddress` Feature Flag.
- Go to Log In > Site Address.
- Verify the nav bar title is in NY font.

<kbd><img width="472" alt="auth" src="https://user-images.githubusercontent.com/1816888/86839790-1d0c6880-c05f-11ea-86f9-ad98daceaa8d.png"></kbd>

- Log in.
  - Login and Signup Epilogues use the same user info UI, so testing one will verify both.
- On the epilogue, verify the user name is in NY font.

<kbd><img width="468" alt="epilogue" src="https://user-images.githubusercontent.com/1816888/86839872-39100a00-c05f-11ea-9881-3e5e17849f93.png"></kbd>


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
