### PR TITLE
[Gutenberg]: Enable UBE for all WPCom simple sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -919,9 +919,9 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
         // Atomic sites can also have SSO disabled (though is an opt-out option).
 
         let blog = post.blog
-        let JetpackSSOEnabled = (blog.jetpack?.isConnected ?? false) && (blog.settings?.jetpackSSOEnabled ?? false)
+        let isJetpackSSOEnabled = (blog.jetpack?.isConnected ?? false) && (blog.settings?.jetpackSSOEnabled ?? false)
 
-        return ( blog.isHostedAtWPcom || JetpackSSOEnabled ) && blog.webEditor == .gutenberg
+        return blog.isHostedAtWPcom || (isJetpackSSOEnabled && blog.webEditor == .gutenberg)
     }
 }
 


### PR DESCRIPTION
This PR enables the Unsupported Block Editor for all WPCom simple sites.
For Jetpack sites we still check if the user has `gutenberg` enabled on web.

To test:
- On a WPCom simple site, open gutenberg with a post that contains an unsupported block.
- Tap on the unsupported block to open the Unsupported Block Editor.
- Check that Gutenberg loads on the WebView displaying the unsupported block.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
