### PR TITLE
ULS: Enable unified Google, SIWA, Site Address.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,10 @@
 * [***] Block Editor: Fixed empty text fields on RTL layout. Now they are selectable and placeholders are visible.
 * [**] Block Editor: Add settings to allow changing column widths
 * [**] Block Editor: Media editing support in Gallery block.
+* [**] Updated UI when logging in with a Site Address.
+* [**] Updated UI when logging in/signing up with Apple.
+* [**] Updated UI when logging in/signing up with Google.
+* [**] Simplified Google authentication. If signup is attempted with an existing WordPress account, automatically redirects to login. If login is attempted without a matching WordPress account, automatically redirects to signup.
 * [*] Block Editor: Improved logic for creating undo levels.
 * [*] Social account login: Fixed an issue that could have inadvertently linked two social accounts.
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -32,13 +32,13 @@ enum FeatureFlag: Int, CaseIterable {
         case .debugMenu:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .unifiedAuth:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .unifiedSiteAddress:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .unifiedGoogle:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .unifiedApple:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .unifiedSignup:
             return false
         case .unifiedLoginLink:


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/182

This enables the unified Google, SIWA, and Site Address flows.

To note, only Log In > Site Address shows the new flow. Any other path into Site Address does not.

To test:
- `Continue with Google` from either login or signup. 
  - Complete Google auth.
  - Verify the new flow is displayed.
- `Continue with Apple` from either login or signup.
  - Complete Apple ID auth.
  - Verify the new flow is displayed.
- Log In > Site Address. Verify the new flow is displayed.

| ![google](https://user-images.githubusercontent.com/1816888/90939909-33ca0d00-e3ca-11ea-9932-ee7d53af118b.jpg) | ![siwa](https://user-images.githubusercontent.com/1816888/90940216-42fd8a80-e3cb-11ea-8ce4-229a58df43a4.jpg) | ![site_address](https://user-images.githubusercontent.com/1816888/90939930-43495600-e3ca-11ea-8a0a-e2923f69585d.jpg) |
|--------|-------|-------|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
