### PR TITLE
Update site header UI 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 15.5
 -----
+* [*] Reader: revamped UI for your site header.
  
 15.4
 -----

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -26,11 +26,10 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 
 
 @objc open class ReaderSiteStreamHeader: UIView, ReaderStreamHeader {
-    @IBOutlet fileprivate weak var borderedView: UIView!
     @IBOutlet fileprivate weak var avatarImageView: UIImageView!
     @IBOutlet fileprivate weak var titleLabel: UILabel!
     @IBOutlet fileprivate weak var detailLabel: UILabel!
-    @IBOutlet fileprivate weak var followButton: PostMetaButton!
+    @IBOutlet fileprivate weak var followButton: UIButton!
     @IBOutlet fileprivate weak var followCountLabel: UILabel!
     @IBOutlet fileprivate weak var descriptionLabel: UILabel!
 
@@ -46,10 +45,6 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     }
 
     @objc func applyStyles() {
-        backgroundColor = .listBackground
-        borderedView.backgroundColor = .listForeground
-        borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = .hairlineBorderWidth
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)
         WPStyleGuide.applyReaderStreamHeaderDetailStyle(detailLabel)
         WPStyleGuide.applyReaderSiteStreamDescriptionStyle(descriptionLabel)
@@ -69,7 +64,7 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         titleLabel.text = siteTopic.title
         detailLabel.text = URL(string: siteTopic.siteURL)?.host
 
-        WPStyleGuide.applyReaderFollowButtonStyle(followButton)
+        WPStyleGuide.applyReaderFollowSiteButtonStyle(followButton)
         followButton.isSelected = topic.following
 
         descriptionLabel.attributedText = attributedSiteDescriptionForTopic(siteTopic)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -14,39 +14,39 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="w1n-O9-Da1" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                    <rect key="frame" x="16" y="24" width="128" height="128"/>
+                    <rect key="frame" x="16" y="16" width="128" height="128"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="128" id="FHE-VZ-Id4"/>
                         <constraint firstAttribute="width" constant="128" id="Nqe-yU-Zya"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqV-yA-rBc">
-                    <rect key="frame" x="164" y="24" width="219" height="20.333333333333329"/>
+                    <rect key="frame" x="164" y="15.999999999999998" width="219" height="20.333333333333329"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fq2-Xh-dYx">
-                    <rect key="frame" x="164" y="48.333333333333336" width="41.666666666666657" height="20.333333333333336"/>
+                    <rect key="frame" x="164" y="40.333333333333336" width="41.666666666666657" height="20.333333333333336"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
-                    <rect key="frame" x="164" y="84.666666666666671" width="30" height="34"/>
+                    <rect key="frame" x="164" y="76.666666666666671" width="30" height="34"/>
                     <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <connections>
                         <action selector="didTapFollowButton:" destination="QDT-3t-9yR" eventType="touchUpInside" id="dRK-lH-Zga"/>
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mi7-dO-TOF">
-                    <rect key="frame" x="16" y="157.66666666666666" width="343" height="20.333333333333343"/>
+                    <rect key="frame" x="16" y="149.66666666666666" width="343" height="20.333333333333343"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHO-IY-cyK">
-                    <rect key="frame" x="164" y="122.66666666666669" width="31" height="15"/>
+                    <rect key="frame" x="164" y="114.66666666666667" width="31" height="15.000000000000014"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -68,7 +68,7 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fq2-Xh-dYx" secondAttribute="trailing" constant="20" id="guR-fw-H6i"/>
                 <constraint firstItem="jvF-YL-IV0" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="nuq-AR-loX"/>
                 <constraint firstAttribute="trailing" secondItem="QqV-yA-rBc" secondAttribute="trailingMargin" id="qUa-8H-hSo"/>
