### PR TITLE
Reset the isExpanded flag on reuse

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -168,13 +168,8 @@ protocol ReaderTopicsChipsDelegate: class {
         imageLoader.prepareForReuse()
         displayTopics = false
 
-        guard let layout = topicsCollectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
-            return
-        }
-
-        layout.isExpanded = false
+        topicsCollectionView.collapse()
     }
-
 
     // MARK: - Configuration
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -167,6 +167,12 @@ protocol ReaderTopicsChipsDelegate: class {
 
         imageLoader.prepareForReuse()
         displayTopics = false
+
+        guard let layout = topicsCollectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
+            return
+        }
+
+        layout.isExpanded = false
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -64,6 +64,14 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         collectionView.invalidateIntrinsicContentSize()
     }
 
+    func changeState(_ state: ReaderTopicCollectionViewState) {
+        guard let layout = collectionView.collectionViewLayout as? ReaderInterestsCollectionViewFlowLayout else {
+            return
+        }
+
+        layout.isExpanded = state == .expanded
+    }
+
     private func configureCollectionView() {
         collectionView.delegate = self
         collectionView.dataSource = self

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
@@ -33,6 +33,10 @@ class TopicsCollectionView: DynamicHeightCollectionView {
         coordinator = ReaderTopicCollectionViewCoordinator(collectionView: self, topics: topics)
         coordinator?.delegate = self
     }
+
+    func collapse() {
+        coordinator?.changeState(.collapsed)
+    }
 }
 
 extension TopicsCollectionView: ReaderTopicCollectionViewCoordinatorDelegate {


### PR DESCRIPTION
Fixes #14681

To test:

1. Enable the Reader Improvements Phase 2 feature flag
2. Tap on the Reader tab
3. Tap on Discover
4. Reload until you see a post that has a lot of tags
5. Expand them
6. Pull top refresh the view
7. The cell should be collapsed and no longer show the 'hide' view


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
