### PR TITLE
Added more details to notification settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -140,8 +140,17 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
         // Single Section Mode: A single section will contain all of the rows
         if singleSectionMode {
-            return [Section(rows: rows)]
+            // Switch on stream type to provide descriptive text in footer for more context
+            switch stream.kind {
+            case .Device:
+                return [Section(rows: rows, footerText: NSLocalizedString("Settings for push notifications that appear on your mobile device.", comment: "Descriptive text for the Push Notifications Settings"))]
+            case .Email:
+                return [Section(rows: rows, footerText: NSLocalizedString("Settings for notifications that are sent to the email tied to your account.", comment: "Descriptive text for the Email Notifications Settings"))]
+            case .Timeline:
+                return [Section(rows: rows, footerText: NSLocalizedString("Settings for notifications that appear in the Notifications tab.", comment: "Descriptive text for the Notifications Tab Settings"))]
+            }
         }
+
 
         // Multi Section Mode: We'll have one Section per Row
         var sections = [Section]()


### PR DESCRIPTION
Fixes #4391  

Details from the notification type selection screen are now carried over to the detailed editing view.

![Simulator Screen Shot - iPhone 11 - 2020-09-03 at 11 44 06](https://user-images.githubusercontent.com/43656898/92143883-83053a00-eddb-11ea-9cbd-b01e57d149f6.png)

To test: Open the app, and select the notifications view from the tab bar. Then select the settings gear at the upper right. Choose your blog, then go into any of the sections for notification options. The details that describe which notification type you selected are now displayed beneath the list of toggles, to help enforce the current context. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
