### PR TITLE
Feature/14625 show or hide follow conversation button

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -192,6 +192,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 #pragma mark - Blog information
 
 - (BOOL)isAtomic;
+- (BOOL)isWPForTeams;
 - (BOOL)isAutomatedTransfer;
 - (BOOL)isPrivate;
 - (BOOL)isPrivateAtWPCom;

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -27,6 +27,7 @@ NSString * const OptionsKeyActiveModules = @"active_modules";
 NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled";
 NSString * const OptionsKeyIsAutomatedTransfer = @"is_automated_transfer";
 NSString * const OptionsKeyIsAtomic = @"is_wpcom_atomic";
+NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 @interface Blog ()
 
@@ -117,6 +118,12 @@ NSString * const OptionsKeyIsAtomic = @"is_wpcom_atomic";
 - (BOOL)isAtomic
 {
     NSNumber *value = (NSNumber *)[self getOptionValue:OptionsKeyIsAtomic];
+    return [value boolValue];
+}
+
+- (BOOL)isWPForTeams
+{
+    NSNumber *value = (NSNumber *)[self getOptionValue:OptionsKeyIsWPForTeams];
     return [value boolValue];
 }
 

--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -109,7 +109,7 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
 /**
  Toggle the subscription status of the specified post.
 
- @param isSubscribed The subscription status for the reader post.
+ @param isSubscribed The current subscription status for the reader post.
  @param post The reader post to subscribe to/unsubscribe from.
  @param success block called on a successful fetch.
  @param failure block called if there is any error. `error` can be any underlying network error.

--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -96,6 +96,30 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
 - (void)refreshPostsForFollowedTopic;
 
 /**
+ Get the subscription status of the specified post.
+
+ @param post The reader post to fetch the subscription status.
+ @param success block called on a successful fetch.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)fetchSubscriptionStatusForPost:(ReaderPost *)post
+                               success:(void (^)(BOOL isSubscribed))success
+                               failure:(void (^)(NSError *error))failure;
+
+/**
+ Toggle the subscription status of the specified post.
+
+ @param isSubscribed The subscription status for the reader post.
+ @param post The reader post to subscribe to/unsubscribe from.
+ @param success block called on a successful fetch.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)toggleSubscribed:(BOOL)isSubscribed
+                 forPost:(ReaderPost *)post
+                 success:(void (^)(void))success
+                 failure:(void (^)(NSError *error))failure;
+
+/**
  Toggle the liked status of the specified post.
 
  @param post The reader post to like/unlike.

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -227,15 +227,15 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 {
     ReaderPostServiceRemote *remoteService = [[ReaderPostServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
     if (isSubscribed) {
-        [remoteService subscribeToPost:[post.postID integerValue]
-                               forSite:[post.siteID integerValue]
-                               success:success
-                               failure:failure];
-    } else {
         [remoteService unsubscribeFromPost:[post.postID integerValue]
                                    forSite:[post.siteID integerValue]
                                    success:success
                                    failure:failure];
+    } else {
+        [remoteService subscribeToPost:[post.postID integerValue]
+                               forSite:[post.siteID integerValue]
+                               success:success
+                               failure:failure];
     }
 }
 

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -192,6 +192,17 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
     }];
 }
 
+-(void)fetchSubscriptionStatusForPost:(ReaderPost *)post
+                              success:(void (^)(BOOL isSubscribed))success
+                              failure:(void (^)(NSError *))failure
+{
+    ReaderPostServiceRemote *remoteService = [[ReaderPostServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
+    [remoteService fetchSubscriptionStatusForPost:[post.postID integerValue]
+                                         fromSite:[post.siteID integerValue]
+                                          success:success
+                                          failure:failure];
+}
+
 - (void)refreshPostsForFollowedTopic
 {
     // Do all of this work on a background thread.
@@ -208,6 +219,25 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 
 
 #pragma mark - Update Methods
+
+- (void)toggleSubscribed:(BOOL)isSubscribed
+                 forPost:(ReaderPost *)post
+                 success:(void (^)(void))success
+                 failure:(void (^)(NSError *))failure
+{
+    ReaderPostServiceRemote *remoteService = [[ReaderPostServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
+    if (isSubscribed) {
+        [remoteService subscribeToPost:[post.postID integerValue]
+                               forSite:[post.siteID integerValue]
+                               success:success
+                               failure:failure];
+    } else {
+        [remoteService unsubscribeFromPost:[post.postID integerValue]
+                                   forSite:[post.siteID integerValue]
+                                   success:success
+                                   failure:failure];
+    }
+}
 
 - (void)toggleLikedForPost:(ReaderPost *)post success:(void (^)(void))success failure:(void (^)(NSError *error))failure
 {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1231,7 +1231,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     // Call the remote service to toggle the subscription status
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];
-    [service toggleSubscribed:newIsSubscribed
+    [service toggleSubscribed:oldIsSubscribed
                       forPost:self.post
                       success:successBlock
                       failure:failureBlock];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -295,7 +295,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     headerView.translatesAutoresizingMaskIntoConstraints = NO;
     headerView.showsDisclosureIndicator = self.allowsPushingPostDetails;
     [headerView setSubtitle:NSLocalizedString(@"Comments on", @"Sentence fragment. The full phrase is 'Comments on' followed by the title of a post on a separate line.")];
-    // headerView.isSubscribedToPost = NO;  // FIXME: Get subscription state
     [headerWrapper addSubview:headerView];
 
     // Border

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -290,7 +290,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     headerView.translatesAutoresizingMaskIntoConstraints = NO;
     headerView.showsDisclosureIndicator = self.allowsPushingPostDetails;
     [headerView setSubtitle:NSLocalizedString(@"Comments on", @"Sentence fragment. The full phrase is 'Comments on' followed by the title of a post on a separate line.")];
-    headerView.isSubscribedToPost = NO;
+    headerView.isSubscribedToPost = NO;  // FIXME: Get subscription state
     [headerWrapper addSubview:headerView];
 
     // Border

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1206,7 +1206,9 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
     // Define success block
     void (^successBlock)(void) = ^void() {
-        NSString *subscriptionString = newIsSubscribed ? @"subscribed to" : @"unsubscribed from";
+        NSString *subscriptionString = newIsSubscribed
+            ? NSLocalizedString(@"subscribed to", "Past tense verb + preposition. A subscription action.")
+            : NSLocalizedString(@"unsubscribed from", "Past tense verb + preposition. A subscription action.");
         NSString *successTitle = [NSString stringWithFormat: NSLocalizedString(@"Successfully %@ the post", @"The app successfully updated the subscription status for the post"), subscriptionString];
         dispatch_async(dispatch_get_main_queue(), ^{
             [generator notificationOccurred:UINotificationFeedbackTypeSuccess];
@@ -1217,7 +1219,9 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     // Define failure block
     void (^failureBlock)(NSError *error) = ^void(NSError *error) {
         DDLogError(@"Error toggling subscription status: %@", error);
-        NSString *subscriptionString = newIsSubscribed ? @"subscribing to" : @"unsubscribing from";
+        NSString *subscriptionString = newIsSubscribed
+            ? NSLocalizedString(@"subscribing to", "Verb + preposition. A subscription action.")
+            : NSLocalizedString(@"unsubscribing from", "Verb + preposition. A subscription action.");
         NSString *errorTitle = [NSString stringWithFormat: NSLocalizedString(@"There has been an unexpected error while %@ the post", "The app failed to update the subscription status for the post"), subscriptionString];
         dispatch_async(dispatch_get_main_queue(), ^{
             [generator notificationOccurred:UINotificationFeedbackTypeError];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -290,6 +290,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     headerView.translatesAutoresizingMaskIntoConstraints = NO;
     headerView.showsDisclosureIndicator = self.allowsPushingPostDetails;
     [headerView setSubtitle:NSLocalizedString(@"Comments on", @"Sentence fragment. The full phrase is 'Comments on' followed by the title of a post on a separate line.")];
+    headerView.isSubscribedToPost = NO;
     [headerWrapper addSubview:headerView];
 
     // Border

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.h
@@ -11,6 +11,12 @@ typedef void (^ReaderPostHeaderCallback)(void);
 @property (nonatomic, copy) ReaderPostHeaderCallback onClick;
 
 /**
+ A ReaderPostHeaderFollowingCallback block to be executed whenever the user pressed this view.
+ */
+typedef void (^ReaderPostHeaderFollowingCallback)(void);
+@property (nonatomic, copy) ReaderPostHeaderFollowingCallback onFollowingConversationClick;
+
+/**
  A BOOL indicating whether if this view should display a disclosure indicator, or not.
  */
 @property (nonatomic, assign) BOOL showsDisclosureIndicator;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.h
