### PR TITLE
[iOS 14] Fix appearance of bottom toolbar in new photo picker

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -76,7 +76,7 @@ extension WPStyleGuide {
             barButtonItemAppearance.tintColor = .barButtonItemTitle
             barButtonItemAppearance.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.barButtonItemTitle], for: .normal)
 
-            let buttonBarAppearance = UIBarButtonItem.appearance()
+            let buttonBarAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [UINavigationBar.self])
             buttonBarAppearance.tintColor = .white
             buttonBarAppearance.setTitleTextAttributes([NSAttributedString.Key.font: WPFontManager.systemRegularFont(ofSize: 17.0),
                                                         NSAttributedString.Key.foregroundColor: UIColor.white],

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -830,7 +830,6 @@ extension WordPressAppDelegate {
         WPStyleGuide.configureLightNavigationBarAppearance()
 
         UISegmentedControl.appearance().setTitleTextAttributes( [NSAttributedString.Key.font: WPStyleGuide.regularTextFont()], for: .normal)
-        UIToolbar.appearance().barTintColor = .primary
         UISwitch.appearance().onTintColor = .primary
 
         let navReferenceAppearance = UINavigationBar.appearance(whenContainedInInstancesOf: [UIReferenceLibraryViewController.self])


### PR DESCRIPTION
Fixes #14939. This PR fixes an issue in iOS 14 where the bottom toolbar of the new system photo picker is coloured blue and hard to read.

<img src="https://user-images.githubusercontent.com/4780/93533334-961b1c80-f93a-11ea-8d5f-f51f488a6081.PNG" width=300 />

I couldn't see an easy way to target this toolbar specifically, as the view controller itself uses private classes. I opted to remove the global configuration we had for `UIToolbar`. I checked through every instance of `toolbar` we had in the app, and as far as I could tell there was only one place we didn't override this value anyway. I also tweaked the color of bar button items, as I found once instance where this was styled incorrectly.

![14939](https://user-images.githubusercontent.com/4780/93811034-6f652a80-fc47-11ea-8c45-6c25917a88e9.png)

**To test**

- Disable the `newNavBarAppearance` feature flag (you can also test with it enabled if you like)
- On iOS 14 / Xcode 12, build and run and go to Media > + and choose the 'select photos' option
- Ensure that the bottom toolbar has default styling and the text is readable
- Also check Me > App Settings > Debug > Encrypted Logs (near the bottom) and ensure the bottom toolbar is visible
- You can also check Media > tap and hold on a **video** thumbnail in your library. Check that the bottom toolbar of the video player is visible.
- Ideally also test in dark mode, and on iOS 12 as that uses different colors due to no dark mode.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
