### PR TITLE
Fix Reader Detail device rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -127,10 +127,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     }
 
     public func deviceDidRotate() {
-        let contentOffset = scrollView?.contentOffset.y ?? 0
-        let isFeaturedImageVisible = contentOffset < 0
-
-        updateInitialHeight(resetContentOffset: isFeaturedImageVisible)
+        updateInitialHeight(resetContentOffset: false)
     }
 
     func applyTransparentNavigationBarAppearance(to navigationBar: UINavigationBar?) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -127,7 +127,10 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     }
 
     public func deviceDidRotate() {
-        updateInitialHeight()
+        let contentOffset = scrollView?.contentOffset.y ?? 0
+        let isFeaturedImageVisible = contentOffset < 0
+
+        updateInitialHeight(resetContentOffset: isFeaturedImageVisible)
     }
 
     func applyTransparentNavigationBarAppearance(to navigationBar: UINavigationBar?) {
@@ -281,7 +284,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
         isHidden = false
     }
 
-    private func updateInitialHeight() {
+    private func updateInitialHeight(resetContentOffset: Bool = true) {
         let height = featuredImageHeight() - topMargin()
 
         heightConstraint.constant = height
@@ -289,8 +292,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
         if let scrollView = self.scrollView {
             scrollView.contentInset = UIEdgeInsets(top: height, left: 0, bottom: 0, right: 0)
 
-            // Only reset offset if the user has scrolled just a little bit
-            if scrollView.contentOffset.y < 0 {
+            if resetContentOffset {
                 scrollView.setContentOffset(CGPoint(x: 0, y: -height), animated: false)
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -288,7 +288,11 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
 
         if let scrollView = self.scrollView {
             scrollView.contentInset = UIEdgeInsets(top: height, left: 0, bottom: 0, right: 0)
-            scrollView.setContentOffset(CGPoint(x: 0, y: -height), animated: false)
+
+            // Only reset offset if the user has scrolled just a little bit
+            if scrollView.contentOffset.y < 0 {
+                scrollView.setContentOffset(CGPoint(x: 0, y: -height), animated: false)
+            }
         }
     }
 


### PR DESCRIPTION
Fixes rotation in the new Reader Detail.

## To test

### Without scrolling

1. Open a post in the new Reader Detail
2. Rotate the device
1. Check that the offset is kinda near the offset you were*

* Calculating the offset precisely seems very complex. I did a lot of explorations in iOS in the Safari app, Messages, and a few others and it seems that when rotating the content is not always kept in the same area.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
