### PR TITLE
Fix upload for HEIC files (live photos)

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -57,7 +57,10 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
         }
         
         if (blog.allowedFileTypes != nil) {
-            allowedFileTypes = blog.allowedFileTypes;
+            // HEIC isn't supported when uploading an image, so we filter it out (http://git.io/JJAae)
+            NSMutableSet *mutableAllowedFileTypes = [blog.allowedFileTypes mutableCopy];
+            [mutableAllowedFileTypes removeObject:@"heic"];
+            allowedFileTypes = mutableAllowedFileTypes;
         }
 
         if (post != nil) {


### PR DESCRIPTION
Fixes #14680

(I'll cherry-pick the fix to `release/15.5` after this is merged)

### To test

**Make sure to test using a real device**

1. Go to My Sites and select an Atomic site
2. Go to Blog Posts to create a new post or edit an existing one and use the image block or gallery block.
3. Select Choose from my device. 
4. Choose a 'live photo' (HEIC) from your albums and add it
5. The image should upload

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
