### PR TITLE
Fix/site header layout fixes

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -32,7 +32,7 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     @IBOutlet fileprivate weak var followButton: UIButton!
     @IBOutlet fileprivate weak var followCountLabel: UILabel!
     @IBOutlet fileprivate weak var descriptionLabel: UILabel!
-    @IBOutlet fileprivate weak var descriptionLableTopConstraint: NSLayoutConstraint!
+    @IBOutlet fileprivate weak var descriptionLabelTopConstraint: NSLayoutConstraint!
 
     open var delegate: ReaderStreamHeaderDelegate?
     fileprivate var defaultBlavatar = "blavatar-default"
@@ -85,7 +85,7 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         WPStyleGuide.applyReaderFollowButtonStyle(followButton)
 
         if siteTopic.siteDescription.isEmpty {
-            descriptionLableTopConstraint.constant = 0.0
+            descriptionLabelTopConstraint.constant = 0.0
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -85,8 +85,7 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         WPStyleGuide.applyReaderFollowButtonStyle(followButton)
 
         if siteTopic.siteDescription.isEmpty {
-            descriptionLableTopConstraint.isActive = false
-            descriptionLabel.topAnchor.constraint(equalTo: avatarImageView.bottomAnchor, constant: 0.0).isActive = true
+            descriptionLableTopConstraint.constant = 0.0
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -83,11 +83,6 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 
         WPStyleGuide.applyReaderFollowButtonStyle(followButton)
 
-        if descriptionLabel.attributedText?.length > 0 {
-            descriptionLabel.isHidden = false
-        } else {
-            descriptionLabel.isHidden = true
-        }
     }
 
     @objc func configureHeaderImage(_ siteBlavatar: String?) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -32,6 +32,7 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     @IBOutlet fileprivate weak var followButton: UIButton!
     @IBOutlet fileprivate weak var followCountLabel: UILabel!
     @IBOutlet fileprivate weak var descriptionLabel: UILabel!
+    @IBOutlet fileprivate weak var descriptionLableTopConstraint: NSLayoutConstraint!
 
     open var delegate: ReaderStreamHeaderDelegate?
     fileprivate var defaultBlavatar = "blavatar-default"
@@ -83,6 +84,10 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 
         WPStyleGuide.applyReaderFollowButtonStyle(followButton)
 
+        if siteTopic.siteDescription.isEmpty {
+            descriptionLableTopConstraint.isActive = false
+            descriptionLabel.topAnchor.constraint(equalTo: avatarImageView.bottomAnchor, constant: 0.0).isActive = true
+        }
     }
 
     @objc func configureHeaderImage(_ siteBlavatar: String?) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -21,32 +21,32 @@
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqV-yA-rBc">
-                    <rect key="frame" x="164" y="15.999999999999998" width="219" height="20.333333333333329"/>
+                    <rect key="frame" x="164" y="15.999999999999998" width="203" height="20.333333333333329"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fq2-Xh-dYx">
-                    <rect key="frame" x="164" y="40.333333333333336" width="41.666666666666657" height="20.333333333333336"/>
+                    <rect key="frame" x="164" y="40.333333333333336" width="203" height="20.333333333333336"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
-                    <rect key="frame" x="164" y="76.666666666666671" width="30" height="34"/>
+                    <rect key="frame" x="164" y="76.666666666666686" width="30" height="119.33333333333331"/>
                     <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <connections>
                         <action selector="didTapFollowButton:" destination="QDT-3t-9yR" eventType="touchUpInside" id="dRK-lH-Zga"/>
                     </connections>
                 </button>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mi7-dO-TOF">
-                    <rect key="frame" x="16" y="149.66666666666666" width="343" height="20.333333333333343"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mi7-dO-TOF">
+                    <rect key="frame" x="16" y="235" width="343" height="0.0"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHO-IY-cyK">
-                    <rect key="frame" x="164" y="114.66666666666667" width="31" height="15.000000000000014"/>
+                    <rect key="frame" x="164" y="200" width="203" height="15"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -58,16 +58,17 @@
                 <constraint firstItem="mi7-dO-TOF" firstAttribute="top" secondItem="JHO-IY-cyK" secondAttribute="bottom" constant="20" id="5pv-Dj-zWG"/>
                 <constraint firstItem="w1n-O9-Da1" firstAttribute="leading" secondItem="QDT-3t-9yR" secondAttribute="leadingMargin" id="AIG-RK-eJh"/>
                 <constraint firstItem="QqV-yA-rBc" firstAttribute="top" secondItem="w1n-O9-Da1" secondAttribute="top" id="Ljb-Gh-VRJ"/>
+                <constraint firstItem="fq2-Xh-dYx" firstAttribute="trailing" secondItem="QqV-yA-rBc" secondAttribute="trailing" id="Lvd-ZE-yI2"/>
                 <constraint firstItem="fq2-Xh-dYx" firstAttribute="top" secondItem="QqV-yA-rBc" secondAttribute="bottom" constant="4" id="Poh-ai-8cd"/>
                 <constraint firstItem="fq2-Xh-dYx" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="SQK-NR-gJ1"/>
