### PR TITLE
Default Modal layout picker to off

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -54,7 +54,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .gutenbergMentions:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .gutenbergModalLayoutPicker:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return false
         }
     }
 }


### PR DESCRIPTION
To test:
- Create A new page either from the FAB button or Page List
- Expect to see the new page editor

- Toggle Modal layout picker on 

    <details>
    <summary>To disable or enable the development version of Modal Layout Picker</summary>

    - Open the app from the build that allows FeatureFlags such as a PR build or a local development build
        - By default, the modal layout picker will be enabled.
        - From the site page:
            - Click on your Gravatar.
            - Click on App Settings.
            - Click on Debug.
            - Toggle "Gutenberg Modal Layout Picker" to enable or disable the picker
            <details>
            <summary>To toggle:</summary>
            <img width=300 src="https://user-images.githubusercontent.com/3384451/87160515-106f5680-c291-11ea-9d49-fac5e6b7e66c.gif" />
            </details>
    </details>

- Create A new page either from the FAB button or Page List
- Expect to see the layout picker

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
