### PR TITLE
Signup Epilogue: show username if there is no email

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 15.8
 -----
 * [*] Image Preview: Fixes an issue where an image would be incorrectly positioned after changing device orientation.
+* [*] Fixed an issue where the username didn't display on the Signup Epilogue after signing up with Apple and hiding the email address. [#14882]
 
 15.7
 -----

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -43,7 +43,15 @@ class EpilogueUserInfoCell: UITableViewCell {
         fullNameLabel.text = userInfo.fullName
         fullNameLabel.fadeInAnimation()
 
-        usernameLabel.text = showEmail ? userInfo.email : "@\(userInfo.username)"
+        var displayUsername: String {
+            if showEmail && !userInfo.email.isEmpty {
+                return userInfo.email
+            }
+
+            return "@\(userInfo.username)"
+        }
+
+        usernameLabel.text = displayUsername
         usernameLabel.fadeInAnimation()
 
         gravatarAddIcon.isHidden = !allowGravatarUploads


### PR DESCRIPTION
Fixes #14725 

This fixes an issue where, after signing up with SIWA, the User Info section didn't display properly.

The intent is to show either the email or username in the bottom label. However, it was assuming the email had a value. But with Apple, with the email hidden, the email was just an empty string. 

This adds a check to see if there actually is an email. If not, display the username.

To test:
- Signup with Apple.
- When prompted, select `Hide My Email`.
- On the epilogue, verify your username is displayed under your name.

| ![siwa](https://user-images.githubusercontent.com/1816888/92955787-0bf72380-f423-11ea-88b9-11b8780e1766.jpg) | ![epilogue](https://user-images.githubusercontent.com/1816888/92955931-4496fd00-f423-11ea-9169-6751065e653f.jpg) |
|--------|-------|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
