### PR TITLE
Add hit area to suggestions UI to allow dismissing on smaller devices

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMentionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMentionsViewController.swift
@@ -4,6 +4,7 @@ import UIKit
 public class GutenbergMentionsViewController: UIViewController {
 
     static let mentionTriggerText = String("@")
+    static let minimumHeaderHeight = CGFloat(50)
 
     public lazy var backgroundView: UIView = {
         let view = UIView(frame: .zero)
@@ -153,6 +154,10 @@ extension GutenbergMentionsViewController: SuggestionsTableViewDelegate {
 
     public func suggestionsTableViewDidTapHeader(_ suggestionsTableView: SuggestionsTableView) {
         onCompletion?(.failure(buildErrorForCancelation()))
+    }
+
+    public func suggestionsTableViewHeaderMinimumHeight(_ suggestionsTableView: SuggestionsTableView) -> CGFloat {
+        return Self.minimumHeaderHeight
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.h
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.h
@@ -67,5 +67,10 @@
 /// @param suggestionsTableView the suggestion view.
 - (void)suggestionsTableViewDidTapHeader:(nonnull SuggestionsTableView *)suggestionsTableView;
 
+/// This method returns the header view minimum height.
+/// Can be used as a hit area for the user to dismiss the suggestions list.
+/// @param suggestionsTableView the suggestion view.
+- (CGFloat)suggestionsTableViewHeaderMinimumHeight:(nonnull SuggestionsTableView *)suggestionsTableView;
+
 
 @end

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -4,6 +4,7 @@
 #import "Suggestion.h"
 #import "SuggestionService.h"
 
+CGFloat const STVDefaultMinHeaderHeight = 0.f;
 NSString * const CellIdentifier = @"SuggestionsTableViewCell";
 CGFloat const STVRowHeight = 44.f;
 CGFloat const STVSeparatorHeight = 1.f;
@@ -16,6 +17,7 @@ CGFloat const STVSeparatorHeight = 1.f;
 @property (nonatomic, strong) NSArray *suggestions;
 @property (nonatomic, strong) NSString *searchText;
 @property (nonatomic, strong) NSMutableArray *searchResults;
+@property (nonatomic, strong) NSLayoutConstraint *headerMinimumHeightConstraint;
 @property (nonatomic, strong) NSLayoutConstraint *heightConstraint;
 
 @end
@@ -58,9 +60,8 @@ CGFloat const STVSeparatorHeight = 1.f;
         [self.separatorView setBackgroundColor: [WPStyleGuide suggestionsSeparatorSmoke]];
     } else {
         [self.headerView setBackgroundColor: [WPStyleGuide suggestionsHeaderSmoke]];
-        [self.separatorView setBackgroundColor: [UIColor clearColor]];
+        [self.separatorView setBackgroundColor: [WPStyleGuide lightGrey]];
     }
-    
 }
 
 - (void)setupHeaderView
@@ -123,6 +124,16 @@ CGFloat const STVSeparatorHeight = 1.f;
                                                                  metrics:metrics
                                                                    views:views]];
 
+    // Add a height constraint to the header view which we can later adjust via the delegate
+    self.headerMinimumHeightConstraint = [NSLayoutConstraint constraintWithItem:self.headerView
+                                                               attribute:NSLayoutAttributeHeight
+                                                               relatedBy:NSLayoutRelationGreaterThanOrEqual
+                                                                  toItem:nil
+                                                               attribute:NSLayoutAttributeNotAnAttribute
+                                                              multiplier:1
+                                                                constant:0.f];
+    [self addConstraint:self.headerMinimumHeightConstraint];
+
     // Add a height constraint to the table view
     self.heightConstraint = [NSLayoutConstraint constraintWithItem:self.tableView
                                                          attribute:NSLayoutAttributeHeight
@@ -167,6 +178,13 @@ CGFloat const STVSeparatorHeight = 1.f;
 
 - (void)updateConstraints
 {
+    // Ask the delegate for a minimum header height, otherwise use default value.
+    CGFloat minimumHeaderHeight = STVDefaultMinHeaderHeight;
+    if ([self.suggestionsDelegate respondsToSelector:@selector(suggestionsTableViewHeaderMinimumHeight:)]) {
+        minimumHeaderHeight = [self.suggestionsDelegate suggestionsTableViewHeaderMinimumHeight:self];
+    }
+    self.headerMinimumHeightConstraint.constant = minimumHeaderHeight;
+
     // Take the height of the table frame and make it so only whole results are displayed
     NSUInteger maxRows = floor(self.frame.size.height / STVRowHeight);
 

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -60,7 +60,7 @@ CGFloat const STVSeparatorHeight = 1.f;
         [self.separatorView setBackgroundColor: [WPStyleGuide suggestionsSeparatorSmoke]];
     } else {
         [self.headerView setBackgroundColor: [WPStyleGuide suggestionsHeaderSmoke]];
-        [self.separatorView setBackgroundColor: [WPStyleGuide lightGrey]];
+        [self.separatorView setBackgroundColor: [WPStyleGuide suggestionsHeaderSmoke]];
     }
 }
 


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/issues/24425

## Description

The PR adds a hit area with a minimum height of 50 points to the suggestion UI list, which allows the UI to be dismissed no matter what the screen size. Currently, on smaller phones such as the iPhone 7, the suggestions UI takes up all available screen space and there is no room to tap outside it to dismiss.

## Screenshots

**Note: the gap in the second screenshot shows the hit area this PR adds to facilitate dismissing the list.**

| Before | After |
| -- | -- |
| <img src="https://user-images.githubusercontent.com/1898325/89603690-a7e7ab00-d837-11ea-8553-a1b4a5c7bea2.PNG"> | <img src="https://user-images.githubusercontent.com/1898325/89603696-ac13c880-d837-11ea-997d-0d90d858216e.PNG"> |

## Testing instructions

_You'll need to test with a smaller device such as an iPhone 7 and a site with enough users that the suggestion UI fills the screen (roughly 7 in my tests)_
1. Open a post
2. Type @ to trigger the mentions UI
3. Notice there is now a gap between the navigation bar and the top username in the list of suggestions
4. Tap anywhere in this gap and notice the suggestions UI dismisses

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
