### PR TITLE
Add quick start next step suggestion for site title and site icon

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
@@ -36,7 +36,9 @@ extension BlogDetailsViewController {
         controller.onValueChanged = { [weak self] value in
             self?.saveSiteTitleSettings(value)
         }
-
+        controller.onDismiss = { [weak self] in
+            self?.startAlertTimer()
+        }
         let navigationController = UINavigationController(rootViewController: controller)
         navigationController.modalPresentationStyle = .formSheet
         present(navigationController, animated: true)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1058,7 +1058,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                          }];
     }
     [updateIconAlertController addCancelActionWithTitle:NSLocalizedString(@"Cancel", @"Cancel button")
-                                                handler:nil];
+                                                handler:^(UIAlertAction *action) {
+                                                    [self startAlertTimer];
+                                                }];
 
     [self presentViewController:updateIconAlertController animated:YES completion:nil];
 }
@@ -1128,6 +1130,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             [weakSelf dismissViewControllerAnimated:YES completion:nil];
         }
         weakSelf.siteIconPickerPresenter = nil;
+        [weakSelf startAlertTimer];
     };
     self.siteIconPickerPresenter.onIconSelection = ^() {
         weakSelf.headerView.updatingIcon = YES;

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.h
@@ -14,6 +14,7 @@ typedef NS_ENUM(NSInteger, SettingsTextModes) {
 typedef void (^SettingsTextAction)(void);
 typedef void (^SettingsTextChanged)(NSString * _Nonnull);
 typedef void (^SettingsAttributedTextChanged)(NSAttributedString * _Nonnull);
+typedef void (^SettingsTextOnDismiss)(void);
 
 /// Reusable component that renders a UITextField + Hint onscreen. Useful for Text / Password / Email data entry.
 ///
@@ -30,6 +31,9 @@ typedef void (^SettingsAttributedTextChanged)(NSAttributedString * _Nonnull);
 /// Block to be executed whenever the Action, if visible, is pressed.
 ///
 @property (nullable, nonatomic, copy) SettingsTextAction onActionPress;
+/// Optional block to be executed when the viewController is dismissed.
+///
+@property (nullable, nonatomic, copy) SettingsTextOnDismiss onDismiss;
 
 /// String to be displayed at the bottom.
 ///

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -342,7 +342,7 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
 - (void)dismissViewController
 {
     if (self.isModal) {
-        [self dismissViewControllerAnimated:YES completion:nil];
+        [self dismissViewControllerAnimated:YES completion:self.onDismiss];
     } else {
         [self.navigationController popViewControllerAnimated:YES];
     }


### PR DESCRIPTION
Fixes #NA

To test:

- Create a new WordPress.com site
- When prompted, select "Yes, Help Me"
- Tap on "Set Site Title"
- Verify that once you are done (by either cancelling or setting a new title) the "Set Site Icon" suggestion appears
- Set your site icon (or cancel the action once started)
- Verify that the "Set theme" suggestion appears

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