-                <constraint firstItem="w1n-O9-Da1" firstAttribute="top" secondItem="QDT-3t-9yR" secondAttribute="top" constant="24" id="ssc-l7-h6V"/>
+                <constraint firstItem="w1n-O9-Da1" firstAttribute="top" secondItem="QDT-3t-9yR" secondAttribute="top" constant="16" id="ssc-l7-h6V"/>
                 <constraint firstItem="QqV-yA-rBc" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="trailing" constant="20" id="uve-ck-hpx"/>
                 <constraint firstItem="jvF-YL-IV0" firstAttribute="top" secondItem="fq2-Xh-dYx" secondAttribute="bottom" constant="16" id="why-cC-543"/>
             </constraints>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -9,67 +9,68 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="QDT-3t-9yR" customClass="ReaderSiteStreamHeader" customModule="WordPress" customModuleProvider="target">
+        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" id="QDT-3t-9yR" customClass="ReaderSiteStreamHeader" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="375" height="251"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="w1n-O9-Da1" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                    <rect key="frame" x="20" y="24" width="112" height="112"/>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="w1n-O9-Da1" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                    <rect key="frame" x="16" y="24" width="128" height="128"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="112" id="FHE-VZ-Id4"/>
-                        <constraint firstAttribute="width" constant="112" id="Nqe-yU-Zya"/>
+                        <constraint firstAttribute="height" constant="128" id="FHE-VZ-Id4"/>
+                        <constraint firstAttribute="width" constant="128" id="Nqe-yU-Zya"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqV-yA-rBc">
-                    <rect key="frame" x="152" y="24" width="41.666666666666657" height="20.333333333333329"/>
+                    <rect key="frame" x="164" y="24" width="219" height="20.333333333333329"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fq2-Xh-dYx">
-                    <rect key="frame" x="152" y="52.333333333333336" width="41.666666666666657" height="20.333333333333336"/>
+                    <rect key="frame" x="164" y="48.333333333333336" width="41.666666666666657" height="20.333333333333336"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
-                    <rect key="frame" x="152" y="92.666666666666671" width="30" height="34"/>
+                    <rect key="frame" x="164" y="84.666666666666671" width="30" height="34"/>
                     <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <connections>
                         <action selector="didTapFollowButton:" destination="QDT-3t-9yR" eventType="touchUpInside" id="dRK-lH-Zga"/>
                     </connections>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHO-IY-cyK">
-                    <rect key="frame" x="60.666666666666657" y="142" width="31" height="15"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mi7-dO-TOF">
-                    <rect key="frame" x="19.999999999999996" y="177" width="41.666666666666657" height="20.333333333333343"/>
+                    <rect key="frame" x="16" y="157.66666666666666" width="343" height="20.333333333333343"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHO-IY-cyK">
+                    <rect key="frame" x="164" y="122.66666666666669" width="31" height="15"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color key="tintColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="mi7-dO-TOF" firstAttribute="top" secondItem="JHO-IY-cyK" secondAttribute="bottom" constant="20" id="5pv-Dj-zWG"/>
-                <constraint firstItem="w1n-O9-Da1" firstAttribute="leading" secondItem="QDT-3t-9yR" secondAttribute="leading" constant="20" id="AIG-RK-eJh"/>
-                <constraint firstItem="JHO-IY-cyK" firstAttribute="centerX" secondItem="w1n-O9-Da1" secondAttribute="centerX" id="JWv-qR-BQi"/>
+                <constraint firstItem="w1n-O9-Da1" firstAttribute="leading" secondItem="QDT-3t-9yR" secondAttribute="leadingMargin" id="AIG-RK-eJh"/>
                 <constraint firstItem="QqV-yA-rBc" firstAttribute="top" secondItem="w1n-O9-Da1" secondAttribute="top" id="Ljb-Gh-VRJ"/>
-                <constraint firstItem="fq2-Xh-dYx" firstAttribute="top" secondItem="QqV-yA-rBc" secondAttribute="bottom" constant="8" id="Poh-ai-8cd"/>
+                <constraint firstItem="fq2-Xh-dYx" firstAttribute="top" secondItem="QqV-yA-rBc" secondAttribute="bottom" constant="4" id="Poh-ai-8cd"/>
                 <constraint firstItem="fq2-Xh-dYx" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="SQK-NR-gJ1"/>
