### PR TITLE
Gutenberg Mentions: Allow editing of existing mentions

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -149,7 +149,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => 'ec9f4111fbf676779666055bd82438a8cae91abc'
+    gutenberg :commit => '2742e91351a907eaa97a89370338ef95fbd7b9b0'
 
     ## Third party libraries
     ## =====================

--- a/Podfile
+++ b/Podfile
@@ -149,7 +149,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => '2b2c7574dc3bcf26c25a2646bdb2142d907df860'
+    gutenberg :commit => 'ec9f4111fbf676779666055bd82438a8cae91abc'
 
     ## Third party libraries
     ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -439,14 +439,14 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/Folly.podspec.json`)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.0.1)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `2b2c7574dc3bcf26c25a2646bdb2142d907df860`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `ec9f4111fbf676779666055bd82438a8cae91abc`)
   - JTAppleCalendar (~> 8.0.2)
   - MediaEditor (~> 1.2.0)
   - MRProgress (= 0.8.3)
@@ -456,36 +456,36 @@ DEPENDENCIES:
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-blur (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-blur.podspec.json`)
-  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-get-random-values.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `2b2c7574dc3bcf26c25a2646bdb2142d907df860`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-blur (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-blur.podspec.json`)
+  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-get-random-values.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `ec9f4111fbf676779666055bd82438a8cae91abc`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -496,7 +496,7 @@ DEPENDENCIES:
   - WordPressShared (= 1.9.1-beta.1)
   - WordPressUI (~> 1.7.1)
   - WPMediaPicker (~> 1.7.0)
-  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -558,93 +558,93 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/FBLazyVector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/FBReactNativeSpec.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/FBReactNativeSpec.podspec.json
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/glog.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :commit: 2b2c7574dc3bcf26c25a2646bdb2142d907df860
+    :commit: ec9f4111fbf676779666055bd82438a8cae91abc
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   RCTRequired:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/RCTRequired.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/RCTTypeSafety.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RCTTypeSafety.podspec.json
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-Core.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-Core.podspec.json
   React-CoreModules:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-CoreModules.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-CoreModules.podspec.json
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-cxxreact.podspec.json
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-jsi.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsinspector.podspec.json
   react-native-blur:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-blur.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-blur.podspec.json
   react-native-get-random-values:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-get-random-values.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-get-random-values.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-linear-gradient:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-linear-gradient.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-linear-gradient.podspec.json
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-slider:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-slider.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-slider.podspec.json
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/react-native-video.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTVibration.podspec.json
   ReactCommon:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/ReactCommon.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/ReactCommon.podspec.json
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/RNSVG.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :commit: 2b2c7574dc3bcf26c25a2646bdb2142d907df860
+    :commit: ec9f4111fbf676779666055bd82438a8cae91abc
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   Yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2b2c7574dc3bcf26c25a2646bdb2142d907df860/third-party-podspecs/Yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :commit: 2b2c7574dc3bcf26c25a2646bdb2142d907df860
+    :commit: ec9f4111fbf676779666055bd82438a8cae91abc
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   RNTAztecView:
-    :commit: 2b2c7574dc3bcf26c25a2646bdb2142d907df860
+    :commit: ec9f4111fbf676779666055bd82438a8cae91abc
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
 
@@ -739,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 44310a6cd8ddf34b064e482d0b707d29a92d1645
+PODFILE CHECKSUM: 619c460e7f8665150b7a6ca35ada2b794f83375f
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -439,14 +439,14 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.5.2)
   - Down (~> 0.6.6)
-  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/FBLazyVector.podspec.json`)
-  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/FBReactNativeSpec.podspec.json`)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/Folly.podspec.json`)
+  - FBLazyVector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/FBLazyVector.podspec.json`)
+  - FBReactNativeSpec (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/FBReactNativeSpec.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/Folly.podspec.json`)
   - FSInteractiveMap (from `https://github.com/wordpress-mobile/FSInteractiveMap.git`, tag `0.2.0`)
   - Gifu (= 3.2.0)
-  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/glog.podspec.json`)
+  - glog (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/glog.podspec.json`)
   - Gridicons (~> 1.0.1)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `ec9f4111fbf676779666055bd82438a8cae91abc`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `2742e91351a907eaa97a89370338ef95fbd7b9b0`)
   - JTAppleCalendar (~> 8.0.2)
   - MediaEditor (~> 1.2.0)
   - MRProgress (= 0.8.3)
