### PR TITLE
ULS: Show unified Auth nav bar without large titles. 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -189,9 +189,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.20.0-beta'
+    # pod 'WordPressAuthenticator', '~> 1.20.0-beta'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/315-remove_large_titles'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -189,9 +189,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.20.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.20.0-beta'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/315-remove_large_titles'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.2)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/315-remove_large_titles`)
+  - WordPressAuthenticator (~> 1.20.0-beta)
   - WordPressKit (= 4.12.0-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.1)
@@ -540,6 +540,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -631,9 +632,6 @@ EXTERNAL SOURCES:
     :commit: aa59dbf65aa670134892db07738071e2a19baba2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
-  WordPressAuthenticator:
-    :branch: feature/315-remove_large_titles
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/aa59dbf65aa670134892db07738071e2a19baba2/third-party-podspecs/Yoga.podspec.json
 
@@ -649,9 +647,6 @@ CHECKOUT OPTIONS:
     :commit: aa59dbf65aa670134892db07738071e2a19baba2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
-  WordPressAuthenticator:
-    :commit: 1ae0c793e1f87c3cd27b17a3e2daa1005c00ad81
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -744,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 085096400945cea26d6bc523d361a78a3f921b5a
+PODFILE CHECKSUM: 937882ab572f178dc40e8e8e9c0fff6df26892c0
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.2)
   - WordPress-Editor-iOS (1.19.2):
     - WordPress-Aztec-iOS (= 1.19.2)
-  - WordPressAuthenticator (1.20.0-beta.5):
+  - WordPressAuthenticator (1.20.0-beta.6):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.2)
-  - WordPressAuthenticator (~> 1.20.0-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/315-remove_large_titles`)
   - WordPressKit (= 4.12.0-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.1)
@@ -540,7 +540,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -632,6 +631,9 @@ EXTERNAL SOURCES:
     :commit: aa59dbf65aa670134892db07738071e2a19baba2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :branch: feature/315-remove_large_titles
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/aa59dbf65aa670134892db07738071e2a19baba2/third-party-podspecs/Yoga.podspec.json
 
@@ -647,6 +649,9 @@ CHECKOUT OPTIONS:
     :commit: aa59dbf65aa670134892db07738071e2a19baba2
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :commit: 1ae0c793e1f87c3cd27b17a3e2daa1005c00ad81
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -722,7 +727,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPress-Aztec-iOS: d01bf0c5e150ae6a046f06ba63b7cc2762061c0b
   WordPress-Editor-iOS: 5b726489e5ae07b7281a2862d69aba2d5c83f140
-  WordPressAuthenticator: fc8fd21cfea46bfc2ba37ca9baca136c2b1189ce
+  WordPressAuthenticator: df789f92e753d62800db97d915c9b727c57fc67e
   WordPressKit: c10ba341c1490cbb30a52a10a1750e8f56a15fb9
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 423779c24b1f8f2ee06d1068d30c7d2ea51ca813
@@ -739,6 +744,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 937882ab572f178dc40e8e8e9c0fff6df26892c0
+PODFILE CHECKSUM: 085096400945cea26d6bc523d361a78a3f921b5a
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -76,8 +76,8 @@ class WordPressAuthenticationManager: NSObject {
                                                               textButtonHighlightColor: .brand,
                                                               viewControllerBackgroundColor: .basicBackground,
                                                               navBarBackgroundColor: .basicBackground,
-                                                              navButtonTextColor: .barButtonItemTitle,
-                                                              largeTitleTextColor: .text)
+                                                              navButtonTextColor: .brand,
+                                                              navTitleTextColor: .text)
 
         WordPressAuthenticator.initialize(configuration: configuration,
                                           style: style,


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/315
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/326

This uses the Auth changes to show the new unified auth nav bar. That is, no large titles.

To test:
- Enable the `unifiedSiteAddress` Feature Flag.
- Go to Log In > Site Address.
- Verify the standard navigation title is displayed.

| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-07-09 at 14 22 24](https://user-images.githubusercontent.com/1816888/87087661-bf0f8a80-c1f0-11ea-97ff-d77721a38abf.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-07-09 at 14 22 41](https://user-images.githubusercontent.com/1816888/87087681-c6cf2f00-c1f0-11ea-8591-526d5e47695f.png) |
|--------|-------|


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