-                <constraint firstItem="JHO-IY-cyK" firstAttribute="top" secondItem="w1n-O9-Da1" secondAttribute="bottom" constant="6" id="VoM-PV-43m"/>
+                <constraint firstItem="JHO-IY-cyK" firstAttribute="top" secondItem="jvF-YL-IV0" secondAttribute="bottom" constant="4" id="VoM-PV-43m"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="mi7-dO-TOF" secondAttribute="bottom" constant="16" id="Zc9-ns-Y8r"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mi7-dO-TOF" secondAttribute="trailing" constant="16" id="blt-Tr-kwH"/>
+                <constraint firstItem="JHO-IY-cyK" firstAttribute="leading" secondItem="fq2-Xh-dYx" secondAttribute="leading" id="bkn-wr-ADc"/>
+                <constraint firstAttribute="trailingMargin" secondItem="mi7-dO-TOF" secondAttribute="trailing" id="blt-Tr-kwH"/>
                 <constraint firstItem="mi7-dO-TOF" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="leading" id="eAG-pR-tpk"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fq2-Xh-dYx" secondAttribute="trailing" constant="20" id="guR-fw-H6i"/>
                 <constraint firstItem="jvF-YL-IV0" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="nuq-AR-loX"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QqV-yA-rBc" secondAttribute="trailing" constant="20" id="qUa-8H-hSo"/>
+                <constraint firstAttribute="trailing" secondItem="QqV-yA-rBc" secondAttribute="trailingMargin" id="qUa-8H-hSo"/>
                 <constraint firstItem="w1n-O9-Da1" firstAttribute="top" secondItem="QDT-3t-9yR" secondAttribute="top" constant="24" id="ssc-l7-h6V"/>
                 <constraint firstItem="QqV-yA-rBc" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="trailing" constant="20" id="uve-ck-hpx"/>
