### PR TITLE
Relax WordPressKit and WordPressShared version control

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def wordpress_shared
-    pod 'WordPressShared', '1.9.2'
+    pod 'WordPressShared', ' ~> 1.10.-beta'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :tag => ''
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
@@ -37,7 +37,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '4.13.0'
+    pod 'WordPressKit', '~> 4.14-beta'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.22.0-beta.12):
+  - WordPressAuthenticator (1.22.0-beta.13):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -722,7 +722,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 447722ad4a3c30b61871351907a2e4a02075ca30
+  WordPressAuthenticator: 924cfb4c37da864453b327e06db5b4ee34918cce
   WordPressKit: eb32b62436777b67862e78e9b3eab51d0210e815
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: d2eede525d5b874a9911362e504da5cc376e5564
@@ -739,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 76f6d576687b5247149736952990ed56148e15e4
+PODFILE CHECKSUM: b0e763a5ab4ea9a638b7a4c05214ada79a4534b9
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -397,15 +397,15 @@ PODS:
     - WordPressKit (~> 4.0-beta.0)
     - WordPressShared (~> 1.9-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.13.0):
+  - WordPressKit (4.14.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1)
-    - WordPressShared (~> 1.9)
+    - WordPressShared (~> 1.10-beta)
     - wpxmlrpc (= 0.8.5)
   - WordPressMocks (0.0.8)
-  - WordPressShared (1.9.2):
+  - WordPressShared (1.10.0-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.7.1)
@@ -491,9 +491,9 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.22.0-beta)
-  - WordPressKit (= 4.13.0)
+  - WordPressKit (~> 4.14-beta)
   - WordPressMocks (~> 0.0.8)
-  - WordPressShared (= 1.9.2)
+  - WordPressShared (~> 1.10.-beta)
   - WordPressUI (~> 1.7.1)
   - WPMediaPicker (~> 1.7.0)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/75ddd7f573ba78e8b0e4bfc1cafd386469658cbb/third-party-podspecs/Yoga.podspec.json`)
@@ -723,9 +723,9 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: 447722ad4a3c30b61871351907a2e4a02075ca30
-  WordPressKit: b912e3436d7203e6a0d04b477aba05c7b78d495a
+  WordPressKit: eb32b62436777b67862e78e9b3eab51d0210e815
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
-  WordPressShared: aab68fab944d8132f488e0f2c1b1abb4399a4aff
+  WordPressShared: d2eede525d5b874a9911362e504da5cc376e5564
   WordPressUI: 9da5d966b8beb091950cd96880db398d7f30e246
   WPMediaPicker: 754bc043ea42abc2eae8a07e5680c777c112666a
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
@@ -739,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 37fcdb7e2545512f6f449cb0e9823c2689be37a8
+PODFILE CHECKSUM: 76f6d576687b5247149736952990ed56148e15e4
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
Diego I'm so sorry! I forgot to explain the WordPressKit / WordPressShared dance that happens between WordPressAuthenticator and WPiOS. When a dependency is updated in Auth that is also a dependency used in WPiOS, they have to be updated at the same time, otherwise it will break pods on `develop` for everyone else. In this case the conflict was that the WPiOS podfile had strict and outdated versions defined for WordPressKit and WordPressShared, while Auth did not.

### To test
To see the errors on `develop`:
1. Check out develop
2. `rm -rf pods`
3. `rake dependencies`
4. Build and run
5. Errors that `AnalyticsEvent` class cannot be found, build fails

To test the fix:
1. Check out this branch
2. `rm -rf pods`
3. `rake dependencies`
4. Build and run (should successfully build now)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
