### PR TITLE
Add support for dark mode screenshots

### DIFF
--- a/Scripts/fastlane/ScreenshotFastfile
+++ b/Scripts/fastlane/ScreenshotFastfile
@@ -54,12 +54,15 @@ platform :ios do
 
     puts languages
 
-    capture_ios_screenshots(
-      test_without_building: true,
-      derived_data_path: derived_data_path,
-      languages: languages,
-      clear_previous_screenshots: should_clear_previous_screenshots,
-    )
+    [true, false].each { | dark_mode_enabled |
+      capture_ios_screenshots(
+        test_without_building: true,
+        derived_data_path: derived_data_path,
+        languages: languages,
+        clear_previous_screenshots: should_clear_previous_screenshots,
+        dark_mode: dark_mode_enabled
+      )
+    }
   end
 
   #####################################################################################

--- a/Scripts/fastlane/ScreenshotFastfile
+++ b/Scripts/fastlane/ScreenshotFastfile
@@ -38,8 +38,6 @@ platform :ios do
       derived_data_path: derived_data_path,
     )
 
-    # By default, clear previous screenshots
-    should_clear_previous_screenshots = true
     languages = "da de-DE en-AU en-CA en-GB es-ES fr-FR id it ja ko no nl-NL pt-BR pt-PT ru sv th tr zh-Hans zh-Hant en-US".split(" ")
 
     # Allow creating screenshots for just one languages
@@ -47,9 +45,6 @@ platform :ios do
       languages.keep_if { |language|
         language.casecmp(options[:language]) == 0
       }
-
-      # Don't clear, because we might just be fixing one locale
-      should_clear_previous_screenshots = false
     end
 
     puts languages
@@ -59,7 +54,6 @@ platform :ios do
         test_without_building: true,
         derived_data_path: derived_data_path,
         languages: languages,
-        clear_previous_screenshots: should_clear_previous_screenshots,
         dark_mode: dark_mode_enabled
       )
     }

--- a/Scripts/fastlane/ScreenshotFastfile
+++ b/Scripts/fastlane/ScreenshotFastfile
@@ -40,7 +40,7 @@ platform :ios do
 
     # By default, clear previous screenshots
     should_clear_previous_screenshots = true
-    languages = "da de-DE en-AU en-CA en-GB en-US es-ES fr-FR id it ja ko no nl-NL pt-BR pt-PT ru sv th tr zh-Hans zh-Hant".split(" ")
+    languages = "da de-DE en-AU en-CA en-GB es-ES fr-FR id it ja ko no nl-NL pt-BR pt-PT ru sv th tr zh-Hans zh-Hant en-US".split(" ")
 
     # Allow creating screenshots for just one languages
     if options[:language] != nil

--- a/Scripts/fastlane/Snapfile
+++ b/Scripts/fastlane/Snapfile
@@ -34,7 +34,6 @@ reinstall_app true
 erase_simulator true
 localize_simulator true
 concurrent_simulators false
-clear_previous_screenshots true
 
 # By default, the latest version should be used automatically. If you want to change it, do it here
 # ios_version '8.1'

