### PR TITLE
Update to Xcode 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,10 @@ parameters:
     default: all-lang
 
 commands:
-  fix-path:
+  fix-image:
     steps:
       - run:
-          name: Fix $PATH
+          name: Fix CI Image
           command: |
             # Add `/usr/local/bin` to the Xcode 11.2 image's $PATH in order to be able to use dependencies
 
@@ -28,13 +28,16 @@ commands:
               echo $PATH
             fi
 
+            chruby ruby-2.6.6
+            gem install bundler
+
 jobs:
   Build Tests:
     executor:
       name: ios/default
       xcode-version: "12.0.0"
     steps:
-      - run: echo 'chruby system' >> ~/.bash_profile
+      - fix-image
       - git/shallow-checkout
       - ios/install-dependencies:
             bundle-install: true
@@ -57,8 +60,7 @@ jobs:
       name: ios/default
       xcode-version: "12.0.0"
     steps:
-      - run: echo 'chruby system' >> ~/.bash_profile
-      - fix-path
+      - fix-image
       - git/shallow-checkout
       - ios/boot-simulator:
           xcode-version: "12.0.0"
@@ -87,7 +89,7 @@ jobs:
       name: ios/default
       xcode-version: "12.0.0"
     steps:
-      - fix-path
+      - fix-image
       - git/shallow-checkout
       - ios/boot-simulator:
           xcode-version: "12.0.0"
@@ -128,6 +130,7 @@ jobs:
       name: ios/default
       xcode-version: "12.0.0"
     steps:
+      - fix-image
       - git/shallow-checkout
       - ios/install-dependencies:
             bundle-install: true
@@ -155,6 +158,7 @@ jobs:
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
+      - fix-image
       - run:
           name: Setup Notifications
           command: |
@@ -197,6 +201,7 @@ jobs:
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
+      - fix-image
       - git/shallow-checkout
       - ios/install-dependencies:
             bundle-install: true
@@ -305,4 +310,3 @@ workflows:
     when: << pipeline.parameters.translation_review_build >>
     jobs:
       - translation-review-build
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,9 @@ jobs:
   Build Tests:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "12.0.0"
     steps:
+      - run: echo 'chruby system' >> ~/.bash_profile
       - git/shallow-checkout
       - ios/install-dependencies:
             bundle-install: true
@@ -54,12 +55,13 @@ jobs:
   Unit Tests:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "12.0.0"
     steps:
+      - run: echo 'chruby system' >> ~/.bash_profile
       - fix-path
       - git/shallow-checkout
       - ios/boot-simulator:
-          xcode-version: "11.2.1"
+          xcode-version: "12.0.0"
           device: iPhone 11
       - attach_workspace:
           at: ./
@@ -83,12 +85,12 @@ jobs:
         default: false
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "12.0.0"
     steps:
       - fix-path
       - git/shallow-checkout
       - ios/boot-simulator:
-          xcode-version: "11.2.1"
+          xcode-version: "12.0.0"
           device: << parameters.device >>
       - attach_workspace:
           at: ./
@@ -124,7 +126,7 @@ jobs:
   Installable Build:
     executor:
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "12.0.0"
     steps:
       - git/shallow-checkout
       - ios/install-dependencies:
@@ -149,7 +151,7 @@ jobs:
   Release Build:
     executor: 
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "12.0.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -191,7 +193,7 @@ jobs:
   translation-review-build:
     executor: 
       name: ios/default
-      xcode-version: "11.2.1"
+      xcode-version: "12.0.0"
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,8 @@ jobs:
           name: Run UI Tests
           working_directory: Scripts
           command: |
-            TEST_PLAN_NAME=$(cd DerivedData/Build/Products/ && ls -l | grep xctestrun | grep UITests | awk '{print $9}')
+            TEST_PLAN_NAME=$(cd ./Scripts/DerivedData/Build/Products/ && ls -l | grep xctestrun | grep UITests | awk '{print $9}')
+            echo $TEST_PLAN_NAME
             bundle exec fastlane test_without_building xctestrun:"DerivedData/Build/Products/$TEST_PLAN_NAME" destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,9 @@ jobs:
       - run:
           name: Install Dependencies
           command: rake dependencies
-      - ios/xcodebuild:
-          command: build-for-testing
-          arguments: -workspace 'WordPress.xcworkspace' -scheme 'WordPress' -configuration 'Debug' -sdk iphonesimulator -derivedDataPath DerivedData
+      - run:
+          name: Build for Testing
+          command: bundle exec fastlane build_for_testing
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,7 @@ jobs:
       - run:
           name: Run Unit Tests
           working_directory: Scripts
