### PR TITLE
New Reader: fix Quick Start

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -59,6 +59,7 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementStats = 18,
     QuickStartTourElementPlans = 19,
     QuickStartTourElementSiteTitle = 20,
+    QuickStartTourElementSelectInterests = 21
 };
 
 typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -178,7 +178,7 @@ open class QuickStartTourGuide: NSObject {
         }
         if element != currentElement {
             let blogDetailEvents: [QuickStartTourElement] = [.blogDetailNavigation, .checklist, .themes, .viewSite, .sharing]
-            let readerElements: [QuickStartTourElement] = [.readerTab, .readerSearch]
+            let readerElements: [QuickStartTourElement] = [.readerTab, .selectInterests, .readerSearch]
 
             if blogDetailEvents.contains(element) {
                 endCurrentTour()
@@ -198,6 +198,11 @@ open class QuickStartTourGuide: NSObject {
             return
         }
         currentTourState = nextStep
+
+        // Don't show a notice for the step after readerTab
+        if element == .readerTab {
+            return
+        }
 
         showCurrentStep()
     }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -208,11 +208,13 @@ struct QuickStartFollowTour: QuickStartTour {
         let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .readerTab, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.reader)))
 
+        let step2: WayPoint = (element: .selectInterests, description: NSAttributedString(string: ""))
+
         let step2DescriptionBase = NSLocalizedString("Select %@ to look for sites with similar interests", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let step2DescriptionTarget = NSLocalizedString("Search", comment: "The menu item to select during a guided tour.")
-        let step2: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.search)))
+        let step3: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.search)))
 
-        return [step1, step2]
+        return [step1, step2, step3]
     }()
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of following other sites.", comment: "This value is used to set the accessibility hint text for following the sites of other users.")

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -127,6 +127,8 @@ extension ReaderTabViewController {
         selectInterestsViewController.userIsFollowingTopics { [unowned self] isFollowing in
             if !isFollowing {
                 self.showSelectInterestsView()
+            } else {
+                self.selectedInterestsVisited()
             }
         }
     }
@@ -137,10 +139,16 @@ extension ReaderTabViewController {
         navigationController?.present(selectInterestsViewController, animated: true, completion: nil)
 
         selectInterestsViewController.didSaveInterests = { [unowned self] in
+            self.selectedInterestsVisited()
+
             self.readerTabView.selectDiscover()
 
             self.selectInterestsViewController.dismiss(animated: true)
         }
+    }
+
+    private func selectedInterestsVisited() {
+        QuickStartTourGuide.find()?.visited(.selectInterests)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -128,7 +128,7 @@ extension ReaderTabViewController {
             if !isFollowing {
                 self.showSelectInterestsView()
             } else {
-                self.selectedInterestsVisited()
+                self.markSelectedInterestsVisited()
             }
         }
     }
@@ -139,7 +139,7 @@ extension ReaderTabViewController {
         navigationController?.present(selectInterestsViewController, animated: true, completion: nil)
 
         selectInterestsViewController.didSaveInterests = { [unowned self] in
-            self.selectedInterestsVisited()
+            self.markSelectedInterestsVisited()
 
             self.readerTabView.selectDiscover()
 
@@ -147,7 +147,7 @@ extension ReaderTabViewController {
         }
     }
 
-    private func selectedInterestsVisited() {
+    private func markSelectedInterestsVisited() {
         QuickStartTourGuide.find()?.visited(.selectInterests)
     }
 }


### PR DESCRIPTION
This PR fixes the Quick Start flow for "Follow other sites" after the addition of the "Select Interests" screen.

| Before  | After |
| ------------- | ------------- |
| ![2020-08-13 11 26 49](https://user-images.githubusercontent.com/7040243/90147041-22dd2400-dd58-11ea-9ff0-ab756f58bb97.gif) | ![2020-08-13 11 20 48](https://user-images.githubusercontent.com/7040243/90147098-312b4000-dd58-11ea-903f-ef92c1aed4e6.gif) |

### To test

#### Scenario: Not following topics

1. Remove all topics you're following
1. Create a new site
1. When the apps ask you if you want a little help getting started, tap Yes
1. Dismiss the "Customize Your Site" screen
1. Tap "Grow Your Audience"
1. Tap "Follow other sites" to start the tour
1. A notice appears aking you to tab the Reader tab, tap it
1. The notice disappears and the interests screen appears
1. Select one or more interests
1. A notice appears asking you to tap the search button
1. Tap it
1. The notice disappears and the tour is complete

#### Scenario: following topics

1. After the steps above, go back into your created site
1. Tap "Grow Your Audience"
1. Tap "Follow other sites" to replay the tour
1. A notice appears aking you to tab the Reader tab, tap it
1. A notice appears asking you to tap the search button
1. Tap it
1. The notice disappears and the tour is complete

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
