### PR TITLE
Remove line breaks from screenshot strings

### DIFF
--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_1.txt
@@ -1,3 +1,1 @@
-The world’s most
-popular website
-builder
+The world’s most popular website builder

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_2.txt
@@ -1,2 +1,1 @@
-Create a site or
-start a blog
+Create a site or start a blog

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_3.txt
@@ -1,2 +1,1 @@
-Discover
-new reads
+Discover new reads

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_4.txt
@@ -1,2 +1,1 @@
-Build an
-audience
+Build an audience

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_5.txt
@@ -1,2 +1,1 @@
-Keep tabs on
-your site
+Keep tabs on your site

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_6.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_6.txt
@@ -1,2 +1,1 @@
-Reply in
-real time
+Reply in real time

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_7.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_7.txt
@@ -1,2 +1,1 @@
-Upload
-on the go
+Upload on the go

--- a/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_8.txt
+++ b/Scripts/fastlane/appstoreres/metadata/source/promo_screenshot_8.txt
@@ -1,0 +1,1 @@
+Write without compromises


### PR DESCRIPTION
This followup to https://github.com/wordpress-mobile/WordPress-iOS/pull/14858 removes the line breaks from our screenshot strings. We'll use text wrapping to fit the strings on smaller screen sizes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
