### PR TITLE
UL&S: Add GravatarEmailTableViewCell base UI and show an example

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -186,9 +186,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.22.0-beta'
+    # pod 'WordPressAuthenticator', '~> 1.22.0-beta'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/349-gravatar-email-cell'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.22.0-beta.6):
+  - WordPressAuthenticator (1.22.0-beta.8):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.22.0-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/349-gravatar-email-cell`)
   - WordPressKit (= 4.13.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.2)
@@ -540,7 +540,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -632,6 +631,9 @@ EXTERNAL SOURCES:
     :commit: 75ddd7f573ba78e8b0e4bfc1cafd386469658cbb
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :branch: feature/349-gravatar-email-cell
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/75ddd7f573ba78e8b0e4bfc1cafd386469658cbb/third-party-podspecs/Yoga.podspec.json
 
@@ -647,6 +649,9 @@ CHECKOUT OPTIONS:
     :commit: 75ddd7f573ba78e8b0e4bfc1cafd386469658cbb
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :commit: 32a232344c51c1681cb1fdc95837fcc9e9398651
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -722,7 +727,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 8e5aabdc0eaf6ab8d758b2ab8ee9e1208d464a37
+  WordPressAuthenticator: 015868ac9deb0945633d5cdaa8d0208c206a5b22
   WordPressKit: b912e3436d7203e6a0d04b477aba05c7b78d495a
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: aab68fab944d8132f488e0f2c1b1abb4399a4aff
@@ -739,6 +744,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 37fcdb7e2545512f6f449cb0e9823c2689be37a8
+PODFILE CHECKSUM: bd0faf7824b1abc004ac575e9e9c5dffc3885e86
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -73,6 +73,7 @@ class WordPressAuthenticationManager: NSObject {
         let unifiedStyle = WordPressAuthenticatorUnifiedStyle(borderColor: .divider,
                                                               errorColor: .error,
                                                               textColor: .text,
+                                                              textSubtleColor: .textSubtle,
                                                               textButtonColor: .brand,
                                                               textButtonHighlightColor: .brand,
                                                               viewControllerBackgroundColor: .basicBackground,


### PR DESCRIPTION
Ref. #14009 
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/350

This PR adds the GravatarEmailTableViewCell base UI and shows an example in UnifiedSignUpViewController.

### To test:
1. Enable the `.unifiedSignup` feature flag
2. `rake dependencies`
3. Build and run
4. Sign up with WordPress.com > Sign up with Email
5. View the example tableview cell in UnifiedSignUpViewController.

**iPhone 11 Pro Max**
| Light mode | Dark mode |
| --- | --- |
| <a href="https://user-images.githubusercontent.com/1062444/89065079-b8c48800-d330-11ea-932b-9b9e2816e560.png"><img src="https://user-images.githubusercontent.com/1062444/89065079-b8c48800-d330-11ea-932b-9b9e2816e560.png" width="350" /></a> | <a href="https://user-images.githubusercontent.com/1062444/89065279-fb866000-d330-11ea-9e55-e85d113220eb.png"><img src="https://user-images.githubusercontent.com/1062444/89065279-fb866000-d330-11ea-9e55-e85d113220eb.png" width="350" /></a> |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
