### PR TITLE
Allow the Unsupported Block Editor on Atomic sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -875,7 +875,13 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
     }
 
     private var isUnsupportedBlockEditorEnabled: Bool {
-        return !(post.blog.jetpack?.isConnected ?? false)
+        // The Unsupported Block Editor is made for
+        // 1. All WP.com sites (Atomic or non-Atomic)
+        // 2. Self-hosted sites that are not authenticated via Jetpack
+        return
+            post.blog.isAtomic() ||
+            post.blog.isAutomatedTransfer() ||
+            !(post.blog.jetpack?.isConnected ?? false)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -875,12 +875,11 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
     }
 
     private var isUnsupportedBlockEditorEnabled: Bool {
-        // The Unsupported Block Editor is made for
-        // 1. All WP.com sites (Atomic or non-Atomic)
-        // 2. Self-hosted sites that are not authenticated via Jetpack
+        // The Unsupported Block Editor is disabled for self-hosted sites that are connected via Jetpack to a WP.com account.
+        // This is because we don't have the self-hosted site's credentials which are required for us to be able to fetch the site's authentication cookie.
+        // This cookie is needed to authenticate the network request that fetches the unsupported block editor web page.
         return
             post.blog.isAtomic() ||
-            post.blog.isAutomatedTransfer() ||
             !(post.blog.jetpack?.isConnected ?? false)
     }
 }


### PR DESCRIPTION
The Unsupported Block Editor feature was disabled on sites connected via Jetpack because of an issue requesting cookies from those sites without having login credentials other than WP.com credentials.
This inadvertently blocked Atomic sites as well, which are also connected via Jetpack. Atomic sites, being WP.com sites, don't have the cookie issue so this PR enables this feature on those sites.

Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/2470

To test, perform [the Unsupported Block test cases 1 to 4](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/unsupported-block-editing.md).


PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
