### PR TITLE
Reader Detail Updates: Fixes swipe to go back on the reader detail view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -111,7 +111,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         coordinator?.start()
 
         // Fixes swipe to go back not working when leftBarButtonItem is set
-        navigationController?.interactivePopGestureRecognizer?.delegate = self;
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -109,6 +109,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         observeWebViewHeight()
         configureNotifications()
         coordinator?.start()
+
+        // Fixes swipe to go back not working when leftBarButtonItem is set
+        navigationController?.interactivePopGestureRecognizer?.delegate = self;
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -428,6 +431,13 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 extension ReaderDetailViewController: StoryboardLoadable {
     static var defaultStoryboardName: String {
         return "ReaderDetailViewController"
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+extension ReaderDetailViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
     }
 }
 


### PR DESCRIPTION
Project Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/14767

Fixes the swipe to go back since it no longer works after setting the `leftBarButtonItem`

### To test:
1. Launch the app
2. Tap on the Reader Tab
3. Tap on any post
4. Swipe the edge to go back

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
