### PR TITLE
Add in-app support for remote feature flags

### DIFF
--- a/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
+++ b/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
@@ -7,11 +7,9 @@ class RemoteFeatureFlagStore {
         DDLogInfo("🚩 Remote Feature Flag Device ID: \(deviceID)")
     }
 
-    /**
-     Fetches remote feature flags from the server.
-
-     - Parameter callback: An optional callback that can be used to update UI following the fetch. It is not called on the UI thread.
-    */
+    /// Fetches remote feature flags from the server.
+    /// - Parameters:
+    ///     - callback: An optional callback that can be used to update UI following the fetch. It is not called on the UI thread.
     public func update(then callback: FetchCallback? = nil) {
         // We currently use an anonymous connection to WordPress.com, because we don't need user state.
         // In the future, we could provide login credentials to the endpoint, which would allow customizing flags server-side on a per-user basis.

--- a/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
+++ b/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
@@ -27,7 +27,7 @@ class RemoteFeatureFlagStore {
     }
 
     /// Checks if the local cache has a value for a given `FeatureFlag`
-    public func hasRemoteValueForFlag(_ flag: FeatureFlag) -> Bool {
+    public func hasValue(for flag: FeatureFlag) -> Bool {
         guard let remoteKey = flag.remoteKey else {
             return false
         }
@@ -40,7 +40,7 @@ class RemoteFeatureFlagStore {
     /// If the flag exists in the local cache, the current value will be returned.  If the flag does not exist in the local cache, the compile-time default will be returned.
     /// - Parameters:
     ///     - flag: The `FeatureFlag` object associated with a remote feature flag
-    public func valueForFlag(_ flag: FeatureFlag) -> Bool {
+    public func value(for flag: FeatureFlag) -> Bool {
         guard
             let remoteKey = flag.remoteKey, // Not all flags need remote keys, since they may not use remote feature flagging
             let value = cache[remoteKey]    // The value may not be in the cache if this is the first run

--- a/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
+++ b/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
@@ -28,7 +28,11 @@ class RemoteFeatureFlagStore {
 
     /// Checks if the local cache has a value for a given `FeatureFlag`
     public func hasRemoteValueForFlag(_ flag: FeatureFlag) -> Bool {
-        return flag.remoteKey != nil && cache[flag.remoteKey!] != nil
+        guard let remoteKey = flag.remoteKey else {
+            return false
+        }
+
+        return cache[remoteKey] != nil
     }
 
     /// Looks up the value for a remote feature flag.

--- a/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
+++ b/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
@@ -1,0 +1,93 @@
+import Foundation
+import WordPressKit
+
+class RemoteFeatureFlagStore {
+
+    init() {
+        DDLogInfo("🚩 Remote Feature Flag Device ID: \(deviceID)")
+    }
+
+    /**
+     Fetches remote feature flags from the server.
+
+     - Parameter callback: An optional callback that can be used to update UI following the fetch. It is not called on the UI thread.
+    */
+    public func update(then callback: FetchCallback? = nil) {
+        // We currently use an anonymous connection to WordPress.com, because we don't need user state.
+        // In the future, we could provide login credentials to the endpoint, which would allow customizing flags server-side on a per-user basis.
+        let remote = FeatureFlagRemote(wordPressComRestApi: WordPressComRestApi.defaultApi())
+        remote.getRemoteFeatureFlags(forDeviceId: deviceID) { [weak self] result in
+            switch result {
+                case .success(let flags):
+                    self?.cache = flags.dictionaryValue
+                    DDLogInfo("🚩 Successfully updated local feature flags: \(flags)")
+                    callback?()
+                case .failure(let error):
+                    DDLogError("🚩 Unable to update Feature Flag Store: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Checks if the local cache has a value for a given `FeatureFlag`
+    public func hasRemoteValueForFlag(_ flag: FeatureFlag) -> Bool {
+        return flag.remoteKey != nil && cache[flag.remoteKey!] != nil
+    }
+
+    /// Looks up the value for a remote feature flag.
+    ///
+    /// If the flag exists in the local cache, the current value will be returned.  If the flag does not exist in the local cache, the compile-time default will be returned.
+    /// - Parameters:
+    ///     - flag: The `FeatureFlag` object associated with a remote feature flag
+    public func valueForFlag(_ flag: FeatureFlag) -> Bool {
+        guard
+            let remoteKey = flag.remoteKey, // Not all flags need remote keys, since they may not use remote feature flagging
+            let value = cache[remoteKey]    // The value may not be in the cache if this is the first run
+            else {
+                DDLogInfo("🚩 Unable to resolve remote feature flag: \(flag.description). Returning compile-time default.")
+                return flag.enabled
+        }
+
+        return value
+    }
+
+    /// Thread Safety Coordinator
+    private let queue = DispatchQueue(label: "remote-feature-flag-store-queue")
+}
+
+extension RemoteFeatureFlagStore {
+    private struct Constants {
+        static let DeviceIdKey = "FeatureFlagDeviceId"
+        static let CachedFlagsKey = "FeatureFlagStoreCache"
+    }
+
+    typealias FetchCallback = () -> Void
+
+    /// The `deviceID` ensures we retain a stable set of Feature Flags between updates. If there are staged rollouts or other dynamic changes
+    /// happening server-side we don't want out flags to change on each fetch, so we provide an anonymous ID to manage this.
+    private var deviceID: String {
+        guard let deviceID = UserDefaults.standard.string(forKey: Constants.DeviceIdKey) else {
+            DDLogInfo("🚩 Unable to find existing device ID – generating a new one")
+            let newID = UUID().uuidString
+            UserDefaults.standard.set(newID, forKey: Constants.DeviceIdKey)
+            return newID
+        }
+
+        return deviceID
+    }
+
+    /// The local cache stores feature flags between runs so that the most recently fetched set are ready to go as soon as this object is instantiated.
+    private var cache: [String: Bool] {
+        get {
+            // Read from the cache in a thread-safe way
+            queue.sync {
+                UserDefaults.standard.dictionary(forKey: Constants.CachedFlagsKey) as? [String: Bool] ?? [:]
+            }
+        }
+        set {
+            // Write to the cache in a thread-safe way.
+            self.queue.sync {
+                UserDefaults.standard.set(newValue, forKey: Constants.CachedFlagsKey)
+            }
+        }
+    }
+}

--- a/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
+++ b/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
@@ -48,7 +48,7 @@ class RemoteFeatureFlagStore {
     ///     - flag: The `FeatureFlag` object associated with a remote feature flag
     public func value(for flag: OverrideableFlag) -> Bool {
         guard
-            let remoteKey = flag.remoteKey, // Not all flags need remote keys, since they may not use remote feature flagging
+            let remoteKey = flag.remoteKey, // Not all flags contain a remote key, since they may not use remote feature flagging
             let value = cache[remoteKey]    // The value may not be in the cache if this is the first run
             else {
                 DDLogInfo("🚩 Unable to resolve remote feature flag: \(flag.description). Returning compile-time default.")

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -34,6 +34,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     private var pingHubManager: PingHubManager?
     private var noticePresenter: NoticePresenter?
     private var bgTask: UIBackgroundTaskIdentifier? = nil
+    private let remoteFeatureFlagStore = RemoteFeatureFlagStore()
 
     private var mainContext: NSManagedObjectContext {
         return ContextManager.shared.mainContext
@@ -84,6 +85,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         configureReachability()
         configureSelfHostedChallengeHandler()
+        remoteFeatureFlagStore.update()
 
         window?.makeKeyAndVisible()
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -63,6 +63,16 @@ enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current == .localDeveloper
         }
     }
+
+    /// This key must match the server-side one for remote feature flagging
+    var remoteKey: String? {
+        switch self {
+            case .unifiedAuth:
+                return "wordpress_ios_unified_login_and_signup"
+            default:
+                return nil
+        }
+    }
 }
 
 /// Objective-C bridge for FeatureFlag.

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -1,7 +1,7 @@
 /// FeatureFlag exposes a series of features to be conditionally enabled on
 /// different builds.
 @objc
-enum FeatureFlag: Int, CaseIterable {
+enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackDisconnect
     case debugMenu
     case unifiedAuth
@@ -85,7 +85,7 @@ class Feature: NSObject {
     }
 }
 
-extension FeatureFlag: OverrideableFlag {
+extension FeatureFlag {
     /// Descriptions used to display the feature flag override menu in debug builds
     var description: String {
         switch self {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlagOverrideStore.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlagOverrideStore.swift
@@ -6,6 +6,7 @@ import Foundation
 protocol OverrideableFlag: CustomStringConvertible {
     var enabled: Bool { get }
     var canOverride: Bool { get }
+    var remoteKey: String? { get }
 }
 
 /// Used to override values for feature flags at runtime in debug builds

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlagOverrideStore.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlagOverrideStore.swift
@@ -6,6 +6,8 @@ import Foundation
 protocol OverrideableFlag: CustomStringConvertible {
     var enabled: Bool { get }
     var canOverride: Bool { get }
+
+    /// An optional key identifying this flag server-side. Not all flags will have this key – they may not use remote feature flagging
     var remoteKey: String? { get }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		1E5D00102493CE240004B708 /* GutenGhostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E5D000F2493CE240004B708 /* GutenGhostView.swift */; };
 		1E5D00142493E8C90004B708 /* GutenGhostView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1E5D00132493E8C90004B708 /* GutenGhostView.xib */; };
 		1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */; };
+		24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */; };
 		2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
 		26D66DEC36ACF7442186B07D /* Pods_WordPressThisWeekWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 979B445A45E13F3289F2E99E /* Pods_WordPressThisWeekWidget.framework */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
@@ -2733,6 +2734,7 @@
 		1E5D00132493E8C90004B708 /* GutenGhostView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GutenGhostView.xib; sourceTree = "<group>"; };
 		1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergRollout.swift; sourceTree = "<group>"; };
 		2262D835FA89938EBF63EADF /* Pods-WordPressShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagStore.swift; sourceTree = "<group>"; };
 		27AE66536E0C5378203F9312 /* Pods-WordPressUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressUITests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressUITests/Pods-WordPressUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		28A0AAE50D9B0CCF005BE974 /* WordPress_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPress_Prefix.pch; sourceTree = "<group>"; };
 		2906F80F110CDA8900169D56 /* EditCommentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditCommentViewController.h; sourceTree = "<group>"; };
@@ -10330,6 +10332,7 @@
 				9A4E271C22EF33F5001F6A6B /* AccountSettingsStore.swift */,
 				9A09F914230C3E9700F42AB7 /* StoreFetchingStatus.swift */,
 				4629E41C243D21400002E15C /* EditorThemeStore.swift */,
+				24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -13478,6 +13481,7 @@
 				8B11B6682489C0A4000F1A0F /* ReaderScrollView.swift in Sources */,
 				8B05D29323AA572A0063B9AA /* GutenbergMediaEditorImage.swift in Sources */,
 				B532D4EA199D4357006E4DF6 /* NoteBlockHeaderTableViewCell.swift in Sources */,
+				24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */,
 				319D6E8519E44F7F0013871C /* SuggestionsTableViewCell.m in Sources */,
 				40A71C69220E1952002E3D25 /* LastPostStatsRecordValue+CoreDataClass.swift in Sources */,
 				7E4A773720F802A8001C706D /* ActivityRangesFactory.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 		1E5D00142493E8C90004B708 /* GutenGhostView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1E5D00132493E8C90004B708 /* GutenGhostView.xib */; };
 		1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */; };
 		24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */; };
+		24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */; };
 		2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
 		26D66DEC36ACF7442186B07D /* Pods_WordPressThisWeekWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 979B445A45E13F3289F2E99E /* Pods_WordPressThisWeekWidget.framework */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
@@ -2735,6 +2736,7 @@
 		1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergRollout.swift; sourceTree = "<group>"; };
 		2262D835FA89938EBF63EADF /* Pods-WordPressShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagStore.swift; sourceTree = "<group>"; };
+		24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagTests.swift; sourceTree = "<group>"; };
 		27AE66536E0C5378203F9312 /* Pods-WordPressUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressUITests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressUITests/Pods-WordPressUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		28A0AAE50D9B0CCF005BE974 /* WordPress_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPress_Prefix.pch; sourceTree = "<group>"; };
 		2906F80F110CDA8900169D56 /* EditCommentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditCommentViewController.h; sourceTree = "<group>"; };
@@ -7744,6 +7746,7 @@
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
 				1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */,
 				173D82E6238EE2A7008432DA /* FeatureFlagTests.swift */,
+				24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */,
 				F551E7F623FC9A5C00751212 /* Collection+RotateTests.swift */,
 			);
 			name = Utility;
@@ -13885,6 +13888,7 @@
 				FF1B11E7238FE27A0038B93E /* GutenbergGalleryUploadProcessorTests.swift in Sources */,
 				8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */,
 				D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */,
+				24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */,
 				E135965D1E7152D1006C6606 /* RecentSitesServiceTests.swift in Sources */,
 				D88A64AC208D9B09008AE9BC /* StockPhotosPageableTests.swift in Sources */,
 				40C403F82215D88100E8C894 /* TopViewedStatsTests.swift in Sources */,

--- a/WordPress/WordPressTest/FeatureFlagTests.swift
+++ b/WordPress/WordPressTest/FeatureFlagTests.swift
@@ -101,14 +101,15 @@ enum MockFeatureFlag: OverrideableFlag {
         }
     }
 
-    var toRemoteFeatureFlag: RemoteFeatureFlag? {
+    var toFeatureFlag: WordPressKit.FeatureFlag? {
         guard
             let remoteKey = remoteKey,
             let remoteValue = remoteValue
         else {
             return nil
         }
-        return RemoteFeatureFlag(title: remoteKey, value: remoteValue)
+
+        return WordPressKit.FeatureFlag(title: remoteKey, value: remoteValue)
     }
 }
 

--- a/WordPress/WordPressTest/FeatureFlagTests.swift
+++ b/WordPress/WordPressTest/FeatureFlagTests.swift
@@ -1,10 +1,28 @@
 import XCTest
 @testable import WordPress
 
-fileprivate enum MockFeatureFlag: OverrideableFlag {
+enum MockFeatureFlag: OverrideableFlag {
     case enabledFeature
     case disabledFeature
     case nonOverrideableFeature
+
+    case remotelyEnabledLocallyEnabledFeature
+    case remotelyEnabledLocallyDisabledFeature
+    case remotelyDisabledLocallyEnabledFeature
+    case remotelyDisabledLocallyDisabledFeature
+    case remotelyUndefinedLocallyEnabledFeature
+    case remotelyUndefinedLocallyDisabledFeature
+
+    static var remoteCases: [MockFeatureFlag] {
+        return [
+            .remotelyEnabledLocallyEnabledFeature,
+            .remotelyEnabledLocallyDisabledFeature,
+            .remotelyDisabledLocallyEnabledFeature,
+            .remotelyDisabledLocallyDisabledFeature,
+            .remotelyUndefinedLocallyEnabledFeature,
+            .remotelyUndefinedLocallyDisabledFeature,
+        ]
+    }
 
     var enabled: Bool {
         switch self {
@@ -14,6 +32,14 @@ fileprivate enum MockFeatureFlag: OverrideableFlag {
             return false
         case .nonOverrideableFeature:
             return true
+        case .remotelyEnabledLocallyEnabledFeature,
+             .remotelyDisabledLocallyEnabledFeature,
+             .remotelyUndefinedLocallyEnabledFeature:
+            return true
+        case .remotelyEnabledLocallyDisabledFeature,
+             .remotelyDisabledLocallyDisabledFeature,
+             .remotelyUndefinedLocallyDisabledFeature:
+            return false
         }
     }
 
@@ -29,7 +55,60 @@ fileprivate enum MockFeatureFlag: OverrideableFlag {
             return "Disabled feature"
         case .nonOverrideableFeature:
             return "Non overrideable feature"
+        case .remotelyEnabledLocallyEnabledFeature:
+            return "Remotely Enabled, Locally Enabled Feature"
+        case .remotelyEnabledLocallyDisabledFeature:
+            return "Remote Enabled, Locally Disabled Feature"
+        case .remotelyDisabledLocallyEnabledFeature:
+            return "Remotely Disabled, Locally Enabled Feature"
+        case .remotelyDisabledLocallyDisabledFeature:
+            return "Remotely Disabled, Locally Disabled Feature"
+        case .remotelyUndefinedLocallyEnabledFeature:
+            return "Locally Enabled Feature with no corresponding remote key"
+        case .remotelyUndefinedLocallyDisabledFeature:
+            return "Locally Disabled Feature with no corresponding remote key"
         }
+    }
+
+    var remoteKey: String? {
+        switch self {
+        case .remotelyEnabledLocallyEnabledFeature,
+             .remotelyEnabledLocallyDisabledFeature,
+             .remotelyDisabledLocallyEnabledFeature,
+             .remotelyDisabledLocallyDisabledFeature:
+            return self.description
+        case .remotelyUndefinedLocallyEnabledFeature,
+             .remotelyUndefinedLocallyDisabledFeature:
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    var remoteValue: Bool? {
+        switch self {
+        case .remotelyEnabledLocallyEnabledFeature,
+             .remotelyEnabledLocallyDisabledFeature:
+            return true
+        case .remotelyDisabledLocallyEnabledFeature,
+             .remotelyDisabledLocallyDisabledFeature:
+            return false
+        case .remotelyUndefinedLocallyEnabledFeature,
+             .remotelyUndefinedLocallyDisabledFeature:
+            return nil
+        default:
+            return nil
+        }
+    }
+
+    var toRemoteFeatureFlag: RemoteFeatureFlag? {
+        guard
+            let remoteKey = remoteKey,
+            let remoteValue = remoteValue
+        else {
+            return nil
+        }
+        return RemoteFeatureFlag(title: remoteKey, value: remoteValue)
     }
 }
 

--- a/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
+++ b/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
@@ -11,8 +11,13 @@ class RemoteFeatureFlagTests: XCTestCase {
     func testThatDeviceIdIsTheSameForEveryInstanceOfTheStore() {
         let mock = MockFeatureFlagRemote()
         var deviceId = ""
+
+        let exp = expectation(description: "deviceIdCallback must be called twice")
+        exp.expectedFulfillmentCount = 2
+
         mock.deviceIdCallback = {
             deviceId == "" ? deviceId = $0 : XCTAssertEqual(deviceId, $0)
+            exp.fulfill()
         }
 
         RemoteFeatureFlagStore(remote: mock).update()

--- a/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
+++ b/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import WordPress
+
+class RemoteFeatureFlagTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        UserDefaults.standard.removeObject(forKey: RemoteFeatureFlagStore.Constants.CachedFlagsKey)
+        UserDefaults.standard.removeObject(forKey: RemoteFeatureFlagStore.Constants.DeviceIdKey)
+    }
+
+    func testThatDeviceIdIsTheSameForEveryInstanceOfTheStore() {
+        let mock = MockFeatureFlagRemote()
+        var deviceId = ""
+        mock.deviceIdCallback = {
+            deviceId == "" ? deviceId = $0 : XCTAssertEqual(deviceId, $0)
+        }
+
+        RemoteFeatureFlagStore(remote: mock).update()
+        RemoteFeatureFlagStore(remote: mock).update()
+    }
+
+    func testThatStoreReturnsCorrectCompileTimeDefaultForColdCache() {
+        let store = RemoteFeatureFlagStore()
+        XCTAssertTrue(store.value(for: MockFeatureFlag.remotelyEnabledLocallyEnabledFeature))
+        XCTAssertTrue(store.value(for: MockFeatureFlag.remotelyDisabledLocallyEnabledFeature))
+        XCTAssertTrue(store.value(for: MockFeatureFlag.remotelyUndefinedLocallyEnabledFeature))
+        XCTAssertFalse(store.value(for: MockFeatureFlag.remotelyEnabledLocallyDisabledFeature))
+        XCTAssertFalse(store.value(for: MockFeatureFlag.remotelyDisabledLocallyDisabledFeature))
+        XCTAssertFalse(store.value(for: MockFeatureFlag.remotelyUndefinedLocallyDisabledFeature))
+    }
+
+    func testThatStoreDoesNotHaveValueForColdCache() {
+        let store = RemoteFeatureFlagStore()
+        let flag = FeatureFlag.allCases.first!
+        XCTAssertFalse(store.hasValue(for: flag))
+    }
+
+    func testThatUpdateCachesNewFlags() {
+        let mock = MockFeatureFlagRemote(flags: MockFeatureFlag.remoteCases)
+
+        let store = RemoteFeatureFlagStore(remote: mock)
+        store.update()
+
+        // All of the remotely defined values should be present
+        XCTAssertTrue(store.hasValue(for: MockFeatureFlag.remotelyEnabledLocallyEnabledFeature))
+        XCTAssertTrue(store.hasValue(for: MockFeatureFlag.remotelyDisabledLocallyEnabledFeature))
+        XCTAssertTrue(store.hasValue(for: MockFeatureFlag.remotelyEnabledLocallyDisabledFeature))
+        XCTAssertTrue(store.hasValue(for: MockFeatureFlag.remotelyDisabledLocallyDisabledFeature))
+
+        // All of the remotely undefined values should not be present
+        XCTAssertFalse(store.hasValue(for: MockFeatureFlag.remotelyUndefinedLocallyEnabledFeature))
+        XCTAssertFalse(store.hasValue(for: MockFeatureFlag.remotelyUndefinedLocallyDisabledFeature))
+
+        // The remotely enabled flags should return true
+        XCTAssertTrue(store.value(for: MockFeatureFlag.remotelyEnabledLocallyEnabledFeature))
+        XCTAssertTrue(store.value(for: MockFeatureFlag.remotelyEnabledLocallyDisabledFeature))
+
+        // The remotely disabled flags should return false
+        XCTAssertFalse(store.value(for: MockFeatureFlag.remotelyDisabledLocallyEnabledFeature))
+        XCTAssertFalse(store.value(for: MockFeatureFlag.remotelyDisabledLocallyDisabledFeature))
+    }
+}
+
+class MockFeatureFlagRemote: FeatureFlagRemote {
+
+    var flags: FeatureFlagList
+    var deviceIdCallback: ((String) -> Void)?
+
+    init(flags: [MockFeatureFlag] = [], shouldSucceed: Bool = true) {
+        self.flags = flags
+            .compactMap { $0.toRemoteFeatureFlag }
+        super.init()
+    }
+
+    public override func getRemoteFeatureFlags(forDeviceId deviceId: String, callback: @escaping FeatureFlagResponseCallback) {
+        deviceIdCallback?(deviceId)
+        callback(.success(flags))
+    }
+}

--- a/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
+++ b/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class RemoteFeatureFlagTests: XCTestCase {
 
-    override func setUpWithError() throws {
+    override func setUp() {
         UserDefaults.standard.removeObject(forKey: RemoteFeatureFlagStore.Constants.CachedFlagsKey)
         UserDefaults.standard.removeObject(forKey: RemoteFeatureFlagStore.Constants.DeviceIdKey)
     }
@@ -22,6 +22,8 @@ class RemoteFeatureFlagTests: XCTestCase {
 
         RemoteFeatureFlagStore(remote: mock).update()
         RemoteFeatureFlagStore(remote: mock).update()
+
+        wait(for: [exp], timeout: 1.0)
     }
 
     func testThatStoreReturnsCorrectCompileTimeDefaultForColdCache() {

--- a/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
+++ b/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
@@ -73,7 +73,7 @@ class MockFeatureFlagRemote: FeatureFlagRemote {
 
     init(flags: [MockFeatureFlag] = [], shouldSucceed: Bool = true) {
         self.flags = flags
-            .compactMap { $0.toRemoteFeatureFlag }
+            .compactMap { $0.toFeatureFlag }
         super.init()
     }
 


### PR DESCRIPTION
Adds app-level support for remote feature flags.

Should be tested alongside https://github.com/wordpress-mobile/WordPressKit-iOS/pull/273

To test:
1. Apply this PR
2. In the `WordPress` scheme, go to Run > Arguments, and enable `-extra_debug 1`
3. Run the app, and filter logs by the 🚩 character.
4. You should see that the app does the following:
   - Generates a new Device ID (note it for later by copying it to the clipboard or something)
   - Updates the local cache of remote feature flags
5. Close the app
6. Run it again – this time it doesn't generate a new device ID – it uses the same one as before
7. If you'd like to test that the cache works, you can add this code at the top of the AppDelegate's `didFinishLaunching` method:

```swift
debugPrint("🚩 \(remoteFeatureFlagStore.valueForFlag(.unifiedAuth))")
```

It will print `true` to the console.

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
