### PR TITLE
Reader Improvements: Removes background from the 'hide' chip

### DIFF
--- a/WordPress/Classes/Models/ReaderCard+CoreDataClass.swift
+++ b/WordPress/Classes/Models/ReaderCard+CoreDataClass.swift
@@ -36,7 +36,7 @@ public class ReaderCard: NSManagedObject {
             post = ReaderPost.createOrReplace(fromRemotePost: remoteCard.post, for: nil, context: managedObjectContext)
         case .interests:
             topics = NSOrderedSet(array: remoteCard.interests?.map {
-                ReaderTagTopic.createIfNeeded(from: $0, context: context)
+                ReaderTagTopic.createOrUpdateIfNeeded(from: $0, context: context)
             } ?? [])
         default:
             break

--- a/WordPress/Classes/Models/ReaderTagTopic.swift
+++ b/WordPress/Classes/Models/ReaderTagTopic.swift
@@ -29,11 +29,19 @@ import Foundation
         showInMenu = true
     }
 
-    /// Returns an existent ReaderTagTopic or create a new one based on remote interest
-    class func createIfNeeded(from remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext) -> ReaderTagTopic {
+    /// Returns an existing ReaderTagTopic or creates a new one based on remote interest
+    /// If an existing topic is returned, the title will be updated with the remote interest
+    class func createOrUpdateIfNeeded(from remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext) -> ReaderTagTopic {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: self.classNameWithoutNamespaces())
         fetchRequest.predicate = NSPredicate(format: "slug = %@", remoteInterest.slug)
         let topics = try? context.fetch(fetchRequest) as? [ReaderTagTopic]
-        return topics?.first ?? ReaderTagTopic(remoteInterest: remoteInterest, context: context)
+
+        guard let topic = topics?.first else {
+            return ReaderTagTopic(remoteInterest: remoteInterest, context: context)
+        }
+
+        topic.title = remoteInterest.title
+
+        return topic
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -180,6 +180,10 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
 
         configure(cell: cell, with: title)
 
+        if layout.isExpanded {
+            cell.label.backgroundColor = .clear
+        }
+
         cell.label.accessibilityHint = layout.isExpanded ? Strings.collapseButtonAccessbilityHint : Strings.expandButtonAccessbilityHint
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(toggleExpanded))


### PR DESCRIPTION
Fixes #14745 

|Dark Mode | Light Mode |
|:--:|:--:|
|![Simulator Screen Shot - iPhone 11 Pro (13 3) - 2020-08-25 at 16 35 47](https://user-images.githubusercontent.com/793774/91225115-eacecd00-e6d7-11ea-9558-ff5e3e57c5a8.png)|![Simulator Screen Shot - iPhone 11 Pro (13 3) - 2020-08-25 at 16 35 49](https://user-images.githubusercontent.com/793774/91225107-e9050980-e6d7-11ea-8955-9dd0c0803da8.png)|

### To test:
1. Enable the Reader Improvements Phase 2 Feature Flag
2. Tap on the Reader tab
3. Tap on the Discover tab
4. Locate a post with hidden tags 
5. Tap the expand item

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
