### PR TITLE
Fix AutoLayout warnings in Blog Header and Posts

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -107,17 +107,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         DDLogInfo("didFinishLaunchingWithOptions state: \(application.applicationState)")
 
-        let queue = DispatchQueue(label: "asd", qos: .background)
-        let deviceInformation = TracksDeviceInformation()
-
-        queue.async {
-            let height = deviceInformation.statusBarHeight
-            let orientation = deviceInformation.orientation!
-
-            print("Height: \(height); orientation: \(orientation)")
-        }
-
-
         InteractiveNotificationsManager.shared.registerForUserNotifications()
         showWelcomeScreenIfNeeded(animated: false)
         setupPingHub()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -127,7 +127,7 @@ class BlogDetailHeaderView: UIView {
         stackView.setCustomSpacing(Constants.spacingBelowTitle, after: titleButton)
 
         /// Constraints for constrained widths (iPad portrait)
-        let minimumPaddingSideConstraints = [
+        let minimumPaddingSideConstraints: [NSLayoutConstraint] = [
             buttonsStackView.leadingAnchor.constraint(greaterThanOrEqualTo: stackView.leadingAnchor, constant: 0),
             buttonsStackView.trailingAnchor.constraint(lessThanOrEqualTo: stackView.trailingAnchor, constant: 0),
         ]
@@ -138,18 +138,22 @@ class BlogDetailHeaderView: UIView {
         let widthConstraint = buttonsStackView.widthAnchor.constraint(equalToConstant: 320)
         widthConstraint.priority = .defaultHigh
 
-        let edgeConstraints = [
+        let stackViewConstraints = [
             stackView.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
             stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: Constants.minimumSideSpacing),
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.interSectionSpacing),
-            stackView.centerXAnchor.constraint(equalTo: layoutMarginsGuide.centerXAnchor),
+            stackView.centerXAnchor.constraint(equalTo: layoutMarginsGuide.centerXAnchor)
+        ]
+        stackViewConstraints.forEach { $0.priority = UILayoutPriority(999) }
+
+        let edgeConstraints = [
             buttonsStackView.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.interSectionSpacing),
             buttonsStackView.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
             bottomConstraint,
             widthConstraint
         ]
 
-        NSLayoutConstraint.activate(minimumPaddingSideConstraints + edgeConstraints)
+        NSLayoutConstraint.activate(minimumPaddingSideConstraints + edgeConstraints + stackViewConstraints)
     }
 
     override init(frame: CGRect) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -808,7 +808,9 @@ class AbstractPostListViewController: UIViewController,
             return
         }
 
-        ghostableTableView.startGhostAnimation()
+        if isViewOnScreen() {
+            ghostableTableView.startGhostAnimation()
+        }
         ghostableTableView.isHidden = false
         noResultsViewController.view.isHidden = true
     }

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
@@ -52,7 +52,7 @@
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="POV-pe-wu8">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="POV-pe-wu8">
                                                 <rect key="frame" x="16" y="153" width="294" height="17"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -285,12 +285,12 @@
                             <constraint firstItem="33v-Uz-9S6" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="84P-oH-EZa"/>
                             <constraint firstAttribute="trailing" secondItem="kcO-mG-FcD" secondAttribute="trailing" id="AEy-Bg-FgQ"/>
                             <constraint firstAttribute="trailing" secondItem="9eW-ex-CSu" secondAttribute="trailing" id="HUj-hh-Ili"/>
-                            <constraint firstAttribute="trailing" secondItem="JqA-of-VBn" secondAttribute="trailing" id="MY8-mP-ASa"/>
+                            <constraint firstAttribute="trailing" secondItem="JqA-of-VBn" secondAttribute="trailing" priority="999" id="MY8-mP-ASa"/>
                             <constraint firstAttribute="bottom" secondItem="JqA-of-VBn" secondAttribute="bottom" priority="999" id="NwA-tt-aRf"/>
                             <constraint firstItem="kcO-mG-FcD" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="WNn-kw-WAj"/>
                             <constraint firstItem="sev-PH-HG8" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="Yrw-8m-Cu0"/>
                             <constraint firstAttribute="bottom" secondItem="9eW-ex-CSu" secondAttribute="bottom" id="a2Y-qy-DA8"/>
-                            <constraint firstItem="JqA-of-VBn" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="bPW-Sv-fZu"/>
+                            <constraint firstItem="JqA-of-VBn" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" priority="999" id="bPW-Sv-fZu"/>
                             <constraint firstItem="JqA-of-VBn" firstAttribute="top" secondItem="Lk7-nZ-b0t" secondAttribute="top" constant="16" id="hLL-be-nDD"/>
                             <constraint firstItem="A8f-pJ-oKt" firstAttribute="top" secondItem="kcO-mG-FcD" secondAttribute="bottom" id="rKR-Zt-Tm7"/>
                             <constraint firstAttribute="trailing" secondItem="sev-PH-HG8" secondAttribute="trailing" id="uus-mZ-ErN"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -125,25 +125,25 @@
                                         <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                     </stackView>
                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="O86-Za-gd3">
