### PR TITLE
Fix buttons border not visible in QuickStart suggestions

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+Notice.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+Notice.swift
@@ -30,4 +30,13 @@ extension UIColor {
     static var invertedLink: UIColor {
         UIColor(light: .primary(.shade30), dark: .primary(.shade50))
     }
+
+    static var invertedSeparator: UIColor {
+        if #available(iOS 13.0, *) {
+            return UIColor(light: UIColor.separator.color(for: UITraitCollection(userInterfaceStyle: .dark)),
+                           dark: UIColor.separator.color(for: UITraitCollection(userInterfaceStyle: .light)))
+        } else {
+            return UIColor(displayP3Red: 84/255, green: 84/255, blue: 88/255, alpha: 0.6)
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -356,7 +356,7 @@ fileprivate extension UIView {
 
     func makeBorderView() -> UIView {
         let borderView = UIView()
-        borderView.backgroundColor = Constants.borderColor
+        borderView.backgroundColor = .invertedSeparator
         borderView.translatesAutoresizingMaskIntoConstraints = false
         self.addSubview(borderView)
 
@@ -364,7 +364,6 @@ fileprivate extension UIView {
     }
 
     struct Constants {
-        static let borderColor = UIColor.white.withAlphaComponent(0.25)
         static let visualEffect = UIBlurEffect(style: .extraLight)
     }
 }


### PR DESCRIPTION

ref #14524, #14136

To test:

- create a new WordPress.com site and, when prompted, tap "Yes, help me"
- follow the Quick Start suggestions and verify that the border of the buttons are visible in both light and dark mode, as well as on iOS 12

here are example screenshots of how they should look like

light appearance | dark appearance
--- | --- 
 <img width="420" alt="quickstart_suggest_light" src="https://user-images.githubusercontent.com/34376330/88739291-d65edb00-d0ff-11ea-8e88-0b5154b0e20b.png"> | <img width="420" alt="quickstart_suggest_dark" src="https://user-images.githubusercontent.com/34376330/88739329-eb3b6e80-d0ff-11ea-8926-bc73a10c0547.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
