### PR TITLE
Fix flaky unit tests

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -783,7 +783,7 @@ extension ReaderPostCardCell: Accessible {
     }
 
     private func datePublished() -> String {
-        return contentProvider?.dateForDisplay()?.readerDateForDisplay() ?? ""
+        return contentProvider?.dateForDisplay()?.mediumString() ?? ""
     }
 }
 
@@ -813,12 +813,5 @@ extension ReaderPostCardCell {
 
     func getReblogButtonForTesting() -> UIButton {
         return reblogActionButton
-    }
-}
-
-private extension Date {
-    func readerDateForDisplay() -> String {
-        let relativeFormatter = ReaderRelativeTimeFormatter()
-        return relativeFormatter.string(from: self)
     }
 }

--- a/WordPress/WordPressTest/ReaderPostCardCellTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCardCellTests.swift
@@ -179,7 +179,7 @@ final class ReaderPostCardCellTests: XCTestCase {
     }
 
     func testHeaderLabelMatchesExpectation() {
-        XCTAssertEqual(cell?.getHeaderButtonForTesting().accessibilityLabel, String(format: TestConstants.headerLabel, "An author", "A blog name" + ", " + mock!.dateForDisplay().mediumString()), "Incorrect accessibility label: Header Button ")
+        XCTAssertEqual(cell?.getHeaderButtonForTesting().accessibilityLabel, String(format: TestConstants.headerLabel, "An author", "A blog name" + ", " + mock!.dateForDisplay().mediumString(timeZone: TimeZone(identifier: "GMT-7"))), "Incorrect accessibility label: Header Button ")
     }
 
     func testSaveForLaterButtonLabelMatchesExpectation() {

--- a/WordPress/WordPressTest/ReaderPostCardCellTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCardCellTests.swift
@@ -179,7 +179,7 @@ final class ReaderPostCardCellTests: XCTestCase {
     }
 
     func testHeaderLabelMatchesExpectation() {
-        XCTAssertEqual(cell?.getHeaderButtonForTesting().accessibilityLabel, String(format: TestConstants.headerLabel, "An author", "A blog name" + ", " + mock!.dateForDisplay().mediumString(timeZone: TimeZone(identifier: "GMT-7"))), "Incorrect accessibility label: Header Button ")
+        XCTAssertEqual(cell?.getHeaderButtonForTesting().accessibilityLabel, String(format: TestConstants.headerLabel, "An author", "A blog name" + ", " + mock!.dateForDisplay().mediumString()), "Incorrect accessibility label: Header Button ")
     }
 
     func testSaveForLaterButtonLabelMatchesExpectation() {


### PR DESCRIPTION
This PR fixes two tests that are failing in some machines but not on the CI:

* `ReaderSelectInterestsCoordinatorTests.testShouldDisplayReturnsTrue`: the order of tests being executed in this suite was causing false negatives because database changes were being persisted;
* `ReaderPostCardCellTests.testHeaderLabelMatchesExpectation`: this one was failing because of the timezone. Now we use a hardcoded timezone in the tests.

### To test

1. Run the whole unit tests suite in your machine
2. Make sure it's all green

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
