### PR TITLE
Menu Section: VoiceOver improvements Mark II

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenuDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuDetailsViewController.m
@@ -55,6 +55,7 @@ static NSTimeInterval const TextfieldEditingAnimationDuration = 0.3;
     textField.textColor = [UIColor murielText];
     textField.tintColor = [UIColor murielListIcon];
     textField.adjustsFontForContentSizeCategory = YES;
+    textField.accessibilityLabel = NSLocalizedString(@"Menu name", @"");
     [self updateTextFieldFont];
     [textField addTarget:self action:@selector(hideTextFieldKeyboard) forControlEvents:UIControlEventEditingDidEndOnExit];
     [textField addTarget:self action:@selector(textFieldValueChanged:) forControlEvents:UIControlEventEditingChanged];
@@ -79,6 +80,7 @@ static NSTimeInterval const TextfieldEditingAnimationDuration = 0.3;
     [trashButton addTarget:self action:@selector(trashButtonPressed) forControlEvents:UIControlEventTouchUpInside];
     trashButton.backgroundColor = [UIColor clearColor];
     trashButton.adjustsImageWhenHighlighted = YES;
+    trashButton.accessibilityLabel = NSLocalizedString(@"Delete menu", @"");
 }
 
 - (void)setupTextFieldDesignViews

--- a/WordPress/Classes/ViewRelated/Menus/MenuDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuDetailsViewController.m
@@ -55,7 +55,7 @@ static NSTimeInterval const TextfieldEditingAnimationDuration = 0.3;
     textField.textColor = [UIColor murielText];
     textField.tintColor = [UIColor murielListIcon];
     textField.adjustsFontForContentSizeCategory = YES;
-    textField.accessibilityLabel = NSLocalizedString(@"Menu name", @"Screen Reader: Description for text filed that edits the menu name.");
+    textField.accessibilityLabel = NSLocalizedString(@"Menu name", @"Screen Reader: Description for text field that edits the menu name.");
     [self updateTextFieldFont];
     [textField addTarget:self action:@selector(hideTextFieldKeyboard) forControlEvents:UIControlEventEditingDidEndOnExit];
     [textField addTarget:self action:@selector(textFieldValueChanged:) forControlEvents:UIControlEventEditingChanged];

--- a/WordPress/Classes/ViewRelated/Menus/MenuDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuDetailsViewController.m
@@ -55,7 +55,7 @@ static NSTimeInterval const TextfieldEditingAnimationDuration = 0.3;
     textField.textColor = [UIColor murielText];
     textField.tintColor = [UIColor murielListIcon];
     textField.adjustsFontForContentSizeCategory = YES;
-    textField.accessibilityLabel = NSLocalizedString(@"Menu name", @"");
+    textField.accessibilityLabel = NSLocalizedString(@"Menu name", @"Screen Reader: Description for text filed that edits the menu name.");
     [self updateTextFieldFont];
     [textField addTarget:self action:@selector(hideTextFieldKeyboard) forControlEvents:UIControlEventEditingDidEndOnExit];
     [textField addTarget:self action:@selector(textFieldValueChanged:) forControlEvents:UIControlEventEditingChanged];
@@ -80,7 +80,7 @@ static NSTimeInterval const TextfieldEditingAnimationDuration = 0.3;
     [trashButton addTarget:self action:@selector(trashButtonPressed) forControlEvents:UIControlEventTouchUpInside];
     trashButton.backgroundColor = [UIColor clearColor];
     trashButton.adjustsImageWhenHighlighted = YES;
-    trashButton.accessibilityLabel = NSLocalizedString(@"Delete menu", @"");
+    trashButton.accessibilityLabel = NSLocalizedString(@"Delete menu", @"Screen Reader: Button that deletes a menu.");
 }
 
 - (void)setupTextFieldDesignViews

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.m
@@ -126,6 +126,10 @@ CGFloat const MenuItemsStackableViewDefaultHeight = 44.0;
     label.adjustsFontForContentSizeCategory = YES;
     label.backgroundColor = [UIColor clearColor];
 
+    // Taps are handled by the UITouches API.
+    // Marking this label as a button is the simplest way to show tappability to a VoiceOver user.
+    label.accessibilityTraits = UIAccessibilityTraitButton;
+
     NSAssert(_stackView != nil, @"stackView is nil");
     [_stackView addArrangedSubview:label];
 

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemView.m
@@ -30,6 +30,7 @@
         [self setupCancelButton];
 
         self.highlighted = NO;
+        self.textLabel.accessibilityHint = NSLocalizedString(@"Edits this menu item", @"Screen reader hint for button to edit a menu item");
     }
 
     return self;
@@ -38,6 +39,7 @@
 - (void)setupAddButton
 {
     UIButton *button = [self addAccessoryButtonIconViewWithImage:[UIImage gridiconOfType:GridiconTypePlus]];
+    button.accessibilityLabel = NSLocalizedString(@"Add new menu item", @"Screen reader text for button that adds a menu item");
     [button addTarget:self action:@selector(addButtonPressed) forControlEvents:UIControlEventTouchUpInside];
     _addButton = button;
 }
@@ -46,6 +48,8 @@
 {
     UIImage *image = [[UIImage imageNamed:@"menus-move-icon"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     UIButton *button = [self addAccessoryButtonIconViewWithImage:image];
+    button.accessibilityLabel = NSLocalizedString(@"Move menu item", @"Screen reader text for button that will move the menu item");
+    button.accessibilityHint = NSLocalizedString(@"Double tap and hold to move this menu item up or down", @"Screen reader hint for button that will move the menu item");
     button.userInteractionEnabled = NO;
     _orderingButton = button;
 }


### PR DESCRIPTION
Fixes second part of https://github.com/wordpress-mobile/WordPress-iOS/issues/12881

This PR adds some extra accessibility labels and hints to make this section more friendly with VoiceOver.
The section design itself makes it difficult to make a better implementation with VoiceOver, since there are many elements appearing and disappearing, elements with many actions including swappable views.

At the end, and after testing a few different things, I have decided to go by the simple way and add labels to missing elements.

**To test:**

- Run WPiOS on this branch.
- Navigate to the Menus section.
- Turn on [VoiceOver ](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/docs/using-voiceover.md)
- Check that there are no elements without a proper accessibility description.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