-                                        <rect key="frame" x="0.0" y="378" width="326" height="24"/>
+                                        <rect key="frame" x="0.0" y="378" width="326" height="0.0"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pUW-s6-y3t">
-                                                <rect key="frame" x="16" y="0.0" width="294" height="24"/>
+                                                <rect key="frame" x="16" y="0.0" width="294" height="0.0"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fbo-xb-RzU">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Foo" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fbo-xb-RzU">
                                                         <rect key="frame" x="0.0" y="0.0" width="179" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i9p-kc-f73">
-                                                        <rect key="frame" x="0.0" y="16" width="264" height="0.0"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Bar" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i9p-kc-f73">
+                                                        <rect key="frame" x="0.0" y="-8" width="264" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GjI-kU-Yyb">
-                                                        <rect key="frame" x="0.0" y="24" width="229" height="0.0"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Zoo" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GjI-kU-Yyb">
+                                                        <rect key="frame" x="0.0" y="0.0" width="229" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -156,7 +156,7 @@
                                                     <constraint firstAttribute="trailing" secondItem="i9p-kc-f73" secondAttribute="trailing" constant="30" id="Lmh-6K-FTN"/>
                                                     <constraint firstItem="i9p-kc-f73" firstAttribute="leading" secondItem="Fbo-xb-RzU" secondAttribute="leading" id="Xbv-bg-VQw"/>
                                                     <constraint firstAttribute="trailing" secondItem="Fbo-xb-RzU" secondAttribute="trailing" constant="115" id="eDn-2Z-X3D"/>
-                                                    <constraint firstItem="i9p-kc-f73" firstAttribute="top" secondItem="Fbo-xb-RzU" secondAttribute="bottom" constant="16" id="h9D-W5-py9"/>
+                                                    <constraint firstItem="i9p-kc-f73" firstAttribute="top" secondItem="Fbo-xb-RzU" secondAttribute="bottom" priority="999" constant="16" id="h9D-W5-py9"/>
                                                     <constraint firstAttribute="bottom" secondItem="GjI-kU-Yyb" secondAttribute="bottom" id="iQA-lR-YoB"/>
                                                     <constraint firstItem="Fbo-xb-RzU" firstAttribute="leading" secondItem="pUW-s6-y3t" secondAttribute="leading" id="koW-HA-yJ4"/>
                                                     <constraint firstItem="GjI-kU-Yyb" firstAttribute="leading" secondItem="i9p-kc-f73" secondAttribute="leading" id="muB-zW-FhM"/>
@@ -238,7 +238,7 @@
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ud6-kQ-Qkb">
                                                 <rect key="frame" x="217.5" y="8" width="108.5" height="44"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="44" id="xGx-cq-ksn"/>
+                                                    <constraint firstAttribute="height" priority="999" constant="44" id="xGx-cq-ksn"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                 <inset key="titleEdgeInsets" minX="8" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -266,7 +266,7 @@
                                 <color key="backgroundColor" name="Gray10"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="Nuu-dr-YF0"/>
-                                    <constraint firstAttribute="width" constant="326" id="Zzv-2b-WyX"/>
+                                    <constraint firstAttribute="width" priority="999" constant="326" id="Zzv-2b-WyX"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9eW-ex-CSu">
@@ -286,7 +286,7 @@
                             <constraint firstAttribute="trailing" secondItem="kcO-mG-FcD" secondAttribute="trailing" id="AEy-Bg-FgQ"/>
                             <constraint firstAttribute="trailing" secondItem="9eW-ex-CSu" secondAttribute="trailing" id="HUj-hh-Ili"/>
                             <constraint firstAttribute="trailing" secondItem="JqA-of-VBn" secondAttribute="trailing" id="MY8-mP-ASa"/>
-                            <constraint firstAttribute="bottom" secondItem="JqA-of-VBn" secondAttribute="bottom" id="NwA-tt-aRf"/>
+                            <constraint firstAttribute="bottom" secondItem="JqA-of-VBn" secondAttribute="bottom" priority="999" id="NwA-tt-aRf"/>
                             <constraint firstItem="kcO-mG-FcD" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="WNn-kw-WAj"/>
                             <constraint firstItem="sev-PH-HG8" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="Yrw-8m-Cu0"/>
                             <constraint firstAttribute="bottom" secondItem="9eW-ex-CSu" secondAttribute="bottom" id="a2Y-qy-DA8"/>
