### PR TITLE
Abort `rake dependencies` if path contains spaces

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ require 'yaml'
 require 'digest'
 
 PROJECT_DIR = File.expand_path(File.dirname(__FILE__))
+abort("Project directory contains one or more spaces – unable to continue.") if PROJECT_DIR.include?(' ')
 
 task default: %w[test]
 


### PR DESCRIPTION
libxml2 doesn’t work if there are spaces in the path, so to prevent weird issues, we’ll just warn the user.

**To test:**
Rename the directory that contains this project so that it has a space in it. Run `rake dependencies` in the directory.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
