### PR TITLE
Updated topic header tile leading and trailing constraints

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.xib
@@ -13,8 +13,8 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="168"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yMm-WX-1gb">
-                    <rect key="frame" x="187.66666666666666" y="40" width="0.0" height="0.0"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yMm-WX-1gb">
+                    <rect key="frame" x="16" y="40" width="343" height="0.0"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -38,6 +38,8 @@
                 <constraint firstItem="yMm-WX-1gb" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="40" id="8dj-78-13r"/>
                 <constraint firstItem="yMm-WX-1gb" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="S6J-qa-Lem"/>
                 <constraint firstAttribute="bottom" secondItem="gN8-Rn-2M3" secondAttribute="bottom" constant="40" id="mzP-6y-xip"/>
+                <constraint firstAttribute="trailingMargin" secondItem="yMm-WX-1gb" secondAttribute="trailing" id="tD0-cD-AwP"/>
+                <constraint firstItem="yMm-WX-1gb" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" id="yft-9s-TNw"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>


### PR DESCRIPTION
Fixes #14635 

To test:
1. Go to Reader
2. Tap on a tag / topic 
3. See the header title leading and trailing constraints  as expected 

![Simulator Screen Shot - iPhone 11 Pro - 2020-08-12 at 18 16 04](https://user-images.githubusercontent.com/1335657/90084250-b1ef2b00-dcc9-11ea-948d-2ea994cf4be8.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
