### PR TITLE
Update Discover section when new interests are selected

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -155,6 +155,9 @@ private extension ReaderCardsStreamViewController {
                 return
             }
 
+            self.displayLoadingStream()
+            self.syncIfAppropriate()
+
             UIView.animate(withDuration: 0.2, animations: {
                 controller.view.alpha = 0
             }) { [unowned self] _ in

--- a/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
@@ -40,7 +40,7 @@ class ReaderSelectInterestsCoordinator {
     /// Determines whether or not the select interests view should be displayed
     /// - Returns: true 
     public func isFollowingInterests(completion: @escaping (Bool) -> Void) {
-        interestsService.fetchFollowedInterestsLocally { [weak self] followedInterests in
+        interestsService.fetchFollowedInterestsLocally { followedInterests in
             guard let interests = followedInterests else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1610,7 +1610,7 @@ extension ReaderStreamViewController: SearchableActivityConvertable {
 
 // MARK: - Handling Loading and No Results
 
-private extension ReaderStreamViewController {
+extension ReaderStreamViewController {
 
     func displayLoadingStream() {
         configureResultsStatus(title: ResultsStatusText.loadingStreamTitle, accessoryView: NoResultsViewController.loadingAccessoryView())


### PR DESCRIPTION
This PR fixes an issue pointed by @yaelirub in #14539:

> Discover content doesn't get updated when Im removing and adding tags so I have to pull to refresh to see the new content:
> 
> <img src="https://user-images.githubusercontent.com/1335657/89010671-e9220d00-d2c3-11ea-9cc6-856cc2fed028.GIF" width="300">

### To test

First, remove all your followed tags (Following -> Cog -> remove all followed tags).

1. Go to Discover
2. Select one interest
3. Tap Done and check that posts related to your selected interest are appearing
4. Go back to following
5. Remove all followed tags (Following -> Cog -> remove all followed tags)
6. Tap Discover again
7. Select an interest different from the previous one you selected
8. Tap Done
9. Make sure the new content is related to your new selected interest

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
