### PR TITLE
Add a feature flag for unified signup

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -7,6 +7,7 @@ enum FeatureFlag: Int, CaseIterable {
     case unifiedAuth
     case unifiedSiteAddress
     case unifiedGoogle
+    case unifiedSignup
     case meMove
     case floatingCreateButton
     case newReaderNavigation
@@ -33,6 +34,8 @@ enum FeatureFlag: Int, CaseIterable {
         case .unifiedSiteAddress:
             return false
         case .unifiedGoogle:
+            return false
+        case .unifiedSignup:
             return false
         case .meMove:
             return true
@@ -80,6 +83,8 @@ extension FeatureFlag: OverrideableFlag {
             return "Unified Auth - Site Address"
         case .unifiedGoogle:
             return "Unified Auth - Google"
+        case .unifiedSignup:
+            return "Unified Auth - Sign Up"
         case .meMove:
             return "Move the Me Scene to My Site"
         case .floatingCreateButton:


### PR DESCRIPTION
Ref. #14009 
Ref. https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/345

This PR adds the .unifiedSignup feature flag. When enabled, it will navigate the user to the Unified Sign Up flow: Sign up with WordPress.com > Sign up Email.

To test:
Nothing to test

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
