### PR TITLE
Update Reader Detail's Toolbar

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -49,11 +49,11 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         self.viewController = viewController
 
         likeCountObserver = post.observe(\.likeCount, options: .new) { [weak self] _, _ in
-            self?.configureButtonTitles()
+            self?.configureLikeActionButton(true)
         }
 
         commentCountObserver = post.observe(\.commentCount, options: .new) { [weak self] _, _ in
-            self?.configureButtonTitles()
+            self?.configureCommentActionButton()
         }
 
         configureActionButtons()
@@ -174,7 +174,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         likeButton.isEnabled = (ReaderHelpers.isLoggedIn() || post.likeCount.intValue > 0) && !post.isExternal
         // as by design spec, only display like counts
         let likeCount = post.likeCount()?.intValue ?? 0
-        let title = likeCount > 0 ? "\(likeCount)" : ""
+        let title = likeLabel(count: likeCount)
 
         let selected = post.isLiked
         let likeImage = UIImage(named: "icon-reader-like")
@@ -310,7 +310,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
         if traitCollection.horizontalSizeClass == .compact {
             // remove title text
-            let likeTitle = likeCount > 0 ?  String(likeCount) : ""
+            let likeTitle = likeLabel(count: likeCount)
             let commentTitle = commentCount > 0 ? String(commentCount) : ""
             likeButton.setTitle(likeTitle, for: .normal)
             commentButton.setTitle(commentTitle, for: .normal)
@@ -318,7 +318,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             WPStyleGuide.applyReaderReblogActionButtonTitle(reblogButton, showTitle: false)
 
         } else {
-            let likeTitle = WPStyleGuide.likeCountForDisplay(likeCount)
+            let likeTitle = likeLabel(count: likeCount)
             let commentTitle = WPStyleGuide.commentCountForDisplay(commentCount)
 
             likeButton.setTitle(likeTitle, for: .normal)
@@ -329,8 +329,14 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton)
             WPStyleGuide.applyReaderReblogActionButtonTitle(reblogButton)
         }
+    }
 
-
+    private func likeLabel(count: Int) -> String {
+        if traitCollection.horizontalSizeClass == .compact {
+            return count > 0 ? String(count) : ""
+        } else {
+            return WPStyleGuide.likeCountForDisplay(count)
+        }
     }
 
     // MARK: - Analytics

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -40,6 +40,8 @@ class ReaderDetailToolbar: UIView, NibLoadable {
                 configureActionButtons()
             }
         }
+
+        configureButtonTitles()
     }
 
     func configure(for post: ReaderPost, in viewController: UIViewController) {
@@ -136,6 +138,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         configureCommentActionButton()
         configureReblogButton()
         configureSaveForLaterButton()
+        configureButtonTitles()
     }
 
     private func resetActionButton(_ button: UIButton) {
@@ -151,9 +154,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     }
 
     private func configureActionButton(_ button: UIButton, title: String?, image: UIImage?, highlightedImage: UIImage?, selected: Bool) {
-        button.setTitle(title, for: UIControl.State())
-        button.setTitle(title, for: .highlighted)
-        button.setTitle(title, for: .disabled)
         button.setImage(image, for: UIControl.State())
         button.setImage(highlightedImage, for: .highlighted)
         button.setImage(highlightedImage, for: .selected)
@@ -161,6 +161,12 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         button.setImage(image, for: .disabled)
         button.isSelected = selected
         button.isHidden = false
+
+        if let title = title {
+            button.setTitle(title, for: UIControl.State())
+            button.setTitle(title, for: .highlighted)
+            button.setTitle(title, for: .disabled)
+        }
 
         WPStyleGuide.applyReaderActionButtonStyle(button)
     }
@@ -260,14 +266,9 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     }
 
     private func configureCommentActionButton() {
-        guard let commentCount = post?.commentCount else {
-            return
-        }
-
-        let title = commentCount.stringValue
         let image = UIImage(named: "icon-reader-comment")?.imageFlippedForRightToLeftLayoutDirection()
         let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageFlippedForRightToLeftLayoutDirection()
-        configureActionButton(commentButton, title: title, image: image, highlightedImage: highlightImage, selected: false)
+        configureActionButton(commentButton, title: nil, image: image, highlightedImage: highlightImage, selected: false)
         commentButton.isEnabled = shouldShowCommentActionButton
     }
 
