### PR TITLE
Go back to My Site when the 'View Site' quick action suggestion is displayed in a child ViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -6,6 +6,7 @@ private var observer: NSObjectProtocol?
 extension BlogDetailsViewController {
 
     @objc static let bottomPaddingForQuickStartNotices: CGFloat = 80.0
+    @objc static var shouldScrollToViewSite = false
 
     @objc func startObservingQuickStart() {
         observer = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
@@ -28,10 +29,21 @@ extension BlogDetailsViewController {
                 case .siteIcon, .siteTitle:
                     // handles the padding in case the element is not in the table view
                     self?.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: BlogDetailsViewController.bottomPaddingForQuickStartNotices, right: 0)
+                case .viewSite:
+                    guard let self = self,
+                        let navigationController = self.navigationController,
+                        navigationController.visibleViewController != self else {
+                        return
+                    }
+
+                    self.dismiss(animated: true) {
+                        self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
+                        BlogDetailsViewController.shouldScrollToViewSite = true
+                        navigationController.popToViewController(self, animated: true)
+                    }
                 default:
                     break
                 }
-
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -6,7 +6,6 @@ private var observer: NSObjectProtocol?
 extension BlogDetailsViewController {
 
     @objc static let bottomPaddingForQuickStartNotices: CGFloat = 80.0
-    @objc static var shouldScrollToViewSite = false
 
     @objc func startObservingQuickStart() {
         observer = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
@@ -38,7 +37,7 @@ extension BlogDetailsViewController {
 
                     self.dismiss(animated: true) {
                         self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
-                        BlogDetailsViewController.shouldScrollToViewSite = true
+                        self.shouldScrollToViewSite = true
                         navigationController.popToViewController(self, animated: true)
                     }
                 default:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -130,6 +130,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 @property (nonatomic, strong) id<ScenePresenter> _Nonnull meScenePresenter;
 @property (nonatomic, strong, readwrite) UITableView * _Nonnull tableView;
 @property (nonatomic, strong, readonly) BlogDetailHeaderView * _Nonnull headerView;
+@property (nonatomic) BOOL shouldScrollToViewSite;
 
 - (id _Nonnull)initWithMeScenePresenter:(id<ScenePresenter> _Nonnull)meScenePresenter;
 - (void)showDetailViewForSubsection:(BlogDetailsSubsection)section;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -427,9 +427,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self createUserActivity];
     [self startAlertTimer];
 
-    if ([BlogDetailsViewController shouldScrollToViewSite] == YES) {
+    if (self.shouldScrollToViewSite == YES) {
         [self scrollToElement:QuickStartTourElementViewSite];
-        BlogDetailsViewController.shouldScrollToViewSite = NO;
+        self.shouldScrollToViewSite = NO;
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -426,6 +426,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
     [self createUserActivity];
     [self startAlertTimer];
+
+    if ([BlogDetailsViewController shouldScrollToViewSite] == YES) {
+        [self scrollToElement:QuickStartTourElementViewSite];
+        BlogDetailsViewController.shouldScrollToViewSite = NO;
+    }
 }
 
 - (CreateButtonCoordinator *)createButtonCoordinator


### PR DESCRIPTION
Fixes #12740

To test:

1. Create a new WordPress.com site in the app.
2. Follow the prompts until you reach the screen saying "Want a little help getting started?".
3. Tap "Yes, Help Me".
4. Go through each of the tour items in order, stopping when you get to the "View your site" prompt with "Now now" and "Yes, show me" options.
5. With that prompt still on the screen, open the Blog Posts section.
6. Tap "View" to preview a post.
7. Verify that you are redirected to 'My Site' and the 'View Site' action is suggested by the notice and the spotlight

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
