### PR TITLE
Fix issue with presenting the New Page editor when selecting from the FAB icon

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 15.4
 -----
- 
+* [**] Fixes issue where the new page editor wouldn't always show when selected from the "My Site" page on iOS versions 12.4 and below. 
+
 15.3
 -----
 * [***] Block Editor: Adds Copy, Cut, Paste, and Duplicate functionality to blocks

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -434,15 +434,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         __weak __typeof(self) weakSelf = self;
         _createButtonCoordinator = [[CreateButtonCoordinator alloc] init:self newPost:^{
             [weakSelf dismissViewControllerAnimated:true completion:nil];
-            [((WPTabBarController *)self.tabBarController) showPostTabWithCompletion:^(void) {
-                [self startAlertTimer];
+            [((WPTabBarController *)weakSelf.tabBarController) showPostTabWithCompletion:^(void) {
+                [weakSelf startAlertTimer];
             }];
         } newPage:^{
-            [weakSelf dismissViewControllerAnimated:true completion:nil];
-            
-            WPTabBarController *controller = (WPTabBarController *)self.tabBarController;
-            Blog *blog = [controller currentOrLastBlog];
-            [controller showPageEditorForBlog:blog];
+            [weakSelf dismissViewControllerAnimated:true completion:^{
+                WPTabBarController *controller = (WPTabBarController *)weakSelf.tabBarController;
+                Blog *blog = [controller currentOrLastBlog];
+                [controller showPageEditorForBlog:blog];
+            }];
         }];
     }
     


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/14483

### To test:
On a Simulator or Device running iOS 12.4 or below and again running 13.0 or above:
- Select the Floating Action Button (FAB)
- Select "Site Page"
- Expect to see the page editor open

<img width=300 src="https://user-images.githubusercontent.com/3384451/87803637-c520ef00-c820-11ea-869b-774e17211263.gif" />

### Additional Context
This could be related to a timing issue that my simulators for 12.4 and below hit more regularly than my 13.0 and above device and simulators.

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
