### PR TITLE
Fix broken UI Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ jobs:
       - ios/install-dependencies:
             bundle-install: true
             pod-install: true
+      - run:
+          name: Install Dependencies
+          command: rake dependencies
       - ios/xcodebuild:
           command: build-for-testing
           arguments: -workspace 'WordPress.xcworkspace' -scheme 'WordPress' -configuration 'Debug' -sdk iphonesimulator -derivedDataPath DerivedData

--- a/.configure
+++ b/.configure
@@ -1,7 +1,7 @@
 {
   "project_name": "WordPress-iOS",
   "branch": "master",
-  "pinned_hash": "43e751540dcdcc86bde9db7b0d08a4acdbc1472c",
+  "pinned_hash": "6e3e6bede3d1e6a1f19e821337a2cf463fcd3a05",
   "files_to_copy": [
     {
       "file": "iOS/WPiOS/wpcom_app_credentials",


### PR DESCRIPTION
UI Tests were broken because we weren't applying the newest mobile secrets before building for tests. 

This PR fixes that, and updates to the latest `mobile-secrets` hash.

Feel free to merge when approved to fix `develop`.