### PR TITLE
Add announcements table view in What's New

### DIFF
--- a/WordPress/Classes/ViewRelated/What's New/AnnouncementsDataSource.swift
+++ b/WordPress/Classes/ViewRelated/What's New/AnnouncementsDataSource.swift
@@ -1,0 +1,48 @@
+
+protocol AnnouncementsDataSource: UITableViewDataSource {
+    func registerCells(for tableView: UITableView)
+}
+
+
+class FeatureAnnouncementsDataSource: NSObject, AnnouncementsDataSource {
+
+    private let cellTypes: [String: UITableViewCell.Type]
+
+    private let announcements: [Announcement]
+
+    private var findOutMoreLink: String
+
+    init(announcements: [Announcement], cellTypes: [String: UITableViewCell.Type], findOutMoreLink: String) {
+        self.announcements = announcements
+        self.cellTypes = cellTypes
+        self.findOutMoreLink = findOutMoreLink
+        super.init()
+    }
+
+    func registerCells(for tableView: UITableView) {
+        cellTypes.forEach {
+            tableView.register($0.value, forCellReuseIdentifier: $0.key)
+        }
+    }
+
+    func numberOfSections(in: UITableView) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return announcements.count + 1
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+        guard indexPath.row <= announcements.count - 1 else {
+            let cell = tableView.dequeueReusableCell(withIdentifier: "findOutMoreCell", for: indexPath) as? FindOutMoreCell ?? FindOutMoreCell()
+            cell.configure(with: URL(string: findOutMoreLink))
+            return cell
+        }
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: "announcementCell", for: indexPath) as? AnnouncementCell ?? AnnouncementCell()
+        cell.configure(announcement: announcements[indexPath.row])
+        return cell
+    }
+}

--- a/WordPress/Classes/ViewRelated/What's New/AnnouncementsDataSource.swift
+++ b/WordPress/Classes/ViewRelated/What's New/AnnouncementsDataSource.swift
@@ -7,10 +7,8 @@ protocol AnnouncementsDataSource: UITableViewDataSource {
 class FeatureAnnouncementsDataSource: NSObject, AnnouncementsDataSource {
 
     private let cellTypes: [String: UITableViewCell.Type]
-
     private let announcements: [Announcement]
-
-    private var findOutMoreLink: String
+    private let findOutMoreLink: String
 
     init(announcements: [Announcement], cellTypes: [String: UITableViewCell.Type], findOutMoreLink: String) {
         self.announcements = announcements

--- a/WordPress/Classes/ViewRelated/What's New/Model/Announcement.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Model/Announcement.swift
@@ -1,0 +1,8 @@
+
+// TODO - WHATSNEW: subject to change
+struct Announcement {
+    let heading: String
+    let subHeading: String
+    let image: UIImage?
+    let imageUrl: String?
+}

--- a/WordPress/Classes/ViewRelated/What's New/Views/AnnouncementCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/AnnouncementCell.swift
@@ -1,0 +1,100 @@
+
+class AnnouncementCell: UITableViewCell {
+
+    // MARK: - View elements
+    private lazy var headingLabel: UILabel = {
+        let label = makeLabel(font: Appearance.headingFont)
+        return label
+    }()
+
+    private lazy var subHeadingLabel: UILabel = {
+        let label = makeLabel(font: Appearance.subHeadingFont, color: .textSubtle)
+        return label
+    }()
+
+    private lazy var descriptionStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [headingLabel, subHeadingLabel])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        return stackView
+    }()
+
+    private lazy var announcementImageView: UIImageView = {
+        let imageView = UIImageView()
+        return imageView
+    }()
+
+    private lazy var mainStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [announcementImageView, descriptionStackView])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.setCustomSpacing(Appearance.imageTextSpacing, after: announcementImageView)
+        return stackView
+    }()
+
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        contentView.addSubview(mainStackView)
+        contentView.pinSubviewToSafeArea(mainStackView, insets: Appearance.mainStackViewInsets)
+
+        NSLayoutConstraint.activate([
+            announcementImageView.heightAnchor.constraint(equalToConstant: Appearance.announcementImageSize),
+            announcementImageView.widthAnchor.constraint(equalToConstant: Appearance.announcementImageSize)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(announcement: Announcement) {
+        // if there's a valid image, use it, otherwise try to download it, if a valid url is passed
+        if let image = announcement.image {
+            announcementImageView.image = image
+        } else if let urlString = announcement.imageUrl, let url = URL(string: urlString) {
+            announcementImageView.af_setImage(withURL: url)
+        }
+        headingLabel.text = announcement.heading
+        subHeadingLabel.text = announcement.subHeading
+        // TODO - WHATSNEW: - remove when images will be passed
+        announcementImageView.backgroundColor = .accent
+    }
+}
+
+
+// MARK: Helpers
+private extension AnnouncementCell {
+
+    func makeLabel(font: UIFont, color: UIColor? = nil) -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.font = font
+        if let color = color {
+            label.textColor = color
+        }
+        return label
+    }
+}
+
+
+// MARK: - Appearance
+private extension AnnouncementCell {
+    enum Appearance {
+        // heading
+        static let headingFont = UIFont(descriptor: UIFontDescriptor.preferredFontDescriptor(withTextStyle: .headline), size: 17)
+
+        // sub-heading
+        static let subHeadingFont = UIFont(descriptor: UIFontDescriptor.preferredFontDescriptor(withTextStyle: .subheadline), size: 15)
+
+        // announcement image
+        static let announcementImageSize: CGFloat = 48
+
+        // main stack view
+        static let imageTextSpacing: CGFloat = 16
+        static let mainStackViewInsets = UIEdgeInsets(top: 0, left: 0, bottom: 24, right: 0)
+    }
+}