+                <constraint firstItem="JHO-IY-cyK" firstAttribute="trailing" secondItem="fq2-Xh-dYx" secondAttribute="trailing" id="V3z-Dz-T7p"/>
                 <constraint firstItem="JHO-IY-cyK" firstAttribute="top" secondItem="jvF-YL-IV0" secondAttribute="bottom" constant="4" id="VoM-PV-43m"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="mi7-dO-TOF" secondAttribute="bottom" constant="16" id="Zc9-ns-Y8r"/>
+                <constraint firstAttribute="bottom" secondItem="mi7-dO-TOF" secondAttribute="bottom" constant="16" id="Zc9-ns-Y8r"/>
                 <constraint firstItem="JHO-IY-cyK" firstAttribute="leading" secondItem="fq2-Xh-dYx" secondAttribute="leading" id="bkn-wr-ADc"/>
                 <constraint firstAttribute="trailingMargin" secondItem="mi7-dO-TOF" secondAttribute="trailing" id="blt-Tr-kwH"/>
                 <constraint firstItem="mi7-dO-TOF" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="leading" id="eAG-pR-tpk"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fq2-Xh-dYx" secondAttribute="trailing" constant="20" id="guR-fw-H6i"/>
                 <constraint firstItem="jvF-YL-IV0" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="nuq-AR-loX"/>
-                <constraint firstAttribute="trailing" secondItem="QqV-yA-rBc" secondAttribute="trailingMargin" id="qUa-8H-hSo"/>
+                <constraint firstAttribute="trailing" secondItem="QqV-yA-rBc" secondAttribute="trailingMargin" constant="16" id="qUa-8H-hSo"/>
                 <constraint firstItem="w1n-O9-Da1" firstAttribute="top" secondItem="QDT-3t-9yR" secondAttribute="top" constant="16" id="ssc-l7-h6V"/>
                 <constraint firstItem="QqV-yA-rBc" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="trailing" constant="20" id="uve-ck-hpx"/>
                 <constraint firstItem="jvF-YL-IV0" firstAttribute="top" secondItem="fq2-Xh-dYx" secondAttribute="bottom" constant="16" id="why-cC-543"/>
@@ -81,7 +82,7 @@
                 <outlet property="followCountLabel" destination="JHO-IY-cyK" id="Axc-dE-raX"/>
                 <outlet property="titleLabel" destination="QqV-yA-rBc" id="nYV-qu-I3d"/>
             </connections>
-            <point key="canvasLocation" x="616.79999999999995" y="45.443349753694584"/>
+            <point key="canvasLocation" x="-108" y="-82"/>
         </view>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -33,7 +33,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
-                    <rect key="frame" x="132" y="76.666666666666686" width="30" height="123.33333333333331"/>
+                    <rect key="frame" x="132" y="76.666666666666686" width="30" height="119.33333333333331"/>
                     <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <connections>
                         <action selector="didTapFollowButton:" destination="QDT-3t-9yR" eventType="touchUpInside" id="dRK-lH-Zga"/>
@@ -62,7 +62,7 @@
                 <constraint firstItem="fq2-Xh-dYx" firstAttribute="top" secondItem="QqV-yA-rBc" secondAttribute="bottom" constant="4" id="Poh-ai-8cd"/>
                 <constraint firstItem="fq2-Xh-dYx" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="SQK-NR-gJ1"/>
                 <constraint firstItem="JHO-IY-cyK" firstAttribute="trailing" secondItem="fq2-Xh-dYx" secondAttribute="trailing" id="V3z-Dz-T7p"/>
-                <constraint firstItem="JHO-IY-cyK" firstAttribute="top" secondItem="jvF-YL-IV0" secondAttribute="bottom" constant="4" id="VoM-PV-43m"/>
+                <constraint firstItem="JHO-IY-cyK" firstAttribute="top" secondItem="jvF-YL-IV0" secondAttribute="bottom" constant="8" id="VoM-PV-43m"/>
                 <constraint firstAttribute="bottom" secondItem="mi7-dO-TOF" secondAttribute="bottom" constant="16" id="Zc9-ns-Y8r"/>
                 <constraint firstItem="JHO-IY-cyK" firstAttribute="leading" secondItem="fq2-Xh-dYx" secondAttribute="leading" id="bkn-wr-ADc"/>
                 <constraint firstAttribute="trailingMargin" secondItem="mi7-dO-TOF" secondAttribute="trailing" id="blt-Tr-kwH"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -33,7 +33,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
-                    <rect key="frame" x="132" y="76.666666666666686" width="30" height="119.33333333333331"/>
+                    <rect key="frame" x="132" y="76.666666666666686" width="30" height="123.33333333333331"/>
                     <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <connections>
                         <action selector="didTapFollowButton:" destination="QDT-3t-9yR" eventType="touchUpInside" id="dRK-lH-Zga"/>
@@ -46,7 +46,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHO-IY-cyK">
-                    <rect key="frame" x="132" y="200" width="235" height="15"/>
+                    <rect key="frame" x="132" y="204" width="235" height="15"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -55,7 +55,7 @@
             <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <color key="tintColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="mi7-dO-TOF" firstAttribute="top" secondItem="JHO-IY-cyK" secondAttribute="bottom" constant="20" id="5pv-Dj-zWG"/>
