### PR TITLE
ULS Site Address: Redirect to WP login if site is hosted on WP.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -191,9 +191,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.24.2'
+    # pod 'WordPressAuthenticator', '~> 1.24.3'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/wp_site_redirect'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.24.2):
+  - WordPressAuthenticator (1.24.3):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.24.2)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/wp_site_redirect`)
   - WordPressKit (~> 4.16.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
@@ -555,7 +555,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -657,6 +656,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.36.0
+  WordPressAuthenticator:
+    :branch: feature/wp_site_redirect
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.36.0/third-party-podspecs/Yoga.podspec.json
 
@@ -675,6 +677,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.36.0
+  WordPressAuthenticator:
+    :commit: 4b38a4fd2ccd9bf82125e2f69852a49d873c41fc
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -755,7 +760,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 8d0160875723572520867841edfed3c4942bd27f
+  WordPressAuthenticator: 384c94223600fd43f4ce851923d44143d3cee4d6
   WordPressKit: 48d56b8d3d25619e32d3a8ae4e934547eb684856
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
@@ -772,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 72840865369e840532f088c3e597be72bdf73eb9
+PODFILE CHECKSUM: 9218f1bbb518d28c7e82575ec7a82c81dcffb938
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-iOS/issues/13870
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/461

This uses the Auth changes to redirect to Get Started flow if a WP hosted site address is entered.

To test:

---
- Select `Enter your site address` on the prologue.
- Enter a site address that is hosted on WP.
- Verify the `Get Started` view is displayed.

| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-15 at 13 44 08](https://user-images.githubusercontent.com/1816888/93257136-aa53f380-f759-11ea-9c9e-231bc321822d.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-15 at 13 44 14](https://user-images.githubusercontent.com/1816888/93257149-ae801100-f759-11ea-9157-8fddadd746aa.png) |
|--------|-------|

---
- Select `Enter your site address` on the prologue.
- Enter a self-hosted site address.
- Verify the site credential view is displayed.

| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-15 at 13 46 05](https://user-images.githubusercontent.com/1816888/93257325-e7b88100-f759-11ea-985b-fcb411677eb1.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-09-15 at 13 46 12](https://user-images.githubusercontent.com/1816888/93257410-0880d680-f75a-11ea-9deb-81e74623e5b8.png) |
|--------|-------|

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
