### PR TITLE
Add what's new feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,6 +17,7 @@ enum FeatureFlag: Int, CaseIterable {
     case readerImprovementsPhase2
     case gutenbergMentions
     case gutenbergModalLayoutPicker
+    case whatIsNew
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -55,6 +56,8 @@ enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .gutenbergModalLayoutPicker:
             return false
+        case .whatIsNew:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 }
@@ -103,6 +106,8 @@ extension FeatureFlag: OverrideableFlag {
             return "Mentions in Gutenberg"
         case .gutenbergModalLayoutPicker:
             return "Gutenberg Modal Layout Picker"
+        case .whatIsNew:
+            return "What's New / Feature Announcement"
         }
     }
 


### PR DESCRIPTION
Fixes #14580

To test:
- build in debug configuration
- go to me/app settings/debug and verify that "What's New / Feature Announcement" is listed in the feature flags

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
