### PR TITLE
Update/translation review builds version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,9 +206,10 @@ jobs:
           name: Build
           working_directory: Scripts
           command: | 
+            sed -i '' "$(awk '/^VERSION_SHORT/{ print NR; exit }' "./config/Version.internal.xcconfig")s/=.*/=15.3-`date +"%Y%d%m"`-"${CIRCLE_BUILD_NUM}"/" "./config/Version.internal.xcconfig"
             bundle exec fastlane build_for_translation_review
 
-            VERSION_NAME="all-land-build-${CIRCLE_BUILD_NUM}"
+            VERSION_NAME="all-lang-build-${CIRCLE_BUILD_NUM}"
             echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
 
             mkdir -p ../Artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,8 @@ jobs:
           name: Build
           working_directory: Scripts
           command: | 
-            sed -i '' "$(awk '/^VERSION_SHORT/{ print NR; exit }' "./config/Version.internal.xcconfig")s/=.*/=15.3-`date +"%Y%d%m"`-"${CIRCLE_BUILD_NUM}"/" "./config/Version.internal.xcconfig"
+            orig_version=`cat ../config/Version.internal.xcconfig | grep VERSION_SHORT | cut -d'=' -f2`
+            sed -i '' "$(awk '/^VERSION_SHORT/{ print NR; exit }' "../config/Version.internal.xcconfig")s/=.*/="${orig_version}"-`date +"%Y%d%m"`-"${CIRCLE_BUILD_NUM}"/" "../config/Version.internal.xcconfig"
             bundle exec fastlane build_for_translation_review
 
             VERSION_NAME="all-lang-build-${CIRCLE_BUILD_NUM}"


### PR DESCRIPTION
This PR updates the CI configuration for the translation reviewers' build to show a custom version number which contains the date and the CI job. This way, the reviewers can easily verify that they are testing the latest build. 

To test:
1. Get a CircleCI personal token.
2. From the terminal, run the following curl command to start the build:
```
curl -u <token>: -X POST --header "Content-Type: application/json" -d '{
 "branch": "update/translation-review-builds-version",
 "parameters": {
   "translation_review_build": true
 }
}' https://circleci.com/api/v2/project/github/wordpress-mobile/WordPress-iOS/pipeline
```

3. Verify that the build finishes without errors.
4. Go to `Appetize.io` and verify that the app runs as expected.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
