### PR TITLE
add ghost view on reader tab bar at the first load

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -11,6 +11,7 @@ class ReaderTabView: UIView {
     private let verticalDivider: UIView
     private let horizontalDivider: UIView
     private let containerView: UIView
+    private var loadingView: UIView?
 
     private let viewModel: ReaderTabViewModel
 
@@ -39,6 +40,7 @@ class ReaderTabView: UIView {
             self?.tabBar.items = tabItems
             self?.tabBar.setSelectedIndex(index)
             self?.configureTabBarElements()
+            self?.hideGhost()
             self?.addContentToContainerView()
         }
         setupViewElements()
@@ -84,6 +86,7 @@ extension ReaderTabView {
         tabBar.tabBarHeight = Appearance.barHeight
         WPStyleGuide.configureFilterTabBar(tabBar)
         tabBar.addTarget(self, action: #selector(selectedTabDidChange(_:)), for: .valueChanged)
+        showGhost()
         viewModel.fetchReaderMenu()
     }
 
@@ -238,10 +241,51 @@ extension ReaderTabView {
     }
 }
 
-// MARK: - Appearance
-extension ReaderTabView {
 
-    private enum Appearance {
+// MARK: - Ghost
+private extension ReaderTabView {
+
+    /// Build the ghost tab bar
+    func makeGhostTabBar() -> FilterTabBar {
+        let ghostTabBar = FilterTabBar()
+
+        ghostTabBar.items = Appearance.ghostTabItems
+        ghostTabBar.isUserInteractionEnabled = false
+        ghostTabBar.tabBarHeight = Appearance.barHeight
+        ghostTabBar.dividerColor = .clear
+
+        return ghostTabBar
+    }
+
+    /// Show the ghost tab bar
+    func showGhost() {
+        let ghostTabBar = makeGhostTabBar()
+        tabBar.addSubview(ghostTabBar)
+        tabBar.pinSubviewToAllEdges(ghostTabBar)
+
+        ghostTabBar.startGhostAnimation(style: GhostStyle(beatDuration: GhostStyle.Defaults.beatDuration,
+                                                          beatStartColor: .placeholderElement,
+                                                          beatEndColor: .placeholderElementFaded))
+        loadingView = ghostTabBar
+    }
+
+    /// Hide the ghost tab bar
+    func hideGhost() {
+        loadingView?.stopGhostAnimation()
+        loadingView?.removeFromSuperview()
+        loadingView = nil
+    }
+
+    struct GhostTabItem: FilterTabBarItem {
+        var title: String
+        let accessibilityIdentifier = ""
+    }
+}
+
+// MARK: - Appearance
+private extension ReaderTabView {
+
+    enum Appearance {
         static let barHeight: CGFloat = 48
 
         static let tabBarAnimationsDuration = 0.2
@@ -261,6 +305,8 @@ extension ReaderTabView {
         static let dividerWidth: CGFloat = .hairlineBorderWidth
         static let dividerColor: UIColor = .divider
         static let verticalDividerHeightMultiplier: CGFloat = 0.6
+        // "ghost" titles are set to the default english titles, as they won't be visible anyway
+        static let ghostTabItems = [GhostTabItem(title: "Following"), GhostTabItem(title: "Discover"), GhostTabItem(title: "Likes"), GhostTabItem(title: "Saved")]
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -263,10 +263,12 @@ private extension ReaderTabView {
         tabBar.addSubview(ghostTabBar)
         tabBar.pinSubviewToAllEdges(ghostTabBar)
 
+        loadingView = ghostTabBar
+
         ghostTabBar.startGhostAnimation(style: GhostStyle(beatDuration: GhostStyle.Defaults.beatDuration,
                                                           beatStartColor: .placeholderElement,
                                                           beatEndColor: .placeholderElementFaded))
-        loadingView = ghostTabBar
+
     }
 
     /// Hide the ghost tab bar


### PR DESCRIPTION
Fixes #14412 (combined with #14454)

To test:
- delete and reinstall or logout/login
- go to the reader
- verify that a ghost animation is displayed in the tab bar area until the menu titles appear (along with the rest of the UI)

tip: to make the loading more noticeable, use a slow network (like in the example below)
<p align=center>
<img width=300 src=https://user-images.githubusercontent.com/34376330/89078201-85dabe00-d349-11ea-956b-7ebc49d65816.gif>
</p>


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
