### PR TITLE
Reset selected interests when the screen appears

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsDataSource.swift
@@ -72,6 +72,11 @@ class ReaderInterestsDataSource {
         }
     }
 
+    /// Reset all selected interests
+    public func reset() {
+        interests.forEach { $0.isSelected = false }
+    }
+
     /// Returns a reader interest for the specified row
     /// - Parameter row: The index of the item you want to return
     /// - Returns: A reader interest model

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -61,6 +61,12 @@ class ReaderSelectInterestsViewController: UIViewController {
         }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        resetSelectedInterests()
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -142,6 +148,11 @@ class ReaderSelectInterestsViewController: UIViewController {
         startLoading(hideLabel: true)
 
         dataSource.reload()
+    }
+
+    private func resetSelectedInterests() {
+        dataSource.reset()
+        refreshData()
     }
 
     private func reloadData() {


### PR DESCRIPTION
## To test

1. Remove all tags you're following
2. Tap Reader
3. Select a few interests
4. Tap "My Sites"
5. Tap Reader again
6. Check that the interests are not selected anymore

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
