### PR TITLE
Fix pulsing dot appearing on My Site instead of Reader for the "Select Reader to continue" step

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -49,6 +49,7 @@ extension WPTabBarController {
     }
 
     private func getTabButton(at index: Int) -> UIView? {
+        tabBar.layoutIfNeeded()
         var tabs = tabBar.subviews.compactMap { return $0 is UIControl ? $0 : nil }
         tabs.sort { $0.frame.origin.x < $1.frame.origin.x }
         return tabs[safe: index]


### PR DESCRIPTION
Fixes #14780

## To test

1. Create a new blog
2. [Apply this patch](https://gist.github.com/leandroalonso/3626eb4b9fff39f1f6cc2fc73ca1e4f3)
3. Tap the blog you created
4. When the notice appears tap "Yes, show me"
5. Check that the spotlight appears in the "Reader" tab

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