--- a/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
@@ -1,0 +1,51 @@
+
+class FindOutMoreCell: UITableViewCell {
+
+    private lazy var findOutMoreButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(Appearance.buttonTitle, for: .normal)
+        button.contentHorizontalAlignment = .leading
+        button.setTitleColor(.primary, for: .normal)
+        button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private var findOutMoreUrl: URL?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        contentView.addSubview(findOutMoreButton)
+
+        NSLayoutConstraint.activate([
+            contentView.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: findOutMoreButton.leadingAnchor),
+            contentView.safeAreaLayoutGuide.topAnchor.constraint(equalTo: findOutMoreButton.topAnchor, constant: Appearance.topMargin),
+            contentView.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: findOutMoreButton.bottomAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(with url: URL?) {
+        self.findOutMoreUrl = url
+    }
+}
+
+// Appearance
+private extension FindOutMoreCell {
+    enum Appearance {
+        static let buttonTitle = NSLocalizedString("Find out more", comment: "Title for the find out more button in the What's New page.")
+        static let buttonFont = UIFont(descriptor: .preferredFontDescriptor(withTextStyle: .callout), size: 16)
+        static let topMargin: CGFloat = -8
+    }
+
+    @objc func buttonTapped() {
+        guard let url = self.findOutMoreUrl else {
+            return
+        }
+        UIApplication.shared.open(url)
+    }
+}

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
@@ -50,7 +50,7 @@ class WhatIsNewView: UIView {
         return view
     }()
 
-    lazy var announcementsTableView: UITableView = {
+    private lazy var announcementsTableView: UITableView = {
         let tableView = UITableView()
         tableView.tableFooterView = UIView() // To hide the separators for empty cells
         tableView.separatorStyle = .none

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
@@ -54,9 +54,7 @@ class WhatIsNewView: UIView {
         let tableView = UITableView()
         tableView.tableFooterView = UIView() // To hide the separators for empty cells
         tableView.separatorStyle = .none
-
         tableView.allowsSelection = false
-
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = Appearance.estimatedRowHeight
         return tableView
@@ -84,7 +82,6 @@ class WhatIsNewView: UIView {
 
     // MARK: - Properties
     private let viewTitles: WhatIsNewViewTitles
-
     private let dataSource: AnnouncementsDataSource
 
     var continueAction: (() -> Void)?

--- a/WordPress/Classes/ViewRelated/What's New/WPTabBarController+WhatIsNew.swift
+++ b/WordPress/Classes/ViewRelated/What's New/WPTabBarController+WhatIsNew.swift
@@ -1,3 +1,4 @@
+
 /// dependency container for the What's New / Feature Announcements scene
 extension WPTabBarController {
 
@@ -10,18 +11,38 @@ extension WPTabBarController {
         let version = Bundle.main.shortVersionString() != nil ?
             WhatIsNewStrings.versionPrefix + Bundle.main.shortVersionString() : ""
 
-        let textContent = WhatIsNewTextContent(title: WhatIsNewStrings.title,
-                                               version: version,
-                                               moreContentButtonTitle: WhatIsNewStrings.moreContentButtonTitle,
-                                               continueButtonTitle: WhatIsNewStrings.continueButtonTitle)
+        let viewTitles = WhatIsNewViewTitles(header: WhatIsNewStrings.title,
+                                             version: version,
+                                             continueButtonTitle: WhatIsNewStrings.continueButtonTitle)
 
-        return WhatIsNewView(textContent: textContent)
+        return WhatIsNewView(viewTitles: viewTitles, dataSource: makeDataSource())
+    }
+
+    private func makeDataSource() -> AnnouncementsDataSource {
+        return FeatureAnnouncementsDataSource(announcements: WhatIsNewStrings.fakeAnnouncements,
+                                              cellTypes: ["announcementCell": AnnouncementCell.self, "findOutMoreCell": FindOutMoreCell.self],
+                                              findOutMoreLink: WhatIsNewStrings.temporaryAnnouncementsLink)
     }
 
     private enum WhatIsNewStrings {
         static let title = NSLocalizedString("What's New in WordPress", comment: "Title of the What's new page.")
         static let versionPrefix = NSLocalizedString("Version ", comment: "Description for the version label in the What's new page.")
-        static let moreContentButtonTitle = NSLocalizedString("Find out more", comment: "Title for the Find out more button in the What's new page.")
         static let continueButtonTitle = NSLocalizedString("Continue", comment: "Title for the continue button in the What's New page.")
+
+        // TODO - WHATSNEW: to be removed when the real data come in
+        static let fakeAnnouncements = [Announcement(heading: "Heading with a single line",
+                                                     subHeading: "Try to write subheadings that run to a max of three lines. See how the icon is centered.",
+                                                     image: nil,
+                                                     imageUrl: nil),
+                                        Announcement(heading: "Heading with a single line",
+                                                     subHeading: "Subheading with only one line.",
+                                                     image: nil,
+                                                     imageUrl: nil),
+                                        Announcement(heading: "Try write headings that don't go beyond 2 lines",
+                                                     subHeading: "If combined with three lines of subheading this is the longest an item should be.",
+                                                     image: nil,
+                                                     imageUrl: nil)]
+        // TODO - WHATSNEW: to be removed when the real data come in
+        static let temporaryAnnouncementsLink = "https://wordpress.com/"
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		3F1AD48123FC87A400BB1375 /* BlogDetailsViewController+MeButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1AD48023FC87A400BB1375 /* BlogDetailsViewController+MeButtonTests.swift */; };
 		3F1B66A323A2F54B0075F09E /* ReaderReblogActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1B66A223A2F54B0075F09E /* ReaderReblogActionTests.swift */; };
 		3F29EB7224042276005313DE /* MeViewController+UIViewControllerRestoration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F29EB7124042276005313DE /* MeViewController+UIViewControllerRestoration.swift */; };
+		3F3087C424EDB7040087B548 /* AnnouncementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3087C324EDB7040087B548 /* AnnouncementCell.swift */; };
 		3F30E50923FB362700225013 /* WPTabBarController+MeNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F30E50823FB362700225013 /* WPTabBarController+MeNavigation.swift */; };
 		3F421DF524A3EC2B00CA9B9E /* Spotlightable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F421DF424A3EC2B00CA9B9E /* Spotlightable.swift */; };
 		3F43602F23F31D48001DEE70 /* ScenePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F43602E23F31D48001DEE70 /* ScenePresenter.swift */; };
