### PR TITLE
Fix error when toggling Jetpack security settings

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def wordpress_shared
-    pod 'WordPressShared', '1.9.2'
+    pod 'WordPressShared'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :tag => ''
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
@@ -37,10 +37,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '4.13.0'
+    #pod 'WordPressKit', '4.13.0'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '455333459cb57120e88c0bb102b71460bc677fb6'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -397,15 +397,15 @@ PODS:
     - WordPressKit (~> 4.0-beta.0)
     - WordPressShared (~> 1.9-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.13.0):
+  - WordPressKit (4.14.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1)
-    - WordPressShared (~> 1.9)
+    - WordPressShared (~> 1.10-beta)
     - wpxmlrpc (= 0.8.5)
   - WordPressMocks (0.0.8)
-  - WordPressShared (1.9.2):
+  - WordPressShared (1.10.0-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.7.1)
@@ -491,9 +491,9 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.22.0-beta)
-  - WordPressKit (= 4.13.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `455333459cb57120e88c0bb102b71460bc677fb6`)
   - WordPressMocks (~> 0.0.8)
-  - WordPressShared (= 1.9.2)
+  - WordPressShared
   - WordPressUI (~> 1.7.1)
   - WPMediaPicker (~> 1.7.0)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/75ddd7f573ba78e8b0e4bfc1cafd386469658cbb/third-party-podspecs/Yoga.podspec.json`)
@@ -541,7 +541,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -632,6 +631,9 @@ EXTERNAL SOURCES:
     :commit: 75ddd7f573ba78e8b0e4bfc1cafd386469658cbb
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressKit:
+    :commit: 455333459cb57120e88c0bb102b71460bc677fb6
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/75ddd7f573ba78e8b0e4bfc1cafd386469658cbb/third-party-podspecs/Yoga.podspec.json
 
@@ -647,6 +649,9 @@ CHECKOUT OPTIONS:
     :commit: 75ddd7f573ba78e8b0e4bfc1cafd386469658cbb
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressKit:
+    :commit: 455333459cb57120e88c0bb102b71460bc677fb6
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -723,9 +728,9 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: 447722ad4a3c30b61871351907a2e4a02075ca30
-  WordPressKit: b912e3436d7203e6a0d04b477aba05c7b78d495a
+  WordPressKit: eb32b62436777b67862e78e9b3eab51d0210e815
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
-  WordPressShared: aab68fab944d8132f488e0f2c1b1abb4399a4aff
+  WordPressShared: d2eede525d5b874a9911362e504da5cc376e5564
   WordPressUI: 9da5d966b8beb091950cd96880db398d7f30e246
   WPMediaPicker: 754bc043ea42abc2eae8a07e5680c777c112666a
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
@@ -739,6 +744,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 37fcdb7e2545512f6f449cb0e9823c2689be37a8
+PODFILE CHECKSUM: c2e9871441bd9e316f847537e5032c23dd554af0
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
PR to test: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/267

### Description

#### Problem:

When "Block malicious login attempts" is disabled, sending `jetpack_protect_global_whitelist` key in the body results on a server 500 error, even though all other settings are set properly.

We receive this error and display it to the user:

<img src="https://user-images.githubusercontent.com/9772967/89433852-1bf45700-d743-11ea-84a6-eab1ed92113b.png" width="300">

#### Solution:

Filtering the request body to not add the `jetpack_protect_global_whitelist` key if `Block malicious login attempts` is disabled solves the problem.


### Testing Details

- Have a Jetpack-connected self-hosted site.
- Go to Settings -> [Jetpack] Security.
- With `Block malicious login attempts` disabled, toggle `Allow WordPress.com login on and off.
  - Check that there are no error alerts.
- Enable `Block malicious login attempts`.
- Go to `Whitelisted IP addressed`
- Add an IP to the list.
  - Check on web that the IP was synchronised property.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