-          command: |
-            TEST_PLAN_NAME=$(cd DerivedData/Build/Products/ && ls -l | grep xctestrun | grep UnitTests | awk '{print $9}')
-            bundle exec fastlane test_without_building xctestrun:"DerivedData/Build/Products/$TEST_PLAN_NAME" destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+          command: bundle exec fastlane test_without_building name:WordPressUnitTests destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
   UI Tests:
@@ -109,10 +107,7 @@ jobs:
       - run:
           name: Run UI Tests
           working_directory: Scripts
-          command: |
-            TEST_PLAN_NAME=$(cd ./Scripts/DerivedData/Build/Products/ && ls -l | grep xctestrun | grep UITests | awk '{print $9}')
-            echo $TEST_PLAN_NAME
-            bundle exec fastlane test_without_building xctestrun:"DerivedData/Build/Products/$TEST_PLAN_NAME" destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+          command: bundle exec fastlane test_without_building name:WordPressUITests destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,8 +281,8 @@ workflows:
           device: iPhone 11
           requires: [ "Optional Tests" ]
       - UI Tests:
-          name: UI Tests (iPad Air 3rd generation)
-          device: iPad Air \\(3rd generation\\)
+          name: UI Tests (iPad Air 4th generation)
+          device: iPad Air \\(4th generation\\)
           requires: [ "Optional Tests" ]
   Installable Build:
     unless: << pipeline.parameters.translation_review_build >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run:
           name: Run Unit Tests
           working_directory: Scripts
-          command: bundle exec fastlane test_without_building name:WordPressUnitTests destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+          command: bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
   UI Tests:
@@ -107,7 +107,7 @@ jobs:
       - run:
           name: Run UI Tests
           working_directory: Scripts
-          command: bundle exec fastlane test_without_building name:WordPressUITests destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+          command: bundle exec fastlane test_without_building name:WordPressUITests try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
       - when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           command: rake dependencies
       - run:
           name: Build for Testing
-          command: bundle exec fastlane build_for_testing
+          command: cd ./Scripts && bundle exec fastlane build_for_testing
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,9 @@ jobs:
       - run:
           name: Run Unit Tests
           working_directory: Scripts
-          command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUnitTests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+          command: |
+            TEST_PLAN_NAME=$(cd DerivedData/Build/Products/ && ls -l | grep xctestrun | grep UnitTests | awk '{print $9}')
+            bundle exec fastlane test_without_building xctestrun:"DerivedData/Build/Products/$TEST_PLAN_NAME" destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
   UI Tests:
@@ -107,7 +109,9 @@ jobs:
       - run:
           name: Run UI Tests
           working_directory: Scripts
-          command: bundle exec fastlane test_without_building xctestrun:DerivedData/Build/Products/WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+          command: |
+            TEST_PLAN_NAME=$(cd DerivedData/Build/Products/ && ls -l | grep xctestrun | grep UITests | awk '{print $9}')
+            bundle exec fastlane test_without_building xctestrun:"DerivedData/Build/Products/$TEST_PLAN_NAME" destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
       - when:

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -614,7 +614,7 @@ import "./ScreenshotFastfile"
   # It requires a prebuilt xctestrun file and simulator destination where the tests will be run.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane test_without_building [name:<Partial name of the .xctestrun file>] [destination:<Simulator>] [try_count:<Number of times to try tests>]
+  # bundle exec fastlane test_without_building [name:<Partial name of the .xctestrun file>] [try_count:<Number of times to try tests>]
   #
   # Example:
   # bundle exec fastlane test_without_building name:UITests try_count:3

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -472,7 +472,17 @@ import "./ScreenshotFastfile"
 
     zip(path: "/var/tmp/Debug-iphonesimulator/WordPress.app", output_path: "/var/tmp/Debug-iphonesimulator/WordPress.zip")
   end
-  
+
+  desc "Build for Testing"
+  lane :build_for_testing do | options |
+    run_tests(
+      workspace: "../WordPress.xcworkspace",
+      scheme: "WordPress",
+      derived_data_path: "DerivedData",
+      build_for_testing: true,
+    )
+  end
+
   #####################################################################################
   # register_new_device
   # -----------------------------------------------------------------------------------

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -628,12 +628,13 @@ import "./ScreenshotFastfile"
       e.include?(options[:name])
     }.first
 
