### PR TITLE
Added analytics tracks for What's New

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -70,11 +70,9 @@ import Foundation
     case readerChipsMoreToggled
     case readerToggleFollowConversation
     case readerPostReported
-    // What's New
-    case whatIsNewShownOnAppUpdate
-    case whatIsNewShownFromAppSettings
-    case whatIsNewContinueTapped
-    case whatIsNewFindOutMoreTapped
+    // What's New - Feature announcements
+    case featureAnnouncementShown
+    case featureAnnouncementButtonTapped
 
     /// A String that represents the event
     var value: String {
@@ -190,15 +188,11 @@ import Foundation
             return "reader_toggle_follow_conversation"
         case .readerPostReported:
             return "reader_post_reported"
-        // What's New
-        case .whatIsNewShownOnAppUpdate:
-            return "whatsnew_shown_on_app_update"
-        case .whatIsNewShownFromAppSettings:
-            return "whatsnew_shown_from_app_settings"
-        case .whatIsNewContinueTapped:
-            return "whatsnew_continue_tapped"
-        case .whatIsNewFindOutMoreTapped:
-            return "whatsnew_find_out_more_tapped"
+        // What's New - Feature announcements
+        case .featureAnnouncementShown:
+            return "feature_announcement_shown"
+        case .featureAnnouncementButtonTapped:
+            return "feature_announcement_button_tapped"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -70,6 +70,11 @@ import Foundation
     case readerChipsMoreToggled
     case readerToggleFollowConversation
     case readerPostReported
+    // What's New
+    case whatIsNewShownOnAppUpdate
+    case whatIsNewShownFromAppSettings
+    case whatIsNewContinueTapped
+    case whatIsNewFindOutMoreTapped
 
     /// A String that represents the event
     var value: String {
@@ -131,6 +136,7 @@ import Foundation
             return "gutenberg_unsupported_block_webview_shown"
         case .gutenbergUnsupportedBlockWebViewClosed:
             return "gutenberg_unsupported_block_webview_closed"
+        // Notifications permissions
         case .pushNotificationsPrimerSeen:
             return "notifications_primer_seen"
         case .pushNotificationsPrimerAllowTapped:
@@ -184,6 +190,15 @@ import Foundation
             return "reader_toggle_follow_conversation"
         case .readerPostReported:
             return "reader_post_reported"
+        // What's New
+        case .whatIsNewShownOnAppUpdate:
+            return "whatsnew_shown_on_app_update"
+        case .whatIsNewShownFromAppSettings:
+            return "whatsnew_shown_from_app_settings"
+        case .whatIsNewContinueTapped:
+            return "whatsnew_continue_tapped"
+        case .whatIsNewFindOutMoreTapped:
+            return "whatsnew_find_out_more_tapped"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
@@ -44,9 +44,9 @@ class WhatIsNewScenePresenter: ScenePresenter {
     // analytics
     private func trackAccess(from viewController: UIViewController) {
         if viewController is AppSettingsViewController {
-            WPAnalytics.track(.whatIsNewShownFromAppSettings)
+            WPAnalytics.track(.featureAnnouncementShown, properties: ["source": "app_settings"])
         } else {
-            WPAnalytics.track(.whatIsNewShownOnAppUpdate)
+            WPAnalytics.track(.featureAnnouncementShown, properties: ["source": "app_upgrade"])
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
@@ -33,11 +33,21 @@ class WhatIsNewScenePresenter: ScenePresenter {
             }
             let controller = self.makeWhatIsNewViewController()
 
+            self.trackAccess(from: viewController)
             viewController.present(controller, animated: true) {
                 UserDefaults.standard.announcementsVersionDisplayed = Bundle.main.shortVersionString()
             }
         }
         store.getAnnouncements()
+    }
+
+    // analytics
+    private func trackAccess(from viewController: UIViewController) {
+        if viewController is AppSettingsViewController {
+            WPAnalytics.track(.whatIsNewShownFromAppSettings)
+        } else {
+            WPAnalytics.track(.whatIsNewShownOnAppUpdate)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
@@ -43,7 +43,7 @@ private extension FindOutMoreCell {
     }
 
     @objc func buttonTapped() {
-        WPAnalytics.track(.whatIsNewFindOutMoreTapped)
+        WPAnalytics.track(.featureAnnouncementButtonTapped, properties: ["button": "find_out_more"])
 
         guard let url = self.findOutMoreUrl else {
             return

--- a/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
@@ -43,6 +43,8 @@ private extension FindOutMoreCell {
     }
 
     @objc func buttonTapped() {
+        WPAnalytics.track(.whatIsNewFindOutMoreTapped)
+
         guard let url = self.findOutMoreUrl else {
             return
         }

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewController.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewController.swift
@@ -9,6 +9,7 @@ class WhatIsNewViewController: UIViewController {
     private lazy var whatIsNewView: WhatIsNewView = {
         let view = makeWhatIsNewView()
         view.continueAction = { [weak self] in
+            WPAnalytics.track(.whatIsNewContinueTapped)
             self?.dismiss(animated: true)
         }
         return view

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewController.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewController.swift
@@ -9,7 +9,7 @@ class WhatIsNewViewController: UIViewController {
     private lazy var whatIsNewView: WhatIsNewView = {
         let view = makeWhatIsNewView()
         view.continueAction = { [weak self] in
-            WPAnalytics.track(.whatIsNewContinueTapped)
+            WPAnalytics.track(.featureAnnouncementButtonTapped, properties: ["button": "close_dialog"])
             self?.dismiss(animated: true)
         }
         return view


### PR DESCRIPTION
Fixes #14586

To test:
- start with a version that is lower than 15.8
- update to this version
- make sure that the "What's New" screen appears and that the event `feature_announcement_shown` with properties `<source: app_upgrade>` is tracked in the console
- tap the Continue button and make sure that the event `feature_announcement_button_tapped` with properties `<button: close_dialog>` is tracked
- go to Me/App Settings/What's New in WordPress and make sure that the event `feature_announcement_shown` with properties `<source: app_settings>` is tracked
- tap 'Find out more` and make sure that the event `feature_announcement_button_tapped` with properties `<button: find_out_more>` is tracked

PR submission checklist:

- [x] ~~I have considered adding unit tests where possible.~~ In a separate PR.
- [x] ~~I have considered adding accessibility improvements for my changes.~~ In a separate PR.
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~ Not yet released.