-                <constraint firstItem="jvF-YL-IV0" firstAttribute="top" secondItem="fq2-Xh-dYx" secondAttribute="bottom" constant="20" id="why-cC-543"/>
+                <constraint firstItem="jvF-YL-IV0" firstAttribute="top" secondItem="fq2-Xh-dYx" secondAttribute="bottom" constant="16" id="why-cC-543"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -1,161 +1,86 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" customClass="ReaderSiteStreamHeader" customModule="WordPress">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="183"/>
-            <autoresizingMask key="autoresizingMask"/>
+        <view contentMode="scaleToFill" id="QDT-3t-9yR" customClass="ReaderSiteStreamHeader" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="340"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="xPh-QH-rhp">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="183"/>
-                    <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8ws-PJ-KvB">
-                            <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
-                            <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Qis-1y-KvO">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
-                                    <subviews>
-                                        <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="sng-2e-9Fd">
-                                            <rect key="frame" x="16" y="16" width="32" height="32"/>
-                                            <gestureRecognizers/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" constant="32" id="4fY-6f-21h"/>
-                                                <constraint firstAttribute="height" constant="32" id="DC5-LJ-Roc"/>
-                                            </constraints>
-                                        </imageView>
-                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ohA-OA-KJg">
-                                            <rect key="frame" x="58" y="16.5" width="194" height="31.5"/>
-                                            <subviews>
-                                                <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="251" horizontalCompressionResistancePriority="740" text="Author, Blog name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vHE-Md-jhn">
-                                                    <rect key="frame" x="0.0" y="0.0" width="194" height="17"/>
-                                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <color key="textColor" red="0.0" green="0.66666666669999997" blue="0.86274509799999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="740" verticalCompressionResistancePriority="740" text="Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t34-RL-Noo">
-                                                    <rect key="frame" x="0.0" y="17" width="194" height="14.5"/>
-                                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </stackView>
-                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="top" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QX0-Ya-vKs" customClass="PostMetaButton">
-                                            <rect key="frame" x="262" y="17.5" width="42" height="29"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="999" constant="32" id="iZj-HF-Xz8"/>
-                                            </constraints>
-                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                            <inset key="imageEdgeInsets" minX="0.0" minY="2" maxX="0.0" maxY="0.0"/>
-                                            <state key="normal" title="Follow">
-                                                <color key="titleColor" red="0.0" green="0.66666666669999997" blue="0.86274509799999999" alpha="1" colorSpace="calibratedRGB"/>
-                                            </state>
-                                            <state key="selected">
-                                                <color key="titleColor" red="0.2901960784" green="0.72156862749999995" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
-                                            </state>
-                                            <state key="highlighted">
-                                                <color key="titleColor" red="0.47058823529999999" green="0.86274509799999999" blue="0.98039215690000003" alpha="1" colorSpace="calibratedRGB"/>
-                                            </state>
-                                            <connections>
-                                                <action selector="didTapFollowButton:" destination="iN0-l3-epB" eventType="touchUpInside" id="Rh0-Sz-O9V"/>
-                                            </connections>
-                                        </button>
-                                    </subviews>
-                                    <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
-                                </stackView>
-                            </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            <constraints>
-                                <constraint firstAttribute="trailing" secondItem="Qis-1y-KvO" secondAttribute="trailing" id="FRg-gc-f0m"/>
-                                <constraint firstAttribute="bottom" secondItem="Qis-1y-KvO" secondAttribute="bottom" id="Lnc-9a-0ac"/>
-                                <constraint firstItem="Qis-1y-KvO" firstAttribute="leading" secondItem="8ws-PJ-KvB" secondAttribute="leading" id="Vkh-52-r1d"/>
-                                <constraint firstItem="Qis-1y-KvO" firstAttribute="top" secondItem="8ws-PJ-KvB" secondAttribute="top" id="lau-xy-1Lo"/>
-                            </constraints>
-                        </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BDq-6m-YPX">
-                            <rect key="frame" x="0.0" y="80" width="320" height="13"/>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        </view>
-                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="pPL-Lk-uSJ">
-                            <rect key="frame" x="0.0" y="109" width="320" height="19.5"/>
-                            <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Site description" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uvZ-h9-MUU">
-                                    <rect key="frame" x="16" y="0.0" width="288" height="19.5"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                                    <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                            </subviews>
-                            <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
-                        </stackView>
-                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="YIl-wa-h6D">
-                            <rect key="frame" x="0.0" y="144.5" width="320" height="38.5"/>
-                            <subviews>
-                                <view contentMode="scaleToFill" horizontalHuggingPriority="240" translatesAutoresizingMaskIntoConstraints="NO" id="olT-MT-DPn">
-                                    <rect key="frame" x="16" y="15" width="90.5" height="1"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="1" id="C4p-fx-ahc"/>
-                                    </constraints>
-                                </view>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="100 followers" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Y5o-aW-T7f">
-                                    <rect key="frame" x="122.5" y="8" width="75" height="14.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                    <color key="textColor" red="0.52941176469999995" green="0.65098039220000004" blue="0.73725490199999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <view contentMode="scaleToFill" horizontalHuggingPriority="240" translatesAutoresizingMaskIntoConstraints="NO" id="MHU-Fa-6Rd">
-                                    <rect key="frame" x="213.5" y="15" width="90.5" height="1"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="1" id="ab3-9s-zRC"/>
-                                    </constraints>
-                                </view>
-                            </subviews>
-                            <constraints>
-                                <constraint firstItem="Y5o-aW-T7f" firstAttribute="centerX" secondItem="YIl-wa-h6D" secondAttribute="centerX" id="FWX-ih-VYe"/>
-                            </constraints>
-                            <edgeInsets key="layoutMargins" top="8" left="16" bottom="16" right="16"/>
-                        </stackView>
-                    </subviews>
-                </stackView>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="w1n-O9-Da1" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                    <rect key="frame" x="16" y="24" width="90" height="90"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="90" id="FHE-VZ-Id4"/>
+                        <constraint firstAttribute="width" constant="90" id="Nqe-yU-Zya"/>
+                    </constraints>
+                </imageView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqV-yA-rBc">
+                    <rect key="frame" x="122.00000000000001" y="24" width="41.666666666666671" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fq2-Xh-dYx">
+                    <rect key="frame" x="122" y="53" width="42" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
+                    <rect key="frame" x="122" y="94" width="46" height="30"/>
+                    <state key="normal" title="Button"/>
+                    <connections>
+                        <action selector="didTapFollowButton:" destination="QDT-3t-9yR" eventType="touchUpInside" id="dRK-lH-Zga"/>
+                    </connections>
+                </button>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHO-IY-cyK">
+                    <rect key="frame" x="45.666666666666664" y="120" width="30.999999999999993" height="15"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mi7-dO-TOF">
+                    <rect key="frame" x="15.999999999999996" y="155" width="41.666666666666657" height="20.333333333333343"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
-                <constraint firstItem="xPh-QH-rhp" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="2Fo-ef-3ue"/>
-                <constraint firstAttribute="trailing" secondItem="xPh-QH-rhp" secondAttribute="trailing" id="Rfm-dj-BUB"/>
-                <constraint firstItem="xPh-QH-rhp" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="dbJ-R0-MaV"/>
-                <constraint firstAttribute="bottom" secondItem="xPh-QH-rhp" secondAttribute="bottom" id="pxN-sa-hXV"/>
+                <constraint firstItem="mi7-dO-TOF" firstAttribute="top" secondItem="JHO-IY-cyK" secondAttribute="bottom" constant="20" id="5pv-Dj-zWG"/>
+                <constraint firstItem="w1n-O9-Da1" firstAttribute="leading" secondItem="QDT-3t-9yR" secondAttribute="leading" constant="16" id="AIG-RK-eJh"/>
+                <constraint firstItem="JHO-IY-cyK" firstAttribute="centerX" secondItem="w1n-O9-Da1" secondAttribute="centerX" id="JWv-qR-BQi"/>
+                <constraint firstItem="QqV-yA-rBc" firstAttribute="top" secondItem="w1n-O9-Da1" secondAttribute="top" id="Ljb-Gh-VRJ"/>
+                <constraint firstItem="fq2-Xh-dYx" firstAttribute="top" secondItem="QqV-yA-rBc" secondAttribute="bottom" constant="8" id="Poh-ai-8cd"/>
+                <constraint firstItem="fq2-Xh-dYx" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="SQK-NR-gJ1"/>
+                <constraint firstItem="JHO-IY-cyK" firstAttribute="top" secondItem="w1n-O9-Da1" secondAttribute="bottom" constant="6" id="VoM-PV-43m"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="mi7-dO-TOF" secondAttribute="bottom" constant="16" id="Zc9-ns-Y8r"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mi7-dO-TOF" secondAttribute="trailing" constant="16" id="blt-Tr-kwH"/>
+                <constraint firstItem="mi7-dO-TOF" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="leading" id="eAG-pR-tpk"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fq2-Xh-dYx" secondAttribute="trailing" constant="16" id="guR-fw-H6i"/>
+                <constraint firstItem="jvF-YL-IV0" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="nuq-AR-loX"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QqV-yA-rBc" secondAttribute="trailing" constant="16" id="qUa-8H-hSo"/>
+                <constraint firstItem="w1n-O9-Da1" firstAttribute="top" secondItem="QDT-3t-9yR" secondAttribute="top" constant="24" id="ssc-l7-h6V"/>
+                <constraint firstItem="QqV-yA-rBc" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="trailing" constant="16" id="uve-ck-hpx"/>
+                <constraint firstItem="jvF-YL-IV0" firstAttribute="top" secondItem="fq2-Xh-dYx" secondAttribute="bottom" constant="20" id="why-cC-543"/>
             </constraints>
