### PR TITLE
ULS: Remove unifiedWordPress flag.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -194,7 +194,7 @@ target 'WordPress' do
 
     # pod 'WordPressAuthenticator', '~> 1.26.0-beta'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/remove_keychain_ff'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'feature/remove_wp_ff'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.26.0-beta.5):
+  - WordPressAuthenticator (1.26.0-beta.6):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/remove_keychain_ff`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `feature/remove_wp_ff`)
   - WordPressKit (~> 4.17.0)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
@@ -657,7 +657,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.37.1
   WordPressAuthenticator:
-    :branch: feature/remove_keychain_ff
+    :branch: feature/remove_wp_ff
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.37.1/third-party-podspecs/Yoga.podspec.json
@@ -678,7 +678,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.37.1
   WordPressAuthenticator:
-    :commit: 62d3e779b5e267d3e3f65a58fb534fe12727bb21
+    :commit: 5faa171d3c768173bb2a0000bd1cb961fe3b1084
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -760,7 +760,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: e9f7c9831f2044505d7db7f84f15e45ed21c5f27
+  WordPressAuthenticator: 53a9c5f40cb39e37095e5de7a879f58858e877a8
   WordPressKit: f1a9e32cf7f46f7eb19d944591aad88b108d90e7
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
@@ -777,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 775cbd3b86abdee714ede3a39f5b63230b83d66d
+PODFILE CHECKSUM: 70193498b54c3954d8de05797680ede7b4d4e1ad
 
 COCOAPODS: 1.9.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 15.9
 -----
- * [internal] Modified feature flags that show unified Site Address, Google, Apple views and iCloud keychain login. Could cause regressions. [#14954, #14969, #14970, #14971]
+ * [internal] Modified feature flags that show unified Site Address, Google, Apple, WordPress views and iCloud keychain login. Could cause regressions. [#14954, #14969, #14970, #14971, #14972]
 
 15.8
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -6,7 +6,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case debugMenu
     case readerCSS
     case unifiedAuth
-    case unifiedWordPress
     case meMove
     case floatingCreateButton
     case newReaderNavigation
@@ -32,8 +31,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .readerCSS:
             return false
         case .unifiedAuth:
-            return true
-        case .unifiedWordPress:
             return true
         case .meMove:
             return true
@@ -91,8 +88,6 @@ extension FeatureFlag {
             return "Ignore Reader CSS Cache"
         case .unifiedAuth:
             return "Unified Auth"
-        case .unifiedWordPress:
-            return "Unified Auth - WordPress"
         case .meMove:
             return "Move the Me Scene to My Site"
         case .floatingCreateButton:

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -38,8 +38,7 @@ class WordPressAuthenticationManager: NSObject {
                                                                 showLoginOptions: true,
                                                                 enableSignInWithApple: enableSignInWithApple,
                                                                 enableSignupWithGoogle: true,
-                                                                enableUnifiedAuth: FeatureFlag.unifiedAuth.enabled,
-                                                                enableUnifiedWordPress: FeatureFlag.unifiedWordPress.enabled)
+                                                                enableUnifiedAuth: FeatureFlag.unifiedAuth.enabled)
 
         let style = WordPressAuthenticatorStyle(primaryNormalBackgroundColor: .primaryButtonBackground,
                                                 primaryNormalBorderColor: nil,


### PR DESCRIPTION
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/480

This removes the `unifiedWordPress` feature flag. In Auth, the master `unifiedAuth` flag is used to show unified unifiedWordPress.

To test:
1. Verify the prologue buttons are `Continue with WordPress.com` and `Enter your site address`.
2. Login with a WP account that has 2FA enabled. Verify the 2FA view is the unified one.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
