### PR TITLE
Adds tag followed tracking to the select interests view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -173,8 +173,15 @@ class ReaderSelectInterestsViewController: UIViewController {
                 return
             }
 
+            self?.trackEvents(with: selectedInterests)
             self?.stopLoading()
             self?.didSaveInterests?()
+        }
+    }
+
+    private func trackEvents(with selectedInterests: [RemoteReaderInterest]) {
+        selectedInterests.forEach {
+            WPAnalytics.track(.readerTagFollowed, withProperties: ["tag": $0.slug])
         }
 
         WPAnalytics.track(.selectInterestsPicked, properties: ["quantity": selectedInterests.count])


### PR DESCRIPTION
### To test:
1. Launch the app
2. Tap on the Reader tab
3. Delete all of your followed tags if needed
4. Tap on the Discover view
5. Select some interests
8. Hit the 'Done' button
9. Verify you see the following track message in console for each tag you selected:

`🔵 Tracked: reader_reader_tag_followed <tag: {$TAG_NAME}>`

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
