### PR TITLE
Fix basic offline support in Reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -29,7 +29,6 @@ struct ReaderCSS {
             return url(appendingTimestamp: now)
         }
 
-        // If the last time we fetched the CSS was 2 days ago and the user is online, refresh it
         return url(appendingTimestamp: lastUpdated)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -21,8 +21,8 @@ struct ReaderCSS {
     ///
     var address: String {
         guard let lastUpdated = store.object(forKey: updatedKey) as? Int,
-                now - lastUpdated >= expirationDaysInSeconds
-                && ReachabilityUtils.isInternetReachable() else {
+                (now - lastUpdated < expirationDaysInSeconds
+                && !ReachabilityUtils.isInternetReachable()) else {
             saveCurrentDate()
             return url(appendingTimestamp: now)
         }

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -24,7 +24,7 @@ struct ReaderCSS {
     var address: String {
         guard let lastUpdated = store.object(forKey: type(of: self).updatedKey) as? Int,
                 (now - lastUpdated < expirationDaysInSeconds
-                && !isInternetReachable()) else {
+                || !isInternetReachable()) else {
             saveCurrentDate()
             return url(appendingTimestamp: now)
         }

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderCSS.swift
@@ -19,7 +19,7 @@ struct ReaderCSS {
     static let updatedKey = "ReaderCSSLastUpdated"
 
     /// Returns the Reader CSS appending a timestamp
-    /// We force it to update every 2 days
+    /// We force it to update based on the `expirationDays` property
     ///
     var address: String {
         guard let lastUpdated = store.object(forKey: type(of: self).updatedKey) as? Int,

--- a/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/DetailWebView/ReaderWebView.swift
@@ -8,7 +8,7 @@ class ReaderWebView: WKWebView {
     /// From: https://www.w3schools.com/tags/att_src.asp
     private let elements = ["audio", "embed", "iframe", "img", "input", "script", "source", "track", "video"]
 
-    let jsToRemoveSrcSet = "document.querySelectorAll('img-placeholder').forEach((el) => {el.removeAttribute('srcset')})"
+    let jsToRemoveSrcSet = "document.querySelectorAll('img, img-placeholder').forEach((el) => {el.removeAttribute('srcset')})"
 
     /// Make the webview transparent
     ///

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1067,6 +1067,7 @@
 		8B1CF00F2433902700578582 /* PasswordAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1CF00E2433902700578582 /* PasswordAlertController.swift */; };
 		8B1CF0112433E61C00578582 /* AbstractPost+TitleForVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1CF0102433E61C00578582 /* AbstractPost+TitleForVisibility.swift */; };
 		8B24C4E3249A4C3E0005E8A5 /* OfflineReaderWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B24C4E2249A4C3E0005E8A5 /* OfflineReaderWebView.swift */; };
+		8B25F8DA24B7683A009DD4C9 /* ReaderCSSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B25F8D924B7683A009DD4C9 /* ReaderCSSTests.swift */; };
 		8B260D7E2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
@@ -3532,6 +3533,7 @@
 		8B1CF00E2433902700578582 /* PasswordAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordAlertController.swift; sourceTree = "<group>"; };
 		8B1CF0102433E61C00578582 /* AbstractPost+TitleForVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+TitleForVisibility.swift"; sourceTree = "<group>"; };
 		8B24C4E2249A4C3E0005E8A5 /* OfflineReaderWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineReaderWebView.swift; sourceTree = "<group>"; };
+		8B25F8D924B7683A009DD4C9 /* ReaderCSSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCSSTests.swift; sourceTree = "<group>"; };
 		8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostVisibilitySelectorViewController.swift; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
@@ -5566,7 +5568,7 @@
 			path = GutenbergWeb;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				98D31BBF239720E4009CFF43 /* MainInterface.storyboard */,
@@ -10236,6 +10238,7 @@
 		E6B9B8AB1B94EA710001B92F /* Reader */ = {
 			isa = PBXGroup;
 			children = (
+				8B25F8D924B7683A009DD4C9 /* ReaderCSSTests.swift */,
 				327B48C4247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift */,
 				3F8CB103239E025F007627BF /* ReaderDetailViewControllerTests.swift */,
 				8BDA5A6C247C2F8400AB124C /* ReaderDetailWebviewViewControllerTests.swift */,
@@ -10929,7 +10932,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -13759,6 +13762,7 @@
 				7E987F5A2108122A00CAFB88 /* NotificationUtility.swift in Sources */,
 				7E442FC720F677CB00DEACA5 /* ActivityLogRangesTest.swift in Sources */,
 				D80EE63A203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift in Sources */,
+				8B25F8DA24B7683A009DD4C9 /* ReaderCSSTests.swift in Sources */,
 				08E77F471EE9D72F006F9515 /* MediaThumbnailExporterTests.swift in Sources */,
 				59FBD5621B5684F300734466 /* ThemeServiceTests.m in Sources */,
 				85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */,

--- a/WordPress/WordPressTest/ReaderCSSTests.swift
+++ b/WordPress/WordPressTest/ReaderCSSTests.swift
@@ -5,6 +5,8 @@ import XCTest
 class ReaderCSSTests: XCTestCase {
     // MARK: - When online
 
+    /// When requesting the CSS for the first time, use the current date in seconds
+    ///
     func testOnlineFirstTime() {
         let now = Int(Date().timeIntervalSince1970)
         let database = EphemeralKeyValueDatabase()
@@ -14,6 +16,8 @@ class ReaderCSSTests: XCTestCase {
         XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(now)")
     }
 
+    /// When the CSS was requested at least 5 days ago, update the address
+    ///
     func testOnlineExpired() {
         let now = Int(Date().timeIntervalSince1970)
         let fiveDaysAgo = now - 5 * 60 * 60 * 24
@@ -25,6 +29,8 @@ class ReaderCSSTests: XCTestCase {
         XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(now)")
     }
 
+    /// When the CSS was requested less than 5 days ago, use the time of when it was requested
+    ///
     func testOnlineNotExpired() {
         let now = Int(Date().timeIntervalSince1970)
         let fourDaysAgo = now - 4 * 60 * 60 * 24
@@ -38,6 +44,8 @@ class ReaderCSSTests: XCTestCase {
 
     // MARK: - When offline
 
+    /// When requesting the CSS for the first time, use the current date in seconds
+    ///
     func testOfflineFirstTime() {
         let now = Int(Date().timeIntervalSince1970)
         let database = EphemeralKeyValueDatabase()
@@ -47,6 +55,8 @@ class ReaderCSSTests: XCTestCase {
         XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(now)")
     }
 
+    /// When the CSS was requested at least 5 days ago but device isssss offline, keep the address
+    ///
     func testOfflineExpired() {
         let now = Int(Date().timeIntervalSince1970)
         let fiveDaysAgo = now - 5 * 60 * 60 * 24
@@ -58,6 +68,8 @@ class ReaderCSSTests: XCTestCase {
         XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(fiveDaysAgo)")
     }
 
+    /// When the CSS was requested less than 5 days ago and we're offline, keep the old timestamp
+    ///
     func testOfflineNotExpired() {
         let now = Int(Date().timeIntervalSince1970)
         let fourDaysAgo = now - 4 * 60 * 60 * 24

--- a/WordPress/WordPressTest/ReaderCSSTests.swift
+++ b/WordPress/WordPressTest/ReaderCSSTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+@testable import WordPress
+
+class ReaderCSSTests: XCTestCase {
+    // MARK: - When online
+
+    func testOnlineFirstTime() {
+        let now = Int(Date().timeIntervalSince1970)
+        let database = EphemeralKeyValueDatabase()
+
+        let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { true })
+
+        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(now)")
+    }
+
+    func testOnlineExpired() {
+        let now = Int(Date().timeIntervalSince1970)
+        let fiveDaysAgo = now - 5 * 60 * 60 * 24
+        let database = EphemeralKeyValueDatabase()
+        database.set(fiveDaysAgo, forKey: ReaderCSS.updatedKey)
+
+        let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { true })
+
+        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(now)")
+    }
+
+    func testOnlineNotExpired() {
+        let now = Int(Date().timeIntervalSince1970)
+        let fourDaysAgo = now - 4 * 60 * 60 * 24
+        let database = EphemeralKeyValueDatabase()
+        database.set(fourDaysAgo, forKey: ReaderCSS.updatedKey)
+
+        let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { true })
+
+        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(fourDaysAgo)")
+    }
+
+    // MARK: - When offline
+
+    func testOfflineFirstTime() {
+        let now = Int(Date().timeIntervalSince1970)
+        let database = EphemeralKeyValueDatabase()
+
+        let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { false })
+
+        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(now)")
+    }
+
+    func testOfflineExpired() {
+        let now = Int(Date().timeIntervalSince1970)
+        let fiveDaysAgo = now - 5 * 60 * 60 * 24
+        let database = EphemeralKeyValueDatabase()
+        database.set(fiveDaysAgo, forKey: ReaderCSS.updatedKey)
+
+        let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { false })
+
+        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(fiveDaysAgo)")
+    }
+
+    func testOfflineNotExpired() {
+        let now = Int(Date().timeIntervalSince1970)
+        let fourDaysAgo = now - 4 * 60 * 60 * 24
+        let database = EphemeralKeyValueDatabase()
+        database.set(fourDaysAgo, forKey: ReaderCSS.updatedKey)
+
+        let readerCSS = ReaderCSS(now: now, store: database, isInternetReachable: { false })
+
+        XCTAssertEqual(readerCSS.address, "https://wordpress.com/calypso/reader-mobile.css?\(fourDaysAgo)")
+    }
+}


### PR DESCRIPTION
This PR fixes the basic offline suport in the new Reader detail.

### To test

1. Open the Reader
2. Save a few posts 
3. Go offline
4. Open the saved posts, they should show the cached images

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