@@ -386,6 +387,9 @@
 		3F751D462491A93D0008A2B1 /* ZendeskUtilsTests+Plans.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F751D452491A93D0008A2B1 /* ZendeskUtilsTests+Plans.swift */; };
 		3F82310F24564A870086E9B8 /* ReaderTabViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F82310E24564A870086E9B8 /* ReaderTabViewTests.swift */; };
 		3F8CB10623A07B17007627BF /* ReaderReblogAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CB10523A07B17007627BF /* ReaderReblogAction.swift */; };
+		3F8CBE0B24EEB0EA00F71234 /* AnnouncementsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CBE0A24EEB0EA00F71234 /* AnnouncementsDataSource.swift */; };
+		3F8CBE0D24EED2CB00F71234 /* FindOutMoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CBE0C24EED2CB00F71234 /* FindOutMoreCell.swift */; };
+		3F8CBE1024EEF41800F71234 /* Announcement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CBE0F24EEF41800F71234 /* Announcement.swift */; };
 		3FC8D19B244F43B500495820 /* ReaderTabItemsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */; };
 		3FCCAA1523F4A1A3004064C0 /* UIBarButtonItem+MeBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCCAA1423F4A1A3004064C0 /* UIBarButtonItem+MeBarButton.swift */; };
 		3FD0316F24201E08005C0993 /* GravatarButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD0316E24201E08005C0993 /* GravatarButtonView.swift */; };
