### PR TITLE
[Gutenberg] Fix ghost/loading view position

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -345,7 +345,12 @@ class GutenbergViewController: UIViewController, PostEditor {
 
     override func viewLayoutMarginsDidChange() {
         super.viewLayoutMarginsDidChange()
-        ghostView.frame = view.safeAreaLayoutGuide.layoutFrame
+        ghostView.frame = view.frame
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        ghostView.frame = view.frame
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -36,7 +36,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" axis="vertical" distribution="equalCentering" alignment="top" spacing="38" translatesAutoresizingMaskIntoConstraints="NO" id="8FS-n0-wtp">
-                    <rect key="frame" x="0.0" y="86" width="414" height="78"/>
+                    <rect key="frame" x="0.0" y="67" width="414" height="78"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MVu-rY-vQW">
                             <rect key="frame" x="16" y="0.0" width="290" height="24"/>
@@ -140,7 +140,7 @@
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="8FS-n0-wtp" secondAttribute="trailing" priority="999" id="Hkq-Cm-1A1"/>
                 <constraint firstAttribute="bottom" secondItem="eg8-Yp-3Ni" secondAttribute="bottom" id="SOo-Wv-gYE"/>
                 <constraint firstItem="eg8-Yp-3Ni" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="dMH-Bk-hck"/>
-                <constraint firstItem="8FS-n0-wtp" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="42" id="fbx-S8-eNZ"/>
+                <constraint firstItem="8FS-n0-wtp" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="23" id="fbx-S8-eNZ"/>
                 <constraint firstItem="8FS-n0-wtp" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" priority="999" id="x9e-vE-4i1"/>
                 <constraint firstItem="eg8-Yp-3Ni" firstAttribute="top" secondItem="5nZ-Cv-Fn8" secondAttribute="top" id="zYn-ZB-YT5"/>
             </constraints>

--- a/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -36,7 +36,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" axis="vertical" distribution="equalCentering" alignment="top" spacing="38" translatesAutoresizingMaskIntoConstraints="NO" id="8FS-n0-wtp">
-                    <rect key="frame" x="0.0" y="67" width="414" height="78"/>
+                    <rect key="frame" x="0.0" y="86" width="414" height="78"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MVu-rY-vQW">
                             <rect key="frame" x="16" y="0.0" width="290" height="24"/>
@@ -140,7 +140,7 @@
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="8FS-n0-wtp" secondAttribute="trailing" priority="999" id="Hkq-Cm-1A1"/>
                 <constraint firstAttribute="bottom" secondItem="eg8-Yp-3Ni" secondAttribute="bottom" id="SOo-Wv-gYE"/>
                 <constraint firstItem="eg8-Yp-3Ni" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="dMH-Bk-hck"/>
-                <constraint firstItem="8FS-n0-wtp" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="23" id="fbx-S8-eNZ"/>
+                <constraint firstItem="8FS-n0-wtp" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="42" id="fbx-S8-eNZ"/>
                 <constraint firstItem="8FS-n0-wtp" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" priority="999" id="x9e-vE-4i1"/>
                 <constraint firstItem="eg8-Yp-3Ni" firstAttribute="top" secondItem="5nZ-Cv-Fn8" secondAttribute="top" id="zYn-ZB-YT5"/>
             </constraints>


### PR DESCRIPTION
Fixes the ghost/loading view for Gutenberg being a few pixels too low

To test:
1. Create a new blog post with Gutenberg
1. Check that the loading view shows similar to the gif attached


## Screenshots <!-- if applicable -->
Before | After
--- | ---
<img width="300" src="https://user-images.githubusercontent.com/1845482/89430963-9ae79080-d73f-11ea-8cc4-653f1e70a3eb.png">|<img width="300" src="https://user-images.githubusercontent.com/1845482/89431004-a935ac80-d73f-11ea-90bc-faaf5ff147c2.png">


Fixed version gif | 
---|
<img width="300" src="https://user-images.githubusercontent.com/1845482/89431168-da15e180-d73f-11ea-9733-f6c01075f800.gif">


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
