### PR TITLE
New Discover Welcome Banner

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -7,6 +7,11 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         return ReaderCardService()
     }()
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        ReaderWelcomeBanner.presentIfNeeded(in: tableView)
+    }
+
     // MARK: - TableView Related
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -9,7 +9,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        ReaderWelcomeBanner.presentIfNeeded(in: tableView)
+        ReaderWelcomeBanner.displayIfNeeded(in: tableView)
     }
 
     // MARK: - TableView Related

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -26,7 +26,7 @@ import WordPressFlux
     /// Called if the stream or tag fails to load
     var streamLoadFailureBlock: (() -> Void)? = nil
 
-    private var tableView: UITableView! {
+    var tableView: UITableView! {
         return tableViewController.tableView
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+class ReaderWelcomeBanner: UIView, NibLoadable {
+    @IBOutlet weak var welcomeLabel: UILabel!
+
+    static var bannerPresentedKey = "welcomeBannerPresented"
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        applyStyles()
+        configureWelcomeLabel()
+    }
+
+    /// Present the Welcome banner just one time
+    class func presentIfNeeded(in tableView: UITableView) {
+        guard !UserDefaults.standard.bool(forKey: Self.bannerPresentedKey) else {
+            return
+        }
+
+        let view: Self = .loadFromNib()
+        tableView.tableHeaderView = view
+        UserDefaults.standard.set(true, forKey: Self.bannerPresentedKey)
+    }
+
+    private func applyStyles() {
+        welcomeLabel.font = WPStyleGuide.serifFontForTextStyle(.title2)
+        backgroundColor = UIColor(light: .muriel(color: MurielColor(name: .blue, shade: .shade0)), dark: .listForeground)
+        welcomeLabel.textColor = UIColor(light: .muriel(color: MurielColor(name: .blue, shade: .shade80)), dark: .white)
+    }
+
+    private func configureWelcomeLabel() {
+        welcomeLabel.text = NSLocalizedString("Welcome to Reader. Discover millions of blogs at your fingertips.", comment: "Welcome message shown under Discover in the Reader just the 1st time the user sees it")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
@@ -2,6 +2,7 @@ import Foundation
 
 class ReaderWelcomeBanner: UIView, NibLoadable {
     @IBOutlet weak var welcomeLabel: UILabel!
+    @IBOutlet weak var iPadDotsView: UIView!
 
     static var bannerPresentedKey = "welcomeBannerPresented"
 
@@ -9,6 +10,7 @@ class ReaderWelcomeBanner: UIView, NibLoadable {
         super.awakeFromNib()
         applyStyles()
         configureWelcomeLabel()
+        configureDotsForiPad()
     }
 
     /// Present the Welcome banner just one time
@@ -30,5 +32,9 @@ class ReaderWelcomeBanner: UIView, NibLoadable {
 
     private func configureWelcomeLabel() {
         welcomeLabel.text = NSLocalizedString("Welcome to Reader. Discover millions of blogs at your fingertips.", comment: "Welcome message shown under Discover in the Reader just the 1st time the user sees it")
+    }
+
+    private func configureDotsForiPad() {
+        iPadDotsView.isHidden = !UIDevice.isPad()
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
@@ -14,14 +14,15 @@ class ReaderWelcomeBanner: UIView, NibLoadable {
     }
 
     /// Present the Welcome banner just one time
-    class func displayIfNeeded(in tableView: UITableView) {
-        guard !UserDefaults.standard.bool(forKey: ReaderWelcomeBanner.bannerPresentedKey) else {
+    class func displayIfNeeded(in tableView: UITableView,
+                               database: KeyValueDatabase = UserDefaults.standard) {
+        guard !database.bool(forKey: ReaderWelcomeBanner.bannerPresentedKey) else {
             return
         }
 
         let view: ReaderWelcomeBanner = .loadFromNib()
         tableView.tableHeaderView = view
-        UserDefaults.standard.set(true, forKey: ReaderWelcomeBanner.bannerPresentedKey)
+        database.set(true, forKey: ReaderWelcomeBanner.bannerPresentedKey)
     }
 
     private func applyStyles() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
@@ -13,13 +13,13 @@ class ReaderWelcomeBanner: UIView, NibLoadable {
 
     /// Present the Welcome banner just one time
     class func presentIfNeeded(in tableView: UITableView) {
-        guard !UserDefaults.standard.bool(forKey: Self.bannerPresentedKey) else {
+        guard !UserDefaults.standard.bool(forKey: ReaderWelcomeBanner.bannerPresentedKey) else {
             return
         }
 
-        let view: Self = .loadFromNib()
+        let view: ReaderWelcomeBanner = .loadFromNib()
         tableView.tableHeaderView = view
-        UserDefaults.standard.set(true, forKey: Self.bannerPresentedKey)
+        UserDefaults.standard.set(true, forKey: ReaderWelcomeBanner.bannerPresentedKey)
     }
 
     private func applyStyles() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
@@ -14,7 +14,7 @@ class ReaderWelcomeBanner: UIView, NibLoadable {
     }
 
     /// Present the Welcome banner just one time
-    class func presentIfNeeded(in tableView: UITableView) {
+    class func displayIfNeeded(in tableView: UITableView) {
         guard !UserDefaults.standard.bool(forKey: ReaderWelcomeBanner.bannerPresentedKey) else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class ReaderWelcomeBanner: UIView, NibLoadable {
     @IBOutlet weak var welcomeLabel: UILabel!
-    @IBOutlet weak var iPadDotsView: UIView!
+    @IBOutlet weak var extraDotsView: UIView!
 
     static var bannerPresentedKey = "welcomeBannerPresented"
 
@@ -10,7 +10,12 @@ class ReaderWelcomeBanner: UIView, NibLoadable {
         super.awakeFromNib()
         applyStyles()
         configureWelcomeLabel()
-        configureDotsForiPad()
+        showExtraDotsIfNeeded()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        showExtraDotsIfNeeded()
     }
 
     /// Present the Welcome banner just one time
@@ -35,7 +40,7 @@ class ReaderWelcomeBanner: UIView, NibLoadable {
         welcomeLabel.text = NSLocalizedString("Welcome to Reader. Discover millions of blogs at your fingertips.", comment: "Welcome message shown under Discover in the Reader just the 1st time the user sees it")
     }
 
-    private func configureDotsForiPad() {
-        iPadDotsView.isHidden = !UIDevice.isPad()
+    private func showExtraDotsIfNeeded() {
+        extraDotsView.isHidden = (traitCollection.horizontalSizeClass == .compact)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.xib
@@ -78,7 +78,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3tq-hH-dLW">
-                                    <rect key="frame" x="364.5" y="176" width="8" height="8"/>
+                                    <rect key="frame" x="344.5" y="176" width="8" height="8"/>
                                     <color key="backgroundColor" red="0.9996476769" green="0.22273772950000001" blue="0.7843405604" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="8" id="4Ok-UH-Rph"/>
@@ -92,7 +92,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </view>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y4i-qr-qbp">
-                                    <rect key="frame" x="321.5" y="178" width="6" height="6"/>
+                                    <rect key="frame" x="301.5" y="178" width="6" height="6"/>
                                     <color key="backgroundColor" red="0.4955180287" green="0.27988967300000001" blue="0.94907099009999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="6" id="YTU-m0-8eG"/>
@@ -169,7 +169,7 @@
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="K0A-mG-QOI">
-                            <rect key="frame" x="342.5" y="164" width="6" height="6"/>
+                            <rect key="frame" x="322.5" y="164" width="6" height="6"/>
                             <color key="backgroundColor" red="0.83128899339999995" green="0.56055289509999995" blue="0.78432911630000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="6" id="4VZ-y7-ddS"/>
@@ -205,7 +205,7 @@
                         <constraint firstItem="OFz-ec-sVe" firstAttribute="top" secondItem="1gp-18-ZYI" secondAttribute="bottom" constant="-15" id="Ltm-Se-OHq"/>
                         <constraint firstItem="K0A-mG-QOI" firstAttribute="top" secondItem="3tq-hH-dLW" secondAttribute="bottom" constant="-20" id="M7P-yP-vGj"/>
                         <constraint firstItem="bhc-pV-bbC" firstAttribute="width" secondItem="PWz-RD-CcE" secondAttribute="width" multiplier="0.78" id="Nsn-fr-CBK"/>
-                        <constraint firstItem="K0A-mG-QOI" firstAttribute="trailing" secondItem="bhc-pV-bbC" secondAttribute="trailing" constant="-20" id="Nwd-Hz-R11"/>
+                        <constraint firstItem="K0A-mG-QOI" firstAttribute="trailing" secondItem="bhc-pV-bbC" secondAttribute="trailing" constant="-40" id="Nwd-Hz-R11"/>
                         <constraint firstAttribute="trailing" secondItem="zcy-Va-sge" secondAttribute="trailing" id="SUz-RD-oh0"/>
                         <constraint firstItem="yuW-6e-MCa" firstAttribute="leading" secondItem="bhc-pV-bbC" secondAttribute="leading" constant="20" id="ThN-EC-oY0"/>
                         <constraint firstItem="TnJ-b1-F37" firstAttribute="top" secondItem="QDm-XB-D63" secondAttribute="bottom" constant="10" id="YaX-kw-xfk"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.xib
@@ -19,7 +19,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1gp-18-ZYI">
-                            <rect key="frame" x="77" y="18" width="6" height="6"/>
+                            <rect key="frame" x="65.5" y="18" width="6" height="6"/>
                             <color key="backgroundColor" red="0.02439756878" green="0.4769592285" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="6" id="F9e-bT-RcP"/>
@@ -33,7 +33,7 @@
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QDm-XB-D63">
-                            <rect key="frame" x="335" y="8" width="12" height="12"/>
+                            <rect key="frame" x="346.5" y="8" width="12" height="12"/>
                             <color key="backgroundColor" red="0.99924427270000005" green="0.17800784110000001" blue="0.33329504729999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="12" id="dO6-C7-RLC"/>
@@ -47,7 +47,7 @@
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yuW-6e-MCa">
-                            <rect key="frame" x="77" y="170" width="6" height="6"/>
+                            <rect key="frame" x="65.5" y="170" width="6" height="6"/>
                             <color key="backgroundColor" red="0.99917966130000002" green="0.83984380960000005" blue="0.037726592269999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="6" id="eS9-fH-rBO"/>
@@ -61,7 +61,7 @@
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QK3-fm-wlt">
-                            <rect key="frame" x="67" y="182" width="8" height="8"/>
+                            <rect key="frame" x="55.5" y="182" width="8" height="8"/>
                             <color key="backgroundColor" red="0.1186744347" green="0.81985646489999997" blue="0.35283032060000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="8" id="2fF-Hy-EDB"/>
@@ -75,7 +75,7 @@
                             </userDefinedRuntimeAttributes>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="K0A-mG-QOI">
-                            <rect key="frame" x="331" y="164" width="6" height="6"/>
+                            <rect key="frame" x="342.5" y="164" width="6" height="6"/>
                             <color key="backgroundColor" red="0.83128899339999995" green="0.56055289509999995" blue="0.78432911630000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="6" id="4VZ-y7-ddS"/>
@@ -89,9 +89,9 @@
                             </userDefinedRuntimeAttributes>
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to Reader. Discover millions of blogs at your fingertips." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bhc-pV-bbC">
-                            <rect key="frame" x="57" y="30" width="300" height="140"/>
+                            <rect key="frame" x="45.5" y="30" width="323" height="140"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="300" id="1bE-4d-vyr"/>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="70" id="ufj-Vl-4Oe"/>
                             </constraints>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                             <color key="textColor" name="Blue80"/>
@@ -102,7 +102,8 @@
                     <constraints>
                         <constraint firstItem="bhc-pV-bbC" firstAttribute="top" secondItem="1gp-18-ZYI" secondAttribute="bottom" constant="6" id="7Hm-DI-Q2n"/>
                         <constraint firstItem="bhc-pV-bbC" firstAttribute="top" secondItem="QDm-XB-D63" secondAttribute="bottom" constant="10" id="7Ti-vl-tdd"/>
-                        <constraint firstItem="bhc-pV-bbC" firstAttribute="centerX" secondItem="PWz-RD-CcE" secondAttribute="centerX" id="FJM-by-w1B"/>
+                        <constraint firstItem="bhc-pV-bbC" firstAttribute="centerX" secondItem="PWz-RD-CcE" secondAttribute="centerX" id="Kbr-gB-xiK"/>
+                        <constraint firstItem="bhc-pV-bbC" firstAttribute="width" secondItem="PWz-RD-CcE" secondAttribute="width" multiplier="0.78" id="Nsn-fr-CBK"/>
                         <constraint firstItem="K0A-mG-QOI" firstAttribute="trailing" secondItem="bhc-pV-bbC" secondAttribute="trailing" constant="-20" id="Nwd-Hz-R11"/>
                         <constraint firstItem="yuW-6e-MCa" firstAttribute="leading" secondItem="bhc-pV-bbC" secondAttribute="leading" constant="20" id="ThN-EC-oY0"/>
                         <constraint firstItem="K0A-mG-QOI" firstAttribute="bottom" secondItem="bhc-pV-bbC" secondAttribute="bottom" id="bdN-ie-ARn"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.xib
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -235,7 +233,7 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
-                <outlet property="iPadDotsView" destination="zcy-Va-sge" id="0xW-Xx-Pbg"/>
+                <outlet property="extraDotsView" destination="zcy-Va-sge" id="0xW-Xx-Pbg"/>
                 <outlet property="welcomeLabel" destination="bhc-pV-bbC" id="eRO-im-4Aa"/>
             </connections>
             <point key="canvasLocation" x="179.71014492753625" y="-429.91071428571428"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.xib
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="ReaderWelcomeBanner" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PWz-RD-CcE">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1gp-18-ZYI">
+                            <rect key="frame" x="77" y="18" width="6" height="6"/>
+                            <color key="backgroundColor" red="0.02439756878" green="0.4769592285" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="6" id="F9e-bT-RcP"/>
+                                <constraint firstAttribute="height" constant="6" id="FRm-ZY-C4V"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                    <integer key="value" value="3"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QDm-XB-D63">
+                            <rect key="frame" x="335" y="8" width="12" height="12"/>
+                            <color key="backgroundColor" red="0.99924427270000005" green="0.17800784110000001" blue="0.33329504729999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="12" id="dO6-C7-RLC"/>
+                                <constraint firstAttribute="width" constant="12" id="zbz-LN-C2x"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                    <integer key="value" value="6"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yuW-6e-MCa">
+                            <rect key="frame" x="77" y="170" width="6" height="6"/>
+                            <color key="backgroundColor" red="0.99917966130000002" green="0.83984380960000005" blue="0.037726592269999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="6" id="eS9-fH-rBO"/>
+                                <constraint firstAttribute="width" constant="6" id="sSi-ym-oja"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                    <integer key="value" value="3"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QK3-fm-wlt">
+                            <rect key="frame" x="67" y="182" width="8" height="8"/>
+                            <color key="backgroundColor" red="0.1186744347" green="0.81985646489999997" blue="0.35283032060000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="8" id="2fF-Hy-EDB"/>
+                                <constraint firstAttribute="height" constant="8" id="uJ2-MM-VEp"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                    <integer key="value" value="4"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="K0A-mG-QOI">
+                            <rect key="frame" x="331" y="164" width="6" height="6"/>
+                            <color key="backgroundColor" red="0.83128899339999995" green="0.56055289509999995" blue="0.78432911630000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="6" id="4VZ-y7-ddS"/>
+                                <constraint firstAttribute="width" constant="6" id="QxX-5b-ujq"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                    <integer key="value" value="3"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Welcome to Reader. Discover millions of blogs at your fingertips." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bhc-pV-bbC">
+                            <rect key="frame" x="57" y="30" width="300" height="140"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="300" id="1bE-4d-vyr"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                            <color key="textColor" name="Blue80"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="bhc-pV-bbC" firstAttribute="top" secondItem="1gp-18-ZYI" secondAttribute="bottom" constant="6" id="7Hm-DI-Q2n"/>
+                        <constraint firstItem="bhc-pV-bbC" firstAttribute="top" secondItem="QDm-XB-D63" secondAttribute="bottom" constant="10" id="7Ti-vl-tdd"/>
+                        <constraint firstItem="bhc-pV-bbC" firstAttribute="centerX" secondItem="PWz-RD-CcE" secondAttribute="centerX" id="FJM-by-w1B"/>
+                        <constraint firstItem="K0A-mG-QOI" firstAttribute="trailing" secondItem="bhc-pV-bbC" secondAttribute="trailing" constant="-20" id="Nwd-Hz-R11"/>
+                        <constraint firstItem="yuW-6e-MCa" firstAttribute="leading" secondItem="bhc-pV-bbC" secondAttribute="leading" constant="20" id="ThN-EC-oY0"/>
+                        <constraint firstItem="K0A-mG-QOI" firstAttribute="bottom" secondItem="bhc-pV-bbC" secondAttribute="bottom" id="bdN-ie-ARn"/>
+                        <constraint firstItem="1gp-18-ZYI" firstAttribute="leading" secondItem="bhc-pV-bbC" secondAttribute="leading" constant="20" id="eRB-jO-Yqc"/>
+                        <constraint firstItem="QK3-fm-wlt" firstAttribute="bottom" secondItem="bhc-pV-bbC" secondAttribute="bottom" constant="20" id="fp0-wl-Kfy"/>
+                        <constraint firstItem="yuW-6e-MCa" firstAttribute="top" secondItem="bhc-pV-bbC" secondAttribute="bottom" id="fwm-Mq-Gg1"/>
+                        <constraint firstItem="bhc-pV-bbC" firstAttribute="top" secondItem="PWz-RD-CcE" secondAttribute="top" constant="30" id="hCW-kr-xoR"/>
+                        <constraint firstItem="QDm-XB-D63" firstAttribute="trailing" secondItem="bhc-pV-bbC" secondAttribute="trailing" constant="-10" id="v42-6w-CdC"/>
+                        <constraint firstItem="QK3-fm-wlt" firstAttribute="leading" secondItem="bhc-pV-bbC" secondAttribute="leading" constant="10" id="wCt-2P-r9R"/>
+                        <constraint firstAttribute="bottom" secondItem="bhc-pV-bbC" secondAttribute="bottom" constant="30" id="wpm-8k-r8O"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <color key="backgroundColor" name="Blue0"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="PWz-RD-CcE" secondAttribute="bottom" id="QW1-n7-97l"/>
+                <constraint firstItem="PWz-RD-CcE" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="XFi-RQ-0hp"/>
+                <constraint firstItem="PWz-RD-CcE" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="gWQ-AV-O15"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="PWz-RD-CcE" secondAttribute="trailing" id="ufw-vR-uhn"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="welcomeLabel" destination="bhc-pV-bbC" id="eRO-im-4Aa"/>
+            </connections>
+            <point key="canvasLocation" x="179.71014492753625" y="-429.91071428571428"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="Blue0">
+            <color red="0.93725490196078431" green="0.95294117647058818" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Blue80">
+            <color red="0.015686274509803921" green="0.22352941176470589" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.xib
@@ -18,6 +18,100 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PWz-RD-CcE">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
                     <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zcy-Va-sge">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OFz-ec-sVe">
+                                    <rect key="frame" x="51.5" y="9" width="8" height="8"/>
+                                    <color key="backgroundColor" red="0.4955180287" green="0.27988967300000001" blue="0.94907099009999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="8" id="WFw-bJ-WoN"/>
+                                        <constraint firstAttribute="width" constant="8" id="WS4-01-fvz"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                            <integer key="value" value="4"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IeS-2e-sHb">
+                                    <rect key="frame" x="33.5" y="144" width="8" height="8"/>
+                                    <color key="backgroundColor" red="0.84244507550000003" green="0.54957705739999996" blue="0.1055607423" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="8" id="hoX-i4-5IW"/>
+                                        <constraint firstAttribute="height" constant="8" id="wOT-OD-VIR"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                            <integer key="value" value="4"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TnJ-b1-F37">
+                                    <rect key="frame" x="335.5" y="30" width="6" height="6"/>
+                                    <color key="backgroundColor" red="0.99917441610000002" green="0.50273358820000003" blue="0.046390153470000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="6" id="3R2-9L-kd9"/>
+                                        <constraint firstAttribute="width" constant="6" id="eNC-CR-nUv"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                            <integer key="value" value="3"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4gu-nG-dp3">
+                                    <rect key="frame" x="324.5" y="11" width="6" height="6"/>
+                                    <color key="backgroundColor" red="0.45240449910000002" green="0.92142575979999997" blue="0.89411652090000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="6" id="Mfi-Vi-JZz"/>
+                                        <constraint firstAttribute="height" constant="6" id="Odl-jv-apQ"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                            <integer key="value" value="3"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3tq-hH-dLW">
+                                    <rect key="frame" x="364.5" y="176" width="8" height="8"/>
+                                    <color key="backgroundColor" red="0.9996476769" green="0.22273772950000001" blue="0.7843405604" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="8" id="4Ok-UH-Rph"/>
+                                        <constraint firstAttribute="width" constant="8" id="PRA-fR-aWB"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                            <integer key="value" value="4"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                </view>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y4i-qr-qbp">
+                                    <rect key="frame" x="321.5" y="178" width="6" height="6"/>
+                                    <color key="backgroundColor" red="0.4955180287" green="0.27988967300000001" blue="0.94907099009999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="6" id="YTU-m0-8eG"/>
+                                        <constraint firstAttribute="height" constant="6" id="wdc-Os-eSH"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                            <integer key="value" value="3"/>
+                                        </userDefinedRuntimeAttribute>
+                                    </userDefinedRuntimeAttributes>
+                                </view>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstItem="TnJ-b1-F37" firstAttribute="leading" secondItem="4gu-nG-dp3" secondAttribute="trailing" constant="5" id="1N5-Zn-tn5"/>
+                                <constraint firstItem="4gu-nG-dp3" firstAttribute="top" secondItem="TnJ-b1-F37" secondAttribute="bottom" constant="-25" id="c1J-2S-tfK"/>
+                            </constraints>
+                        </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1gp-18-ZYI">
                             <rect key="frame" x="65.5" y="18" width="6" height="6"/>
                             <color key="backgroundColor" red="0.02439756878" green="0.4769592285" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -102,15 +196,29 @@
                     <constraints>
                         <constraint firstItem="bhc-pV-bbC" firstAttribute="top" secondItem="1gp-18-ZYI" secondAttribute="bottom" constant="6" id="7Hm-DI-Q2n"/>
                         <constraint firstItem="bhc-pV-bbC" firstAttribute="top" secondItem="QDm-XB-D63" secondAttribute="bottom" constant="10" id="7Ti-vl-tdd"/>
+                        <constraint firstItem="QK3-fm-wlt" firstAttribute="top" secondItem="IeS-2e-sHb" secondAttribute="bottom" constant="30" id="7p5-9L-91W"/>
+                        <constraint firstAttribute="bottom" secondItem="zcy-Va-sge" secondAttribute="bottom" id="9R7-R0-GBs"/>
+                        <constraint firstItem="K0A-mG-QOI" firstAttribute="leading" secondItem="3tq-hH-dLW" secondAttribute="trailing" constant="-30" id="DfX-VG-GMx"/>
+                        <constraint firstItem="zcy-Va-sge" firstAttribute="leading" secondItem="PWz-RD-CcE" secondAttribute="leading" id="IJB-gb-kbi"/>
+                        <constraint firstItem="IeS-2e-sHb" firstAttribute="leading" secondItem="QK3-fm-wlt" secondAttribute="trailing" constant="-30" id="IeU-Mo-HY0"/>
                         <constraint firstItem="bhc-pV-bbC" firstAttribute="centerX" secondItem="PWz-RD-CcE" secondAttribute="centerX" id="Kbr-gB-xiK"/>
+                        <constraint firstItem="OFz-ec-sVe" firstAttribute="top" secondItem="1gp-18-ZYI" secondAttribute="bottom" constant="-15" id="Ltm-Se-OHq"/>
+                        <constraint firstItem="K0A-mG-QOI" firstAttribute="top" secondItem="3tq-hH-dLW" secondAttribute="bottom" constant="-20" id="M7P-yP-vGj"/>
                         <constraint firstItem="bhc-pV-bbC" firstAttribute="width" secondItem="PWz-RD-CcE" secondAttribute="width" multiplier="0.78" id="Nsn-fr-CBK"/>
                         <constraint firstItem="K0A-mG-QOI" firstAttribute="trailing" secondItem="bhc-pV-bbC" secondAttribute="trailing" constant="-20" id="Nwd-Hz-R11"/>
+                        <constraint firstAttribute="trailing" secondItem="zcy-Va-sge" secondAttribute="trailing" id="SUz-RD-oh0"/>
                         <constraint firstItem="yuW-6e-MCa" firstAttribute="leading" secondItem="bhc-pV-bbC" secondAttribute="leading" constant="20" id="ThN-EC-oY0"/>
+                        <constraint firstItem="TnJ-b1-F37" firstAttribute="top" secondItem="QDm-XB-D63" secondAttribute="bottom" constant="10" id="YaX-kw-xfk"/>
+                        <constraint firstItem="OFz-ec-sVe" firstAttribute="leading" secondItem="1gp-18-ZYI" secondAttribute="trailing" constant="-20" id="ZfN-ZJ-dOh"/>
                         <constraint firstItem="K0A-mG-QOI" firstAttribute="bottom" secondItem="bhc-pV-bbC" secondAttribute="bottom" id="bdN-ie-ARn"/>
+                        <constraint firstItem="K0A-mG-QOI" firstAttribute="leading" secondItem="y4i-qr-qbp" secondAttribute="trailing" constant="15" id="bfK-iS-h7y"/>
+                        <constraint firstItem="zcy-Va-sge" firstAttribute="top" secondItem="PWz-RD-CcE" secondAttribute="top" id="cfV-gL-dc0"/>
+                        <constraint firstItem="QDm-XB-D63" firstAttribute="leading" secondItem="TnJ-b1-F37" secondAttribute="trailing" constant="5" id="e6b-e0-8Un"/>
                         <constraint firstItem="1gp-18-ZYI" firstAttribute="leading" secondItem="bhc-pV-bbC" secondAttribute="leading" constant="20" id="eRB-jO-Yqc"/>
                         <constraint firstItem="QK3-fm-wlt" firstAttribute="bottom" secondItem="bhc-pV-bbC" secondAttribute="bottom" constant="20" id="fp0-wl-Kfy"/>
                         <constraint firstItem="yuW-6e-MCa" firstAttribute="top" secondItem="bhc-pV-bbC" secondAttribute="bottom" id="fwm-Mq-Gg1"/>
                         <constraint firstItem="bhc-pV-bbC" firstAttribute="top" secondItem="PWz-RD-CcE" secondAttribute="top" constant="30" id="hCW-kr-xoR"/>
+                        <constraint firstItem="K0A-mG-QOI" firstAttribute="top" secondItem="y4i-qr-qbp" secondAttribute="bottom" constant="-20" id="roh-1X-9w6"/>
                         <constraint firstItem="QDm-XB-D63" firstAttribute="trailing" secondItem="bhc-pV-bbC" secondAttribute="trailing" constant="-10" id="v42-6w-CdC"/>
                         <constraint firstItem="QK3-fm-wlt" firstAttribute="leading" secondItem="bhc-pV-bbC" secondAttribute="leading" constant="10" id="wCt-2P-r9R"/>
                         <constraint firstAttribute="bottom" secondItem="bhc-pV-bbC" secondAttribute="bottom" constant="30" id="wpm-8k-r8O"/>
@@ -127,6 +235,7 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
+                <outlet property="iPadDotsView" destination="zcy-Va-sge" id="0xW-Xx-Pbg"/>
                 <outlet property="welcomeLabel" destination="bhc-pV-bbC" id="eRO-im-4Aa"/>
             </connections>
             <point key="canvasLocation" x="179.71014492753625" y="-429.91071428571428"/>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1112,6 +1112,8 @@
 		8BD36E022395CAEA00EFFF1C /* MediaEditorOperation+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36E012395CAEA00EFFF1C /* MediaEditorOperation+Description.swift */; };
 		8BD36E062395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD36E052395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift */; };
 		8BD6E34A2477514E009AE97C /* TestContextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD6E3492477514E009AE97C /* TestContextManager.m */; };
+		8BD8201924BCCE8600FF25FD /* ReaderWelcomeBanner.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BD8201824BCCE8600FF25FD /* ReaderWelcomeBanner.xib */; };
+		8BD8201B24BCDBFF00FF25FD /* ReaderWelcomeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD8201A24BCDBFF00FF25FD /* ReaderWelcomeBanner.swift */; };
 		8BDA5A6B247C2EAF00AB124C /* ReaderDetailWebviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5A6A247C2EAF00AB124C /* ReaderDetailWebviewViewController.swift */; };
 		8BDA5A6D247C2F8400AB124C /* ReaderDetailWebviewViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5A6C247C2F8400AB124C /* ReaderDetailWebviewViewControllerTests.swift */; };
 		8BDA5A70247C36C100AB124C /* ReaderDetailViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8BDA5A6E247C308300AB124C /* ReaderDetailViewController.storyboard */; };
@@ -3598,6 +3600,8 @@
 		8BD6E3492477514E009AE97C /* TestContextManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestContextManager.m; sourceTree = "<group>"; };
 		8BD6E34B24775164009AE97C /* TestContextManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestContextManager.h; sourceTree = "<group>"; };
 		8BD8201724BC93B500FF25FD /* WordPress 98.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 98.xcdatamodel"; sourceTree = "<group>"; };
+		8BD8201824BCCE8600FF25FD /* ReaderWelcomeBanner.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderWelcomeBanner.xib; sourceTree = "<group>"; };
+		8BD8201A24BCDBFF00FF25FD /* ReaderWelcomeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderWelcomeBanner.swift; sourceTree = "<group>"; };
 		8BDA5A6A247C2EAF00AB124C /* ReaderDetailWebviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailWebviewViewController.swift; sourceTree = "<group>"; };
 		8BDA5A6C247C2F8400AB124C /* ReaderDetailWebviewViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailWebviewViewControllerTests.swift; sourceTree = "<group>"; };
 		8BDA5A6E247C308300AB124C /* ReaderDetailViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ReaderDetailViewController.storyboard; sourceTree = "<group>"; };
@@ -6700,6 +6704,8 @@
 				5D5A6E921B613CA400DAF819 /* ReaderPostCardCell.xib */,
 				D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */,
 				D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */,
+				8BD8201824BCCE8600FF25FD /* ReaderWelcomeBanner.xib */,
+				8BD8201A24BCDBFF00FF25FD /* ReaderWelcomeBanner.swift */,
 			);
 			name = Cards;
 			sourceTree = "<group>";
@@ -11236,6 +11242,7 @@
 				D82247F92113EF5C00918CEB /* News.strings in Resources */,
 				1724DDCC1C6121D00099D273 /* Plans.storyboard in Resources */,
 				40A2778120191B5E00D078D5 /* PluginDirectoryCollectionViewCell.xib in Resources */,
+				8BD8201924BCCE8600FF25FD /* ReaderWelcomeBanner.xib in Resources */,
 				D82253E02199418B0014D0E2 /* WebAddressWizardContent.xib in Resources */,
 				17DC4C5A22C5E6D60059CA11 /* open_source_icon_76pt.png in Resources */,
 				17DC4C5622C5E6D60059CA11 /* open_source_icon_29pt@3x.png in Resources */,
@@ -12213,6 +12220,7 @@
 				40A71C67220E1952002E3D25 /* LastPostStatsRecordValue+CoreDataProperties.swift in Sources */,
 				F50B0E7B246212B8006601DD /* NoticeAnimator.swift in Sources */,
 				74CEF0781F9AA10100B729CA /* ShareExtensionSessionManager.swift in Sources */,
+				8BD8201B24BCDBFF00FF25FD /* ReaderWelcomeBanner.swift in Sources */,
 				74FA4BE51FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */,
 				986CC4D220E1B2F6004F300E /* CustomLogFormatter.swift in Sources */,
 				3236F77524ABB7770088E8F3 /* ReaderInterestsCollectionViewCell.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1114,6 +1114,7 @@
 		8BD6E34A2477514E009AE97C /* TestContextManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD6E3492477514E009AE97C /* TestContextManager.m */; };
 		8BD8201924BCCE8600FF25FD /* ReaderWelcomeBanner.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BD8201824BCCE8600FF25FD /* ReaderWelcomeBanner.xib */; };
 		8BD8201B24BCDBFF00FF25FD /* ReaderWelcomeBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD8201A24BCDBFF00FF25FD /* ReaderWelcomeBanner.swift */; };
+		8BD8201D24BF9E5200FF25FD /* ReaderWelcomeBannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD8201C24BF9E5200FF25FD /* ReaderWelcomeBannerTests.swift */; };
 		8BDA5A6B247C2EAF00AB124C /* ReaderDetailWebviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5A6A247C2EAF00AB124C /* ReaderDetailWebviewViewController.swift */; };
 		8BDA5A6D247C2F8400AB124C /* ReaderDetailWebviewViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5A6C247C2F8400AB124C /* ReaderDetailWebviewViewControllerTests.swift */; };
 		8BDA5A70247C36C100AB124C /* ReaderDetailViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8BDA5A6E247C308300AB124C /* ReaderDetailViewController.storyboard */; };