@@ -30,4 +30,9 @@ typedef void (^ReaderPostHeaderCallback)(void);
  */
 @property (nonatomic, strong) NSString *subtitle;
 
+/**
+ A BOOL indicating whether the User is subscribed to the post, or not.
+ */
+@property (nonatomic, assign, setter=setSubscribedToPost:) BOOL isSubscribedToPost;
+
 @end

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.h
@@ -22,6 +22,11 @@ typedef void (^ReaderPostHeaderFollowingCallback)(void);
 @property (nonatomic, assign) BOOL showsDisclosureIndicator;
 
 /**
+ A BOOL indicating whether if this view should display a follow conversation button, or not.
+ */
+@property (nonatomic, assign) BOOL showsFollowConversationButton;
+
+/**
  A UIImage instance to be displayed as the User's avatar.
  */
 @property (nonatomic, strong) UIImage *avatarImage;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -1,8 +1,6 @@
 #import "ReaderPostHeaderView.h"
 #import "WordPress-Swift.h"
 
-@import Gridicons;
-
 const CGFloat PostHeaderViewAvatarSize = 32.0;
 const CGFloat PostHeaderViewLabelHeight = 18.0;
 const CGFloat PostHeaderDisclosureButtonWidth = 8.0;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -183,6 +183,12 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     self.disclosureButton.hidden = !showsDisclosure;
 }
 
