### PR TITLE
Reader Improvements: Detail Update: Add topics to the detail view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -267,6 +267,11 @@ class ReaderDetailCoordinator {
         ReaderPostMenu.showMenuForPost(post, topic: siteTopic, fromView: anchorView, inViewController: viewController)
     }
 
+    private func showTopic(_ topic: String) {
+        let controller = ReaderStreamViewController.controllerWithTagSlug(topic)
+        viewController?.navigationController?.pushViewController(controller, animated: true)
+    }
+
     /// Show a list with posts contianing this tag
     ///
     private func showTag() {
@@ -453,6 +458,10 @@ extension ReaderDetailCoordinator: ReaderDetailHeaderViewDelegate {
 
     func didTapFollowButton() {
         followSite()
+    }
+
+    func didSelectTopic(_ topic: String) {
+        showTopic(topic)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -234,12 +234,18 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
         navBar.tintColor = tintColor
     }
 
+    static func shouldDisplayFeaturedImage(with post: ReaderPost) -> Bool {
+        let imageURL = URL(string: post.featuredImage)
+
+        return imageURL != nil && !post.contentIncludesFeaturedImage()
+    }
+
     // MARK: - Private: Network Helpers
     public func load(completion: @escaping () -> Void) {
         guard
             let post = self.post,
             let imageURL = URL(string: post.featuredImage),
-            !post.contentIncludesFeaturedImage()
+            Self.shouldDisplayFeaturedImage(with: post)
         else {
             reset()
             isLoaded = true

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
@@ -22,6 +22,8 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
     @IBOutlet weak var dateLabel: UILabel!
     @IBOutlet weak var followButton: UIButton!
     @IBOutlet weak var iPadFollowButton: UIButton!
+
+    @IBOutlet weak var collectionViewPaddingView: UIView!
     @IBOutlet weak var topicsCollectionView: TopicsCollectionView!
 
     /// The post to show details in the header
@@ -191,8 +193,12 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
             !tags.isEmpty
         else {
             topicsCollectionView.isHidden = true
+            collectionViewPaddingView.isHidden = true
             return
         }
+
+        let featuredImageIsDisplayed = ReaderDetailFeaturedImageView.shouldDisplayFeaturedImage(with: post)
+        collectionViewPaddingView.isHidden = !featuredImageIsDisplayed
 
         topicsCollectionView.topicDelegate = self
         topicsCollectionView.topics = tags

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
@@ -6,6 +6,7 @@ protocol ReaderDetailHeaderViewDelegate {
     func didTapMenuButton(_ sender: UIView)
     func didTapHeaderAvatar()
     func didTapFollowButton()
+    func didSelectTopic(_ topic: String)
 }
 
 class ReaderDetailHeaderView: UIStackView, NibLoadable {
@@ -21,7 +22,7 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
     @IBOutlet weak var dateLabel: UILabel!
     @IBOutlet weak var followButton: UIButton!
     @IBOutlet weak var iPadFollowButton: UIButton!
-
+    @IBOutlet weak var topicsCollectionView: TopicsCollectionView!
 
     /// The post to show details in the header
     ///
@@ -49,6 +50,7 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
         configureDateLabel()
         configureFollowButton()
         configureNotifications()
+        configureTopicsCollectionView()
 
         prepareForVoiceOver()
         prepareMenuForVoiceOver()
@@ -182,6 +184,21 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
         NotificationCenter.default.addObserver(self, selector: #selector(preferredContentSizeChanged), name: UIContentSizeCategory.didChangeNotification, object: nil)
     }
 
+    func configureTopicsCollectionView() {
+        guard
+            let post = post,
+            let tags = post.tagsForDisplay(),
+            !tags.isEmpty
+        else {
+            topicsCollectionView.isHidden = true
+            return
+        }
+
+        topicsCollectionView.topicDelegate = self
+        topicsCollectionView.topics = tags
+        topicsCollectionView.isHidden = false
+    }
+
     @objc private func preferredContentSizeChanged() {
         configureTitle()
     }
@@ -232,4 +249,14 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
         titleLabel.accessibilityTraits = .staticText
     }
 
+}
+
+extension ReaderDetailHeaderView: ReaderTopicCollectionViewCoordinatorDelegate {
+    func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didChangeState: ReaderTopicCollectionViewState) {
+        self.layoutIfNeeded()
+    }
+
+    func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didSelectTopic topic: String) {
+        delegate?.didSelectTopic(topic)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.xib
@@ -18,26 +18,26 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QPG-TJ-mSj">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="10"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="16"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="10" id="4PO-aU-A3l"/>
+                        <constraint firstAttribute="height" constant="16" id="4PO-aU-A3l"/>
                     </constraints>
                 </view>
                 <collectionView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="20" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="hs4-NA-2lr" customClass="TopicsCollectionView" customModule="WordPress" customModuleProvider="target">
-                    <rect key="frame" x="16" y="10" width="382" height="0.0"/>
+                    <rect key="frame" x="16" y="16" width="382" height="0.0"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                     <collectionViewLayout key="collectionViewLayout" id="Ucj-vS-mRR"/>
                 </collectionView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PfO-Ue-G3x">
-                    <rect key="frame" x="0.0" y="10" width="414" height="10"/>
+                    <rect key="frame" x="0.0" y="16" width="414" height="8"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="10" id="icJ-zH-xxc"/>
+                        <constraint firstAttribute="height" constant="8" id="icJ-zH-xxc"/>
                     </constraints>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="vvq-7F-Zcz">
-                    <rect key="frame" x="16" y="20" width="382" height="99"/>
+                    <rect key="frame" x="16" y="24" width="382" height="95"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -207,6 +207,7 @@
                 <outlet property="blogNameButton" destination="nBe-4U-XT8" id="XDf-iB-EKh"/>
                 <outlet property="blogURLLabel" destination="LdR-mh-skh" id="Jpq-BT-i1D"/>
                 <outlet property="byLabel" destination="jmd-NR-EOk" id="MiZ-ih-Gdl"/>
+                <outlet property="collectionViewPaddingView" destination="QPG-TJ-mSj" id="IxN-dx-KTC"/>
                 <outlet property="dateLabel" destination="CJe-cC-zGx" id="cIX-oU-7Gh"/>
                 <outlet property="followButton" destination="EaI-jA-EG4" id="PMJ-Ah-b0r"/>
                 <outlet property="headerView" destination="KHc-Ky-UGH" id="eLs-Cu-7cX"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.xib
@@ -18,14 +18,26 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="200"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QPG-TJ-mSj">
-                    <rect key="frame" x="0.0" y="0.0" width="414" height="6"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="10"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="6" id="4PO-aU-A3l"/>
+                        <constraint firstAttribute="height" constant="10" id="4PO-aU-A3l"/>
+                    </constraints>
+                </view>
+                <collectionView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="20" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="hs4-NA-2lr" customClass="TopicsCollectionView" customModule="WordPress" customModuleProvider="target">
+                    <rect key="frame" x="16" y="10" width="382" height="0.0"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <collectionViewLayout key="collectionViewLayout" id="Ucj-vS-mRR"/>
+                </collectionView>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PfO-Ue-G3x">
+                    <rect key="frame" x="0.0" y="10" width="414" height="10"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="10" id="icJ-zH-xxc"/>
                     </constraints>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="vvq-7F-Zcz">
-                    <rect key="frame" x="16" y="6" width="382" height="113"/>
+                    <rect key="frame" x="16" y="20" width="382" height="99"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -177,9 +189,11 @@
             </subviews>
             <constraints>
                 <constraint firstItem="vvq-7F-Zcz" firstAttribute="leading" secondItem="qVA-Br-hgv" secondAttribute="leading" constant="16" id="5Yh-Yt-Pm9"/>
+                <constraint firstAttribute="trailing" secondItem="hs4-NA-2lr" secondAttribute="trailing" constant="16" id="7E7-9R-UTl"/>
                 <constraint firstAttribute="trailing" secondItem="dMP-sD-Xuf" secondAttribute="trailing" constant="16" id="9eO-Rp-2dJ"/>
                 <constraint firstItem="9pz-cp-bwp" firstAttribute="leading" secondItem="qVA-Br-hgv" secondAttribute="leading" id="G5t-Sf-gmz"/>
                 <constraint firstAttribute="trailing" secondItem="9pz-cp-bwp" secondAttribute="trailing" id="Jf3-x1-ED8"/>
+                <constraint firstItem="hs4-NA-2lr" firstAttribute="leading" secondItem="qVA-Br-hgv" secondAttribute="leading" constant="16" id="akO-co-t2p"/>
                 <constraint firstItem="VZW-x2-i8F" firstAttribute="leading" secondItem="qVA-Br-hgv" secondAttribute="leading" id="jFa-IF-qGe"/>
                 <constraint firstAttribute="trailing" secondItem="vvq-7F-Zcz" secondAttribute="trailing" constant="16" id="tTY-SF-4qB"/>
                 <constraint firstItem="dMP-sD-Xuf" firstAttribute="leading" secondItem="qVA-Br-hgv" secondAttribute="leading" constant="16" id="vQH-5F-dZg"/>
@@ -200,6 +214,7 @@
                 <outlet property="menuButton" destination="1v1-3D-xzR" id="12P-dV-Zzr"/>
                 <outlet property="titleBottomPaddingView" destination="VZW-x2-i8F" id="hHj-gn-v51"/>
                 <outlet property="titleLabel" destination="vvq-7F-Zcz" id="c17-PA-dEb"/>
+                <outlet property="topicsCollectionView" destination="hs4-NA-2lr" id="GvY-pa-Wyc"/>
             </connections>
             <point key="canvasLocation" x="720" y="-107"/>
         </stackView>

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -130,7 +130,7 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
         // Update content size
         contentSize.width = maxContentWidth
-        contentSize.height = (currentRow + 1) * (cellHeight + itemSpacing) + contentInsets.top + contentInsets.bottom
+        contentSize.height = (currentRow + 1) * cellHeight + contentInsets.top + contentInsets.bottom + (currentRow * itemSpacing)
     }
 
     override func invalidateLayout() {


### PR DESCRIPTION
Depends on: https://github.com/wordpress-mobile/WordPress-iOS/pull/14821

Main Project: #14767

### Screenshots

|Collapsed|Expanded|
|---|---|
|<img src="https://user-images.githubusercontent.com/793774/92036893-c8ffc680-ed25-11ea-9edc-8c351e818545.png" /> |<img src="https://user-images.githubusercontent.com/793774/92036884-c604d600-ed25-11ea-81ba-402d7d6721ec.png" />|

### To test:
1. Launch the app 
2. Tap on the Reader tab
3. Tap on a card with some tags

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
