### PR TITLE
UL&S: Support RTL languages on login epilogue

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -23,7 +23,7 @@
                             <constraint firstAttribute="height" constant="72" id="UTE-fR-kMZ"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full Name" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MbK-Ns-TbF">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MbK-Ns-TbF">
                         <rect key="frame" x="20" y="119" width="343" height="22"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="LJN-z2-A6L"/>
@@ -32,7 +32,7 @@
                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="89f-vg-HlI">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="89f-vg-HlI">
                         <rect key="frame" x="20" y="141" width="343" height="18"/>
                         <accessibility key="accessibilityConfiguration" identifier="username"/>
                         <constraints>


### PR DESCRIPTION
Partial fix for https://github.com/wordpress-mobile/WordPress-iOS/issues/7584.

### To test
1. Set your schema system language to Arabic or any other RTL language
2. Log out if logged in
3. Follow any flow to reach the login epilogue

| Before | After |
| --- | --- |
| <a href="https://user-images.githubusercontent.com/1062444/92946474-55904000-f41c-11ea-8ef5-bf4dc5e451e6.png"><img src="https://user-images.githubusercontent.com/1062444/92946474-55904000-f41c-11ea-8ef5-bf4dc5e451e6.png" width="350" /></a> | <a href="https://user-images.githubusercontent.com/1062444/93365638-aaaec600-f80f-11ea-9642-a3c0a2036d7e.png"><img src="https://user-images.githubusercontent.com/1062444/93365638-aaaec600-f80f-11ea-9642-a3c0a2036d7e.png" width="350" /></a> |

**(Left-to-Right after bug fix)**
<a href="https://user-images.githubusercontent.com/1062444/93365550-8b179d80-f80f-11ea-8901-52f3d41e0a5b.png"><img src="https://user-images.githubusercontent.com/1062444/93365550-8b179d80-f80f-11ea-8901-52f3d41e0a5b.png" width="350" /></a>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