+- (void)setShowsFollowConversationButton:(BOOL)showsFollowConversationButton
+{
+    _showsFollowConversationButton = showsFollowConversationButton;
+    self.followConversationButton.hidden = !showsFollowConversationButton;
+}
+
 - (UIImage *)avatarImage
 {
     return self.avatarImageView.image;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -135,9 +135,8 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 {
     NSAssert(self.labelsStackView != nil, @"labelsStackView was nil");
 
-    // FIXME: refine design specs later
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
-    button.titleLabel.font = [WPStyleGuide subtitleFont];
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+    [WPStyleGuide applyReaderFollowConversationButtonStyle:button];
     button.translatesAutoresizingMaskIntoConstraints = NO;
     [self.labelsStackView addArrangedSubview:button];
     self.followButton = button;
@@ -214,18 +213,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 - (void)setSubscribedToPost:(BOOL)isSubscribedToPost
 {
     _isSubscribedToPost = isSubscribedToPost;
-    NSString *subscriptionStatusTitle = isSubscribedToPost
-        ? NSLocalizedString(@"Following conversation", @"Title for subscription status button, if the User is subscribed to the post.")
-        : NSLocalizedString(@"Follow conversation", @"Title for subscription status button, if the User is not subscribed to the post.");
-    
-    // FIXME: use correct asset
-    CGSize iconSize = CGSizeMake(18.0, 18.0);
-    UIImage *image = isSubscribedToPost
-        ? [UIImage gridiconOfType:GridiconTypeReaderFollowingConversation withSize:iconSize]
-        : [UIImage gridiconOfType:GridiconTypeReaderFollowConversation withSize:iconSize];
-
-    [self.followButton setTitle:subscriptionStatusTitle forState:UIControlStateNormal];
-    [self.followButton setImage:image forState:UIControlStateNormal];
+    [self.followButton setSelected:isSubscribedToPost];
 }
 
 #pragma mark - Recognizer Helpers

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -1,6 +1,8 @@
 #import "ReaderPostHeaderView.h"
 #import "WordPress-Swift.h"
 
+@import Gridicons;
+
 const CGFloat PostHeaderViewAvatarSize = 32.0;
 const CGFloat PostHeaderViewLabelHeight = 18.0;
 const CGFloat PostHeaderDisclosureButtonWidth = 8.0;
@@ -13,6 +15,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 @property (nonatomic, strong) UIStackView *labelsStackView;
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *subtitleLabel;
+@property (nonatomic, strong) UIButton *followButton;
 @property (nonatomic, strong) UIButton *disclosureButton;
 @property (nonatomic, strong) UITapGestureRecognizer *tapRecognizer;
 
@@ -34,6 +37,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
         [self setupLabelsStackView];
         [self setupSubtitleLabel];
         [self setupTitleLabel];
+        [self setupFollowButton];
         [self setupDisclosureButton];
         [self setupTapGesture];
     }
@@ -46,7 +50,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     stackView.translatesAutoresizingMaskIntoConstraints = NO;
     stackView.axis = UILayoutConstraintAxisHorizontal;
     stackView.distribution = UIStackViewAlignmentFill;
-    stackView.alignment = UIStackViewAlignmentCenter;
+    stackView.alignment = UIStackViewAlignmentTop;
     stackView.spacing = 8.0;
 
     [self addSubview:stackView];
@@ -87,7 +91,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     stackView.preservesSuperviewLayoutMargins = YES;
     stackView.axis = UILayoutConstraintAxisVertical;
     stackView.distribution = UIStackViewAlignmentFill;
-    stackView.alignment = UIStackViewAlignmentFill;
+    stackView.alignment = UIStackViewAlignmentLeading;
 
     [self.stackView addArrangedSubview:stackView];
     self.labelsStackView = stackView;
@@ -125,6 +129,18 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 
     [self.labelsStackView addArrangedSubview:label];
     self.titleLabel = label;
+}
+
+- (void)setupFollowButton
+{
+    NSAssert(self.labelsStackView != nil, @"labelsStackView was nil");
+
+    // FIXME: refine design specs later
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    button.titleLabel.font = [WPStyleGuide subtitleFont];
+    button.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.labelsStackView addArrangedSubview:button];
+    self.followButton = button;
 }
 
 - (void)setupDisclosureButton
