### PR TITLE
Log error if WP.com preview auth cookie is not found

### DIFF
--- a/WordPress/Classes/Services/AuthenticationService.swift
+++ b/WordPress/Classes/Services/AuthenticationService.swift
@@ -96,7 +96,6 @@ class AuthenticationService {
                 self.getAuthCookiesForWPCom(username: username, authToken: authToken, success: { cookies in
                     cookieJar.setCookies(cookies) {
 
-                        // Verify that the WP.com auth cookie was indeed returned by the server.
                         cookieJar.hasWordPressComAuthCookie(username: username, atomicSite: false) { hasCookie in
                             guard hasCookie else {
                                 failure(RequestAuthCookieError.wpcomCookieNotReturned)


### PR DESCRIPTION
Addresses #14220

When the user previews a post or page, the app fetches an authentication cookie from the server. There are user reports (see linked issue above) where the preview screen for WP.com sites mapped to custom domains show a "Page not found" error. While I could only ever reproduce this once, in that instance I saw that the `wordpress_logged_in` cookie had an empty string as its value. 

### The potential fix

This PR aims to provide logs that will allow us to better assess whether a missing cookie is indeed the problem on WP.com Simple sites. If the cookie request returns error will appear in Sentry as:

<img width="1185" alt="Response to request for auth cookie for WP.com site failed to return cookie." src="https://user-images.githubusercontent.com/1898325/90292263-94e46480-de4f-11ea-8ad6-46bcecf74f6c.png">

### What's not included

- **Self-hosted sites**: although self-hosted sites may benefit from similar error logging, but in my brief tests, I found the requests were different and so were the cookies. Since there's no reports of this error on self-hosted sites, I think we can omit them.
- **Atomic sites**: atomic sites use an auth cookie named `wordpress_logged_in_` (note the trailing underscore) and their previews are handled different (looks like there's a distinction between private and non-private Atomic), so I've excluded them from the scope of this PR.


### How to test

Testing requires recreating the scenario where the `wordpress_logged_in` cookie is present in the server response, but has an empty value — and then checking Sentry to ensure the error is being logged correctly.

I used Charles proxy to remove the cookie from the server response. Setting up Charles proxy required some patience to get working correctly, but it did work in the end. I used the iOS simulator instead of a physical device because it was easier to setup the proxy there, but either should work. Here's the steps to test:

1. Setup Charles proxy to intercept traffic from an iOS simulator
2. Build and run this branch on the device (do a clean install to ensure no cookies are left over from a previous session)
3. Log in to a WP.com site that uses a custom domain
4. If running this from Xcode, you need to turn on error logging in the app (to allow errors to be sent to Sentry): Select a site > Tap profile photo > App Settings > Debug > Always Send Crash Logs
5. Create a post in the block editor, and add content
6. Import this [breakpoint](https://github.com/wordpress-mobile/WordPress-iOS/files/5077322/Breakpoints.xml.zip) into Charles (or manually add a breakpoint to Charles for the **response** of the `https://wordpress.com:443/wp-login.php` URL)
7. Ensure breakpoints are enabled in Charles (Proxy > Breakpoint Settings)
8. Tap the ellipsis menu (three dots) and select Preview
9. When Charles opens the Breakpoints window *, click the Edit Response button, and find both instances of the `wordpress_logged_in` cookie (technically, you only need to remove the one that's marked "secure" or for HTTPS) and remove their values
10. Click Execute in the Breakpoints window
11. Expect the app to show a "Page not found" error
11. Verify the error can be found in Sentry (search for the error message "Response to request for auth cookie for WP.com site failed to return cookie.")
12. Finally, remove the breakpoint (or quit Charles), open the preview screen in the app again and ensure it loads the post or page correctly

_* If the Breakpoints window doesn't open, quitting the simulator, restarting Charles, and running the simulator again fixed this for me_


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
