### PR TITLE
Call Reader Card API with the list of followed interests

### DIFF
--- a/WordPress/WordPressTest/Test Data/reader-cards-success.json
+++ b/WordPress/WordPressTest/Test Data/reader-cards-success.json
@@ -8,11 +8,11 @@
 			"type": "interests_you_may_like",
 			"data": [{
 					"title": "Activism",
-					"slug-en": "activism"
+					"slug": "activism"
 				},
 				{
 					"title": "Advice",
-					"slug-en": "advice"
+					"slug": "advice"
 				}
 			]
 		},


### PR DESCRIPTION
Part of #14399

This PR calls the API giving the list of followed interests/topics.

### To test

There are no visual changes to be tested.

Please, rely on the code and unit tests when reviewing. :)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
