### PR TITLE
Present quick start next step after the theme preview has been dismissed

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -87,6 +87,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     private var reachabilityObserver: Any?
     private var tapLocation = CGPoint(x: 0.0, y: 0.0)
     private var widthConstraint: NSLayoutConstraint?
+    private var onClose: (() -> Void)?
 
     private struct WebViewErrors {
         static let frameLoadInterrupted = 102
@@ -104,6 +105,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         navigationDelegate = configuration.navigationDelegate
         linkBehavior = configuration.linkBehavior
         opensNewInSafari = configuration.opensNewInSafari
+        onClose = configuration.onClose
         super.init(nibName: nil, bundle: nil)
         hidesBottomBarWhenPushed = true
         startObservingWebView()
@@ -380,7 +382,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     // MARK: User Actions
 
     @objc func close() {
-        dismiss(animated: true)
+        dismiss(animated: true, completion: onClose)
     }
 
     @objc func share() {

--- a/WordPress/Classes/Utility/WebViewControllerConfiguration.swift
+++ b/WordPress/Classes/Utility/WebViewControllerConfiguration.swift
@@ -16,6 +16,7 @@ class WebViewControllerConfiguration: NSObject {
     @objc var customTitle: String?
     @objc var authenticator: RequestAuthenticator?
     @objc weak var navigationDelegate: WebNavigationDelegate?
+    var onClose: (() -> Void)?
 
     @objc init(url: URL?) {
         self.url = url

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -41,11 +41,18 @@ extension BlogDetailsViewController {
     }
 
     @objc func startAlertTimer() {
+        guard shouldStartAlertTimer else {
+            return
+        }
         let newWorkItem = DispatchWorkItem { [weak self] in
             self?.showNoticeOrAlertAsNeeded()
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: newWorkItem)
         alertWorkItem = newWorkItem
+    }
+    // do not start alert timer if the themes modal is still being presented
+    private var shouldStartAlertTimer: Bool {
+        !((self.presentedViewController as? UINavigationController)?.visibleViewController is WebKitViewController)
     }
 
     @objc func stopAlertTimer() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1595,6 +1595,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [WPAppAnalytics track:WPAnalyticsStatThemesAccessedThemeBrowser withBlog:self.blog];
     ThemeBrowserViewController *viewController = [ThemeBrowserViewController browserWithBlog:self.blog];
+    viewController.onWebkitViewControllerClose = ^(void) {
+        [self startAlertTimer];
+    };
     [self showDetailViewController:viewController sender:self];
 
     [[QuickStartTourGuide find] visited:QuickStartTourElementThemes];

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -764,6 +764,8 @@ public protocol ThemePresenter: class {
     }
 
     // MARK: - ThemePresenter
+    // optional closure that will be executed when the presented WebkitViewController closes
+    @objc var onWebkitViewControllerClose: (() -> Void)?
 
     @objc open func activateTheme(_ theme: Theme?) {
         guard let theme = theme, !theme.isCurrentTheme() else {
@@ -843,10 +845,10 @@ public protocol ThemePresenter: class {
 
     @objc open func presentViewForTheme(_ theme: Theme?) {
         WPAppAnalytics.track(.themesDemoAccessed, with: self.blog)
-        presentUrlForTheme(theme, url: theme?.viewUrl())
+        presentUrlForTheme(theme, url: theme?.viewUrl(), onClose: onWebkitViewControllerClose)
     }
 
-    @objc open func presentUrlForTheme(_ theme: Theme?, url: String?, activeButton: Bool = true, modalStyle: UIModalPresentationStyle = .pageSheet) {
+    @objc open func presentUrlForTheme(_ theme: Theme?, url: String?, activeButton: Bool = true, modalStyle: UIModalPresentationStyle = .pageSheet, onClose: (() -> Void)? = nil) {
         guard let theme = theme, let url = url.flatMap(URL.init(string:)) else {
             return
         }
@@ -859,6 +861,7 @@ public protocol ThemePresenter: class {
         configuration.customTitle = theme.name
         configuration.addsHideMasterbarParameters = false
         configuration.navigationDelegate = customizerNavigationDelegate
+        configuration.onClose = onClose
         let webViewController = WebViewControllerFactory.controller(configuration: configuration)
         var buttons: [UIBarButtonItem]?
         if activeButton && !theme.isCurrentTheme() {


### PR DESCRIPTION
Fixes #13070

See note: https://github.com/wordpress-mobile/WordPress-iOS/issues/13070#issuecomment-658271671

To test:

1. Create a new site in the app.
2. When prompted, accept more help getting started to get the Quick Start tours.
3. Select the "Choose a theme" tour.
4. Open the Themes section.
5. Select and activate a new theme.
6. Tap 'OK' and then close the theme preview
7. Verify that the next quick start prompt is shown

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