-            <nil key="simulatedStatusBarMetrics"/>
-            <nil key="simulatedTopBarMetrics"/>
-            <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="avatarImageView" destination="sng-2e-9Fd" id="7of-On-Qql"/>
-                <outlet property="borderedView" destination="8ws-PJ-KvB" id="C9R-Zq-iEQ"/>
-                <outlet property="descriptionLabel" destination="uvZ-h9-MUU" id="xoH-cv-YZl"/>
-                <outlet property="detailLabel" destination="t34-RL-Noo" id="DHm-Uq-SPU"/>
-                <outlet property="followButton" destination="QX0-Ya-vKs" id="Ok8-fk-N8h"/>
-                <outlet property="followCountLabel" destination="Y5o-aW-T7f" id="pQR-px-3FJ"/>
-                <outlet property="titleLabel" destination="vHE-Md-jhn" id="15m-Cd-g51"/>
+                <outlet property="avatarImageView" destination="w1n-O9-Da1" id="hV7-Pe-s6A"/>
+                <outlet property="descriptionLabel" destination="mi7-dO-TOF" id="vyT-Xy-U2P"/>
+                <outlet property="detailLabel" destination="fq2-Xh-dYx" id="ygC-Hp-5Xe"/>
+                <outlet property="followButton" destination="jvF-YL-IV0" id="EVa-VJ-sLt"/>
+                <outlet property="followCountLabel" destination="JHO-IY-cyK" id="Axc-dE-raX"/>
+                <outlet property="titleLabel" destination="QqV-yA-rBc" id="nYV-qu-I3d"/>
             </connections>
