### PR TITLE
[Reader P2 follow conversations] add button in comments view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -290,7 +290,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     headerView.translatesAutoresizingMaskIntoConstraints = NO;
     headerView.showsDisclosureIndicator = self.allowsPushingPostDetails;
     [headerView setSubtitle:NSLocalizedString(@"Comments on", @"Sentence fragment. The full phrase is 'Comments on' followed by the title of a post on a separate line.")];
-    headerView.isSubscribedToPost = NO;
+    headerView.isSubscribedToPost = NO;  // FIXME: Get subscription state
     [headerWrapper addSubview:headerView];
 
     // Border

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -290,6 +290,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     headerView.translatesAutoresizingMaskIntoConstraints = NO;
     headerView.showsDisclosureIndicator = self.allowsPushingPostDetails;
     [headerView setSubtitle:NSLocalizedString(@"Comments on", @"Sentence fragment. The full phrase is 'Comments on' followed by the title of a post on a separate line.")];
+    headerView.isSubscribedToPost = NO;
     [headerWrapper addSubview:headerView];
 
     // Border

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.h
@@ -30,4 +30,9 @@ typedef void (^ReaderPostHeaderCallback)(void);
  */
 @property (nonatomic, strong) NSString *subtitle;
 
+/**
+ A BOOL indicating whether the User is subscribed to the post, or not.
+ */
+@property (nonatomic, assign, setter=setSubscribedToPost:) BOOL isSubscribedToPost;
+
 @end

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -1,8 +1,6 @@
 #import "ReaderPostHeaderView.h"
 #import "WordPress-Swift.h"
 
-@import Gridicons;
-
 const CGFloat PostHeaderViewAvatarSize = 32.0;
 const CGFloat PostHeaderViewLabelHeight = 18.0;
 const CGFloat PostHeaderDisclosureButtonWidth = 8.0;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -5,11 +5,13 @@ const CGFloat PostHeaderViewAvatarSize = 32.0;
 const CGFloat PostHeaderViewLabelHeight = 18.0;
 const CGFloat PostHeaderDisclosureButtonWidth = 8.0;
 const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
+const CGFloat PostHeadeerVerticalStackViewSpacing = 4.0;
 
 @interface ReaderPostHeaderView()
 
 @property (nonatomic, strong) UIStackView *stackView;
 @property (nonatomic, strong) CircularImageView *avatarImageView;
+@property (nonatomic, strong) UIStackView *verticalStackView;
 @property (nonatomic, strong) UIStackView *labelsStackView;
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *subtitleLabel;
@@ -32,6 +34,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 
         [self setupStackView];
         [self setupAvatarImageView];
+        [self setupVerticalStackView];
         [self setupLabelsStackView];
         [self setupSubtitleLabel];
         [self setupTitleLabel];
@@ -79,7 +82,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     self.avatarImageView = imageView;
 }
 