@@ -3602,6 +3603,7 @@
 		8BD8201724BC93B500FF25FD /* WordPress 98.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 98.xcdatamodel"; sourceTree = "<group>"; };
 		8BD8201824BCCE8600FF25FD /* ReaderWelcomeBanner.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderWelcomeBanner.xib; sourceTree = "<group>"; };
 		8BD8201A24BCDBFF00FF25FD /* ReaderWelcomeBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderWelcomeBanner.swift; sourceTree = "<group>"; };
+		8BD8201C24BF9E5200FF25FD /* ReaderWelcomeBannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderWelcomeBannerTests.swift; sourceTree = "<group>"; };
 		8BDA5A6A247C2EAF00AB124C /* ReaderDetailWebviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailWebviewViewController.swift; sourceTree = "<group>"; };
 		8BDA5A6C247C2F8400AB124C /* ReaderDetailWebviewViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailWebviewViewControllerTests.swift; sourceTree = "<group>"; };
 		8BDA5A6E247C308300AB124C /* ReaderDetailViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ReaderDetailViewController.storyboard; sourceTree = "<group>"; };
@@ -10325,6 +10327,7 @@
 				D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */,
 				748437ED1F1D4A7300E8DDAF /* RichContentFormatterTests.swift */,
 				E6B9B8AE1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift */,