@@ -306,6 +307,37 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         for button in buttonsToAdjust {
             button.flipInsetsForRightToLeftLayoutDirection()
         }
+    }
+
+    fileprivate func configureButtonTitles() {
+        guard let post = post else {
+            return
+        }
+
+        let likeCount = post.likeCount()?.intValue ?? 0
+        let commentCount = post.commentCount()?.intValue ?? 0
+
+        if self.traitCollection.horizontalSizeClass == .compact {
+            // remove title text
+            let likeTitle = likeCount > 0 ?  String(likeCount) : ""
+            let commentTitle = commentCount > 0 ? String(commentCount) : ""
+            likeButton.setTitle(likeTitle, for: .normal)
+            commentButton.setTitle(commentTitle, for: .normal)
+            WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton, showTitle: false)
+            WPStyleGuide.applyReaderReblogActionButtonTitle(reblogButton, showTitle: false)
+
+        } else {
+            let likeTitle = WPStyleGuide.likeCountForDisplay(likeCount)
+            let commentTitle = WPStyleGuide.commentCountForDisplay(commentCount)
+
+            likeButton.setTitle(likeTitle, for: .normal)
+            commentButton.setTitle(commentTitle, for: .normal)
+
+            WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton)
+            WPStyleGuide.applyReaderReblogActionButtonTitle(reblogButton)
+        }
+
+
     }
 
     // MARK: - Analytics

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -149,7 +149,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         button.setImage(nil, for: .highlighted)
         button.setImage(nil, for: .disabled)
         button.isSelected = false
-        button.isHidden = true
         button.isEnabled = true
     }
 
@@ -163,7 +162,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         button.setImage(highlightedImage, for: [.highlighted, .selected])
         button.setImage(image, for: .disabled)
         button.isSelected = selected
-        button.isHidden = false
 
         WPStyleGuide.applyReaderActionButtonStyle(button)
     }
@@ -196,7 +194,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         }
 
         reblogButton.isEnabled = ReaderHelpers.isLoggedIn() && !post.isPrivate()
-        reblogButton.isHidden = false
         WPStyleGuide.applyReaderReblogActionButtonStyle(reblogButton, showTitle: false)
     }
 
@@ -263,9 +260,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     }
 
     private func configureCommentActionButton() {
-        let image = UIImage(named: "icon-reader-comment")?.imageFlippedForRightToLeftLayoutDirection()
-        let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageFlippedForRightToLeftLayoutDirection()
-        configureActionButton(commentButton, title: nil, image: image, highlightedImage: highlightImage, selected: false)
+        WPStyleGuide.applyReaderCardCommentButtonStyle(commentButton, defaultSize: true)
         commentButton.isEnabled = shouldShowCommentActionButton
     }
 
@@ -291,7 +286,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         WPStyleGuide.applyReaderSaveForLaterButtonStyle(saveForLaterButton)
         WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton, showTitle: false)
 
-        saveForLaterButton.isHidden = false
         saveForLaterButton.isSelected = post?.isSavedForLater ?? false
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -49,11 +49,11 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         self.viewController = viewController
 
         likeCountObserver = post.observe(\.likeCount, options: .new) { [weak self] _, _ in
-            self?.configureLikeActionButton(true)
+            self?.configureButtonTitles()
         }
 
         commentCountObserver = post.observe(\.commentCount, options: .new) { [weak self] _, _ in
-            self?.configureCommentActionButton()
+            self?.configureButtonTitles()
         }
 
         configureActionButtons()
