### PR TITLE
Fix crash in mergeFollowedSites

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -949,7 +949,10 @@ array are marked as being unfollowed in Core Data.
          NSMutableArray *remoteFeedIds = [NSMutableArray array];
 
          for (RemoteReaderSiteInfo *siteInfo in sites) {
-             [remoteFeedIds addObject:siteInfo.feedID];
+             if (siteInfo.feedID) {
+                 [remoteFeedIds addObject:siteInfo.feedID];
+             }
+
              [self siteTopicForRemoteSiteInfo:siteInfo];
          }
 


### PR DESCRIPTION
## To test

1. Follow `apps.wordpress.org`
2. Close the app and reopen it again
3. The app should not crash

(if you test this on `develop` the app will crash)