### PR TITLE
Add Reader's CSS debug options

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -100,7 +100,7 @@ extension FeatureFlag {
         case .debugMenu:
             return "Debug menu"
         case .readerCSS:
-            return "Always fetches a fresh Reader CSS"
+            return "Ignore Reader CSS Cache"
         case .unifiedAuth:
             return "Unified Auth"
         case .unifiedSiteAddress:

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,6 +4,7 @@
 enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackDisconnect
     case debugMenu
+    case readerCSS
     case unifiedAuth
     case unifiedSiteAddress
     case unifiedGoogle
@@ -32,6 +33,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return BuildConfiguration.current == .localDeveloper
         case .debugMenu:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+        case .readerCSS:
+            return false
         case .unifiedAuth:
             return true
         case .unifiedSiteAddress:
@@ -96,6 +99,8 @@ extension FeatureFlag {
             return "Jetpack disconnect"
         case .debugMenu:
             return "Debug menu"
+        case .readerCSS:
+            return "Always fetches a fresh Reader CSS"
         case .unifiedAuth:
             return "Unified Auth"
         case .unifiedSiteAddress:

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -29,7 +29,8 @@ class DebugMenuViewController: UITableViewController {
 
         ImmuTable.registerRows([
             SwitchWithSubtitleRow.self,
-            ButtonRow.self
+            ButtonRow.self,
+            EditableTextRow.self
         ], tableView: tableView)
 
         handler = ImmuTableViewHandler(takeOver: self)
@@ -47,6 +48,7 @@ class DebugMenuViewController: UITableViewController {
             ImmuTableSection(headerText: Strings.featureFlags, rows: rows),
             ImmuTableSection(headerText: Strings.tools, rows: toolsRows),
             ImmuTableSection(headerText: Strings.crashLogging, rows: crashLoggingRows),
+            ImmuTableSection(headerText: Strings.reader, rows: readerRows),
         ])
     }
 
@@ -70,6 +72,8 @@ class DebugMenuViewController: UITableViewController {
             }),
         ]
     }
+
+    // MARK: Crash Logging
 
     private var crashLoggingRows: [ImmuTableRow] {
         return [
@@ -126,6 +130,24 @@ class DebugMenuViewController: UITableViewController {
         QuickStartTourGuide.find()?.setup(for: blog)
     }
 
+    // MARK: Reader
+
+    private var readerRows: [ImmuTableRow] {
+        return [
+            EditableTextRow(title: Strings.readerCssTitle, value: ReaderCSS().customAddress ?? "") { row in
+                let textViewController = SettingsTextViewController(text: ReaderCSS().customAddress, placeholder: Strings.readerURLPlaceholder, hint: Strings.readerURLHint)
+                textViewController.title = Strings.readerCssTitle
+                textViewController.onAttributedValueChanged = { [weak self] url in
+                    var readerCSS = ReaderCSS()
+                    readerCSS.customAddress = url.string
+                    self?.reloadViewModel()
+                }
+
+                self.navigationController?.pushViewController(textViewController, animated: true)
+            }
+        ]
+    }
+
     enum Strings {
         static let overridden = NSLocalizedString("Overridden", comment: "Used to indicate a setting is overridden in debug builds of the app")
         static let featureFlags = NSLocalizedString("Feature flags", comment: "Title of the Feature Flags screen used in debug builds of the app")
@@ -136,5 +158,9 @@ class DebugMenuViewController: UITableViewController {
         static let alwaysSendLogs = NSLocalizedString("Always Send Crash Logs", comment: "Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't")
         static let crashLogging = NSLocalizedString("Crash Logging", comment: "Title of a section on the debug screen that shows a list of actions related to crash logging")
         static let encryptedLogging = NSLocalizedString("Encrypted Logs", comment: "Title of a row displayed on the debug screen used to display a screen that shows a list of encrypted logs")
+        static let reader = NSLocalizedString("Reader", comment: "Title of the Reader section of the debug screen used in debug builds of the app")
+        static let readerCssTitle = NSLocalizedString("Reader CSS URL", comment: "Title of the screen that allows the user to change the Reader CSS URL for debug builds")
+        static let readerURLPlaceholder = NSLocalizedString("Default URL", comment: "Placeholder for the reader CSS URL")
+        static let readerURLHint = NSLocalizedString("Add a custom CSS URL here to be loaded in Reader. If you're running Calypso locally this can be something like: http://192.168.15.23:3000/calypso/reader-mobile.css", comment: "Hint for the reader CSS URL field")
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderCSS.swift
@@ -18,10 +18,27 @@ struct ReaderCSS {
 
     static let updatedKey = "ReaderCSSLastUpdated"
 
+    /// Returns a custom Reader CSS URL
+    /// This value can be changed under Settings > Debug
+    ///
+    var customAddress: String? {
+        get {
+            return store.object(forKey: "reader-css-url") as? String
+        }
+        set {
+            store.set(newValue, forKey: "reader-css-url")
+        }
+    }
+
     /// Returns the Reader CSS appending a timestamp
     /// We force it to update based on the `expirationDays` property
     ///
     var address: String {
+        // Always returns a fresh CSS if the flag is enabled
+        guard !FeatureFlag.readerCSS.enabled else {
+            return url(appendingTimestamp: now)
+        }
+
         guard let lastUpdated = store.object(forKey: type(of: self).updatedKey) as? Int,
                 (now - lastUpdated < expirationDaysInSeconds
                 || !isInternetReachable()) else {
@@ -45,7 +62,12 @@ struct ReaderCSS {
     }
 
     private func url(appendingTimestamp appending: Int) -> String {
+        guard let customURL = customAddress else {
+            let timestamp = String(appending)
+            return "https://wordpress.com/calypso/reader-mobile.css?\(timestamp)"
+        }
+
         let timestamp = String(appending)
-        return "https://wordpress.com/calypso/reader-mobile.css?\(timestamp)"
+        return "\(customURL)?\(timestamp)"
     }
 }


### PR DESCRIPTION
This PR adds two debug options for the Reader, to make it easier to update blocks and CSS:

1. It allows to always retrieve a fresh/uncached CSS from the server
2. It allows the user to change the CSS URL (using a local one, for example)

<img src="https://user-images.githubusercontent.com/7040243/92510806-cba96280-f1e2-11ea-873f-3d52caab9f91.png" width="300">

## To test

### Retrieving an uncached CSS

1. Go to Settings > Debug
2. Enable "Always fetches a fresh Reader CSS"
3. Add a breakpoint [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift#L40)
4. Load a post in Reader, check the timestamp
5. Open another post, check that the timestamp at the end of the URL is different

### Overriding the URL

1. Go to Settings > Debug
2. Tap "Reader CSS URL" (at the end of the view)
3. Change the URL to something else
4. Add a breakpoint [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift#L40)
5. Load a post in Reader and check that the returned URL is the one you just added

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
