### PR TITLE
Reader Improvements Phase 2: Add random posts on pull to refresh support

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -37,10 +37,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 4.14.1-beta-1'
+    pod 'WordPressKit', '~> 4.15.0-beta.1'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '35d011650ea9616a2aa20c369484ce39691564d9'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -37,10 +37,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.14-beta'
+    #pod 'WordPressKit', '~> 4.14.1-beta-1'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '35d011650ea9616a2aa20c369484ce39691564d9'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -397,7 +397,7 @@ PODS:
     - WordPressKit (~> 4.14-beta)
     - WordPressShared (~> 1.10-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.14.1-beta.1):
+  - WordPressKit (4.14.0):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -491,7 +491,6 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.22.0-beta)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `35d011650ea9616a2aa20c369484ce39691564d9`)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.10-beta)
   - WordPressUI (~> 1.7.1)
@@ -541,6 +540,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -631,9 +631,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.34.0
-  WordPressKit:
-    :commit: 35d011650ea9616a2aa20c369484ce39691564d9
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.34.0/third-party-podspecs/Yoga.podspec.json
 
@@ -649,9 +646,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.34.0
-  WordPressKit:
-    :commit: 35d011650ea9616a2aa20c369484ce39691564d9
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -728,7 +722,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: f1409be31cb8ed5076a00e84b19458ffa55e23a1
-  WordPressKit: d5ebeec85515c28f196369bf5e5211e4363dc4a1
+  WordPressKit: dcab41057f0c39af3280b7c0d17bdc36271e01ae
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b77083325416b075c99155ab2770f0dff8ba04eb
   WordPressUI: 9da5d966b8beb091950cd96880db398d7f30e246
@@ -744,6 +738,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: b44b7e73330e13e27505a651a7b1019eb2ec0d5f
+PODFILE CHECKSUM: e7d5b8c7b1dec864509f270fe3e31c7f1b5fd9b3
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -397,7 +397,7 @@ PODS:
     - WordPressKit (~> 4.14-beta)
     - WordPressShared (~> 1.10-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.14.0):
+  - WordPressKit (4.15.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -491,6 +491,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.22.0-beta)
+  - WordPressKit (~> 4.15.0-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.10-beta)
   - WordPressUI (~> 1.7.1)
@@ -722,7 +723,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: f1409be31cb8ed5076a00e84b19458ffa55e23a1
-  WordPressKit: dcab41057f0c39af3280b7c0d17bdc36271e01ae
+  WordPressKit: c0b0221ea81c4f1a1089b2b4bcf402b39a966738
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b77083325416b075c99155ab2770f0dff8ba04eb
   WordPressUI: 9da5d966b8beb091950cd96880db398d7f30e246
@@ -738,6 +739,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: e7d5b8c7b1dec864509f270fe3e31c7f1b5fd9b3
+PODFILE CHECKSUM: a623267af2a069b09f2d28cddcbea4127ba5ad6a
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -397,7 +397,7 @@ PODS:
     - WordPressKit (~> 4.14-beta)
     - WordPressShared (~> 1.10-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.14.0):
+  - WordPressKit (4.14.1-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -491,7 +491,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.22.0-beta)
-  - WordPressKit (~> 4.14-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `35d011650ea9616a2aa20c369484ce39691564d9`)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.10-beta)
   - WordPressUI (~> 1.7.1)
@@ -541,7 +541,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -632,6 +631,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.34.0
+  WordPressKit:
+    :commit: 35d011650ea9616a2aa20c369484ce39691564d9
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.34.0/third-party-podspecs/Yoga.podspec.json
 
@@ -647,6 +649,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.34.0
+  WordPressKit:
+    :commit: 35d011650ea9616a2aa20c369484ce39691564d9
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -723,7 +728,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: f1409be31cb8ed5076a00e84b19458ffa55e23a1
-  WordPressKit: dcab41057f0c39af3280b7c0d17bdc36271e01ae
+  WordPressKit: d5ebeec85515c28f196369bf5e5211e4363dc4a1
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b77083325416b075c99155ab2770f0dff8ba04eb
   WordPressUI: 9da5d966b8beb091950cd96880db398d7f30e246
@@ -739,6 +744,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: fbea6ba9d3bd3914d189c22edd2bab899f580e4a
+PODFILE CHECKSUM: b44b7e73330e13e27505a651a7b1019eb2ec0d5f
 
 COCOAPODS: 1.8.4

--- a/WordPress/Classes/Services/ReaderCardService.swift
+++ b/WordPress/Classes/Services/ReaderCardService.swift
@@ -25,7 +25,7 @@ class ReaderCardService {
         self.followedInterestsService = followedInterestsService ?? ReaderTopicService(managedObjectContext: coreDataStack.mainContext)
     }
 
-    func fetch(isFirstPage: Bool, success: @escaping (Int, Bool) -> Void, failure: @escaping (Error?) -> Void) {
+    func fetch(isFirstPage: Bool, refreshCount: Int = 0, success: @escaping (Int, Bool) -> Void, failure: @escaping (Error?) -> Void) {
         followedInterestsService.fetchFollowedInterestsLocally { [unowned self] topics in
             guard let interests = topics, !interests.isEmpty else {
                 failure(Errors.noInterests)
@@ -33,7 +33,9 @@ class ReaderCardService {
             }
 
             let slugs = interests.map { $0.slug }
-            self.service.fetchCards(for: slugs, page: self.pageHandle(isFirstPage: isFirstPage),
+            self.service.fetchCards(for: slugs,
+                                    page: self.pageHandle(isFirstPage: isFirstPage),
+                                    refreshCount: refreshCount,
                                success: { [weak self] cards, pageHandle in
 
                                 guard let self = self else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -6,6 +6,9 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     /// Page number used for Analytics purpose
     private var page = 1
 
+    /// Refresh counter used to for random posts on pull to refresh
+    private var refreshCount = 0
+
     private var cards: [ReaderCard]? {
         content.content as? [ReaderCard]
     }
@@ -83,7 +86,9 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
 
     override func fetch(for topic: ReaderAbstractTopic, success: @escaping ((Int, Bool) -> Void), failure: @escaping ((Error?) -> Void)) {
         page = 1
-        cardsService.fetch(isFirstPage: true, success: success, failure: failure)
+        refreshCount += 1
+        
+        cardsService.fetch(isFirstPage: true, refreshCount: refreshCount, success: success, failure: failure)
     }
 
     override func loadMoreItems(_ success: ((Bool) -> Void)?, failure: ((NSError) -> Void)?) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -87,7 +87,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     override func fetch(for topic: ReaderAbstractTopic, success: @escaping ((Int, Bool) -> Void), failure: @escaping ((Error?) -> Void)) {
         page = 1
         refreshCount += 1
-        
+
         cardsService.fetch(isFirstPage: true, refreshCount: refreshCount, success: success, failure: failure)
     }
 


### PR DESCRIPTION
Fixes #14666

Related WordPressKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/271

### To test:
1. Enable the Reader Improvements Phase 2 feature flag
2. Tap on the Reader tab
3. Tap on the Discover tab
4. Wait for the posts to load
5. Pull to refresh
6. You should see a new set of posts
7. Pull to refresh again
8. You'll see a new data set


### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