+    puts testPlanPath
+
     multi_scan(
       workspace: "../WordPress.xcworkspace",
       scheme: "WordPress",
       test_without_building: true,
       xctestrun: testPlanPath,
-      destination: options[:destination],
       try_count: options[:try_count],
       output_directory: "../build/results",
       result_bundle: true

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -626,7 +626,7 @@ import "./ScreenshotFastfile"
     buildProductsPath = File.expand_path("../DerivedData/Build/Products/", Dir.pwd)
     testPlanPath = Dir.glob(File.join(buildProductsPath, '*.xctestrun') ).select { |e|
       e.include?(options[:name])
-    }
+    }.first
 
     multi_scan(
       workspace: "../WordPress.xcworkspace",

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -478,7 +478,7 @@ import "./ScreenshotFastfile"
     run_tests(
       workspace: "../WordPress.xcworkspace",
       scheme: "WordPress",
-      derived_data_path: "DerivedData",
+      derived_data_path: "../DerivedData",
       build_for_testing: true,
     )
   end
@@ -617,18 +617,19 @@ import "./ScreenshotFastfile"
   # bundle exec fastlane test_without_building [name:<Partial name of the .xctestrun file>] [destination:<Simulator>] [try_count:<Number of times to try tests>]
   #
   # Example:
-  # bundle exec fastlane test_without_building xctestrun:UITests destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+  # bundle exec fastlane test_without_building name:UITests try_count:3
   #####################################################################################
   desc "Run tests without building"
   lane :test_without_building do | options |
 
     # Find the referenced .xctestrun file based on its name
-    buildProductsPath = File.expand_path("../DerivedData/Build/Products/", Dir.pwd)
+    buildProductsPath = File.expand_path("../DerivedData/Build/Products/", File.dirname(Dir.pwd))
+
     testPlanPath = Dir.glob(File.join(buildProductsPath, '*.xctestrun') ).select { |e|
       e.include?(options[:name])
     }.first
 
-    puts testPlanPath
+    UI.user_error!("Unable to find .xctestrun file") unless testPlanPath != nil and File.exists? (testPlanPath)
 
     multi_scan(
       workspace: "../WordPress.xcworkspace",

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -614,18 +614,25 @@ import "./ScreenshotFastfile"
   # It requires a prebuilt xctestrun file and simulator destination where the tests will be run.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane test_without_building [xctestrun:<Path to xctestrun file>] [destination:<Simulator>] [try_count:<Number of times to try tests>]
+  # bundle exec fastlane test_without_building [name:<Partial name of the .xctestrun file>] [destination:<Simulator>] [try_count:<Number of times to try tests>]
   #
   # Example:
-  # bundle exec fastlane test_without_building xctestrun:WordPress_WordPressUITests_iphonesimulator13.2-x86_64.xctestrun destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
+  # bundle exec fastlane test_without_building xctestrun:UITests destination:"platform=iOS Simulator,id=$SIMULATOR_UDID" try_count:3
   #####################################################################################
   desc "Run tests without building"
   lane :test_without_building do | options |
+
+    # Find the referenced .xctestrun file based on its name
+    buildProductsPath = File.expand_path("../DerivedData/Build/Products/", Dir.pwd)
+    testPlanPath = Dir.glob(File.join(buildProductsPath, '*.xctestrun') ).select { |e|
+      e.include?(options[:name])
+    }
+
     multi_scan(
       workspace: "../WordPress.xcworkspace",
       scheme: "WordPress",
       test_without_building: true,
-      xctestrun: "../#{options[:xctestrun]}",
+      xctestrun: testPlanPath,
       destination: options[:destination],
       try_count: options[:try_count],
       output_directory: "../build/results",

--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -63,7 +63,7 @@ extension UIImageView {
         with request: URLRequest,
         placeholderImage: UIImage?) {
 
-        af_setImage(withURLRequest: request, placeholderImage: placeholderImage) { [weak self] dataResponse in
+        af_setImage(withURLRequest: request, placeholderImage: placeholderImage, completion: { [weak self] dataResponse in
             switch dataResponse.result {
             case .success(let image):
                 guard let self = self else {
@@ -94,7 +94,7 @@ extension UIImageView {
                     CrashLogging.logError(error)
                 }
             }
-        }
+        })
     }
 
 

--- a/WordPress/Classes/Utility/iAds/SearchAdsAttribution.swift
+++ b/WordPress/Classes/Utility/iAds/SearchAdsAttribution.swift
@@ -123,7 +123,7 @@ import AutomatticTracks
     private func didReceiveError(_ error: Error) {
         let nsError = error as NSError
 
-        guard nsError.code == ADClientError.Code.limitAdTracking.rawValue else {
+        guard nsError.code == ADClientError.Code.trackingRestrictedOrDenied.rawValue else {
             tryAgain(after: 5) // Possible connectivity issues
             return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -577,12 +577,12 @@ extension SiteStatsInsightsTableViewController: NoResultsViewHost {
         configureAndDisplayNoResults(on: tableView,
                                      title: NoResultConstants.errorTitle,
                                      subtitle: NoResultConstants.errorSubtitle,
-                                     buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
+                                     buttonTitle: NoResultConstants.refreshButtonTitle, customizationBlock: { [weak self] noResults in
                                         noResults.delegate = self
                                         if !noResults.isReachable {
                                             noResults.resetButtonText()
                                         }
-        }
+                                     })
     }
 
     private func displayEmptyViewIfNecessary() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -210,12 +210,12 @@ extension SiteStatsPeriodTableViewController: NoResultsViewHost {
         configureAndDisplayNoResults(on: tableView,
                                      title: NoResultConstants.errorTitle,
                                      subtitle: NoResultConstants.errorSubtitle,
-                                     buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
+                                     buttonTitle: NoResultConstants.refreshButtonTitle, customizationBlock: { [weak self] noResults in
                                         noResults.delegate = self
                                         if !noResults.isReachable {
                                             noResults.resetButtonText()
                                         }
-        }
+                                     })
     }
 
     private enum NoResultConstants {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -244,12 +244,12 @@ extension PostStatsTableViewController: NoResultsViewHost {
         configureAndDisplayNoResults(on: tableView,
                                      title: NoResultConstants.errorTitle,
                                      subtitle: NoResultConstants.errorSubtitle,
-                                     buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
+                                     buttonTitle: NoResultConstants.refreshButtonTitle, customizationBlock: { [weak self] noResults in
                                         noResults.delegate = self
                                         if !noResults.isReachable {
                                             noResults.resetButtonText()
                                         }
-        }
+                                     })
     }
 
     private enum NoResultConstants {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -322,12 +322,12 @@ extension SiteStatsDetailTableViewController: NoResultsViewHost {
         configureAndDisplayNoResults(on: tableView,
                                      title: NoResultConstants.errorTitle,
                                      subtitle: NoResultConstants.errorSubtitle,
-                                     buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
+                                     buttonTitle: NoResultConstants.refreshButtonTitle, customizationBlock: { [weak self] noResults in
                                         noResults.delegate = self
                                         if !noResults.isReachable {
                                             noResults.resetButtonText()
                                         }
-        }
+                                     })
     }
 
     private enum NoResultConstants {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -43,9 +43,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		00F2E3F8166EEF9800D0527C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7371256D0F60046A4A3 /* CoreGraphics.framework */; };
-		00F2E3FA166EEFBE00D0527C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E10B3653158F2D4500419A93 /* UIKit.framework */; };
-		00F2E3FB166EEFE100D0527C /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E10B3651158F2D3F00419A93 /* QuartzCore.framework */; };
 		02761EC02270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */; };
 		02761EC222700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */; };
 		02761EC4227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EC3227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift */; };
