### PR TITLE
ULS: Remove unifiedApple flag. 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -194,7 +194,7 @@ target 'WordPress' do
 
     # pod 'WordPressAuthenticator', '~> 1.26.0-beta'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/remove_google_ff'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/remove_apple_ff'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.26.0-beta.3):
+  - WordPressAuthenticator (1.26.0-beta.4):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/remove_google_ff`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/remove_apple_ff`)
   - WordPressKit (~> 4.17.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
@@ -657,7 +657,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.37.1
   WordPressAuthenticator:
-    :branch: feature/remove_google_ff
+    :branch: feature/remove_apple_ff
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.37.1/third-party-podspecs/Yoga.podspec.json
@@ -678,7 +678,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.37.1
   WordPressAuthenticator:
-    :commit: 95dad7e8a9370a99511b006461d289d984c9bc10
+    :commit: dc5afec4779f5d8c4af0d7a82bfe67a605cb0e16
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -760,7 +760,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 6701a9484adbffa37883311a0c9663f1e5089fdb
+  WordPressAuthenticator: 979fb486b7c7b8657219390fe9565add511166d5
   WordPressKit: f1a9e32cf7f46f7eb19d944591aad88b108d90e7
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
@@ -777,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 8702271c6b744e64f4a53049d3cc67abe19946f0
+PODFILE CHECKSUM: 8b0dee617b002345a6e53d3c656a6c0610168e1b
 
 COCOAPODS: 1.9.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,7 @@
 15.9
 -----
- * [internal] Removed feature flags for unified Site Address and Google views. Could cause regressions. [#14954, #14969]
+ * [internal] Modified feature flags that show unified Site Address, Google, and Apple views. Could cause regressions. [#14954, #14969, #14970]
 
- 
 15.8
 -----
 * [*] Image Preview: Fixes an issue where an image would be incorrectly positioned after changing device orientation.

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -6,7 +6,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case debugMenu
     case readerCSS
     case unifiedAuth
-    case unifiedApple
     case unifiedWordPress
     case unifiedKeychainLogin
     case meMove
@@ -34,8 +33,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .readerCSS:
             return false
         case .unifiedAuth:
-            return true
-        case .unifiedApple:
             return true
         case .unifiedWordPress:
             return true
@@ -97,8 +94,6 @@ extension FeatureFlag {
             return "Ignore Reader CSS Cache"
         case .unifiedAuth:
             return "Unified Auth"
-        case .unifiedApple:
-            return "Unified Auth - Apple"
         case .unifiedWordPress:
             return "Unified Auth - WordPress"
         case .unifiedKeychainLogin:

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -39,7 +39,6 @@ class WordPressAuthenticationManager: NSObject {
                                                                 enableSignInWithApple: enableSignInWithApple,
                                                                 enableSignupWithGoogle: true,
                                                                 enableUnifiedAuth: FeatureFlag.unifiedAuth.enabled,
-                                                                enableUnifiedApple: FeatureFlag.unifiedApple.enabled,
                                                                 enableUnifiedWordPress: FeatureFlag.unifiedWordPress.enabled,
                                                                 enableUnifiedKeychainLogin: FeatureFlag.unifiedKeychainLogin.enabled)
 


### PR DESCRIPTION
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/478

This removes the `unifiedApple` feature flag. In Auth, the master `unifiedAuth` flag is used to show unified Apple.

**Prerequisite:** 
You'll need an Apple account that:
- Has WP 2FA setup.
- Has no WP password.

To test:
1. Verify `Continue with WordPress` >` Continue with Apple` shows the unified Apple flow.
2. Select the Apple account. Verify the 2FA view is the unified view.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
