### PR TITLE
Fix finalize_hotfix_release lane description

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -218,7 +218,7 @@ import "./ScreenshotFastfile"
   # Example:
   # bundle exec fastlane finalize_hotfix_release skip_confirm:true  
   #####################################################################################
-  desc "Creates a new hotfix branch from the given tag"
+  desc "Performs the final checks and tags the hotfix in the current branch"
   lane :finalize_hotfix_release do | options |
     ios_finalize_prechecks(options)
     ios_tag_build()


### PR DESCRIPTION
This PR fixes the description of the `finalize_hotfix_release`.
Thank you @oguzkocer for spotting this!


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
