### PR TITLE
UL&S Tracking: tracks dismissal of the Help screen. 

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -177,6 +177,10 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     var showSupportNotificationIndicator: Bool {
         return ZendeskUtils.showSupportNotificationIndicator
     }
+    
+    private var tracker: AuthenticatorAnalyticsTracker {
+        AuthenticatorAnalyticsTracker.shared
+    }
 
     /// We allow to connect with WordPress.com account only if there is no default account connected already.
     var allowWPComLogin: Bool {
@@ -190,7 +194,9 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         // Reset the nav style so the Support nav bar has the WP style, not the Auth style.
         WPStyleGuide.configureNavigationAppearance()
 
-        let controller = SupportTableViewController()
+        let controller = SupportTableViewController { [weak self] in
+            self?.tracker.track(click: .dismiss)
+        }
         controller.sourceTag = sourceTag
 
         let navController = UINavigationController(rootViewController: controller)

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -177,7 +177,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     var showSupportNotificationIndicator: Bool {
         return ZendeskUtils.showSupportNotificationIndicator
     }
-    
+
     private var tracker: AuthenticatorAnalyticsTracker {
         AuthenticatorAnalyticsTracker.shared
     }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -14,6 +14,11 @@ class SupportTableViewController: UITableViewController {
     private var tableHandler: ImmuTableViewHandler?
     private let userDefaults = UserDefaults.standard
 
+    /// This closure is called when this VC is about to be dismissed due to the user
+    /// tapping the dismiss button.
+    ///
+    private var dismissTapped: (() -> ())?
+
     // MARK: - Init
 
     override init(style: UITableView.Style) {
@@ -24,8 +29,9 @@ class SupportTableViewController: UITableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    required convenience init() {
+    required convenience init(dismissTapped: (() -> ())? = nil) {
         self.init(style: .grouped)
+        self.dismissTapped = dismissTapped
     }
 
     // MARK: - View
@@ -69,6 +75,7 @@ class SupportTableViewController: UITableViewController {
     // MARK: - Button Actions
 
     @IBAction func dismissPressed(_ sender: AnyObject) {
+        dismissTapped?()
         dismiss(animated: true)
     }
 


### PR DESCRIPTION
Adds missing tracking of the dismissal of the help dialogue during the sign in flows.

## Testing:

### Test 1: Tracking works

In your console in Xcode, filter by "Tracked: unified".

1. Pic one of the enabled flows (Site Address, Google, SIWA) to Sign In.
2. Once you see the Help button in the top right corner of any screen tap it.
3. When the help screen is up, tap "Close".

Make sure you see this event in Xcode's console:

🔵 Tracked: unified_login_interaction <click: dismiss, flow: XXXX, source: default, step: help>

### Test 2: no tracking in outside of Sign In

1. Once logged in go to "Me"
2. Tap "Help & Support"
3. Tap close.

Make sure you don't see the unified track event reported above.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
