### PR TITLE
Reader Improvements: Detail: Update reader detail navigation buttons to be 44px

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -530,7 +530,6 @@ private extension ReaderDetailViewController {
         let rightItems = [
             moreButtonItem(),
             shareButtonItem(),
-            UIBarButtonItem.fixedSpace(19), // Visually it's 24px
             safariButtonItem()
         ]
 
@@ -561,7 +560,7 @@ private extension ReaderDetailViewController {
             return nil
         }
 
-        let button = barButtonItem(with: icon, action: #selector(didTapMenuButton(_:)), customWidth: 33)
+        let button = barButtonItem(with: icon, action: #selector(didTapMenuButton(_:)))
         button.accessibilityLabel = Strings.moreButtonAccessibilityLabel
 
         return button
@@ -574,16 +573,10 @@ private extension ReaderDetailViewController {
         return button
     }
 
-    func barButtonItem(with image: UIImage, action: Selector, customWidth: CGFloat? = nil) -> UIBarButtonItem {
+    func barButtonItem(with image: UIImage, action: Selector) -> UIBarButtonItem {
         let image = image.withRenderingMode(.alwaysTemplate)
 
-        let width = customWidth ?? image.size.width
-
-        let button = CustomHighlightButton(frame: CGRect(x: 0, y: 0, width: width, height: image.size.height))
-        button.setImage(image, for: UIControl.State())
-        button.addTarget(self, action: action, for: .touchUpInside)
-
-        return UIBarButtonItem(customView: button)
+        return UIBarButtonItem(image: image, style: .plain, target: self, action: action)
     }
 }
 
@@ -626,12 +619,3 @@ extension ReaderDetailViewController: PrefersFullscreenDisplay {}
 
 // Let's the split view know this vc changes the status bar style.
 extension ReaderDetailViewController: DefinesVariableStatusBarStyle {}
-
-// Helper extension to create spacing between items
-private extension UIBarButtonItem {
-    static func fixedSpace(_ spacing: CGFloat) -> UIBarButtonItem {
-        let button = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
-        button.width = spacing
-        return button
-    }
-}

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -572,7 +572,7 @@ private extension ReaderDetailViewController {
 
         let button = barButtonItem(with: icon, action: #selector(didTapMenuButton(_:)))
         button.accessibilityLabel = Strings.moreButtonAccessibilityLabel
-
+        button.width = 44
         return button
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -65,6 +65,12 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     /// this allows us to reset it when the view disappears
     private var originalNavBarAppearance: NavBarAppearance?
 
+    private var navBarTintColor: UIColor = Styles.endTintColor {
+        didSet {
+            navigationBar?.setItemTintColor(navBarTintColor)
+        }
+    }
+
     deinit {
         scrollViewObserver?.invalidate()
     }
@@ -135,7 +141,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
 
         NavBarAppearance.transparent.apply(navigationBar)
         if isLoaded, imageView.image == nil {
-            navigationBar.tintColor = Styles.endTintColor
+            navBarTintColor = Styles.endTintColor
         }
 
         updateUI()
@@ -212,7 +218,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     }
 
     private func updateNavigationBar(with offset: CGFloat) {
-        guard let navBar = navigationBar else {
+        guard navigationBar != nil else {
             return
         }
 
@@ -231,7 +237,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
             }
         }
 
-        navBar.tintColor = tintColor
+        navBarTintColor = tintColor
     }
 
     static func shouldDisplayFeaturedImage(with post: ReaderPost) -> Bool {
@@ -287,7 +293,8 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     }
 
     private func reset() {
-        navigationBar?.tintColor = Styles.endTintColor
+        navigationBar?.setItemTintColor(Styles.endTintColor)
+
         resetStatusBarStyle()
         heightConstraint.constant = 0
         isHidden = true
@@ -356,7 +363,7 @@ struct NavBarAppearance {
 
     func apply(_ navigationBar: UINavigationBar) {
         navigationBar.isTranslucent = isTranslucent
-        navigationBar.tintColor = tintColor ?? nil
+        navigationBar.setItemTintColor(tintColor)
         navigationBar.titleTextAttributes = titleTextAttributes ?? nil
 
         if #available(iOS 13.0, *) {
@@ -403,5 +410,25 @@ private extension NavBarAppearance {
         isTranslucent = navigationBar.isTranslucent
         tintColor = navigationBar.tintColor
         titleTextAttributes = navigationBar.titleTextAttributes
+    }
+}
+
+
+// MARK: - UINavigationBar Tint Color Helper Extension
+private extension UINavigationBar {
+    func setItemTintColor(_ color: UIColor?) {
+        tintColor = color
+
+        items?.forEach { $0.setTintColor(color) }
+    }
+}
+
+private extension UINavigationItem {
+    /// Forcibly sets the tint color of all the button items
+    func setTintColor(_ color: UIColor?) {
+        leftBarButtonItem?.tintColor = color
+        leftBarButtonItems?.forEach { $0.tintColor = color }
+        rightBarButtonItem?.tintColor = color
+        rightBarButtonItems?.forEach { $0.tintColor = color }
     }
 }


### PR DESCRIPTION
Project: #14767 

Uses UIBarButtonItem's instead of CustomHighlightButton's to use the system spacing/sizing for the reader detail view. 

| Before | After |
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/793774/92616273-e0cdd200-f272-11ea-9800-3b763f1c7cab.png" />|<img src="https://user-images.githubusercontent.com/793774/92615804-5d13e580-f272-11ea-909f-166737d1234c.png" />|

### To test:
1. Launch the app
2. Tap on the Reader Tab
3. Tap on any post to see the detail

The spacing should be consistent, and the hit boxes should be consistent.

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