-            <point key="canvasLocation" x="624" y="409.7451274362819"/>
+            <point key="canvasLocation" x="616.79999999999995" y="45.443349753694584"/>
         </view>
     </objects>
-    <resources>
-        <image name="post-blavatar-placeholder" width="32" height="32"/>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -10,43 +10,43 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="QDT-3t-9yR" customClass="ReaderSiteStreamHeader" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="340"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="251"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="w1n-O9-Da1" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                    <rect key="frame" x="16" y="24" width="90" height="90"/>
+                    <rect key="frame" x="20" y="24" width="112" height="112"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="90" id="FHE-VZ-Id4"/>
-                        <constraint firstAttribute="width" constant="90" id="Nqe-yU-Zya"/>
+                        <constraint firstAttribute="height" constant="112" id="FHE-VZ-Id4"/>
+                        <constraint firstAttribute="width" constant="112" id="Nqe-yU-Zya"/>
                     </constraints>
                 </imageView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqV-yA-rBc">
-                    <rect key="frame" x="122.00000000000001" y="24" width="41.666666666666671" height="21"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqV-yA-rBc">
+                    <rect key="frame" x="152" y="24" width="41.666666666666657" height="20.333333333333329"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fq2-Xh-dYx">
-                    <rect key="frame" x="122" y="53" width="42" height="21"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fq2-Xh-dYx">
+                    <rect key="frame" x="152" y="52.333333333333336" width="41.666666666666657" height="20.333333333333336"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
-                    <rect key="frame" x="122" y="94" width="46" height="30"/>
-                    <state key="normal" title="Button"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
+                    <rect key="frame" x="152" y="92.666666666666671" width="30" height="34"/>
+                    <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <connections>
                         <action selector="didTapFollowButton:" destination="QDT-3t-9yR" eventType="touchUpInside" id="dRK-lH-Zga"/>
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHO-IY-cyK">
-                    <rect key="frame" x="45.666666666666664" y="120" width="30.999999999999993" height="15"/>
+                    <rect key="frame" x="60.666666666666657" y="142" width="31" height="15"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mi7-dO-TOF">
-                    <rect key="frame" x="15.999999999999996" y="155" width="41.666666666666657" height="20.333333333333343"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mi7-dO-TOF">
+                    <rect key="frame" x="19.999999999999996" y="177" width="41.666666666666657" height="20.333333333333343"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -55,7 +55,7 @@
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
                 <constraint firstItem="mi7-dO-TOF" firstAttribute="top" secondItem="JHO-IY-cyK" secondAttribute="bottom" constant="20" id="5pv-Dj-zWG"/>
