### PR TITLE
ULS: Update Auth to use new password view

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -186,9 +186,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.22.0-beta'
+    # pod 'WordPressAuthenticator', '~> 1.22.0-beta'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/352-password_initial_view'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -186,9 +186,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.22.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.22.0-beta'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/352-password_initial_view'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.22.0-beta.7):
+  - WordPressAuthenticator (1.22.0-beta.8):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.22.0-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/352-password_initial_view`)
   - WordPressKit (= 4.13.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.2)
@@ -540,7 +540,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -632,6 +631,9 @@ EXTERNAL SOURCES:
     :commit: 75ddd7f573ba78e8b0e4bfc1cafd386469658cbb
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :branch: feature/352-password_initial_view
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/75ddd7f573ba78e8b0e4bfc1cafd386469658cbb/third-party-podspecs/Yoga.podspec.json
 
@@ -647,6 +649,9 @@ CHECKOUT OPTIONS:
     :commit: 75ddd7f573ba78e8b0e4bfc1cafd386469658cbb
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :commit: 5e0e96849d67fea8c8342cfab5b6f0b13c9db66c
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -722,7 +727,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 48b994a5c98f3a5cf87734dd2f757afd2b775da3
+  WordPressAuthenticator: 015868ac9deb0945633d5cdaa8d0208c206a5b22
   WordPressKit: b912e3436d7203e6a0d04b477aba05c7b78d495a
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: aab68fab944d8132f488e0f2c1b1abb4399a4aff
@@ -739,6 +744,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 37fcdb7e2545512f6f449cb0e9823c2689be37a8
+PODFILE CHECKSUM: cf04c8a1531901e52a5af2f2fbcf9bfc69d0d0d9
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/352-password_initial_view`)
+  - WordPressAuthenticator (~> 1.22.0-beta)
   - WordPressKit (= 4.13.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (= 1.9.2)
@@ -540,6 +540,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -631,9 +632,6 @@ EXTERNAL SOURCES:
     :commit: 75ddd7f573ba78e8b0e4bfc1cafd386469658cbb
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
-  WordPressAuthenticator:
-    :branch: feature/352-password_initial_view
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/75ddd7f573ba78e8b0e4bfc1cafd386469658cbb/third-party-podspecs/Yoga.podspec.json
 
@@ -649,9 +647,6 @@ CHECKOUT OPTIONS:
     :commit: 75ddd7f573ba78e8b0e4bfc1cafd386469658cbb
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
-  WordPressAuthenticator:
-    :commit: 3b50a3f59a687b822bf845e7e2b41729966e7e71
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -744,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: cf04c8a1531901e52a5af2f2fbcf9bfc69d0d0d9
+PODFILE CHECKSUM: 37fcdb7e2545512f6f449cb0e9823c2689be37a8
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/352
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/353

This updates Auth to show the new password view in the unified Google flow. 

To test:

- Visit WordPress.com > Me > Security > Social Logins and ensure your Google account is disconnected.
- Enable the `unifiedGoogle` feature flag.
- Select `Continue with Google` from either login or signup.
- Select a Google account that _has a WP password set_, and complete Google's auth.
- Verify the new view is displayed:

<kbd>![Simulator Screen Shot - iPhone 11 Pro Max - 2020-07-31 at 15 23 02](https://user-images.githubusercontent.com/1816888/89078833-5c6a6400-d342-11ea-9ad7-41783e003354.png)</kbd>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
