### PR TITLE
Update topic page header UI 

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -39,7 +39,7 @@ extension ReaderStreamViewController {
         }
 
         // if tag
-        if ReaderHelpers.isTopicTag(topic) {
+        if ReaderHelpers.isTopicTag(topic) && !isContentFiltered {
             return Bundle.main.loadNibNamed("ReaderTagStreamHeader", owner: nil, options: nil)!.first as! ReaderTagStreamHeader
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -117,7 +117,7 @@ import WordPressFlux
         didSet {
             if tagSlug != nil {
                 // Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/5223
-                title = tagSlug
+                title = NSLocalizedString("TOPIC", comment: "Topic page title")
 
                 fetchTagTopic()
             }
@@ -164,6 +164,8 @@ import WordPressFlux
             }
         }
     }
+    
+    var isContentFiltered: Bool = false
 
     var contentType: ReaderContentType = .topic {
         willSet {
@@ -618,7 +620,11 @@ import WordPressFlux
             return
         }
 
-        title = topic.title
+        if ReaderHelpers.isTopicTag(topic) {
+             title = NSLocalizedString("TOPIC", comment: "Topic page title")
+        } else {
+            title = topic.title
+        }
     }
 
 
@@ -1798,6 +1804,7 @@ extension ReaderStreamViewController: UIViewControllerTransitioningDelegate {
 // MARK: - ReaderContentViewController
 extension ReaderStreamViewController: ReaderContentViewController {
     func setContent(_ content: ReaderContent) {
+        isContentFiltered = content.topicType == .tag
         hideHeader = content.topicType == .site
         readerTopic = content.topicType == .discover ? nil : content.topic
         contentType = content.type
@@ -1807,6 +1814,8 @@ extension ReaderStreamViewController: ReaderContentViewController {
         siteID = content.topicType == .discover ? ReaderHelpers.discoverSiteID : nil
 
         displaySelectInterestsIfNeeded(content)
+        
+        
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -117,7 +117,7 @@ import WordPressFlux
         didSet {
             if tagSlug != nil {
                 // Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/5223
-                title = NSLocalizedString("TOPIC", comment: "Topic page title")
+                title = NSLocalizedString("Topic", comment: "Topic page title")
 
                 fetchTagTopic()
             }
@@ -621,7 +621,7 @@ import WordPressFlux
         }
 
         if ReaderHelpers.isTopicTag(topic) {
-             title = NSLocalizedString("TOPIC", comment: "Topic page title")
+             title = NSLocalizedString("Topic", comment: "Topic page title")
         } else {
             title = topic.title
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -164,7 +164,7 @@ import WordPressFlux
             }
         }
     }
-    
+
     var isContentFiltered: Bool = false
 
     var contentType: ReaderContentType = .topic {
@@ -1814,8 +1814,6 @@ extension ReaderStreamViewController: ReaderContentViewController {
         siteID = content.topicType == .discover ? ReaderHelpers.discoverSiteID : nil
 
         displaySelectInterestsIfNeeded(content)
-        
-        
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -5,8 +5,9 @@ import WordPressShared
     @IBOutlet fileprivate weak var titleLabel: UILabel!
     @IBOutlet fileprivate weak var followButton: UIButton!
 
-    open var delegate: ReaderStreamHeaderDelegate?
+    let followButtonBorderColor: CGColor =  UIColor.gray(.shade30).cgColor
 
+    open var delegate: ReaderStreamHeaderDelegate?
 
     // MARK: - Lifecycle Methods
     open override func awakeFromNib() {
@@ -29,7 +30,7 @@ import WordPressShared
 
         WPStyleGuide.applyReaderFollowTopicButtonStyle(followButton)
         if #available(iOS 13, *) {
-            traitCollection.performAsCurrent { followButton.layer.borderColor = UIColor.gray(.shade30).cgColor }
+            traitCollection.performAsCurrent { followButton.layer.borderColor = followButtonBorderColor }
             setNeedsDisplay()
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -5,8 +5,6 @@ import WordPressShared
     @IBOutlet fileprivate weak var titleLabel: UILabel!
     @IBOutlet fileprivate weak var followButton: UIButton!
 
-    let followButtonBorderColor: CGColor =  UIColor.gray(.shade30).cgColor
-
     open var delegate: ReaderStreamHeaderDelegate?
 
     // MARK: - Lifecycle Methods
@@ -20,6 +18,16 @@ import WordPressShared
     @objc func applyStyles() {
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)
     }
+    
+    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                WPStyleGuide.applyReaderFollowTopicButtonStyle(followButton)
+            }
+        }
+    }
 
 
     // MARK: - Configuration
@@ -27,12 +35,7 @@ import WordPressShared
     @objc open func configureHeader(_ topic: ReaderAbstractTopic) {
         titleLabel.text = topic.title
         followButton.isSelected = topic.following
-
         WPStyleGuide.applyReaderFollowTopicButtonStyle(followButton)
-        if #available(iOS 13, *) {
-            traitCollection.performAsCurrent { followButton.layer.borderColor = followButtonBorderColor }
-            setNeedsDisplay()
-        }
     }
 
     @objc open func enableLoggedInFeatures(_ enable: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -2,7 +2,6 @@ import Foundation
 import WordPressShared
 
 @objc open class ReaderTagStreamHeader: UIView, ReaderStreamHeader {
-    @IBOutlet fileprivate weak var borderedView: UIView!
     @IBOutlet fileprivate weak var titleLabel: UILabel!
     @IBOutlet fileprivate weak var followButton: UIButton!
 
@@ -18,7 +17,6 @@ import WordPressShared
     }
 
     @objc func applyStyles() {
-        backgroundColor = .basicBackground
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -4,13 +4,14 @@ import WordPressShared
 @objc open class ReaderTagStreamHeader: UIView, ReaderStreamHeader {
     @IBOutlet fileprivate weak var borderedView: UIView!
     @IBOutlet fileprivate weak var titleLabel: UILabel!
-    @IBOutlet fileprivate weak var followButton: PostMetaButton!
+    @IBOutlet fileprivate weak var followButton: UIButton!
 
     open var delegate: ReaderStreamHeaderDelegate?
 
 
     // MARK: - Lifecycle Methods
 
+    
     open override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -20,9 +21,6 @@ import WordPressShared
 
     @objc func applyStyles() {
         backgroundColor = .listBackground
-        borderedView.backgroundColor = .listForeground
-        borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = .hairlineBorderWidth
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)
     }
 
@@ -31,8 +29,13 @@ import WordPressShared
 
     @objc open func configureHeader(_ topic: ReaderAbstractTopic) {
         titleLabel.text = topic.title
-        WPStyleGuide.applyReaderFollowButtonStyle(followButton)
         followButton.isSelected = topic.following
+
+        WPStyleGuide.applyReaderFollowTopicButtonStyle(followButton)
+        if #available(iOS 13, *) {
+            traitCollection.performAsCurrent { followButton.layer.borderColor = UIColor.gray(.shade30).cgColor }
+            setNeedsDisplay()
+        }
     }
 
     @objc open func enableLoggedInFeatures(_ enable: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -18,10 +18,10 @@ import WordPressShared
     @objc func applyStyles() {
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)
     }
-    
+
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        
+
         if #available(iOS 13.0, *) {
             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
                 WPStyleGuide.applyReaderFollowTopicButtonStyle(followButton)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -18,7 +18,7 @@ import WordPressShared
     }
 
     @objc func applyStyles() {
-        backgroundColor = .listBackground
+        backgroundColor = .basicBackground
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -10,8 +10,6 @@ import WordPressShared
 
 
     // MARK: - Lifecycle Methods
-
-    
     open override func awakeFromNib() {
         super.awakeFromNib()
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
@@ -1,85 +1,52 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="15G1108" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" customClass="ReaderTagStreamHeader" customModule="WordPress">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="72"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="168"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yok-SJ-qnw">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                </view>
-                <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="HdV-no-5Ds">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
-                    <subviews>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-reader-header-tag" translatesAutoresizingMaskIntoConstraints="NO" id="OeG-5o-P7K">
-                            <rect key="frame" x="16" y="16" width="32" height="32"/>
-                            <color key="backgroundColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.88235294117647056" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="32" id="Lw5-mV-4oQ"/>
-                                <constraint firstAttribute="width" priority="999" constant="32" id="g5H-RL-frL"/>
-                            </constraints>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="240" text="Tagname" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="f85-bJ-w04">
-                            <rect key="frame" x="58" y="23.5" width="194" height="17"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S0E-MM-cCj" customClass="PostMetaButton">
-                            <rect key="frame" x="262" y="17.5" width="42" height="29"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="0.0" maxY="0.0"/>
-                            <state key="normal" title="Follow">
-                                <color key="titleColor" red="0.0" green="0.50196081399917603" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="selected">
-                                <color key="titleColor" red="0.29019607843137252" green="0.72156862745098038" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
-                            </state>
-                            <state key="highlighted">
-                                <color key="titleColor" red="0.47058823529411764" green="0.86274509803921573" blue="0.98039215686274506" alpha="1" colorSpace="calibratedRGB"/>
-                            </state>
-                            <connections>
-                                <action selector="didTapFollowButton:" destination="iN0-l3-epB" eventType="touchUpInside" id="Yxp-WC-ada"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
-                </stackView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yMm-WX-1gb">
+                    <rect key="frame" x="187.66666666666666" y="40" width="0.0" height="0.0"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gN8-Rn-2M3">
+                    <rect key="frame" x="160.66666666666666" y="60" width="54" height="68"/>
+                    <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <state key="normal" title="Button">
+                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </state>
+                    <connections>
+                        <action selector="didTapFollowButton:" destination="iN0-l3-epB" eventType="touchUpInside" id="j2i-aS-tUw"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="HdV-no-5Ds" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="24g-Cp-PBm"/>
-                <constraint firstItem="yok-SJ-qnw" firstAttribute="top" secondItem="HdV-no-5Ds" secondAttribute="top" id="2zt-6X-2gQ"/>
-                <constraint firstItem="yok-SJ-qnw" firstAttribute="trailing" secondItem="HdV-no-5Ds" secondAttribute="trailing" id="7E2-xw-h1M"/>
-                <constraint firstItem="HdV-no-5Ds" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="hwr-CE-JBR"/>
-                <constraint firstItem="yok-SJ-qnw" firstAttribute="leading" secondItem="HdV-no-5Ds" secondAttribute="leading" id="kmU-nj-5bd"/>
-                <constraint firstAttribute="trailing" secondItem="HdV-no-5Ds" secondAttribute="trailing" id="tm8-ZX-h98"/>
-                <constraint firstAttribute="bottom" secondItem="HdV-no-5Ds" secondAttribute="bottom" priority="999" constant="8" id="voz-yM-sep"/>
-                <constraint firstItem="yok-SJ-qnw" firstAttribute="bottom" secondItem="HdV-no-5Ds" secondAttribute="bottom" id="z96-Jg-zLC"/>
+                <constraint firstItem="gN8-Rn-2M3" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="0ga-1S-GtT"/>
+                <constraint firstItem="gN8-Rn-2M3" firstAttribute="top" secondItem="yMm-WX-1gb" secondAttribute="bottom" constant="20" id="554-ja-cGb"/>
+                <constraint firstItem="yMm-WX-1gb" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="40" id="8dj-78-13r"/>
+                <constraint firstItem="yMm-WX-1gb" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="S6J-qa-Lem"/>
+                <constraint firstAttribute="bottom" secondItem="gN8-Rn-2M3" secondAttribute="bottom" constant="40" id="mzP-6y-xip"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="borderedView" destination="yok-SJ-qnw" id="JJE-ob-9Iq"/>
-                <outlet property="followButton" destination="S0E-MM-cCj" id="PEW-za-Q8v"/>
-                <outlet property="titleLabel" destination="f85-bJ-w04" id="fKz-3G-lF4"/>
+                <outlet property="followButton" destination="gN8-Rn-2M3" id="Htf-nc-scN"/>
+                <outlet property="titleLabel" destination="yMm-WX-1gb" id="3v5-vk-Kw0"/>
             </connections>
+            <point key="canvasLocation" x="139" y="155"/>
         </view>
     </objects>
-    <resources>
-        <image name="icon-reader-header-tag" width="24" height="24"/>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
@@ -30,7 +30,7 @@
                     </connections>
                 </button>
             </subviews>
-            <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="tintColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="gN8-Rn-2M3" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="0ga-1S-GtT"/>
                 <constraint firstItem="gN8-Rn-2M3" firstAttribute="top" secondItem="yMm-WX-1gb" secondAttribute="bottom" constant="20" id="554-ja-cGb"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
@@ -30,6 +30,7 @@
                     </connections>
                 </button>
             </subviews>
+            <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <color key="tintColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="gN8-Rn-2M3" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="0ga-1S-GtT"/>

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -236,7 +236,7 @@ extension WPStyleGuide {
     // MARK: - Apply Stream Header Styles
 
     @objc public class func applyReaderStreamHeaderTitleStyle(_ label: UILabel) {
-        WPStyleGuide.configureLabel(label, textStyle: Cards.buttonTextStyle)
+        label.font = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .bold)
         label.textColor = .text
     }
 
@@ -323,6 +323,49 @@ extension WPStyleGuide {
         button.setTitleColor(normalColor, for: UIControl.State())
         button.setTitleColor(highlightedColor, for: .highlighted)
         button.setTitleColor(selectedColor, for: .selected)
+    }
+
+
+    @objc public class func applyReaderFollowTopicButtonStyle(_ button: UIButton) {
+        let side = WPStyleGuide.fontSizeForTextStyle(.headline)
+        let size = CGSize(width: side, height: side)
+
+        let followIcon = UIImage.gridicon(.readerFollow, size: size)
+        let followingIcon = UIImage.gridicon(.readerFollowing, size: size)
+        
+        button.titleLabel?.font = fontForTextStyle(.headline, fontWeight: .semibold)
+        button.layer.cornerRadius = 4.0
+        
+        let followBackgroundColor: UIColor = .primaryButtonBackground
+        let followTextColor: UIColor = .white
+        let followingBackgroundColor: UIColor = .basicBackground
+        let followingTextColor: UIColor = .textSubtle
+
+        button.backgroundColor = button.isSelected ? followingBackgroundColor : followBackgroundColor
+        button.tintColor = button.isSelected ? followingTextColor : followTextColor
+        
+        button.setTitleColor(followTextColor, for: .normal)
+        button.setTitleColor(followingTextColor, for: .selected)
+
+        let imageTitleSpace: CGFloat = 2.0
+        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: -imageTitleSpace, bottom: 0, right: imageTitleSpace)
+        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: imageTitleSpace, bottom: 0, right: -imageTitleSpace)
+        button.contentEdgeInsets = UIEdgeInsets(top: 6.0, left: 12.0, bottom: 6.0, right: 12.0)
+
+        let tintedFollowIcon = followIcon.imageWithTintColor(followTextColor)
+        let tintedFollowingIcon = followingIcon.imageWithTintColor(followingTextColor)
+
+        button.setImage(tintedFollowIcon, for: .normal)
+        button.setImage(tintedFollowingIcon, for: .selected)
+
+        button.setTitle(followStringForDisplay, for: .normal)
+        button.setTitle(followingStringForDisplay, for: .selected)
+        
+        button.layer.borderWidth = button.isSelected ? 1.0 : 0.0
+        
+        // Default accessibility label and hint.
+        button.accessibilityLabel = button.isSelected ? followingStringForDisplay : followStringForDisplay
+        button.accessibilityHint = NSLocalizedString("Follows the tag.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")
     }
 
     @objc public class func applyReaderSaveForLaterButtonStyle(_ button: UIButton) {

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -585,13 +585,13 @@ extension WPStyleGuide {
             static let followTextColor: UIColor = .white
             static let followingBackgroundColor: UIColor = .basicBackground
             static let followingTextColor: UIColor = .textSubtle
-            
+
             static let imageTitleSpace: CGFloat = 2.0
             static let imageEdgeInsets = UIEdgeInsets(top: 0, left: -imageTitleSpace, bottom: 0, right: imageTitleSpace)
             static let titleEdgeInsets = UIEdgeInsets(top: 0, left: imageTitleSpace, bottom: 0, right: -imageTitleSpace)
             static let contentEdgeInsets = UIEdgeInsets(top: 6.0, left: 12.0, bottom: 6.0, right: 12.0)
         }
-        
+
         struct Text {
             static let accessibilityHint = NSLocalizedString("Follows the tag.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")
             static let followStringForDisplay =  NSLocalizedString("Follow", comment: "Verb. Button title. Follow a new blog.")

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -332,7 +332,7 @@ extension WPStyleGuide {
 
         let followIcon = UIImage.gridicon(.readerFollow, size: size)
         let followingIcon = UIImage.gridicon(.readerFollowing, size: size)
-        
+
         button.titleLabel?.font = fontForTextStyle(.headline, fontWeight: .semibold)
         button.layer.cornerRadius = 4.0
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -578,7 +578,7 @@ extension WPStyleGuide {
         public static let titleTextStyle: UIFont.TextStyle = .title1
         public static let contentTextStyle: UIFont.TextStyle = .callout
     }
-    
+
     public struct FollowButton {
         struct Style {
             static let followBackgroundColor: UIColor = .primaryButtonBackground

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -335,7 +335,7 @@ extension WPStyleGuide {
         
         button.titleLabel?.font = fontForTextStyle(.headline, fontWeight: .semibold)
         button.layer.cornerRadius = 4.0
-        
+
         let followBackgroundColor: UIColor = .primaryButtonBackground
         let followTextColor: UIColor = .white
         let followingBackgroundColor: UIColor = .basicBackground
@@ -343,7 +343,7 @@ extension WPStyleGuide {
 
         button.backgroundColor = button.isSelected ? followingBackgroundColor : followBackgroundColor
         button.tintColor = button.isSelected ? followingTextColor : followTextColor
-        
+
         button.setTitleColor(followTextColor, for: .normal)
         button.setTitleColor(followingTextColor, for: .selected)
 
@@ -360,9 +360,9 @@ extension WPStyleGuide {
 
         button.setTitle(followStringForDisplay, for: .normal)
         button.setTitle(followingStringForDisplay, for: .selected)
-        
+
         button.layer.borderWidth = button.isSelected ? 1.0 : 0.0
-        
+
         // Default accessibility label and hint.
         button.accessibilityLabel = button.isSelected ? followingStringForDisplay : followStringForDisplay
         button.accessibilityHint = NSLocalizedString("Follows the tag.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -316,9 +316,9 @@ extension WPStyleGuide {
         button.setImage(tintedFollowingIcon, for: .selected)
         button.setImage(highlightIcon, for: .highlighted)
 
-        button.setTitle(followStringForDisplay, for: UIControl.State())
-        button.setTitle(followingStringForDisplay, for: .selected)
-        button.setTitle(followingStringForDisplay, for: .highlighted)
+        button.setTitle(FollowButton.Text.followStringForDisplay, for: UIControl.State())
+        button.setTitle(FollowButton.Text.followingStringForDisplay, for: .selected)
+        button.setTitle(FollowButton.Text.followingStringForDisplay, for: .highlighted)
 
         button.setTitleColor(normalColor, for: UIControl.State())
         button.setTitleColor(highlightedColor, for: .highlighted)
@@ -336,36 +336,30 @@ extension WPStyleGuide {
         button.titleLabel?.font = fontForTextStyle(.headline, fontWeight: .semibold)
         button.layer.cornerRadius = 4.0
 
-        let followBackgroundColor: UIColor = .primaryButtonBackground
-        let followTextColor: UIColor = .white
-        let followingBackgroundColor: UIColor = .basicBackground
-        let followingTextColor: UIColor = .textSubtle
+        button.backgroundColor = button.isSelected ? FollowButton.Style.followingBackgroundColor : FollowButton.Style.followBackgroundColor
+        button.tintColor = button.isSelected ? FollowButton.Style.followingTextColor : FollowButton.Style.followTextColor
 
-        button.backgroundColor = button.isSelected ? followingBackgroundColor : followBackgroundColor
-        button.tintColor = button.isSelected ? followingTextColor : followTextColor
+        button.setTitleColor(FollowButton.Style.followTextColor, for: .normal)
+        button.setTitleColor(FollowButton.Style.followingTextColor, for: .selected)
 
-        button.setTitleColor(followTextColor, for: .normal)
-        button.setTitleColor(followingTextColor, for: .selected)
+        button.imageEdgeInsets = FollowButton.Style.imageEdgeInsets
+        button.titleEdgeInsets = FollowButton.Style.titleEdgeInsets
+        button.contentEdgeInsets = FollowButton.Style.contentEdgeInsets
 
-        let imageTitleSpace: CGFloat = 2.0
-        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: -imageTitleSpace, bottom: 0, right: imageTitleSpace)
-        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: imageTitleSpace, bottom: 0, right: -imageTitleSpace)
-        button.contentEdgeInsets = UIEdgeInsets(top: 6.0, left: 12.0, bottom: 6.0, right: 12.0)
-
-        let tintedFollowIcon = followIcon.imageWithTintColor(followTextColor)
-        let tintedFollowingIcon = followingIcon.imageWithTintColor(followingTextColor)
+        let tintedFollowIcon = followIcon.imageWithTintColor(FollowButton.Style.followTextColor)
+        let tintedFollowingIcon = followingIcon.imageWithTintColor(FollowButton.Style.followingTextColor)
 
         button.setImage(tintedFollowIcon, for: .normal)
         button.setImage(tintedFollowingIcon, for: .selected)
 
-        button.setTitle(followStringForDisplay, for: .normal)
-        button.setTitle(followingStringForDisplay, for: .selected)
+        button.setTitle(FollowButton.Text.followStringForDisplay, for: .normal)
+        button.setTitle(FollowButton.Text.followingStringForDisplay, for: .selected)
 
         button.layer.borderWidth = button.isSelected ? 1.0 : 0.0
 
         // Default accessibility label and hint.
-        button.accessibilityLabel = button.isSelected ? followingStringForDisplay : followStringForDisplay
-        button.accessibilityHint = NSLocalizedString("Follows the tag.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")
+        button.accessibilityLabel = button.isSelected ? FollowButton.Text.followingStringForDisplay : FollowButton.Text.followStringForDisplay
+        button.accessibilityHint = FollowButton.Text.accessibilityHint
     }
 
     @objc public class func applyReaderSaveForLaterButtonStyle(_ button: UIButton) {
@@ -505,14 +499,6 @@ extension WPStyleGuide {
         }
     }
 
-    @objc public static var followStringForDisplay: String {
-        return NSLocalizedString("Follow", comment: "Verb. Button title. Follow a new blog.")
-    }
-
-    @objc public static var followingStringForDisplay: String {
-        return NSLocalizedString("Following", comment: "Verb. Button title. The user is following a blog.")
-    }
-
     @objc public class func savePostStringForDisplay(_ isSaved: Bool) -> String {
         if isSaved {
             return NSLocalizedString("Saved", comment: "Title of action button for a Reader post that has been saved to read later.")
@@ -592,5 +578,24 @@ extension WPStyleGuide {
         public static let titleTextStyle: UIFont.TextStyle = .title1
         public static let contentTextStyle: UIFont.TextStyle = .callout
     }
-
+    
+    public struct FollowButton {
+        struct Style {
+            static let followBackgroundColor: UIColor = .primaryButtonBackground
+            static let followTextColor: UIColor = .white
+            static let followingBackgroundColor: UIColor = .basicBackground
+            static let followingTextColor: UIColor = .textSubtle
+            
+            static let imageTitleSpace: CGFloat = 2.0
+            static let imageEdgeInsets = UIEdgeInsets(top: 0, left: -imageTitleSpace, bottom: 0, right: imageTitleSpace)
+            static let titleEdgeInsets = UIEdgeInsets(top: 0, left: imageTitleSpace, bottom: 0, right: -imageTitleSpace)
+            static let contentEdgeInsets = UIEdgeInsets(top: 6.0, left: 12.0, bottom: 6.0, right: 12.0)
+        }
+        
+        struct Text {
+            static let accessibilityHint = NSLocalizedString("Follows the tag.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")
+            static let followStringForDisplay =  NSLocalizedString("Follow", comment: "Verb. Button title. Follow a new blog.")
+            static let followingStringForDisplay = NSLocalizedString("Following", comment: "Verb. Button title. The user is following a blog.")
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -335,6 +335,7 @@ extension WPStyleGuide {
 
         button.titleLabel?.font = fontForTextStyle(.headline, fontWeight: .semibold)
         button.layer.cornerRadius = 4.0
+        button.layer.borderColor = UIColor(light: .gray(.shade30), dark: .gray(.shade60)).cgColor
 
         button.backgroundColor = button.isSelected ? FollowButton.Style.followingBackgroundColor : FollowButton.Style.followBackgroundColor
         button.tintColor = button.isSelected ? FollowButton.Style.followingTextColor : FollowButton.Style.followTextColor

--- a/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
@@ -1,38 +1,20 @@
 {
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
   "colors" : [
     {
+      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
+          "red" : "142",
           "alpha" : "1.000",
           "blue" : "150",
-          "green" : "145",
-          "red" : "142"
+          "green" : "145"
         }
-      },
-      "idiom" : "universal"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.369",
-          "green" : "0.341",
-          "red" : "0.314"
-        }
-      },
-      "idiom" : "universal"
+      }
     }
-  ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
-  }
+  ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  },
   "colors" : [
     {
-      "idiom" : "universal",
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "red" : "142",
           "alpha" : "1.000",
           "blue" : "150",
-          "green" : "145"
+          "green" : "145",
+          "red" : "142"
         }
-      }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.369",
+          "green" : "0.341",
+          "red" : "0.314"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }


### PR DESCRIPTION
This PR updates the topic header according to designs. 
It also removes the "old" header from a filtered following stream since the filter bar already shows the topic and the user is already in the Following tab (screenshots to explain more)

 ### Filtered Following screen - removed header
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1335657/88441824-2fa8d080-cdc7-11ea-8ca5-38cdee8829ef.PNG)  |  ![](https://user-images.githubusercontent.com/1335657/88441235-57973480-cdc5-11ea-8afa-3da1b8835591.png)

### Topic page header before
Follow              |  Following
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1335657/88441878-5f57d880-cdc7-11ea-9926-8f6375b496fd.PNG)  |  ![](https://user-images.githubusercontent.com/1335657/88441928-81515b00-cdc7-11ea-83eb-5e3ab6d2df14.PNG)

### Topic page header After - Dark mode
Follow              |  Following
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1335657/88445411-5242e580-cdd7-11ea-8d69-14f59e0f91f8.png)  |  ![](https://user-images.githubusercontent.com/1335657/88445410-4f47f500-cdd7-11ea-988d-548facde47c2.png)

### Topic page header After - Light mode 
Follow              |  Following
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1335657/88445412-52db7c00-cdd7-11ea-828c-84c38a5903c9.png)  |  ![](https://user-images.githubusercontent.com/1335657/88445413-53741280-cdd7-11ea-8fee-3f00ec5be05b.png)

To test:

Filtered Following:
1. Open the reader
2. Tap on filter 
3. Tap on Tags
4. Tap on a tag
5. See no header 
6. Remove filter and make sure everything works 

Topic page
1. Tap on an article tag 
2. See topic page according to new designs 
3. Make sure things look good in dark and light mode

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
