### PR TITLE
Add missing period to merge translation strings.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -135,7 +135,7 @@ struct QuickStartCustomizeTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let step1DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step1DescriptionBase = NSLocalizedString("Select %@ to continue.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let step1DescriptionTarget = NSLocalizedString("Themes", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .themes, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.themes)))
 
@@ -160,7 +160,7 @@ struct QuickStartShareTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let step1DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step1DescriptionBase = NSLocalizedString("Select %@ to continue.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let step1DescriptionTarget = NSLocalizedString("Sharing", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .sharing, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.share)))
 
@@ -204,7 +204,7 @@ struct QuickStartFollowTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
 
     var waypoints: [WayPoint] = {
-        let step1DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step1DescriptionBase = NSLocalizedString("Select %@ to continue.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .readerTab, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.reader)))
 


### PR DESCRIPTION
While translating we find two near identical strings that can be merged. I added a period to make the others sentence case and address this.
<img width="641" alt="Screen Shot 2020-08-05 at 10 51 11 AM" src="https://user-images.githubusercontent.com/8726005/89447248-89d05c80-d70a-11ea-807d-0289322344e3.png">
