### PR TITLE
UL&S iCloud Keychain: Add feature flag, implement basic UI

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -194,8 +194,8 @@ target 'WordPress' do
     # pod 'WordPressAuthenticator', '~> 1.24.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-    pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'ded63ca91e1012ae376558a8aef07c224bc036c6'
+    # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.0'
     # pod 'MediaEditor', :git => 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', :commit => 'a4178ed9b0f3622faafb41dd12503e26c5523a32'

--- a/Podfile
+++ b/Podfile
@@ -191,11 +191,11 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.24.0-beta'
+    # pod 'WordPressAuthenticator', '~> 1.24.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
-    # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
+    pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.0'
     # pod 'MediaEditor', :git => 'https://github.com/wordpress-mobile/MediaEditor-iOS.git', :commit => 'a4178ed9b0f3622faafb41dd12503e26c5523a32'

--- a/Podfile
+++ b/Podfile
@@ -194,7 +194,7 @@ target 'WordPress' do
     # pod 'WordPressAuthenticator', '~> 1.24.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'ded63ca91e1012ae376558a8aef07c224bc036c6'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c0052f3b48d876eabe30fb2951595c8ba265cbf9'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.0'

--- a/Podfile
+++ b/Podfile
@@ -194,7 +194,7 @@ target 'WordPress' do
     # pod 'WordPressAuthenticator', '~> 1.24.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c0052f3b48d876eabe30fb2951595c8ba265cbf9'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'f569f9aec54e2690b3bf002780fffc6008b10b02'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.0'

--- a/Podfile
+++ b/Podfile
@@ -191,10 +191,10 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.24.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.24.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '4197aa2c7ee933fcd8670637f40cdc5f7e7a8e1a'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `ded63ca91e1012ae376558a8aef07c224bc036c6`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c0052f3b48d876eabe30fb2951595c8ba265cbf9`)
   - WordPressKit (~> 4.15.0-beta.2)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11)
@@ -657,7 +657,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.35.0
   WordPressAuthenticator:
-    :commit: ded63ca91e1012ae376558a8aef07c224bc036c6
+    :commit: c0052f3b48d876eabe30fb2951595c8ba265cbf9
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.35.0/third-party-podspecs/Yoga.podspec.json
@@ -678,7 +678,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.35.0
   WordPressAuthenticator:
-    :commit: ded63ca91e1012ae376558a8aef07c224bc036c6
+    :commit: c0052f3b48d876eabe30fb2951595c8ba265cbf9
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -777,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 7817c6aedfe619a1de2d2b1db863fa5cd089bfe2
+PODFILE CHECKSUM: 0c43c66f167be6aa25fcbca312bef4410824bdb7
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.24.0-beta)
+  - WordPressAuthenticator (from `../WordPressAuthenticator-iOS`)
   - WordPressKit (~> 4.15.0-beta.2)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11)
@@ -555,7 +555,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -657,6 +656,8 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.35.0
+  WordPressAuthenticator:
+    :path: "../WordPressAuthenticator-iOS"
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.35.0/third-party-podspecs/Yoga.podspec.json
 
@@ -772,6 +773,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 4f8928a6de9f81e6b94ef89e26489399e7606f41
+PODFILE CHECKSUM: 8518ccabbb8cf50fc7f4e7a67995dcb710091bc8
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `../WordPressAuthenticator-iOS`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `ded63ca91e1012ae376558a8aef07c224bc036c6`)
   - WordPressKit (~> 4.15.0-beta.2)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11)
@@ -657,7 +657,8 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.35.0
   WordPressAuthenticator:
-    :path: "../WordPressAuthenticator-iOS"
+    :commit: ded63ca91e1012ae376558a8aef07c224bc036c6
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.35.0/third-party-podspecs/Yoga.podspec.json
 
@@ -676,6 +677,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.35.0
+  WordPressAuthenticator:
+    :commit: ded63ca91e1012ae376558a8aef07c224bc036c6
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -773,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 8518ccabbb8cf50fc7f4e7a67995dcb710091bc8
+PODFILE CHECKSUM: 7817c6aedfe619a1de2d2b1db863fa5cd089bfe2
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.24.0-beta.1):
+  - WordPressAuthenticator (1.24.0-beta.2):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c0052f3b48d876eabe30fb2951595c8ba265cbf9`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `f569f9aec54e2690b3bf002780fffc6008b10b02`)
   - WordPressKit (~> 4.15.0-beta.2)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11)
@@ -657,7 +657,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.35.0
   WordPressAuthenticator:
-    :commit: c0052f3b48d876eabe30fb2951595c8ba265cbf9
+    :commit: f569f9aec54e2690b3bf002780fffc6008b10b02
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.35.0/third-party-podspecs/Yoga.podspec.json
@@ -678,7 +678,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.35.0
   WordPressAuthenticator:
-    :commit: c0052f3b48d876eabe30fb2951595c8ba265cbf9
+    :commit: f569f9aec54e2690b3bf002780fffc6008b10b02
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -760,7 +760,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 17b762af591be43f96629d5169e4a8a23c98a5e8
+  WordPressAuthenticator: 82b18d2774589e57f71857337c42efd989b87d79
   WordPressKit: c826b111887299024822fee12432ce62accf4d7c
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
@@ -777,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 0c43c66f167be6aa25fcbca312bef4410824bdb7
+PODFILE CHECKSUM: 12fd96a4c951358647ef0d3eabc9e7ef75a37bdd
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.24.0-beta.3):
+  - WordPressAuthenticator (1.24.0-beta.4):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `4197aa2c7ee933fcd8670637f40cdc5f7e7a8e1a`)
+  - WordPressAuthenticator (~> 1.24.0-beta)
   - WordPressKit (~> 4.15.0-beta.2)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11)
