### PR TITLE
Disable the Unsupported Block Editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,6 @@
 15.3
 -----
 * [***] Block Editor: Adds Copy, Cut, Paste, and Duplicate functionality to blocks
-* [***] Block Editor: Users can now individually edit unsupported blocks found in posts or pages. Not available on self-hosted sites.
 * [*] Block Editor: Improved editor loading experience with Ghost Effect.
  
 15.2

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -875,11 +875,8 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
     }
 
     private var isUnsupportedBlockEditorEnabled: Bool {
-        // The Unsupported Block Editor is disabled for all self-hosted sites even the one that are connected via Jetpack to a WP.com account.
-        // The option is disabled on Self-hosted sites because they can have their web editor to be set to classic and then the fallback will not work.
-        // We disable in Jetpack site because we don't have the self-hosted site's credentials which are required for us to be able to fetch the site's authentication cookie.
-        // This cookie is needed to authenticate the network request that fetches the unsupported block editor web page.
-        return ( post.blog.isAtomic() || post.blog.isHostedAtWPcom ) && post.blog.webEditor == .gutenberg
+        // The Unsupported Block Editor is disabled on all sites until it is ready.
+        return false
     }
 }
 


### PR DESCRIPTION
This is being disabled because late on the final day of code freeze, it became clear that there this feature would not work on some WordPress.com sites - in addition to the fact that we were already disabling it on all self-hosted sites.

Fixes #

To test:

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
