### PR TITLE
Fixes a crash caused by CachedAnimatedImageView on iOS 13 and below.

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
@@ -97,6 +97,9 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
     // MARK: - Public methods
 
     override open func display(_ layer: CALayer) {
+        // Fixes an unrecognized selector crash on iOS 13 and below when calling super.display(_:) directly
+        // This was first reported here: p5T066-1xs-p2#comment-5908
+        // Investigating the issue I came across this discussion with a workaround in the Gifu repo: https://git.io/JUPxC
         if UIImageView.instancesRespond(to: #selector(display(_:))) {
             super.display(layer)
         }

--- a/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
@@ -97,7 +97,9 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
     // MARK: - Public methods
 
     override open func display(_ layer: CALayer) {
-        super.display(layer)
+        if UIImageView.instancesRespond(to: #selector(display(_:))) {
+            super.display(layer)
+        }
 
         updateImageIfNeeded()
     }


### PR DESCRIPTION
Fixes #14991

### Description
This PR adds a check to the display(_:) method prior to calling it on super. This mirrors the same fix used on the [main repo.
](https://github.com/kaishin/Gifu/blob/9b1a6461aa3b5f66cb0ed3a50c5523db0b4fb007/Sources/Gifu/Classes/GIFImageView.swift
)

### To test:
1. On a device or simulator running iOS 13 or below
2. Run the app
3. Tap on the My Sites tab
4. Tap on a site
5. Tap on the + button to add a post
6. Add an image block
7. Tap 'Add image' 
8. Select 'Free GIF Library'
9. Type `cat` 
10. After the results load, verify the gifs play and there is no crash
11. Select an image
12. Tap Preview
13. Verify the gif preview loads correctly
14. Tap Add
15. Verify the gif appears correct in the post
16. Publish the post
17. Verify the gif appears and plays correctly in the post

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
