### PR TITLE
Clean cards when Reader starts for the first time

### DIFF
--- a/WordPress/Classes/Services/ReaderCardService.swift
+++ b/WordPress/Classes/Services/ReaderCardService.swift
@@ -79,6 +79,12 @@ class ReaderCardService {
         }
     }
 
+    /// Remove all cards and saves the context
+    func clean() {
+        removeAllCards()
+        coreDataStack.save(syncContext)
+    }
+
     private func removeAllCards() {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ReaderCard.classNameWithoutNamespaces())
         fetchRequest.returnsObjectsAsFaults = false

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -22,7 +22,7 @@ class ReaderTabViewController: UIViewController {
 
         ReaderTabViewController.configureRestoration(on: self)
 
-        ReaderCardService().removeAllCards()
+        ReaderCardService().clean()
 
         viewModel.filterTapped = { [weak self] (fromView, completion) in
             guard let self = self else {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -22,6 +22,8 @@ class ReaderTabViewController: UIViewController {
 
         ReaderTabViewController.configureRestoration(on: self)
 
+        ReaderCardService().removeAllCards()
+
         viewModel.filterTapped = { [weak self] (fromView, completion) in
             guard let self = self else {
                 return


### PR DESCRIPTION
Fixes #14910 

## To test

1. Run the app
1. Tap Reader > Discover
1. Kill the app
1. Run the app again
1. Tap Reader > Discover
1. Check that the content is reloaded and there are no cards there

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