@@ -154,6 +154,9 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     }
 
     private func configureActionButton(_ button: UIButton, title: String?, image: UIImage?, highlightedImage: UIImage?, selected: Bool) {
+        button.setTitle(title, for: UIControl.State())
+        button.setTitle(title, for: .highlighted)
+        button.setTitle(title, for: .disabled)
         button.setImage(image, for: UIControl.State())
         button.setImage(highlightedImage, for: .highlighted)
         button.setImage(highlightedImage, for: .selected)
@@ -161,12 +164,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         button.setImage(image, for: .disabled)
         button.isSelected = selected
         button.isHidden = false
-
-        if let title = title {
-            button.setTitle(title, for: UIControl.State())
-            button.setTitle(title, for: .highlighted)
-            button.setTitle(title, for: .disabled)
-        }
 
         WPStyleGuide.applyReaderActionButtonStyle(button)
     }
@@ -317,7 +314,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         let likeCount = post.likeCount()?.intValue ?? 0
         let commentCount = post.commentCount()?.intValue ?? 0
 
-        if self.traitCollection.horizontalSizeClass == .compact {
+        if traitCollection.horizontalSizeClass == .compact {
             // remove title text
             let likeTitle = likeCount > 0 ?  String(likeCount) : ""
             let commentTitle = commentCount > 0 ? String(commentCount) : ""

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -122,10 +122,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         resetActionButton(saveForLaterButton)
         resetActionButton(reblogButton)
 
-        guard let post = post else {
-            return
-        }
-
         configureLikeActionButton()
         configureCommentActionButton()
         configureReblogButton()

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -199,10 +199,8 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
     private func playLikeButtonAnimation() {
         let likeImageView = likeButton.imageView!
-        let frame = likeButton.convert(likeImageView.frame, from: likeImageView)
 
         let imageView = UIImageView(image: UIImage(named: "icon-reader-liked"))
-        imageView.frame = frame
         likeButton.addSubview(imageView)
 
         let animationDuration = 0.3
@@ -211,7 +209,9 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             // Prep a mask to hide the likeButton's image, since changes to visiblility and alpha are ignored
             let mask = UIView(frame: frame)
             mask.backgroundColor = backgroundColor
-            likeButton.addSubview(mask)
+            likeImageView.addSubview(mask)
+            likeImageView.pinSubviewToAllEdges(mask)
+            mask.translatesAutoresizingMaskIntoConstraints = false
             likeButton.bringSubviewToFront(imageView)
 
             // Configure starting state

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -32,6 +32,16 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         prepareActionButtonsForVoiceOver()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                configureActionButtons()
+            }
+        }
+    }
+
     func configure(for post: ReaderPost, in viewController: UIViewController) {
         self.post = post
         self.viewController = viewController

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -313,7 +313,9 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             let likeTitle = likeLabel(count: likeCount)
             let commentTitle = commentCount > 0 ? String(commentCount) : ""
             likeButton.setTitle(likeTitle, for: .normal)
+            likeButton.setTitle(likeTitle, for: .highlighted)
             commentButton.setTitle(commentTitle, for: .normal)
+            commentButton.setTitle(commentTitle, for: .highlighted)
             WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton, showTitle: false)
             WPStyleGuide.applyReaderReblogActionButtonTitle(reblogButton, showTitle: false)
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -308,28 +308,25 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         let likeCount = post.likeCount()?.intValue ?? 0
         let commentCount = post.commentCount()?.intValue ?? 0
 
