### PR TITLE
Fix failing image loading in Gutenberg

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -69,6 +69,7 @@ class GutenbergMediaInserterHelper: NSObject {
         options.deliveryMode = .fastFormat
         options.version = .current
         options.resizeMode = .fast
+        options.isNetworkAccessAllowed = true
         let mediaUploadID = media.gutenbergUploadID
         // Getting a quick thumbnail of the asset to display while the image is being exported and uploaded.
         PHImageManager.default().requestImage(for: asset, targetSize: asset.pixelSize(), contentMode: .default, options: options) { (image, info) in


### PR DESCRIPTION
When fetching images, we now set `isNetworkAccessAllowed` in the `PHImageRequestOptions` object. This allows even images from the network (e.g. iCloud) to be fetched. It's not clear why this fixed the "Cannot add image from device gallery when limited photo access is enabled" bug, but makes sense for it to be there.

Fixes https://github.com/WordPress/gutenberg/issues/24989

To test:

1. Open the WordPress for iOS app
2. Create a new post on a site using the block editor
3. Add an Image block
4. Tap ADD IMAGE
5. Select "Choose from device" or "Take a photo"
6. Ensure the app only has permission to selected photos — not all photos
    - If needed, go to Settings > Privacy > Photos > WordPress and select "Selected Photos" under ALLOW PHOTO ACCESS
7. Select an image
8. Ensure that the progress bar in the image block loads 

Note: Due to a separate bug (https://github.com/WordPress/gutenberg/issues/25431) that affects Xcode 12 builds, the image won't actually render in the block. If you test this PR using the CircleCI build, you won't see this issue (it likely still uses Xcode 11 to make the build).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