+                <constraint firstItem="mi7-dO-TOF" firstAttribute="top" secondItem="JHO-IY-cyK" secondAttribute="bottom" constant="16" id="5pv-Dj-zWG"/>
                 <constraint firstItem="w1n-O9-Da1" firstAttribute="leading" secondItem="QDT-3t-9yR" secondAttribute="leadingMargin" id="AIG-RK-eJh"/>
                 <constraint firstItem="QqV-yA-rBc" firstAttribute="top" secondItem="w1n-O9-Da1" secondAttribute="top" id="Ljb-Gh-VRJ"/>
                 <constraint firstItem="fq2-Xh-dYx" firstAttribute="trailing" secondItem="QqV-yA-rBc" secondAttribute="trailing" id="Lvd-ZE-yI2"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -77,6 +77,7 @@
             <connections>
                 <outlet property="avatarImageView" destination="w1n-O9-Da1" id="hV7-Pe-s6A"/>
                 <outlet property="descriptionLabel" destination="mi7-dO-TOF" id="vyT-Xy-U2P"/>
+                <outlet property="descriptionLableTopConstraint" destination="5pv-Dj-zWG" id="Owz-T7-tVl"/>
                 <outlet property="detailLabel" destination="fq2-Xh-dYx" id="ygC-Hp-5Xe"/>
                 <outlet property="followButton" destination="jvF-YL-IV0" id="EVa-VJ-sLt"/>
                 <outlet property="followCountLabel" destination="JHO-IY-cyK" id="Axc-dE-raX"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -77,7 +77,7 @@
             <connections>
                 <outlet property="avatarImageView" destination="w1n-O9-Da1" id="hV7-Pe-s6A"/>
                 <outlet property="descriptionLabel" destination="mi7-dO-TOF" id="vyT-Xy-U2P"/>
-                <outlet property="descriptionLableTopConstraint" destination="5pv-Dj-zWG" id="Owz-T7-tVl"/>
+                <outlet property="descriptionLabelTopConstraint" destination="5pv-Dj-zWG" id="PlO-AJ-nti"/>
                 <outlet property="detailLabel" destination="fq2-Xh-dYx" id="ygC-Hp-5Xe"/>
                 <outlet property="followButton" destination="jvF-YL-IV0" id="EVa-VJ-sLt"/>
                 <outlet property="followCountLabel" destination="JHO-IY-cyK" id="Axc-dE-raX"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -14,26 +14,26 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="w1n-O9-Da1" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                    <rect key="frame" x="16" y="16" width="128" height="128"/>
+                    <rect key="frame" x="16" y="16" width="96" height="96"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="128" id="FHE-VZ-Id4"/>
-                        <constraint firstAttribute="width" constant="128" id="Nqe-yU-Zya"/>
+                        <constraint firstAttribute="height" constant="96" id="FHE-VZ-Id4"/>
+                        <constraint firstAttribute="width" constant="96" id="Nqe-yU-Zya"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqV-yA-rBc">
-                    <rect key="frame" x="164" y="15.999999999999998" width="203" height="20.333333333333329"/>
+                    <rect key="frame" x="132" y="15.999999999999998" width="235" height="20.333333333333329"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fq2-Xh-dYx">
-                    <rect key="frame" x="164" y="40.333333333333336" width="203" height="20.333333333333336"/>
+                    <rect key="frame" x="132" y="40.333333333333336" width="235" height="20.333333333333336"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
-                    <rect key="frame" x="164" y="76.666666666666686" width="30" height="119.33333333333331"/>
+                    <rect key="frame" x="132" y="76.666666666666686" width="30" height="119.33333333333331"/>
                     <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <connections>
                         <action selector="didTapFollowButton:" destination="QDT-3t-9yR" eventType="touchUpInside" id="dRK-lH-Zga"/>
@@ -46,7 +46,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHO-IY-cyK">
-                    <rect key="frame" x="164" y="200" width="203" height="15"/>
+                    <rect key="frame" x="132" y="200" width="235" height="15"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>


### PR DESCRIPTION
Fixes #14617 and #14618 
To test:

Site name trailing 
1. Go to reader
2. Tap on a site name in the post card (a site with a long name like theinquisitivebee.co.uk)
3. See that the site name doesn't get cut and has a 16 trailing to superview.

Empty site description 
1. Go to reader
2. Tap on a site name in the post card (a site that doesn't have description like aerych.blog)
3. See that the header bottom is 16 to image bottom .

Make sure the header looks as expected with 1 liner and long description

![Simulator Screen Shot - iPhone 11 Pro - 2020-08-11 at 17 52 07](https://user-images.githubusercontent.com/1335657/89964965-64f35200-dc00-11ea-8050-1a406b3aa5da.png)
![Simulator Screen Shot - iPhone 11 Pro - 2020-08-11 at 18 19 02](https://user-images.githubusercontent.com/1335657/89964973-691f6f80-dc00-11ea-82c9-9d65c1fd75c2.png)



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
