### PR TITLE
Rename Contact Us to Contact Support

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -316,7 +316,7 @@ private extension SupportTableViewController {
         static let viewTitle = NSLocalizedString("Support", comment: "View title for Support page.")
         static let closeButton = NSLocalizedString("Close", comment: "Dismiss the current view")
         static let wpHelpCenter = NSLocalizedString("WordPress Help Center", comment: "Option in Support view to launch the Help Center.")
-        static let contactUs = NSLocalizedString("Contact Us", comment: "Option in Support view to contact the support team.")
+        static let contactUs = NSLocalizedString("Contact Support", comment: "Option in Support view to contact the support team.")
         static let wpForums = NSLocalizedString("WordPress Forums", comment: "Option in Support view to view the Forums.")
         static let myTickets = NSLocalizedString("My Tickets", comment: "Option in Support view to access previous help tickets.")
         static let helpFooter = NSLocalizedString("Visit the Help Center to get answers to common questions, or contact us for more help.", comment: "Support screen footer text displayed when Zendesk is enabled.")


### PR DESCRIPTION
To clarify to app users that the Contact button is to contact WordPress.com support and not a place to leave contact details for _their_ site visitors to contact their the site, we clarified the button title to "Contact Support".

Note: The Zendesk chat screen title should also be changed, but it requires manually adding a string to the localized string files, which is incompatible with our approach of auto-generating string files from NSLocalizedString usage in the codebase.
There might be a way of doing using [extract-framework-translations.swift](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/Scripts/extract-framework-translations.swift), but it was deemed low priority.
For the record, `"ios.ZDKRequests.createRequest.title" = "Contact Support";` is what would need to be added to all the `Localizable.strings` files to achieve this, as described in [the Zendesk iOS SDK docs](https://developer.zendesk.com/embeddables/docs/ios-unified-sdk/localize_text).

Fixes #14616

To test:
1. Log into the app
2. Select any site
3. Tap the profile button (avatar on the right-hand side of the navigation bar)
4. Tap "Help & Support"
5. Observe that the second button reads "Contact Support" instead of "Contact Us" (as it did previously)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