@@ -555,6 +555,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -656,9 +657,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.35.0
-  WordPressAuthenticator:
-    :commit: 4197aa2c7ee933fcd8670637f40cdc5f7e7a8e1a
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.35.0/third-party-podspecs/Yoga.podspec.json
 
@@ -677,9 +675,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.35.0
-  WordPressAuthenticator:
-    :commit: 4197aa2c7ee933fcd8670637f40cdc5f7e7a8e1a
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -760,7 +755,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: b7174eb49c0be4c5f064d53601c637523e6e77ec
+  WordPressAuthenticator: a97f8530e8c29e0c65766b909a4926285971f56a
   WordPressKit: c826b111887299024822fee12432ce62accf4d7c
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
@@ -777,6 +772,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: b3f4a827dba71da93a355a06d30b57bcbe7bddf0
+PODFILE CHECKSUM: 4f8928a6de9f81e6b94ef89e26489399e7606f41
 
 COCOAPODS: 1.9.3

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -10,6 +10,7 @@ enum FeatureFlag: Int, CaseIterable {
     case unifiedApple
     case unifiedSignup
     case unifiedLoginLink
+    case unifiedKeychainLogin
     case meMove
     case floatingCreateButton
     case newReaderNavigation
@@ -42,6 +43,8 @@ enum FeatureFlag: Int, CaseIterable {
         case .unifiedSignup:
             return false
         case .unifiedLoginLink:
+            return false
+        case .unifiedKeychainLogin:
             return false
         case .meMove:
             return true
@@ -95,6 +98,8 @@ extension FeatureFlag: OverrideableFlag {
             return "Unified Auth - Sign Up"
         case .unifiedLoginLink:
             return "Unified Auth - Login Magic Link"
+        case .unifiedKeychainLogin:
+            return "Unified Auth - iCloud Keychain"
         case .meMove:
             return "Move the Me Scene to My Site"
         case .floatingCreateButton:

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -43,7 +43,7 @@ class WordPressAuthenticationManager: NSObject {
                                                                 enableUnifiedGoogle: FeatureFlag.unifiedGoogle.enabled,
                                                                 enableUnifiedApple: FeatureFlag.unifiedApple.enabled,
                                                                 enableUnifiedWordPress: FeatureFlag.unifiedWordPress.enabled,
-                                                                enableUnifiedKeychainLogin: FeatureFlag.unifiedKeychainLogin.enabled) {
+                                                                enableUnifiedKeychainLogin: FeatureFlag.unifiedKeychainLogin.enabled)
 
         let style = WordPressAuthenticatorStyle(primaryNormalBackgroundColor: .primaryButtonBackground,
                                                 primaryNormalBorderColor: nil,

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -43,7 +43,8 @@ class WordPressAuthenticationManager: NSObject {
                                                                 enableUnifiedGoogle: FeatureFlag.unifiedGoogle.enabled,
                                                                 enableUnifiedApple: FeatureFlag.unifiedApple.enabled,
                                                                 enableUnifiedSignup: FeatureFlag.unifiedSignup.enabled,
-                                                                enableUnifiedLoginLink: FeatureFlag.unifiedLoginLink.enabled)
+                                                                enableUnifiedLoginLink: FeatureFlag.unifiedLoginLink.enabled,
+                                                                enableUnifiedKeychainLogin: FeatureFlag.unifiedKeychainLogin.enabled)
 
         let style = WordPressAuthenticatorStyle(primaryNormalBackgroundColor: .primaryButtonBackground,
                                                 primaryNormalBorderColor: nil,


### PR DESCRIPTION
Ref: #14734 
WPAuth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/413

This PR implements the basic UI for iCloud Keychain login behind a new feature flag.

#### Notes about iCloud Keychain:

To enable iCloud Kechain in your device, go to Settings > Your Apple ID > iCloud > Keychain.

You can check if you have WP.com credentials stored by using the "Keychain Access" app in your Mac (make sure you have iCloud Keychain enabled in your Mac as well if you're doing this).

The way to create the credentials if they're missing, is to log into WP.com using Safari and letting it save your credentials.

I want to avoid this PR to become an extended guide on this topic, so please let me know if you need further assistance.

## Testing:

### Test 1: feature OFF

#### Preconditions:

- Disable feature flag `unifiedKeychainLogin`.
- Make sure you're logged out of the App.

#### Steps:

- Run the App
- When the prologue screen is shown, make sure you're NOT prompted to log in with your stored credentials.

### Test 2: feature ON, continue

#### Preconditions:

- Enable feature flag `unifiedKeychainLogin`.
- Use a device running iOS 13 or later.
- Make sure you're logged out of the App.
- Make sure iCloud Keychain is enabled in your device and that you have credentials for WP.com stored.

#### Steps:

- Run the App
- When the prologue screen is shown you should be prompted to log in with your stored iCloud Keychain credentials.
- Select the credentials and tap "Continue", the credentials picker will go away.

#### Expected tracks:

🔵 Tracked: unified_login_step <flow: icloud_keychain_login, source: default, step: start>

### Test 3: feature ON, cancel

#### Preconditions:

- Enable feature flag `unifiedKeychainLogin`.
- Use a device running iOS 13 or later.
- Make sure you're logged out of the App.
- Make sure iCloud Keychain is enabled in your device and that you have credentials for WP.com stored.

#### Steps:

- Run the App
- When the prologue screen is shown you should be prompted to log in with your stored iCloud Keychain credentials.
- Tap cancel and see the prompt going away.

#### Expected tracks:

🔵 Tracked: unified_login_step <flow: icloud_keychain_login, source: default, step: start>
🔵 Tracked: unified_login_interaction <click: dismiss, flow: icloud_keychain_login, source: default, step: start>

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