+        let likeTitle = likeLabel(count: likeCount)
+        let commentTitle: String = commentLabel(count: commentCount)
+        let showTitle: Bool = traitCollection.horizontalSizeClass != .compact
+
+        likeButton.setTitle(likeTitle, for: .normal)
+        likeButton.setTitle(likeTitle, for: .highlighted)
+
+        commentButton.setTitle(commentTitle, for: .normal)
+        commentButton.setTitle(commentTitle, for: .highlighted)
+
+        WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton, showTitle: showTitle)
+        WPStyleGuide.applyReaderReblogActionButtonTitle(reblogButton, showTitle: showTitle)
+    }
+
+    private func commentLabel(count: Int) -> String {
         if traitCollection.horizontalSizeClass == .compact {
-            // remove title text
-            let likeTitle = likeLabel(count: likeCount)
-            let commentTitle = commentCount > 0 ? String(commentCount) : ""
-            likeButton.setTitle(likeTitle, for: .normal)
-            likeButton.setTitle(likeTitle, for: .highlighted)
-            commentButton.setTitle(commentTitle, for: .normal)
-            commentButton.setTitle(commentTitle, for: .highlighted)
-            WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton, showTitle: false)
-            WPStyleGuide.applyReaderReblogActionButtonTitle(reblogButton, showTitle: false)
-
+            return count > 0 ? String(count) : ""
         } else {
-            let likeTitle = likeLabel(count: likeCount)
-            let commentTitle = WPStyleGuide.commentCountForDisplay(commentCount)
-
-            likeButton.setTitle(likeTitle, for: .normal)
-            likeButton.setTitle(likeTitle, for: .highlighted)
-            commentButton.setTitle(commentTitle, for: .normal)
-            commentButton.setTitle(commentTitle, for: .highlighted)
-
-            WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton)
-            WPStyleGuide.applyReaderReblogActionButtonTitle(reblogButton)
+            return WPStyleGuide.commentCountForDisplay(count)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -322,7 +322,9 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             let commentTitle = WPStyleGuide.commentCountForDisplay(commentCount)
 
             likeButton.setTitle(likeTitle, for: .normal)
+            likeButton.setTitle(likeTitle, for: .highlighted)
             commentButton.setTitle(commentTitle, for: .normal)
+            commentButton.setTitle(commentTitle, for: .highlighted)
 
             WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton)
             WPStyleGuide.applyReaderReblogActionButtonTitle(reblogButton)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
@@ -19,7 +19,7 @@
                         <constraint firstAttribute="height" constant="1" id="ikP-PI-Is1"/>
                     </constraints>
                 </view>
-                <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" distribution="equalSpacing" spacing="60" translatesAutoresizingMaskIntoConstraints="NO" id="TSN-68-1mv">
+                <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="TSN-68-1mv">
                     <rect key="frame" x="28" y="426" width="358" height="44"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kYk-HZ-8zf">
@@ -38,7 +38,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TVh-aP-o67" customClass="PostMetaButton">
-                            <rect key="frame" x="104" y="0.0" width="46" height="44"/>
+                            <rect key="frame" x="100.5" y="0.0" width="48" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="Z2e-Ky-bYe"/>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="j4t-0h-sz7"/>
@@ -53,7 +53,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ndi-cj-PVP" customClass="PostMetaButton">
-                            <rect key="frame" x="210" y="0.0" width="44" height="44"/>
+                            <rect key="frame" x="205.5" y="0.0" width="44" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="GbG-ii-IcP"/>
                                 <constraint firstAttribute="height" constant="44" id="qNK-wQ-gIc"/>
@@ -68,7 +68,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Ht-4U-b7J" customClass="PostMetaButton">
-                            <rect key="frame" x="314" y="0.0" width="44" height="44"/>
+                            <rect key="frame" x="306" y="0.0" width="52" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="Fio-gF-mFy"/>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="JqZ-KF-mxs"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
@@ -20,12 +20,12 @@
                     </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" distribution="equalSpacing" spacing="60" translatesAutoresizingMaskIntoConstraints="NO" id="TSN-68-1mv">
-                    <rect key="frame" x="28" y="436" width="358" height="24"/>
+                    <rect key="frame" x="28" y="426" width="358" height="44"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kYk-HZ-8zf">
-                            <rect key="frame" x="0.0" y="0.0" width="44" height="24"/>
+                            <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="24" id="fqQ-GT-Dks"/>
+                                <constraint firstAttribute="height" constant="44" id="fqQ-GT-Dks"/>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="sbH-ur-3hQ"/>
                             </constraints>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
@@ -38,9 +38,9 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TVh-aP-o67" customClass="PostMetaButton">
-                            <rect key="frame" x="104" y="0.0" width="46" height="24"/>
+                            <rect key="frame" x="104" y="0.0" width="46" height="44"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="24" id="Z2e-Ky-bYe"/>
+                                <constraint firstAttribute="height" constant="44" id="Z2e-Ky-bYe"/>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="j4t-0h-sz7"/>
                             </constraints>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