@@ -1896,8 +1893,6 @@
 		E12BE5EE1C5235DB000FD5CA /* get-me-settings-v1.1.json in Resources */ = {isa = PBXBuildFile; fileRef = E12BE5ED1C5235DB000FD5CA /* get-me-settings-v1.1.json */; };
 		E12DB07B1C48D1C200A6C1D4 /* WPAccount+AccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12DB07A1C48D1C200A6C1D4 /* WPAccount+AccountSettings.swift */; };
 		E12FE0741FA0CEE000F28710 /* ImmuTable+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = E12FE0731FA0CEE000F28710 /* ImmuTable+Optional.swift */; };
-		E131CB5216CACA6B004B0314 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E131CB5116CACA6B004B0314 /* CoreText.framework */; };
-		E131CB5416CACB05004B0314 /* libxml2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E131CB5316CACB05004B0314 /* libxml2.dylib */; };
 		E131CB5616CACF1E004B0314 /* get-user-blogs_has-blog.json in Resources */ = {isa = PBXBuildFile; fileRef = E131CB5516CACF1E004B0314 /* get-user-blogs_has-blog.json */; };
 		E131CB5816CACFB4004B0314 /* get-user-blogs_doesnt-have-blog.json in Resources */ = {isa = PBXBuildFile; fileRef = E131CB5716CACFB4004B0314 /* get-user-blogs_doesnt-have-blog.json */; };
 		E135965D1E7152D1006C6606 /* RecentSitesServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E135965C1E7152D1006C6606 /* RecentSitesServiceTests.swift */; };
