### PR TITLE
Removes a silent failure.

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -305,9 +305,23 @@ class MediaCoordinator: NSObject {
                             success: {
                                 self.end(media)
         }, failure: { error in
-            guard let nserror = error as NSError? else {
-                return
-            }
+            // Ideally the upload service should always return an error.  This may be easier to enforce
+            // if we update the service to Swift, but in the meanwhile I'm instantiating an unknown upload
+            // error whenever the service doesn't provide one.
+            //
+            let nserror = error as NSError?
+                ?? NSError(
+                    domain: MediaServiceErrorDomain,
+                    code: MediaServiceError.unknownUploadError.rawValue,
+                    userInfo: [
+                        "filename": media.filename ?? "",
+                        "filesize": media.filesize ?? "",
+                        "height": media.height ?? "",
+                        "width": media.width ?? "",
+                        "localURL": media.localURL ?? "",
+                        "remoteURL": media.remoteURL ?? "",
+                ])
+
             self.coordinator(for: media).attach(error: nserror, toMediaID: media.uploadID)
             self.fail(nserror, media: media)
         })

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -14,7 +14,8 @@ typedef NS_ERROR_ENUM(MediaServiceErrorDomain, MediaServiceError) {
     MediaServiceErrorFileDoesNotExist = 0,
     MediaServiceErrorFileLargerThanDiskQuotaAvailable = 1,
     MediaServiceErrorFileLargerThanMaxFileSize = 2,
-    MediaServiceErrorUnableToCreateMedia = 3
+    MediaServiceErrorUnableToCreateMedia = 3,
+    MediaServiceErrorUnknownUploadError = 4
 };
 
 @interface MediaService : LocalCoreDataService


### PR DESCRIPTION
This is an attempt to fix what looks like a silent failure here: https://github.com/wordpress-mobile/WordPress-iOS/issues/14561

Unfortunately I wasn't able to reproduce the issue, but there's a chance this change could at least raise the error so that both our users and the App detect it.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
