### PR TITLE
What's New: header and version scroll with content

### DIFF
--- a/WordPress/Classes/ViewRelated/What's New/Dependency container/WPTabBarController+WhatIsNew.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Dependency container/WPTabBarController+WhatIsNew.swift
@@ -41,6 +41,18 @@ extension WPTabBarController {
                                         Announcement(heading: "Try write headings that don't go beyond 2 lines",
                                                      subHeading: "If combined with three lines of subheading this is the longest an item should be.",
                                                      image: nil,
+                                                     imageUrl: nil),
+                                        Announcement(heading: "Heading with a single line",
+                                                     subHeading: "Try to write subheadings that run to a max of three lines. See how the icon is centered.",
+                                                     image: nil,
+                                                     imageUrl: nil),
+                                        Announcement(heading: "Heading with a single line",
+                                                     subHeading: "Subheading with only one line.",
+                                                     image: nil,
+                                                     imageUrl: nil),
+                                        Announcement(heading: "Try write headings that don't go beyond 2 lines",
+                                                     subHeading: "If combined with three lines of subheading this is the longest an item should be.",
+                                                     image: nil,
                                                      imageUrl: nil)]
         // TODO - WHATSNEW: to be removed when the real data come in
         static let temporaryAnnouncementsLink = "https://wordpress.com/"

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
@@ -53,6 +53,7 @@ class WhatIsNewView: UIView {
     private lazy var announcementsTableView: UITableView = {
         let tableView = UITableView()
         tableView.tableFooterView = UIView() // To hide the separators for empty cells
+        tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.separatorStyle = .none
         tableView.allowsSelection = false
         tableView.rowHeight = UITableView.automaticDimension
@@ -60,18 +61,25 @@ class WhatIsNewView: UIView {
         return tableView
     }()
 
-    private lazy var contentStackView: UIStackView = {
-        let stackView = makeVerticalStackView(arrangedSubviews: [titleLabel, versionLabel, announcementsTableView])
+    private lazy var headerStackView: UIStackView = {
+        let stackView = makeVerticalStackView(arrangedSubviews: [titleLabel, versionLabel])
         stackView.setCustomSpacing(Appearance.titleVersionSpacing, after: titleLabel)
-        stackView.setCustomSpacing(Appearance.versionTableviewSpacing, after: versionLabel)
         return stackView
+    }()
+
+    private lazy var headerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(headerStackView)
+        view.pinSubviewToAllEdges(headerStackView, insets: Appearance.headerViewInsets)
+        return view
     }()
 
     private lazy var contentView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(contentStackView)
-        view.pinSubviewToSafeArea(contentStackView, insets: Appearance.mainContentInsets)
+        view.addSubview(announcementsTableView)
+        view.pinSubviewToSafeArea(announcementsTableView, insets: Appearance.mainContentInsets)
         return view
     }()
 
@@ -95,10 +103,14 @@ class WhatIsNewView: UIView {
         backgroundColor = .basicBackground
         addSubview(mainStackView)
         pinSubviewToAllEdges(mainStackView)
+        announcementsTableView.tableHeaderView = headerView
 
         NSLayoutConstraint.activate([
-            continueButton.heightAnchor.constraint(equalToConstant: Appearance.continueButtonHeight)
+            continueButton.heightAnchor.constraint(equalToConstant: Appearance.continueButtonHeight),
+            headerView.widthAnchor.constraint(equalTo: announcementsTableView.widthAnchor)
         ])
+
+
         setupTableViewDataSource()
     }
 
@@ -136,6 +148,32 @@ private extension WhatIsNewView {
 }
 
 
+// MARK: - Layout
+extension WhatIsNewView {
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        adjustTableHeaderViewLayout()
+    }
+
+    /// Resizes the `tableHeaderView` in `announcementsTableView` as necessary whenever its size changes.
+    private func adjustTableHeaderViewLayout() {
+        guard let headerView = announcementsTableView.tableHeaderView else {
+            return
+        }
+
+        let height = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+        var headerFrame = headerView.frame
+
+        if height != headerFrame.size.height {
+            headerFrame.size.height = height
+            headerView.frame = headerFrame
+            announcementsTableView.tableHeaderView = headerView
+        }
+    }
+}
+
+
 // MARK: - Appearance
 private extension WhatIsNewView {
 
@@ -162,6 +200,7 @@ private extension WhatIsNewView {
         static let versionTableviewSpacing: CGFloat = 32
 
         // table view
+        static let headerViewInsets = UIEdgeInsets(top: 0, left: 0, bottom: 32, right: 0)
         static let estimatedRowHeight: CGFloat = 72 // image height + vertical spacing
 
         // continue button

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
@@ -57,6 +57,7 @@ class WhatIsNewView: UIView {
         tableView.separatorStyle = .none
         tableView.allowsSelection = false
         tableView.rowHeight = UITableView.automaticDimension
+        tableView.showsVerticalScrollIndicator = false
         tableView.estimatedRowHeight = Appearance.estimatedRowHeight
         return tableView
     }()
@@ -179,7 +180,7 @@ private extension WhatIsNewView {
 
     enum Appearance {
         // main view
-        static let mainContentInsets = UIEdgeInsets(top: 80, left: 48, bottom: 0, right: 48)
+        static let mainContentInsets = UIEdgeInsets(top: 0, left: 48, bottom: 0, right: 48)
 
         // title
         static var headlineFont: UIFont {
@@ -200,7 +201,7 @@ private extension WhatIsNewView {
         static let versionTableviewSpacing: CGFloat = 32
 
         // table view
-        static let headerViewInsets = UIEdgeInsets(top: 0, left: 0, bottom: 32, right: 0)
+        static let headerViewInsets = UIEdgeInsets(top: 80, left: 0, bottom: 32, right: 0)
         static let estimatedRowHeight: CGFloat = 72 // image height + vertical spacing
 
         // continue button


### PR DESCRIPTION
Fixes #14718

To test:

- go to Me/App Settings/What's New in WordPress
- scroll the announcements and verify that the header and version scroll with them.
- Try different device sizes and orientations and make sure that view elements look right.

here are a couple of example screenshots

iPhone | iPad compact
--- | ---
<img height="400" alt="whatsnewiphone" src="https://user-images.githubusercontent.com/34376330/90957358-b1396000-e452-11ea-83d6-d28a733be3c8.png"> | <img height="400" alt="whatsnewipad" src="https://user-images.githubusercontent.com/34376330/90957368-bc8c8b80-e452-11ea-8506-10dcb542e52e.png">



**Note: I added a few more fake announcements to emphasize the scrolling. These will all go away once the real data come in.**

PR submission checklist:

- [x] ~~I have considered adding unit tests where possible.~~ Will be added in a separate PR.
- [x] ~~I have considered adding accessibility improvements for my changes.~~ Will be added in a separate PR.
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~ Not released
