### PR TITLE
Track which tag is followed

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -360,7 +360,8 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     ReaderTopicServiceRemote *remoteService = [[ReaderTopicServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
     [remoteService followTopicNamed:topicName withSuccess:^(NSNumber *topicID) {
         [self fetchReaderMenuWithSuccess:^{
-            [WPAnalytics track:WPAnalyticsStatReaderTagFollowed];
+            NSDictionary *properties = @{@"tag":topicName};
+            [WPAnalytics track:WPAnalyticsStatReaderTagFollowed withProperties:properties];
             [self selectTopicWithID:topicID];
             if (success) {
                 success();
@@ -377,7 +378,8 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 - (void)followTagWithSlug:(NSString *)slug withSuccess:(void (^)(void))success failure:(void (^)(NSError *error))failure
 {
     void (^successBlock)(void) = ^{
-        [WPAnalytics track:WPAnalyticsStatReaderTagFollowed];
+        NSDictionary *properties = @{@"tag":slug};
+        [WPAnalytics track:WPAnalyticsStatReaderTagFollowed withProperties:properties];
         if (success) {
             success();
         }


### PR DESCRIPTION
Add the missing `tag` information for `reader_tag_followed`.

### To test

1. Follow a topic
1. Check that a `reader_reader_tag_followed` event is triggered with a `tag` property

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
