### PR TITLE
Reader: enable scroll for #hash links

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailCoordinator.swift
@@ -258,7 +258,9 @@ class ReaderDetailCoordinator {
     ///
     /// - Parameter url: the URL to be handled
     func handle(_ url: URL) {
-        if url.pathExtension.contains("gif") || url.pathExtension.contains("jpg") || url.pathExtension.contains("jpeg") || url.pathExtension.contains("png") {
+        if let hash = URLComponents(url: url, resolvingAgainstBaseURL: true)?.fragment {
+            view?.scroll(to: hash)
+        } else if url.pathExtension.contains("gif") || url.pathExtension.contains("jpg") || url.pathExtension.contains("jpeg") || url.pathExtension.contains("png") {
             presentImage(url)
         } else if readerLinkRouter.canHandle(url: url) {
             readerLinkRouter.handle(url: url, shouldTrack: false, source: viewController)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailWebviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailWebviewViewController.swift
@@ -7,6 +7,7 @@ protocol ReaderDetailView: class {
     func showError()
     func showErrorWithWebAction()
     func show(title: String?)
+    func scroll(to: String)
 }
 
 class ReaderDetailWebviewViewController: UIViewController, ReaderDetailView {
@@ -147,6 +148,18 @@ class ReaderDetailWebviewViewController: UIViewController, ReaderDetailView {
         let titleView = UILabel()
         titleView.attributedText = NSAttributedString.init(string: title ?? placeholder, attributes: UINavigationBar.appearance().titleTextAttributes)
         navigationItem.titleView = titleView
+    }
+
+    /// Scroll the content to a given #hash
+    ///
+    func scroll(to hash: String) {
+        webView.evaluateJavaScript("document.getElementById('\(hash)').offsetTop", completionHandler: { [unowned self] height, _ in
+            guard let height = height as? CGFloat else {
+                return
+            }
+
+            self.scrollView.setContentOffset(CGPoint(x: 0, y: height + self.webView.frame.origin.y), animated: true)
+        })
     }
 
     deinit {

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -256,6 +256,20 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         expect(presentedViewController).to(beAKindOf(WebKitViewController.self))
     }
 
+    /// Tell the view to scroll when URL is a hash link
+    ///
+    func testScrollWhenUrlIsHash() {
+        let post: ReaderPost = ReaderPostBuilder().build()
+        let serviceMock = ReaderPostServiceMock()
+        let viewMock = ReaderDetailViewMock()
+        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        coordinator.post = post
+
+        coordinator.handle(URL(string: "#hash")!)
+
+        expect(viewMock.didCallScrollToWith).to(equal("hash"))
+    }
+
 }
 
 private class ReaderPostServiceMock: ReaderPostService {
@@ -304,6 +318,7 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
     var didCallPresentWith: UIViewController?
     var didCallShowLoading = false
     var didCallShowErrorWithWebAction = false
+    var didCallScrollToWith: String?
 
     private var _navigationController: UINavigationController?
     override var navigationController: UINavigationController? {
@@ -334,6 +349,10 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
 
     func showLoading() {
         didCallShowLoading = true
+    }
+
+    func scroll(to: String) {
+        didCallScrollToWith = to
     }
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {


### PR DESCRIPTION
Fixes #9140 

### To test

1. Use this post: https://wordpress.com/read/blogs/93917131/posts/2091
2. Tap on a link and check that the page scrolls

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
