### PR TITLE
Fixes Reader Following search bar color + style

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -129,14 +129,10 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self, ReaderFollowedSitesViewController.self]).attributedPlaceholder = attributedPlaceholder
         let textAttributes = WPStyleGuide.defaultSearchBarTextAttributesSwifted(.neutral(.shade60))
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self, ReaderFollowedSitesViewController.self]).defaultTextAttributes = textAttributes
+        WPStyleGuide.configureSearchBar(searchBar)
 
         searchBar.autocapitalizationType = .none
         searchBar.keyboardType = .URL
-        searchBar.isTranslucent = false
-        searchBar.tintColor = .neutral(.shade30)
-        searchBar.barTintColor = .neutral(.shade5)
-        searchBar.backgroundImage = UIImage()
-        searchBar.returnKeyType = .done
         searchBar.setImage(UIImage(named: "icon-clear-textfield"), for: .clear, state: UIControl.State())
         searchBar.setImage(UIImage(named: "icon-reader-search-plus"), for: .search, state: UIControl.State())
         if #available(iOS 13.0, *) {


### PR DESCRIPTION
Fixes #14409

Configures the Reader Following search bar using the method from `WPStyleGuide`.

| Before | After |
|--|--|
| <a href="https://user-images.githubusercontent.com/3250/87353821-c9949180-c51a-11ea-8060-e42483126b42.png"><img src="https://user-images.githubusercontent.com/3250/87353821-c9949180-c51a-11ea-8060-e42483126b42.png" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/87353843-d1543600-c51a-11ea-844d-609057b50d6f.png"><img src="https://user-images.githubusercontent.com/3250/87353843-d1543600-c51a-11ea-844d-609057b50d6f.png" width="300"></a> |

#### Testing

1. Go to Reader > Manage (cog icon).
2. Check the color of the search bar.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