@@ -53,10 +53,10 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ndi-cj-PVP" customClass="PostMetaButton">
-                            <rect key="frame" x="210" y="0.0" width="44" height="24"/>
+                            <rect key="frame" x="210" y="0.0" width="44" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="GbG-ii-IcP"/>
-                                <constraint firstAttribute="height" constant="24" id="qNK-wQ-gIc"/>
+                                <constraint firstAttribute="height" constant="44" id="qNK-wQ-gIc"/>
                             </constraints>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
@@ -68,9 +68,9 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Ht-4U-b7J" customClass="PostMetaButton">
-                            <rect key="frame" x="314" y="0.0" width="44" height="24"/>
+                            <rect key="frame" x="314" y="0.0" width="44" height="44"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="24" id="Fio-gF-mFy"/>
+                                <constraint firstAttribute="height" constant="44" id="Fio-gF-mFy"/>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="JqZ-KF-mxs"/>
                             </constraints>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -19,11 +19,11 @@
                         <constraint firstAttribute="height" constant="1" id="ikP-PI-Is1"/>
                     </constraints>
                 </view>
-                <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TSN-68-1mv">
-                    <rect key="frame" x="28" y="423" width="358" height="50"/>
+                <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" distribution="fillEqually" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TSN-68-1mv">
+                    <rect key="frame" x="28" y="436" width="358" height="24"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kYk-HZ-8zf">
-                            <rect key="frame" x="0.0" y="13" width="32" height="24"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kYk-HZ-8zf">
+                            <rect key="frame" x="0.0" y="0.0" width="77.5" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="24" id="fqQ-GT-Dks"/>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="sbH-ur-3hQ"/>
@@ -37,11 +37,8 @@
                                 <action selector="didTapSaveForLater:" destination="opk-iy-IwF" eventType="touchUpInside" id="PDn-1T-rlh"/>
                             </connections>
                         </button>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p01-2J-g2A">
-                            <rect key="frame" x="48" y="0.0" width="143" height="50"/>
-                        </view>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TVh-aP-o67" customClass="PostMetaButton">
-                            <rect key="frame" x="207" y="13" width="40" height="24"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TVh-aP-o67" customClass="PostMetaButton">
+                            <rect key="frame" x="93.5" y="0.0" width="77.5" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="24" id="Z2e-Ky-bYe"/>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="j4t-0h-sz7"/>
@@ -54,8 +51,8 @@
                                 <action selector="didTapReblog:" destination="opk-iy-IwF" eventType="touchUpInside" id="4SX-vl-xza"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ndi-cj-PVP" customClass="PostMetaButton">
-                            <rect key="frame" x="263" y="13" width="32" height="24"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ndi-cj-PVP" customClass="PostMetaButton">
+                            <rect key="frame" x="187" y="0.0" width="77.5" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="GbG-ii-IcP"/>
                                 <constraint firstAttribute="height" constant="24" id="qNK-wQ-gIc"/>
@@ -69,8 +66,8 @@
                                 <action selector="didTapComment:" destination="opk-iy-IwF" eventType="touchUpInside" id="QGB-ei-h8b"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Ht-4U-b7J" customClass="PostMetaButton">
-                            <rect key="frame" x="311" y="13" width="47" height="24"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Ht-4U-b7J" customClass="PostMetaButton">
+                            <rect key="frame" x="280.5" y="0.0" width="77.5" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="24" id="Fio-gF-mFy"/>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="JqZ-KF-mxs"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
@@ -19,16 +19,16 @@
                         <constraint firstAttribute="height" constant="1" id="ikP-PI-Is1"/>
                     </constraints>
                 </view>
-                <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" distribution="fillEqually" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="TSN-68-1mv">
+                <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" distribution="equalSpacing" spacing="60" translatesAutoresizingMaskIntoConstraints="NO" id="TSN-68-1mv">
                     <rect key="frame" x="28" y="436" width="358" height="24"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kYk-HZ-8zf">
