### PR TITLE
Reader: Adds report action to the reader post overflow menu

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -69,6 +69,7 @@ import Foundation
     case readerBlogBlocked
     case readerChipsMoreToggled
     case readerToggleFollowConversation
+    case readerPostReported
 
     /// A String that represents the event
     var value: String {
@@ -181,6 +182,8 @@ import Foundation
             return "reader_chips_more_toggled"
         case .readerToggleFollowConversation:
             return "reader_toggle_follow_conversation"
+        case .readerPostReported:
+            return "reader_post_reported"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -5,6 +5,7 @@ import SVProgressHUD
 struct ReaderPostMenuButtonTitles {
     static let cancel = NSLocalizedString("Cancel", comment: "The title of a cancel button.")
     static let blockSite = NSLocalizedString("Block This Site", comment: "The title of a button that triggers blocking a site from the user's reader.")
+    static let reportPost = NSLocalizedString("Report This Post", comment: "The title of a button that triggers reporting of a post from the user's reader.")
     static let share = NSLocalizedString("Share", comment: "Verb. Title of a button. Pressing lets the user share a post to others.")
     static let visit = NSLocalizedString("Visit", comment: "An option to visit the site to which a specific post belongs")
     static let unfollow = NSLocalizedString("Unfollow Site", comment: "Verb. An option to unfollow a site.")

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReportPostAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReportPostAction.swift
@@ -1,0 +1,43 @@
+/// Encapsulates a command to report a post
+final class ReaderReportPostAction {
+    func execute(with post: ReaderPost, context: NSManagedObjectContext, origin: UIViewController) {
+        guard
+            let permalink = post.permaLink,
+            let url = reportURL(with: permalink)
+        else {
+            return
+        }
+
+        let configuration = WebViewControllerConfiguration(url: url)
+        configuration.addsWPComReferrer = true
+        let service = AccountService(managedObjectContext: context)
+
+        if let account = service.defaultWordPressComAccount() {
+            configuration.authenticate(account: account)
+        }
+
+        let controller = WebViewControllerFactory.controller(configuration: configuration)
+        let navController = UINavigationController(rootViewController: controller)
+        origin.present(navController, animated: true)
+
+        // Track the report action
+        let properties = ReaderHelpers.statsPropertiesForPost(post, andValue: nil, forKey: nil)
+        WPAnalytics.track(.readerPostReported, properties: properties)
+    }
+
+    /// Safely generate the report URL
+    private func reportURL(with postURLString: String) -> URL? {
+        guard var components = URLComponents(string: Constants.reportURLString) else {
+            return nil
+        }
+
+        let queryItem = URLQueryItem(name: Constants.reportKey, value: postURLString)
+        components.queryItems = [queryItem]
+        return components.url
+    }
+
+    private struct Constants {
+        static let reportURLString = "https://wordpress.com/abuse/"
+        static let reportKey = "report_url"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -11,6 +11,7 @@ final class ReaderShowMenuAction {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alertController.addCancelActionWithTitle(ReaderPostMenuButtonTitles.cancel, handler: nil)
 
+
         // Block button
         if shouldShowBlockSiteMenuItem(readerTopic: readerTopic) {
             alertController.addActionWithTitle(ReaderPostMenuButtonTitles.blockSite,
@@ -18,6 +19,17 @@ final class ReaderShowMenuAction {
                                                handler: { (action: UIAlertAction) in
                                                 if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
                                                     ReaderBlockSiteAction(asBlocked: true).execute(with: post, context: context, completion: {})
+                                                }
+            })
+        }
+
+        // Report button
+        if shouldShowReportPostMenuItem(readerTopic: readerTopic) {
+            alertController.addActionWithTitle(ReaderPostMenuButtonTitles.reportPost,
+                                               style: .default,
+                                               handler: { (action: UIAlertAction) in
+                                                if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
+                                                    ReaderReportPostAction().execute(with: post, context: context, origin: vc)
                                                 }
             })
         }
@@ -91,5 +103,9 @@ final class ReaderShowMenuAction {
                 || ReaderHelpers.topicIsFreshlyPressed(topic)
         }
         return false
+    }
+
+    fileprivate func shouldShowReportPostMenuItem(readerTopic: ReaderAbstractTopic?) -> Bool {
+        return shouldShowBlockSiteMenuItem(readerTopic: readerTopic)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -364,6 +364,7 @@
 		327B48C5247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327B48C4247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift */; };
 		329F8E5624DDAC61002A5311 /* DynamicHeightCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329F8E5524DDAC61002A5311 /* DynamicHeightCollectionView.swift */; };
 		329F8E5824DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329F8E5724DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift */; };
+		32A218D8251109DB00D1AE6C /* ReaderReportPostAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A218D7251109DB00D1AE6C /* ReaderReportPostAction.swift */; };
 		32C765BA23F715E4000A7F11 /* PostSignUpInterstitialCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F1A6CE23F7083500AB8CA9 /* PostSignUpInterstitialCoordinator.swift */; };
 		32C765BB23F7170C000A7F11 /* PostSignUpInterstitialCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F1A6D323F7111800AB8CA9 /* PostSignUpInterstitialCoordinatorTests.swift */; };
 		32CA6EC02390C61F00B51347 /* PostListEditorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32CA6EBF2390C61F00B51347 /* PostListEditorPresenter.swift */; };
