### PR TITLE
Fix empty notifications on release builds failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,10 @@ jobs:
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
+      - run:
+          name: Setup Notifications
+          command: |
+            echo "export SLACK_FAILURE_MESSAGE=':red_circle: Build for WordPress iOS failed!'" >> $BASH_ENV
       - git/shallow-checkout
       - ios/install-dependencies:
             bundle-install: true


### PR DESCRIPTION
We noticed that sometimes empty notifications are posted on Slack when the Release Build task fails on CI. It turns out that we currently setup the notification message quite late in the flow in order to be able to extract the version number, so if failures happen during checkout or early install, the message is empty. 

This PR adds the setup of a generic failure message early in the flow that will be replaced by the current one if the process makes it to when we can extract the version number. 

To test:
 - Checkout a new branch from this one. 
 - Add a failure in the Release Build flow before the Build step, commit and push.
 - Tag with a beta tag and push it. 
 - Verify that the failure message is published on Slack.

** Clean up**
 - Remove the test beta tag.
 - Remove the test branch


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
