### PR TITLE
Completes Google tracking for UL&S

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -194,8 +194,8 @@ target 'WordPress' do
     # pod 'WordPressAuthenticator', '~> 1.23.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-    pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'f7f3431eb44237cc2b4374bf429f7d9f615c8e27'
+    # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.0'
     # pod 'MediaEditor', :git => 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', :commit => 'a4178ed9b0f3622faafb41dd12503e26c5523a32'

--- a/Podfile
+++ b/Podfile
@@ -194,7 +194,7 @@ target 'WordPress' do
     # pod 'WordPressAuthenticator', '~> 1.23.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'f7f3431eb44237cc2b4374bf429f7d9f615c8e27'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'e3a78a2d019ec25894b570dd03e09457e158f25a'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.0'

--- a/Podfile
+++ b/Podfile
@@ -191,11 +191,11 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.23.0-beta'
+    # pod 'WordPressAuthenticator', '~> 1.23.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-    # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
+    pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.0'
     # pod 'MediaEditor', :git => 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', :commit => 'a4178ed9b0f3622faafb41dd12503e26c5523a32'

--- a/Podfile
+++ b/Podfile
@@ -194,7 +194,7 @@ target 'WordPress' do
     # pod 'WordPressAuthenticator', '~> 1.23.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'e3a78a2d019ec25894b570dd03e09457e158f25a'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c23c09466b1d75fe4316e59b35632628d565a374'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.0'

--- a/Podfile
+++ b/Podfile
@@ -191,10 +191,10 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.23.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.23.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c23c09466b1d75fe4316e59b35632628d565a374'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c23c09466b1d75fe4316e59b35632628d565a374'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.23.0-beta.13):
+  - WordPressAuthenticator (1.23.0-beta.xx):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `e3a78a2d019ec25894b570dd03e09457e158f25a`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c23c09466b1d75fe4316e59b35632628d565a374`)
   - WordPressKit (~> 4.14)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11-beta)
@@ -657,7 +657,7 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   WordPressAuthenticator:
-    :commit: e3a78a2d019ec25894b570dd03e09457e158f25a
+    :commit: c23c09466b1d75fe4316e59b35632628d565a374
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bd76109049d2eeead78478d20d66ffd7b1567dd3/third-party-podspecs/Yoga.podspec.json
@@ -678,7 +678,7 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   WordPressAuthenticator:
-    :commit: e3a78a2d019ec25894b570dd03e09457e158f25a
+    :commit: c23c09466b1d75fe4316e59b35632628d565a374
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -760,7 +760,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: b47ffac83711b19d9303b1ababece889faa6fb51
+  WordPressAuthenticator: 87525d01277eeff8bf39c8cefda8400db5ae9563
   WordPressKit: dcab41057f0c39af3280b7c0d17bdc36271e01ae
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
@@ -777,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: e9bfafaf381a6c568d0b59da66285010ea7fe7e3
+PODFILE CHECKSUM: 6e919d742aead75fe024af1af130412f3f677255
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `../WordPressAuthenticator-iOS`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `f7f3431eb44237cc2b4374bf429f7d9f615c8e27`)
   - WordPressKit (~> 4.14)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11-beta)
@@ -657,7 +657,8 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   WordPressAuthenticator:
-    :path: "../WordPressAuthenticator-iOS"
+    :commit: f7f3431eb44237cc2b4374bf429f7d9f615c8e27
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bd76109049d2eeead78478d20d66ffd7b1567dd3/third-party-podspecs/Yoga.podspec.json
 
@@ -676,6 +677,9 @@ CHECKOUT OPTIONS:
     :commit: bd76109049d2eeead78478d20d66ffd7b1567dd3
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :commit: f7f3431eb44237cc2b4374bf429f7d9f615c8e27
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -773,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: fb199387374d1214985c516270f0a42c0c255793
+PODFILE CHECKSUM: 91443188de9044c7ea6ce8a420ff22255bc4251b
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `f7f3431eb44237cc2b4374bf429f7d9f615c8e27`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `e3a78a2d019ec25894b570dd03e09457e158f25a`)
   - WordPressKit (~> 4.14)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11-beta)
@@ -657,7 +657,7 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   WordPressAuthenticator:
-    :commit: f7f3431eb44237cc2b4374bf429f7d9f615c8e27
+    :commit: e3a78a2d019ec25894b570dd03e09457e158f25a
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bd76109049d2eeead78478d20d66ffd7b1567dd3/third-party-podspecs/Yoga.podspec.json
@@ -678,7 +678,7 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
   WordPressAuthenticator:
-    :commit: f7f3431eb44237cc2b4374bf429f7d9f615c8e27
+    :commit: e3a78a2d019ec25894b570dd03e09457e158f25a
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -777,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 91443188de9044c7ea6ce8a420ff22255bc4251b
+PODFILE CHECKSUM: e9bfafaf381a6c568d0b59da66285010ea7fe7e3
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.23.0-beta)
+  - WordPressAuthenticator (from `../WordPressAuthenticator-iOS`)
   - WordPressKit (~> 4.14)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11-beta)
@@ -555,7 +555,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -657,6 +656,8 @@ EXTERNAL SOURCES:
     :commit: bd76109049d2eeead78478d20d66ffd7b1567dd3
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressAuthenticator:
+    :path: "../WordPressAuthenticator-iOS"
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bd76109049d2eeead78478d20d66ffd7b1567dd3/third-party-podspecs/Yoga.podspec.json
 
@@ -772,6 +773,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 52bd25bcfe9d6b46f7f7cdafbcbe5b931a953e93
+PODFILE CHECKSUM: fb199387374d1214985c516270f0a42c0c255793
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.23.0-beta.xx):
+  - WordPressAuthenticator (1.23.0-beta.14):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c23c09466b1d75fe4316e59b35632628d565a374`)
+  - WordPressAuthenticator (~> 1.23.0-beta)
   - WordPressKit (~> 4.14)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11-beta)
