### PR TITLE
Reader Improvements: Fix Discover indefinite ghost mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -103,6 +103,10 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         })
     }
 
+    override var topicPostsCount: Int {
+        return cards?.count ?? 0
+    }
+
     override func syncIfAppropriate() {
         // Only sync if the tableview is at the top, otherwise this will change tableview's offset
         if isTableViewAtTheTop() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -72,8 +72,11 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
             return
         }
 
-        readerTabBarViewController.displaySelectInterestsIfNeeded()
-        showGhost()
+        readerTabBarViewController.displaySelectInterestsIfNeeded { [unowned self] (isDisplaying) in
+            if isDisplaying {
+                self.showGhost()
+            }
+        }
     }
 
     // MARK: - Sync

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -904,7 +904,7 @@ import WordPressFlux
             return
         }
 
-        if ReaderHelpers.isTopicSearchTopic(topic) && topic.posts.count > 0 {
+        if ReaderHelpers.isTopicSearchTopic(topic) && topicPostsCount > 0 {
             // We only perform an initial sync if the topic has no results.
             // The rest of the time it should just support infinite scroll.
             // Normal the newly added topic will have no existing posts. The
@@ -915,13 +915,23 @@ import WordPressFlux
 
         let lastSynced = topic.lastSynced ?? Date(timeIntervalSince1970: 0)
         let interval = Int( Date().timeIntervalSince(lastSynced))
-        if canSync() && (interval >= refreshInterval || topic.posts.count == 0) {
+
+        if canSync() && (interval >= refreshInterval || topicPostsCount == 0) {
             syncHelper?.syncContentWithUserInteraction(false)
         } else {
             handleConnectionError()
         }
     }
 
+    /// Returns the number of posts for the current topic
+    /// This allows the count to be overriden by subclasses
+    var topicPostsCount: Int {
+        guard let topic = readerTopic else {
+            return 0
+        }
+
+        return topic.posts.count
+    }
     /// Used to fetch new content in response to a background refresh event.  
     /// Not intended for use as part of a user interaction. See syncIfAppropriate instead.
     ///

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -369,7 +369,6 @@ import WordPressFlux
             self.tableView.beginUpdates()
             self.tableView.endUpdates()
         })
-
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -926,11 +925,7 @@ import WordPressFlux
     /// Returns the number of posts for the current topic
     /// This allows the count to be overriden by subclasses
     var topicPostsCount: Int {
-        guard let topic = readerTopic else {
-            return 0
-        }
-
-        return topic.posts.count
+        return readerTopic?.posts.count ?? 0
     }
     /// Used to fetch new content in response to a background refresh event.  
     /// Not intended for use as part of a user interaction. See syncIfAppropriate instead.

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -119,16 +119,19 @@ extension ReaderTabViewController {
 
 // MARK: - Select Interests Display
 extension ReaderTabViewController {
-    func displaySelectInterestsIfNeeded() {
+    func displaySelectInterestsIfNeeded(isDisplaying: ((Bool) -> Void)? = nil) {
         guard viewModel.itemsLoaded, isViewOnScreen() else {
+            isDisplaying?(false)
             return
         }
 
         selectInterestsViewController.userIsFollowingTopics { [unowned self] isFollowing in
             if !isFollowing {
                 self.showSelectInterestsView()
+                isDisplaying?(true)
             } else {
                 self.markSelectedInterestsVisited()
+                isDisplaying?(false)
             }
         }
     }


### PR DESCRIPTION
Fixes #14660

### To test:
1. Run the app with the Reader Improvements Phase 2 flag enabled
2. Tap on the Reader tab
3. Tap on the Discover tab
3. Scroll down a few posts
4. Tap on a topic at the top of a post
5. Wait for it to load
6. Tap back

**Expectation:** The app displays the posts that were there before

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
