### PR TITLE
Reader Improvements: Adds accessibility support to the reader topics collection view 

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewCell.swift
@@ -2,4 +2,16 @@ import UIKit
 
 class ReaderInterestsCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var label: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        guard let label = self.label else {
+            return
+        }
+
+        label.isAccessibilityElement = true
+        accessibilityElements = [label]
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -206,6 +206,9 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
     }
 
     override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        guard indexPath.row < layoutAttributes.count else {
+            return nil
+        }
         return layoutAttributes[indexPath.row]
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -151,6 +151,7 @@ class ReaderSelectInterestsViewController: UIViewController {
 
     private func saveSelectedInterests() {
         startLoading()
+        announceLoadingTopics()
 
         let selectedInterests = dataSource.selectedInterests.map { $0.interest }
 
@@ -192,6 +193,12 @@ class ReaderSelectInterestsViewController: UIViewController {
             self.loadingView.alpha = 0
         }) { _ in
             self.loadingView.isHidden = true
+        }
+    }
+
+    private func announceLoadingTopics() {
+        DispatchQueue.main.asyncAfter(deadline: .now()) {
+            UIAccessibility.post(notification: .screenChanged, argument: self.loadingLabel)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -197,9 +197,7 @@ class ReaderSelectInterestsViewController: UIViewController {
     }
 
     private func announceLoadingTopics() {
-        DispatchQueue.main.asyncAfter(deadline: .now()) {
-            UIAccessibility.post(notification: .screenChanged, argument: self.loadingLabel)
-        }
+        UIAccessibility.post(notification: .screenChanged, argument: self.loadingLabel)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -215,6 +215,7 @@ extension ReaderSelectInterestsViewController: UICollectionViewDataSource {
 
         cell.layer.cornerRadius = Constants.cellCornerRadius
         cell.label.text = interest.title
+        cell.label.accessibilityTraits = interest.isSelected ? [.selected, .button] : .button
 
         return cell
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/DynamicHeightCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/DynamicHeightCollectionView.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class DynamicHeightCollectionView: UICollectionView {
+class DynamicHeightCollectionView: AccessibleCollectionView {
     override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -30,6 +30,12 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
     private struct Strings {
         static let collapseButtonTitle: String = NSLocalizedString("Hide", comment: "Title of a button used to collapse a group")
+
+        static let expandButtonAccessbilityHint: String = NSLocalizedString("Tap to see all the tags for this post", comment: "VoiceOver Hint to inform the user what action the expand button performs")
+
+        static let collapseButtonAccessbilityHint: String = NSLocalizedString("Tap to collapse the post tags", comment: "Accessibility hint to inform the user what action the hide button performs")
+
+         static let accessbilityHint: String = NSLocalizedString("Tap to view posts for this tag", comment: "Accessibility hint to inform the user what action the post tag chip performs")
     }
 
     weak var delegate: ReaderTopicCollectionViewCoordinatorDelegate?
@@ -73,6 +79,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
     }
 
     private func configureCollectionView() {
+        collectionView.isAccessibilityElement = false
         collectionView.delegate = self
         collectionView.dataSource = self
 
@@ -121,6 +128,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
 
         cell.layer.cornerRadius = Constants.cellCornerRadius
         cell.label.text = title
+        cell.label.accessibilityHint = Strings.accessbilityHint
     }
 
     private func string(for remainingItems: Int?) -> String {
@@ -170,6 +178,8 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
         let title = string(for: remainingItems)
 
         configure(cell: cell, with: title)
+
+        cell.label.accessibilityHint = layout.isExpanded ? Strings.collapseButtonAccessbilityHint : Strings.expandButtonAccessbilityHint
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(toggleExpanded))
         cell.addGestureRecognizer(tapGestureRecognizer)

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -129,6 +129,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         cell.layer.cornerRadius = Constants.cellCornerRadius
         cell.label.text = title
         cell.label.accessibilityHint = Strings.accessbilityHint
+        cell.label.accessibilityTraits = .button
     }
 
     private func string(for remainingItems: Int?) -> String {


### PR DESCRIPTION
**Review after**: https://github.com/wordpress-mobile/WordPress-iOS/pull/14735

This adds VoiceOver support to the new topics collection view. 

**Note: Accessibility Inspector doesn't work well. Please run on a real device**

### To test:
Install the One Off Build: 33581

1. Run the app on a real device
2. Enable the Reader Improvements Phase 2 feature flag
3. Enable VoiceOver 
4. Navigate to the Discover tab in Reader
5. Tap on the stream
6. Swipe right to highlight the next item in the list
7. Swipe until you get to the topics view in the reader card
8. Swipe to highlight the more item
9. Double tap to expand
10. Swipe left to highlight a topic
11. Double tap to select it

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
