### PR TITLE
ULS: Update Auth to use iPad table widths

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -186,9 +186,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.21.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.21.0-beta'
     # While in PR
-		pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/283-unified_views_ipad_layout'
+		# pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -186,9 +186,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.21.0-beta'
+    # pod 'WordPressAuthenticator', '~> 1.21.0-beta'
     # While in PR
-		# pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+		pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/283-unified_views_ipad_layout'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.21.0-beta.4):
+  - WordPressAuthenticator (1.21.0-beta.5):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.21.0-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/283-unified_views_ipad_layout`)
   - WordPressKit (= 4.13.0-beta.4)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.2-beta.1)
@@ -540,7 +540,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -632,6 +631,9 @@ EXTERNAL SOURCES:
     :commit: 7443b1a7f8739149e82a504992afddd59446154d
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :branch: feature/283-unified_views_ipad_layout
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/7443b1a7f8739149e82a504992afddd59446154d/third-party-podspecs/Yoga.podspec.json
 
@@ -647,6 +649,9 @@ CHECKOUT OPTIONS:
     :commit: 7443b1a7f8739149e82a504992afddd59446154d
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :commit: 2210aa6fe494fca823930732c10b895bde579c6c
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -722,7 +727,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: f634b784301296593d44b72767eec93f3bc8df38
+  WordPressAuthenticator: 89aa58dab06b23e380bf20fad9693c577052fdbf
   WordPressKit: c430dc757de5024a783621c625c326606561fa9d
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 2d1975a170a01f7dae5dac226fbf9b33b925c2c2
@@ -739,6 +744,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 823b8161a7523bfef6cd65451ff64027b7494fa1
+PODFILE CHECKSUM: 2db7178f34f592f5c0947243aa1961c499632e3e
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/283-unified_views_ipad_layout`)
+  - WordPressAuthenticator (~> 1.21.0-beta)
   - WordPressKit (= 4.13.0-beta.4)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.2-beta.1)
@@ -540,6 +540,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -631,9 +632,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.33.0
-  WordPressAuthenticator:
-    :branch: feature/283-unified_views_ipad_layout
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.33.0/third-party-podspecs/Yoga.podspec.json
 
@@ -649,9 +647,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.33.0
-  WordPressAuthenticator:
-    :commit: 2210aa6fe494fca823930732c10b895bde579c6c
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -744,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 69be67d8e1aaaa20abe9405f3230549d4597982a
+PODFILE CHECKSUM: 25bd3157c1742a4894c165d870867e05671e951b
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/283
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/334

To test:
- Enable the `unifiedSiteAddress` feature flag.
- Go to Log In > Site Address.
- On both the Site Address and Site Credentials views, verify the table and button widths are sized properly:
  - On iPad portrait.
  - On iPad landscape.
  - On iPhone portrait (views don't rotate to landscape on iPhone), or multi-tasking on iPad.

As noted on the Auth PR:
- For the Regular x Regular size class:
  - In portrait, the table is 66% of the view width.
  - In landscape, the table is 50% of the view width.
- For all other size classes, the table is 100% of the view width.
- The Continue button width resizes with the table.

---
**Regular x Regular:**

| Portrait | Landscape |
|--------|-------|
| ![site_addr_port](https://user-images.githubusercontent.com/1816888/88237398-6b635f00-cc3c-11ea-80ae-67400bb5adc3.png) | ![site_addr_land](https://user-images.githubusercontent.com/1816888/88237406-6ef6e600-cc3c-11ea-81e2-7ecd45156037.png) |
| ![creds_port](https://user-images.githubusercontent.com/1816888/88237532-a796bf80-cc3c-11ea-9dff-d18501d237d6.png) | ![creds_land](https://user-images.githubusercontent.com/1816888/88237537-ab2a4680-cc3c-11ea-875e-2e58caec04b6.png) |

---
**Compact:**

| iPhone | iPad multi-tasking |
|--------|-------|
| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-07-22 at 17 02 29](https://user-images.githubusercontent.com/1816888/88237751-25f36180-cc3d-11ea-87bf-866347dbeb0f.png) | ![IMG_1EEBA3887E1C-1](https://user-images.githubusercontent.com/1816888/88237708-0a885680-cc3d-11ea-90f4-65eac9185cdc.jpeg) |

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
