### PR TITLE
ULS: Support view: use the app's nav bar style when presented from Auth

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -183,6 +183,9 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     /// Returns an instance of a SupportView, configured to be displayed from a specified Support Source.
     ///
     func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {
+        // Reset the nav style so the Support nav bar has the WP style, not the Auth style.
+        WPStyleGuide.configureNavigationAppearance()
+
         let controller = SupportTableViewController()
         controller.sourceTag = sourceTag
 


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/315

This fixes an issue where the Support nav bar style was (incorrectly) inheriting the unified Auth nav style. Now, when Support is displayed from Auth, the nav bar style is set to the app's nav style.

To test:
- Enable the `unifiedSiteAddress` feature flag.
- Go to Log In > Site Address.
- Tap `Help` on the nav bar.
- Verify the `Support` nav bar is now back to the original style, i.e. blue background with white text.

| Before | After |
|--------|-------|
| <img width="499" alt="Screen Shot 2020-07-21 at 1 17 18 PM" src="https://user-images.githubusercontent.com/1816888/88096851-8b1f5800-cb54-11ea-9fd7-2e372ed79920.png"> | <img width="497" alt="Screen Shot 2020-07-21 at 1 15 47 PM" src="https://user-images.githubusercontent.com/1816888/88096780-70e57a00-cb54-11ea-9c7d-3fb58fdea0f4.png"> |


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
