### PR TITLE
Remove inline styles from Reader post's content

### DIFF
--- a/WordPress/Classes/Models/ReaderPost.m
+++ b/WordPress/Classes/Models/ReaderPost.m
@@ -172,7 +172,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     }
 
     if ([Feature enabled:FeatureFlagReaderWebview]) {
-        post.content = [RichContentFormatter removeForbiddenTags:remotePost.content];
+        post.content = [RichContentFormatter removeInlineStyles:[RichContentFormatter removeForbiddenTags:remotePost.content]];
     } else {
         post.content = [RichContentFormatter formatContentString:remotePost.content isPrivateSite:remotePost.isBlogPrivate];
     }


### PR DESCRIPTION
Fixes #14531

This PR removes all the inline `style` in a Reader post's content.

We do this to prevent weird styles from showing in the Reader, like this:

<img src="https://user-images.githubusercontent.com/7040243/88669421-40ed2800-d0ba-11ea-80ba-a794a2954952.jpg" width="300" />

### To test

1. Create a post in a blog you follow
2. Add the timeline block
3. Fill with some content
4. Go to the Reader
5. Open your post
6. Make sure that no grey background appears (test in both light and dark mode)

You can also add any other `style` tag you want and test (custom colors, size, etc). The style should not appear.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
