### PR TITLE
[Gutenberg] Fix Editor loading view on device orientation changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -334,7 +334,6 @@ class GutenbergViewController: UIViewController, PostEditor {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         verificationPromptHelper?.updateVerificationStatus()
-        ghostView.frame = view.safeAreaLayoutGuide.layoutFrame
         ghostView.startAnimation()
     }
 
@@ -342,6 +341,11 @@ class GutenbergViewController: UIViewController, PostEditor {
         super.viewDidAppear(animated)
         // Handles refreshing controls with state context after options screen is dismissed
         editorContentWasUpdated()
+    }
+
+    override func viewLayoutMarginsDidChange() {
+        super.viewLayoutMarginsDidChange()
+        ghostView.frame = view.safeAreaLayoutGuide.layoutFrame
     }
 
     // MARK: - Functions


### PR DESCRIPTION
Fixes an issue where the Block Editor Loading View wouldn't adjust to changes when the device changes orientation.

To test:
- Open a post/page with gutenberg.
- While the editor is loading, rotate the device.
- Check that the Loading View responds accordingly to the orientation change.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