@@ -2801,6 +2805,7 @@
 		3F1B66A223A2F54B0075F09E /* ReaderReblogActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogActionTests.swift; sourceTree = "<group>"; };
 		3F26DFD124930B5900B5EBD1 /* WordPress 96.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 96.xcdatamodel"; sourceTree = "<group>"; };
 		3F29EB7124042276005313DE /* MeViewController+UIViewControllerRestoration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MeViewController+UIViewControllerRestoration.swift"; sourceTree = "<group>"; };
+		3F3087C324EDB7040087B548 /* AnnouncementCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementCell.swift; sourceTree = "<group>"; };
 		3F30E50823FB362700225013 /* WPTabBarController+MeNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPTabBarController+MeNavigation.swift"; sourceTree = "<group>"; };
 		3F421DF424A3EC2B00CA9B9E /* Spotlightable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spotlightable.swift; sourceTree = "<group>"; };
 		3F43602E23F31D48001DEE70 /* ScenePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScenePresenter.swift; sourceTree = "<group>"; };
@@ -2819,6 +2824,9 @@
 		3F751D452491A93D0008A2B1 /* ZendeskUtilsTests+Plans.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZendeskUtilsTests+Plans.swift"; sourceTree = "<group>"; };
 		3F82310E24564A870086E9B8 /* ReaderTabViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabViewTests.swift; sourceTree = "<group>"; };
 		3F8CB10523A07B17007627BF /* ReaderReblogAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogAction.swift; sourceTree = "<group>"; };
+		3F8CBE0A24EEB0EA00F71234 /* AnnouncementsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsDataSource.swift; sourceTree = "<group>"; };
+		3F8CBE0C24EED2CB00F71234 /* FindOutMoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindOutMoreCell.swift; sourceTree = "<group>"; };
+		3F8CBE0F24EEF41800F71234 /* Announcement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Announcement.swift; sourceTree = "<group>"; };
 		3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabItemsStore.swift; sourceTree = "<group>"; };
 		3FCCAA1423F4A1A3004064C0 /* UIBarButtonItem+MeBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+MeBarButton.swift"; sourceTree = "<group>"; };
 		3FD0316E24201E08005C0993 /* GravatarButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GravatarButtonView.swift; sourceTree = "<group>"; };
@@ -6111,6 +6119,16 @@
 			path = "Account Settings";
 			sourceTree = "<group>";
 		};
+		3F3087C024EDB6900087B548 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				3F3087C324EDB7040087B548 /* AnnouncementCell.swift */,
+				3F8CBE0C24EED2CB00F71234 /* FindOutMoreCell.swift */,
+				3F73BE5E24EB3B4400BE99FF /* WhatIsNewView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		3F37609B23FD803300F0D87F /* Blog + Me */ = {
 			isa = PBXGroup;
 			children = (
@@ -6216,9 +6234,11 @@
 		3F662C4824DC9F8300CAEA95 /* What's New */ = {
 			isa = PBXGroup;
 			children = (
+				3F8CBE0A24EEB0EA00F71234 /* AnnouncementsDataSource.swift */,
 				3F662C4924DC9FAC00CAEA95 /* WhatIsNewViewController.swift */,
 				3F73BE5C24EB38E200BE99FF /* WPTabBarController+WhatIsNew.swift */,
-				3F73BE5E24EB3B4400BE99FF /* WhatIsNewView.swift */,
+				3F8CBE0E24EEF40900F71234 /* Model */,
+				3F3087C024EDB6900087B548 /* Views */,
 			);
 			path = "What's New";
 			sourceTree = "<group>";
@@ -6229,6 +6249,14 @@
 				3F751D452491A93D0008A2B1 /* ZendeskUtilsTests+Plans.swift */,
 			);
 			name = Zendesk;
+			sourceTree = "<group>";
+		};
+		3F8CBE0E24EEF40900F71234 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				3F8CBE0F24EEF41800F71234 /* Announcement.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		3FD83CBD246C74B800381999 /* Migrator */ = {
@@ -12620,6 +12648,7 @@
 				C81CCD81243BF7A600A83E27 /* TenorService.swift in Sources */,
 				E105205B1F2B1CF400A948F6 /* BlogToBlogMigration_61_62.swift in Sources */,
 				E16FB7E31F8B61040004DD9F /* WebKitViewController.swift in Sources */,
+				3F8CBE0B24EEB0EA00F71234 /* AnnouncementsDataSource.swift in Sources */,
 				7305138321C031FC006BD0A1 /* AssembledSiteView.swift in Sources */,
 				321955C324BF77E400E3F316 /* ReaderTopicService+FollowedInterests.swift in Sources */,
 				93414DE51E2D25AE003143A3 /* PostEditorState.swift in Sources */,
@@ -12729,6 +12758,7 @@
 				17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */,
 				984B139221F66AC60004B6A2 /* SiteStatsPeriodViewModel.swift in Sources */,
 				98A437AE20069098004A8A57 /* DomainSuggestionsTableViewController.swift in Sources */,
+				3F3087C424EDB7040087B548 /* AnnouncementCell.swift in Sources */,
 				5D1D04761B7A50B100CDE646 /* ReaderStreamViewController.swift in Sources */,
 				B57B92BD1B73B08100DFF00B /* SeparatorsView.swift in Sources */,
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,
@@ -12829,6 +12859,7 @@
 				08D978591CD2AF7D0054F19A /* MenuItemSourceTextBar.m in Sources */,
 				40E469952017FB1F0030DB5F /* PluginDirectoryViewModel.swift in Sources */,
 				F1527301243B290E00C8DC7A /* AbstractPost+Autosave.swift in Sources */,
+				3F8CBE1024EEF41800F71234 /* Announcement.swift in Sources */,
 				745A41B02065405600299D75 /* ReaderPost+Searchable.swift in Sources */,
 				E1A8CACB1C22FF7C0038689E /* MeViewController.swift in Sources */,
 				9A341E5321997A1F0036662E /* BlogService+BlogAuthors.swift in Sources */,
@@ -13267,6 +13298,7 @@
 				7E4123C820F417EF00DF8486 /* FormattableActivity.swift in Sources */,
 				9A162F2B21C2A21A00FDC035 /* RevisionPreviewTextViewManager.swift in Sources */,
 				73D86969223AF4040064920F /* StatsChartLegendView.swift in Sources */,
+				3F8CBE0D24EED2CB00F71234 /* FindOutMoreCell.swift in Sources */,
 				FF286C761DE70A4500383A62 /* NSURL+Exporters.swift in Sources */,
 				988AC37522F10DD900BC1433 /* FileDownloadsStatsRecordValue+CoreDataProperties.swift in Sources */,
 				E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */,


### PR DESCRIPTION

Fixes #14581

Adds announcements and "Find out more" button to "What's New"

**Notes:** 
- the announcements shown are just examples, temporarily hardcoded in the dependency container `WpTabBarController+WhatIsNew`. These will be removed in future PRs
- Colored boxes appear instead of the real images. This will be fixed in future PRs
- "Find out more" temporarily points to WordPress.com, will be updated with the actual blog post in future PRs
- iPad modals are not customized at this time, using the default

To test:

- Go to Me/App Settings/What's New in WordPress
- Verify that announcements are shown and look like the screenshots below (for reference, also look at #14581
- Verify that tapping on "Find out more" opens WordPress.com in Safari

iPhone | iPad
--- | ---
<img height="400" alt="whatsnewiphone" src="https://user-images.githubusercontent.com/34376330/90815417-4b34c780-e2f0-11ea-9a8d-c675b6655a02.png"> | <img height="400" alt="whatsnewipad" src="https://user-images.githubusercontent.com/34376330/90815489-6acbf000-e2f0-11ea-9944-84773e70ba39.png">

PR submission checklist:

- [x] ~~I have considered adding unit tests where possible.~~ To be added in future PR.
- [x] ~~I have considered adding accessibility improvements for my changes.~~ To be added in future PR.
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~ Not released.
