### PR TITLE
Removes Plans from 15.3

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -783,18 +783,19 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                      }]];
     }
 
-    if ([self.blog supports:BlogFeaturePlans]) {
-        BlogDetailsRow *plansRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plans", @"Action title. Noun. Links to a blog's Plans screen.")
-                                                         identifier:BlogDetailsPlanCellIdentifier
-                                                              image:[UIImage gridiconOfType:GridiconTypePlans]
-                                                           callback:^{
-                                                               [weakSelf showPlans];
-                                                           }];
-
-        plansRow.detail = self.blog.planTitle;
-        plansRow.quickStartIdentifier = QuickStartTourElementPlans;
-        [rows addObject:plansRow];
-    }
+// Temporarily disabled
+//    if ([self.blog supports:BlogFeaturePlans]) {
+//        BlogDetailsRow *plansRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plans", @"Action title. Noun. Links to a blog's Plans screen.")
+//                                                         identifier:BlogDetailsPlanCellIdentifier
+//                                                              image:[UIImage gridiconOfType:GridiconTypePlans]
+//                                                           callback:^{
+//                                                               [weakSelf showPlans];
+//                                                           }];
+//
+//        plansRow.detail = self.blog.planTitle;
+//        plansRow.quickStartIdentifier = QuickStartTourElementPlans;
+//        [rows addObject:plansRow];
+//    }
 
     return [[BlogDetailsSection alloc] initWithTitle:nil andRows:rows category:BlogDetailsSectionCategoryGeneral];
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -270,8 +270,9 @@ open class QuickStartTourGuide: NSObject {
         QuickStartShareTour(),
         QuickStartPublishTour(),
         QuickStartFollowTour(),
-        QuickStartCheckStatsTour(),
-        QuickStartExplorePlansTour()
+        QuickStartCheckStatsTour()
+// Temporarily disabled
+//        QuickStartExplorePlansTour()
     ]
 }
 


### PR DESCRIPTION
This PR removes Plans from 15.3.

**To test**

- In the app, view a WordPress.com site. Ensure that Plans doesn't appear as the last item in the first section of blog details:

<img width="395" alt="Screenshot 2020-07-24 at 14 51 46" src="https://user-images.githubusercontent.com/4780/88399128-4860b880-cdbe-11ea-822c-8a086655959f.png">

- Using the debug menu (blog details > me avatar > App Settings > Debug), enable Quick Start for a site. Ensure that the Plans item doesn't show in the Grow Your Audience quickstart list:

<img width="395" alt="Simulator Screen Shot - iPhone 11 - 2020-07-24 at 14 51 20" src="https://user-images.githubusercontent.com/4780/88399511-e6ed1980-cdbe-11ea-8af7-d460a5e81b6a.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