-                <constraint firstItem="w1n-O9-Da1" firstAttribute="leading" secondItem="QDT-3t-9yR" secondAttribute="leading" constant="16" id="AIG-RK-eJh"/>
+                <constraint firstItem="w1n-O9-Da1" firstAttribute="leading" secondItem="QDT-3t-9yR" secondAttribute="leading" constant="20" id="AIG-RK-eJh"/>
                 <constraint firstItem="JHO-IY-cyK" firstAttribute="centerX" secondItem="w1n-O9-Da1" secondAttribute="centerX" id="JWv-qR-BQi"/>
                 <constraint firstItem="QqV-yA-rBc" firstAttribute="top" secondItem="w1n-O9-Da1" secondAttribute="top" id="Ljb-Gh-VRJ"/>
                 <constraint firstItem="fq2-Xh-dYx" firstAttribute="top" secondItem="QqV-yA-rBc" secondAttribute="bottom" constant="8" id="Poh-ai-8cd"/>
@@ -64,11 +64,11 @@
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="mi7-dO-TOF" secondAttribute="bottom" constant="16" id="Zc9-ns-Y8r"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mi7-dO-TOF" secondAttribute="trailing" constant="16" id="blt-Tr-kwH"/>
                 <constraint firstItem="mi7-dO-TOF" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="leading" id="eAG-pR-tpk"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fq2-Xh-dYx" secondAttribute="trailing" constant="16" id="guR-fw-H6i"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fq2-Xh-dYx" secondAttribute="trailing" constant="20" id="guR-fw-H6i"/>
                 <constraint firstItem="jvF-YL-IV0" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="nuq-AR-loX"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QqV-yA-rBc" secondAttribute="trailing" constant="16" id="qUa-8H-hSo"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QqV-yA-rBc" secondAttribute="trailing" constant="20" id="qUa-8H-hSo"/>
                 <constraint firstItem="w1n-O9-Da1" firstAttribute="top" secondItem="QDT-3t-9yR" secondAttribute="top" constant="24" id="ssc-l7-h6V"/>
-                <constraint firstItem="QqV-yA-rBc" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="trailing" constant="16" id="uve-ck-hpx"/>
+                <constraint firstItem="QqV-yA-rBc" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="trailing" constant="20" id="uve-ck-hpx"/>
                 <constraint firstItem="jvF-YL-IV0" firstAttribute="top" secondItem="fq2-Xh-dYx" secondAttribute="bottom" constant="20" id="why-cC-543"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -24,7 +24,7 @@ import WordPressShared
 
         if #available(iOS 13.0, *) {
             if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-                WPStyleGuide.applyReaderFollowTopicButtonStyle(followButton)
+                WPStyleGuide.applyReaderFollowButtonStyle(followButton)
             }
         }
     }
