### PR TITLE
Fix: #14787: Update WordPressKit to 4.17.0-beta.2

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -407,7 +407,7 @@ PODS:
     - WordPressKit (~> 4.16-beta)
     - WordPressShared (~> 1.11-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.17.0-beta.1):
+  - WordPressKit (4.17.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -756,7 +756,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: 7e21f75235152e8daf95ce6ecb4ca33b1a3a9a0d
-  WordPressKit: f47b1a01c24c96814e5449fdb3894de37fe17d9d
+  WordPressKit: 9adbaee6ee83dce93353d4b3bcd1fd7d81b90f25
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: 9da5d966b8beb091950cd96880db398d7f30e246


### PR DESCRIPTION
Fixes #14787 

The counterpart to https://github.com/wordpress-mobile/WordPressKit-iOS/pull/283

Fixes a crash when weak self references to WordPressOrgXMLRPCAPI could not be created during deinitliazation.

To test:

- Log in to a self-hosted site
- Navigate to the post list and ensure posts load
- Publish a post
- Log out of the account

PR submission checklist:

- [x] ~I have considered adding unit tests where possible.~ Hard to test since this is a hard crash.
- [x] ~I have considered adding accessibility improvements for my changes.~
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
