### PR TITLE
iOS 14 More Popover Fix (targetting 15.3)

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -574,6 +574,13 @@ class AztecPostViewController: UIViewController, PostEditor {
         })
 
         optionsTablePresenter.dismiss()
+
+        // Required to work around an issue present in iOS 14 beta 2
+        // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
+        if #available(iOS 14.0, *),
+            presentedViewController?.view.accessibilityIdentifier == MoreSheetAlert.accessibilityIdentifier {
+            dismiss(animated: true)
+        }
     }
 
     override func willMove(toParent parent: UIViewController?) {
@@ -588,7 +595,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         navigationController.delegate = self
         configureMediaProgressView(in: navigationController.navigationBar)
     }
-
 
     // MARK: - Title and Title placeholder position methods
 
@@ -1266,6 +1272,7 @@ private extension AztecPostViewController {
             // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
             alert.popoverPresentationController?.sourceRect = button.convert(button.bounds, to: navigationController?.navigationBar)
             alert.popoverPresentationController?.sourceView = navigationController?.navigationBar
+            alert.view.accessibilityIdentifier = MoreSheetAlert.accessibilityIdentifier
         } else {
             alert.popoverPresentationController?.barButtonItem = navigationBarManager.moreBarButtonItem
         }
@@ -3390,6 +3397,7 @@ extension AztecPostViewController {
         static let historyTitle = NSLocalizedString("History", comment: "Displays the History screen from the editor's alert sheet")
         static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
+        static let accessibilityIdentifier = "MoreSheetAccessibilityIdentifier"
     }
 
     struct MediaAttachmentActionSheet {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1260,7 +1260,15 @@ private extension AztecPostViewController {
 
         alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
 
-        alert.popoverPresentationController?.barButtonItem = navigationBarManager.moreBarButtonItem
+        if #available(iOS 14.0, *),
+            let button = navigationBarManager.moreBarButtonItem.customView {
+            // Required to work around an issue present in iOS 14 beta 2
+            // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
+            alert.popoverPresentationController?.sourceRect = button.convert(button.bounds, to: navigationController?.navigationBar)
+            alert.popoverPresentationController?.sourceView = navigationController?.navigationBar
+        } else {
+            alert.popoverPresentationController?.barButtonItem = navigationBarManager.moreBarButtonItem
+        }
 
         present(alert, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -65,6 +65,7 @@ extension GutenbergViewController {
             // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
             alert.popoverPresentationController?.sourceRect = button.convert(button.bounds, to: navigationController?.navigationBar)
             alert.popoverPresentationController?.sourceView = navigationController?.navigationBar
+            alert.view.accessibilityIdentifier = MoreSheetAlert.accessibilityIdentifier
         } else {
             alert.popoverPresentationController?.barButtonItem = navigationBarManager.moreBarButtonItem
         }
@@ -100,7 +101,7 @@ extension GutenbergViewController {
 // MARK: - Constants
 
 extension GutenbergViewController {
-    private struct MoreSheetAlert {
+    struct MoreSheetAlert {
         static let classicTitle = NSLocalizedString(
             "Switch to classic editor",
             comment: "Switches from Gutenberg mobile to the classic editor"
@@ -111,5 +112,6 @@ extension GutenbergViewController {
         static let historyTitle = NSLocalizedString("History", comment: "Displays the History screen from the editor's alert sheet")
         static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
+        static let accessibilityIdentifier = "MoreSheetAccessibilityIdentifier"
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -59,7 +59,15 @@ extension GutenbergViewController {
 
         alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
 
-        alert.popoverPresentationController?.barButtonItem = navigationBarManager.moreBarButtonItem
+        if #available(iOS 14.0, *),
+            let button = navigationBarManager.moreBarButtonItem.customView {
+            // Required to work around an issue present in iOS 14 beta 2
+            // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
+            alert.popoverPresentationController?.sourceRect = button.convert(button.bounds, to: navigationController?.navigationBar)
+            alert.popoverPresentationController?.sourceView = navigationController?.navigationBar
+        } else {
+            alert.popoverPresentationController?.barButtonItem = navigationBarManager.moreBarButtonItem
+        }
 
         present(alert, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -348,6 +348,17 @@ class GutenbergViewController: UIViewController, PostEditor {
         ghostView.frame = view.safeAreaLayoutGuide.layoutFrame
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+
+        // Required to work around an issue present in iOS 14 beta 2
+        // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
+        if #available(iOS 14.0, *),
+            presentedViewController?.view.accessibilityIdentifier == MoreSheetAlert.accessibilityIdentifier {
+            dismiss(animated: true)
+        }
+    }
+
     // MARK: - Functions
 
     private var keyboardShowObserver: Any?


### PR DESCRIPTION
Exact same changes as #14461, but targetting 15.3 – it would be nicer to get this fix out sooner than 15.4 as the menu is currently pretty unusable for anyone on the iOS 14 betas on iPad.

**To test:**

- You'll need to build using Xcode 11.5 to an iPad running iOS 14.2. To do this, you'll also need the latest Xcode 12 beta installed, and to symlink to the device support folder as detailed here: https://gist.github.com/steipete/d9b44d8e9f341e81414e86d7ff8fb62d#file-gistfile1-txt
- Build and run on an iPad running iOS 14b2
- Open Aztec and open the More menu multiple times. Ensure you can see the contents.
- Open the block editor and open the More menu multiple times. Ensure you can see the contents.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary (I don't think we should or can mention iOS 14 changes in release notes).