-- (void)setupLabelsStackView
+- (void)setupVerticalStackView
 {
     NSAssert(self.stackView != nil, @"stackView was nil");
 
@@ -90,8 +93,27 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     stackView.axis = UILayoutConstraintAxisVertical;
     stackView.distribution = UIStackViewAlignmentFill;
     stackView.alignment = UIStackViewAlignmentLeading;
+    stackView.spacing = PostHeadeerVerticalStackViewSpacing;
 
     [self.stackView addArrangedSubview:stackView];
+    self.verticalStackView = stackView;
+
+    [stackView setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
+}
+
+- (void)setupLabelsStackView
+{
+    NSAssert(self.verticalStackView != nil, @"verticalStackView was nil");
+
+    UIStackView *stackView = [[UIStackView alloc] init];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.layoutMarginsRelativeArrangement = YES;
+    stackView.preservesSuperviewLayoutMargins = YES;
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.distribution = UIStackViewAlignmentFill;
+    stackView.alignment = UIStackViewAlignmentLeading;
+
+    [self.verticalStackView addArrangedSubview:stackView];
     self.labelsStackView = stackView;
 
     [stackView setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
@@ -136,7 +158,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     [WPStyleGuide applyReaderFollowConversationButtonStyle:button];
     button.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.labelsStackView addArrangedSubview:button];
+    [self.verticalStackView addArrangedSubview:button];
     self.followConversationButton = button;
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -135,9 +135,8 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 {
     NSAssert(self.labelsStackView != nil, @"labelsStackView was nil");
 
-    // FIXME: refine design specs later
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
-    button.titleLabel.font = [WPStyleGuide subtitleFont];
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+    [WPStyleGuide applyReaderFollowConversationButtonStyle:button];
     button.translatesAutoresizingMaskIntoConstraints = NO;
     [self.labelsStackView addArrangedSubview:button];
     self.followButton = button;
@@ -214,18 +213,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 - (void)setSubscribedToPost:(BOOL)isSubscribedToPost
 {
     _isSubscribedToPost = isSubscribedToPost;
-    NSString *subscriptionStatusTitle = isSubscribedToPost
-        ? NSLocalizedString(@"Following conversation", @"Title for subscription status button, if the User is subscribed to the post.")
-        : NSLocalizedString(@"Follow conversation", @"Title for subscription status button, if the User is not subscribed to the post.");
-    
-    // FIXME: use correct asset
-    CGSize iconSize = CGSizeMake(18.0, 18.0);
-    UIImage *image = isSubscribedToPost
-        ? [UIImage gridiconOfType:GridiconTypeReaderFollowingConversation withSize:iconSize]
-        : [UIImage gridiconOfType:GridiconTypeReaderFollowConversation withSize:iconSize];
-
-    [self.followButton setTitle:subscriptionStatusTitle forState:UIControlStateNormal];
-    [self.followButton setImage:image forState:UIControlStateNormal];
+    [self.followButton setSelected:isSubscribedToPost];
 }
 
 #pragma mark - Recognizer Helpers

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -5,13 +5,12 @@ const CGFloat PostHeaderViewAvatarSize = 32.0;
 const CGFloat PostHeaderViewLabelHeight = 18.0;
 const CGFloat PostHeaderDisclosureButtonWidth = 8.0;
 const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
-const CGFloat PostHeadeerVerticalStackViewSpacing = 4.0;
+const CGFloat PostHeaderViewFollowConversationButtonHeight = 32.0;
 
 @interface ReaderPostHeaderView()
 
 @property (nonatomic, strong) UIStackView *stackView;
 @property (nonatomic, strong) CircularImageView *avatarImageView;
-@property (nonatomic, strong) UIStackView *verticalStackView;
 @property (nonatomic, strong) UIStackView *labelsStackView;
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *subtitleLabel;
@@ -34,7 +33,6 @@ const CGFloat PostHeadeerVerticalStackViewSpacing = 4.0;
 
         [self setupStackView];
         [self setupAvatarImageView];
-        [self setupVerticalStackView];
         [self setupLabelsStackView];
         [self setupSubtitleLabel];
         [self setupTitleLabel];
@@ -82,7 +80,7 @@ const CGFloat PostHeadeerVerticalStackViewSpacing = 4.0;
     self.avatarImageView = imageView;
 }
 
-- (void)setupVerticalStackView
+- (void)setupLabelsStackView
 {
     NSAssert(self.stackView != nil, @"stackView was nil");
 
@@ -93,27 +91,8 @@ const CGFloat PostHeadeerVerticalStackViewSpacing = 4.0;
     stackView.axis = UILayoutConstraintAxisVertical;
     stackView.distribution = UIStackViewAlignmentFill;
     stackView.alignment = UIStackViewAlignmentLeading;
-    stackView.spacing = PostHeadeerVerticalStackViewSpacing;
 
     [self.stackView addArrangedSubview:stackView];
-    self.verticalStackView = stackView;
-
-    [stackView setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
-}
-
-- (void)setupLabelsStackView
-{
-    NSAssert(self.verticalStackView != nil, @"verticalStackView was nil");
-
-    UIStackView *stackView = [[UIStackView alloc] init];
-    stackView.translatesAutoresizingMaskIntoConstraints = NO;
-    stackView.layoutMarginsRelativeArrangement = YES;
-    stackView.preservesSuperviewLayoutMargins = YES;
-    stackView.axis = UILayoutConstraintAxisVertical;
-    stackView.distribution = UIStackViewAlignmentFill;
-    stackView.alignment = UIStackViewAlignmentLeading;
-
-    [self.verticalStackView addArrangedSubview:stackView];
     self.labelsStackView = stackView;
 
     [stackView setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
@@ -158,7 +137,11 @@ const CGFloat PostHeadeerVerticalStackViewSpacing = 4.0;
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
     [WPStyleGuide applyReaderFollowConversationButtonStyle:button];
     button.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.verticalStackView addArrangedSubview:button];
+    
+    NSLayoutConstraint *height = [button.heightAnchor constraintEqualToConstant:PostHeaderViewFollowConversationButtonHeight];
+    [NSLayoutConstraint activateConstraints:@[height]];
+    
+    [self.labelsStackView addArrangedSubview:button];
     self.followConversationButton = button;
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -1,6 +1,8 @@
 #import "ReaderPostHeaderView.h"
 #import "WordPress-Swift.h"
 
+@import Gridicons;
+
 const CGFloat PostHeaderViewAvatarSize = 32.0;
 const CGFloat PostHeaderViewLabelHeight = 18.0;
 const CGFloat PostHeaderDisclosureButtonWidth = 8.0;
@@ -13,6 +15,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 @property (nonatomic, strong) UIStackView *labelsStackView;
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *subtitleLabel;
+@property (nonatomic, strong) UIButton *followButton;
 @property (nonatomic, strong) UIButton *disclosureButton;
 @property (nonatomic, strong) UITapGestureRecognizer *tapRecognizer;
 
@@ -34,6 +37,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
         [self setupLabelsStackView];
         [self setupSubtitleLabel];
         [self setupTitleLabel];
+        [self setupFollowButton];
         [self setupDisclosureButton];
         [self setupTapGesture];
     }
@@ -46,7 +50,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     stackView.translatesAutoresizingMaskIntoConstraints = NO;
     stackView.axis = UILayoutConstraintAxisHorizontal;
     stackView.distribution = UIStackViewAlignmentFill;
-    stackView.alignment = UIStackViewAlignmentCenter;
+    stackView.alignment = UIStackViewAlignmentTop;
     stackView.spacing = 8.0;
 
     [self addSubview:stackView];
@@ -87,7 +91,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     stackView.preservesSuperviewLayoutMargins = YES;
     stackView.axis = UILayoutConstraintAxisVertical;
     stackView.distribution = UIStackViewAlignmentFill;
-    stackView.alignment = UIStackViewAlignmentFill;
+    stackView.alignment = UIStackViewAlignmentLeading;
 
     [self.stackView addArrangedSubview:stackView];
     self.labelsStackView = stackView;
@@ -125,6 +129,18 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 
     [self.labelsStackView addArrangedSubview:label];
     self.titleLabel = label;
+}
+
+- (void)setupFollowButton
+{
+    NSAssert(self.labelsStackView != nil, @"labelsStackView was nil");
+
+    // FIXME: refine design specs later
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    button.titleLabel.font = [WPStyleGuide subtitleFont];
+    button.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.labelsStackView addArrangedSubview:button];
+    self.followButton = button;
 }
 
 - (void)setupDisclosureButton
@@ -193,6 +209,23 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 - (void)setSubtitle:(NSString *)title
 {
     self.subtitleLabel.text = title;
+}
+
+- (void)setSubscribedToPost:(BOOL)isSubscribedToPost
+{
+    _isSubscribedToPost = isSubscribedToPost;
+    NSString *subscriptionStatusTitle = isSubscribedToPost
+        ? NSLocalizedString(@"Following conversation", @"Title for subscription status button, if the User is subscribed to the post.")
+        : NSLocalizedString(@"Follow conversation", @"Title for subscription status button, if the User is not subscribed to the post.");
+    
+    // FIXME: use correct asset
+    CGSize iconSize = CGSizeMake(18.0, 18.0);
+    UIImage *image = isSubscribedToPost
+        ? [UIImage gridiconOfType:GridiconTypeReaderFollowingConversation withSize:iconSize]
+        : [UIImage gridiconOfType:GridiconTypeReaderFollowConversation withSize:iconSize];
+
+    [self.followButton setTitle:subscriptionStatusTitle forState:UIControlStateNormal];
+    [self.followButton setImage:image forState:UIControlStateNormal];
 }
 
 #pragma mark - Recognizer Helpers

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -13,7 +13,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 @property (nonatomic, strong) UIStackView *labelsStackView;
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *subtitleLabel;
-@property (nonatomic, strong) UIButton *followButton;
+@property (nonatomic, strong) UIButton *followConversationButton;
 @property (nonatomic, strong) UIButton *disclosureButton;
 @property (nonatomic, strong) UITapGestureRecognizer *tapRecognizer;
 
@@ -35,7 +35,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
         [self setupLabelsStackView];
         [self setupSubtitleLabel];
         [self setupTitleLabel];
-        [self setupFollowButton];
+        [self setupFollowConversationButton];
         [self setupDisclosureButton];
         [self setupTapGesture];
     }
