### PR TITLE
Update Follow button UI

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -280,7 +280,7 @@ extension UIColor {
             return .systemGray2
         }
 
-        return UIColor.neutral(.shade5)
+        return .neutral(.shade5)
     }
 
     static var filterBarBackground: UIColor {

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -213,7 +213,7 @@ extension UIColor {
                return .opaqueSeparator
            }
 
-        return UIColor(displayP3Red: 198.0, green: 198.0, blue: 200.0, alpha: 1.0)
+        return muriel(color: .gray, .shade10)
     }
 
     /// WP color for table foregrounds (cells, etc)
@@ -272,7 +272,7 @@ extension UIColor {
             return .systemGray
         }
 
-        return UIColor.neutral(.shade20)
+        return .neutral(.shade20)
     }
 
     static var buttonIcon: UIColor {

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -207,7 +207,7 @@ extension UIColor {
 
         return muriel(color: .divider)
     }
-    
+
     static var primaryButtonBorder: UIColor {
            if #available(iOS 13, *) {
                return .opaqueSeparator
@@ -274,7 +274,7 @@ extension UIColor {
 
         return UIColor.neutral(.shade20)
     }
-    
+
     static var buttonIcon: UIColor {
         if #available(iOS 13, *) {
             return .systemGray2

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -207,6 +207,14 @@ extension UIColor {
 
         return muriel(color: .divider)
     }
+    
+    static var primaryButtonBorder: UIColor {
+           if #available(iOS 13, *) {
+               return .opaqueSeparator
+           }
+
+        return UIColor(displayP3Red: 198.0, green: 198.0, blue: 200.0, alpha: 1.0)
+    }
 
     /// WP color for table foregrounds (cells, etc)
     static var listForeground: UIColor {
@@ -265,6 +273,14 @@ extension UIColor {
         }
 
         return UIColor.neutral(.shade20)
+    }
+    
+    static var buttonIcon: UIColor {
+        if #available(iOS 13, *) {
+            return .systemGray2
+        }
+
+        return UIColor.neutral(.shade5)
     }
 
     static var filterBarBackground: UIColor {

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -282,15 +282,18 @@ extension WPStyleGuide {
     }
 
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton) {
-        let side = WPStyleGuide.fontSizeForTextStyle(.headline)
+        let side = WPStyleGuide.fontSizeForTextStyle(.callout)
         let size = CGSize(width: side, height: side)
 
         let followIcon = UIImage.gridicon(.readerFollow, size: size)
         let followingIcon = UIImage.gridicon(.readerFollowing, size: size)
 
-        button.titleLabel?.font = fontForTextStyle(.headline, fontWeight: .semibold)
+        let followFont: UIFont = fontForTextStyle(.callout, fontWeight: .semibold)
+        let followingFont: UIFont = fontForTextStyle(.callout, fontWeight: .regular)
+        button.titleLabel?.font = button.isSelected ? followingFont : followFont
+
         button.layer.cornerRadius = 4.0
-        button.layer.borderColor = UIColor(light: .gray(.shade30), dark: .gray(.shade60)).cgColor
+        button.layer.borderColor = UIColor.primaryButtonBorder.cgColor
 
         button.backgroundColor = button.isSelected ? FollowButton.Style.followingBackgroundColor : FollowButton.Style.followBackgroundColor
         button.tintColor = button.isSelected ? FollowButton.Style.followingTextColor : FollowButton.Style.followTextColor
@@ -539,8 +542,8 @@ extension WPStyleGuide {
         struct Style {
             static let followBackgroundColor: UIColor = .primaryButtonBackground
             static let followTextColor: UIColor = .white
-            static let followingBackgroundColor: UIColor = .basicBackground
-            static let followingTextColor: UIColor = .textSubtle
+            static let followingBackgroundColor: UIColor = .clear
+            static let followingTextColor: UIColor = .buttonIcon
 
             static let imageTitleSpace: CGFloat = 2.0
             static let imageEdgeInsets = UIEdgeInsets(top: 0, left: -imageTitleSpace, bottom: 0, right: imageTitleSpace)

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -296,7 +296,7 @@ extension WPStyleGuide {
         button.layer.borderColor = UIColor.primaryButtonBorder.cgColor
 
         button.backgroundColor = button.isSelected ? FollowButton.Style.followingBackgroundColor : FollowButton.Style.followBackgroundColor
-        button.tintColor = button.isSelected ? FollowButton.Style.followingTextColor : FollowButton.Style.followTextColor
+        button.tintColor = button.isSelected ? FollowButton.Style.followingIconColor : FollowButton.Style.followTextColor
 
         button.setTitleColor(FollowButton.Style.followTextColor, for: .normal)
         button.setTitleColor(FollowButton.Style.followingTextColor, for: .selected)
@@ -543,7 +543,8 @@ extension WPStyleGuide {
             static let followBackgroundColor: UIColor = .primaryButtonBackground
             static let followTextColor: UIColor = .white
             static let followingBackgroundColor: UIColor = .clear
-            static let followingTextColor: UIColor = .buttonIcon
+            static let followingIconColor: UIColor = .buttonIcon
+            static let followingTextColor: UIColor = .textSubtle
 
             static let imageTitleSpace: CGFloat = 2.0
             static let imageEdgeInsets = UIEdgeInsets(top: 0, left: -imageTitleSpace, bottom: 0, right: imageTitleSpace)


### PR DESCRIPTION
Following design feedback in: #14612 

In this PR:
- Added 2 colors, buttonIcon and primaryButtonBorder to UIColor+MurielColors.
- updated button font from headline to callout
- updated following font from semibold to regular
- updated button's border color to opaqueSeparator
- updated following background color to clear instead of black
- update following text and icon color to .systemGray2

#### Dark

Follow             |  Following 
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1335657/89955085-1b4a3d80-dbe7-11ea-9318-adec40d3368c.png)  |  ![](https://user-images.githubusercontent.com/1335657/89955087-1c7b6a80-dbe7-11ea-9f91-1629729df05a.png)

#### Light

Follow             |  Following 
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1335657/89955095-1e452e00-dbe7-11ea-871f-6e755b094250.png)  |  ![](https://user-images.githubusercontent.com/1335657/89955093-1dac9780-dbe7-11ea-81cf-a07560a6e780.png)

To test:
1. Go to reader
2. Tap on a site name in a post card
3. See the follow / following button looks good and applies designs updates 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
