### PR TITLE
Menus: Disable Save button if the menu selected hasn't changed

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -38,6 +38,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
 
 @property (nonatomic, strong) MenuLocation *selectedMenuLocation;
 @property (nonatomic, strong) Menu *updatedMenuForSaving;
+@property (nonatomic, strong) Menu *initialMenuSelection;
 
 @property (nonatomic, assign) BOOL observesKeyboardChanges;
 @property (nonatomic, assign) BOOL animatesAppearanceAfterSync;
@@ -221,7 +222,8 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
          */
         [self setNeedsSave:YES forMenu:self.selectedMenuLocation.menu significantChanges:NO];
     } else {
-        [self setNeedsSave:YES forMenu:menu significantChanges:NO];
+        BOOL needsSave = (menu != self.initialMenuSelection) || self.hasMadeSignificantMenuChanges;
+        [self setNeedsSave:needsSave forMenu:menu significantChanges:NO];
     }
     self.selectedMenuLocation.menu = menu;
     [self.headerViewController setSelectedMenu:menu];
@@ -256,6 +258,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
     self.headerViewController.blog = self.blog;
     MenuLocation *selectedLocation = [self.blog.menuLocations firstObject];
     self.selectedMenuLocation = selectedLocation;
+    self.initialMenuSelection = selectedLocation.menu;
 
     if (!self.animatesAppearanceAfterSync) {
         self.scrollView.alpha = 1.0;
@@ -643,9 +646,11 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
         [self promptForDiscardingChangesBeforeSelectingADifferentLocation:^{
             [self discardAllChanges];
             self.selectedMenuLocation = location;
+            self.initialMenuSelection = location.menu;
         } cancellation:nil];
     } else {
         self.selectedMenuLocation = location;
+        self.initialMenuSelection = location.menu;
     }
 }
 


### PR DESCRIPTION
Fixes #9832  

This PR fixes the issue where the Save button on the Menus section was still tappable even if the selected menu was the same than the initial (saved) one. Now if the user selects the same menu as it is saved (not changing state), the Save button will be disabled.
 
![menu_reset_save](https://user-images.githubusercontent.com/9772967/93463363-f16fef00-f8e7-11ea-8463-1800d8c908c4.gif)


To test:

- Go to the Menus section of a site.
- On the `Menu for location` section (second drop down), select a different menu.
  - Check that the `Save` button is now active.
  - Check that the `< Back` button now says `Discard`.
- Select again the menu initially selected.
  - Check that the `Save` button is now disabled.
  - Check that the `< Back` button is back.
- Smoke-test other interactions in the menu section.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