@@ -129,7 +129,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     self.titleLabel = label;
 }
 
-- (void)setupFollowButton
+- (void)setupFollowConversationButton
 {
     NSAssert(self.labelsStackView != nil, @"labelsStackView was nil");
 
@@ -137,7 +137,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     [WPStyleGuide applyReaderFollowConversationButtonStyle:button];
     button.translatesAutoresizingMaskIntoConstraints = NO;
     [self.labelsStackView addArrangedSubview:button];
-    self.followButton = button;
+    self.followConversationButton = button;
 }
 
 - (void)setupDisclosureButton
@@ -211,7 +211,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 - (void)setSubscribedToPost:(BOOL)isSubscribedToPost
 {
     _isSubscribedToPost = isSubscribedToPost;
-    [self.followButton setSelected:isSubscribedToPost];
+    [self.followConversationButton setSelected:isSubscribedToPost];
 }
 
 #pragma mark - Recognizer Helpers

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -281,6 +281,46 @@ extension WPStyleGuide {
         button.setTitleColor(disabledColor, for: .disabled)
     }
 
+    @objc public class func applyReaderFollowConversationButtonStyle(_ button: UIButton) {
+        // General
+        button.naturalContentHorizontalAlignment = .leading
+        button.backgroundColor = .clear
+        button.titleLabel?.font = WPStyleGuide.subtitleFont()
+
+        // Color(s)
+        let normalColor = UIColor.neutral(.shade50)
+        let highlightedColor = UIColor.neutral(.shade40)
+        let selectedColor = UIColor.success
+
+        button.setTitleColor(normalColor, for: .normal)
+        button.setTitleColor(selectedColor, for: .selected)
+        button.setTitleColor(highlightedColor, for: .highlighted)
+
+        // Image(s)
+        let side = WPStyleGuide.fontSizeForTextStyle(.headline)
+        let size = CGSize(width: side, height: side)
+        let followIcon = UIImage.gridicon(.readerFollowConversation, size: size)
+        let followingIcon = UIImage.gridicon(.readerFollowingConversation, size: size)
+
+        button.setImage(followIcon.imageWithTintColor(normalColor), for: .normal)
+        button.setImage(followingIcon.imageWithTintColor(selectedColor), for: .selected)
+        button.setImage(followingIcon.imageWithTintColor(highlightedColor), for: .highlighted)
+        button.imageEdgeInsets = FollowConversationButton.Style.imageEdgeInsets
+        button.contentEdgeInsets = FollowConversationButton.Style.contentEdgeInsets
+
+        // Strings
+        let normalText = FollowConversationButton.Text.followConversationStringForDisplay
+        let selectedText = FollowConversationButton.Text.followingConversationStringForDisplay
+
+        button.setTitle(normalText, for: .normal)
+        button.setTitle(selectedText, for: .selected)
+        button.setTitle(selectedText, for: .highlighted)
+
+        // Default accessibility label and hint.
+        button.accessibilityLabel = normalText
+        button.accessibilityHint = NSLocalizedString("Follows the blog.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a blog.")
+    }
+
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton) {
         let side = WPStyleGuide.fontSizeForTextStyle(.headline)
         let size = CGSize(width: side, height: side)
@@ -552,6 +592,19 @@ extension WPStyleGuide {
             static let accessibilityHint = NSLocalizedString("Follows the tag.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")
             static let followStringForDisplay =  NSLocalizedString("Follow", comment: "Verb. Button title. Follow a new blog.")
             static let followingStringForDisplay = NSLocalizedString("Following", comment: "Verb. Button title. The user is following a blog.")
+        }
+    }
+
+    public struct FollowConversationButton {
+        struct Style {
+            static let imageEdgeInsets = UIEdgeInsets(top: 1.0, left: -4.0, bottom: 0.0, right: -4.0)
+            static let contentEdgeInsets = UIEdgeInsets(top: 0.0, left: 4.0, bottom: 0.0, right: 0.0)
+        }
+
+        struct Text {
+            static let accessibilityHint = NSLocalizedString("Follows the post.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")
+            static let followConversationStringForDisplay =  NSLocalizedString("Follow conversation", comment: "Verb. Button title. Follow a post.")
+            static let followingConversationStringForDisplay = NSLocalizedString("Following conversation", comment: "Verb. Button title. The user is following a post.")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -317,8 +317,8 @@ extension WPStyleGuide {
         button.setTitle(selectedText, for: .highlighted)
 
         // Default accessibility label and hint.
-        button.accessibilityLabel = normalText
-        button.accessibilityHint = NSLocalizedString("Follows the blog.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a blog.")
+        button.accessibilityLabel =  button.isSelected ? selectedText : normalText
+        button.accessibilityHint = FollowConversationButton.Text.accessibilityHint
     }
 
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton) {
@@ -602,7 +602,7 @@ extension WPStyleGuide {
         }
 
         struct Text {
-            static let accessibilityHint = NSLocalizedString("Follows the post.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")
+            static let accessibilityHint = NSLocalizedString("Follows the post.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a post.")
             static let followConversationStringForDisplay =  NSLocalizedString("Follow conversation", comment: "Verb. Button title. Follow a post.")
             static let followingConversationStringForDisplay = NSLocalizedString("Following conversation", comment: "Verb. Button title. The user is following a post.")
         }

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -288,8 +288,8 @@ extension WPStyleGuide {
         button.titleLabel?.font = WPStyleGuide.subtitleFont()
 
         // Color(s)
-        let normalColor = UIColor.neutral(.shade50)
-        let highlightedColor = UIColor.neutral(.shade40)
+        let normalColor = UIColor.primary(.shade40)
+        let highlightedColor =  UIColor.neutral
         let selectedColor = UIColor.success
 
         button.setTitleColor(normalColor, for: .normal)

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -602,9 +602,9 @@ extension WPStyleGuide {
         }
 
         struct Text {
-            static let accessibilityHint = NSLocalizedString("Follows the post.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a post.")
-            static let followConversationStringForDisplay =  NSLocalizedString("Follow conversation", comment: "Verb. Button title. Follow a post.")
-            static let followingConversationStringForDisplay = NSLocalizedString("Following conversation", comment: "Verb. Button title. The user is following a post.")
+            static let accessibilityHint = NSLocalizedString("Follows the comments on a post.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow the comments a post.")
+            static let followConversationStringForDisplay =  NSLocalizedString("Follow conversation", comment: "Verb. Button title. Follow the comments on a post.")
+            static let followingConversationStringForDisplay = NSLocalizedString("Following conversation", comment: "Verb. Button title. The user is following the comments on a post.")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -288,7 +288,7 @@ extension WPStyleGuide {
         button.titleLabel?.font = fontForTextStyle(.footnote)
 
         // Color(s)
-        let normalColor = UIColor.primary(.shade40)
+        let normalColor = UIColor.primary
         let highlightedColor =  UIColor.neutral
         let selectedColor = UIColor.success
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -285,7 +285,7 @@ extension WPStyleGuide {
         // General
         button.naturalContentHorizontalAlignment = .leading
         button.backgroundColor = .clear
-        button.titleLabel?.font = WPStyleGuide.subtitleFont()
+        button.titleLabel?.font = fontForTextStyle(.footnote)
 
         // Color(s)
         let normalColor = UIColor.primary(.shade40)


### PR DESCRIPTION
Fixes #14623

To test:

### Follow Conversation Button

1. Navigate to the “Reader” tab
2. Tap on the comments button on a post
3. Check that a follow conversation button is displayed ✅ 
8. Check that the follow button matches [design specs](https://wpmobilep2.wordpress.com/2020/08/06/follow-conversations-design/) ✅ 
2. Check that by setting the `isSubscribedToPost` flag in code, the button is updated accordingly ✅ 

Follow conversation | Following conversation
--- | ---
![Screen Shot 2020-08-15 at 10 06 53](https://user-images.githubusercontent.com/6711616/90302665-b9d5e780-dee2-11ea-91d6-10f371758194.png) | ![Screen Shot 2020-08-15 at 10 00 35](https://user-images.githubusercontent.com/6711616/90302600-2ef4ed00-dee2-11ea-9372-b94f7504fc37.png)




PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~
