### PR TITLE
Present Select Interests fullscreen

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -70,6 +70,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         }
 
         readerTabBarViewController.displaySelectInterestsIfNeeded()
+        showGhost()
     }
 
     // MARK: - Sync

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -17,6 +17,11 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         tableView.register(ReaderTopicsCardCell.self, forCellReuseIdentifier: readerCardTopicsIdentifier)
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        displaySelectInterestsIfNeeded()
+    }
+
     // MARK: - TableView Related
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -57,6 +62,14 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
 
     private func isTableViewAtTheTop() -> Bool {
         return tableView.contentOffset.y == 0
+    }
+
+    private func displaySelectInterestsIfNeeded() {
+        guard let readerTabBarViewController = parent as? ReaderTabViewController else {
+            return
+        }
+
+        readerTabBarViewController.displaySelectInterestsIfNeeded()
     }
 
     // MARK: - Sync

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -11,18 +11,10 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         return ReaderCardService()
     }()
 
-    private var selectInterestsViewController: ReaderSelectInterestsViewController? = ReaderSelectInterestsViewController()
-
     override func viewDidLoad() {
         super.viewDidLoad()
         ReaderWelcomeBanner.displayIfNeeded(in: tableView)
         tableView.register(ReaderTopicsCardCell.self, forCellReuseIdentifier: readerCardTopicsIdentifier)
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        displaySelectInterestsIfNeeded()
     }
 
     // MARK: - TableView Related
