### PR TITLE
Set clear backgrounds for stackviews on iOS 14

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -830,6 +830,11 @@ extension WordPressAppDelegate {
         window?.backgroundColor = .black
         window?.tintColor = WPStyleGuide.wordPressBlue()
 
+        // iOS 14 started rendering backgrounds for stack views, when previous versions
+        // of iOS didn't show them. This is a little hacky, but ensures things keep
+        // looking the same on newer versions of iOS.
+        UIStackView.appearance().backgroundColor = .clear
+
         WPStyleGuide.configureTabBarAppearance()
         WPStyleGuide.configureNavigationAppearance()
         WPStyleGuide.configureDefaultTint()
@@ -857,7 +862,6 @@ extension WordPressAppDelegate {
         let barItemAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [WPMediaPickerViewController.self])
         barItemAppearance.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white, NSAttributedString.Key.font: WPFontManager.systemSemiBoldFont(ofSize: 16.0)], for: .disabled)
         UICollectionView.appearance(whenContainedInInstancesOf: [WPMediaPickerViewController.self]).backgroundColor = .neutral(.shade5)
-
 
         let cellAppearance = WPMediaCollectionViewCell.appearance(whenContainedInInstancesOf: [WPMediaPickerViewController.self])
         cellAppearance.loadingBackgroundColor = .listBackground


### PR DESCRIPTION
This PR fixes some appearance issues in iOS 14. In iOS 14, stack views now render their backgrounds, which was never the case before. This led to some visual issues like this:

<img src="https://user-images.githubusercontent.com/4780/93480133-04d58700-f8f5-11ea-9140-12fb87fe53f1.PNG" width=300 />

This PR 'fixes' that by setting all stack views to have a clear background with UIAppearance. This seems to have the desired effect in my testing, but it's possible we'll need to tweak some places individually.

<img src="https://user-images.githubusercontent.com/4780/93480325-39494300-f8f5-11ea-9edd-8537672b893a.png" width=300 />

**To test:**

- This PR does not include changes required to build correctly on Xcode 12. It's probably easiest to cherry-pick or just copy this change into a an existing Xcode 12 branch you may have.
- Build and run, put the app into dark mode, and navigate to the Reader.
- Check that cards appear as expected.
- Smoke test the rest of the app.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
