### PR TITLE
Select topics refactoring

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -135,35 +135,28 @@ private extension ReaderCardsStreamViewController {
     func displaySelectInterestsIfNeeded() {
         selectInterestsViewController?.userIsFollowingTopics { [unowned self] isFollowing in
             if isFollowing {
-                self.makeSelectInterestsViewControllerIfNeeded()
-                self.showSelectInterestsViewIfNeeded()
+                self.showSelectInterestsView()
             } else {
                 self.selectInterestsViewController = nil
             }
         }
     }
 
-    func showSelectInterestsViewIfNeeded() {
+    func showSelectInterestsView() {
         guard let controller = selectInterestsViewController else {
             return
         }
 
         controller.view.frame = self.view.bounds
         self.add(controller)
-    }
 
-    func makeSelectInterestsViewControllerIfNeeded() {
-        if selectInterestsViewController != nil {
-            return
-        }
-
-        selectInterestsViewController?.didSaveInterests = { [unowned self] in
+        controller.didSaveInterests = { [unowned self] in
             guard let controller = self.selectInterestsViewController else {
                 return
             }
 
             UIView.animate(withDuration: 0.2, animations: {
-                controller.view.alpha = 0.0
+                controller.view.alpha = 0
             }) { [unowned self] _ in
                 controller.remove()
                 self.selectInterestsViewController = nil

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -135,9 +135,9 @@ private extension ReaderCardsStreamViewController {
     func displaySelectInterestsIfNeeded() {
         selectInterestsViewController?.userIsFollowingTopics { [unowned self] isFollowing in
             if isFollowing {
-                self.showSelectInterestsView()
-            } else {
                 self.selectInterestsViewController = nil
+            } else {
+                self.showSelectInterestsView()
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -11,12 +11,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         return ReaderCardService()
     }()
 
-    // Select Interests
-    private lazy var interestsCoordinator: ReaderSelectInterestsCoordinator = {
-        return ReaderSelectInterestsCoordinator()
-    }()
-
-    private var selectInterestsViewController: ReaderSelectInterestsViewController?
+    private var selectInterestsViewController: ReaderSelectInterestsViewController? = ReaderSelectInterestsViewController()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -138,16 +133,12 @@ extension ReaderCardsStreamViewController: ReaderTopicsCardCellDelegate {
 // MARK: - Select Interests Display
 private extension ReaderCardsStreamViewController {
     func displaySelectInterestsIfNeeded() {
-        if self.selectInterestsViewController != nil {
-            showSelectInterestsViewIfNeeded()
-            return
-        }
-
-        // If we're not showing the select interests view, check to see if we should
-        interestsCoordinator.shouldDisplay { [unowned self] shouldDisplay in
-            if shouldDisplay {
+        selectInterestsViewController?.userIsFollowingTopics { [unowned self] isFollowing in
+            if isFollowing {
                 self.makeSelectInterestsViewControllerIfNeeded()
                 self.showSelectInterestsViewIfNeeded()
+            } else {
+                self.selectInterestsViewController = nil
             }
         }
     }
@@ -157,11 +148,8 @@ private extension ReaderCardsStreamViewController {
             return
         }
 
-        // Using duration zero to prevent the screen from blinking
-        UIView.animate(withDuration: 0) {
-            controller.view.frame = self.view.bounds
-            self.add(controller)
-        }
+        controller.view.frame = self.view.bounds
+        self.add(controller)
     }
 
     func makeSelectInterestsViewControllerIfNeeded() {
@@ -169,8 +157,7 @@ private extension ReaderCardsStreamViewController {
             return
         }
 
-        let controller = ReaderSelectInterestsViewController()
-        controller.didSaveInterests = { [unowned self] in
+        selectInterestsViewController?.didSaveInterests = { [unowned self] in
             guard let controller = self.selectInterestsViewController else {
                 return
             }
@@ -182,7 +169,5 @@ private extension ReaderCardsStreamViewController {
                 self.selectInterestsViewController = nil
             }
         }
-
-        selectInterestsViewController = controller
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
@@ -1,19 +1,8 @@
 import Foundation
 
 class ReaderSelectInterestsCoordinator {
-    private struct Constants {
-        static let userDefaultsKeyFormat: String = "Reader.SelectInterests.hasSeenBefore.%@"
-        static let loggedOutUserKey: String = "logged-out"
-    }
-
     private let interestsService: ReaderFollowedInterestsService
-    private let store: KeyValueDatabase
     private let userId: NSNumber?
-
-    /// Generates the user defaults key for the current user
-    private var userDefaultsKey: String {
-        return String(format: Constants.userDefaultsKeyFormat, userId ?? Constants.loggedOutUserKey)
-    }
 
     /// Creates a new instance of the coordinator
     /// - Parameter service: An Optional `ReaderFollowedInterestsService` to use. If this is `nil` one will be created on the main context
@@ -25,7 +14,6 @@ class ReaderSelectInterestsCoordinator {
          context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
 
         self.interestsService = service ?? ReaderTopicService(managedObjectContext: context)
-        self.store = store
         self.userId = userId ?? {
             let acctServ = AccountService(managedObjectContext: context)
             let account = acctServ.defaultWordPressComAccount()
@@ -51,29 +39,14 @@ class ReaderSelectInterestsCoordinator {
 
     /// Determines whether or not the select interests view should be displayed
     /// - Returns: true 
-    public func shouldDisplay(completion: @escaping (Bool) -> Void) {
-        interestsService.fetchFollowedInterestsLocally { [weak self] (followedInterests) in
-            let shouldDisplay: Bool = self?.shouldDisplaySelectInterests(with: followedInterests) ?? false
-            completion(shouldDisplay)
+    public func isFollowingInterests(completion: @escaping (Bool) -> Void) {
+        interestsService.fetchFollowedInterestsLocally { [weak self] followedInterests in
+            guard let interests = followedInterests else {
+                return
+            }
+
+            let isFollowingInterests = interests.count > 0
+            completion(isFollowingInterests)
         }
-    }
-
-    private func shouldDisplaySelectInterests(with interests: [ReaderTagTopic]?) -> Bool {
-        guard let interests = interests else {
-            return false
-        }
-
-        return !hasSeenBefore() && interests.count <= 0
-    }
-
-    // MARK: - View Tracking
-    /// Determines whether the select interests view has been seen before
-    func hasSeenBefore() -> Bool {
-        return store.bool(forKey: userDefaultsKey)
-    }
-
-    /// Marks the view as seen for the user
-    func markAsSeen() {
-        store.set(true, forKey: userDefaultsKey)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -23,13 +23,6 @@ import WordPressFlux
 
     // MARK: - Properties
 
-    // Select Interests
-    private lazy var interestsCoordinator: ReaderSelectInterestsCoordinator = {
-        return ReaderSelectInterestsCoordinator()
-    }()
-
-    private var selectInterestsViewController: ReaderSelectInterestsViewController?
-
     /// Called if the stream or tag fails to load
     var streamLoadFailureBlock: (() -> Void)? = nil
 
@@ -1832,8 +1825,6 @@ extension ReaderStreamViewController: ReaderContentViewController {
             return
         }
         siteID = content.topicType == .discover ? ReaderHelpers.discoverSiteID : nil
-
-        displaySelectInterestsIfNeeded(content)
     }
 }
 
@@ -1856,66 +1847,6 @@ extension ReaderStreamViewController: ReaderPostUndoCellDelegate {
                 postCellActions?.restoreUnsavedPost(post)
                 tableView.reloadRows(at: [cellIndex], with: .fade)
         }
-    }
-}
-
-
-// MARK: - Select Interests Display
-private extension ReaderStreamViewController {
-    func displaySelectInterestsIfNeeded(_ content: ReaderContent) {
-        guard FeatureFlag.readerImprovementsPhase2.enabled,
-            content.topicType == .discover else {
-            // Removes the view if we're not on the discover tab, and it exists
-            selectInterestsViewController?.remove()
-            return
-        }
-
-        if self.selectInterestsViewController != nil {
-            showSelectInterestsViewIfNeeded()
-            return
-        }
-
-        // If we're not showing the select interests view, check to see if we should
-        interestsCoordinator.shouldDisplay { [unowned self] shouldDisplay in
-            if shouldDisplay {
-                self.makeSelectInterestsViewControllerIfNeeded()
-                self.showSelectInterestsViewIfNeeded()
-            }
-        }
-    }
-
-    func showSelectInterestsViewIfNeeded() {
-        guard let controller = selectInterestsViewController else {
-            return
-        }
-
-        // Using duration zero to prevent the screen from blinking
-        UIView.animate(withDuration: 0) {
-            controller.view.frame = self.view.bounds
-            self.add(controller, asChildOf: self)
-        }
-    }
-
-    func makeSelectInterestsViewControllerIfNeeded() {
-        if selectInterestsViewController != nil {
-            return
-        }
-
-        let controller = ReaderSelectInterestsViewController()
-        controller.didSaveInterests = { [unowned self] in
-            guard let controller = self.selectInterestsViewController else {
-                return
-            }
-
-            UIView.animate(withDuration: 0.2, animations: {
-                controller.view.alpha = 0.0
-            }) { [unowned self] _ in
-                controller.remove()
-                self.selectInterestsViewController = nil
-            }
-        }
-
-        selectInterestsViewController = controller
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -453,7 +453,7 @@ import WordPressFlux
 
     private func setupTableView() {
         configureRefreshControl()
-        add(tableViewController, asChildOf: self)
+        add(tableViewController)
         layoutTableView()
         tableConfiguration.setup(tableView)
         setupUndoCell(tableView)
@@ -461,12 +461,6 @@ import WordPressFlux
 
     @objc func configureRefreshControl() {
         refreshControl.addTarget(self, action: #selector(ReaderStreamViewController.handleRefresh(_:)), for: .valueChanged)
-    }
-
-    private func add(_ childController: UIViewController, asChildOf controller: UIViewController) {
-        controller.addChild(childController)
-        controller.view.addSubview(childController.view)
-        childController.didMove(toParent: controller)
     }
 
     private func layoutTableView() {

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -51,6 +51,11 @@ class ReaderSelectInterestsViewController: UIViewController {
         configureNoResultsViewController()
         applyStyles()
         updateNextButtonState()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
         refreshData()
     }
 
@@ -67,6 +72,11 @@ class ReaderSelectInterestsViewController: UIViewController {
     // MARK: - IBAction's
     @IBAction func nextButtonTapped(_ sender: Any) {
         saveSelectedInterests()
+    }
+
+    // MARK: - Display logic
+    func userIsFollowingTopics(completion: @escaping (Bool) -> Void) {
+        coordinator.shouldDisplay(completion: completion)
     }
 
     // MARK: - Private: Configuration

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -76,7 +76,7 @@ class ReaderSelectInterestsViewController: UIViewController {
 
     // MARK: - Display logic
     func userIsFollowingTopics(completion: @escaping (Bool) -> Void) {
-        coordinator.shouldDisplay(completion: completion)
+        coordinator.isFollowingInterests(completion: completion)
     }
 
     // MARK: - Private: Configuration

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -160,10 +160,8 @@ class ReaderSelectInterestsViewController: UIViewController {
 
         activityIndicatorView.startAnimating()
 
-        UIView.animate(withDuration: Constants.animationDuration) {
-            self.contentContainerView.alpha = 0
-            self.loadingView.alpha = 1
-        }
+        contentContainerView.alpha = 0
+        loadingView.alpha = 1
     }
 
     private func stopLoading() {

--- a/WordPress/WordPressTest/ReaderSelectInterestsCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderSelectInterestsCoordinatorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import WordPress
 
 class ReaderSelectInterestsCoordinatorTests: XCTestCase {
-    func testShouldDisplayReturnsTrue() {
+    func testisFollowingInterestsReturnsFalse() {
         let store = EphemeralKeyValueDatabase()
         let service = MockFollowedInterestsService(populateItems: false)
         let coordinator = ReaderSelectInterestsCoordinator(service: service, store: store, userId: 1)
@@ -11,72 +11,33 @@ class ReaderSelectInterestsCoordinatorTests: XCTestCase {
         service.fetchSuccessExpectation = expectation(description: "Fetching of interests succeeds")
 
         let displayExpectation = expectation(description: "Should display returns true")
-        coordinator.shouldDisplay { (result) in
+        coordinator.isFollowingInterests { (result) in
+            displayExpectation.fulfill()
+
+            XCTAssertFalse(result)
+        }
+
+        waitForExpectations(timeout: 4, handler: nil)
+    }
+
+    func testisFollowingInterestsReturnsTrue() {
+        let store = EphemeralKeyValueDatabase()
+        let service = MockFollowedInterestsService(populateItems: true)
+        let coordinator = ReaderSelectInterestsCoordinator(service: service, store: store, userId: 1)
+
+        let successExpectation = expectation(description: "Fetching of interests succeeds")
+
+        service.success = true
+        service.fetchSuccessExpectation = successExpectation
+
+        let displayExpectation = expectation(description: "Should display returns true")
+        coordinator.isFollowingInterests { (result) in
             displayExpectation.fulfill()
 
             XCTAssertTrue(result)
         }
 
         waitForExpectations(timeout: 4, handler: nil)
-    }
-
-    func testShouldDisplayReturnsFalseIfUserHasFollowedInterests() {
-        let store = EphemeralKeyValueDatabase()
-        let service = MockFollowedInterestsService(populateItems: true)
-        let coordinator = ReaderSelectInterestsCoordinator(service: service, store: store, userId: 1)
-
-        let successExpectation = expectation(description: "Fetching of interests succeeds")
-
-        service.success = true
-        service.fetchSuccessExpectation = successExpectation
-
-        let displayExpectation = expectation(description: "Should display returns true")
-        coordinator.shouldDisplay { (result) in
-            displayExpectation.fulfill()
-
-            XCTAssertFalse(result)
-        }
-
-        waitForExpectations(timeout: 4, handler: nil)
-    }
-
-    func testShouldDisplayReturnsFalseIfUserHasSeenBefore() {
-        let store = EphemeralKeyValueDatabase()
-        let service = MockFollowedInterestsService(populateItems: true)
-        let coordinator = ReaderSelectInterestsCoordinator(service: service, store: store, userId: 1)
-        coordinator.markAsSeen()
-
-        let successExpectation = expectation(description: "Fetching of interests succeeds")
-
-        service.success = true
-        service.fetchSuccessExpectation = successExpectation
-
-        let displayExpectation = expectation(description: "Should display returns true")
-        coordinator.shouldDisplay { (result) in
-            displayExpectation.fulfill()
-
-            XCTAssertFalse(result)
-        }
-
-        waitForExpectations(timeout: 4, handler: nil)
-    }
-
-    func testMarkAsSeen() {
-        let store = EphemeralKeyValueDatabase()
-        let service = MockFollowedInterestsService(populateItems: false)
-        let coordinator = ReaderSelectInterestsCoordinator(service: service, store: store, userId: 1)
-
-        coordinator.markAsSeen()
-
-        XCTAssertTrue(coordinator.hasSeenBefore())
-    }
-
-    func testHasSeenBeforeFalse() {
-        let store = EphemeralKeyValueDatabase()
-        let service = MockFollowedInterestsService(populateItems: false)
-        let coordinator = ReaderSelectInterestsCoordinator(service: service, store: store, userId: 1)
-
-        XCTAssertFalse(coordinator.hasSeenBefore())
     }
 
     func testSaveInterestsTriggersSuccess() {


### PR DESCRIPTION
Part of #14399

Review only after #14532 is merged.

This PR doesn't add any new features. Instead, it refactors logics related to the topics selecting screen.

What was done:

1. Code moved from `ReaderStreamViewController` to `ReaderCardsViewController`
2. Decoupling between the Interests Coordinator and Reader screen
3. Removed the logic to track if the user has seen the selects interests screen or not (this isn't relevant anymore, we always show this screen if the user is not following any topic)
4. Removed a few view animations to simplify code understanding

#### To test

#### 01 - Select Interests Picker
1. Login using a WP.com account
2. Launch the app
3. Delete all of your followed tags if you have any
4. Tap on the Reader tab
5. Tap on the 'Discover' tab

**Expectation:** You are presented with the Select Interests View

#### 02 - Save Interests: Loading View
1. Continuing with the steps from 01
2. Select some interests
3. Tap the 'Done' button

**Expectation:** The select interests view fades out, and you're presented with posts based on the interests you selected.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
