### PR TITLE
Fix nil crash in iOS/iPadOS 14

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -29,7 +29,7 @@ class ReaderCommentCell: UITableViewCell {
     @IBOutlet var replyButton: UIButton!
     @IBOutlet var likeButton: UIButton!
     @IBOutlet var actionBar: UIStackView!
-    @IBOutlet var leadingContentConstraint: NSLayoutConstraint!
+    @IBOutlet var leadingContentConstraint: NSLayoutConstraint?
 
     private let textView: WPRichContentView = {
         let newTextView = WPRichContentView(frame: .zero, textContainer: nil)
@@ -235,7 +235,7 @@ class ReaderCommentCell: UITableViewCell {
 
 
     @objc func updateLeadingContentConstraint() {
-        leadingContentConstraint.constant = CGFloat(indentationLevel) * indentationWidth
+        leadingContentConstraint?.constant = CGFloat(indentationLevel) * indentationWidth
     }
 
 


### PR DESCRIPTION
Fixes #14933

This PR fixes a crash happening in iOS/iPadOS 14 (device-only).

**Please, do not test using a simulator. Use a device with iOS or iPadOS 14 and build using Xcode 12.**

## To test

1. Open the app
1. Open Notifications
1. Tap in a comment notification
1. Tap in the header (the one that contains the post title)
1. Comments should be rendered without crashes nor issues

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