@@ -127,43 +119,5 @@ extension ReaderCardsStreamViewController: ReaderTopicsCardCellDelegate {
     func didSelect(topic: ReaderTagTopic) {
         let topicStreamViewController = ReaderStreamViewController.controllerWithTopic(topic)
         navigationController?.pushViewController(topicStreamViewController, animated: true)
-    }
-}
-
-// MARK: - Select Interests Display
-private extension ReaderCardsStreamViewController {
-    func displaySelectInterestsIfNeeded() {
-        selectInterestsViewController?.userIsFollowingTopics { [unowned self] isFollowing in
-            if isFollowing {
-                self.selectInterestsViewController = nil
-            } else {
-                self.showSelectInterestsView()
-            }
-        }
-    }
-
-    func showSelectInterestsView() {
-        guard let controller = selectInterestsViewController else {
-            return
-        }
-
-        controller.view.frame = self.view.bounds
-        self.add(controller)
-
-        controller.didSaveInterests = { [unowned self] in
-            guard let controller = self.selectInterestsViewController else {
-                return
-            }
-
-            self.displayLoadingStream()
-            self.syncIfAppropriate()
-
-            UIView.animate(withDuration: 0.2, animations: {
-                controller.view.alpha = 0
-            }) { [unowned self] _ in
-                controller.remove()
-                self.selectInterestsViewController = nil
-            }
-        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -33,6 +33,8 @@ class ReaderSelectInterestsViewController: UIViewController {
     @IBOutlet weak var loadingLabel: UILabel!
     @IBOutlet weak var loadingView: UIStackView!
 
+    @IBOutlet weak var bottomSpaceHeightConstraint: NSLayoutConstraint!
+
     // MARK: - Data
     private let dataSource: ReaderInterestsDataSource = ReaderInterestsDataSource()
     private let coordinator: ReaderSelectInterestsCoordinator = ReaderSelectInterestsCoordinator()
@@ -51,12 +53,23 @@ class ReaderSelectInterestsViewController: UIViewController {
         configureNoResultsViewController()
         applyStyles()
         updateNextButtonState()
+        refreshData()
+
+        // If the view is being presented overCurrentContext take into account tab bar height
+        if modalPresentationStyle == .overCurrentContext {
+            bottomSpaceHeightConstraint.constant = presentingViewController?.tabBarController?.tabBar.bounds.size.height ?? 0
+        }
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
 
-        refreshData()
+        // If this view was presented over current context and it's disappearing
+        // it means that the user switched tabs. Keeping it in the view hierarchy cause
+        // weird black screens, so we dismiss it to avoid that.
+        if modalPresentationStyle == .overCurrentContext {
+            dismiss(animated: false)
+        }
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
@@ -11,6 +11,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReaderSelectInterestsViewController" customModule="WordPress" customModuleProvider="target">
             <connections>
                 <outlet property="activityIndicatorView" destination="a7r-YY-Vl7" id="IQc-pB-zlX"/>
+                <outlet property="bottomSpaceHeightConstraint" destination="XCs-b1-Ce2" id="Wdz-a3-j40"/>
                 <outlet property="buttonContainerView" destination="X4F-fc-WqY" id="TtA-Ul-l6R"/>
                 <outlet property="collectionView" destination="fUq-vV-Pah" id="ueF-52-q8k"/>
                 <outlet property="contentContainerView" destination="y7t-k2-AgA" id="KvG-Vr-Y5Y"/>
@@ -93,16 +94,26 @@
                                 <constraint firstItem="5kh-rf-B5P" firstAttribute="leading" secondItem="X4F-fc-WqY" secondAttribute="leading" constant="20" id="zV4-Ir-MFf"/>
                             </constraints>
                         </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="be9-lX-CD7">
+                            <rect key="frame" x="0.0" y="736" width="414" height="0.0"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" id="XCs-b1-Ce2"/>
+                            </constraints>
+                        </view>
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <constraints>
+                        <constraint firstAttribute="trailing" secondItem="be9-lX-CD7" secondAttribute="trailing" id="0de-fR-YWW"/>
+                        <constraint firstItem="be9-lX-CD7" firstAttribute="top" secondItem="X4F-fc-WqY" secondAttribute="bottom" id="67o-fb-UOy"/>
                         <constraint firstItem="X4F-fc-WqY" firstAttribute="leading" secondItem="y7t-k2-AgA" secondAttribute="leading" id="9mr-Wg-Hvq"/>
                         <constraint firstAttribute="trailing" secondItem="X4F-fc-WqY" secondAttribute="trailing" id="AzF-5F-ioe"/>
                         <constraint firstAttribute="trailing" secondItem="2ka-fB-oWM" secondAttribute="trailing" id="Fnt-G7-QEW"/>
                         <constraint firstItem="2ka-fB-oWM" firstAttribute="leading" secondItem="y7t-k2-AgA" secondAttribute="leading" id="Mso-AA-bvt"/>
                         <constraint firstItem="2ka-fB-oWM" firstAttribute="top" secondItem="y7t-k2-AgA" secondAttribute="top" id="NQz-F4-hfI"/>
                         <constraint firstItem="X4F-fc-WqY" firstAttribute="top" secondItem="2ka-fB-oWM" secondAttribute="bottom" id="PrH-sw-ZRT"/>
-                        <constraint firstAttribute="bottom" secondItem="X4F-fc-WqY" secondAttribute="bottom" id="e2B-2S-d5a"/>
+                        <constraint firstItem="be9-lX-CD7" firstAttribute="leading" secondItem="y7t-k2-AgA" secondAttribute="leading" id="ZZq-Y8-qmh"/>
+                        <constraint firstAttribute="bottom" secondItem="be9-lX-CD7" secondAttribute="bottom" id="zzz-rJ-cDv"/>
                     </constraints>
                 </view>
                 <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="33" translatesAutoresizingMaskIntoConstraints="NO" id="DIz-pa-QD0" userLabel="Loading Container View">
@@ -122,7 +133,7 @@
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="y7t-k2-AgA" secondAttribute="bottom" id="1eg-oJ-DKt"/>
+                <constraint firstAttribute="bottom" secondItem="y7t-k2-AgA" secondAttribute="bottom" id="1eg-oJ-DKt"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="DIz-pa-QD0" secondAttribute="trailing" constant="20" id="LAe-0c-dgq"/>
                 <constraint firstItem="DIz-pa-QD0" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="W40-bk-aVZ"/>
                 <constraint firstItem="y7t-k2-AgA" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Wnu-bP-bRf"/>

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -87,6 +87,9 @@ extension ReaderTabItemsStore {
         }
         state = .loading
 
+        // Return the tab bar items right away to avoid waiting for the request to finish
+        fetchTabBarItems()
+
         // Sync the reader menu
         service.fetchReaderMenu(success: { [weak self] in
             self?.fetchTabBarItemsAndFollowedSites()

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -35,7 +35,7 @@ class ReaderTabView: UIView {
             self?.toggleButtonsView()
         }
 
-        viewModel.onDidChangeTabBar { [weak self] tabItems, index in
+        viewModel.onTabBarItemsDidChange { [weak self] tabItems, index in
             self?.tabBar.items = tabItems
             self?.tabBar.setSelectedIndex(index)
             self?.configureTabBarElements()

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -47,6 +47,16 @@ class ReaderTabView: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    func selectDiscover() {
+        guard let discoverIndex = tabBar.items
+            .firstIndex(where: { $0.title == NSLocalizedString("Discover", comment: "Discover tab name") }) else {
+            return
+        }
+
+        tabBar.setSelectedIndex(discoverIndex)
+        selectedTabDidChange(tabBar)
+    }
 }
 
 // MARK: - UI setup

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -35,7 +35,7 @@ class ReaderTabView: UIView {
             self?.toggleButtonsView()
         }
 
-        viewModel.refreshTabBar { [weak self] tabItems, index in
+        viewModel.onDidChangeTabBar { [weak self] tabItems, index in
             self?.tabBar.items = tabItems
             self?.tabBar.setSelectedIndex(index)
             self?.configureTabBarElements()

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -42,6 +42,8 @@ class ReaderTabView: UIView {
             self?.addContentToContainerView()
         }
         setupViewElements()
+
+        viewModel.fetchReaderMenu()
     }
 
     required init?(coder: NSCoder) {
@@ -94,7 +96,6 @@ extension ReaderTabView {
         tabBar.tabBarHeight = Appearance.barHeight
         WPStyleGuide.configureFilterTabBar(tabBar)
         tabBar.addTarget(self, action: #selector(selectedTabDidChange(_:)), for: .valueChanged)
-        viewModel.fetchReaderMenu()
     }
 
     private func configureTabBarElements() {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -39,10 +39,6 @@ class ReaderTabViewController: UIViewController {
             viewModel.presentManage(from: self)
         }
 
-        viewModel.onDidChangeTabBar { [weak self] items, _ in
-            self?.displaySelectInterestsIfNeeded()
-        }
-
         NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountDidChange(_:)), name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged, object: nil)
     }
 
@@ -54,6 +50,10 @@ class ReaderTabViewController: UIViewController {
         super.viewDidAppear(animated)
 
         displaySelectInterestsIfNeeded()
+
+        viewModel.onDidChangeTabBar { [weak self] items, _ in
+            self?.displaySelectInterestsIfNeeded()
+        }
     }
 
     func setupSearchButton() {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -118,7 +118,7 @@ extension ReaderTabViewController {
 }
 
 // MARK: - Select Interests Display
-private extension ReaderTabViewController {
+extension ReaderTabViewController {
     func displaySelectInterestsIfNeeded() {
         guard viewModel.itemsLoaded, isViewOnScreen() else {
             return

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -4,15 +4,15 @@ class ReaderTabViewController: UIViewController {
 
     private let viewModel: ReaderTabViewModel
 
-    private let makeReaderTabView: (ReaderTabViewModel) -> UIView
+    private let makeReaderTabView: (ReaderTabViewModel) -> ReaderTabView
 
-    private lazy var readerTabView: UIView = {
+    private lazy var readerTabView: ReaderTabView = {
         return makeReaderTabView(viewModel)
     }()
 
     private var selectInterestsViewController: ReaderSelectInterestsViewController = ReaderSelectInterestsViewController()
 
-    init(viewModel: ReaderTabViewModel, readerTabViewFactory: @escaping (ReaderTabViewModel) -> UIView) {
+    init(viewModel: ReaderTabViewModel, readerTabViewFactory: @escaping (ReaderTabViewModel) -> ReaderTabView) {
         self.viewModel = viewModel
         self.makeReaderTabView = readerTabViewFactory
         super.init(nibName: nil, bundle: nil)
@@ -137,7 +137,7 @@ private extension ReaderTabViewController {
         navigationController?.present(selectInterestsViewController, animated: true, completion: nil)
 
         selectInterestsViewController.didSaveInterests = { [unowned self] in
-            // TODO: present Discover feed
+            self.readerTabView.selectDiscover()
 
             self.selectInterestsViewController.dismiss(animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -36,6 +36,8 @@ class ReaderTabViewController: UIViewController {
             }
             viewModel.presentManage(from: self)
         }
+
+        NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountDidChange(_:)), name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged, object: nil)
     }
 
     required init?(coder: NSCoder) {
@@ -92,6 +94,13 @@ extension ReaderTabViewController: UIViewControllerRestoration {
 
     func setStartIndex(_ index: Int) {
         viewModel.selectedIndex = index
+    }
+}
+
+// MARK: - Notifications
+extension ReaderTabViewController {
+    @objc private func defaultAccountDidChange(_ notification: Foundation.Notification) {
+        loadView()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -51,7 +51,7 @@ class ReaderTabViewController: UIViewController {
 
         displaySelectInterestsIfNeeded()
 
-        viewModel.onDidChangeTabBar { [weak self] items, _ in
+        viewModel.onTabBarItemsDidChange { [weak self] items, _ in
             self?.displaySelectInterestsIfNeeded()
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -99,6 +99,7 @@ extension ReaderTabViewController: UIViewControllerRestoration {
 
 // MARK: - Notifications
 extension ReaderTabViewController {
+    // Ensure that topics and sites are synced when account changes
     @objc private func defaultAccountDidChange(_ notification: Foundation.Notification) {
         loadView()
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -7,7 +7,7 @@ import WordPressFlux
     /// tab bar items
     private let tabItemsStore: ItemsStore
     private var subscription: Receipt?
-    private var setTabBarItems: (([ReaderTabItem], Int) -> Void)?
+    private var didChangeTabBarItems: [(([ReaderTabItem], Int) -> Void)] = []
 
     private var tabItems: [ReaderTabItem] {
         tabItemsStore.items
@@ -47,7 +47,7 @@ import WordPressFlux
             guard let viewModel = self else {
                 return
             }
-            viewModel.setTabBarItems?(viewModel.tabItems, viewModel.selectedIndex)
+            viewModel.didChangeTabBarItems.forEach { $0(viewModel.tabItems, viewModel.selectedIndex) }
         }
         addNotificationsObservers()
         observeNetworkStatus()
@@ -58,8 +58,8 @@ import WordPressFlux
 // MARK: - Tab bar items
 extension ReaderTabViewModel {
 
-    func refreshTabBar(completion: @escaping ([ReaderTabItem], Int) -> Void) {
-        setTabBarItems = completion
+    func onDidChangeTabBar(completion: @escaping ([ReaderTabItem], Int) -> Void) {
+        didChangeTabBarItems.append(completion)
     }
 
     func fetchReaderMenu() {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -7,7 +7,7 @@ import WordPressFlux
     /// tab bar items
     private let tabItemsStore: ItemsStore
     private var subscription: Receipt?
-    private var didChangeTabBarItems: [(([ReaderTabItem], Int) -> Void)] = []
+    private var onTabBarItemsDidChange: [(([ReaderTabItem], Int) -> Void)] = []
 
     private var tabItems: [ReaderTabItem] {
         tabItemsStore.items
@@ -52,7 +52,7 @@ import WordPressFlux
             guard let viewModel = self else {
                 return
             }
-            viewModel.didChangeTabBarItems.forEach { $0(viewModel.tabItems, viewModel.selectedIndex) }
+            viewModel.onTabBarItemsDidChange.forEach { $0(viewModel.tabItems, viewModel.selectedIndex) }
         }
         addNotificationsObservers()
         observeNetworkStatus()
@@ -63,8 +63,8 @@ import WordPressFlux
 // MARK: - Tab bar items
 extension ReaderTabViewModel {
 
-    func onDidChangeTabBar(completion: @escaping ([ReaderTabItem], Int) -> Void) {
-        didChangeTabBarItems.append(completion)
+    func onTabBarItemsDidChange(completion: @escaping ([ReaderTabItem], Int) -> Void) {
+        onTabBarItemsDidChange.append(completion)
     }
 
     func fetchReaderMenu() {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -29,6 +29,11 @@ import WordPressFlux
     /// search
     var navigateToSearch: () -> Void
 
+    /// if items are loaded
+    var itemsLoaded: Bool {
+        return tabItems.count > 0
+    }
+
     /// Settings
     private let settingsPresenter: ScenePresenter
     var settingsTapped: ((UIView) -> Void)?

--- a/WordPress/WordPressTest/ReaderTabItemsStoreTests.swift
+++ b/WordPress/WordPressTest/ReaderTabItemsStoreTests.swift
@@ -55,13 +55,9 @@ class ReaderTabItemsStoreTests: XCTestCase {
         let mockTopics = [mockTopic]
 
         context.returnedObjects = mockTopics
-        context.fetchExpectation = expectation(description: "fetch request executed")
-        context.successExpectation = expectation(description: "fetch request succeeded")
-
-        service.fetchReaderMenuExpectation = expectation(description: "fetch menu items executed")
-        service.fetchMenuSuccessExpectation = expectation(description: "fetch from remote service succeeded")
 
         let stateChangeExpectation = expectation(description: "state change emitted")
+        stateChangeExpectation.expectedFulfillmentCount = 2
 
         subscription = store.onChange {
             stateChangeExpectation.fulfill()
@@ -86,14 +82,13 @@ class ReaderTabItemsStoreTests: XCTestCase {
         let mockTopics = [mockTopic]
 
         context.returnedObjects = mockTopics
-        context.fetchExpectation = expectation(description: "fetch request executed")
-        context.successExpectation = expectation(description: "fetch request succeeded")
 
         service.success = false
         service.fetchReaderMenuExpectation = expectation(description: "fetch menu items executed")
         service.fetchMenuFailureExpectation = expectation(description: "fetch from remote service failed")
 
         let stateChangeExpectation = expectation(description: "state change emitted")
+        stateChangeExpectation.expectedFulfillmentCount = 2
 
         subscription = store.onChange {
             stateChangeExpectation.fulfill()
@@ -114,14 +109,13 @@ class ReaderTabItemsStoreTests: XCTestCase {
     func testGetItemsFetchRequestFailure() {
         // Given
         context.success = false
-        context.fetchExpectation = expectation(description: "fetch request executed")
-        context.failureExpectation = expectation(description: "fetch request failed")
         context.fetchError = mockError
 
         service.fetchReaderMenuExpectation = expectation(description: "fetch menu items executed")
         service.fetchMenuSuccessExpectation = expectation(description: "fetch from remote service succeeded")
 
         let stateChangeExpectation = expectation(description: "state change emitted")
+        stateChangeExpectation.expectedFulfillmentCount = 2
 
         subscription = store.onChange {
             stateChangeExpectation.fulfill()
@@ -150,13 +144,11 @@ class ReaderTabItemsStoreTests: XCTestCase {
 
         context.returnedObjects = mockTopics
 
-        context.fetchExpectation = expectation(description: "fetch request executed")
-        context.successExpectation = expectation(description: "fetch request succeeded")
-
         service.fetchReaderMenuExpectation = expectation(description: "fetch menu items executed")
         service.fetchMenuSuccessExpectation = expectation(description: "fetch from remote service succeeded")
 
         let stateChangeExpectation = expectation(description: "state change emitted")
+        stateChangeExpectation.expectedFulfillmentCount = 2
 
         subscription = store.onChange {
             stateChangeExpectation.fulfill()

--- a/WordPress/WordPressTest/ReaderTabViewModelTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewModelTests.swift
@@ -68,7 +68,7 @@ class ReaderTabViewModelTests: XCTestCase {
         let setTabBarItemsExpectation = expectation(description: "tab bar items were set")
         store.getItemsExpectation = expectation(description: "Items were fetched")
         // When
-        viewModel.onDidChangeTabBar { items, index in
+        viewModel.onTabBarItemsDidChange { items, index in
             setTabBarItemsExpectation.fulfill()
             XCTAssertEqual(index, 0)
             XCTAssertEqual(items.map { $0.title }, ["Following", "Following"])

--- a/WordPress/WordPressTest/ReaderTabViewModelTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewModelTests.swift
@@ -68,7 +68,7 @@ class ReaderTabViewModelTests: XCTestCase {
         let setTabBarItemsExpectation = expectation(description: "tab bar items were set")
         store.getItemsExpectation = expectation(description: "Items were fetched")
         // When
-        viewModel.refreshTabBar { items, index in
+        viewModel.onDidChangeTabBar { items, index in
             setTabBarItemsExpectation.fulfill()
             XCTAssertEqual(index, 0)
             XCTAssertEqual(items.map { $0.title }, ["Following", "Following"])


### PR DESCRIPTION
This PR has two different (but inter-connected) changes:

* It displays the Select Interests fullscreen
* It doesn't wait for a request to finish to show the Reader and preload the topics when the user login

<img src="https://user-images.githubusercontent.com/7040243/89670968-7cf16b80-d8b8-11ea-969b-9872fc592582.gif" width="300">

## To test

### Showing the Reader right away

1. Open the app
2. Tap Reader
3. Check that it appears right away, without waiting for a request with the server to finish

### Showing Select Interests

#### Logged out

1. Do a fresh install of the app
2. Login with a self-hosted site
3. Tap the Reader, check that the Interests screen pops up
4. Select at least one topic
5. Tap Done and check that the Discover session is shown

#### Logged in

1. You can either do a fresh install or login into an account
2. Tap Reader
3. Make sure to remove any topic you're already following
4. Tap "My Site" and then Reader again
3. Check that the Interests screen pops up
4. Select at least one topic
5. Tap Done and check that the Discover session is shown

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
