### PR TITLE
Reader Improvements Phase 2: Adds a tags chips group to the top of the reader card cell

### DIFF
--- a/WordPress/Classes/Models/PostContentProvider.h
+++ b/WordPress/Classes/Models/PostContentProvider.h
@@ -15,4 +15,5 @@
 - (NSURL *)featuredImageURLForDisplay;
 - (NSURL *)authorURL;
 - (NSString *)slugForDisplay;
+- (NSArray <NSString *> *)tagsForDisplay;
 @end

--- a/WordPress/Classes/Models/ReaderPost.m
+++ b/WordPress/Classes/Models/ReaderPost.m
@@ -360,7 +360,9 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
         return @[];
     }
 
-    return [self.tags componentsSeparatedByString:@", "];
+    NSArray *tags = [self.tags componentsSeparatedByString:@", "];
+
+    return [tags sortedArrayUsingSelector:@selector(localizedCompare:)];
 }
 
 - (NSString *)authorForDisplay

--- a/WordPress/Classes/Models/ReaderPost.m
+++ b/WordPress/Classes/Models/ReaderPost.m
@@ -354,6 +354,15 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     return title;
 }
 
+- (NSArray <NSString *> *)tagsForDisplay
+{
+    if (self.tags.length <= 0) {
+        return @[];
+    }
+
+    return [self.tags componentsSeparatedByString:@", "];
+}
+
 - (NSString *)authorForDisplay
 {
     return [self authorString];

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -49,7 +49,7 @@ import Foundation
     case secondNotificationsAlertAllowTapped
     case secondNotificationsAlertNoTapped
 
-    // Reader Chips
+    // Reader
     case readerChipsMoreToggled
 
     /// A String that represents the event

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -49,6 +49,9 @@ import Foundation
     case secondNotificationsAlertAllowTapped
     case secondNotificationsAlertNoTapped
 
+    // Reader Chips
+    case readerChipsMoreToggled
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -121,6 +124,8 @@ import Foundation
             return "notifications_second_alert_allow_tapped"
         case .secondNotificationsAlertNoTapped:
             return "notifications_second_alert_no_tapped"
+        case .readerChipsMoreToggled:
+            return "reader_chips_more_toggled"
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
@@ -29,7 +29,13 @@ final class ReaderCellConfiguration {
         cell.setSiteName(post.blogName)
     }
 
-    func configurePostCardCell(_ cell: UITableViewCell, withPost post: ReaderPost, topic: ReaderAbstractTopic? = nil, delegate: ReaderPostCellDelegate?, loggedInActionVisibility: ReaderActionsVisibility) {
+    func configurePostCardCell(_ cell: UITableViewCell,
+                               withPost post: ReaderPost,
+                               topic: ReaderAbstractTopic? = nil,
+                               delegate: ReaderPostCellDelegate?,
+                               loggedInActionVisibility: ReaderActionsVisibility,
+                               cardDelegate: ReaderPostCardCellDelegate? = nil,
+                               displayTopics: Bool = true) {
         // To help avoid potential crash: https://github.com/wordpress-mobile/WordPress-iOS/issues/6757
         guard !post.isDeleted else {
             return
@@ -38,8 +44,10 @@ final class ReaderCellConfiguration {
         let postCell = cell as! ReaderPostCardCell
 
         postCell.delegate = delegate
+        postCell.cardDelegate = cardDelegate
 
         postCell.loggedInActionVisibility = loggedInActionVisibility
+        postCell.displayTopics = displayTopics
         postCell.configureCell(post)
         postCell.layoutIfNeeded()
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
@@ -41,6 +41,7 @@ final class ReaderCellConfiguration {
 
         postCell.loggedInActionVisibility = loggedInActionVisibility
         postCell.configureCell(post)
+        postCell.layoutIfNeeded()
     }
 
     func configureGapMarker(_ cell: ReaderGapMarkerCell, filling: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
@@ -34,7 +34,7 @@ final class ReaderCellConfiguration {
                                topic: ReaderAbstractTopic? = nil,
                                delegate: ReaderPostCellDelegate?,
                                loggedInActionVisibility: ReaderActionsVisibility,
-                               cardDelegate: ReaderPostCardCellDelegate? = nil,
+                               topicChipsDelegate: ReaderTopicsChipsDelegate? = nil,
                                displayTopics: Bool = true) {
         // To help avoid potential crash: https://github.com/wordpress-mobile/WordPress-iOS/issues/6757
         guard !post.isDeleted else {
@@ -44,7 +44,7 @@ final class ReaderCellConfiguration {
         let postCell = cell as! ReaderPostCardCell
 
         postCell.delegate = delegate
-        postCell.cardDelegate = cardDelegate
+        postCell.topicChipsDelegate = topicChipsDelegate
 
         postCell.loggedInActionVisibility = loggedInActionVisibility
         postCell.displayTopics = displayTopics

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -11,7 +11,7 @@ private struct Constants {
     static let summaryMaxNumberOfLines: NSInteger = 2
 }
 
-protocol ReaderPostCardCellDelegate: class {
+protocol ReaderTopicsChipsDelegate: class {
     func didSelect(topic: String)
     func heightDidChange()
 }
@@ -84,7 +84,7 @@ protocol ReaderPostCardCellDelegate: class {
         return  width <= 320
     }
 
-    weak var cardDelegate: ReaderPostCardCellDelegate?
+    weak var topicChipsDelegate: ReaderTopicsChipsDelegate?
     var displayTopics: Bool = false
 
     // MARK: - Accessors
@@ -870,10 +870,10 @@ extension ReaderPostCardCell: ReaderTopicCollectionViewCoordinatorDelegate {
     func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didChangeState: ReaderTopicCollectionViewState) {
         layoutIfNeeded()
 
-        cardDelegate?.heightDidChange()
+        topicChipsDelegate?.heightDidChange()
     }
 
     func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didSelectTopic topic: String) {
-        cardDelegate?.didSelect(topic: topic)
+        topicChipsDelegate?.didSelect(topic: topic)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -148,8 +148,6 @@ protocol ReaderTopicsChipsDelegate: class {
         setupSummaryLabel()
         setupAttributionView()
         adjustInsetsForTextDirection()
-
-        topicsCollectionView.topicDelegate = self
     }
 
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -274,6 +272,7 @@ protocol ReaderTopicsChipsDelegate: class {
             return
         }
 
+        topicsCollectionView.topicDelegate = self
         topicsCollectionView.topics = tags
         topicsCollectionView.isHidden = false
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -268,7 +268,7 @@ protocol ReaderPostCardCellDelegate: class {
             displayTopics,
             let contentProvider = contentProvider,
             let tags = contentProvider.tagsForDisplay?(),
-            tags.count != 0
+            !tags.isEmpty
         else {
             topicsCollectionView.isHidden = true
             return

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -86,7 +86,7 @@ protocol ReaderPostCardCellDelegate: class {
 
     var topicsCoordinator: ReaderTopicCollectionViewCoordinator?
     weak var cardDelegate: ReaderPostCardCellDelegate?
-    var displayTopics: Bool
+    var displayTopics: Bool = false
 
     // MARK: - Accessors
     var loggedInActionVisibility: ReaderActionsVisibility = .visible(enabled: true)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -11,8 +11,9 @@ private struct Constants {
     static let summaryMaxNumberOfLines: NSInteger = 2
 }
 
-extension NSNotification.Name {
-    static let postCardCellHeightDidChange = NSNotification.Name(rawValue: "PostCardCellHeightDidChange")
+protocol ReaderPostCardCellDelegate: class {
+    func didSelect(topic: String)
+    func heightDidChange()
 }
 
 @objc public protocol ReaderPostCellDelegate: NSObjectProtocol {
@@ -74,6 +75,7 @@ extension NSNotification.Name {
 
     @objc open weak var delegate: ReaderPostCellDelegate?
     @objc open weak var contentProvider: ReaderPostContentProvider?
+    weak var cardDelegate: ReaderPostCardCellDelegate?
 
     fileprivate var featuredImageDesiredWidth = CGFloat()
 
@@ -241,6 +243,7 @@ extension NSNotification.Name {
         summaryLabel.backgroundColor = .listForeground
         commentActionButton.titleLabel?.backgroundColor = .listForeground
         likeActionButton.titleLabel?.backgroundColor = .listForeground
+        topicsCollectionView.backgroundColor = .listForeground
     }
 
     @objc open func configureCell(_ contentProvider: ReaderPostContentProvider) {
@@ -865,10 +868,10 @@ extension ReaderPostCardCell: ReaderTopicCollectionViewCoordinatorDelegate {
     func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didChangeState: ReaderTopicCollectionViewState) {
         layoutIfNeeded()
 
-        NotificationCenter.default.post(name: NSNotification.Name.postCardCellHeightDidChange, object: self)
+        cardDelegate?.heightDidChange()
     }
 
     func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didSelectTopic topic: String) {
-        print("topic selected", topic)
+        cardDelegate?.didSelect(topic: topic)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -35,7 +35,7 @@ protocol ReaderPostCardCellDelegate: class {
     // Wrapper views
     @IBOutlet fileprivate weak var contentStackView: UIStackView!
 
-    @IBOutlet weak var topicsCollectionView: UICollectionView!
+    @IBOutlet weak var topicsCollectionView: TopicsCollectionView!
 
     // Header realated Views
 
@@ -84,7 +84,6 @@ protocol ReaderPostCardCellDelegate: class {
         return  width <= 320
     }
 
-    var topicsCoordinator: ReaderTopicCollectionViewCoordinator?
     weak var cardDelegate: ReaderPostCardCellDelegate?
     var displayTopics: Bool = false
 
@@ -149,6 +148,8 @@ protocol ReaderPostCardCellDelegate: class {
         setupSummaryLabel()
         setupAttributionView()
         adjustInsetsForTextDirection()
+
+        topicsCollectionView.topicDelegate = self
     }
 
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -166,7 +167,6 @@ protocol ReaderPostCardCellDelegate: class {
     open override func prepareForReuse() {
         super.prepareForReuse()
 
-        topicsCoordinator = nil
         imageLoader.prepareForReuse()
         displayTopics = false
     }
@@ -274,10 +274,7 @@ protocol ReaderPostCardCellDelegate: class {
             return
         }
 
-        let coordinator = ReaderTopicCollectionViewCoordinator(collectionView: topicsCollectionView, topics: tags)
-        coordinator.delegate = self
-
-        self.topicsCoordinator = coordinator
+        topicsCollectionView.topics = tags
         topicsCollectionView.isHidden = false
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -86,6 +86,7 @@ protocol ReaderPostCardCellDelegate: class {
 
     var topicsCoordinator: ReaderTopicCollectionViewCoordinator?
     weak var cardDelegate: ReaderPostCardCellDelegate?
+    var displayTopics: Bool
 
     // MARK: - Accessors
     var loggedInActionVisibility: ReaderActionsVisibility = .visible(enabled: true)
@@ -167,6 +168,7 @@ protocol ReaderPostCardCellDelegate: class {
 
         topicsCoordinator = nil
         imageLoader.prepareForReuse()
+        displayTopics = false
     }
 
 
@@ -263,8 +265,8 @@ protocol ReaderPostCardCellDelegate: class {
 
     func configureTopicsCollectionView() {
         guard
+            displayTopics,
             let contentProvider = contentProvider,
-            let tags = contentProvider.tagsForDisplay?()
             let tags = contentProvider.tagsForDisplay?(),
             tags.count != 0
         else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -274,7 +274,7 @@ protocol ReaderPostCardCellDelegate: class {
             return
         }
 
-        let coordinator = ReaderTopicCollectionViewCoordinator(collectionView: topicsCollectionView, tags: tags)
+        let coordinator = ReaderTopicCollectionViewCoordinator(collectionView: topicsCollectionView, topics: tags)
         coordinator.delegate = self
 
         self.topicsCoordinator = coordinator

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -75,7 +75,6 @@ protocol ReaderPostCardCellDelegate: class {
 
     @objc open weak var delegate: ReaderPostCellDelegate?
     @objc open weak var contentProvider: ReaderPostContentProvider?
-    weak var cardDelegate: ReaderPostCardCellDelegate?
 
     fileprivate var featuredImageDesiredWidth = CGFloat()
 
@@ -86,6 +85,7 @@ protocol ReaderPostCardCellDelegate: class {
     }
 
     var topicsCoordinator: ReaderTopicCollectionViewCoordinator?
+    weak var cardDelegate: ReaderPostCardCellDelegate?
 
     // MARK: - Accessors
     var loggedInActionVisibility: ReaderActionsVisibility = .visible(enabled: true)
@@ -265,6 +265,8 @@ protocol ReaderPostCardCellDelegate: class {
         guard
             let contentProvider = contentProvider,
             let tags = contentProvider.tagsForDisplay?()
+            let tags = contentProvider.tagsForDisplay?(),
+            tags.count != 0
         else {
             topicsCollectionView.isHidden = true
             return
@@ -274,6 +276,7 @@ protocol ReaderPostCardCellDelegate: class {
         coordinator.delegate = self
 
         self.topicsCoordinator = coordinator
+        topicsCollectionView.isHidden = false
     }
 
     fileprivate func configureHeader() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
@@ -52,7 +52,7 @@
                     <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="k3b-5o-H9u">
                         <rect key="frame" x="0.0" y="8" width="320" height="476"/>
                         <subviews>
-                            <collectionView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="20" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="pbj-mu-PTK" customClass="DynamicHeightCollectionView" customModule="WordPress" customModuleProvider="target">
+                            <collectionView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="20" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="pbj-mu-PTK" customClass="TopicsCollectionView" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="16" y="16" width="288" height="0.0"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <collectionViewLayout key="collectionViewLayout" id="t6g-bE-oxG" customClass="ReaderInterestsCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
@@ -52,6 +52,11 @@
                     <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="k3b-5o-H9u">
                         <rect key="frame" x="0.0" y="8" width="320" height="476"/>
                         <subviews>
+                            <collectionView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="20" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="pbj-mu-PTK" customClass="DynamicHeightCollectionView" customModule="WordPress" customModuleProvider="target">
+                                <rect key="frame" x="16" y="16" width="288" height="0.0"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <collectionViewLayout key="collectionViewLayout" id="t6g-bE-oxG" customClass="ReaderInterestsCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target"/>
+                            </collectionView>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="xwk-ft-EDo" userLabel="Header Stack View">
                                 <rect key="frame" x="16" y="16" width="288" height="40"/>
                                 <subviews>
@@ -339,12 +344,13 @@
                 <outlet property="saveForLaterButton" destination="YRe-Q4-Aq4" id="6Hb-rc-u9V"/>
                 <outlet property="summaryLabel" destination="u1n-gR-1xw" id="jsD-Vc-hr5"/>
                 <outlet property="titleLabel" destination="Zf5-cD-Pd2" id="56V-Zc-1sF"/>
+                <outlet property="topicsCollectionView" destination="pbj-mu-PTK" id="JeG-YH-hdo"/>
                 <outletCollection property="actionButtons" destination="YRe-Q4-Aq4" collectionClass="NSMutableArray" id="VSk-GF-Wg6"/>
                 <outletCollection property="actionButtons" destination="3W2-KV-isX" collectionClass="NSMutableArray" id="4sJ-zt-Nh2"/>
                 <outletCollection property="actionButtons" destination="z4x-8W-5Dc" collectionClass="NSMutableArray" id="isM-Mg-Ff8"/>
                 <outletCollection property="actionButtons" destination="Mch-Ja-RJu" collectionClass="NSMutableArray" id="ff2-tZ-cST"/>
             </connections>
-            <point key="canvasLocation" x="-281" y="331"/>
+            <point key="canvasLocation" x="-506" y="247"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
@@ -55,7 +55,7 @@
                             <collectionView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="20" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="pbj-mu-PTK" customClass="TopicsCollectionView" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="16" y="16" width="288" height="0.0"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <collectionViewLayout key="collectionViewLayout" id="t6g-bE-oxG" customClass="ReaderInterestsCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target"/>
+                                <collectionViewLayout key="collectionViewLayout" id="t6g-bE-oxG"/>
                             </collectionView>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="xwk-ft-EDo" userLabel="Header Stack View">
                                 <rect key="frame" x="16" y="16" width="288" height="40"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1198,17 +1198,27 @@ import WordPressFlux
         postCellActions?.isLoggedIn = isLoggedIn
         postCellActions?.savedPostsDelegate = self
 
+        // Restrict the topics header to only display on
+        var displayTopics = true
+
+        if let topic = readerTopic {
+            let type = ReaderHelpers.topicType(topic)
+
+            switch type {
+            case .discover, .tag:
+                displayTopics = true
+            default:
+                displayTopics = false
+            }
+        }
+
         cellConfiguration.configurePostCardCell(cell,
                                                 withPost: post,
                                                 topic: readerTopic ?? post.topic,
                                                 delegate: postCellActions,
-                                                loggedInActionVisibility: .visible(enabled: isLoggedIn))
-
-        guard let postCardCell = cell as? ReaderPostCardCell else {
-            return
-        }
-
-        postCardCell.cardDelegate = self
+                                                loggedInActionVisibility: .visible(enabled: isLoggedIn),
+                                                cardDelegate: self,
+                                                displayTopics: displayTopics)
 
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -305,8 +305,6 @@ import WordPressFlux
 
         NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountDidChange(_:)), name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged, object: nil)
 
-        NotificationCenter.default.addObserver(self, selector: #selector(postCardCellHeightDidChange(_:)), name: NSNotification.Name.postCardCellHeightDidChange, object: nil)
-
         refreshImageRequestAuthToken()
 
         setupTableView()
@@ -1158,11 +1156,6 @@ import WordPressFlux
         refreshImageRequestAuthToken()
     }
 
-    @objc private func postCardCellHeightDidChange(_ notification: Foundation.Notification) {
-        tableView.beginUpdates()
-        tableView.endUpdates()
-    }
-
     // MARK: - Helpers for TableViewHandler
 
 
@@ -1210,6 +1203,12 @@ import WordPressFlux
                                                 topic: readerTopic ?? post.topic,
                                                 delegate: postCellActions,
                                                 loggedInActionVisibility: .visible(enabled: isLoggedIn))
+
+        guard let postCardCell = cell as? ReaderPostCardCell else {
+            return
+        }
+
+        postCardCell.cardDelegate = self
 
     }
 
@@ -1932,5 +1931,15 @@ private extension ReaderStreamViewController {
         static let contentErrorTitle = NSLocalizedString("Unable to load this content right now.", comment: "Default title shown for no-results when the device is offline.")
         static let contentErrorSubtitle = NSLocalizedString("Check your network connection and try again.", comment: "Default subtitle for no-results when there is no connection")
         static let contentErrorImage = "cloud"
+    }
+}
+
+extension ReaderStreamViewController: ReaderPostCardCellDelegate {
+    func heightDidChange() {
+        tableView.beginUpdates()
+        tableView.endUpdates()
+    }
+
+    func didSelect(topic: String) {
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -365,13 +365,16 @@ import WordPressFlux
             if self.isShowingResultStatusView {
                 self.resultsStatusView.updateAccessoryViewsVisibility()
             }
+
+            self.tableView.beginUpdates()
+            self.tableView.endUpdates()
         })
+
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
     }
-
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
@@ -1946,8 +1949,7 @@ private extension ReaderStreamViewController {
 
 extension ReaderStreamViewController: ReaderPostCardCellDelegate {
     func heightDidChange() {
-        WPAnalytics.track(.readerChipsMoreToggled)
-
+        // Forces the table view to layout the cells and update their heights
         tableView.beginUpdates()
         tableView.endUpdates()
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1941,5 +1941,7 @@ extension ReaderStreamViewController: ReaderPostCardCellDelegate {
     }
 
     func didSelect(topic: String) {
+        let topicStreamViewController = ReaderStreamViewController.controllerWithTagSlug(topic)
+        navigationController?.pushViewController(topicStreamViewController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1946,6 +1946,8 @@ private extension ReaderStreamViewController {
 
 extension ReaderStreamViewController: ReaderPostCardCellDelegate {
     func heightDidChange() {
+        WPAnalytics.track(.readerChipsMoreToggled)
+
         tableView.beginUpdates()
         tableView.endUpdates()
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -304,6 +304,9 @@ import WordPressFlux
         view.isUserInteractionEnabled = readerTopic != nil
 
         NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountDidChange(_:)), name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged, object: nil)
+
+        NotificationCenter.default.addObserver(self, selector: #selector(postCardCellHeightDidChange(_:)), name: NSNotification.Name.postCardCellHeightDidChange, object: nil)
+
         refreshImageRequestAuthToken()
 
         setupTableView()
@@ -1155,6 +1158,10 @@ import WordPressFlux
         refreshImageRequestAuthToken()
     }
 
+    @objc private func postCardCellHeightDidChange(_ notification: Foundation.Notification) {
+        tableView.beginUpdates()
+        tableView.endUpdates()
+    }
 
     // MARK: - Helpers for TableViewHandler
 
@@ -1203,6 +1210,7 @@ import WordPressFlux
                                                 topic: readerTopic ?? post.topic,
                                                 delegate: postCellActions,
                                                 loggedInActionVisibility: .visible(enabled: isLoggedIn))
+
     }
 
     @objc private func handleContextDidSaveNotification(_ notification: Foundation.Notification) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1220,7 +1220,7 @@ import WordPressFlux
                                                 topic: readerTopic ?? post.topic,
                                                 delegate: postCellActions,
                                                 loggedInActionVisibility: .visible(enabled: isLoggedIn),
-                                                cardDelegate: self,
+                                                topicChipsDelegate: self,
                                                 displayTopics: displayTopics)
 
     }
@@ -1947,7 +1947,7 @@ private extension ReaderStreamViewController {
     }
 }
 
-extension ReaderStreamViewController: ReaderPostCardCellDelegate {
+extension ReaderStreamViewController: ReaderTopicsChipsDelegate {
     func heightDidChange() {
         // Forces the table view to layout the cells and update their heights
         tableView.beginUpdates()

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 protocol ReaderInterestsCollectionViewFlowLayoutDelegate: UICollectionViewDelegateFlowLayout {
-    func collectionView(_ collectionView: UICollectionView, layout: ReaderInterestsCollectionViewFlowLayout, sizeForOverflowItem at: IndexPath, remainingItems: Int) -> CGSize
+    func collectionView(_ collectionView: UICollectionView, layout: ReaderInterestsCollectionViewFlowLayout, sizeForOverflowItem at: IndexPath, remainingItems: Int?) -> CGSize
 }
 
 class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
@@ -66,7 +66,7 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
         for item in 0 ..< count {
             let indexPath: IndexPath = IndexPath(row: item, section: 0)
             let isCollapseItem = item == numberOfItems
-            let itemSize = isCollapseItem ? sizeForOverflowItem(at: indexPath, remainingItems: 0) : sizeForItem(at: indexPath)
+            let itemSize = isCollapseItem ? sizeForOverflowItem(at: indexPath) : sizeForItem(at: indexPath)
             var frame: CGRect = CGRect(origin: .zero, size: itemSize)
 
             if item == 0 {
@@ -90,7 +90,7 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
                         let lastFrame = layoutAttributes.last?.frame ?? previousFrame
                         var overflowFrame = previousFrame
 
-                        overflowFrame.size = sizeForOverflowItem(at: indexPath, remainingItems: remainingItems ?? 0)
+                        overflowFrame.size = sizeForOverflowItem(at: indexPath, remainingItems: remainingItems)
                         overflowFrame.origin.x = isRightToLeft ? lastFrame.minX - itemSpacing - overflowFrame.width : lastFrame.maxX + itemSpacing
 
                         let overflowAttribute = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: Self.overflowItemKind,
@@ -151,7 +151,7 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
         return CGSize(width: size.width, height: cellHeight)
     }
 
-    private func sizeForOverflowItem(at indexPath: IndexPath, remainingItems: Int) -> CGSize {
+    private func sizeForOverflowItem(at indexPath: IndexPath, remainingItems: Int? = nil) -> CGSize {
         guard
             let collectionView = collectionView,
             let delegate = delegate

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -84,7 +84,10 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
                         remainingItems = numberOfItems - item + 1
 
                         // Remove the last added item and replace it with the expand item
-                        layoutAttributes.removeLast()
+                        // If there's only 1 token left, don't remove it
+                        if layoutAttributes.count > 1 {
+                            layoutAttributes.removeLast()
+                        }
 
                         // Get the frame for the item that appears before the item we just removed
                         let lastFrame = layoutAttributes.last?.frame ?? previousFrame

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -9,6 +9,7 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
     @IBInspectable var itemSpacing: CGFloat = 6
     @IBInspectable var cellHeight: CGFloat = 40
+    @IBInspectable var allowsCentering: Bool = true
 
     // Collapsing/Expanding support
     static let overflowItemKind = "InterestsOverflowItem"
@@ -168,7 +169,8 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
 
     override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        if collectionView?.traitCollection.horizontalSizeClass == .regular {
+        if allowsCentering,
+            collectionView?.traitCollection.horizontalSizeClass == .regular {
             return centeredLayoutAttributesForElements(in: rect)
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -1,13 +1,25 @@
 import UIKit
 
+protocol ReaderInterestsCollectionViewFlowLayoutDelegate: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout: ReaderInterestsCollectionViewFlowLayout, sizeForOverflowItem at: IndexPath, remainingItems: Int) -> CGSize
+}
+
 class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
-    @IBInspectable public var itemSpacing: CGFloat = 6
-    @IBInspectable public var cellHeight: CGFloat = 40
+    weak var delegate: ReaderInterestsCollectionViewFlowLayoutDelegate?
+
+    @IBInspectable var itemSpacing: CGFloat = 6
+    @IBInspectable var cellHeight: CGFloat = 40
+
+    // Collapsing/Expanding support
+    static let overflowItemKind = "InterestsOverflowItem"
+    var maxNumberOfDisplayedLines: Int?
+    var isExpanded: Bool = false
+    var remainingItems: Int?
 
     private var layoutAttributes: [UICollectionViewLayoutAttributes] = []
 
     private var isRightToLeft: Bool {
-        let layoutDirection: UIUserInterfaceLayoutDirection  = collectionView?.effectiveUserInterfaceLayoutDirection ?? .leftToRight
+        let layoutDirection: UIUserInterfaceLayoutDirection = collectionView?.effectiveUserInterfaceLayoutDirection ?? .leftToRight
         return layoutDirection == .rightToLeft
     }
 
@@ -29,6 +41,10 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
         return contentSize
     }
 
+    func collectionView(_ collectionView: UICollectionView, layout: ReaderInterestsCollectionViewFlowLayout, sizeForOverflowItem at: IndexPath) -> CGSize {
+        return .zero
+    }
+
     override func prepare() {
         guard let collectionView = collectionView else {
             return
@@ -44,10 +60,13 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
         let numberOfItems: Int = collectionView.numberOfItems(inSection: 0)
 
-        for item in 0 ..< numberOfItems {
-            let indexPath: IndexPath = IndexPath(row: item, section: 0)
+        // If we're expanded we will show the 'hide' option at the end
+        let count = isExpanded ? numberOfItems + 1 : numberOfItems
 
-            let itemSize = sizeForItem(at: indexPath)
+        for item in 0 ..< count {
+            let indexPath: IndexPath = IndexPath(row: item, section: 0)
+            let isCollapseItem = item == numberOfItems
+            let itemSize = isCollapseItem ? sizeForOverflowItem(at: indexPath, remainingItems: 0) : sizeForItem(at: indexPath)
             var frame: CGRect = CGRect(origin: .zero, size: itemSize)
 
             if item == 0 {
@@ -59,15 +78,47 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
                 // If the new X position will go off screen move it to the next row
                 let needsNewRow = isRightToLeft ? frame.origin.x < 0 : frame.maxX > maxContentWidth
                 if needsNewRow {
+                    // Cap the display to the maximum number of lines, and display the grouped item
+                    // If we're in the expanded state display all the items
+                    if let maxLines = maxNumberOfDisplayedLines, isExpanded == false, Int(currentRow) >= maxLines - 1 {
+                        remainingItems = numberOfItems - item + 1
+
+                        // Remove the last added item and replace it with the expand item
+                        layoutAttributes.removeLast()
+
+                        // Get the frame for the item that appears before the item we just removed
+                        let lastFrame = layoutAttributes.last?.frame ?? previousFrame
+                        var overflowFrame = previousFrame
+
+                        overflowFrame.size = sizeForOverflowItem(at: indexPath, remainingItems: remainingItems ?? 0)
+                        overflowFrame.origin.x = isRightToLeft ? lastFrame.minX - itemSpacing - overflowFrame.width : lastFrame.maxX + itemSpacing
+
+                        let overflowAttribute = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: Self.overflowItemKind,
+                                                                                 with: indexPath)
+                        overflowAttribute.frame = overflowFrame
+
+                        layoutAttributes.append(overflowAttribute)
+
+                        break
+                    }
+
                     frame.origin.x = isRightToLeft ? (maxContentWidth - frame.width) : 0
                     currentRow += 1
                 }
+
                 frame.origin.y = currentRow * (cellHeight + itemSpacing) + contentInsets.top
+                remainingItems = nil
             }
 
-            let attribute = UICollectionViewLayoutAttributes(forCellWith: indexPath)
-            attribute.frame = frame
+            let attribute: UICollectionViewLayoutAttributes
 
+            if isCollapseItem {
+                attribute = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: Self.overflowItemKind, with: indexPath)
+            } else {
+                attribute = UICollectionViewLayoutAttributes(forCellWith: indexPath)
+            }
+
+            attribute.frame = frame
             layoutAttributes.append(attribute)
 
             previousFrame = frame
@@ -99,6 +150,19 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
         return CGSize(width: size.width, height: cellHeight)
     }
+
+    private func sizeForOverflowItem(at indexPath: IndexPath, remainingItems: Int) -> CGSize {
+        guard
+            let collectionView = collectionView,
+            let delegate = delegate
+        else {
+            return CGSize(width: itemSize.width, height: cellHeight)
+        }
+
+        let size = delegate.collectionView(collectionView, layout: self, sizeForOverflowItem: indexPath, remainingItems: remainingItems)
+        return CGSize(width: size.width, height: cellHeight)
+    }
+
 
     override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
         if collectionView?.traitCollection.horizontalSizeClass == .regular {

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -24,6 +24,17 @@ class ReaderInterestsStyleGuide {
         label.backgroundColor = isSelected ? .muriel(color: .primary, .shade40) : .quaternaryBackground
     }
 
+    // MARK: - Compact Collection View Cell Styles
+    public class var compactCellLabelTitleFont: UIFont {
+        return WPStyleGuide.fontForTextStyle(.footnote)
+    }
+
+    public class func applyCompactCellLabelStyle(label: UILabel) {
+        label.font = Self.compactCellLabelTitleFont
+        label.textColor = .text
+        label.backgroundColor = .quaternaryBackground
+    }
+
     // MARK: - Next Button
     public class var buttonContainerViewBackgroundColor: UIColor {
         if #available(iOS 13, *) {

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/DynamicHeightCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/DynamicHeightCollectionView.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+class DynamicHeightCollectionView: UICollectionView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        self.invalidateIntrinsicContentSize()
+    }
+
+    override var intrinsicContentSize: CGSize {
+        var size = contentSize
+        size.width = superview?.bounds.size.width ?? 0
+        return size
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -56,11 +56,6 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     }
 
     private func configureCollectionView() {
-        guard tags.count != 0 else {
-            collectionView.isHidden = true
-            return
-        }
-
         collectionView.delegate = self
         collectionView.dataSource = self
 
@@ -83,8 +78,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         layout.maxNumberOfDisplayedLines = 1
         layout.itemSpacing = Constants.cellSpacing
         layout.cellHeight = Constants.cellHeight
-
-        collectionView.isHidden = false
+        layout.allowsCentering = false
     }
 
     private func sizeForCell(title: String) -> CGSize {

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -10,6 +10,11 @@ protocol ReaderTopicCollectionViewCoordinatorDelegate: AnyObject {
     func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didChangeState: ReaderTopicCollectionViewState)
 }
 
+
+/// The topics coordinator manages the layout and configuration of a topics chip group collection view.
+/// When created it will link to a collectionView and perform all the necessary configuration to
+/// display the group with expanding/collapsing support.
+///
 class ReaderTopicCollectionViewCoordinator: NSObject {
     private struct Constants {
         static let reuseIdentifier = ReaderInterestsCollectionViewCell.classNameWithoutNamespaces()

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -20,6 +20,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         static let cellCornerRadius: CGFloat = 4
         static let cellSpacing: CGFloat = 6
         static let cellHeight: CGFloat = 26
+        static let maxCellWidthMultiplier: CGFloat = 0.8
     }
 
     private struct Strings {
@@ -88,15 +89,20 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
     private func sizeForCell(title: String) -> CGSize {
         let attributes: [NSAttributedString.Key: Any] = [
-             .font: ReaderInterestsStyleGuide.compactCellLabelTitleFont
-         ]
+            .font: ReaderInterestsStyleGuide.compactCellLabelTitleFont
+        ]
 
-         let title: NSString = title as NSString
 
-         var size = title.size(withAttributes: attributes)
-         size.width += (Constants.interestsLabelMargin * 2)
+        let title: NSString = title as NSString
 
-         return size
+        var size = title.size(withAttributes: attributes)
+
+        // Prevent 1 token from being too long
+        let maxWidth = collectionView.bounds.width * Constants.maxCellWidthMultiplier
+        let width = min(size.width, maxWidth)
+        size.width = width + (Constants.interestsLabelMargin * 2)
+
+        return size
     }
 
     private func configure(cell: ReaderInterestsCollectionViewCell, with title: String) {

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -168,6 +168,8 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
         layout.isExpanded = !layout.isExpanded
         layout.invalidateLayout()
 
+        WPAnalytics.track(.readerChipsMoreToggled)
+
         delegate?.coordinator(self, didChangeState: layout.isExpanded ? .expanded: .collapsed)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -174,6 +174,17 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         return sizeForCell(title: tags[indexPath.row])
     }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        // We create a remote service because we need to convert the topic to a slug an this contains the
+        // code to do that
+        let service = ReaderTopicServiceRemote(wordPressComRestApi: WordPressComRestApi.defaultApi())
+        guard let topic = service.slug(forTopicName: tags[indexPath.row]) else {
+            return
+        }
+
+        delegate?.coordinator(self, didSelectTopic: topic)
+    }
 }
 
 extension ReaderTopicCollectionViewCoordinator: ReaderInterestsCollectionViewFlowLayoutDelegate {

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -30,7 +30,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     weak var delegate: ReaderTopicCollectionViewCoordinatorDelegate?
 
     let collectionView: UICollectionView
-    let tags: [String]
+    let topics: [String]
 
     deinit {
         guard let layout = collectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
@@ -41,9 +41,9 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         layout.invalidateLayout()
     }
 
-    init(collectionView: UICollectionView, tags: [String]) {
+    init(collectionView: UICollectionView, topics: [String]) {
         self.collectionView = collectionView
-        self.tags = tags
+        self.topics = topics
 
         super.init()
 
@@ -121,7 +121,7 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDataSource {
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return tags.count
+        return topics.count
     }
 }
 
@@ -133,7 +133,7 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
             fatalError("Expected a ReaderInterestsCollectionViewCell for identifier: \(Constants.reuseIdentifier)")
         }
 
-        configure(cell: cell, with: tags[indexPath.row])
+        configure(cell: cell, with: topics[indexPath.row])
 
         return cell
     }
@@ -172,14 +172,14 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return sizeForCell(title: tags[indexPath.row])
+        return sizeForCell(title: topics[indexPath.row])
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // We create a remote service because we need to convert the topic to a slug an this contains the
         // code to do that
         let service = ReaderTopicServiceRemote(wordPressComRestApi: WordPressComRestApi.defaultApi())
-        guard let topic = service.slug(forTopicName: tags[indexPath.row]) else {
+        guard let topic = service.slug(forTopicName: topics[indexPath.row]) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -24,7 +24,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     }
 
     private struct Strings {
-        static let collapseButtonTitle: String = NSLocalizedString("Hide", comment: "")
+        static let collapseButtonTitle: String = NSLocalizedString("Hide", comment: "Title of a button used to collapse a group")
     }
 
     weak var delegate: ReaderTopicCollectionViewCoordinatorDelegate?
@@ -148,13 +148,13 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
         else {
             fatalError("Expected a ReaderInterestsCollectionViewCell for identifier: \(Constants.overflowReuseIdentifier) with kind: \(overflowKind)")
         }
-        
+
         let remainingItems = layout.remainingItems
         let title = string(for: remainingItems)
 
         configure(cell: cell, with: title)
 
-        let tapGestureRecognizer = UITapGestureRecognizer(target:self, action:#selector(toggleExpanded))
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(toggleExpanded))
         cell.addGestureRecognizer(tapGestureRecognizer)
 
         return cell

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -42,7 +42,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
     init(collectionView: UICollectionView, tags: [String]) {
         self.collectionView = collectionView
-        self.tags = tags + tags + tags
+        self.tags = tags
 
         super.init()
 

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -30,7 +30,11 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     weak var delegate: ReaderTopicCollectionViewCoordinatorDelegate?
 
     let collectionView: UICollectionView
-    let topics: [String]
+    var topics: [String] {
+        didSet {
+            reloadData()
+        }
+    }
 
     deinit {
         guard let layout = collectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+/// A drop in collection view that will configure the collection view to display the topics chip group:
+/// - Overrides the layout to be `ReaderInterestsCollectionViewFlowLayout`
+/// - Creates the ReaderTopicCollectionViewCoordinator
+/// - Uses the dynamic height collection view class to automatically change its size to the content
+///
+/// When implementing you can also use the `topicDelegate` to know when the group is expanded/collapsed, or if a topic chip was selected
 class TopicsCollectionView: DynamicHeightCollectionView {
     var coordinator: ReaderTopicCollectionViewCoordinator?
 
@@ -23,7 +29,7 @@ class TopicsCollectionView: DynamicHeightCollectionView {
 
     func commonInit() {
         collectionViewLayout = ReaderInterestsCollectionViewFlowLayout()
-        
+
         coordinator = ReaderTopicCollectionViewCoordinator(collectionView: self, topics: topics)
         coordinator?.delegate = self
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+class TopicsCollectionView: DynamicHeightCollectionView {
+    var coordinator: ReaderTopicCollectionViewCoordinator?
+
+    weak var topicDelegate: ReaderTopicCollectionViewCoordinatorDelegate?
+
+    var topics: [String] = [] {
+        didSet {
+            coordinator?.topics = topics
+        }
+    }
+
+    override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(frame: frame, collectionViewLayout: layout)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    func commonInit() {
+        coordinator = ReaderTopicCollectionViewCoordinator(collectionView: self, topics: topics)
+        coordinator?.delegate = self
+    }
+}
+
+extension TopicsCollectionView: ReaderTopicCollectionViewCoordinatorDelegate {
+    func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didSelectTopic topic: String) {
+        topicDelegate?.coordinator(coordinator, didSelectTopic: topic)
+    }
+
+    func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didChangeState: ReaderTopicCollectionViewState) {
+        topicDelegate?.coordinator(coordinator, didChangeState: didChangeState)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
@@ -22,6 +22,8 @@ class TopicsCollectionView: DynamicHeightCollectionView {
     }
 
     func commonInit() {
+        collectionViewLayout = ReaderInterestsCollectionViewFlowLayout()
+        
         coordinator = ReaderTopicCollectionViewCoordinator(collectionView: self, topics: topics)
         coordinator?.delegate = self
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		327B48C3247CC7E000C3DE61 /* ReaderRelativeTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327B48C2247CC7E000C3DE61 /* ReaderRelativeTimeFormatter.swift */; };
 		327B48C5247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327B48C4247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift */; };
 		329F8E5624DDAC61002A5311 /* DynamicHeightCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329F8E5524DDAC61002A5311 /* DynamicHeightCollectionView.swift */; };
+		329F8E5824DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329F8E5724DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift */; };
 		32C765BA23F715E4000A7F11 /* PostSignUpInterstitialCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F1A6CE23F7083500AB8CA9 /* PostSignUpInterstitialCoordinator.swift */; };
 		32C765BB23F7170C000A7F11 /* PostSignUpInterstitialCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F1A6D323F7111800AB8CA9 /* PostSignUpInterstitialCoordinatorTests.swift */; };
 		32CA6EC02390C61F00B51347 /* PostListEditorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CA6EBF2390C61F00B51347 /* PostListEditorPresenter.swift */; };
@@ -2772,6 +2773,7 @@
 		327B48C4247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderRelativeTimeFormatterTests.swift; sourceTree = "<group>"; };
 		328CEC5D23A532BA00A6899E /* FullScreenCommentReplyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewController.swift; sourceTree = "<group>"; };
 		329F8E5524DDAC61002A5311 /* DynamicHeightCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicHeightCollectionView.swift; sourceTree = "<group>"; };
+		329F8E5724DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTopicCollectionViewCoordinator.swift; sourceTree = "<group>"; };
 		32A29A16236BC8BC009488C2 /* WordPress 93.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 93.xcdatamodel"; sourceTree = "<group>"; };
 		32C6CDDA23A1FF0D002556FF /* SiteCreationRotatingMessageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationRotatingMessageViewTests.swift; sourceTree = "<group>"; };
 		32CA6EBF2390C61F00B51347 /* PostListEditorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListEditorPresenter.swift; sourceTree = "<group>"; };
@@ -5920,6 +5922,7 @@
 			isa = PBXGroup;
 			children = (
 				329F8E5524DDAC61002A5311 /* DynamicHeightCollectionView.swift */,
+				329F8E5724DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift */,
 			);
 			path = "Tags View";
 			sourceTree = "<group>";
@@ -13257,6 +13260,7 @@
 				40EC1F102249CA8400F6785E /* OtherAndTotalViewsCount+CoreDataProperties.swift in Sources */,
 				B50EED791C0E5B2400D278CA /* SettingsPickerViewController.swift in Sources */,
 				E1F5A1BC1771C90A00E0495F /* WPTableImageSource.m in Sources */,
+				329F8E5824DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift in Sources */,
 				5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */,
 				B53AD9BF1BE9584B009AB87E /* SettingsSelectionViewController.m in Sources */,
 				7E4123C420F4097B00DF8486 /* FormattableContentActionCommand.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1094,6 +1094,7 @@
 		8B6BD55024293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6BD54F24293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift */; };
 		8B6EA62323FDE50B004BA312 /* PostServiceUploadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */; };
 		8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */; };
+		8B7F25A724E6EDB4007D82CC /* TopicsCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7F25A624E6EDB4007D82CC /* TopicsCollectionView.swift */; };
 		8B821F3C240020E2006B697E /* PostServiceUploadingListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B821F3B240020E2006B697E /* PostServiceUploadingListTests.swift */; };
 		8B8C814D2318073300A0E620 /* BasePostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8C814C2318073300A0E620 /* BasePostTests.swift */; };
 		8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */; };
@@ -3579,6 +3580,7 @@
 		8B6BD54F24293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingNudgesViewControllerTests.swift; sourceTree = "<group>"; };
 		8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceUploadingList.swift; sourceTree = "<group>"; };
 		8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewControllerTests.swift; sourceTree = "<group>"; };
+		8B7F25A624E6EDB4007D82CC /* TopicsCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsCollectionView.swift; sourceTree = "<group>"; };
 		8B821F3B240020E2006B697E /* PostServiceUploadingListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceUploadingListTests.swift; sourceTree = "<group>"; };
 		8B8C814C2318073300A0E620 /* BasePostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePostTests.swift; sourceTree = "<group>"; };
 		8B8FE8562343952B00F9AD2E /* PostAutoUploadMessages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadMessages.swift; sourceTree = "<group>"; };
@@ -5923,6 +5925,7 @@
 			children = (
 				329F8E5524DDAC61002A5311 /* DynamicHeightCollectionView.swift */,
 				329F8E5724DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift */,
+				8B7F25A624E6EDB4007D82CC /* TopicsCollectionView.swift */,
 			);
 			path = "Tags View";
 			sourceTree = "<group>";
@@ -12327,6 +12330,7 @@
 				FFC02B83222687BF00E64FDE /* GutenbergImageLoader.swift in Sources */,
 				E6C09B3E1BF0FDEB003074CB /* ReaderCrossPostMeta.swift in Sources */,
 				7E3E7A5520E44B4B0075D159 /* SnippetsContentStyles.swift in Sources */,
+				8B7F25A724E6EDB4007D82CC /* TopicsCollectionView.swift in Sources */,
 				D8CB56202181A8CE00554EAE /* SiteSegmentsService.swift in Sources */,
 				E11E775A1E72932F0072AD40 /* BlogListDataSource.swift in Sources */,
 				1730D4A31E97E3E400326B7C /* MediaItemTableViewCells.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 		325D3B3D23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 325D3B3C23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift */; };
 		327B48C3247CC7E000C3DE61 /* ReaderRelativeTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327B48C2247CC7E000C3DE61 /* ReaderRelativeTimeFormatter.swift */; };
 		327B48C5247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327B48C4247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift */; };
+		329F8E5624DDAC61002A5311 /* DynamicHeightCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329F8E5524DDAC61002A5311 /* DynamicHeightCollectionView.swift */; };
 		32C765BA23F715E4000A7F11 /* PostSignUpInterstitialCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F1A6CE23F7083500AB8CA9 /* PostSignUpInterstitialCoordinator.swift */; };
 		32C765BB23F7170C000A7F11 /* PostSignUpInterstitialCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F1A6D323F7111800AB8CA9 /* PostSignUpInterstitialCoordinatorTests.swift */; };
 		32CA6EC02390C61F00B51347 /* PostListEditorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CA6EBF2390C61F00B51347 /* PostListEditorPresenter.swift */; };
@@ -2770,6 +2771,7 @@
 		327B48C2247CC7E000C3DE61 /* ReaderRelativeTimeFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderRelativeTimeFormatter.swift; sourceTree = "<group>"; };
 		327B48C4247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderRelativeTimeFormatterTests.swift; sourceTree = "<group>"; };
 		328CEC5D23A532BA00A6899E /* FullScreenCommentReplyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewController.swift; sourceTree = "<group>"; };
+		329F8E5524DDAC61002A5311 /* DynamicHeightCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicHeightCollectionView.swift; sourceTree = "<group>"; };
 		32A29A16236BC8BC009488C2 /* WordPress 93.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 93.xcdatamodel"; sourceTree = "<group>"; };
 		32C6CDDA23A1FF0D002556FF /* SiteCreationRotatingMessageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationRotatingMessageViewTests.swift; sourceTree = "<group>"; };
 		32CA6EBF2390C61F00B51347 /* PostListEditorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListEditorPresenter.swift; sourceTree = "<group>"; };
@@ -5611,7 +5613,7 @@
 			path = GutenbergWeb;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				98D31BBF239720E4009CFF43 /* MainInterface.storyboard */,
@@ -5912,6 +5914,14 @@
 				325D3B3C23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift */,
 			);
 			path = Controllers;
+			sourceTree = "<group>";
+		};
+		329F8E4C24DD74F0002A5311 /* Tags View */ = {
+			isa = PBXGroup;
+			children = (
+				329F8E5524DDAC61002A5311 /* DynamicHeightCollectionView.swift */,
+			);
+			path = "Tags View";
 			sourceTree = "<group>";
 		};
 		32E1BFD824A66801007A08F0 /* Select Interests */ = {
@@ -6696,6 +6706,7 @@
 		5D5A6E901B613C1800DAF819 /* Cards */ = {
 			isa = PBXGroup;
 			children = (
+				329F8E4C24DD74F0002A5311 /* Tags View */,
 				327B48C2247CC7E000C3DE61 /* ReaderRelativeTimeFormatter.swift */,
 				E65219FA1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift */,
 				E65219F81B8D10C2000B1217 /* ReaderBlockedSiteCell.xib */,
@@ -10998,7 +11009,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -13014,6 +13025,7 @@
 				F11C9F78243B3C9600921DDC /* MediaHost+ReaderPostContentProvider.swift in Sources */,
 				985793C822F23D7000643DBF /* CustomizeInsightsCell.swift in Sources */,
 				8261B4CC1EA8E13700668298 /* SVProgressHUD+Dismiss.m in Sources */,
+				329F8E5624DDAC61002A5311 /* DynamicHeightCollectionView.swift in Sources */,
 				436D56242117312700CEAA33 /* RegisterDomainDetailsViewModel+RowList.swift in Sources */,
 				C81CCD65243AECA200A83E27 /* TenorGIF.swift in Sources */,
 				596C035E1B84F21D00899EEB /* ThemeBrowserViewController.swift in Sources */,


### PR DESCRIPTION
Main Issue #14570

### Demo
<img src="https://user-images.githubusercontent.com/793774/90161460-ffaa7880-dd47-11ea-9cc1-532f5e28fa17.gif" width="30%" />

### Screenshots
#### Portrait
| Collapsed | Expanded |
| :---: | :---: |
|<img src="https://user-images.githubusercontent.com/793774/90162908-31bcda00-dd4a-11ea-874c-8fcd4ba0448c.png" width="50%"/>| <img src="https://user-images.githubusercontent.com/793774/90162907-31244380-dd4a-11ea-9407-1a4952fb8111.png" width="50%"/> |

#### Landscape
| Collapsed | Expanded |
| :---: | :---: |
|<img src="https://user-images.githubusercontent.com/793774/90163101-81030a80-dd4a-11ea-947a-b5a08680f091.png" width=""/>| <img src="https://user-images.githubusercontent.com/793774/90163119-86f8eb80-dd4a-11ea-9ff7-8406f70190ef.png" width=""/> |

### Testing
#### 01 - Tag chips appear on Discover tab
1. Tap on the Reader tab
2. Tap on the Discover tab

- [x] Expectation: Posts that have tags should now display the chips at the top of the cell

#### 02 - Expand Works
1. Follow the steps from 01
2. Locate a post that has an expansion cell indicated by the 'X+' where X is the number of chips left to be displayed
3. Tap on the expansion cell

- [x] Expectation: The rest of the chips should be displayed
- [x] Expectation 2: The number displayed in the expansion cell is the number of chips that appeared, example if the number displays 2+, then 2 more chips should be displayed
- [x] Expectation 3: A cell with the localized title "Hide" should be displayed as the last chip

#### 03 - Hide Button
1. Follow the steps in 02
2. Tap on the Hide chip

- [x] Expectation: The chips collapse, and display the expansion tooltip

#### 04 - Landscape
1. Following the steps from 03
2. Rotate the device so it appears in landscape mode

- [x] Expectation: If the device is wide enough to display all the chips, no expansion cell is displayed
- [x] Expectation 2: If there are still some chips that are hidden the expansion cell's number should be updated to reflect the number of remaining cells
- [x] Expectation 3: Rotating the device back to portrait updates the count as well

#### 05 - Chips only appear on Discover
1. With the Reader tab active
2. Tap on any other tab besides Discover

- [x] Expectation: The chips should not appear

### PR submission checklist:

- [X] I have considered adding unit tests where possible.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