@@ -349,7 +349,7 @@
         <image name="icon-post-actionbar-view" width="18" height="18"/>
         <image name="icon-post-undo" width="18" height="18"/>
         <namedColor name="Gray10">
-            <color red="0.80392156862745101" green="0.78823529411764703" blue="0.80392156862745101" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.76470588235294112" green="0.7686274509803922" blue="0.7803921568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
@@ -130,19 +130,19 @@
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pUW-s6-y3t">
                                                 <rect key="frame" x="16" y="0.0" width="294" height="0.0"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Foo" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fbo-xb-RzU">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fbo-xb-RzU">
                                                         <rect key="frame" x="0.0" y="0.0" width="179" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Bar" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i9p-kc-f73">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i9p-kc-f73">
                                                         <rect key="frame" x="0.0" y="-8" width="264" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" Zoo" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GjI-kU-Yyb">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GjI-kU-Yyb">
                                                         <rect key="frame" x="0.0" y="0.0" width="229" height="0.0"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <nil key="textColor"/>

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -155,11 +155,16 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         title = NSLocalizedString("Blog Posts", comment: "Title of the screen showing the list of posts for a blog.")
 
-        configureCompactOrDefault()
         configureFilterBarTopConstraint()
         updateGhostableTableViewOptions()
 
         configureNavigationButtons()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        configureCompactOrDefault()
     }
 
     func configureNavigationButtons() {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -303,18 +303,16 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func showCompactOrDefault() {
-        guard isViewOnScreen() else {
-            return
-        }
-
-        tableView.reloadSections([0], with: .automatic)
-
         updateGhostableTableViewOptions()
-        ghostableTableView.reloadSections([0], with: .automatic)
 
         postsViewButtonItem.accessibilityLabel = NSLocalizedString("List style", comment: "The accessibility label for the list style button in the Post List.")
         postsViewButtonItem.accessibilityValue = isCompact ? NSLocalizedString("Compact", comment: "Accessibility indication that the current Post List style is currently Compact.") : NSLocalizedString("Expanded", comment: "Accessibility indication that the current Post List style is currently Expanded.")
         postsViewButtonItem.image = postViewIcon
+
+        if isViewOnScreen() {
+            tableView.reloadSections([0], with: .automatic)
+            ghostableTableView.reloadSections([0], with: .automatic)
+        }
     }
 
     // Mark - Layout Methods

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -218,7 +218,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
     /// Update the `GhostOptions` to correctly show compact or default cells
     private func updateGhostableTableViewOptions() {
-        let ghostOptions = GhostOptions(displaysSectionHeader: false, reuseIdentifier: postCellIdentifier, rowsPerSection: [10])
+        let ghostOptions = GhostOptions(displaysSectionHeader: false, reuseIdentifier: postCellIdentifier, rowsPerSection: [50])
         let style = GhostStyle(beatDuration: GhostStyle.Defaults.beatDuration,
                                beatStartColor: .placeholderElement,
                                beatEndColor: .placeholderElementFaded)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -303,6 +303,10 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func showCompactOrDefault() {
+        guard isViewOnScreen() else {
+            return
+        }
+
         tableView.reloadSections([0], with: .automatic)
 
         updateGhostableTableViewOptions()

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/PostListViewControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/PostListViewControllerTests.swift
@@ -46,7 +46,7 @@ class PostListViewControllerTests: XCTestCase {
 
         postListViewController.startGhost()
 
-        expect(postListViewController.ghostableTableView.numberOfRows(inSection: 0)).to(equal(10))
+        expect(postListViewController.ghostableTableView.numberOfRows(inSection: 0)).to(equal(50))
     }
 
     func testItCanHandleNewPostUpdatesEvenIfTheGhostViewIsStillVisible() {


### PR DESCRIPTION
Fixes #14690
Fixes #14689

This PR fixes warnings in:

* `BlogDetailHeaderView`
* `PostCardCell`
* `PostListViewController`
* Some debug code was removed

### To test

#### No warnings when running the app

1. Run the app
1. Check that no Autolayout warnings are shown
1. Check that no "[TableView] Warning once only: UITableView was told to layout its visible cells and other (...)" warnings are shown

#### No warnings when showing posts

1. Run the app
1. Tap "Blog Posts" on any site
1. Check that no Autolayout warnings are shown
1. Check that no "[TableView] Warning once only: UITableView was told to layout its visible cells and other (...)" warnings are shown

#### No visual changes in Blog Header

1. Run the app
1. Tap any blog
1. Check the site header, there shouldn't be any changes or regressions

#### No visual changes in Blog Posts

1. Run the app
1. Tap any blog
1. Tap Blog Posts
1. Check the large post cells (not the compact one), there shouldn't be any changes or regressions

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
