### PR TITLE
Reader: Support Stories in detail view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -281,6 +281,7 @@ class ReaderDetailCoordinator {
     /// Given a URL presents it the best way possible.
     ///
     /// If it's an image, shows it fullscreen.
+    /// If it's a fullscreen Story link, open it in the webview controller
     /// If it's a post, open a new detail screen.
     /// If it's a regular URL, open it in the webview controller
     ///
@@ -290,6 +291,8 @@ class ReaderDetailCoordinator {
             view?.scroll(to: hash)
         } else if url.pathExtension.contains("gif") || url.pathExtension.contains("jpg") || url.pathExtension.contains("jpeg") || url.pathExtension.contains("png") {
             presentImage(url)
+        } else if url.query?.contains("wp-story") ?? false {
+            presentWebViewController(url)
         } else if readerLinkRouter.canHandle(url: url) {
             readerLinkRouter.handle(url: url, shouldTrack: false, source: viewController)
         } else if url.isWordPressDotComPost {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -70,7 +70,10 @@ class ReaderWebView: WKWebView {
             })
 
             // Make all images tappable
-            document.querySelectorAll('img').forEach((el) => { el.outerHTML = `<a href="${el.src}">${el.outerHTML}</a>` })
+            // Exception for images in Stories, which have their own link structure
+            document.querySelectorAll('img:not(.wp-story-image)').forEach((el) => {
+                el.outerHTML = `<a href="${el.src}">${el.outerHTML}</a>`
+            })
 
             // Only display images after they have fully loaded, to have a native feel
             document.querySelectorAll('img').forEach((el) => {


### PR DESCRIPTION
Tweaks the Reader to support the Story block in detail view:

![Simulator Screen Shot - iPhone 11 Pro - 2020-09-22 at 14 31 32](https://user-images.githubusercontent.com/9613966/93846932-71c79300-fce0-11ea-97ba-9cf08c18cff8.png)

The bulk of the work for this has been done in the shared CSS file in Calypso and already deployed: https://github.com/Automattic/wp-calypso/pull/45397

Extra changes that were needed for WPiOS:

#### Image `a href` tag wrapping

The in-app custom CSS wraps all images with a link tag, which breaks the Story markup (and Stories have their own link set anyway). I added an exception for Stories in f7667f5.

(Incidentally the existing behavior also wraps images that already had custom links of their own, so the original link can no longer be visited -not sure if this was intentional, just noting it here.)

#### Story link handling

I had to modify the logic when tapping a Reader detail link. The idea is for tapping a story to open the WebView so the story can be loaded in fullscreen and autoplay. The link is to the post itself, with extra query parameters, like this:

`https://site.wordpress.com/2020/09/02/a-story-post/?wp-story-load-in-fullscreen=true&wp-story-play-on-load=true`

This worked correctly for Jetpack sites, however for WordPress.com sites the `ReaderDetailCoordinator` interprets the link as a WordPress.com post and opens it in a new detail screen. This looks like the same post being loaded again and again.

I added an exception for stories in 242781b, by filtering for a query param containing `wp-story`.

Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/13002

### To test:

1. Proxy WP.com on your device (because the Story block is currently a beta block and poorly supported by the API)
2. Start from a clean install of turn off the CSS cache to make sure you get a fresh copy of `reader-mobile.css`
3. Follow a Jetpack and a WP.com site with Stories (DM me for some samples)
4. Check that opening a story in Reader detail shows a properly formatted story, like the screenshot above
5. Jetpack: Check that tapping the story opens it in the WebView, and it automatically plays once the page loads
6. WP.com: Check that tapping the story opens it in the WebView (autoplay/fullscreen won't work at the moment due to an unrelated issue with Stories on WP.com)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