+				8BD8201C24BF9E5200FF25FD /* ReaderWelcomeBannerTests.swift */,
 				3F1B66A123A2F52A0075F09E /* ReaderPostActions */,
 				3F5094592454EC7A00C4470B /* Tabbed Reader */,
 			);
@@ -13908,6 +13911,7 @@
 				73178C2921BEE09300E37C9A /* SiteSegmentsStepTests.swift in Sources */,
 				08F8CD311EBD2A960049D0C0 /* MediaImageExporterTests.swift in Sources */,
 				400A2C912217B308000A8A59 /* CountryStatsRecordValueTests.swift in Sources */,
+				8BD8201D24BF9E5200FF25FD /* ReaderWelcomeBannerTests.swift in Sources */,
 				02761EC222700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift in Sources */,
 				D800D87C20999CA200E7C7E5 /* SearchMenuItemCreatorTests.swift in Sources */,
 				F1450CF72437E8F800A28BFE /* MediaHostTests.swift in Sources */,

--- a/WordPress/WordPressTest/ReaderWelcomeBannerTests.swift
+++ b/WordPress/WordPressTest/ReaderWelcomeBannerTests.swift
@@ -1,0 +1,29 @@
+import UIKit
+import XCTest
+
+@testable import WordPress
+
+class ReaderWelcomeBannerTests: XCTestCase {
+
+    // Displays the Welcome Banner in a Table View
+    //
+    func testShouldDisplay() {
+        let tableView = UITableView()
+        let database = EphemeralKeyValueDatabase()
+
+        ReaderWelcomeBanner.displayIfNeeded(in: tableView, database: database)
+
+        XCTAssertTrue(tableView.tableHeaderView is ReaderWelcomeBanner)
+    }
+
+    // Do not display the Welcome Banner in a TableView
+    func testShouldNotDisplay() {
+        let tableView = UITableView()
+        let database = EphemeralKeyValueDatabase()
+        database.set(true, forKey: ReaderWelcomeBanner.bannerPresentedKey)
+
+        ReaderWelcomeBanner.displayIfNeeded(in: tableView, database: database)
+
+        XCTAssertNil(tableView.tableHeaderView)
+    }
+}


### PR DESCRIPTION
Part of #14399

This PRs adds the welcome banner the first time the user sees the Discover section.

### iPhone

| Light  | Dark |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 11 - 2020-07-14 at 09 49 04](https://user-images.githubusercontent.com/7040243/87429451-2d21cc00-c5ba-11ea-81cf-936ea30d927e.png) | ![Simulator Screen Shot - iPhone 11 - 2020-07-14 at 09 48 54](https://user-images.githubusercontent.com/7040243/87429498-3f9c0580-c5ba-11ea-9437-7933017d146c.png) |


### iPad

| Light  | Dark |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-07-14 at 09 53 01](https://user-images.githubusercontent.com/7040243/87429556-57738980-c5ba-11ea-9aab-3bd7f94b466d.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-07-14 at 09 51 51](https://user-images.githubusercontent.com/7040243/87429581-60645b00-c5ba-11ea-8a3c-1dd2cd122629.png) |

### To test

**Make sure that you have overridden the Reader Improvements Phase 2 Feature Flag (Me -> App Settings -> Debug -> "Reader Improvements Phase 2" should be ON)**

1. Go to the Discover section
2. Check that the welcome banner appear at the top
3. Change to another section
4. Go back, check that the welcome banner doesn't appear

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
