### PR TITLE
Domain Registration: Sanitize form fields

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -12,7 +12,8 @@ import WordPressAuthenticator
 }
 
 class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
-
+    typealias ValueSanitizerBlock = (_ value: String?) -> String?
+    
     fileprivate enum Const {
         enum Color {
             static let nameText = UIColor.text
@@ -29,7 +30,8 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
     @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var valueTextField: LoginTextField!
     weak var delegate: InlineEditableNameValueCellDelegate?
-
+    var valueSanitizer: ValueSanitizerBlock?
+    
     override var accessoryType: UITableViewCell.AccessoryType {
         didSet {
             let textFieldEnabled = accessoryType == .none
@@ -70,19 +72,24 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
 
     @objc func textFieldDidChange(textField: UITextField) {
         textField.text = textField.text?.replacingOccurrences(of: Const.Text.space, with: Const.Text.nonBreakingSpace)
-
-        let text = sanitizedText(for: textField)
+        
+        let text = replaceNonBreakingSpaceWithSpace(for: textField)
         delegate?.inlineEditableNameValueCell?(self, valueTextFieldDidChange: text)
     }
 
     @objc func textEditingDidEnd(textField: UITextField) {
-        let text = sanitizedText(for: textField)
+        if let valueSanitizer = valueSanitizer {
+            textField.text = valueSanitizer(textField.text)
+        }
+        
+        let text = replaceNonBreakingSpaceWithSpace(for: textField)
 
         textField.text = text
+        
         delegate?.inlineEditableNameValueCell?(self, valueTextFieldEditingDidEnd: text)
     }
 
-    private func sanitizedText(for textField: UITextField) -> String {
+    private func replaceNonBreakingSpaceWithSpace(for textField: UITextField) -> String {
         return textField.text?.replacingOccurrences(of: Const.Text.nonBreakingSpace, with: Const.Text.space) ?? ""
     }
 
@@ -104,6 +111,7 @@ extension InlineEditableNameValueCell {
         var placeholder: String?
         var valueColor: UIColor?
         var accessoryType: UITableViewCell.AccessoryType?
+        var valueSanitizer: ValueSanitizerBlock?
     }
 
     func update(with model: Model) {
@@ -112,5 +120,6 @@ extension InlineEditableNameValueCell {
         valueTextField.placeholder = model.placeholder
         valueTextField.textColor = model.valueColor ?? Const.Color.valueText
         accessoryType = model.accessoryType ?? .none
+        valueSanitizer = model.valueSanitizer
     }
 }

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -13,7 +13,7 @@ import WordPressAuthenticator
 
 class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
     typealias ValueSanitizerBlock = (_ value: String?) -> String?
-    
+
     fileprivate enum Const {
         enum Color {
             static let nameText = UIColor.text
@@ -31,7 +31,7 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
     @IBOutlet weak var valueTextField: LoginTextField!
     weak var delegate: InlineEditableNameValueCellDelegate?
     var valueSanitizer: ValueSanitizerBlock?
-    
+
     override var accessoryType: UITableViewCell.AccessoryType {
         didSet {
             let textFieldEnabled = accessoryType == .none
@@ -72,7 +72,7 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
 
     @objc func textFieldDidChange(textField: UITextField) {
         textField.text = textField.text?.replacingOccurrences(of: Const.Text.space, with: Const.Text.nonBreakingSpace)
-        
+
         let text = replaceNonBreakingSpaceWithSpace(for: textField)
         delegate?.inlineEditableNameValueCell?(self, valueTextFieldDidChange: text)
     }
@@ -81,11 +81,11 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
         if let valueSanitizer = valueSanitizer {
             textField.text = valueSanitizer(textField.text)
         }
-        
+
         let text = replaceNonBreakingSpaceWithSpace(for: textField)
 
         textField.text = text
-        
+
         delegate?.inlineEditableNameValueCell?(self, valueTextFieldEditingDidEnd: text)
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+Cells.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+Cells.swift
@@ -45,7 +45,8 @@ extension RegisterDomainDetailsViewController {
             value: row.value,
             placeholder: row.placeholder,
             valueColor: valueColor(row: row),
-            accessoryType: row.accessoryType()
+            accessoryType: row.accessoryType(),
+            valueSanitizer: row.valueSanitizer
         ))
 
         updateStyle(of: cell, at: indexPath)

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -213,7 +213,7 @@ extension RegisterDomainDetailsViewController: InlineEditableNameValueCellDelega
                 viewModel.enableAddAddressRow()
         }
     }
-    
+
     func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell, valueTextFieldEditingDidEnd text: String) {
         inlineEditableNameValueCell(cell, valueTextFieldDidChange: text)
     }

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -213,6 +213,10 @@ extension RegisterDomainDetailsViewController: InlineEditableNameValueCellDelega
                 viewModel.enableAddAddressRow()
         }
     }
+    
+    func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell, valueTextFieldEditingDidEnd text: String) {
+        inlineEditableNameValueCell(cell, valueTextFieldDidChange: text)
+    }
 
     func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell, valueTextFieldShouldReturn textField: UITextField) -> Bool {
         guard let indexPath = tableView.indexPath(for: cell) else {

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowDefinitions.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowDefinitions.swift
@@ -67,7 +67,8 @@ extension RegisterDomainDetailsViewModel {
 
             typealias ValidationStateChangedHandler = ((EditableKeyValueRow, ValidationRule) -> Void)
             typealias ValueChangeHandler = ((EditableKeyValueRow) -> Void)
-
+            typealias ValueSanitizerBlock = (_ value: String?) -> String?
+            
             enum EditingStyle: Int {
                 case inline
                 case multipleChoice
@@ -99,13 +100,15 @@ extension RegisterDomainDetailsViewModel {
                 }
             }
             var valueChangeHandler: ValueChangeHandler?
+            var valueSanitizer: ValueSanitizerBlock?
 
             init(key: String,
                  jsonKey: String,
                  value: String?,
                  placeholder: String?,
                  editingStyle: EditingStyle,
-                 validationRules: [ValidationRule] = []) {
+                 validationRules: [ValidationRule] = [],
+                 valueSanitizer: ValueSanitizerBlock? = nil) {
 
                 self.key = key
                 self.jsonKey = jsonKey
@@ -113,6 +116,7 @@ extension RegisterDomainDetailsViewModel {
                 self.placeholder = placeholder
                 self.editingStyle = editingStyle
                 self.validationRules = validationRules
+                self.valueSanitizer = valueSanitizer
             }
 
             private func registerForValidationStateChangedEvent() {

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowDefinitions.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowDefinitions.swift
@@ -68,7 +68,7 @@ extension RegisterDomainDetailsViewModel {
             typealias ValidationStateChangedHandler = ((EditableKeyValueRow, ValidationRule) -> Void)
             typealias ValueChangeHandler = ((EditableKeyValueRow) -> Void)
             typealias ValueSanitizerBlock = (_ value: String?) -> String?
-            
+
             enum EditingStyle: Int {
                 case inline
                 case multipleChoice

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowList.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowList.swift
@@ -79,6 +79,13 @@ extension RegisterDomainDetailsViewModel {
                               errorMessage: errorMessage)
     }
 
+    static func transformToLatinASCII(value: String?) -> String? {
+        let toLatinASCII = StringTransform(rawValue: "Latin-ASCII") // See http://userguide.icu-project.org/transforms/general for more options.
+        return value?.applyingTransform(toLatinASCII, reverse: false)
+    }
+    
+    // MARK: - Rows
+
     static var contactInformationRows: [RowType] {
         return [
             .inlineEditable(.init(
@@ -88,7 +95,8 @@ extension RegisterDomainDetailsViewModel {
                 placeholder: Localized.ContactInformation.firstName,
                 editingStyle: .inline,
                 validationRules: [nonEmptyRule,
-                                  serverSideRule(with: Localized.ContactInformation.firstName)]
+                                  serverSideRule(with: Localized.ContactInformation.firstName)],
+                valueSanitizer: transformToLatinASCII
                 )),
             .inlineEditable(.init(
                 key: Localized.ContactInformation.lastName,
@@ -97,14 +105,16 @@ extension RegisterDomainDetailsViewModel {
                 placeholder: Localized.ContactInformation.lastName,
                 editingStyle: .inline,
                 validationRules: [nonEmptyRule,
-                                  serverSideRule(with: Localized.ContactInformation.lastName)]
+                                  serverSideRule(with: Localized.ContactInformation.lastName)],
+                valueSanitizer: transformToLatinASCII
                 )),
             .inlineEditable(.init(
                 key: Localized.ContactInformation.organization,
                 jsonKey: "organization",
                 value: nil,
                 placeholder: Localized.ContactInformation.organizationPlaceholder,
-                editingStyle: .inline
+                editingStyle: .inline,
+                valueSanitizer: transformToLatinASCII
                 )),
             .inlineEditable(.init(
                 key: Localized.ContactInformation.email,
@@ -158,7 +168,8 @@ extension RegisterDomainDetailsViewModel {
             value: nil,
             placeholder: Localized.Address.addressPlaceholder,
             editingStyle: .inline,
-            validationRules: optional ? [] : [nonEmptyRule, serverSideRule(with: Localized.Address.addressLine)]
+            validationRules: optional ? [] : [nonEmptyRule, serverSideRule(with: Localized.Address.addressLine)],
+            valueSanitizer: transformToLatinASCII
             ))
     }
 
@@ -171,7 +182,8 @@ extension RegisterDomainDetailsViewModel {
                 value: nil,
                 placeholder: Localized.Address.city,
                 editingStyle: .inline,
-                validationRules: [nonEmptyRule, serverSideRule(with: Localized.Address.city)]
+                validationRules: [nonEmptyRule, serverSideRule(with: Localized.Address.city)],
+                valueSanitizer: transformToLatinASCII
                 )),
             .inlineEditable(.init(
                 key: Localized.Address.state,
@@ -179,7 +191,8 @@ extension RegisterDomainDetailsViewModel {
                 value: nil,
                 placeholder: Localized.Address.statePlaceHolder,
                 editingStyle: .multipleChoice,
-                validationRules: [serverSideRule(with: Localized.Address.state)]
+                validationRules: [serverSideRule(with: Localized.Address.state)],
+                valueSanitizer: transformToLatinASCII
                 )),
             .inlineEditable(.init(
                 key: Localized.Address.postalCode,
@@ -187,7 +200,8 @@ extension RegisterDomainDetailsViewModel {
                 value: nil,
                 placeholder: Localized.Address.postalCode,
                 editingStyle: .inline,
-                validationRules: [nonEmptyRule, serverSideRule(with: Localized.Address.postalCode)]
+                validationRules: [nonEmptyRule, serverSideRule(with: Localized.Address.postalCode)],
+                valueSanitizer: transformToLatinASCII
                 ))
         ]
     }

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowList.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowList.swift
@@ -83,7 +83,7 @@ extension RegisterDomainDetailsViewModel {
         let toLatinASCII = StringTransform(rawValue: "Latin-ASCII") // See http://userguide.icu-project.org/transforms/general for more options.
         return value?.applyingTransform(toLatinASCII, reverse: false)
     }
-    
+
     // MARK: - Rows
 
     static var contactInformationRows: [RowType] {

--- a/WordPress/WordPressTest/RegisterDomainDetailsViewModelTests.swift
+++ b/WordPress/WordPressTest/RegisterDomainDetailsViewModelTests.swift
@@ -189,4 +189,14 @@ class RegisterDomainDetailsViewModelTests: XCTestCase {
         XCTAssert(phoneSection.rows[CellIndex.PhoneNumber.countryCode.rawValue].editableRow?.value == MockData.phoneCountryCode)
         XCTAssert(phoneSection.rows[CellIndex.PhoneNumber.number.rawValue].editableRow?.value == MockData.phoneNumber)
     }
+    
+    func testValueSanitizer() {
+        let latin1SupplementAndLatinExtendedALetters = "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ"
+         
+        let latinASCIIApproximates = "AAAAAAAECEEEEIIIIDNOOOOOOUUUUYTHssaaaaaaaeceeeeiiiidnoooooouuuuythyAaAaAaCcCcCcCcDdDdEeEeEeEeEeGgGgGgGgHhHhIiIiIiIiIiIJijJjKkqLlLlLlLlLlNnNnNn'nNnOoOoOoOEoeRrRrRrSsSsSsSsTtTtTtUuUuUuUuUuUuWwYyYZzZzZzs"
+
+        let result = RegisterDomainDetailsViewModel.transformToLatinASCII(value: latin1SupplementAndLatinExtendedALetters)
+        
+        XCTAssertEqual(result, latinASCIIApproximates)
+    }
 }

--- a/WordPress/WordPressTest/RegisterDomainDetailsViewModelTests.swift
+++ b/WordPress/WordPressTest/RegisterDomainDetailsViewModelTests.swift
@@ -189,14 +189,14 @@ class RegisterDomainDetailsViewModelTests: XCTestCase {
         XCTAssert(phoneSection.rows[CellIndex.PhoneNumber.countryCode.rawValue].editableRow?.value == MockData.phoneCountryCode)
         XCTAssert(phoneSection.rows[CellIndex.PhoneNumber.number.rawValue].editableRow?.value == MockData.phoneNumber)
     }
-    
+
     func testValueSanitizer() {
         let latin1SupplementAndLatinExtendedALetters = "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ"
-         
+
         let latinASCIIApproximates = "AAAAAAAECEEEEIIIIDNOOOOOOUUUUYTHssaaaaaaaeceeeeiiiidnoooooouuuuythyAaAaAaCcCcCcCcDdDdEeEeEeEeEeGgGgGgGgHhHhIiIiIiIiIiIJijJjKkqLlLlLlLlLlNnNnNn'nNnOoOoOoOEoeRrRrRrSsSsSsSsTtTtTtUuUuUuUuUuUuWwYyYZzZzZzs"
 
         let result = RegisterDomainDetailsViewModel.transformToLatinASCII(value: latin1SupplementAndLatinExtendedALetters)
-        
+
         XCTAssertEqual(result, latinASCIIApproximates)
     }
 }


### PR DESCRIPTION
In domain registration form text field on edit end now transforms non-ASCII-range Latin letters to an approximate ASCII-range equivalent letters

Fixes #10536

To test:
There is a "Register Domain" button appearing for premium accounts who have free premium domain or other accounts with domain credits.

1. Open domain registration suggestions
1. Search a random domain name
1. Select it
1. In the form type [Latin-1 Supplement](https://en.wikipedia.org/wiki/Latin-1_Supplement_(Unicode_block)#Character_table) or [Latin Extended-A](https://en.wikipedia.org/wiki/Latin_Extended-A) letters in various fields
1. If you go to another field those letters should be transformed to ASCII-range letters

![domain_registration_form](https://user-images.githubusercontent.com/1845482/87708747-7ed97a80-c7a3-11ea-9dc4-995103137eca.gif)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
