### PR TITLE
Debug menu: Add option to clear CSS cache

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -72,7 +72,7 @@ class DebugMenuViewController: UITableViewController {
                 ReaderCSS().clearCache()
                 let alert = UIAlertController(title: NSLocalizedString("Cache cleared!", comment: "Debug message informing the user that the cache for CSS in the Reader has been cleared"),
                                               message: nil, preferredStyle: .alert)
-                alert.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: ""))
+                alert.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: "Dismisses an alert"))
                 self?.present(alert, animated: true, completion: nil)
                 self?.tableView.deselectSelectedRowWithAnimationAfterDelay(true)
             })

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -68,6 +68,14 @@ class DebugMenuViewController: UITableViewController {
             ButtonRow(title: Strings.quickStartRow, action: { [weak self] _ in
                 self?.displayBlogPickerForQuickStart()
             }),
+            ButtonRow(title: Strings.clearCSSCache, action: { [weak self] _ in
+                ReaderCSS().clearCache()
+                let alert = UIAlertController(title: NSLocalizedString("Cache cleared!", comment: "Debug message informing the user that the cache for CSS in the Reader has been cleared"),
+                                              message: nil, preferredStyle: .alert)
+                alert.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: ""))
+                self?.present(alert, animated: true, completion: nil)
+                self?.tableView.deselectSelectedRowWithAnimationAfterDelay(true)
+            })
         ]
     }
 
@@ -136,5 +144,6 @@ class DebugMenuViewController: UITableViewController {
         static let alwaysSendLogs = NSLocalizedString("Always Send Crash Logs", comment: "Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't")
         static let crashLogging = NSLocalizedString("Crash Logging", comment: "Title of a section on the debug screen that shows a list of actions related to crash logging")
         static let encryptedLogging = NSLocalizedString("Encrypted Logs", comment: "Title of a row displayed on the debug screen used to display a screen that shows a list of encrypted logs")
+        static let clearCSSCache = NSLocalizedString("Clear Reader CSS Cache", comment: "Title of a row displayed on the debug screen used to clear any cached CSS for the Reader")
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderCSS.swift
@@ -48,4 +48,8 @@ struct ReaderCSS {
         let timestamp = String(appending)
         return "https://wordpress.com/calypso/reader-mobile.css?\(timestamp)"
     }
+
+    func clearCache() {
+        store.removeObject(forKey: type(of: self).updatedKey)
+    }
 }


### PR DESCRIPTION
This PR adds an option to the debug menu to clear the cache timestamp for CSS in the Reader.

<img width="376" alt="Screenshot 2020-09-03 at 10 11 50" src="https://user-images.githubusercontent.com/4780/92096459-d1600c00-edce-11ea-85b7-393644c14703.png">

**To test:**

- Add breakpoints to the `address` property in `ReaderCSS.swift` where each possible URL is returned.
- Visit a couple of pages in the Reader and check that the same URL is returned each time.
- Head to **Me > App Settings > Debug** and tap **Clear Reader CSS Cache**.
- Go back to the Reader and load another article. Check that the URL is now returned with the `now` timestamp.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