-                            <rect key="frame" x="0.0" y="0.0" width="77.5" height="24"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kYk-HZ-8zf">
+                            <rect key="frame" x="0.0" y="0.0" width="44" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="24" id="fqQ-GT-Dks"/>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="sbH-ur-3hQ"/>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="sbH-ur-3hQ"/>
                             </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="-4" maxY="0.0"/>
                             <state key="normal" title="0" image="icon-reader-comment">
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -37,13 +37,14 @@
                                 <action selector="didTapSaveForLater:" destination="opk-iy-IwF" eventType="touchUpInside" id="PDn-1T-rlh"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TVh-aP-o67" customClass="PostMetaButton">
-                            <rect key="frame" x="93.5" y="0.0" width="77.5" height="24"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TVh-aP-o67" customClass="PostMetaButton">
+                            <rect key="frame" x="104" y="0.0" width="46" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="24" id="Z2e-Ky-bYe"/>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="j4t-0h-sz7"/>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="j4t-0h-sz7"/>
                             </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                            <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="-4" maxY="0.0"/>
                             <state key="normal" title="Reblog">
                                 <color key="titleShadowColor" red="0.50196078430000002" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>
@@ -51,13 +52,13 @@
                                 <action selector="didTapReblog:" destination="opk-iy-IwF" eventType="touchUpInside" id="4SX-vl-xza"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ndi-cj-PVP" customClass="PostMetaButton">
-                            <rect key="frame" x="187" y="0.0" width="77.5" height="24"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ndi-cj-PVP" customClass="PostMetaButton">
+                            <rect key="frame" x="210" y="0.0" width="44" height="24"/>
                             <constraints>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="GbG-ii-IcP"/>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="GbG-ii-IcP"/>
                                 <constraint firstAttribute="height" constant="24" id="qNK-wQ-gIc"/>
                             </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
                             <state key="normal" title="0" image="icon-reader-comment">
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -66,13 +67,13 @@
                                 <action selector="didTapComment:" destination="opk-iy-IwF" eventType="touchUpInside" id="QGB-ei-h8b"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Ht-4U-b7J" customClass="PostMetaButton">
-                            <rect key="frame" x="280.5" y="0.0" width="77.5" height="24"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="999" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Ht-4U-b7J" customClass="PostMetaButton">
+                            <rect key="frame" x="314" y="0.0" width="44" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="24" id="Fio-gF-mFy"/>
-                                <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="JqZ-KF-mxs"/>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="JqZ-KF-mxs"/>
                             </constraints>
-                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
                             <state key="normal" title="Like" image="icon-reader-like">
                                 <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.xib
@@ -44,7 +44,7 @@
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="44" id="j4t-0h-sz7"/>
                             </constraints>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="-4" maxY="0.0"/>
+                            <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="-4" maxY="0.0"/>
                             <state key="normal" title="Reblog">
                                 <color key="titleShadowColor" red="0.50196078430000002" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </state>

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -363,8 +363,8 @@ extension WPStyleGuide {
         applyReaderStreamActionButtonStyle(button)
     }
 
-    @objc public class func applyReaderCardCommentButtonStyle(_ button: UIButton) {
-        let size = Cards.actionButtonSize
+    @objc public class func applyReaderCardCommentButtonStyle(_ button: UIButton, defaultSize: Bool = false) {
+        let size = defaultSize ? Gridicon.defaultSize : Cards.actionButtonSize
         let icon = UIImage(named: "icon-reader-comment-outline")?.imageFlippedForRightToLeftLayoutDirection()
         let selectedIcon = UIImage(named: "icon-reader-comment-outline-highlighted")?.imageFlippedForRightToLeftLayoutDirection()
 


### PR DESCRIPTION
Part of #14767

This PR updates the Reader Detail's toolbar — changes are just visual.

| iPhone  | iPad |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone 11 - 2020-09-02 at 14 04 05](https://user-images.githubusercontent.com/7040243/92014848-44617800-ed26-11ea-9099-c75f49319a19.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-09-02 at 14 07 44](https://user-images.githubusercontent.com/7040243/92014879-504d3a00-ed26-11ea-97ce-2afbf4799282.png) |

## To test

Test the toolbar in multiple devices (portrait and landscape) and in light/dark mode.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
