### PR TITLE
Fix "Topics You Might Like" interaction

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -35,6 +35,12 @@ class ReaderTopicsCardCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupTableView()
         applyStyles()
+
+        // iOS 14 puts the contentView in the top of the view hierarchy
+        // This conflicts with the tableView interaction, so we disable it
+        if #available(iOS 14, *) {
+            contentView.isUserInteractionEnabled = false
+        }
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -88,7 +88,7 @@ class ReaderTopicsCardCell: UITableViewCell {
     private func applyStyles() {
         containerView.backgroundColor = .listForeground
 
-        tableView.backgroundColor = .none
+        tableView.backgroundColor = .listForeground
         tableView.separatorColor = .placeholderElement
 
         backgroundColor = .none
@@ -120,7 +120,7 @@ extension ReaderTopicsCardCell: UITableViewDataSource {
         cell.textLabel?.text = topics[indexPath.row].title
         cell.accessoryType = .disclosureIndicator
         cell.separatorInset = UIEdgeInsets.zero
-        cell.backgroundColor = .none
+        cell.backgroundColor = .listForeground
         return cell
     }
 


### PR DESCRIPTION
Fixes the tap on the topics under the "Topics You Might Like" card.

## To test

1. Tap Reader
1. Tap Discover
1. In the "Topics You Might Like" card, tap any topic
1. The topic screen should be displayed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
