### PR TITLE
UL&S iCloud Keychain: attempt to fix backgrounding issue.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -191,10 +191,10 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.24.0'
+    # pod 'WordPressAuthenticator', '~> 1.24.0'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'b5ea5d1da8b70b2efb26cb8b4e464e3649f551ff'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.24.0):
+  - WordPressAuthenticator (1.24.1):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.24.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `b5ea5d1da8b70b2efb26cb8b4e464e3649f551ff`)
   - WordPressKit (~> 4.16.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
@@ -555,7 +555,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -657,6 +656,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.36.0
+  WordPressAuthenticator:
+    :commit: b5ea5d1da8b70b2efb26cb8b4e464e3649f551ff
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.36.0/third-party-podspecs/Yoga.podspec.json
 
@@ -675,6 +677,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.36.0
+  WordPressAuthenticator:
+    :commit: b5ea5d1da8b70b2efb26cb8b4e464e3649f551ff
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -741,7 +746,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 20deb1f6f001000d1f2603722ec110c66c74796b
   ReactCommon: 48926fc48fcd7c8a629860049ffba9c23b4005dc
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
-  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
+  RNCMaskedView: 72b5012baac53b13a9ba717eaa554afd3f2930c5
   RNGestureHandler: 82a89b0fde0a37e633c6233418f7249e2f8e59b5
   RNReanimated: 13f7a6a22667c4f00aac217bc66f94e8560b3d59
   RNScreens: 6833ac5c29cf2f03eed12103140530bbd75b6aea
@@ -755,7 +760,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: a9497866f5d480974988312c92d61c9db70f91d6
+  WordPressAuthenticator: 4c4ce58c1b78adc58b3b2a24c1ae839c95c6195a
   WordPressKit: 48d56b8d3d25619e32d3a8ae4e934547eb684856
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
@@ -772,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 1b3a1cb7932752eb2376e7e396fd562010129058
+PODFILE CHECKSUM: 6d93edc5f6a86a1a405b733e29e24ebf51f04688
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
WPAuth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/446

As reported by @ScoutHarris via a private conversation, it seems that some conditions are making the iCloud Keychain flow to sometimes start under these conditions:

1. WPiOS is running in the background.
2. WPiOS is logged out.
3. The device is idling.

## Theory:

My theory is that there's some background process that triggers calls to `viewDidAppear` in the root VC.

### Examples of this being an issue:
- [PushKit background notifications triggering calls to `viewDidAppear` in root VC](https://stackoverflow.com/questions/53881314/pushkit-background-notification-triggers-viewdidappear-on-initial-view-controlle)
- [Location changes triggering calls to `viewDidAppear` in root VC](https://stackoverflow.com/questions/30584356/viewdidappear-is-called-when-app-is-started-due-to-significant-location-change)

## Attempts to reproduce the issue:

I tried to reproduce this issue by sending notifications to the device:

1. I first logged in to WPiOS to enable notifications.
2. Then I logged back out.

Then I tried simulating notifications using `xcrun simctl push <SIMULATOR_DEVICE_ID> <YOUR_APP_BUNDLE_ID> <APNS_FILE_NAME>` but those notifications weren't really triggering calls to:

```swift
func application(_:, didReceiveRemoteNotification:, fetchCompletionHandler:)
```

I also tried a tool provided by @jkmassel, but that tool would only work while logged in.  I wonder if there's any type of notification or background update that we use that can trigger activity in the app while logged out and in the background.

## Proposed solution:

The submitted code is a proposed solution IF the issue is caused by background processes triggering a call to `viewDidAppear`.

## Testing:

Due to what I described above, there are no known testing steps for this issue.  This is a tentative fix.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