@@ -1939,7 +1934,6 @@
 		E166FA1B1BB0656B00374B5B /* PeopleCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E166FA1A1BB0656B00374B5B /* PeopleCellViewModel.swift */; };
 		E16A76F11FC4758300A661E3 /* JetpackSiteRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16A76F01FC4758300A661E3 /* JetpackSiteRef.swift */; };
 		E16A76F31FC4766900A661E3 /* CredentialsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16A76F21FC4766900A661E3 /* CredentialsService.swift */; };
-		E16AB92E14D978240047A2E5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		E16FB7E11F8B5D7D0004DD9F /* WebViewControllerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16FB7E01F8B5D7D0004DD9F /* WebViewControllerConfiguration.swift */; };
 		E16FB7E31F8B61040004DD9F /* WebKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16FB7E21F8B61030004DD9F /* WebKitViewController.swift */; };
 		E174F6E6172A73960004F23A /* WPAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E105E9CE1726955600C0D9E7 /* WPAccount.m */; };
@@ -1951,25 +1945,6 @@
 		E180BD4E1FB4681E00D0D781 /* MockCookieJar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E180BD4D1FB4681E00D0D781 /* MockCookieJar.swift */; };
 		E18165FD14E4428B006CE885 /* loader.html in Resources */ = {isa = PBXBuildFile; fileRef = E18165FC14E4428B006CE885 /* loader.html */; };
 		E1823E6C1E42231C00C19F53 /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1823E6B1E42231C00C19F53 /* UIEdgeInsets.swift */; };
-		E183EC9C16B215FE00C2EB11 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A01C542D0E24E88400D411F2 /* SystemConfiguration.framework */; };
-		E183EC9D16B2160200C2EB11 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D67D11D13EAD00A61362 /* MobileCoreServices.framework */; };
-		E183ECA216B2179B00C2EB11 /* Accounts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC24E5F41577E16B00A6D5B5 /* Accounts.framework */; };
-		E183ECA316B2179B00C2EB11 /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC24E5F01577DBC300A6D5B5 /* AddressBook.framework */; };
-		E183ECA416B2179B00C2EB11 /* AssetsLibrary.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 835E2402126E66E50085940B /* AssetsLibrary.framework */; };
-		E183ECA516B2179B00C2EB11 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 374CB16115B93C0800DD0EBC /* AudioToolbox.framework */; };
-		E183ECA616B2179B00C2EB11 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A386C714DB05C300954CF8 /* AVFoundation.framework */; };
-		E183ECA716B2179B00C2EB11 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7331256D0DE0046A4A3 /* CFNetwork.framework */; };
-		E183ECA816B2179B00C2EB11 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D7D811D260AA00A61362 /* CoreData.framework */; };
-		E183ECA916B2179B00C2EB11 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E2D211276371004CD686 /* CoreLocation.framework */; };
-		E183ECAA16B2179B00C2EB11 /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1A386C914DB05F700954CF8 /* CoreMedia.framework */; };
-		E183ECAB16B2179B00C2EB11 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD3D6D2B1349F5D30061136A /* ImageIO.framework */; };
-		E183ECAC16B2179B00C2EB11 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FD21397E13128C5300099582 /* libiconv.dylib */; };
-		E183ECAD16B2179B00C2EB11 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = E19DF740141F7BDD000002F3 /* libz.dylib */; };
-		E183ECAE16B2179B00C2EB11 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
-		E183ECAF16B2179B00C2EB11 /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83FB4D3E122C38F700DB9506 /* MediaPlayer.framework */; };
-		E183ECB016B2179B00C2EB11 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83043E54126FA31400EC9953 /* MessageUI.framework */; };
-		E183ECB116B2179B00C2EB11 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296890770FE971DC00770264 /* Security.framework */; };
-		E183ECB216B2179B00C2EB11 /* Twitter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC24E5F21577DFF400A6D5B5 /* Twitter.framework */; };
 		E185042F1EE6ABD9005C234C /* Restorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E185042E1EE6ABD9005C234C /* Restorer.swift */; };
 		E185474E1DED8D8800D875D7 /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E185474D1DED8D8800D875D7 /* UserNotifications.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		E18549D9230EED73003C620E /* BlogService+Deduplicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E18549D8230EED73003C620E /* BlogService+Deduplicate.swift */; };
