### PR TITLE
ULS: update Login tests to use unified auth views

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -191,9 +191,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    #pod 'WordPressAuthenticator', '~> 1.24.1'
+    pod 'WordPressAuthenticator', '~> 1.24.1'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/ui_tests'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -191,9 +191,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.24.0'
+    #pod 'WordPressAuthenticator', '~> 1.24.1'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/ui_tests'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.24.0):
+  - WordPressAuthenticator (1.24.1):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.24.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/ui_tests`)
   - WordPressKit (~> 4.16.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
@@ -555,7 +555,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -657,6 +656,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.36.0
+  WordPressAuthenticator:
+    :branch: fix/ui_tests
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.36.0/third-party-podspecs/Yoga.podspec.json
 
@@ -675,6 +677,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.36.0
+  WordPressAuthenticator:
+    :commit: 7b6349668ec16faaf1888fc37062d82da6b916ca
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -741,7 +746,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 20deb1f6f001000d1f2603722ec110c66c74796b
   ReactCommon: 48926fc48fcd7c8a629860049ffba9c23b4005dc
   ReactNativeDarkMode: f61376360c5d983907e5c316e8e1c853a8c2f348
-  RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
+  RNCMaskedView: 72b5012baac53b13a9ba717eaa554afd3f2930c5
   RNGestureHandler: 82a89b0fde0a37e633c6233418f7249e2f8e59b5
   RNReanimated: 13f7a6a22667c4f00aac217bc66f94e8560b3d59
   RNScreens: 6833ac5c29cf2f03eed12103140530bbd75b6aea
@@ -755,7 +760,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: a9497866f5d480974988312c92d61c9db70f91d6
+  WordPressAuthenticator: 4c4ce58c1b78adc58b3b2a24c1ae839c95c6195a
   WordPressKit: 48d56b8d3d25619e32d3a8ae4e934547eb684856
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
@@ -772,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 1b3a1cb7932752eb2376e7e396fd562010129058
+PODFILE CHECKSUM: ce8b036b9299d1c9f863e969f69df3d9ecd03eaf
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/ui_tests`)
+  - WordPressAuthenticator (~> 1.24.1)
   - WordPressKit (~> 4.16.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
@@ -555,6 +555,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -656,9 +657,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.36.0
-  WordPressAuthenticator:
-    :branch: fix/ui_tests
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.36.0/third-party-podspecs/Yoga.podspec.json
 
@@ -677,9 +675,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.36.0
-  WordPressAuthenticator:
-    :commit: 7b6349668ec16faaf1888fc37062d82da6b916ca
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -777,6 +772,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: ce8b036b9299d1c9f863e969f69df3d9ecd03eaf
+PODFILE CHECKSUM: 70ee3a838d9ff8343626b85db8ca1e2c01da1fc9
 
 COCOAPODS: 1.9.3

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1359,6 +1359,9 @@
 		98A6B993239881860031AEBD /* MurielColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4326191422FCB9DC003C7642 /* MurielColor.swift */; };
 		98A6B9942398821B0031AEBD /* WidgetTwoColumnCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 989064FE237CC1DE00218CD2 /* WidgetTwoColumnCell.xib */; };
 		98A6B996239882350031AEBD /* WidgetUnconfiguredCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 989064FC237CC1DE00218CD2 /* WidgetUnconfiguredCell.xib */; };
+		98AA22BD25082A87005CCC13 /* PrologueScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AA22BC25082A86005CCC13 /* PrologueScreen.swift */; };
+		98AA22BF25082B1E005CCC13 /* GetStartedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AA22BE25082B1E005CCC13 /* GetStartedScreen.swift */; };
+		98ADDDDA25083CA9008FF6EE /* PasswordScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98ADDDD925083CA9008FF6EE /* PasswordScreen.swift */; };
 		98AE3DF5219A1789003C0E24 /* StatsInsightsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AE3DF4219A1788003C0E24 /* StatsInsightsStore.swift */; };
 		98B11B892216535100B7F2D7 /* StatsChildRowsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B11B882216535100B7F2D7 /* StatsChildRowsView.swift */; };
 		98B11B8B2216536C00B7F2D7 /* StatsChildRowsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98B11B8A2216536C00B7F2D7 /* StatsChildRowsView.xib */; };
