### PR TITLE
Show post content when navigating between notifications

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -68,6 +68,10 @@ class NotificationDetailsViewController: UIViewController {
     ///
     fileprivate let estimatedRowHeightsCache = NSCache<AnyObject, AnyObject>()
 
+    /// A Reader Detail VC to display post content if needed
+    ///
+    private var readerDetailViewController: ReaderDetailWebviewViewController?
+
     /// Previous NavBar Navigation Button
     ///
     var previousNavigationButton: UIButton!
@@ -201,6 +205,7 @@ class NotificationDetailsViewController: UIViewController {
         tableView.reloadData()
         attachReplyViewIfNeeded()
         attachSuggestionsViewIfNeeded()
+        attachReaderViewIfNeeded()
         adjustLayoutConstraintsIfNeeded()
         refreshNavigationBar()
     }
@@ -494,6 +499,31 @@ extension NotificationDetailsViewController {
     }
 }
 
+
+
+// MARK: - Reader Helpers
+//
+private extension NotificationDetailsViewController {
+    func attachReaderViewIfNeeded() {
+        guard shouldAttachReaderView,
+            let postID = note.metaPostID,
+            let siteID = note.metaSiteID else {
+                readerDetailViewController?.remove()
+            return
+        }
+
+        readerDetailViewController?.remove()
+        let readerDetailViewController = ReaderDetailWebviewViewController.controllerWithPostID(postID, siteID: siteID)
+        add(readerDetailViewController)
+        readerDetailViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToSafeArea(readerDetailViewController.view)
+        self.readerDetailViewController = readerDetailViewController
+    }
+
+    var shouldAttachReaderView: Bool {
+        return note.kind == .newPost
+    }
+}
 
 
 // MARK: - Suggestions View Helpers

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -205,7 +205,6 @@ class NotificationDetailsViewController: UIViewController {
         tableView.reloadData()
         attachReplyViewIfNeeded()
         attachSuggestionsViewIfNeeded()
-        attachReaderViewIfNeeded()
         adjustLayoutConstraintsIfNeeded()
         refreshNavigationBar()
     }
@@ -509,7 +508,7 @@ private extension NotificationDetailsViewController {
             let postID = note.metaPostID,
             let siteID = note.metaSiteID else {
                 readerDetailViewController?.remove()
-            return
+                return
         }
 
         readerDetailViewController?.remove()


### PR DESCRIPTION
This PR adds the feature to show the post content when using the arrows to navigate between notifications.

Previous, we just showed the post title with an image or an excerpt, now the full post is shown.

| Before  | After |
| ------------- | ------------- |
| ![2020-07-22 14 17 08](https://user-images.githubusercontent.com/7040243/88207387-1ae10700-cc26-11ea-890b-057b5b8865ea.gif) | ![2020-07-22 14 15 07](https://user-images.githubusercontent.com/7040243/88207407-22081500-cc26-11ea-8b8b-d8cdb2a12958.gif) |

### To test

1. Go in the Notifications tab
2. Make sure you have at least one notification of a new post published in any site
3. Tap the closest notification (below or above) that one
4. Use the arrow to navigate to the post notification
5. Make sure the content is rendered

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
