### PR TITLE
ULS: Reset nav bar style when initial views are dismissed.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -174,6 +174,10 @@ private extension LoginEpilogueViewController {
 
     @IBAction func dismissEpilogue() {
         onDismiss?()
+
+        // Reset the nav style so the nav bar has the WP style, not the Auth style.
+        WPStyleGuide.configureNavigationAppearance()
+
         navigationController?.dismiss(animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -68,6 +68,13 @@ class PostSignUpInterstitialViewController: UIViewController {
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        // Reset the nav style so the nav bar has the WP style, not the Auth style.
+        WPStyleGuide.configureNavigationAppearance()
+    }
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return UIDevice.isPad() ? .all : .portrait
     }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -263,6 +263,10 @@ private extension SignupEpilogueViewController {
     }
 
     func dismissEpilogue() {
+
+        // Reset the nav style so the nav bar has the WP style, not the Auth style.
+        WPStyleGuide.configureNavigationAppearance()
+
         guard let onContinue = self.onContinue else {
             self.navigationController?.dismiss(animated: true)
             return


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/315

After these views are dismissed, the nav bar style is reset to the app style. This fixes the issue noted on [this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/14386#issuecomment-650316300) where the nav bar was incorrect after accessing a unified Auth flow.
- `LoginEpilogueViewController`
- `SignupEpilogueViewController`
- `PostSignUpInterstitialViewController`


**To test:**

The bug is triggered by _first_ accessing the Site Address view, which changes the nav bar style, _then_ logging in with an Apple that requires no WP information. That is:
- Does not have a WP password.
- Does not have 2FA enabled.

In short, you need an Apple account that immediately logs in after entering the Apple credentials.

**Prerequisite:**
- Enable the `unifiedSiteAddress` feature flag.

---
**Login:**
- Go to Log In > Site Address.
- Go back, and select Log In > Continue with Apple.
- Enter Apple credentials.
- Dismiss the Login Epilogue.
- Verify the nav bar is the correct style (blue background with white text).

<img width="498" alt="after_login" src="https://user-images.githubusercontent.com/1816888/88115535-98980a80-cb73-11ea-8b8f-5a47c55c00b7.png">

---
**Post Sign Up Interstitial:**
- Since the Interestitial doesn't always show, you can force it by:
  - In `WordPressAuthenticationManager:presentLoginEpilogue`, comment out the `if PostSignUpInterstitialViewController.shouldDisplay()` check.

```
    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void) {
//        if PostSignUpInterstitialViewController.shouldDisplay() {
            self.presentPostSignUpInterstitial(in: navigationController, onDismiss: onDismiss)
            return
//        }
...
```

- Go to Log In > Site Address.
- Go back, and select Log In > Continue with Apple.
- Enter Apple credentials.
- Dismiss the Interstitial.
- Verify the nav bar is the correct style.

---
**Signup:**
- Go to Log In > Site Address.
- Go back, and select Sign Up > Continue with Apple.
  - If you don't actually want to sign up, see below for an Auth hack.
  - If you do the hack, you'll want to do Log In > Apple instead.
- Enter Apple credentials.
- Dismiss the Signup Epilogue.
- Verify the nav bar is the correct style.

---
To show the Signup Epilogue without actually signing up:
- In WPiOS Podfile, point WordPressAuthenticator to your local Auth.
- In `AppleAuthenticator`, change `showLoginEpilogue` to show the signup epilogue:

```
    func showLoginEpilogue(for credentials: AuthenticatorCredentials) {
        guard let navigationController = showFromViewController?.navigationController else {
            fatalError()
        }

        showSignupEpilogue(for: credentials)
        
//        authenticationDelegate.presentLoginEpilogue(in: navigationController, for: credentials) {}
    }
```

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