@@ -5184,31 +5159,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E131CB5416CACB05004B0314 /* libxml2.dylib in Frameworks */,
-				E183EC9D16B2160200C2EB11 /* MobileCoreServices.framework in Frameworks */,
-				E183EC9C16B215FE00C2EB11 /* SystemConfiguration.framework in Frameworks */,
-				E131CB5216CACA6B004B0314 /* CoreText.framework in Frameworks */,
-				E183ECA216B2179B00C2EB11 /* Accounts.framework in Frameworks */,
-				E183ECA316B2179B00C2EB11 /* AddressBook.framework in Frameworks */,
-				E183ECA416B2179B00C2EB11 /* AssetsLibrary.framework in Frameworks */,
-				E183ECA516B2179B00C2EB11 /* AudioToolbox.framework in Frameworks */,
-				E183ECA616B2179B00C2EB11 /* AVFoundation.framework in Frameworks */,
-				E183ECA716B2179B00C2EB11 /* CFNetwork.framework in Frameworks */,
-				E183ECA816B2179B00C2EB11 /* CoreData.framework in Frameworks */,
-				00F2E3F8166EEF9800D0527C /* CoreGraphics.framework in Frameworks */,
-				E183ECA916B2179B00C2EB11 /* CoreLocation.framework in Frameworks */,
-				E183ECAA16B2179B00C2EB11 /* CoreMedia.framework in Frameworks */,
-				E16AB92E14D978240047A2E5 /* Foundation.framework in Frameworks */,
-				E183ECAB16B2179B00C2EB11 /* ImageIO.framework in Frameworks */,
-				E183ECAC16B2179B00C2EB11 /* libiconv.dylib in Frameworks */,
-				E183ECAD16B2179B00C2EB11 /* libz.dylib in Frameworks */,
-				E183ECAE16B2179B00C2EB11 /* MapKit.framework in Frameworks */,
-				E183ECAF16B2179B00C2EB11 /* MediaPlayer.framework in Frameworks */,
-				E183ECB016B2179B00C2EB11 /* MessageUI.framework in Frameworks */,
-				00F2E3FB166EEFE100D0527C /* QuartzCore.framework in Frameworks */,
-				E183ECB116B2179B00C2EB11 /* Security.framework in Frameworks */,
-				E183ECB216B2179B00C2EB11 /* Twitter.framework in Frameworks */,
-				00F2E3FA166EEFBE00D0527C /* UIKit.framework in Frameworks */,
 				E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -79,8 +79,8 @@ class PostServiceWPComTests: XCTestCase {
 
         expect(posts).to(haveCount(2))
         posts?.forEach { post in
-            expect(expectedStatuses).to(contain(post.status!))
-            expect(expectedStatuses).to(contain(post.statusAfterSync!))
+            expect(expectedStatuses as NMBContainer).to(contain(post.status))
+            expect(expectedStatuses as NMBContainer).to(contain(post.statusAfterSync))
             expect(post.status).to(equal(post.statusAfterSync))
         }
     }


### PR DESCRIPTION
This PR migrates our CI system to Xcode 12. It makes a few changes:

- It uses `fastlane` to build for testing, rather than using `xcodebuild` directly. This better aligns with how we do release builds, and it fixed a weird issue with a Swift compiler mismatch. IMHO moving forward we should probably deprecate the direct `xcodebuild` part of the orb and use `fastlane` for all the things?
- It uses the iPad Air 4th generation (X-style) for UI tests. If we want a simulator with a home button, we could use the 8th generation iPad instead.
- Instead of passing the exact path to the `.xctestrun` file that you want, now you can just pass part of the name of the file to match (ie – `UITest` or `UnitTest`), and it'll do the right thing. This should make future upgrades easier.
- It removes the "destination" string – fastlane was warning that we shouldn't use it, so I've removed that argument
- There are a couple specific fixes that needed to happen – we were linking the test bundles against a bunch of libraries unnecessarily, so I've removed that, and I fixed a compiler error in a test

To Test:
- Ensure CI passes