@@ -2809,6 +2810,7 @@
 		328CEC5D23A532BA00A6899E /* FullScreenCommentReplyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewController.swift; sourceTree = "<group>"; };
 		329F8E5524DDAC61002A5311 /* DynamicHeightCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicHeightCollectionView.swift; sourceTree = "<group>"; };
 		329F8E5724DDBD11002A5311 /* ReaderTopicCollectionViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTopicCollectionViewCoordinator.swift; sourceTree = "<group>"; };
+		32A218D7251109DB00D1AE6C /* ReaderReportPostAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderReportPostAction.swift; sourceTree = "<group>"; };
 		32A29A16236BC8BC009488C2 /* WordPress 93.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 93.xcdatamodel"; sourceTree = "<group>"; };
 		32C6CDDA23A1FF0D002556FF /* SiteCreationRotatingMessageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationRotatingMessageViewTests.swift; sourceTree = "<group>"; };
 		32CA6EBF2390C61F00B51347 /* PostListEditorPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListEditorPresenter.swift; sourceTree = "<group>"; };
@@ -9901,6 +9903,7 @@
 				D8212CC020AA7C58008E8AE8 /* ReaderShowMenuAction.swift */,
 				D8212CB420AA68D5008E8AE8 /* ReaderSubscribingNotificationAction.swift */,
 				D8212CBC20AA7A7A008E8AE8 /* ReaderVisitSiteAction.swift */,
+				32A218D7251109DB00D1AE6C /* ReaderReportPostAction.swift */,
 			);
 			name = ReaderPostActions;
 			sourceTree = "<group>";
@@ -12696,6 +12699,7 @@
 				74AF4D741FE417D200E3EBFE /* MediaUploadOperation.swift in Sources */,
 				981C986E21B9D71400A7C0C8 /* PostingActivityCollectionViewCell.swift in Sources */,
 				436D55D9210F85DD00CEAA33 /* NibLoadable.swift in Sources */,
+				32A218D8251109DB00D1AE6C /* ReaderReportPostAction.swift in Sources */,
 				D8D7DF5A20AD18A400B40A2D /* ImgUploadProcessor.swift in Sources */,
 				436D56222117312700CEAA33 /* RegisterDomainDetailsViewModel.swift in Sources */,
 				7E407121237163B8003627FA /* GutenbergStockPhotos.swift in Sources */,


### PR DESCRIPTION
Fixes #14895

### Screenshots
<img src="https://user-images.githubusercontent.com/793774/93131038-4d3c3d00-f688-11ea-8903-4681e401246a.png" width="30%" />

### To test:
1. Launch the app
2. Tap on the Reader tab
3. Locate a post you want to report
4. Tap the vertical ellipsis `︙` button 
5. Locate the 'Report This Site' option in the menu
6. Tap on it

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
