### PR TITLE
Social account logins: Don't update username when using a password manager.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -186,9 +186,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.23.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.23.0-beta'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/14620-social_password_manager'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -186,9 +186,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.23.0-beta'
+    # pod 'WordPressAuthenticator', '~> 1.23.0-beta'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/14620-social_password_manager'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -650,7 +650,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.34.0
   WordPressAuthenticator:
-    :commit: f1900901c552f6eed14b73bb21764dd37b533a15
+    :commit: e9c0fa3b97cf9587942f5c858c9ec1df2cfd06fd
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.23.0-beta.4):
+  - WordPressAuthenticator (1.23.0-beta.5):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.23.0-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/14620-social_password_manager`)
   - WordPressKit (~> 4.14-beta)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11-beta)
@@ -540,7 +540,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -632,6 +631,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.34.0
+  WordPressAuthenticator:
+    :branch: fix/14620-social_password_manager
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.34.0/third-party-podspecs/Yoga.podspec.json
 
@@ -647,6 +649,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.34.0
+  WordPressAuthenticator:
+    :commit: 1bcc0db7ff74fa8fb6745c68802bc488e09ff9f0
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -722,7 +727,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 3d0ff67acb27a8918be5f8e5d37c55292bd6e1d5
+  WordPressAuthenticator: 262baefef34b2a967d5e72bdde1e7836ec4a1456
   WordPressKit: dc7e501537b0f67e2bbfcdcb51ae4f71f0eee96b
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: a6fe876744bed80d54f920f5ae6f9dcdad338863
@@ -739,6 +744,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 79686b594ead037c06efa77b426c80ee1e56cb9e
+PODFILE CHECKSUM: dab370a6bbe4ca320870d9685bd9c0a1b987af47
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -650,7 +650,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.34.0
   WordPressAuthenticator:
-    :commit: 1bcc0db7ff74fa8fb6745c68802bc488e09ff9f0
+    :commit: f1900901c552f6eed14b73bb21764dd37b533a15
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -385,7 +385,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.23.0-beta.5):
+  - WordPressAuthenticator (1.23.0-beta.6):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -490,7 +490,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/14620-social_password_manager`)
+  - WordPressAuthenticator (~> 1.23.0-beta)
   - WordPressKit (~> 4.14-beta)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11-beta)
@@ -540,6 +540,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -631,9 +632,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.34.0
-  WordPressAuthenticator:
-    :branch: fix/14620-social_password_manager
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.34.0/third-party-podspecs/Yoga.podspec.json
 
@@ -649,9 +647,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.34.0
-  WordPressAuthenticator:
-    :commit: e9c0fa3b97cf9587942f5c858c9ec1df2cfd06fd
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -727,7 +722,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 262baefef34b2a967d5e72bdde1e7836ec4a1456
+  WordPressAuthenticator: d10e8a0493215024669cc6113136bd3ab182fffb
   WordPressKit: dc7e501537b0f67e2bbfcdcb51ae4f71f0eee96b
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: a6fe876744bed80d54f920f5ae6f9dcdad338863
@@ -744,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: dab370a6bbe4ca320870d9685bd9c0a1b987af47
+PODFILE CHECKSUM: 79686b594ead037c06efa77b426c80ee1e56cb9e
 
 COCOAPODS: 1.8.4

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+15.6
+-----
+* [*] Social account login: Fixed an issue that could have inadvertently linked two social accounts.
+
 15.5
 -----
 * [*] Reader: revamped UI for your site header.


### PR DESCRIPTION
Fixes #14620 
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/372

This uses the Auth changes to _not_ update the username on the Password view when logging in via a social account. To note, this fixes the issue in the current flow, not the unified. I'll fix that in a later PR.

**Prereqs:**
- You'll need to use an actual device to get the password manager button on the keyboard. 
- Two gmail accounts that:
  - Have been used to create WP accounts.
  - Are _not_ connected to Google*.
  - Have WP passwords set.

* You can check Google connection at https://wordpress.com/me/security/social-login:

<img width="500" alt="Screen Shot 2020-08-11 at 1 59 25 PM" src="https://user-images.githubusercontent.com/1816888/89943226-1bdcd700-dbdb-11ea-955d-af855fdfef76.png">

**To test:**

Google Login:
- Go to Log In > Continue with Google.
- Select account A.
- On the password entry view, tap the password manager button on the keyboard, and select account B. 
- Verify:
  - The displayed email address _does not_ change.
  - The password field is populated.
- Finish logging in with account A. Verify it is the correct account.
- Log out.
- Go to Log In > Continue with Google.
- Verify you can login with both accounts successfully, and they are the correct accounts.

WP Login:
- Go to Log In > Continue with WordPress.com.
- Select account A.
- On the password entry view, tap the password manager button on the keyboard, and select account B. 
- Verify:
  - The email address _does_ change.
  - The password is populated.
  - You successfully log into account B.

1Password:
- On a device with 1Password set up, please test both scenarios above (Google Login and WP Login), using the 1Password button on the username field:

![1p_button](https://user-images.githubusercontent.com/1816888/90179060-21b4f280-dd6a-11ea-8ca2-ef50c70af560.jpg)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