--- a/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
+++ b/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
@@ -38,22 +38,13 @@ func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
 }
 
 enum SnapshotError: Error, CustomDebugStringConvertible {
-    case cannotDetectUser
-    case cannotFindHomeDirectory
     case cannotFindSimulatorHomeDirectory
-    case cannotAccessSimulatorHomeDirectory(String)
     case cannotRunOnPhysicalDevice
 
     var debugDescription: String {
         switch self {
-        case .cannotDetectUser:
-            return "Couldn't find Snapshot configuration files - can't detect current user "
-        case .cannotFindHomeDirectory:
-            return "Couldn't find Snapshot configuration files - can't detect `Users` dir"
         case .cannotFindSimulatorHomeDirectory:
             return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
-        case .cannotAccessSimulatorHomeDirectory(let simulatorHostHome):
-            return "Can't prepare environment. Simulator home location is inaccessible. Does \(simulatorHostHome) exist?"
         case .cannotRunOnPhysicalDevice:
             return "Can't use Snapshot on a physical device."
         }
@@ -75,7 +66,7 @@ open class Snapshot: NSObject {
         Snapshot.waitForAnimations = waitForAnimations
 
         do {
-            let cacheDir = try pathPrefix()
+            let cacheDir = try getCacheDirectory()
             Snapshot.cacheDirectory = cacheDir
             setLanguage(app)
             setLocale(app)
@@ -174,6 +165,8 @@ open class Snapshot: NSObject {
             }
 
             let screenshot = XCUIScreen.main.screenshot()
+            let image = XCUIDevice.shared.orientation.isLandscape ?  fixLandscapeOrientation(image: screenshot.image) : screenshot.image
+
             guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
 
             do {
@@ -183,12 +176,25 @@ open class Snapshot: NSObject {
                 simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
 
                 let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
-                try screenshot.pngRepresentation.write(to: path)
+                try image.pngData()?.write(to: path, options: .atomic)
             } catch let error {
                 NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
                 NSLog(error.localizedDescription)
             }
         #endif
+    }
+
+    class func fixLandscapeOrientation(image: UIImage) -> UIImage {
+        if #available(iOS 10.0, *) {
+            let format = UIGraphicsImageRendererFormat()
+            format.scale = image.scale
+            let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+            return renderer.image { context in
+                image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+            }
+        } else {
+            return image
+        }
     }
 
     class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
@@ -206,40 +212,28 @@ open class Snapshot: NSObject {
         _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
 
-    class func pathPrefix() throws -> URL? {
-        let homeDir: URL
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
         // on OSX config is stored in /Users/<username>/Library
         // and on iOS/tvOS/WatchOS it's in simulator's home dir
         #if os(OSX)
-            guard let user = ProcessInfo().environment["USER"] else {
-                throw SnapshotError.cannotDetectUser
+            let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+            return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64)
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
             }
-
-            guard let usersDir = FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
-                throw SnapshotError.cannotFindHomeDirectory
-            }
-
-            homeDir = usersDir.appendingPathComponent(user)
+            let homeDir = URL(fileURLWithPath: simulatorHostHome)
+            return homeDir.appendingPathComponent(cachePath)
         #else
-            #if arch(i386) || arch(x86_64)
-                guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
-                    throw SnapshotError.cannotFindSimulatorHomeDirectory
-                }
-                guard let homeDirUrl = URL(string: simulatorHostHome) else {
-                    throw SnapshotError.cannotAccessSimulatorHomeDirectory(simulatorHostHome)
-                }
-                homeDir = URL(fileURLWithPath: homeDirUrl.path)
-            #else
-                throw SnapshotError.cannotRunOnPhysicalDevice
-            #endif
+            throw SnapshotError.cannotRunOnPhysicalDevice
         #endif
-        return homeDir.appendingPathComponent("Library/Caches/tools.fastlane")
     }
 }
 
 private extension XCUIElementAttributes {
     var isNetworkLoadingIndicator: Bool {
-        if hasWhiteListedIdentifier { return false }
+        if hasAllowListedIdentifier { return false }
 
         let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
         let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
@@ -247,10 +241,10 @@ private extension XCUIElementAttributes {
         return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
     }
 
-    var hasWhiteListedIdentifier: Bool {
-        let whiteListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+    var hasAllowListedIdentifier: Bool {
+        let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
 
-        return whiteListedIdentifiers.contains(identifier)
+        return allowListedIdentifiers.contains(identifier)
     }
 
     func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
@@ -300,4 +294,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.21]
+// SnapshotHelperVersion [1.24]

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -46,11 +46,13 @@ class WordPressScreenshotGeneration: XCTestCase {
         let postEditorScreenshot = postList.selectPost(withSlug: "our-services")
         sleep(imagesWaitTime) // wait for post images to load
         if isIpad {
-            thenTakeScreenshot(1, named: "Editor")
+            BlockEditorScreen()
+                .thenTakeScreenshot(1, named: "Editor")
         } else {
-            BlockEditorScreen().openBlockPicker()
-            thenTakeScreenshot(1, named: "Editor-With-BlockPicker")
-            BlockEditorScreen().closeBlockPicker()
+            BlockEditorScreen()
+                .openBlockPicker()
+                .thenTakeScreenshot(1, named: "Editor-With-BlockPicker")
+                .closeBlockPicker()
         }
         postEditorScreenshot.close()
 
@@ -62,9 +64,9 @@ class WordPressScreenshotGeneration: XCTestCase {
                 .gotoPostsScreen()
                 .showOnly(.drafts)
                 .selectPost(withSlug: "easy-blueberry-muffins")
-                BlockEditorScreen().selectBlock(containingText: "Ingredients")
+            BlockEditorScreen().selectBlock(containingText: "Ingredients")
             sleep(imagesWaitTime) // wait for post images to load
-            thenTakeScreenshot(7, named: "Editor-With-Keyboard")
+            BlockEditorScreen().thenTakeScreenshot(7, named: "Editor-With-Keyboard")
             ipadScreenshot.close()
         } else {
             postList.pop()
@@ -74,12 +76,12 @@ class WordPressScreenshotGeneration: XCTestCase {
         let mySite = MySiteScreen()
             .showSiteSwitcher()
             .switchToSite(withTitle: "tricountyrealestate.wordpress.com")
-        thenTakeScreenshot(4, named: "MySite")
+            .thenTakeScreenshot(4, named: "MySite")
 
         // Get Media screenshot
         _ = mySite.gotoMediaScreen()
         sleep(imagesWaitTime) // wait for post images to load
-        thenTakeScreenshot(6, named: "Media")
+        mySite.thenTakeScreenshot(6, named: "Media")
 
         if !isIpad {
             postList.pop()
@@ -90,32 +92,36 @@ class WordPressScreenshotGeneration: XCTestCase {
         statsScreen
             .dismissCustomizeInsightsNotice()
             .switchTo(mode: .months)
-        thenTakeScreenshot(3, named: "Stats")
+            .thenTakeScreenshot(3, named: "Stats")
 
         // Get Discover screenshot
         // Currently, the view includes the "You Might Like" section
         TabNavComponent()
             .gotoReaderScreen()
             .openDiscover()
-        thenTakeScreenshot(2, named: "Discover")
+            .thenTakeScreenshot(2, named: "Discover")
 
         // Get Notifications screenshot
         let notificationList = TabNavComponent()
             .gotoNotificationsScreen()
             .dismissNotificationAlertIfNeeded()
         if isIpad {
-            notificationList.openNotification(withText: "Reyansh Pawar commented on My Top 10 Pastry Recipes")
-            .replyToNotification()
+            notificationList
+                .openNotification(withText: "Reyansh Pawar commented on My Top 10 Pastry Recipes")
+                .replyToNotification()
         }
-        thenTakeScreenshot(5, named: "Notifications")
+        notificationList.thenTakeScreenshot(5, named: "Notifications")
     }
 }
 
-extension XCTestCase {
-    func thenTakeScreenshot(_ index: Int, named title: String) {
+extension BaseScreen {
+    @discardableResult
+    func thenTakeScreenshot(_ index: Int, named title: String) -> Self {
         let mode = isDarkMode ? "dark" : "light"
         let filename = "\(index)-\(mode)-\(title)"
 
         snapshot(filename)
+
+        return self
     }
 }

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -46,10 +46,10 @@ class WordPressScreenshotGeneration: XCTestCase {
         let postEditorScreenshot = postList.selectPost(withSlug: "our-services")
         sleep(imagesWaitTime) // wait for post images to load
         if isIpad {
-            snapshot("1-Editor")
+            thenTakeScreenshot(1, named: "Editor")
         } else {
             BlockEditorScreen().openBlockPicker()
-            snapshot("1-Editor-With-BlockPicker")
+            thenTakeScreenshot(1, named: "Editor-With-BlockPicker")
             BlockEditorScreen().closeBlockPicker()
         }
         postEditorScreenshot.close()
@@ -64,7 +64,7 @@ class WordPressScreenshotGeneration: XCTestCase {
                 .selectPost(withSlug: "easy-blueberry-muffins")
                 BlockEditorScreen().selectBlock(containingText: "Ingredients")
             sleep(imagesWaitTime) // wait for post images to load
-            snapshot("7-Editor-With-Keyboard")
+            thenTakeScreenshot(7, named: "Editor-With-Keyboard")
             ipadScreenshot.close()
         } else {
             postList.pop()
@@ -74,12 +74,12 @@ class WordPressScreenshotGeneration: XCTestCase {
         let mySite = MySiteScreen()
             .showSiteSwitcher()
             .switchToSite(withTitle: "tricountyrealestate.wordpress.com")
-        snapshot("4-MySite")
+        thenTakeScreenshot(4, named: "MySite")
 
         // Get Media screenshot
         _ = mySite.gotoMediaScreen()
         sleep(imagesWaitTime) // wait for post images to load
-        snapshot("6-Media")
+        thenTakeScreenshot(6, named: "Media")
 
         if !isIpad {
             postList.pop()
@@ -90,14 +90,14 @@ class WordPressScreenshotGeneration: XCTestCase {
         statsScreen
             .dismissCustomizeInsightsNotice()
             .switchTo(mode: .months)
-        snapshot("3-Stats")
+        thenTakeScreenshot(3, named: "Stats")
 
         // Get Discover screenshot
         // Currently, the view includes the "You Might Like" section
         TabNavComponent()
             .gotoReaderScreen()
             .openDiscover()
-        snapshot("2-Discover")
+        thenTakeScreenshot(2, named: "Discover")
 
         // Get Notifications screenshot
         let notificationList = TabNavComponent()
@@ -107,6 +107,15 @@ class WordPressScreenshotGeneration: XCTestCase {
             notificationList.openNotification(withText: "Reyansh Pawar commented on My Top 10 Pastry Recipes")
             .replyToNotification()
         }
-        snapshot("5-Notifications")
+        thenTakeScreenshot(5, named: "Notifications")
+    }
+}
+
+extension XCTestCase {
+    func thenTakeScreenshot(_ index: Int, named title: String) {
+        let mode = isDarkMode ? "dark" : "light"
+        let filename = "\(index)-\(mode)-\(title)"
+
+        snapshot(filename)
     }
 }

--- a/WordPress/WordPressUITests/Screens/ReaderScreen.swift
+++ b/WordPress/WordPressUITests/Screens/ReaderScreen.swift
@@ -22,7 +22,9 @@ class ReaderScreen: BaseScreen {
         return XCUIApplication().tables[ElementStringIDs.readerTable].exists
     }
 
-    func openDiscover() {
+    func openDiscover() -> ReaderScreen {
         discoverButton.tap()
+
+        return self
     }
 }

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -8,6 +8,14 @@ var isIpad: Bool {
     return UIDevice.current.userInterfaceIdiom == .pad
 }
 
+var isDarkMode: Bool {
+    if #available(iOS 12.0, *) {
+        return UIViewController().traitCollection.userInterfaceStyle == .dark
+    } else {
+        return false
+    }
+}
+
 let navBackButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)
 
 extension XCUIElement {


### PR DESCRIPTION
Adds dark mode screenshots and updates the Fastlane `SnapshotHelper`.

### Changes

The UI tests now support setting the simulator to dark mode, and the Fastlane `screenshots` lane runs through the screenshots twice — once in dark mode and once in light mode. The screenshot test also uses a new helper method to include light/dark mode in the filename.

(These changes match the approach used in the WooCommerce iOS screenshots to support light/dark mode, h/t @jkmassel for that implementation.)

The `SnapshotHelper` update resolves an issue with the iPad landscape screenshots (part of the [2.159.0 Fastlane release](https://github.com/fastlane/fastlane/releases/tag/2.159.0)). Previously those screenshots would appear incorrectly rotated even when the simulator was in landscape orientation.

### To test

1. Open the fastlane directory: `cd Scripts/fastlane`
2. Generate the screenshots: `bundle exec fastlane screenshots` (or `bundle exec fastlane screenshots language:"en-US" ` to run it for a single language — the full run can take a long time and there aren't language-specific changes.)
3. Confirm there’s now a full set of screenshots in both light & dark mode, and iPad screenshots have the correct landscape orientation.

These generated screenshots will also come in handy for reviewing an upcoming PR (changing the app store screenshot composition).

### To review

This PR only requires a single reviewer.

### PR submission checklist

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
