### PR TITLE
Reader Improvements Phase 2: Fixes a potential crash 

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -206,6 +206,9 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
     }
 
     override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        guard indexPath.row < layoutAttributes.count else {
+            return nil
+        }
         return layoutAttributes[indexPath.row]
     }
 }


### PR DESCRIPTION
Fixes an out of bounds issue I encountered this morning. I have never seen this before, so I don't know how reproducible it is for everyone. 

### To test:
1. Open the app, and enable the Reader Improvements Phase 2 feature flag
2. Tap on the Reader
3. Tap on the Discover tab
4. Scroll down past the related interests

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
