### PR TITLE
iOS 14: Fixes CachedAnimatedImageView not loading the image

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
@@ -96,7 +96,9 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
 
     // MARK: - Public methods
 
-    override public func display(_ layer: CALayer) {
+    override open func display(_ layer: CALayer) {
+        super.display(layer)
+
         updateImageIfNeeded()
     }
 


### PR DESCRIPTION
Fixes #14932

<img src="https://user-images.githubusercontent.com/793774/93524218-07ca7a80-f8e9-11ea-9a32-cdbe4d355681.png" width="30%" />

### To test:
1. Build the app using Xcode 12
2. Launch the app on iOS 14
3. Tap the Reader
4. Tap on following
5. Locate a post that has an image
6. You should see the image
7. Tap on the post to see the detail view
8. Tap on the image to open it full size
9. You should see the image
10. Locate a post with a gif featured image
11. Verify the gif plays

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