@@ -193,6 +209,23 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 - (void)setSubtitle:(NSString *)title
 {
     self.subtitleLabel.text = title;
+}
+
+- (void)setSubscribedToPost:(BOOL)isSubscribedToPost
+{
+    _isSubscribedToPost = isSubscribedToPost;
+    NSString *subscriptionStatusTitle = isSubscribedToPost
+        ? NSLocalizedString(@"Following conversation", @"Title for subscription status button, if the User is subscribed to the post.")
+        : NSLocalizedString(@"Follow conversation", @"Title for subscription status button, if the User is not subscribed to the post.");
+    
+    // FIXME: use correct asset
+    CGSize iconSize = CGSizeMake(18.0, 18.0);
+    UIImage *image = isSubscribedToPost
+        ? [UIImage gridiconOfType:GridiconTypeReaderFollowingConversation withSize:iconSize]
+        : [UIImage gridiconOfType:GridiconTypeReaderFollowConversation withSize:iconSize];
+
+    [self.followButton setTitle:subscriptionStatusTitle forState:UIControlStateNormal];
+    [self.followButton setImage:image forState:UIControlStateNormal];
 }
 
 #pragma mark - Recognizer Helpers

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -134,8 +134,13 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     NSAssert(self.labelsStackView != nil, @"labelsStackView was nil");
 
     UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
-    [WPStyleGuide applyReaderFollowConversationButtonStyle:button];
     button.translatesAutoresizingMaskIntoConstraints = NO;
+    [button addTarget:self
+               action:@selector(followConversationButtonTapped)
+     forControlEvents:UIControlEventTouchUpInside];
+
+    [WPStyleGuide applyReaderFollowConversationButtonStyle:button];
+
     [self.labelsStackView addArrangedSubview:button];
     self.followConversationButton = button;
 }
@@ -212,6 +217,15 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 {
     _isSubscribedToPost = isSubscribedToPost;
     [self.followConversationButton setSelected:isSubscribedToPost];
+}
+
+#pragma mark - Button Action Helpers
+
+- (void)followConversationButtonTapped
+{
+    if (self.onFollowingConversationClick) {
+        self.onFollowingConversationClick();
+    }
 }
 
 #pragma mark - Recognizer Helpers

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -13,7 +13,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 @property (nonatomic, strong) UIStackView *labelsStackView;
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *subtitleLabel;
-@property (nonatomic, strong) UIButton *followButton;
+@property (nonatomic, strong) UIButton *followConversationButton;
 @property (nonatomic, strong) UIButton *disclosureButton;
 @property (nonatomic, strong) UITapGestureRecognizer *tapRecognizer;
 
@@ -35,7 +35,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
         [self setupLabelsStackView];
         [self setupSubtitleLabel];
         [self setupTitleLabel];
-        [self setupFollowButton];
+        [self setupFollowConversationButton];
         [self setupDisclosureButton];
         [self setupTapGesture];
     }
@@ -129,7 +129,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     self.titleLabel = label;
 }
 
-- (void)setupFollowButton
+- (void)setupFollowConversationButton
 {
     NSAssert(self.labelsStackView != nil, @"labelsStackView was nil");
 
@@ -137,7 +137,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     [WPStyleGuide applyReaderFollowConversationButtonStyle:button];
     button.translatesAutoresizingMaskIntoConstraints = NO;
     [self.labelsStackView addArrangedSubview:button];
-    self.followButton = button;
+    self.followConversationButton = button;
 }
 
 - (void)setupDisclosureButton
@@ -211,7 +211,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 - (void)setSubscribedToPost:(BOOL)isSubscribedToPost
 {
     _isSubscribedToPost = isSubscribedToPost;
-    [self.followButton setSelected:isSubscribedToPost];
+    [self.followConversationButton setSelected:isSubscribedToPost];
 }
 
 #pragma mark - Recognizer Helpers

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -281,6 +281,46 @@ extension WPStyleGuide {
         button.setTitleColor(disabledColor, for: .disabled)
     }
 
