### PR TITLE
Update Block Editor RELEASE-NOTES.txt for 15.5

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,10 +1,9 @@
 15.5
 -----
- * [***] Block Editor: New feature for WordPress.com and Jetpack sites: auto-complete username mentions. An auto-complete popup will show up when the user types the @ character in the block editor.
-
 * [*] Reader: revamped UI for your site header.
- 
- * [***] Block Editor: New feature for WordPress.com and Jetpack sites: auto-complete username mentions. An auto-complete popup will show up when the user types the @ character in the block editor.
+* [***] Block Editor: New feature for WordPress.com and Jetpack sites: auto-complete username mentions. An auto-complete popup will show up when the user types the @ character in the block editor.
+* [*] Block Editor: Media editing support in Cover block.
+* [*] Block Editor: Fixed a bug on the Heading block, where a heading with a link and string formatting showed a white shadow in dark mode.
 
 15.4
 -----


### PR DESCRIPTION
[Release notes from the 1.34.0 Editor release](https://github.com/wordpress-mobile/gutenberg-mobile/blob/854b28c051f457f7293824ea1278dc59e1f63ed6/RELEASE-NOTES.txt#L3-L4) are added here for 15.5

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
