### PR TITLE
Follow topics while logged out

### DIFF
--- a/WordPress/Classes/Models/ReaderTagTopic.swift
+++ b/WordPress/Classes/Models/ReaderTagTopic.swift
@@ -17,12 +17,6 @@ import Foundation
         return NSNotFound as NSNumber
     }
 
-    /// If an interest was followed while the user is not logged into a WP.com account
-    /// The tagID will be 0
-    @objc var wasFollowedWhileLoggedOut: Bool {
-        return tagID == Self.loggedOutTagID && following
-    }
-
     /// Creates a new ReaderTagTopic object from a RemoteReaderInterest
     convenience init(remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext) {
         self.init(context: context)

--- a/WordPress/Classes/Models/ReaderTagTopic.swift
+++ b/WordPress/Classes/Models/ReaderTagTopic.swift
@@ -18,14 +18,14 @@ import Foundation
     }
 
     /// Creates a new ReaderTagTopic object from a RemoteReaderInterest
-    convenience init(remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext) {
+    convenience init(remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext, isFollowing: Bool = false) {
         self.init(context: context)
 
         title = remoteInterest.title
         slug = remoteInterest.slug
         tagID = Self.loggedOutTagID
         type = Self.TopicType
-        following = true
+        following = isFollowing
         showInMenu = true
     }
 

--- a/WordPress/Classes/Services/ReaderTopicService+FollowedInterests.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+FollowedInterests.swift
@@ -72,7 +72,7 @@ extension ReaderTopicService: ReaderFollowedInterestsService {
 
 
         interests.forEach { interest in
-            let topic = ReaderTagTopic(remoteInterest: interest, context: managedObjectContext)
+            let topic = ReaderTagTopic(remoteInterest: interest, context: managedObjectContext, isFollowing: true)
             topic.path = path(slug: interest.slug)
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -39,7 +39,7 @@ import WordPressShared
     }
 
     @objc open func enableLoggedInFeatures(_ enable: Bool) {
-        followButton.isHidden = !enable
+        
     }
 
     fileprivate func adjustInsetsForTextDirection() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -39,7 +39,7 @@ import WordPressShared
     }
 
     @objc open func enableLoggedInFeatures(_ enable: Bool) {
-        
+
     }
 
     fileprivate func adjustInsetsForTextDirection() {


### PR DESCRIPTION
This PR allows logged out users to follow topics.

### To test

#### Logged out

1. Do a fresh install and login with a self-hosted site
2. Go to Reader
3. Tap Discover
4. Follow Art
5. Once the cards appear, scroll down until you see the topics you might like
6. Choose one and follow it
7. Close the app
8. Open again, open the topic view you just followed and make sure you're following it (you can also tap the cog under Following and make sure the topic is there)

#### Logged in

Scenario: removing followed topics while logged out

1. Login with an account
2. Go to Reader -> Following
3. Tap the cog
4. Only the topic you were following before with this account will be presented

Scenario: following topics while logged in

1. While still logged in follow any new topic
2. Go to https://wordpress.com/read
3. Make sure the topic is there (under Tags)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