@@ -3876,6 +3879,9 @@
 		98A3C30C2399A6570048D38D /* WordPressThisWeekWidget-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WordPressThisWeekWidget-Alpha.entitlements"; sourceTree = "<group>"; };
 		98A3C30D2399A6580048D38D /* WordPressThisWeekWidget-Internal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WordPressThisWeekWidget-Internal.entitlements"; sourceTree = "<group>"; };
 		98A437AD20069097004A8A57 /* DomainSuggestionsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainSuggestionsTableViewController.swift; sourceTree = "<group>"; };
+		98AA22BC25082A86005CCC13 /* PrologueScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrologueScreen.swift; sourceTree = "<group>"; };
+		98AA22BE25082B1E005CCC13 /* GetStartedScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetStartedScreen.swift; sourceTree = "<group>"; };
+		98ADDDD925083CA9008FF6EE /* PasswordScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PasswordScreen.swift; sourceTree = "<group>"; };
 		98AE3DF4219A1788003C0E24 /* StatsInsightsStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsInsightsStore.swift; sourceTree = "<group>"; };
 		98B11B882216535100B7F2D7 /* StatsChildRowsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsChildRowsView.swift; sourceTree = "<group>"; };
 		98B11B8A2216536C00B7F2D7 /* StatsChildRowsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StatsChildRowsView.xib; sourceTree = "<group>"; };
@@ -8447,6 +8453,16 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		98AA22B925082A5B005CCC13 /* Unified */ = {
+			isa = PBXGroup;
+			children = (
+				98AA22BC25082A86005CCC13 /* PrologueScreen.swift */,
+				98AA22BE25082B1E005CCC13 /* GetStartedScreen.swift */,
+				98ADDDD925083CA9008FF6EE /* PasswordScreen.swift */,
+			);
+			path = Unified;
+			sourceTree = "<group>";
+		};
 		98C43E841FE98041006FEF54 /* Social Signup */ = {
 			isa = PBXGroup;
 			children = (
@@ -9652,6 +9668,7 @@
 		BED4D83D1FF13C7300A11345 /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				98AA22B925082A5B005CCC13 /* Unified */,
 				985F06B42303866200949733 /* WelcomeScreenLoginComponent.swift */,
 				BE2B4E9A1FD66423007AE3E4 /* WelcomeScreen.swift */,
 				BE2B4EA31FD6659B007AE3E4 /* LoginEmailScreen.swift */,
@@ -14102,6 +14119,7 @@
 			files = (
 				CC52189A2279CF3B008998CE /* MediaPickerAlbumListScreen.swift in Sources */,
 				CC94FC6A2214532D002E5825 /* FancyAlertComponent.swift in Sources */,
+				98ADDDDA25083CA9008FF6EE /* PasswordScreen.swift in Sources */,
 				BE2B4E9B1FD66423007AE3E4 /* WelcomeScreen.swift in Sources */,
 				CCE911BC221D8497007E1D4E /* LoginSiteAddressScreen.swift in Sources */,
 				CC7CB98722B28F4600642EE9 /* WelcomeScreenSignupComponent.swift in Sources */,
@@ -14125,6 +14143,7 @@
 				CC8498D32241477F00DB490A /* TagsComponent.swift in Sources */,
 				FFD47BDF2474228C00F00660 /* FeaturedImageScreen.swift in Sources */,
 				BE2B4E9F1FD664F5007AE3E4 /* BaseScreen.swift in Sources */,
+				98AA22BF25082B1E005CCC13 /* GetStartedScreen.swift in Sources */,
 				CC7CB97A22B15C1000642EE9 /* SignupEpilogueScreen.swift in Sources */,
 				F5E032EC240D49FF003AF350 /* ActionSheetComponent.swift in Sources */,
 				1AE0F2B12297F7E9000BDD7F /* WireMock.swift in Sources */,
@@ -14144,6 +14163,7 @@
 				CC52188C2278C622008998CE /* EditorFlow.swift in Sources */,
 				CC52189C2279D295008998CE /* MediaPickerAlbumScreen.swift in Sources */,
 				BED4D8331FF11E3800A11345 /* LoginFlow.swift in Sources */,
+				98AA22BD25082A87005CCC13 /* PrologueScreen.swift in Sources */,
 				BE8707192006E48E004FB5A4 /* ReaderScreen.swift in Sources */,
 				985F06B52303866200949733 /* WelcomeScreenLoginComponent.swift in Sources */,
 				FF2716A11CABC7D40006E2D4 /* XCTest+Extensions.swift in Sources */,

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -6,12 +6,20 @@ class LoginFlow {
     static func login(siteUrl: String, username: String, password: String) -> MySiteScreen {
         logoutIfNeeded()
 
-        return WelcomeScreen().selectLogin()
-            .goToSiteAddressLogin()
+        return PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: siteUrl)
             .proceedWith(username: username, password: password)
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()
+        
+        // TODO: remove when unifiedAuth is permanent.
+        // Leaving here for now in case unifiedAuth is disabled.
+//        return WelcomeScreen().selectLogin()
+//            .goToSiteAddressLogin()
+//            .proceedWith(siteUrl: siteUrl)
+//            .proceedWith(username: username, password: password)
+//            .continueWithSelectedSite()
+//            .dismissNotificationAlertIfNeeded()
     }
 
     static func loginIfNeeded(siteUrl: String, username: String, password: String) -> TabNavComponent {
@@ -27,7 +35,7 @@ class LoginFlow {
                 Logger.log(message: "Logging out...", event: .i)
                 let meScreen = TabNavComponent().gotoMeScreen()
                 if meScreen.isLoggedInToWpcom() {
-                    _ = meScreen.logout()
+                    _ = meScreen.logoutToPrologue()
                 } else {
                     _ = TabNavComponent().gotoMySiteScreen()
                         .removeSelfHostedSite()

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -11,7 +11,7 @@ class LoginFlow {
             .proceedWith(username: username, password: password)
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()
-        
+
         // TODO: remove when unifiedAuth is permanent.
         // Leaving here for now in case unifiedAuth is disabled.
 //        return WelcomeScreen().selectLogin()

--- a/WordPress/WordPressUITests/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LinkOrPasswordScreen.swift
@@ -1,6 +1,8 @@
 import Foundation
 import XCTest
 
+// TODO: remove when unifiedAuth is permanent.
+
 private struct ElementStringIDs {
     static let passwordOption = "Use Password"
     static let linkButton = "Send Link Button"

--- a/WordPress/WordPressUITests/Screens/Login/LoginEmailScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LoginEmailScreen.swift
@@ -1,6 +1,8 @@
 import Foundation
 import XCTest
 
+// TODO: remove when unifiedAuth is permanent.
+
 private struct ElementStringIDs {
     static let navBar = "WordPress.LoginEmailView"
     static let emailTextField = "Login Email Address"

--- a/WordPress/WordPressUITests/Screens/Login/LoginPasswordScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LoginPasswordScreen.swift
@@ -1,6 +1,8 @@
 import Foundation
 import XCTest
 
+// TODO: remove when unifiedAuth is permanent.
+
 private struct ElementStringIDs {
     static let passwordTextField = "Password"
     static let loginButton = "Password Next Button"

--- a/WordPress/WordPressUITests/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -3,7 +3,6 @@ import XCTest
 
 private struct ElementStringIDs {
     static let navBar = "WordPressAuthenticator.LoginSelfHostedView"
-    static let nextButton = "submitButton"
 
     // TODO: clean up comments when unifiedSiteAddress is permanently enabled.
 
@@ -11,10 +10,12 @@ private struct ElementStringIDs {
     // Leaving here for now in case unifiedSiteAddress is disabled.
     // static let usernameTextField = "usernameField"
     // static let passwordTextField = "passwordField"
+    // static let nextButton = "submitButton"
 
     // For unified Site Address. This matches TextFieldTableViewCell.accessibilityIdentifier.
     static let usernameTextField = "Username"
     static let passwordTextField = "Password"
+    static let nextButton = "Continue Button"
 }
 
 class LoginUsernamePasswordScreen: BaseScreen {

--- a/WordPress/WordPressUITests/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/Unified/GetStartedScreen.swift
@@ -1,0 +1,33 @@
+import Foundation
+import XCTest
+
+private struct ElementStringIDs {
+    static let navBar = "WordPress.GetStartedView"
+    static let emailTextField = "Email address"
+    static let continueButton = "Get Started Email Continue Button"
+}
+
+class GetStartedScreen: BaseScreen {
+    let navBar: XCUIElement
+    let emailTextField: XCUIElement
+    let continueButton: XCUIElement
+
+    init() {
+        let app = XCUIApplication()
+        navBar = app.navigationBars[ElementStringIDs.navBar]
+        emailTextField = app.textFields[ElementStringIDs.emailTextField]
+        continueButton = app.buttons[ElementStringIDs.continueButton]
+
+        super.init(element: emailTextField)
+    }
+
+    func proceedWith(email: String) -> PasswordScreen {
+        emailTextField.tap()
+        emailTextField.typeText(email)
+        continueButton.tap()
+
+        return PasswordScreen()
+    }
+
+
+}

--- a/WordPress/WordPressUITests/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/Unified/PasswordScreen.swift
@@ -1,0 +1,52 @@
+import Foundation
+import XCTest
+
+private struct ElementStringIDs {
+    static let navBar = "WordPress.PasswordView"
+    static let passwordTextField = "Password"
+    static let continueButton = "Continue Button"
+    static let errorLabel = "Password Error"
+}
+
+class PasswordScreen: BaseScreen {
+    let navBar: XCUIElement
+    let passwordTextField: XCUIElement
+    let continueButton: XCUIElement
+    
+    init() {
+        let app = XCUIApplication()
+        navBar = app.navigationBars[ElementStringIDs.navBar]
+        passwordTextField = app.secureTextFields[ElementStringIDs.passwordTextField]
+        continueButton = app.buttons[ElementStringIDs.continueButton]
+
+        super.init(element: passwordTextField)
+    }
+
+    func proceedWith(password: String) -> LoginEpilogueScreen {
+        _ = tryProceed(password: password)
+
+        return LoginEpilogueScreen()
+    }
+
+    func tryProceed(password: String) -> PasswordScreen {
+        passwordTextField.tap()
+        passwordTextField.typeText(password)
+        continueButton.tap()
+        if continueButton.exists && !continueButton.isHittable {
+            waitFor(element: continueButton, predicate: "isEnabled == true")
+        }
+        return self
+    }
+    
+    func verifyLoginError() -> PasswordScreen {
+        let errorLabel = app.cells[ElementStringIDs.errorLabel]
+        _ = errorLabel.waitForExistence(timeout: 2)
+
+        XCTAssertTrue(errorLabel.exists)
+        return self
+    }
+    
+    static func isLoaded() -> Bool {
+        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+    }
+}

--- a/WordPress/WordPressUITests/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/Unified/PasswordScreen.swift
@@ -12,7 +12,7 @@ class PasswordScreen: BaseScreen {
     let navBar: XCUIElement
     let passwordTextField: XCUIElement
     let continueButton: XCUIElement
-    
+
     init() {
         let app = XCUIApplication()
         navBar = app.navigationBars[ElementStringIDs.navBar]
@@ -37,7 +37,7 @@ class PasswordScreen: BaseScreen {
         }
         return self
     }
-    
+
     func verifyLoginError() -> PasswordScreen {
         let errorLabel = app.cells[ElementStringIDs.errorLabel]
         _ = errorLabel.waitForExistence(timeout: 2)
@@ -45,7 +45,7 @@ class PasswordScreen: BaseScreen {
         XCTAssertTrue(errorLabel.exists)
         return self
     }
-    
+
     static func isLoaded() -> Bool {
         return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
     }

--- a/WordPress/WordPressUITests/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/Unified/PrologueScreen.swift
@@ -25,10 +25,10 @@ class PrologueScreen: BaseScreen {
 
     func selectSiteAddress() -> LoginSiteAddressScreen {
         siteAddressButton.tap()
-        
+
         return LoginSiteAddressScreen()
     }
-    
+
     static func isLoaded() -> Bool {
         return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
     }

--- a/WordPress/WordPressUITests/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/Unified/PrologueScreen.swift
@@ -1,0 +1,35 @@
+import Foundation
+import XCTest
+
+private struct ElementStringIDs {
+    static let continueButton = "Prologue Continue Button"
+    static let siteAddressButton = "Prologue Self Hosted Button"
+}
+
+class PrologueScreen: BaseScreen {
+    let continueButton: XCUIElement
+    let siteAddressButton: XCUIElement
+
+    init() {
+        continueButton = XCUIApplication().buttons[ElementStringIDs.continueButton]
+        siteAddressButton = XCUIApplication().buttons[ElementStringIDs.siteAddressButton]
+
+        super.init(element: continueButton)
+    }
+
+    func selectContinue() -> GetStartedScreen {
+        continueButton.tap()
+
+        return GetStartedScreen()
+    }
+
+    func selectSiteAddress() -> LoginSiteAddressScreen {
+        siteAddressButton.tap()
+        
+        return LoginSiteAddressScreen()
+    }
+    
+    static func isLoaded() -> Bool {
+        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+    }
+}

--- a/WordPress/WordPressUITests/Screens/Login/WelcomeScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/WelcomeScreen.swift
@@ -1,6 +1,8 @@
 import Foundation
 import XCTest
 
+// TODO: remove when unifiedAuth is permanent.
+
 private struct ElementStringIDs {
     static let loginButton = "Prologue Log In Button"
     static let signupButton = "Prologue Signup Button"

--- a/WordPress/WordPressUITests/Screens/Login/WelcomeScreenLoginComponent.swift
+++ b/WordPress/WordPressUITests/Screens/Login/WelcomeScreenLoginComponent.swift
@@ -1,6 +1,8 @@
 import Foundation
 import XCTest
 
+// TODO: remove when unifiedAuth is permanent.
+
 private struct ElementStringIDs {
     static let emailLoginButton = "Log in with Email Button"
     static let siteAddressButton = "Self Hosted Login Button"

--- a/WordPress/WordPressUITests/Screens/MeTabScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MeTabScreen.swift
@@ -41,7 +41,7 @@ class MeTabScreen: BaseScreen {
 
         return WelcomeScreen()
     }
-    
+
     func logoutToPrologue() -> PrologueScreen {
         app.cells["logOutFromWPcomButton"].tap()
 

--- a/WordPress/WordPressUITests/Screens/MeTabScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MeTabScreen.swift
@@ -41,4 +41,19 @@ class MeTabScreen: BaseScreen {
 
         return WelcomeScreen()
     }
+    
+    func logoutToPrologue() -> PrologueScreen {
+        app.cells["logOutFromWPcomButton"].tap()
+
+        // Some localizations have very long "log out" text, which causes the UIAlertView
+        // to stack. We need to detect these cases in order to reliably tap the correct button
+        if logOutAlert.buttons.allElementsShareCommonXAxis {
+            logOutAlert.buttons.element(boundBy: 0).tap()
+        }
+        else {
+            logOutAlert.buttons.element(boundBy: 1).tap()
+        }
+
+        return PrologueScreen()
+    }
 }

--- a/WordPress/WordPressUITests/Screens/Signup/SignupEmailScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Signup/SignupEmailScreen.swift
@@ -1,6 +1,8 @@
 import Foundation
 import XCTest
 
+// TODO: remove when unifiedAuth is permanent.
+
 private struct ElementStringIDs {
     static let emailTextField = "Signup Email Address"
     static let nextButton = "Signup Email Next Button"

--- a/WordPress/WordPressUITests/Screens/Signup/WelcomeScreenSignupComponent.swift
+++ b/WordPress/WordPressUITests/Screens/Signup/WelcomeScreenSignupComponent.swift
@@ -1,6 +1,8 @@
 import Foundation
 import XCTest
 
+// TODO: remove when unifiedAuth is permanent.
+
 private struct ElementStringIDs {
     static let emailSignupButton = "Sign up with Email Button"
 }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -25,10 +25,10 @@ class LoginTests: XCTestCase {
             .dismissNotificationAlertIfNeeded()
             .tabBar.gotoMeScreen()
             .logoutToPrologue()
-        
+
         XCTAssert(prologueScreen.isLoaded())
     }
-    
+
     // Old email login/out
     // TODO: remove when unifiedAuth is permanent.
     func testEmailPasswordLoginLogout() {
@@ -72,10 +72,10 @@ class LoginTests: XCTestCase {
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()
-        
+
         XCTAssert(MySiteScreen().isLoaded())
     }
-    
+
     // Old WordPress.com login/out
     // TODO: remove when unifiedAuth is permanent.
     func testWpcomUsernamePasswordLogin() {
@@ -100,10 +100,10 @@ class LoginTests: XCTestCase {
             .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .continueWithSelectedSite()
             .removeSelfHostedSite()
-        
+
         XCTAssert(PrologueScreen().isLoaded())
     }
-    
+
     // Old self hosted login/out
     // TODO: remove when unifiedAuth is permanent.
     func testSelfHostedUsernamePasswordLoginLogout() {
@@ -126,7 +126,7 @@ class LoginTests: XCTestCase {
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()
     }
-    
+
     // Old email login fail
     // TODO: remove when unifiedAuth is permanent.
     func testUnsuccessfulLogin() {

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -14,6 +14,23 @@ class LoginTests: XCTestCase {
         super.tearDown()
     }
 
+    // Unified email login/out
+    // Replaces testEmailPasswordLoginLogout
+    func testWordPressLoginLogout() {
+        let prologueScreen = PrologueScreen().selectContinue()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
+            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .continueWithSelectedSite()
+            .dismissNotificationAlertIfNeeded()
+            .tabBar.gotoMeScreen()
+            .logoutToPrologue()
+        
+        XCTAssert(prologueScreen.isLoaded())
+    }
+    
+    // Old email login/out
+    // TODO: remove when unifiedAuth is permanent.
     func testEmailPasswordLoginLogout() {
         let welcomeScreen = WelcomeScreen().selectLogin()
             .selectEmailLogin()
@@ -46,6 +63,21 @@ class LoginTests: XCTestCase {
         XCTAssert(welcomeScreen.isLoaded())
     }
 
+    // Unified WordPress.com login/out
+    // Replaces testWpcomUsernamePasswordLogin
+    func testWpcomLogin() {
+        _ = PrologueScreen().selectSiteAddress()
+            .proceedWith(siteUrl: "WordPress.com")
+            .proceedWith(username: WPUITestCredentials.testWPcomSitePrimaryAddress, password: WPUITestCredentials.testWPcomPassword)
+            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .continueWithSelectedSite()
+            .dismissNotificationAlertIfNeeded()
+        
+        XCTAssert(MySiteScreen().isLoaded())
+    }
+    
+    // Old WordPress.com login/out
+    // TODO: remove when unifiedAuth is permanent.
     func testWpcomUsernamePasswordLogin() {
         _ = WelcomeScreen().selectLogin()
             .selectEmailLogin()
@@ -59,6 +91,21 @@ class LoginTests: XCTestCase {
         XCTAssert(MySiteScreen().isLoaded())
     }
 
+    // Unified self hosted login/out
+    // Replaces testSelfHostedUsernamePasswordLoginLogout
+    func testSelfHostedLoginLogout() {
+        _ = PrologueScreen().selectSiteAddress()
+            .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
+            .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
+            .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
+            .continueWithSelectedSite()
+            .removeSelfHostedSite()
+        
+        XCTAssert(PrologueScreen().isLoaded())
+    }
+    
+    // Old self hosted login/out
+    // TODO: remove when unifiedAuth is permanent.
     func testSelfHostedUsernamePasswordLoginLogout() {
         _ = WelcomeScreen().selectLogin()
             .goToSiteAddressLogin()
@@ -71,6 +118,17 @@ class LoginTests: XCTestCase {
         XCTAssert(WelcomeScreen().isLoaded())
     }
 
+    // Unified email login fail
+    // Replaces testUnsuccessfulLogin
+    func testWordPressUnsuccessfulLogin() {
+        _ = PrologueScreen().selectContinue()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .tryProceed(password: "invalidPswd")
+            .verifyLoginError()
+    }
+    
+    // Old email login fail
+    // TODO: remove when unifiedAuth is permanent.
     func testUnsuccessfulLogin() {
         _ = WelcomeScreen().selectLogin()
             .selectEmailLogin()

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -20,18 +20,12 @@
   "testTargets" : [
     {
       "skippedTests" : [
-        "EditorAztecTests\/testBasicPostPublish()",
-        "EditorAztecTests\/testLongTitle()",
-        "EditorAztecTests\/testTextPostPublish()",
-        "EditorGutenbergTests\/testBasicPostPublish()",
-        "EditorGutenbergTests\/testTextPostPublish()",
         "EditorTests\/testPlayground()",
         "LoginTests\/testEmailMagicLinkLogin()",
         "LoginTests\/testEmailPasswordLoginLogout()",
         "LoginTests\/testSelfHostedUsernamePasswordLoginLogout()",
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
-        "MainNavigationTests\/testTabBarNavigation()",
         "SignupTests\/testEmailSignup()"
       ],
       "target" : {


### PR DESCRIPTION
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/448

You can see [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/14845/files#diff-1489fffc9f300b6fa2c85d73c1433683) the tests that were disabled when the WP unified flow was released. This change replaces/fixes those tests.
- All `EditorAztecTests` have been re-enabled.
- All `EditorGutenbergTests` have been re-enabled.
- `MainNavigationTests:testTabBarNavigation` has been re-enabled.
- `LoginTests`:
  - `testEmailPasswordLoginLogout`: replaced with `testWordPressLoginLogout`.
  - `testSelfHostedUsernamePasswordLoginLogout`: replaced with `testSelfHostedLoginLogout`.
  - `testUnsuccessfulLogin`: replaced with `testWordPressUnsuccessfulLogin`.
  - `testWpcomUsernamePasswordLogin`: replaced with `testWpcomLogin`.


The old tests are still present (and disabled) just in case. We'll clean them up later.


To test:
- Verify the UI tests pass on this PR.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
