### PR TITLE
Fix crash on iOS12 when trying to open Unsupported Block Editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebNavigationViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebNavigationViewController.swift
@@ -9,7 +9,8 @@ class GutenbergWebNavigationController: UINavigationController {
     init(with post: AbstractPost, block: Block) throws {
         gutenbergWebController = try GutenbergWebViewController(with: post, block: block)
         blockName = block.name
-        super.init(rootViewController: gutenbergWebController)
+        super.init(nibName: nil, bundle: nil)
+        viewControllers = [gutenbergWebController]
         gutenbergWebController.delegate = self
     }
 


### PR DESCRIPTION
On iOS12, UIKit was trying to call `init(nibName:bundle:)` after the subclass called `super.init(rootViewController:)`.
This sounds like an internal UIKit bug and it's been fixed on iOS13, but we still need to consider it for older versions.

This is intended to be merged to the current frozen branch `15.6`.

Fixes #14792

To test:
- Run the project on a device (or sim) running iOS 12.x.
- Open a post with Gutenberg Mobile on a simple site that has an unsupported block in it.
- Open the unsupported block editor ((?) button on the Missing block UI).
- Check that the app doesn't crash.

cc @designsimply @jkmassel 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
