### PR TITLE
Update app store screenshot strings for new designs

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -131,6 +131,8 @@ import "./ScreenshotFastfile"
       "app_store_screenshot-3" => File.join(source_metadata_folder, "promo_screenshot_3.txt"),
       "app_store_screenshot-4" => File.join(source_metadata_folder, "promo_screenshot_4.txt"),
       "app_store_screenshot-5" => File.join(source_metadata_folder, "promo_screenshot_5.txt"),
+      "app_store_screenshot-6" => File.join(source_metadata_folder, "promo_screenshot_6.txt"),
+      "app_store_screenshot-7" => File.join(source_metadata_folder, "promo_screenshot_7.txt"),
     }
 
     ios_update_metadata_source(po_file_path: prj_folder + "/WordPress/Resources/AppStoreStrings.po", 

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
@@ -1,2 +1,3 @@
-Enjoy your
-favorite sites
+The world’s most
+popular website
+builder

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
@@ -1,2 +1,2 @@
-Get notified 
-in real-time
+Create a site or
+start a blog

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
@@ -1,2 +1,2 @@
-Manage your site
-everywhere you go
+Discover
+new reads

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
@@ -1,2 +1,2 @@
-Share your ideas
-with the world
+Build an
+audience

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
@@ -1,2 +1,2 @@
-All the stats
-in your hand
+Keep tabs on
+your site

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_6.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_6.txt
@@ -1,0 +1,2 @@
+Reply in
+real time

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_7.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_7.txt
@@ -1,0 +1,2 @@
+Upload
+on the go


### PR DESCRIPTION
Updates the app store screenshot strings (and adds 2 strings, for a total of 7) to match the new designs:

![image](https://user-images.githubusercontent.com/8658164/92467674-e7543f00-f1c9-11ea-9585-3b1dc04c2a72.png)

The changes to use these new strings for screenshot composition will come in a later PR.

(Internal ref: paaHJt-1kJ-p2)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.