@@ -35,7 +35,7 @@ import WordPressShared
     @objc open func configureHeader(_ topic: ReaderAbstractTopic) {
         titleLabel.text = topic.title
         followButton.isSelected = topic.following
-        WPStyleGuide.applyReaderFollowTopicButtonStyle(followButton)
+        WPStyleGuide.applyReaderFollowButtonStyle(followButton)
     }
 
     @objc open func enableLoggedInFeatures(_ enable: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -241,7 +241,7 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderStreamHeaderDetailStyle(_ label: UILabel) {
-        WPStyleGuide.configureLabel(label, textStyle: Cards.subtextTextStyle)
+        label.font = WPStyleGuide.serifFontForTextStyle(.subheadline)
         label.textColor = .textSubtle
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -164,22 +164,6 @@ extension WPStyleGuide {
         ]
     }
 
-    // MARK: - Stream Header Attributed Text Attributes
-
-    @objc public class func readerStreamHeaderDescriptionAttributes() -> [NSAttributedString.Key: Any] {
-        let font = WPStyleGuide.notoFontForTextStyle(Cards.contentTextStyle)
-
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = Cards.defaultLineSpacing
-        paragraphStyle.alignment = .center
-
-        return [
-            .paragraphStyle: paragraphStyle,
-            .font: font
-        ]
-    }
-
-
     // MARK: - Apply Card Styles
 
     @objc public class func applyReaderCardSiteButtonStyle(_ button: UIButton) {
@@ -241,12 +225,12 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderStreamHeaderDetailStyle(_ label: UILabel) {
-        label.font = WPStyleGuide.serifFontForTextStyle(.subheadline)
+        label.font = fontForTextStyle(.subheadline, fontWeight: .regular)
         label.textColor = .textSubtle
     }
 
     @objc public class func applyReaderSiteStreamDescriptionStyle(_ label: UILabel) {
-        WPStyleGuide.configureLabelForNotoFont(label, textStyle: .subheadline)
+        label.font = fontForTextStyle(.body, fontWeight: .regular)
         label.textColor = .text
     }
 
@@ -298,35 +282,6 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton) {
-        let side = WPStyleGuide.fontSizeForTextStyle(Cards.buttonTextStyle)
-        let size = CGSize(width: side, height: side)
-
-        let followIcon = UIImage.gridicon(.readerFollow, size: size)
-        let followingIcon = UIImage.gridicon(.readerFollowing, size: size)
-
-        let normalColor = UIColor.primary
-        let highlightedColor = UIColor.primaryDark
-        let selectedColor = UIColor.success
-
-        let tintedFollowIcon = followIcon.imageWithTintColor(normalColor)
-        let tintedFollowingIcon = followingIcon.imageWithTintColor(selectedColor)
-        let highlightIcon = followingIcon.imageWithTintColor(highlightedColor)
-
-        button.setImage(tintedFollowIcon, for: .normal)
-        button.setImage(tintedFollowingIcon, for: .selected)
-        button.setImage(highlightIcon, for: .highlighted)
-
-        button.setTitle(FollowButton.Text.followStringForDisplay, for: UIControl.State())
-        button.setTitle(FollowButton.Text.followingStringForDisplay, for: .selected)
-        button.setTitle(FollowButton.Text.followingStringForDisplay, for: .highlighted)
-
-        button.setTitleColor(normalColor, for: UIControl.State())
-        button.setTitleColor(highlightedColor, for: .highlighted)
-        button.setTitleColor(selectedColor, for: .selected)
-    }
-
-
-    @objc public class func applyReaderFollowTopicButtonStyle(_ button: UIButton) {
         let side = WPStyleGuide.fontSizeForTextStyle(.headline)
         let size = CGSize(width: side, height: side)
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -235,7 +235,7 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderSiteStreamCountStyle(_ label: UILabel) {
-        WPStyleGuide.configureLabel(label, textStyle: Cards.subtextTextStyle)
+        WPStyleGuide.configureLabel(label, textStyle: Cards.contentTextStyle)
         label.textColor = .textSubtle
     }
 


### PR DESCRIPTION
After updating the topic page header in #14525 , we are now giving the site header a fresh new look as well.

To test:
1. Go to reader 
2. Tap on a site name in a post card 
3. See the new site header

Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1335657/88749923-35751d80-d109-11ea-9ab0-c46b4662d708.jpeg)  |  ![](https://user-images.githubusercontent.com/1335657/88749972-550c4600-d109-11ea-808c-5a5bbed12b87.png)

### With a longer site description 
![Screen Shot 2020-07-28 at 6 36 31 PM](https://user-images.githubusercontent.com/1335657/88750179-cc41da00-d109-11ea-939b-a645ffa8f682.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
