### PR TITLE
Fix offline support for posts

### DIFF
--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -224,6 +224,10 @@ class Post: AbstractPost {
         return (tags?.trim().count > 0)
     }
 
+    override func authorForDisplay() -> String? {
+        return author ?? blog.account?.displayName
+    }
+
     // MARK: - BasePost
 
     override func contentPreviewForDisplay() -> String {

--- a/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
+++ b/WordPress/Classes/Services/PostService+MarkAsFailedAndDraftIfNeeded.swift
@@ -27,7 +27,6 @@
         }
 
         post.remoteStatus = .failed
-        post.author = post.blog.account?.displayName
 
         if !post.hasRemote() && post is Page {
             post.status = .draft

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -8,13 +8,12 @@ import Foundation
 final class BlogBuilder {
     private let blog: Blog
 
-    init(_ context: NSManagedObjectContext) {
-        blog = NSEntityDescription.insertNewObject(forEntityName: Blog.entityName(), into: context) as! Blog
+    private let context: NSManagedObjectContext
 
-        // Add Account
-        let account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: context) as! WPAccount
-        account.displayName = "displayName"
-        blog.account = account
+    init(_ context: NSManagedObjectContext) {
+        self.context = context
+
+        blog = NSEntityDescription.insertNewObject(forEntityName: Blog.entityName(), into: context) as! Blog
 
         // Non-null properties in Core Data
         blog.dotComID = NSNumber(value: arc4random_uniform(UInt32.max))
@@ -28,6 +27,15 @@ final class BlogBuilder {
             "value": atomic ? 1 : 0
         ]
         blog.options = options
+
+        return self
+    }
+
+    func withAnAccount() -> Self {
+        // Add Account
+        let account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: context) as! WPAccount
+        account.displayName = "displayName"
+        blog.account = account
 
         return self
     }

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -11,6 +11,11 @@ final class BlogBuilder {
     init(_ context: NSManagedObjectContext) {
         blog = NSEntityDescription.insertNewObject(forEntityName: Blog.entityName(), into: context) as! Blog
 
+        // Add Account
+        let account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: context) as! WPAccount
+        account.displayName = "displayName"
+        blog.account = account
+
         // Non-null properties in Core Data
         blog.dotComID = NSNumber(value: arc4random_uniform(UInt32.max))
         blog.url = "https://example.com"

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -34,7 +34,8 @@ class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
     }
 
     func testMarkAPostAsFailedKeepShouldAttemptAutoUpload() {
-        let post = PostBuilder(context)
+        let blog = BlogBuilder(context).withAnAccount().build()
+        let post = PostBuilder(context, blog: blog)
             .with(status: .pending)
             .confirmedAutoUpload()
             .build()

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -33,6 +33,18 @@ class PostServiceMarkAsFailedAndDraftIfNeededTests: XCTestCase {
         expect(post.status).to(equal(.pending))
     }
 
+    func testMarkAPostAsFailedKeepShouldAttemptAutoUpload() {
+        let post = PostBuilder(context)
+            .with(status: .pending)
+            .confirmedAutoUpload()
+            .build()
+        let postService = PostService()
+
+        postService.markAsFailedAndDraftIfNeeded(post: post)
+
+        expect(post.shouldAttemptAutoUpload).to(beTrue())
+    }
+
     func testMarksALocalPageAsFailedAndResetsItToDraft() {
         let page = PageBuilder(context)
             .with(status: .publish)


### PR DESCRIPTION
Fixes #14493

This PR fixes offline support regression caused by a single and small line change. 🙃

A unit test was added to make sure the regression will not happen again. 

### To test

#### Offline Support

1. Go offline
2. Create a new post and publish it
3. Check that the message says "We'll publish your post..."
4. Go back online and make sure the post is **published**

#### Author username

1. Go offline
2. Create a new post and publish it
3. In the post list, make sure to select _Everyone_ to see posts from all users
4. Check that your post has your username

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
