### PR TITLE
UI Tests: Update site address tests to use the Get Started flow when a WP site is used

### DIFF
--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -2,6 +2,7 @@ import XCTest
 
 class LoginFlow {
 
+    // Login with self-hosted site via Site Address.
     @discardableResult
     static func login(siteUrl: String, username: String, password: String) -> MySiteScreen {
         logoutIfNeeded()
@@ -22,9 +23,31 @@ class LoginFlow {
 //            .dismissNotificationAlertIfNeeded()
     }
 
+    // Login with WP site via Site Address.
+    @discardableResult
+    static func login(siteUrl: String, email: String, password: String) -> MySiteScreen {
+        logoutIfNeeded()
+
+        return PrologueScreen().selectSiteAddress()
+            .proceedWithWP(siteUrl: siteUrl)
+            .proceedWith(email: email)
+            .proceedWith(password: password)
+        .continueWithSelectedSite()
+        .dismissNotificationAlertIfNeeded()
+    }
+
+    // Login with self-hosted site via Site Address.
     static func loginIfNeeded(siteUrl: String, username: String, password: String) -> TabNavComponent {
         guard TabNavComponent.isLoaded() else {
             return login(siteUrl: siteUrl, username: username, password: password).tabBar
+        }
+        return TabNavComponent()
+    }
+
+    // Login with WP site via Site Address.
+    static func loginIfNeeded(siteUrl: String, email: String, password: String) -> TabNavComponent {
+        guard TabNavComponent.isLoaded() else {
+            return login(siteUrl: siteUrl, email: email, password: password).tabBar
         }
         return TabNavComponent()
     }
@@ -45,14 +68,25 @@ class LoginFlow {
         }
 
         XCTContext.runActivity(named: "Return to app prologue screen if needed") { (activity) in
-            if !WelcomeScreen.isLoaded() {
-                while LoginPasswordScreen.isLoaded() || LoginEmailScreen.isLoaded() || LinkOrPasswordScreen.isLoaded() || LoginSiteAddressScreen.isLoaded() || LoginUsernamePasswordScreen.isLoaded() || LoginCheckMagicLinkScreen.isLoaded() {
-                    if LoginEmailScreen.isLoaded() && LoginEmailScreen.isEmailEntered() {
-                        LoginEmailScreen().emailTextField.clearTextIfNeeded()
+            if !PrologueScreen.isLoaded() {
+                while PasswordScreen.isLoaded() || GetStartedScreen.isLoaded() || LinkOrPasswordScreen.isLoaded() || LoginSiteAddressScreen.isLoaded() || LoginUsernamePasswordScreen.isLoaded() || LoginCheckMagicLinkScreen.isLoaded() {
+                    if GetStartedScreen.isLoaded() && GetStartedScreen.isEmailEntered() {
+                        GetStartedScreen().emailTextField.clearTextIfNeeded()
                     }
                     navBackButton.tap()
                 }
             }
+
+            // TODO: remove when unifiedAuth is permanent.
+            // Leaving here for now in case unifiedAuth is disabled.
+//            if !WelcomeScreen.isLoaded() {
+//                while LoginPasswordScreen.isLoaded() || LoginEmailScreen.isLoaded() || LinkOrPasswordScreen.isLoaded() || LoginSiteAddressScreen.isLoaded() || LoginUsernamePasswordScreen.isLoaded() || LoginCheckMagicLinkScreen.isLoaded() {
+//                    if LoginEmailScreen.isLoaded() && LoginEmailScreen.isEmailEntered() {
+//                        LoginEmailScreen().emailTextField.clearTextIfNeeded()
+//                    }
+//                    navBackButton.tap()
+//                }
+//            }
         }
     }
 }

--- a/WordPress/WordPressUITests/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LoginSiteAddressScreen.swift
@@ -37,6 +37,14 @@ class LoginSiteAddressScreen: BaseScreen {
         return LoginUsernamePasswordScreen()
     }
 
+    func proceedWithWP(siteUrl: String) -> GetStartedScreen {
+        siteAddressTextField.tap()
+        siteAddressTextField.typeText(siteUrl)
+        nextButton.tap()
+
+        return GetStartedScreen()
+    }
+    
     static func isLoaded() -> Bool {
         return XCUIApplication().buttons[ElementStringIDs.nextButton].exists
     }

--- a/WordPress/WordPressUITests/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LoginSiteAddressScreen.swift
@@ -44,7 +44,7 @@ class LoginSiteAddressScreen: BaseScreen {
 
         return GetStartedScreen()
     }
-    
+
     static func isLoaded() -> Bool {
         return XCUIApplication().buttons[ElementStringIDs.nextButton].exists
     }

--- a/WordPress/WordPressUITests/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/Unified/GetStartedScreen.swift
@@ -29,5 +29,13 @@ class GetStartedScreen: BaseScreen {
         return PasswordScreen()
     }
 
+    static func isLoaded() -> Bool {
+        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+    }
+
+    static func isEmailEntered() -> Bool {
+        let emailTextField = XCUIApplication().textFields[ElementStringIDs.emailTextField]
+        return emailTextField.value != nil
+    }
 
 }

--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -6,7 +6,7 @@ class EditorAztecTests: XCTestCase {
     override func setUp() {
         setUpTestSuite()
 
-        _ = LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, username: WPUITestCredentials.testWPcomUsername, password: WPUITestCredentials.testWPcomPassword)
+        _ = LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         editorScreen = EditorFlow
             .toggleBlockEditor(to: .off)
             .goBackToMySite()

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -6,7 +6,7 @@ class EditorGutenbergTests: XCTestCase {
     override func setUp() {
         setUpTestSuite()
 
-        _ = LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, username: WPUITestCredentials.testWPcomUsername, password: WPUITestCredentials.testWPcomPassword)
+        _ = LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         editorScreen = EditorFlow
             .toggleBlockEditor(to: .on)
             .goBackToMySite()

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -67,7 +67,7 @@ class LoginTests: XCTestCase {
     // Replaces testWpcomUsernamePasswordLogin
     func testWpcomLogin() {
         _ = PrologueScreen().selectSiteAddress()
-            .proceedWithWP(siteUrl: "WordPress.com")
+            .proceedWithWP(siteUrl: "https://wordpress.com")
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWith(password: WPUITestCredentials.testWPcomPassword)
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -67,8 +67,9 @@ class LoginTests: XCTestCase {
     // Replaces testWpcomUsernamePasswordLogin
     func testWpcomLogin() {
         _ = PrologueScreen().selectSiteAddress()
-            .proceedWith(siteUrl: "WordPress.com")
-            .proceedWith(username: WPUITestCredentials.testWPcomSitePrimaryAddress, password: WPUITestCredentials.testWPcomPassword)
+            .proceedWithWP(siteUrl: "WordPress.com")
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -6,7 +6,7 @@ class MainNavigationTests: XCTestCase {
     override func setUp() {
         setUpTestSuite()
 
-        _ = LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, username: WPUITestCredentials.testWPcomUsername, password: WPUITestCredentials.testWPcomPassword)
+        _ = LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         mySiteScreen = TabNavComponent()
          .gotoMySiteScreen()
     }


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/pull/14908

To test:
- Verify the UI tests on this PR pass.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
