### PR TITLE
Fix site header is not updated when follow / unfollow from post actions

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -42,7 +42,12 @@ final class ReaderShowMenuAction {
                                                style: .default,
                                                handler: { (action: UIAlertAction) in
                                                 if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
-                                                    ReaderFollowAction().execute(with: post, context: context)
+                                                    ReaderFollowAction().execute(with: post, context: context) {
+                                                        guard let vc = vc as? ReaderStreamViewController else {
+                                                            return
+                                                        }
+                                                        vc.refreshTableHeaderIfNeeded()
+                                                    }
                                                 }
             })
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -46,7 +46,7 @@ final class ReaderShowMenuAction {
                                                         guard let vc = vc as? ReaderStreamViewController else {
                                                             return
                                                         }
-                                                        vc.refreshTableHeaderIfNeeded()
+                                                        vc.updateStreamHeaderIfNeeded()
                                                     }
                                                 }
             })

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -33,20 +33,20 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
-                    <rect key="frame" x="132" y="76.666666666666686" width="30" height="119.33333333333331"/>
+                    <rect key="frame" x="132" y="76.666666666666671" width="30" height="34"/>
                     <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <connections>
                         <action selector="didTapFollowButton:" destination="QDT-3t-9yR" eventType="touchUpInside" id="dRK-lH-Zga"/>
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mi7-dO-TOF">
-                    <rect key="frame" x="16" y="235" width="343" height="0.0"/>
+                    <rect key="frame" x="16" y="149.66666666666666" width="343" height="0.0"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHO-IY-cyK">
-                    <rect key="frame" x="132" y="204" width="235" height="15"/>
+                    <rect key="frame" x="132" y="118.66666666666667" width="235" height="15.000000000000014"/>
                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
@@ -63,7 +63,7 @@
                 <constraint firstItem="fq2-Xh-dYx" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="SQK-NR-gJ1"/>
                 <constraint firstItem="JHO-IY-cyK" firstAttribute="trailing" secondItem="fq2-Xh-dYx" secondAttribute="trailing" id="V3z-Dz-T7p"/>
                 <constraint firstItem="JHO-IY-cyK" firstAttribute="top" secondItem="jvF-YL-IV0" secondAttribute="bottom" constant="8" id="VoM-PV-43m"/>
-                <constraint firstAttribute="bottom" secondItem="mi7-dO-TOF" secondAttribute="bottom" constant="16" id="Zc9-ns-Y8r"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="mi7-dO-TOF" secondAttribute="bottom" constant="16" id="Zc9-ns-Y8r"/>
                 <constraint firstItem="JHO-IY-cyK" firstAttribute="leading" secondItem="fq2-Xh-dYx" secondAttribute="leading" id="bkn-wr-ADc"/>
                 <constraint firstAttribute="trailingMargin" secondItem="mi7-dO-TOF" secondAttribute="trailing" id="blt-Tr-kwH"/>
                 <constraint firstItem="mi7-dO-TOF" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="leading" id="eAG-pR-tpk"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -543,7 +543,7 @@ import WordPressFlux
 
     // Refresh the header of a site topic when returning in case the
     // topic's following status changed.
-    private func refreshTableHeaderIfNeeded() {
+    func refreshTableHeaderIfNeeded() {
         guard let _ = readerTopic else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -543,7 +543,7 @@ import WordPressFlux
 
     // Refresh the header of a site topic when returning in case the
     // topic's following status changed.
-    func refreshTableHeaderIfNeeded() {
+    private func refreshTableHeaderIfNeeded() {
         guard let _ = readerTopic else {
             return
         }
@@ -724,7 +724,7 @@ import WordPressFlux
     }
 
 
-    private func updateStreamHeaderIfNeeded() {
+    func updateStreamHeaderIfNeeded() {
         guard let topic = readerTopic else {
             assertionFailure("A reader topic is required")
             return


### PR DESCRIPTION
when follow/ unfollow from post menu action

Fixes #13315 

To test:
1.Navigate to the “Reader” tab.
2.Tap “Followed Sites”.
3. Tap on site title
4. See site page
5. Follow / Unfollow the Site through the header and one of the posts repeatedly.
6. Wait a couple of seconds
7. See that the Follow / Following header button is updated 
8. See post actions are synced with following / unfollowing state 

![20200816_180751](https://user-images.githubusercontent.com/1335657/90349097-48369000-dfed-11ea-900b-cad4ae517d45.GIF)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