@@ -555,6 +555,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -656,9 +657,6 @@ EXTERNAL SOURCES:
     :commit: bd76109049d2eeead78478d20d66ffd7b1567dd3
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
-  WordPressAuthenticator:
-    :commit: c23c09466b1d75fe4316e59b35632628d565a374
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/bd76109049d2eeead78478d20d66ffd7b1567dd3/third-party-podspecs/Yoga.podspec.json
 
@@ -677,9 +675,6 @@ CHECKOUT OPTIONS:
     :commit: bd76109049d2eeead78478d20d66ffd7b1567dd3
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
-  WordPressAuthenticator:
-    :commit: c23c09466b1d75fe4316e59b35632628d565a374
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -760,7 +755,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 87525d01277eeff8bf39c8cefda8400db5ae9563
+  WordPressAuthenticator: 73ab38055fe38032c2ba0a2c752fb4f97ffa92f1
   WordPressKit: dcab41057f0c39af3280b7c0d17bdc36271e01ae
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
@@ -777,6 +772,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 6e919d742aead75fe024af1af130412f3f677255
+PODFILE CHECKSUM: b4286dded54621e556422c6e8793aa8f1cef2d88
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -134,7 +134,7 @@ private extension EpilogueUserInfoCell {
 extension EpilogueUserInfoCell: GravatarUploader {
     @IBAction func gravatarTapped() {
         AuthenticatorAnalyticsTracker.shared.track(click: .selectAvatar)
-        
+
         guard let vcProvider = viewControllerProvider else {
             return
         }

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressAuthenticator
 
 protocol EpilogueUserInfoCellViewControllerProvider {
     func viewControllerForEpilogueUserInfoCell() -> UIViewController
@@ -132,6 +133,8 @@ private extension EpilogueUserInfoCell {
 //
 extension EpilogueUserInfoCell: GravatarUploader {
     @IBAction func gravatarTapped() {
+        AuthenticatorAnalyticsTracker.shared.track(click: .selectAvatar)
+        
         guard let vcProvider = viewControllerProvider else {
             return
         }

--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -113,7 +113,7 @@ class PostSignUpInterstitialViewController: UIViewController {
         WPTabBarController.sharedInstance().showReaderTab()
         navigationController?.dismiss(animated: true, completion: nil)
 
-        tracker.track(click: .dismiss, ifTrackingNotEnabled: {
+        tracker.track(click: .continue, ifTrackingNotEnabled: {
             WPAnalytics.track(.welcomeNoSitesInterstitialDismissed)
         })
     }


### PR DESCRIPTION
Fixes #14592 
WPAuth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/383

Implements all remaining tracking for Google Sign In.

## Note:

Since we're ditching `GoogleSignupConfirmationViewController.swift` soon, some of the tracking that's currently in there will be moved, but that's beyond the scope of this PR.

## Testing:

### Test 1

#### Preconditions:

- Enabled the `unifiedGoogle` feature flag.

#### Steps:

1. Either login or signup with Google.
2. When the dialog that requests permission to use google.com for signup comes up, tap "Cancel"

There will be more events, but these two are the important ones to check out near the end of your log:

🔵 Tracked: unified_login_failure <failure: The user canceled the sign-in flow., flow: google_login, source: default, step: start>
2020-08-17 18:11:18.168107-0300 WordPress[16173:5944979] [Warning] Attempting to load the view of a view controller while it is deallocating is not allowed and may result in undefined behavior (<SFAuthenticationViewController: 0x149944000>)
🔵 Tracked: unified_login_interaction <click: dismiss, flow: google_login, source: default, step: start>

### Test 2

#### Preconditions:

- Clean install of WP
- Make sure no WordPress account exists for the Google email you're planning to use.
- Enabled the `unifiedGoogle` feature flag.

#### Steps:

1. At the prologue, select "Sign up for WordPress.com"
2. Tap "Continue with Google"
3. Complete the log in to your Google Account.
4. At the Sign Up Confirmation screen, tap "Back".

You should see this:

🔵 Tracked: unified_login_interaction <click: dismiss, flow: google_login, source: default, step: start>

### Test 3

#### Preconditions:

- Clean install of WP
- Make sure no WordPress account exists for the Google email you're planning to use.
- Enabled the `unifiedGoogle` feature flag.

#### Steps:

1. At the prologue, select "Sign up for WordPress.com"
2. Tap "Continue with Google"
3. Complete the log in to your Google Account.
4. At the Signup Confirmation screen tap "Next".
6. At the signup epilogue screen tap on the avatar to edit it.

There will be a lot of broken constraints, so you'll have to scroll quite a bit up.

Check that you see this event:

🔵 Tracked: unified_login_interaction <click: select_avatar, flow: google_signup, source: default, step: success>

7. Cancel editing the avatar.
8. Tap "Done"

🔵 Tracked: unified_login_interaction <click: continue, flow: google_signup, source: default, step: success>

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
