### PR TITLE
Update translators review builds

### DIFF
--- a/Scripts/update-translations.rb
+++ b/Scripts/update-translations.rb
@@ -84,12 +84,14 @@ ALL_LANGS={
 langs = {}
 strings_filter = ""
 strings_file_ext = ""
+download_url = "https://translate.wordpress.org/projects/apps/ios/dev"
 if ARGV.count > 0
   if (ARGV[0] == "review") then
     langs = ALL_LANGS
 
     strings_filter = "filters[status]=#{ARGV[1]}\&"
     strings_file_ext = "_#{ARGV[1]}"
+    download_url = "https://translate.wordpress.com/projects/wporg/apps/ios/"
   else
     for key in ARGV
       unless local = ALL_LANGS[key]
@@ -111,7 +113,7 @@ langs.each do |code,local|
   # Download for production
   system "if [ -e #{lang_dir}/Localizable#{strings_file_ext}.strings ]; then cp #{lang_dir}/Localizable#{strings_file_ext}.strings #{lang_dir}/Localizable#{strings_file_ext}.strings.bak; fi"
 
-  url = "https://translate.wordpress.org/projects/apps/ios/dev/#{code}/default/export-translations?#{strings_filter}format=strings"
+  url = "#{download_url}/#{code}/default/export-translations?#{strings_filter}format=strings"
   destination = "#{lang_dir}/Localizable#{strings_file_ext}.strings"
 
   system "curl -fLso #{destination} \"#{url}\"" or begin

--- a/Scripts/update-translations.rb
+++ b/Scripts/update-translations.rb
@@ -81,13 +81,32 @@ ALL_LANGS={
   'zh-tw' => 'zh-Hant', # Chinese (Taiwan)
 }
 
+REVIEW_LANGS={
+  'ar' => 'ar',         # Arabic
+  'de' => 'de',         # German
+  'es' => 'es',         # Spanish
+  'fr' => 'fr',         # French
+  'he' => 'he',         # Hebrew
+  'id' => 'id',         # Indonesian
+  'it' => 'it',         # Italian
+  'ja' => 'ja',         # Japanese
+  'ko' => 'ko',         # Korean
+  'nl' => 'nl',         # Dutch
+  'pt-br' => 'pt-BR',   # Portuguese (Brazil)
+  'ru' => 'ru',         # Russian
+  'sv' => 'sv',         # Swedish
+  'tr' => 'tr',         # Turkish
+  'zh-cn' => 'zh-Hans', # Chinese (China)
+  'zh-tw' => 'zh-Hant', # Chinese (Taiwan)
+}
+
 langs = {}
 strings_filter = ""
 strings_file_ext = ""
 download_url = "https://translate.wordpress.org/projects/apps/ios/dev"
 if ARGV.count > 0
   if (ARGV[0] == "review") then
-    langs = ALL_LANGS
+    langs = REVIEW_LANGS
 
     strings_filter = "filters[status]=#{ARGV[1]}\&"
     strings_file_ext = "_#{ARGV[1]}"


### PR DESCRIPTION
This PR updates the build for translators to use the .com GlotPress instance. Currently, the .com instance is sync'ed only for some languages, so the script will download only those. 

To test:
1. Run `bundle exec fastlane build_for_translation_review` and verify that the build succeeds and that the translations for the languages in the  `REVIEW_LANGS` array have been downloaded. 
2. Clean up any local change. 
3. Run `.Scripts/update-translations.rb` from the project root folder and verify that it succeeds and that all the translations have been downloaded.  

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
