### PR TITLE
ULS Site Address: fixing UI tests

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -191,9 +191,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.23.0-beta'
+    # pod 'WordPressAuthenticator', '~> 1.23.0-beta'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/283-site_addr_ui_tests'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -191,9 +191,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.23.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.23.0-beta'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/283-site_addr_ui_tests'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.23.0-beta.21):
+  - WordPressAuthenticator (1.23.0-beta.x):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.23.0-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/283-site_addr_ui_tests`)
   - WordPressKit (~> 4.15.0-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11-beta)
@@ -555,7 +555,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -657,6 +656,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.35.0
+  WordPressAuthenticator:
+    :branch: feature/283-site_addr_ui_tests
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.35.0/third-party-podspecs/Yoga.podspec.json
 
@@ -675,6 +677,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.35.0
+  WordPressAuthenticator:
+    :commit: f1c054133a2736273a0c99e9ff40e72d0fbbf214
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -741,7 +746,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 20deb1f6f001000d1f2603722ec110c66c74796b
   ReactCommon: 48926fc48fcd7c8a629860049ffba9c23b4005dc
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
-  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
+  RNCMaskedView: 72b5012baac53b13a9ba717eaa554afd3f2930c5
   RNGestureHandler: 82a89b0fde0a37e633c6233418f7249e2f8e59b5
   RNReanimated: 13f7a6a22667c4f00aac217bc66f94e8560b3d59
   RNScreens: 6833ac5c29cf2f03eed12103140530bbd75b6aea
@@ -755,7 +760,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 5fc551cc1d43a3ea1fcf49ac7522a44b69bb2210
+  WordPressAuthenticator: 4b05934a44a704feb9059c9d921d007914df7921
   WordPressKit: c0b0221ea81c4f1a1089b2b4bcf402b39a966738
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
@@ -772,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: e51db98c7a934174fa8392cdca8fed49eedb5380
+PODFILE CHECKSUM: 792987e373816b59c477f73d954cb51c55bd211a
 
 COCOAPODS: 1.8.4

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.23.0-beta.x):
+  - WordPressAuthenticator (1.23.0-beta.22):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/283-site_addr_ui_tests`)
+  - WordPressAuthenticator (~> 1.23.0-beta)
   - WordPressKit (~> 4.15.0-beta.1)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11-beta)
@@ -555,6 +555,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -656,9 +657,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.35.0
-  WordPressAuthenticator:
-    :branch: feature/283-site_addr_ui_tests
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.35.0/third-party-podspecs/Yoga.podspec.json
 
@@ -677,9 +675,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.35.0
-  WordPressAuthenticator:
-    :commit: f1c054133a2736273a0c99e9ff40e72d0fbbf214
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -760,7 +755,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 4b05934a44a704feb9059c9d921d007914df7921
+  WordPressAuthenticator: 996559c434307c153eb2f54e144d51f6ec2e0635
   WordPressKit: c0b0221ea81c4f1a1089b2b4bcf402b39a966738
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
@@ -777,6 +772,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 792987e373816b59c477f73d954cb51c55bd211a
+PODFILE CHECKSUM: e51db98c7a934174fa8392cdca8fed49eedb5380
 
 COCOAPODS: 1.8.4

--- a/WordPress/WordPressUITests/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LoginSiteAddressScreen.swift
@@ -3,8 +3,16 @@ import XCTest
 
 private struct ElementStringIDs {
     static let navBar = "WordPressAuthenticator.LoginSiteAddressView"
-    static let siteAddressTextField = "usernameField"
     static let nextButton = "Site Address Next Button"
+
+    // TODO: clean up comments when unifiedSiteAddress is permanently enabled.
+
+    // For original Site Address. This matches accessibilityIdentifier in Login.storyboard.
+    // Leaving here for now in case unifiedSiteAddress is disabled.
+    // static let siteAddressTextField = "usernameField"
+
+    // For unified Site Address. This matches TextFieldTableViewCell.accessibilityIdentifier.
+    static let siteAddressTextField = "Site address"
 }
 
 class LoginSiteAddressScreen: BaseScreen {

--- a/WordPress/WordPressUITests/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -3,9 +3,18 @@ import XCTest
 
 private struct ElementStringIDs {
     static let navBar = "WordPressAuthenticator.LoginSelfHostedView"
-    static let usernameTextField = "usernameField"
-    static let passwordTextField = "passwordField"
     static let nextButton = "submitButton"
+
+    // TODO: clean up comments when unifiedSiteAddress is permanently enabled.
+
+    // For original Site Address. These match accessibilityIdentifier in Login.storyboard.
+    // Leaving here for now in case unifiedSiteAddress is disabled.
+    // static let usernameTextField = "usernameField"
+    // static let passwordTextField = "passwordField"
+
+    // For unified Site Address. This matches TextFieldTableViewCell.accessibilityIdentifier.
+    static let usernameTextField = "Username"
+    static let passwordTextField = "Password"
 }
 
 class LoginUsernamePasswordScreen: BaseScreen {


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/283
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/393

This updates the strings the UI tests use to validate Site Address views.

To test:

- Follow the "[Running tests](https://github.com/wordpress-mobile/WordPress-iOS/tree/develop/WordPress/WordPressUITests#running-tests)" steps. 
- Run the `LoginTests`. Verify they pass.

To note, local UI tests can be...persnickity. If the UI tests pass on this PR it should be good.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