@@ -456,36 +456,36 @@ DEPENDENCIES:
   - OCMock (= 3.4.3)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RCTRequired.podspec.json`)
-  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RCTTypeSafety.podspec.json`)
+  - RCTRequired (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/RCTRequired.podspec.json`)
+  - RCTTypeSafety (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/RCTTypeSafety.podspec.json`)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React.podspec.json`)
-  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-Core.podspec.json`)
-  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-CoreModules.podspec.json`)
-  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-cxxreact.podspec.json`)
-  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsi.podspec.json`)
-  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsiexecutor.podspec.json`)
-  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsinspector.podspec.json`)
-  - react-native-blur (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-blur.podspec.json`)
-  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-get-random-values.podspec.json`)
-  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
-  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-linear-gradient.podspec.json`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-safe-area.podspec.json`)
-  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-slider.podspec.json`)
-  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-video.podspec.json`)
-  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTActionSheet.podspec.json`)
-  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTAnimation.podspec.json`)
-  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTBlob.podspec.json`)
-  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTImage.podspec.json`)
-  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTLinking.podspec.json`)
-  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTNetwork.podspec.json`)
-  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTSettings.podspec.json`)
-  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTText.podspec.json`)
-  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTVibration.podspec.json`)
-  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/ReactCommon.podspec.json`)
-  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
-  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RNSVG.podspec.json`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `ec9f4111fbf676779666055bd82438a8cae91abc`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React.podspec.json`)
+  - React-Core (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-Core.podspec.json`)
+  - React-CoreModules (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-CoreModules.podspec.json`)
+  - React-cxxreact (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-cxxreact.podspec.json`)
+  - React-jsi (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-jsi.podspec.json`)
+  - React-jsiexecutor (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-jsiexecutor.podspec.json`)
+  - React-jsinspector (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-jsinspector.podspec.json`)
+  - react-native-blur (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-blur.podspec.json`)
+  - react-native-get-random-values (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-get-random-values.podspec.json`)
+  - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
+  - react-native-linear-gradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-linear-gradient.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-slider (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-slider.podspec.json`)
+  - react-native-video (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-video.podspec.json`)
+  - React-RCTActionSheet (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTActionSheet.podspec.json`)
+  - React-RCTAnimation (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTAnimation.podspec.json`)
+  - React-RCTBlob (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTBlob.podspec.json`)
+  - React-RCTImage (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTImage.podspec.json`)
+  - React-RCTLinking (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTLinking.podspec.json`)
+  - React-RCTNetwork (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTNetwork.podspec.json`)
+  - React-RCTSettings (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTSettings.podspec.json`)
+  - React-RCTText (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTText.podspec.json`)
+  - React-RCTVibration (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTVibration.podspec.json`)
+  - ReactCommon (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/ReactCommon.podspec.json`)
+  - ReactNativeDarkMode (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/ReactNativeDarkMode.podspec.json`)
+  - RNSVG (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/RNSVG.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `2742e91351a907eaa97a89370338ef95fbd7b9b0`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -496,7 +496,7 @@ DEPENDENCIES:
   - WordPressShared (= 1.9.1-beta.1)
   - WordPressUI (~> 1.7.1)
   - WPMediaPicker (~> 1.7.0)
-  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/Yoga.podspec.json`)
+  - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.0.0)
   - ZIPFoundation (~> 0.9.8)
 
@@ -558,93 +558,93 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FBLazyVector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/FBLazyVector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/FBReactNativeSpec.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/FBReactNativeSpec.podspec.json
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/Folly.podspec.json
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   glog:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/glog.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/glog.podspec.json
   Gutenberg:
-    :commit: ec9f4111fbf676779666055bd82438a8cae91abc
+    :commit: 2742e91351a907eaa97a89370338ef95fbd7b9b0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   RCTRequired:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RCTRequired.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RCTTypeSafety.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/RCTTypeSafety.podspec.json
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React.podspec.json
   React-Core:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-Core.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-Core.podspec.json
   React-CoreModules:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-CoreModules.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-CoreModules.podspec.json
   React-cxxreact:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-cxxreact.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-cxxreact.podspec.json
   React-jsi:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsi.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-jsi.podspec.json
   React-jsiexecutor:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsiexecutor.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-jsiexecutor.podspec.json
   React-jsinspector:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-jsinspector.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-jsinspector.podspec.json
   react-native-blur:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-blur.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-blur.podspec.json
   react-native-get-random-values:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-get-random-values.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-get-random-values.podspec.json
   react-native-keyboard-aware-scroll-view:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json
   react-native-linear-gradient:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-linear-gradient.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-linear-gradient.podspec.json
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-safe-area.podspec.json
   react-native-slider:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-slider.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-slider.podspec.json
   react-native-video:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/react-native-video.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/react-native-video.podspec.json
   React-RCTActionSheet:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTActionSheet.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTActionSheet.podspec.json
   React-RCTAnimation:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTAnimation.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTAnimation.podspec.json
   React-RCTBlob:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTBlob.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTBlob.podspec.json
   React-RCTImage:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTImage.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTImage.podspec.json
   React-RCTLinking:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTLinking.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTLinking.podspec.json
   React-RCTNetwork:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTNetwork.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTNetwork.podspec.json
   React-RCTSettings:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTSettings.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTSettings.podspec.json
   React-RCTText:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTText.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTText.podspec.json
   React-RCTVibration:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/React-RCTVibration.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/React-RCTVibration.podspec.json
   ReactCommon:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/ReactCommon.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/ReactCommon.podspec.json
   ReactNativeDarkMode:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/ReactNativeDarkMode.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/ReactNativeDarkMode.podspec.json
   RNSVG:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/RNSVG.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/RNSVG.podspec.json
   RNTAztecView:
-    :commit: ec9f4111fbf676779666055bd82438a8cae91abc
+    :commit: 2742e91351a907eaa97a89370338ef95fbd7b9b0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   Yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/ec9f4111fbf676779666055bd82438a8cae91abc/third-party-podspecs/Yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/2742e91351a907eaa97a89370338ef95fbd7b9b0/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
   Gutenberg:
-    :commit: ec9f4111fbf676779666055bd82438a8cae91abc
+    :commit: 2742e91351a907eaa97a89370338ef95fbd7b9b0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   RNTAztecView:
-    :commit: ec9f4111fbf676779666055bd82438a8cae91abc
+    :commit: 2742e91351a907eaa97a89370338ef95fbd7b9b0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
 
@@ -739,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 619c460e7f8665150b7a6ca35ada2b794f83375f
+PODFILE CHECKSUM: 7a5a46dfdcc41458204ce7de7f6f46c58c97023e
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMentionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMentionsViewController.swift
@@ -23,7 +23,7 @@ public class GutenbergMentionsViewController: UIViewController {
     public lazy var searchView: UITextField = {
         let textField = UITextField(frame: CGRect.zero)
         textField.placeholder = NSLocalizedString("Search users...", comment: "Placeholder message when showing mentions search field")
-        textField.text = Self.mentionTriggerText
+        textField.text = self.initialSearchTerm
         textField.clearButtonMode = .whileEditing
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.delegate = self
@@ -36,7 +36,7 @@ public class GutenbergMentionsViewController: UIViewController {
         suggestionsView.animateWithKeyboard = false
         suggestionsView.enabled = true
         suggestionsView.showLoading = true
-        suggestionsView.showSuggestions(forWord: Self.mentionTriggerText)
+        suggestionsView.showSuggestions(forWord: self.initialSearchTerm)
         suggestionsView.suggestionsDelegate = self
         suggestionsView.translatesAutoresizingMaskIntoConstraints = false
         suggestionsView.siteID = siteID
@@ -45,10 +45,12 @@ public class GutenbergMentionsViewController: UIViewController {
     }()
 
     private let siteID: NSNumber
+    private let initialSearchTerm: String
     public var onCompletion: ((Result<String, NSError>) -> Void)?
 
-    public init(siteID: NSNumber) {
+    public init(siteID: NSNumber, initialSearchTerm: String = "") {
         self.siteID = siteID
+        self.initialSearchTerm = initialSearchTerm.isEmpty ? Self.mentionTriggerText : initialSearchTerm.trim()
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -100,7 +102,7 @@ public class GutenbergMentionsViewController: UIViewController {
     }
 
     override public func viewDidAppear(_ animated: Bool) {
-        suggestionsView.showSuggestions(forWord: Self.mentionTriggerText)
+        suggestionsView.showSuggestions(forWord: self.initialSearchTerm)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -779,9 +779,9 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         }
     }
 
-    func gutenbergDidRequestMention(callback: @escaping (Swift.Result<String, NSError>) -> Void) {
+    func gutenbergDidRequestMention(mention: String, callback: @escaping (Swift.Result<String, NSError>) -> Void) {
         DispatchQueue.main.async(execute: { [weak self] in
-            self?.mentionShow(callback: callback)
+            self?.mentionShow(searchTerm: mention, callback: callback)
         })
     }
 
@@ -797,14 +797,14 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 
 extension GutenbergViewController {
 
-    private func mentionShow(callback: @escaping (Swift.Result<String, NSError>) -> Void) {
+    private func mentionShow(searchTerm: String, callback: @escaping (Swift.Result<String, NSError>) -> Void) {
         guard let siteID = post.blog.dotComID else {
             callback(.failure(GutenbergMentionsViewController.MentionError.notAvailable as NSError))
             return
         }
 
         previousFirstResponder = view.findFirstResponder()
-        let mentionsController = GutenbergMentionsViewController(siteID: siteID)
+        let mentionsController = GutenbergMentionsViewController(siteID: siteID, initialSearchTerm: searchTerm)
         mentionsController.onCompletion = { (result) in
             callback(result)
             mentionsController.view.removeFromSuperview()


### PR DESCRIPTION
Fixes #

This PR adds the possibility to edit an existing mention

To test:
 - Start a new post in a P2 site
 - Add a mention to the content of a block
 - Move the cursor/caret over a location in a mention
 - Tap on the @ button in the toolbar 
 - Check that the mention UI shows up prefilled with the current value of the mention
 - Select another value for the mention
 - See if the new mention replaces the previous mention
 - Move the cursor again somewhere inside the mention
 - This time tap backspace on the keyboard
 - Check that the mention UI shows up and you can change the existing mention like explained above.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
