### PR TITLE
Match Android's Reader events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -54,6 +54,7 @@ import Foundation
     case selectInterestsPicked
     case readerDiscoverShown
     case readerFollowingShown
+    case readerLikedShown
     case readerBlogPreviewed
     case readerDiscoverPaginated
     case readerPostCardTapped
@@ -149,6 +150,8 @@ import Foundation
             return "reader_discover_shown"
         case .readerFollowingShown:
             return "reader_following_shown"
+        case .readerLikedShown:
+            return "reader_liked_shown"
         case .readerBlogPreviewed:
             return "reader_blog_previewed"
         case .readerDiscoverPaginated:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -54,6 +54,7 @@ import Foundation
     case selectInterestsPicked
     case readerDiscoverShown
     case readerFollowingShown
+    case readerSavedListShown
     case readerLikedShown
     case readerBlogPreviewed
     case readerDiscoverPaginated
@@ -152,6 +153,8 @@ import Foundation
             return "reader_following_shown"
         case .readerLikedShown:
             return "reader_liked_shown"
+        case .readerSavedListShown:
+            return "reader_saved_list_shown"
         case .readerBlogPreviewed:
             return "reader_blog_previewed"
         case .readerDiscoverPaginated:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -53,6 +53,7 @@ import Foundation
     case selectInterestsShown
     case selectInterestsPicked
     case readerDiscoverShown
+    case readerFollowingShown
     case readerBlogPreviewed
     case readerDiscoverPaginated
     case readerPostCardTapped
@@ -146,6 +147,8 @@ import Foundation
             return "select_interests_picked"
         case .readerDiscoverShown:
             return "reader_discover_shown"
+        case .readerFollowingShown:
+            return "reader_following_shown"
         case .readerBlogPreviewed:
             return "reader_blog_previewed"
         case .readerDiscoverPaginated:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -144,9 +144,6 @@ import WordPressShared
         } else if topicIsLiked(topic) {
             WPAnalytics.track(.readerLikedShown, properties: properties)
 
-        } else if topicIsSavedForLater(topic) {
-            WPAnalytics.track(.readerSavedListShown, properties: properties)
-
         } else if isTopicSite(topic) {
             WPAnalytics.track(.readerBlogPreviewed, properties: properties)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -141,6 +141,9 @@ import WordPressShared
         } else if topicIsFollowing(topic) {
             WPAnalytics.track(.readerFollowingShown, properties: properties)
 
+        } else if topicIsLiked(topic) {
+            WPAnalytics.track(.readerLikedShown, properties: properties)
+
         } else if isTopicSite(topic) {
             WPAnalytics.track(.readerBlogPreviewed, properties: properties)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -122,7 +122,7 @@ import WordPressShared
     /// - Parameters:
     ///     - topic: A ReaderAbstractTopic
     ///
-    /// - Returns: True if the topic is for Discover
+    /// - Returns: True if the topic is for Saved For Later
     ///
     @objc open class func topicIsSavedForLater(_ topic: ReaderAbstractTopic) -> Bool {
         //TODO. Update this logic with the right one. I am not sure how this is going to be modeeled now.
@@ -143,6 +143,9 @@ import WordPressShared
 
         } else if topicIsLiked(topic) {
             WPAnalytics.track(.readerLikedShown, properties: properties)
+
+        } else if topicIsSavedForLater(topic) {
+            WPAnalytics.track(.readerSavedListShown, properties: properties)
 
         } else if isTopicSite(topic) {
             WPAnalytics.track(.readerBlogPreviewed, properties: properties)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -138,6 +138,9 @@ import WordPressShared
         if topicIsFreshlyPressed(topic) {
             stat = .readerFreshlyPressedLoaded
 
+        } else if topicIsFollowing(topic) {
+            WPAnalytics.track(.readerFollowingShown, properties: properties)
+
         } else if isTopicSite(topic) {
             WPAnalytics.track(.readerBlogPreviewed, properties: properties)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -66,13 +66,13 @@ extension ReaderSaveForLaterAction {
     func trackViewAllSavedPostsAction(origin: ReaderSaveForLaterOrigin) {
         let properties = [ readerSaveForLaterSourceKey: origin.viewAllPostsValue ]
 
-        WPAppAnalytics.track(.readerSavedListViewed, withProperties: properties)
+        WPAnalytics.track(.readerSavedListShown, properties: properties)
     }
 }
 
 extension ReaderMenuViewController {
     func trackSavedPostsNavigation() {
-        WPAppAnalytics.track(.readerSavedListViewed, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.readerMenu.viewAllPostsValue ])
+        WPAnalytics.track(.readerSavedListShown, properties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.readerMenu.viewAllPostsValue ])
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -176,6 +176,6 @@ extension ReaderStreamViewController {
 // MARK: - Tracks
 extension ReaderStreamViewController {
     func trackSavedListAccessed() {
-        WPAppAnalytics.track(.readerSavedListViewed, withProperties: ["source": ReaderSaveForLaterOrigin.readerMenu.viewAllPostsValue])
+        WPAnalytics.track(.readerSavedListShown, properties: ["source": ReaderSaveForLaterOrigin.readerMenu.viewAllPostsValue])
     }
 }


### PR DESCRIPTION
This PR adds some missing events introduced [in Android here](https://github.com/wordpress-mobile/WordPress-Android/pull/12818).

## To test

### Following

1. Tap Reader
2. Tap Following
3. Check that `reader_following_shown` is fired

### Saved

1. Tap Reader
2. Tap Saved
3. Check that `reader_saved_list_shown` is fired

### Liked

1. Tap Reader
2. Tap Liked
3. Check that `reader_liked_shown` is fired

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
