### PR TITLE
Reader Improvements Phase 2: Select Interests: Add next button enable/disable selection toggle

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -34,6 +34,17 @@ class ReaderInterestsStyleGuide {
     }
 
     public class func applyNextButtonStyle(button: FancyButton) {
-        // TODO
+        let disabledBackgroundColor: UIColor
+
+        if #available(iOS 13.0, *) {
+            // System Gray 4 on Dark mode is the same color as tertiarySystemBackground
+            disabledBackgroundColor = UIColor(light: .systemGray4, dark: .systemGray3)
+        } else {
+            disabledBackgroundColor = .lightGray
+        }
+
+        button.disabledTitleColor = .textTertiary
+        button.disabledBorderColor = disabledBackgroundColor
+        button.disabledBackgroundColor = disabledBackgroundColor
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -36,6 +36,7 @@ class ReaderSelectInterestsViewController: UIViewController {
         configureI18N()
         configureCollectionView()
         applyStyles()
+        updateNextButtonState()
         refreshData()
     }
 
@@ -90,6 +91,11 @@ class ReaderSelectInterestsViewController: UIViewController {
 
         collectionView.reloadData()
     }
+
+    // MARK: - Private: UI Helpers
+    private func updateNextButtonState() {
+        nextButton.isEnabled = dataSource.selectedInterests.count > 0
+    }
 }
 
 // MARK: - UICollectionViewDataSource
@@ -120,6 +126,7 @@ extension ReaderSelectInterestsViewController: UICollectionViewDataSource {
 extension ReaderSelectInterestsViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         dataSource.interest(for: indexPath.row).toggleSelected()
+        updateNextButtonState()
 
         UIView.animate(withDuration: 0) {
             collectionView.reloadItems(at: [indexPath])

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -50,7 +50,14 @@ class ReaderSelectInterestsViewController: UIViewController {
         layout.invalidateLayout()
     }
 
-    // MARK: - Private Methods
+    // MARK: - IBAction's
+    @IBAction func goNext(_ sender: Any) {
+        saveSelectedInterests()
+        
+        dismiss(animated: true)
+    }
+
+    // MARK: - Private: Configuration
     private func configureCollectionView() {
         let nib = UINib(nibName: String(describing: ReaderInterestsCollectionViewCell.self), bundle: nil)
         collectionView.register(nib, forCellWithReuseIdentifier: Constants.reuseIdentifier)
@@ -90,6 +97,10 @@ class ReaderSelectInterestsViewController: UIViewController {
         activityIndicatorView.stopAnimating()
 
         collectionView.reloadData()
+    }
+
+    private func saveSelectedInterests() {
+        // TODO
     }
 
     // MARK: - Private: UI Helpers

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -51,7 +51,7 @@ class ReaderSelectInterestsViewController: UIViewController {
     }
 
     // MARK: - IBAction's
-    @IBAction func goNext(_ sender: Any) {
+    @IBAction func nextButtonTapped(_ sender: Any) {
         saveSelectedInterests()
 
         dismiss(animated: true)

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -53,7 +53,7 @@ class ReaderSelectInterestsViewController: UIViewController {
     // MARK: - IBAction's
     @IBAction func goNext(_ sender: Any) {
         saveSelectedInterests()
-        
+
         dismiss(animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
@@ -74,7 +74,7 @@
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
                             </userDefinedRuntimeAttributes>
                             <connections>
-                                <action selector="goNext:" destination="-1" eventType="touchUpInside" id="yJS-tM-wui"/>
+                                <action selector="nextButtonTapped:" destination="-1" eventType="touchUpInside" id="OYJ-EI-lUA"/>
                             </connections>
                         </button>
                     </subviews>

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
@@ -87,7 +87,7 @@
                         <constraint firstItem="5kh-rf-B5P" firstAttribute="leading" secondItem="X4F-fc-WqY" secondAttribute="leading" constant="20" id="zV4-Ir-MFf"/>
                     </constraints>
                 </view>
-                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="a7r-YY-Vl7">
+                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="a7r-YY-Vl7">
                     <rect key="frame" x="197" y="410" width="20" height="20"/>
                 </activityIndicatorView>
             </subviews>

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
@@ -73,6 +73,9 @@
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
                             </userDefinedRuntimeAttributes>
+                            <connections>
+                                <action selector="goNext:" destination="-1" eventType="touchUpInside" id="yJS-tM-wui"/>
+                            </connections>
                         </button>
                     </subviews>
                     <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
Main Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/14396

### Screenshots
<img src="https://user-images.githubusercontent.com/793774/87191926-4a992200-c2aa-11ea-8b99-4e9670927867.gif" width="30%" />

### To test:

#### 01 - Testing Toggle State
1. If it's not already enabled, enable the Feature Flag for Reader Improvements Phase 2
2. Launch the app
3. Tap the Reader tab
4. The view will be presented
5. Verify the button is now disabled and says "Select a few to continue"
6. Tap an interest to select it
7. Verify the button is now enabled and says "done"
8. Deselect the interest
9. Verify the button is now disabled and says "Select a few to continue"

#### 02 - Testing Temporary next action
1. Follow the steps above
2. When the button is enabled
3. Tap it
4. Verify the view is dismissed


### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
