### PR TITLE
Launch quick start next step after dismissing post editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -434,7 +434,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         __weak __typeof(self) weakSelf = self;
         _createButtonCoordinator = [[CreateButtonCoordinator alloc] init:self newPost:^{
             [weakSelf dismissViewControllerAnimated:true completion:nil];
-            [((WPTabBarController *)self.tabBarController) showPostTab];
+            [((WPTabBarController *)self.tabBarController) showPostTabWithCompletion:^(void) {
+                [self startAlertTimer];
+            }];
         } newPage:^{
             [weakSelf dismissViewControllerAnimated:true completion:nil];
             


### PR DESCRIPTION
Fixes #13702

To test:

1. Create a new site in the app.
2. When prompted, accept more help getting started to get the Quick Start tours.
3. Select the "Publish a post" tour from the 'Grow Your Audience' groups in 'Next Steps'
4. Follow the prompt to open the post editor on the FAB
5. Publish a post.
6. Publish or dismiss a post
7. Verify that quick start next step notice appears when the post editor is dismissed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
