### PR TITLE
Update cards when performing actions on post card

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -21,6 +21,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         super.viewDidLoad()
         ReaderWelcomeBanner.displayIfNeeded(in: tableView)
         tableView.register(ReaderTopicsCardCell.self, forCellReuseIdentifier: readerCardTopicsIdentifier)
+        observeDisplayContext()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -80,6 +81,10 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
                 self.showGhost()
             }
         }
+    }
+
+    @objc private func reload(_ notification: Foundation.Notification) {
+        tableView.reloadData()
     }
 
     // MARK: - Sync
@@ -143,6 +148,11 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         let controller = ReaderCardsStreamViewController()
         controller.readerTopic = topic
         return controller
+    }
+
+    /// Observe the managedObjectContext for changes (likes, saves) and reload the tableView
+    private func observeDisplayContext() {
+        NotificationCenter.default.addObserver(self, selector: #selector(reload(_:)), name: NSNotification.Name.NSManagedObjectContextDidSave, object: managedObjectContext())
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -286,6 +286,8 @@ import WordPressFlux
             topic.inUse = false
             ContextManager.sharedInstance().save(topic.managedObjectContext!)
         }
+
+        NotificationCenter.default.removeObserver(self)
     }
 
 


### PR DESCRIPTION
Fixes an issue mentioned in: https://github.com/wordpress-mobile/WordPress-iOS/issues/14745#issuecomment-680051531

> For some reason I'm not able to like posts straight from the discover feed. I need to go tap into the post to like it. I'm using an iPhone Xs 13.6.

## To test

1. Go to Discover
2. Tap to Like/Dislike or Save/Unsave any post
3. Check that the change is immediately reflected in the post card

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