+    @objc public class func applyReaderFollowConversationButtonStyle(_ button: UIButton) {
+        // General
+        button.naturalContentHorizontalAlignment = .leading
+        button.backgroundColor = .clear
+        button.titleLabel?.font = WPStyleGuide.subtitleFont()
+
+        // Color(s)
+        let normalColor = UIColor.neutral(.shade50)
+        let highlightedColor = UIColor.neutral(.shade40)
+        let selectedColor = UIColor.success
+
+        button.setTitleColor(normalColor, for: .normal)
+        button.setTitleColor(selectedColor, for: .selected)
+        button.setTitleColor(highlightedColor, for: .highlighted)
+
+        // Image(s)
+        let side = WPStyleGuide.fontSizeForTextStyle(.headline)
+        let size = CGSize(width: side, height: side)
+        let followIcon = UIImage.gridicon(.readerFollowConversation, size: size)
+        let followingIcon = UIImage.gridicon(.readerFollowingConversation, size: size)
+
+        button.setImage(followIcon.imageWithTintColor(normalColor), for: .normal)
+        button.setImage(followingIcon.imageWithTintColor(selectedColor), for: .selected)
+        button.setImage(followingIcon.imageWithTintColor(highlightedColor), for: .highlighted)
+        button.imageEdgeInsets = FollowConversationButton.Style.imageEdgeInsets
+        button.contentEdgeInsets = FollowConversationButton.Style.contentEdgeInsets
+
+        // Strings
+        let normalText = FollowConversationButton.Text.followConversationStringForDisplay
+        let selectedText = FollowConversationButton.Text.followingConversationStringForDisplay
+
+        button.setTitle(normalText, for: .normal)
+        button.setTitle(selectedText, for: .selected)
+        button.setTitle(selectedText, for: .highlighted)
+
+        // Default accessibility label and hint.
+        button.accessibilityLabel = normalText
+        button.accessibilityHint = NSLocalizedString("Follows the blog.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a blog.")
+    }
+
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton) {
         let side = WPStyleGuide.fontSizeForTextStyle(.headline)
         let size = CGSize(width: side, height: side)
@@ -552,6 +592,19 @@ extension WPStyleGuide {
             static let accessibilityHint = NSLocalizedString("Follows the tag.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")
             static let followStringForDisplay =  NSLocalizedString("Follow", comment: "Verb. Button title. Follow a new blog.")
             static let followingStringForDisplay = NSLocalizedString("Following", comment: "Verb. Button title. The user is following a blog.")
+        }
+    }
+
+    public struct FollowConversationButton {
+        struct Style {
+            static let imageEdgeInsets = UIEdgeInsets(top: 1.0, left: -4.0, bottom: 0.0, right: -4.0)
+            static let contentEdgeInsets = UIEdgeInsets(top: 0.0, left: 4.0, bottom: 0.0, right: 0.0)
+        }
+
+        struct Text {
+            static let accessibilityHint = NSLocalizedString("Follows the post.", comment: "VoiceOver accessibility hint, informing the user the button can be used to follow a tag.")
+            static let followConversationStringForDisplay =  NSLocalizedString("Follow conversation", comment: "Verb. Button title. Follow a post.")
+            static let followingConversationStringForDisplay = NSLocalizedString("Following conversation", comment: "Verb. Button title. The user is following a post.")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -288,8 +288,8 @@ extension WPStyleGuide {
         button.titleLabel?.font = WPStyleGuide.subtitleFont()
 
         // Color(s)
-        let normalColor = UIColor.neutral(.shade50)
-        let highlightedColor = UIColor.neutral(.shade40)
+        let normalColor = UIColor.primary(.shade40)
+        let highlightedColor =  UIColor.neutral
         let selectedColor = UIColor.success
 
         button.setTitleColor(normalColor, for: .normal)


### PR DESCRIPTION
Fixes #14625
Note: Please merge after https://github.com/wordpress-mobile/WordPress-iOS/pull/14655

To test:

### Show Follow Conversation Button
1. Navigate to the comments view of a P2 blog post marked as `"is_wpforteams_site": true`
2. Check that the follow conversation button is visible ✅ 

### Hide Follow Conversation Button
1. Navigate to the comments view of a P2 blog post marked as `"is_wpforteams_site": false`
2. Check that the follow conversation button is hidden ✅ 

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
