### PR TITLE
Add What's New entry in App Settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -302,6 +302,14 @@ class AppSettingsViewController: UITableViewController {
             ActionDispatcher.dispatch(NoticeAction.post(notice))
         }
     }
+
+    func presentWhatIsNew() -> ImmuTableAction {
+        return { [weak self] row in
+            let controller = WhatIsNewViewController()
+            self?.present(controller, animated: true)
+            self?.tableView.deselectSelectedRowWithAnimation(false)
+        }
+    }
 }
 
 // MARK: - SearchableActivity Conformance
@@ -461,6 +469,8 @@ private extension AppSettingsViewController {
             action: pushAbout()
         )
 
+        let whatIsNewRow = NavigationItemRow(title: NSLocalizedString("What's New in WordPress", comment: "Opens the What's New / Feature Announcement modal"), action: presentWhatIsNew())
+
         var rows: [ImmuTableRow] = [settingsRow, aboutRow]
         if #available(iOS 10.3, *),
             UIApplication.shared.supportsAlternateIcons {
@@ -469,6 +479,10 @@ private extension AppSettingsViewController {
 
         if FeatureFlag.debugMenu.enabled {
             rows.append(debugRow)
+        }
+
+        if FeatureFlag.whatIsNew.enabled {
+            rows.append(whatIsNewRow)
         }
 
         if #available(iOS 13.0, *) {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -305,9 +305,12 @@ class AppSettingsViewController: UITableViewController {
 
     func presentWhatIsNew() -> ImmuTableAction {
         return { [weak self] row in
+            guard let self = self else {
+                return
+            }
             let controller = WhatIsNewViewController()
-            self?.present(controller, animated: true)
-            self?.tableView.deselectSelectedRowWithAnimation(false)
+            self.present(controller, animated: true)
+            self.tableView.deselectSelectedRowWithAnimation(false)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/What's New/WhatIsNewViewController.swift
+++ b/WordPress/Classes/ViewRelated/What's New/WhatIsNewViewController.swift
@@ -1,0 +1,65 @@
+
+import UIKit
+
+
+class WhatIsNewViewController: UIViewController {
+
+    private lazy var whatIsNewView: UIView = {
+        WhatIsNewView()
+    }()
+
+    override func loadView() {
+        self.view = whatIsNewView
+    }
+}
+
+
+class WhatIsNewView: UIView {
+
+    lazy var continueButton: UIButton = {
+        let button = FancyButton()
+        button.isPrimary = true
+        button.titleFont = Constants.continueButtonFont
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(NSLocalizedString("Continue",
+                                          comment: "Title for the continue button in the What's New modal"), for: .normal)
+        button.addTarget(self, action: #selector(continueButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = .basicBackground
+        addSubview(continueButton)
+
+        NSLayoutConstraint.activate([
+            safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: continueButton.leadingAnchor, constant: -Constants.continueButtonInset),
+            safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: continueButton.trailingAnchor, constant: Constants.continueButtonInset),
+            safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: continueButton.bottomAnchor, constant: Constants.continueButtonInset),
+            continueButton.heightAnchor.constraint(equalToConstant: Constants.continueButtonHeight)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+
+
+    @objc private func continueButtonTapped() {
+        guard let controller = self.next as? UIViewController else {
+            return
+        }
+        controller.dismiss(animated: true)
+    }
+}
+
+
+extension WhatIsNewView {
+
+    enum Constants {
+        static let continueButtonHeight: CGFloat = 48
+        static let continueButtonInset: CGFloat = 16
+        static let continueButtonFont = UIFont.systemFont(ofSize: 22, weight: .medium)
+    }
+}

--- a/WordPress/Classes/ViewRelated/What's New/WhatIsNewViewController.swift
+++ b/WordPress/Classes/ViewRelated/What's New/WhatIsNewViewController.swift
@@ -1,7 +1,7 @@
 
 import UIKit
 
-
+/// UIViewController for the What's New - Feature Announcements scene
 class WhatIsNewViewController: UIViewController {
 
     private lazy var whatIsNewView: UIView = {
@@ -13,7 +13,7 @@ class WhatIsNewViewController: UIViewController {
     }
 }
 
-
+/// The view that gets assigned to WhatIsNewViewController at load time
 class WhatIsNewView: UIView {
 
     lazy var continueButton: UIButton = {

--- a/WordPress/Classes/ViewRelated/What's New/WhatIsNewViewController.swift
+++ b/WordPress/Classes/ViewRelated/What's New/WhatIsNewViewController.swift
@@ -47,6 +47,7 @@ class WhatIsNewView: UIView {
 
 
     @objc private func continueButtonTapped() {
+        // TODO - WHATSNEW: this will likely need to be changed to not rely on the responder chain
         guard let controller = self.next as? UIViewController else {
             return
         }
@@ -55,7 +56,7 @@ class WhatIsNewView: UIView {
 }
 
 
-extension WhatIsNewView {
+private extension WhatIsNewView {
 
     enum Constants {
         static let continueButtonHeight: CGFloat = 48

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 		3F50945F245537A700C4470B /* ReaderTabViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50945E245537A700C4470B /* ReaderTabViewModelTests.swift */; };
 		3F5B3EAF23A851330060FF1F /* ReaderReblogPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */; };
 		3F5B3EB123A851480060FF1F /* ReaderReblogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B3EB023A851480060FF1F /* ReaderReblogFormatter.swift */; };
+		3F662C4A24DC9FAC00CAEA95 /* WhatIsNewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F662C4924DC9FAC00CAEA95 /* WhatIsNewViewController.swift */; };
 		3F6975FF242D941E001F1807 /* ReaderTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6975FE242D941E001F1807 /* ReaderTabViewModel.swift */; };
 		3F751D462491A93D0008A2B1 /* ZendeskUtilsTests+Plans.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F751D452491A93D0008A2B1 /* ZendeskUtilsTests+Plans.swift */; };
 		3F82310F24564A870086E9B8 /* ReaderTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82310E24564A870086E9B8 /* ReaderTabViewTests.swift */; };
@@ -2789,6 +2790,7 @@
 		3F50945E245537A700C4470B /* ReaderTabViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabViewModelTests.swift; sourceTree = "<group>"; };
 		3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogPresenter.swift; sourceTree = "<group>"; };
 		3F5B3EB023A851480060FF1F /* ReaderReblogFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogFormatter.swift; sourceTree = "<group>"; };
+		3F662C4924DC9FAC00CAEA95 /* WhatIsNewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewViewController.swift; sourceTree = "<group>"; };
 		3F6975FE242D941E001F1807 /* ReaderTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabViewModel.swift; sourceTree = "<group>"; };
 		3F751D452491A93D0008A2B1 /* ZendeskUtilsTests+Plans.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZendeskUtilsTests+Plans.swift"; sourceTree = "<group>"; };
 		3F82310E24564A870086E9B8 /* ReaderTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabViewTests.swift; sourceTree = "<group>"; };
@@ -6157,6 +6159,14 @@
 			name = "Tabbed Reader";
 			sourceTree = "<group>";
 		};
+		3F662C4824DC9F8300CAEA95 /* What's New */ = {
+			isa = PBXGroup;
+			children = (
+				3F662C4924DC9FAC00CAEA95 /* WhatIsNewViewController.swift */,
+			);
+			path = "What's New";
+			sourceTree = "<group>";
+		};
 		3F751D442491A8B20008A2B1 /* Zendesk */ = {
 			isa = PBXGroup;
 			children = (
@@ -7632,6 +7642,7 @@
 				5DA5BF4918E32DDB005F11F9 /* Themes */,
 				B53AD9B31BE9560F009AB87E /* Tools */,
 				031662E60FFB14C60045D052 /* Views */,
+				3F662C4824DC9F8300CAEA95 /* What's New */,
 				D86572182186C36E0023A99C /* Wizards */,
 			);
 			path = ViewRelated;
@@ -12202,6 +12213,7 @@
 				E68580F61E0D91470090EE63 /* WPHorizontalRuleAttachment.swift in Sources */,
 				E12FE0741FA0CEE000F28710 /* ImmuTable+Optional.swift in Sources */,
 				1A433B1D2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift in Sources */,
+				3F662C4A24DC9FAC00CAEA95 /* WhatIsNewViewController.swift in Sources */,
 				7EFF208C20EADF68009C4699 /* FormattableCommentContent.swift in Sources */,
 				E1E5EE37231E47A80018E9E3 /* ContextManager+ErrorHandling.swift in Sources */,
 				F52CACCC24512EA700661380 /* EmptyActionView.swift in Sources */,


### PR DESCRIPTION
Ref #14594

Adds the "What's New" Entry in app settings and presents a modal that will become the Feature Announcement screen (see the flow in #14594).

**Note: this PR only sets the basis. Things that will be addressed in future PRs:**

- Content of the "What's New" screen: at the moment, only the "continue" button is there (and actionable)
- Size of the modal on iPad: at the moment it uses the standard size and does not reflect the designs
- Accessibility
- Unit tests

To test:

- go to 'Me' -> 'App Settings'
- scroll to the bottom and verify that there is a "What's New in WordPress" row
- tap on it and verify that a modal with a 'Continue' button is presented (see below)
- tap 'Continue' and verify that the modal is dismissed

<p align=center>
<img width=270 src=https://user-images.githubusercontent.com/34376330/89594933-d43fff00-d818-11ea-991b-1d5b195e6d24.png>
</p>


PR submission checklist:

- [x] ~~I have considered adding unit tests where possible.~~ Not in this PR
- [x] ~~I have considered adding accessibility improvements for my changes.~~ Not in this PR
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~ Not released.
