### PR TITLE
Remove heic from the allowed list of files

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -57,7 +57,10 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
         }
         
         if (blog.allowedFileTypes != nil) {
-            allowedFileTypes = blog.allowedFileTypes;
+            // HEIC isn't supported when uploading an image, so we filter it out (http://git.io/JJAae)
+            NSMutableSet *mutableAllowedFileTypes = [blog.allowedFileTypes mutableCopy];
+            [mutableAllowedFileTypes removeObject:@"heic"];
+            allowedFileTypes = mutableAllowedFileTypes;
         }
 
         if (post != nil) {


### PR DESCRIPTION
Fixes #14680 

This PR just cherry-pick the solution from #14686

More details: https://github.com/wordpress-mobile/WordPress-iOS/pull/14686
