### PR TITLE
UL&S: Adds tracking to the prologue, and fixes some other tracking issues.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -191,10 +191,10 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.1'
 
-    pod 'WordPressAuthenticator', '~> 1.24.4'
+    # pod 'WordPressAuthenticator', '~> 1.24.4'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '979cb242eb5f3b234dfb546e82aa93e0a8a7f896'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.1'

--- a/Podfile
+++ b/Podfile
@@ -194,7 +194,7 @@ target 'WordPress' do
     # pod 'WordPressAuthenticator', '~> 1.24.4'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '7df620055eefc4245fb241ad48f203020fadf62c'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'dc357ae35fa4dd7ddb3232b004d417079298e08c'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.1'

--- a/Podfile
+++ b/Podfile
@@ -194,7 +194,7 @@ target 'WordPress' do
     # pod 'WordPressAuthenticator', '~> 1.24.4'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '979cb242eb5f3b234dfb546e82aa93e0a8a7f896'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '7df620055eefc4245fb241ad48f203020fadf62c'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `7df620055eefc4245fb241ad48f203020fadf62c`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `dc357ae35fa4dd7ddb3232b004d417079298e08c`)
   - WordPressKit (~> 4.16.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
@@ -657,7 +657,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.36.1
   WordPressAuthenticator:
-    :commit: 7df620055eefc4245fb241ad48f203020fadf62c
+    :commit: dc357ae35fa4dd7ddb3232b004d417079298e08c
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.36.1/third-party-podspecs/Yoga.podspec.json
@@ -678,7 +678,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.36.1
   WordPressAuthenticator:
-    :commit: 7df620055eefc4245fb241ad48f203020fadf62c
+    :commit: dc357ae35fa4dd7ddb3232b004d417079298e08c
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -777,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: de72acff3157e00581d4ecd89b66cd06b12f46cf
+PODFILE CHECKSUM: 1b5ec5af41faba9a4d36233cd662309f719ca226
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `979cb242eb5f3b234dfb546e82aa93e0a8a7f896`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `7df620055eefc4245fb241ad48f203020fadf62c`)
   - WordPressKit (~> 4.16.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
@@ -657,7 +657,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.36.1
   WordPressAuthenticator:
-    :commit: 979cb242eb5f3b234dfb546e82aa93e0a8a7f896
+    :commit: 7df620055eefc4245fb241ad48f203020fadf62c
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.36.1/third-party-podspecs/Yoga.podspec.json
@@ -678,7 +678,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.36.1
   WordPressAuthenticator:
-    :commit: 979cb242eb5f3b234dfb546e82aa93e0a8a7f896
+    :commit: 7df620055eefc4245fb241ad48f203020fadf62c
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -777,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 87f8d0b1556a2e67afab9ebb3ded9833664ded1c
+PODFILE CHECKSUM: de72acff3157e00581d4ecd89b66cd06b12f46cf
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.24.4):
+  - WordPressAuthenticator (1.24.5):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.24.4)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `979cb242eb5f3b234dfb546e82aa93e0a8a7f896`)
   - WordPressKit (~> 4.16.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
@@ -555,7 +555,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -657,6 +656,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.36.1
+  WordPressAuthenticator:
+    :commit: 979cb242eb5f3b234dfb546e82aa93e0a8a7f896
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.36.1/third-party-podspecs/Yoga.podspec.json
 
@@ -675,6 +677,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.36.1
+  WordPressAuthenticator:
+    :commit: 979cb242eb5f3b234dfb546e82aa93e0a8a7f896
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -755,7 +760,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 1b710ddc97b208e1ac5ed487bdb5209756943295
+  WordPressAuthenticator: b1a8afff6fa0ab4b822f918bee2fcb06228e9c0a
   WordPressKit: 48d56b8d3d25619e32d3a8ae4e934547eb684856
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
@@ -772,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: a58546a088007529b19fe03c2a03d6fbbb1ad23e
+PODFILE CHECKSUM: 87f8d0b1556a2e67afab9ebb3ded9833664ded1c
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
WPAuth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/470

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/14804

This PR implements tracking for the prologue, and fixes some issues in the "Get Started" screen.

## Testing:

### Test 1:

1. As soon as the app is launched, verify the following track

🔵 Tracked: unified_login_step <flow: prologue, source: default, step: start>

2. Tap “Continue with WordPress.com”

🔵 Tracked: unified_login_interaction <click: continue_with_wordpress_com, flow: prologue, source: default, step: start>
🔵 Tracked: unified_login_step <flow: wordpress_com, source: default, step: start>

3. Tap “Continue with Apple”

🔵 Tracked: unified_login_interaction <click: login_with_apple, flow: wordpress_com, source: default, step: start>

4. Tap “Cancel”

Make sure there’s no dismissal event tracked (this is consistent with iCloud Keychain).

5. Tap “Terms of Service”

🔵 Tracked: unified_login_interaction <click: terms_of_service_clicked, flow: wordpress_com, source: default, step: start>

### Test 2:

1. In the prologue screen, tap "Enter your site address"

🔵 Tracked: unified_login_interaction <click: login_with_site_address, flow: prologue, source: default, step: start>
🔵 Tracked: unified_login_step <flow: login_site_address, source: default, step: start>

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
