### PR TITLE
Remove unused Reader Detail protocol conformance

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -519,13 +519,3 @@ extension ReaderDetailViewController: UIViewControllerRestoration {
         return super.awakeAfter(using: aDecoder)
     }
 }
-
-// MARK: - PrefersFullscreenDisplay (iPad)
-
-// Expand this view controller to full screen if possible
-extension ReaderDetailViewController: PrefersFullscreenDisplay {}
-
-// MARK: - DefinesVariableStatusBarStyle (iPad)
-
-// Let's the split view know this vc changes the status bar style.
-extension ReaderDetailViewController: DefinesVariableStatusBarStyle {}


### PR DESCRIPTION
This PR fixes an issue in the release branch where the status bar was showing dark content when in a Reader Detail view:

<img width="376" alt="Screenshot 2020-09-14 at 13 53 47" src="https://user-images.githubusercontent.com/4780/93088434-ca1fe480-f691-11ea-9172-0d8d080ab065.png">

This was due to a leftover declaraction of `ReaderDetailViewController` conforming to `DefinesVariableStatusBarStyle`. This causes the navigation controller to query the view controller for the preferred status bar style, but this view controller no longer declares one. As such, the default style would be used.

I've also removed an unused use of `PrefersFullscreenDisplay`, which is no longer needed now that the Reader doesn't use a split view.

**To test:**

- Note: while I can see the original issue with the current test builds of the app, I was only able to recreate it building to an iOS 12.2 simulator. It wasn't happening with iOS 13.7
- Build and run, and navigate to a Reader detail view. Ensure that the status bar content remains white.
- Ideally check on both device and simulator.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
