### PR TITLE
Reader: fix unfollowed sites not being removed from list of followed sites

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -241,6 +241,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 @end
 
 @interface ReaderTopicService (Tests)
+- (void)mergeFollowedSites:(NSArray *)sites withSuccess:(void (^)(void))success;
 - (void)mergeMenuTopics:(NSArray *)topics withSuccess:(void (^)(void))success;
 - (NSString *)formatTitle:(NSString *)str;
 @end

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -918,7 +918,6 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     return [title capitalizedStringWithLocale:[NSLocale currentLocale]];
 }
 
-
 /**
 Saves the specified `ReaderSiteTopics`. Any `ReaderSiteTopics` not included in the passed
 array are marked as being unfollowed in Core Data.
@@ -930,7 +929,7 @@ array are marked as being unfollowed in Core Data.
      [self.managedObjectContext performBlock:^{
          NSArray *currentSiteTopics = [self allSiteTopics];
          NSMutableArray *remoteFeedIds = [NSMutableArray array];
-         
+
          for (RemoteReaderSiteInfo *siteInfo in sites) {
              [remoteFeedIds addObject:siteInfo.feedID];
              [self siteTopicForRemoteSiteInfo:siteInfo];
@@ -943,7 +942,7 @@ array are marked as being unfollowed in Core Data.
                  siteTopic.following = NO;
              }
          }
-         
+
          [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
              if (success) {
                  success();

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -51,27 +51,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 {
     ReaderTopicServiceRemote *service = [[ReaderTopicServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
     [service fetchFollowedSitesWithSuccess:^(NSArray *sites) {
-        NSArray *currentSiteTopics = [self allSiteTopics];
-        NSMutableArray *remoteFeedIds = [NSMutableArray array];
-
-        for (RemoteReaderSiteInfo *siteInfo in sites) {
-            [remoteFeedIds addObject:siteInfo.feedID];
-            [self siteTopicForRemoteSiteInfo:siteInfo];
-        }
-
-        for (ReaderSiteTopic *siteTopic in currentSiteTopics) {
-            // If a site fetched from Core Data isn't included in the list of sites
-            // fetched from remote, that means it's no longer being followed.
-            if (![remoteFeedIds containsObject:siteTopic.feedID]) {
-                siteTopic.following = NO;
-            }
-        }
-
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
-            if (success) {
-                success();
-            }
-        }];
+        [self mergeFollowedSites:sites withSuccess:success];
     } failure:^(NSError *error) {
         if (failure) {
             failure(error);
@@ -936,6 +916,40 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     }
 
     return [title capitalizedStringWithLocale:[NSLocale currentLocale]];
+}
+
+
+/**
+Saves the specified `ReaderSiteTopics`. Any `ReaderSiteTopics` not included in the passed
+array are marked as being unfollowed in Core Data.
+
+@param topics An array of `ReaderSiteTopics` to save.
+*/
+- (void)mergeFollowedSites:(NSArray *)sites withSuccess:(void (^)(void))success
+{
+     [self.managedObjectContext performBlock:^{
+         NSArray *currentSiteTopics = [self allSiteTopics];
+         NSMutableArray *remoteFeedIds = [NSMutableArray array];
+         
+         for (RemoteReaderSiteInfo *siteInfo in sites) {
+             [remoteFeedIds addObject:siteInfo.feedID];
+             [self siteTopicForRemoteSiteInfo:siteInfo];
+         }
+
+         for (ReaderSiteTopic *siteTopic in currentSiteTopics) {
+             // If a site fetched from Core Data isn't included in the list of sites
+             // fetched from remote, that means it's no longer being followed.
+             if (![remoteFeedIds containsObject:siteTopic.feedID]) {
+                 siteTopic.following = NO;
+             }
+         }
+         
+         [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
+             if (success) {
+                 success();
+             }
+         }];
+     }];
 }
 
 /**

--- a/WordPress/WordPressTest/ReaderTopicServiceTest.swift
+++ b/WordPress/WordPressTest/ReaderTopicServiceTest.swift
@@ -95,6 +95,25 @@ final class ReaderTopicSwiftTest: XCTestCase {
         }
     }
 
+    func remoteSiteInfoForTests() -> [RemoteReaderSiteInfo] {
+        let foo = RemoteReaderSiteInfo()
+        foo.feedID = 1
+        foo.isFollowing = true
+        foo.postsEndpoint = "/sites/foo"
+
+        let bar = RemoteReaderSiteInfo()
+        bar.feedID = 2
+        bar.isFollowing = true
+        bar.postsEndpoint = "/sites/bar"
+
+        let baz = RemoteReaderSiteInfo()
+        baz.feedID = 3
+        baz.isFollowing = true
+        baz.postsEndpoint = "/sites/baz"
+
+        return [foo, bar, baz]
+    }
+
     func remoteTopicsForTests() -> [RemoteReaderTopic] {
         let foo = RemoteReaderTopic()
         foo.topicID = 1
@@ -137,6 +156,51 @@ final class ReaderTopicSwiftTest: XCTestCase {
 
 
     // MARK: Tests
+
+    /**
+    Ensure that followed sites a user unfollows from are set to unfollowed in core data when merging
+    results from the REST API.
+    */
+    func testUnfollowedSiteIsUnfollowedDuringSync() {
+        guard let context = context else {
+            XCTFail("Context is nil")
+            return
+        }
+        let remoteSites = remoteSiteInfoForTests()
+
+        // Setup
+        var expect = expectation(description: "sites saved expectation")
+        let service = ReaderTopicService(managedObjectContext: context)
+        service.mergeFollowedSites(remoteSites, withSuccess: { () -> Void in
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: expectationTimeout, handler: nil)
+
+        // Sites exist in the context
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ReaderSiteTopic.classNameWithoutNamespaces())
+        request.predicate = NSPredicate(format: "following = YES")
+        var count = try! context.count(for: request)
+        XCTAssertEqual(count, remoteSites.count, "Number of sites in context did not match expectations")
+
+        // Merge new set of sites
+        expect = expectation(description: "sites saved expectation")
+        let foo = remoteSites.first as RemoteReaderSiteInfo?
+        service.mergeFollowedSites([foo!], withSuccess: { () -> Void in
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: expectationTimeout, handler: nil)
+
+        // Make sure the unfollowed sites were unfollowed when merged
+        count = try! context.count(for: request)
+        XCTAssertEqual(count, 1, "Number of sites in context did not match expectations")
+        do {
+            let results = try context.fetch(request)
+            let site = results.first as! ReaderSiteTopic
+            XCTAssertEqual(site.feedID, foo?.feedID, "The site returned was not the one expected.")
+        } catch let error as NSError {
+            XCTAssertNil(error, "Error executing fetch request.")
+        }
+    }
 
     /**
     Ensure that topics a user unsubscribes from are removed from core data when merging


### PR DESCRIPTION
Fixes #14387

### Changes:
- If a site is unfollowed from the browser, remove it from the app's followed site list
  - Keep track of sites fetched from remote
  - Compare them against sites fetched from CoreData
  - If a site fetched from CoreData isn't in the the list of sites fetched from remote, mark that site as being unfollowed

### To test:

1. Log into WordPress.com in a browser and go to your reader followed site list.
2. Select a site to unfollow.
3. Go to the reader in the app and click the gear icon to switch to "Followed Sites".
4. Pull down to refresh the list.
5. Check that the site unfollowed from the browser is removed from the app followed site list ✅   

![unfollow-and-remove-from-followed-sites](https://user-images.githubusercontent.com/6711616/89980362-b78a4800-dcac-11ea-84e7-3ea96340ad55.gif)


### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
