### PR TITLE
Fixes reader UI too slow to load at first load

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -94,7 +94,6 @@ extension ReaderTabItemsStore {
             self?.fetchTabBarItemsAndFollowedSites()
             let actualError = error ?? ReaderTopicsConstants.remoteServiceError
             DDLogError("Error syncing menu: \(String(describing: actualError))")
-
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -87,34 +87,30 @@ extension ReaderTabItemsStore {
         }
         state = .loading
 
-        let dispatchGroup = DispatchGroup()
-
         // Sync the reader menu
-        dispatchGroup.enter()
-        service.fetchReaderMenu(success: {
-            dispatchGroup.leave()
-        }, failure: { (error) in
+        service.fetchReaderMenu(success: { [weak self] in
+            self?.fetchTabBarItemsAndFollowedSites()
+        }, failure: { [weak self] (error) in
+            self?.fetchTabBarItemsAndFollowedSites()
             let actualError = error ?? ReaderTopicsConstants.remoteServiceError
             DDLogError("Error syncing menu: \(String(describing: actualError))")
 
-            dispatchGroup.leave()
         })
+    }
 
-        // Sync the followed sites
-        dispatchGroup.enter()
+    private func fetchTabBarItemsAndFollowedSites() {
+        DispatchQueue.main.async {
+            self.fetchFollowedSites()
+        }
+        fetchTabBarItems()
+    }
+
+    private func fetchFollowedSites() {
         service.fetchFollowedSites(success: {
-            dispatchGroup.leave()
         }, failure: { (error) in
             let actualError = error ?? ReaderTopicsConstants.remoteServiceError
             DDLogError("Could not sync sites: \(String(describing: actualError))")
-
-            dispatchGroup.leave()
         })
-
-        // Wait for both the requests to finish
-        dispatchGroup.notify(queue: .main) { [weak self] in
-            self?.fetchTabBarItems()
-        }
     }
 
     private enum ReaderTopicsConstants {


### PR DESCRIPTION
Ref #14412 (improves the performance but does not totally fixes the issue)

Loads followed sites asynchronously to avoid blocking the Reader UI when it first loads.

To test:
1. Do a fresh install of the app or log out and back in to a different account.
2. Go to Reader.
3. Verify that the reader UI loads quickly and there is no noticeable blank screen before it loads
4. verify that issue #14370 does not occur

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
