### PR TITLE
Reader Detail: Fixes status bar appearing black

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -6,6 +6,19 @@ protocol ReaderContentViewController: UIViewController {
 
 // MARK: - Reader Factory
 extension WPTabBarController {
+    override open var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
+    override open var childForStatusBarStyle: UIViewController? {
+        guard
+            let topViewController = readerNavigationController?.topViewController,
+            ((topViewController as? DefinesVariableStatusBarStyle) != nil)
+        else {
+            return nil
+        }
+        return topViewController
+    }
 
     var readerTabViewController: ReaderTabViewController? {
         readerNavigationController?.topViewController as? ReaderTabViewController

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -3,8 +3,7 @@ protocol ReaderContentViewController: UIViewController {
     func setContent(_ content: ReaderContent)
 }
 
-
-// MARK: - Reader Factory
+// MARK: - DefinesVariableStatusBarStyle Support
 extension WPTabBarController {
     override open var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
@@ -19,7 +18,10 @@ extension WPTabBarController {
         }
         return topViewController
     }
+}
 
+// MARK: - Reader Factory
+extension WPTabBarController {
     var readerTabViewController: ReaderTabViewController? {
         readerNavigationController?.topViewController as? ReaderTabViewController
     }


### PR DESCRIPTION
Depends on: https://github.com/wordpress-mobile/WordPress-iOS/pull/14821

This PR implements the `childForStatusBarStyle` in an extension. This is implemented for the `UINavigationController` already. 

This lets child view controllers of the tab bar to change the status bar color if they implement: `DefinesVariableStatusBarStyle`

### To test:
1. Open the app
2. Tap on the Reader tab
3. Tap on a post
4. Scroll down 

The status bar should change when the background will turn white. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
