### PR TITLE
ULS: unified Google fixes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -191,9 +191,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.23.2'
+    #pod 'WordPressAuthenticator', '~> 1.23.3'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/unified_google_issues'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.23.2):
+  - WordPressAuthenticator (1.23.3):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.23.2)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/unified_google_issues`)
   - WordPressKit (~> 4.15.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.11)
@@ -555,7 +555,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -657,6 +656,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.35.0
+  WordPressAuthenticator:
+    :branch: fix/unified_google_issues
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.35.0/third-party-podspecs/Yoga.podspec.json
 
@@ -675,6 +677,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.35.0
+  WordPressAuthenticator:
+    :commit: 485f49964e4e83c7a329dfe8ec6b0961854a70ae
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -755,7 +760,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: ba506a78ab8fc482f5f2d3457fb5d7ea519277ae
+  WordPressAuthenticator: 19a4f2039a764fe380da4ff35f83be582d1e2815
   WordPressKit: c826b111887299024822fee12432ce62accf4d7c
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: b56046080c99d41519d097c970df663fda48e218
@@ -772,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 76ba848acc0381e9000a772c2cf9043c9b572ff2
+PODFILE CHECKSUM: 5abfc7c9bacd46d2ffeedb9b21296f9a036bb379
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/282
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/419

This updates Auth to use the unified Google fixes as noted in the Auth PR description.

**Notes:**
All these technically affect both iPhone and iPad, but some can only been seen on the iPad.

The only way I found to trigger the error view is attempting to get a second WP 2FA code too quickly. Thus, you will need a Google account that:
- Does not have a WP password (or is already connected to Google so you don't get prompted for the password).
- Does have WP 2FA.

**To test:**

- `Continue with Google` from either login or signup.
  - On the Waiting for Google view, verify the image is no longer huge on iPad.
- Complete Google's auth.
  - Verify the `Processing Account` message is no longer displayed on the HUD.
- On the 2FA view, `Back` and go through the process again. You should get the error view.
  - Verify the signup option is no longer displayed (it was the last option).
- Either tap off the signup error view or drag it down to dismiss.
  - Verify the Waiting for Google view is dismissed and you're returned to the prologue.

| ![hud](https://user-images.githubusercontent.com/1816888/91499850-7a62b000-e87f-11ea-87d4-197a61d983c7.png) | ![social_error_view](https://user-images.githubusercontent.com/1816888/91499889-8e0e1680-e87f-11ea-9263-100fe1e16d8d.png) |
|--------|-------|


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
