### PR TITLE
Hide the tab bar when presenting Reader Detail

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -82,15 +82,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     override var hidesBottomBarWhenPushed: Bool {
-        set {
-
-        }
-
-        get {
-            true
-        }
+        set { }
+        get { true }
     }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import AMScrollingNavbar
 
 protocol ReaderDetailView: class {
     func render(_ post: ReaderPost)
@@ -107,22 +106,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         coordinator?.start()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        followScrollView()
-    }
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         ReaderTracker.shared.start(.readerPost)
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        stopFollowingScrollView()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -290,7 +277,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private func configureScrollView() {
         scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomMargin + Constants.toolbarHeight, right: 0)
         scrollView.navigationBar = navigationController?.navigationBar
-        scrollView.delegate = self
     }
 
     /// Configure the NoResultsViewController
@@ -307,37 +293,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     ///
     @objc func didTapShareButton(_ sender: UIButton) {
         coordinator?.share(fromView: sender)
-    }
-
-    /// Start following the scroll view to hide nav bar and toolbar
-    /// Only if VoiceOver is not active
-    ///
-    private func followScrollView() {
-        if isFollowingScrollView,
-            UIAccessibility.isVoiceOverRunning {
-            return
-        }
-
-        if let navigationController = navigationController as? ScrollingNavigationController {
-            navigationController.followScrollView(scrollView, delay: Constants.delay, followers: [NavigationBarFollower(view: toolbarContainerView, direction: .scrollDown)])
-            navigationController.shouldUpdateContentInset = false
-            isFollowingScrollView = true
-        }
-    }
-
-    /// Stop following the scroll view to hide nav bar and toolbar
-    ///
-    private func stopFollowingScrollView() {
-        if let navigationController = navigationController as? ScrollingNavigationController {
-            navigationController.stopFollowingScrollView(showingNavbar: true)
-            isFollowingScrollView = false
-        }
-    }
-
-    /// Update scroll view insets to take into account if toolbar is visible or not
-    private func updateScrollInsets(toolbarVisible: Bool) {
-        let bottomInset: CGFloat = toolbarVisible ? Constants.toolbarHeight : 0
-        scrollView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
     }
 
     /// A View Controller that displays a Post content.
@@ -485,35 +440,6 @@ private extension ReaderDetailViewController {
 extension ReaderDetailViewController: NoResultsViewControllerDelegate {
     func actionButtonPressed() {
         coordinator?.openInBrowser()
-    }
-}
-
-// MARK: - Scroll View Delegate
-
-extension ReaderDetailViewController: UIScrollViewDelegate {
-    // If we're at the end of the article, show nav bar and toolbar when the user stops scrolling
-    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        if scrollView.contentOffset.y >= scrollView.contentSize.height + scrollView.contentInset.bottom - scrollView.frame.size.height - toolbar.frame.height {
-            guard let navigationController = self.navigationController as? ScrollingNavigationController,
-                navigationController.state != .expanded else {
-                    return
-            }
-
-            stopFollowingScrollView()
-            updateScrollInsets(toolbarVisible: true)
-        } else {
-            followScrollView()
-            updateScrollInsets(toolbarVisible: false)
-        }
-    }
-
-    /// Show the nav bar when scrolling to top
-    ///
-    func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
-        if let navigationController = navigationController as? ScrollingNavigationController {
-            navigationController.showNavbar(animated: true, scrollToTop: true)
-        }
-        return true
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -82,6 +82,16 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         return currentPreferredStatusBarStyle
     }
 
+    override var hidesBottomBarWhenPushed: Bool {
+        set {
+
+        }
+
+        get {
+            true
+        }
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -200,9 +200,9 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 {
     if (!_readerNavigationController) {
         if ([Feature enabled:FeatureFlagNewReaderNavigation]) {
-            _readerNavigationController = [[ScrollingNavigationController alloc] initWithRootViewController:self.makeReaderTabViewController];
+            _readerNavigationController = [[UINavigationController alloc] initWithRootViewController:self.makeReaderTabViewController];
         } else {
-            _readerNavigationController = [[ScrollingNavigationController alloc] initWithRootViewController:self.readerMenuViewController];
+            _readerNavigationController = [[UINavigationController alloc] initWithRootViewController:self.readerMenuViewController];
         }
         _readerNavigationController.navigationBar.translucent = NO;
 


### PR DESCRIPTION
Part of #14767 

This PR:

* Shows the Reader Detail hiding the Tab Bar (thanks @emilylaguna)
* Removes the show/hide effect in the navigation bar and action bar in Reader Detail

Note that `AMScrollingNavBar` is still present in `Podfile`. 

## To test

1. Run the app
2. Go to Reader
3. Tap any post
4. Check that the tab bar is not visible
5. Scroll the article
6. Check that the navigation bar and the action bar stays fixed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
