### PR TITLE
Remove Tenor feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -10,7 +10,6 @@ enum FeatureFlag: Int, CaseIterable {
     case meMove
     case floatingCreateButton
     case newReaderNavigation
-    case tenor
     case readerWebview
     case swiftCoreData
     case homepageSettings
@@ -39,8 +38,6 @@ enum FeatureFlag: Int, CaseIterable {
         case .floatingCreateButton:
             return true
         case .newReaderNavigation:
-            return true
-        case .tenor:
             return true
         case .readerWebview:
             return true
@@ -86,8 +83,6 @@ extension FeatureFlag: OverrideableFlag {
             return "Floating Create Button"
         case .newReaderNavigation:
             return "New Reader Navigation"
-        case .tenor:
-            return "Tenor GIF media source"
         case .readerWebview:
             return "Reader content displayed in a WebView"
         case .swiftCoreData:

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -873,7 +873,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
     func gutenbergMediaSources() -> [Gutenberg.MediaSource] {
         return [
             post.blog.supports(.stockPhotos) ? .stockPhotos : nil,
-            FeatureFlag.tenor.enabled ? .tenor : nil,
+            .tenor,
             .filesApp,
         ].compactMap { $0 }
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -40,10 +40,7 @@ final class MediaLibraryMediaPickingCoordinator {
             menuAlert.addAction(freePhotoAction(origin: origin, blog: blog))
         }
 
-        if FeatureFlag.tenor.enabled {
-            menuAlert.addAction(tenorAction(origin: origin, blog: blog))
-        }
-
+        menuAlert.addAction(tenorAction(origin: origin, blog: blog))
         menuAlert.addAction(otherAppsAction(origin: origin, blog: blog))
         menuAlert.addAction(cancelAction())
 

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
@@ -26,10 +26,7 @@ final class AztecMediaPickingCoordinator {
             alertController.addAction(freePhotoAction(origin: origin, blog: blog))
         }
 
-        if FeatureFlag.tenor.enabled {
-            alertController.addAction(tenorAction(origin: origin, blog: blog))
-        }
-
+        alertController.addAction(tenorAction(origin: origin, blog: blog))
         alertController.addAction(otherAppsAction(origin: origin, blog: blog))
         alertController.addAction(cancelAction())
 


### PR DESCRIPTION
Fixes #13803 

This removes the `tenor` feature flag and associated checks.

To test:
Detailed testing steps can be found on https://github.com/wordpress-mobile/WordPress-iOS/pull/13949. In short, verify you can add GIFs from:
- Media Library
- Block Editor
- Classic Editor 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
