### PR TITLE
Login Epilogue: don't show cells under header

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -166,6 +166,7 @@ extension LoginEpilogueTableViewController {
 
         cell.accessibilityIdentifier = "siteListHeaderCell"
         cell.accessibilityLabel = cell.titleLabel?.text
+        cell.contentView.backgroundColor = .basicBackground
         cell.accessibilityHint = NSLocalizedString("A list of sites on this account.", comment: "Accessibility hint for My Sites list.")
 
         return cell

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -88,7 +88,7 @@ class SignupEpilogueTableViewController: UITableViewController, EpilogueUserInfo
 
         cell.titleLabel?.numberOfLines = 0
         cell.topConstraint.constant = Constants.footerTopMargin
-        cell.titleLabel?.text = NSLocalizedString("You can always log in with a magic link like the one you just used, but you can also set up a password if you prefer.", comment: "Information shown below the optional password field after new account creation.")
+        cell.titleLabel?.text = NSLocalizedString("You can always log in with a link like the one you just used, but you can also set up a password if you prefer.", comment: "Information shown below the optional password field after new account creation.")
         cell.accessibilityLabel = cell.titleLabel?.text
 
         return cell


### PR DESCRIPTION
Fixes #14762 

This adds a background color to the "My Sites" header on the Login Epilogue to prevent the cell info from showing under it.

Bonus: the word "magic" is removed from the Signup Epilogue text `You can always log in with a link...` as requested by @mattmiklic .

To test:
- Login with an account that has a lot of sites.
- On the epilogue, scroll down.
- Verify the table cell content is no longer visible under the "My Sites" header.

| <img width="455" alt="light" src="https://user-images.githubusercontent.com/1816888/92791941-58caf380-f36a-11ea-888a-1ec77e12129b.png"> | <img width="455" alt="dark" src="https://user-images.githubusercontent.com/1816888/92791954-5bc5e400-f36a-11ea-8a20-25622f5b4579.png"> |
|--------|-------|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
