### PR TITLE
Fix invisible editor overlay issue implementing state restoration capability for page editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Fixed issue that caused duplicate views to be displayed when requesting a login link. [#14975]
 * [internal] Modified feature flags that show unified Site Address, Google, Apple, WordPress views and iCloud keychain login. Could cause regressions. [#14954, #14969, #14970, #14971, #14972]
+* [*] Fixed an issue that caused page editor to become an invisible overlay. [#15012]
 
 15.8
 -----

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -441,32 +441,9 @@ fileprivate extension SearchManager {
     func openEditor(for page: Page) {
         closePreviewIfNeeded(for: page)
         openListView(for: page)
-        let editorFactory = EditorFactory()
 
-        let editor = editorFactory.instantiateEditor(
-            for: page,
-            replaceEditor: { [weak self] (editor, replacement) in
-                self?.replaceEditor(editor: editor, replacement: replacement)
-        })
-
-        open(editor)
-    }
-
-    private func open(_ editor: EditorViewController) {
-        editor.onClose = { [unowned editor] changesSaved, _ in
-            editor.dismiss(animated: true)
-        }
-
-        let navController = UINavigationController(rootViewController: editor)
-        navController.restorationIdentifier = Restorer.Identifier.navigationController.rawValue
-        navController.modalPresentationStyle = .fullScreen
-        WPTabBarController.sharedInstance().present(navController, animated: true)
-    }
-
-    func replaceEditor(editor: EditorViewController, replacement: EditorViewController) {
-        editor.dismiss(animated: true) { [weak self] in
-            self?.open(replacement)
-        }
+        let editorViewController = EditPageViewController(page: page)
+        WPTabBarController.sharedInstance().present(editorViewController, animated: false)
     }
 
     // MARK: - Preview

--- a/WordPress/Classes/ViewRelated/Pages/EditPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/EditPageViewController.swift
@@ -1,0 +1,133 @@
+import UIKit
+
+class EditPageViewController: UIViewController {
+    fileprivate var page: Page?
+    fileprivate var blog: Blog
+    fileprivate var postTitle: String?
+    fileprivate var content: String?
+    fileprivate var hasShownEditor = false
+
+    convenience init(page: Page) {
+        self.init(page: page, blog: page.blog, postTitle: nil, content: nil)
+    }
+
+    convenience init(blog: Blog, postTitle: String?, content: String?) {
+        self.init(page: nil, blog: blog, postTitle: postTitle, content: content)
+    }
+
+    fileprivate init(page: Page?, blog: Blog, postTitle: String?, content: String?) {
+        self.page = page
+        self.blog = blog
+        self.postTitle = postTitle
+        self.content = content
+
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .coverVertical
+        restorationIdentifier = RestorationKey.viewController.rawValue
+        restorationClass = EditPageViewController.self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if  !hasShownEditor {
+            showEditor()
+            hasShownEditor = true
+        }
+    }
+
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        return WPStyleGuide.preferredStatusBarStyle
+    }
+
+    fileprivate func pageToEdit() -> Page {
+        if let page = self.page {
+            return page
+        } else {
+            let context = ContextManager.sharedInstance().mainContext
+            let postService = PostService(managedObjectContext: context)
+            let newPage = postService.createDraftPage(for: blog)
+            newPage.content = self.content
+            newPage.postTitle = self.postTitle
+            self.page = newPage
+            return newPage
+        }
+    }
+
+    fileprivate func showEditor() {
+        let editorFactory = EditorFactory()
+
+        let editorViewController = editorFactory.instantiateEditor(
+            for: self.pageToEdit(),
+            replaceEditor: { [weak self] (editor, replacement) in
+                self?.replaceEditor(editor: editor, replacement: replacement)
+        })
+
+        show(editorViewController)
+    }
+
+    private func show(_ editor: EditorViewController) {
+        editor.onClose = { [weak self] _, _ in
+            // Dismiss navigation controller
+            self?.dismiss(animated: true) {
+                // Dismiss self
+                self?.dismiss(animated: false)
+            }
+        }
+
+        let navController = AztecNavigationController(rootViewController: editor)
+        navController.modalPresentationStyle = .fullScreen
+
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.prepare()
+
+        present(navController, animated: true) {
+            generator.impactOccurred()
+        }
+    }
+
+    func replaceEditor(editor: EditorViewController, replacement: EditorViewController) {
+        editor.dismiss(animated: true) { [weak self] in
+            self?.show(replacement)
+        }
+    }
+
+}
+
+
+extension EditPageViewController: UIViewControllerRestoration {
+    enum RestorationKey: String {
+        case viewController = "EditPageViewControllerRestorationID"
+        case page = "EditPageViewControllerPageRestorationID"
+    }
+
+    class func viewController(withRestorationIdentifierPath identifierComponents: [String],
+                              coder: NSCoder) -> UIViewController? {
+        guard let identifier = identifierComponents.last, identifier == RestorationKey.viewController.rawValue else {
+            return nil
+        }
+
+        let context = ContextManager.sharedInstance().mainContext
+
+        guard let pageURL = coder.decodeObject(forKey: RestorationKey.page.rawValue) as? URL,
+            let pageID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: pageURL),
+            let page = try? context.existingObject(with: pageID),
+            let reloadedPage = page as? Page
+            else {
+                return nil
+        }
+
+        return EditPageViewController(page: reloadedPage)
+    }
+
+    override func encodeRestorableState(with coder: NSCoder) {
+        super.encodeRestorableState(with: coder)
+        if let page = self.page {
+            coder.encode(page.objectID.uriRepresentation(), forKey: RestorationKey.page.rawValue)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -30,38 +30,7 @@ extension WPTabBarController {
     }
 
     private func showEditor(blog: Blog, title: String?, content: String?) {
-        let context = ContextManager.sharedInstance().mainContext
-        let postService = PostService(managedObjectContext: context)
-        let page = postService.createDraftPage(for: blog)
-        page.postTitle = title
-        page.content = content
-
-        let editorFactory = EditorFactory()
-
-        let pageViewController = editorFactory.instantiateEditor(
-            for: page,
-            replaceEditor: { [weak self] (editor, replacement) in
-                self?.replaceEditor(editor: editor, replacement: replacement)
-        })
-
-        show(pageViewController)
-    }
-
-    private func replaceEditor(editor: EditorViewController, replacement: EditorViewController) {
-        editor.dismiss(animated: true) { [weak self] in
-            self?.show(replacement)
-        }
-    }
-
-    private func show(_ editorViewController: EditorViewController) {
-        editorViewController.onClose = { [weak editorViewController] _, _ in
-            editorViewController?.dismiss(animated: true)
-        }
-
-        let navController = UINavigationController(rootViewController: editorViewController)
-        navController.restorationIdentifier = Restorer.Identifier.navigationController.rawValue
-        navController.modalPresentationStyle = .fullScreen
-
-        present(navController, animated: true, completion: nil)
+        let editorViewController = EditPageViewController(blog: blog, postTitle: title, content: content)
+        present(editorViewController, animated: false)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -965,6 +965,7 @@
 		74FA4BE51FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 74FA4BE31FBFA0660031EAAD /* Extensions.xcdatamodeld */; };
 		74FA4BE61FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 74FA4BE31FBFA0660031EAAD /* Extensions.xcdatamodeld */; };
 		74FA4BED1FBFA2350031EAAD /* SharedCoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746D6B241FBF701F003C45BE /* SharedCoreDataStack.swift */; };
+		7D21280D251CF0850086DD2C /* EditPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D21280C251CF0850086DD2C /* EditPageViewController.swift */; };
 		7E14635720B3BEAB00B95F41 /* WPStyleGuide+Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E14635620B3BEAB00B95F41 /* WPStyleGuide+Loader.swift */; };
 		7E21C761202BBC8E00837CF5 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E21C760202BBC8D00837CF5 /* iAd.framework */; };
 		7E21C765202BBF4400837CF5 /* SearchAdsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */; };
@@ -3447,6 +3448,7 @@
 		74FA2EE3200E8A6C001DDC13 /* AppExtensionsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppExtensionsService.swift; sourceTree = "<group>"; };
 		74FA4BE41FBFA0660031EAAD /* Extensions.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Extensions.xcdatamodel; sourceTree = "<group>"; };
 		75305C06D345590B757E3890 /* Pods-WordPress.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.debug.xcconfig"; sourceTree = "<group>"; };
+		7D21280C251CF0850086DD2C /* EditPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditPageViewController.swift; sourceTree = "<group>"; };
 		7DFD69454E24EC0A1A0BACCD /* Pods-WordPressThisWeekWidget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressThisWeekWidget.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressThisWeekWidget/Pods-WordPressThisWeekWidget.release.xcconfig"; sourceTree = "<group>"; };
 		7E14635620B3BEAB00B95F41 /* WPStyleGuide+Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Loader.swift"; sourceTree = "<group>"; };
 		7E21C760202BBC8D00837CF5 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
@@ -7019,6 +7021,7 @@
 			children = (
 				59DCA5201CC68AF3000F245F /* PageListViewController.swift */,
 				9AF724EE2146813C00F63A61 /* ParentPageSettingsViewController.swift */,
+				7D21280C251CF0850086DD2C /* EditPageViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -12839,6 +12842,7 @@
 				1782BE841E70063100A91E7D /* MediaItemViewController.swift in Sources */,
 				E10A2E9B134E8AD3007643F9 /* PostAnnotation.m in Sources */,
 				7E3E9B702177C9DC00FD5797 /* GutenbergViewController.swift in Sources */,
+				7D21280D251CF0850086DD2C /* EditPageViewController.swift in Sources */,
 				738B9A4F21B85CF20005062B /* SiteCreator.swift in Sources */,
 				F5660D09235D1CDD00020B1E /* CalendarMonthView.swift in Sources */,
 				FFB7B8201A0012E80032E723 /* ApiCredentials.m in Sources */,


### PR DESCRIPTION
Fixes #14674

## To test:

1. Start the app from Xcode
2. Go through one of the cases to open page editor
- [x] My Site -> Select site -> Floating + button (bottom right) -> Site page
- [x] My Site -> Select site -> Pages -> + (top right)
- [x] My Site -> Select site -> Pages -> Select any page to edit
- [x] My Site -> Select site -> Pages -> Search -> Select any page to edit
- [x] Press home button -> Pull down to search in Spotlight -> search the name of a **draft** page  -> select to open the app and see the editor
3. Background app using the Home button
4. Stop the debugger in Xcode ⚠️ Do not use the app switcher to force quit it during debugging. The system automatically deletes its preserved state when the user force quits the app. See [here](https://developer.apple.com/documentation/uikit/uiviewcontroller/restoring_your_app_s_state) to learn more.
5. Launch the app again using Xcode (Now UIKit initiates the state restoration process)
6. **Expect** page editor to be shown from where it left off


### Deep link test:

1. Need to change build configuration to `Release-Internal` for this to work (Changing only the scheme to `WordPress Internal` won't work, need to "Edit Scheme..." and modify the "Build Configuration" as well)
2. Start the app from Xcode
3. Background app using the Home button
4. Run in terminal `xcrun simctl openurl booted "https://apps.wordpress.com/get#/page"` 
5. App should open with the editor to create a new page
6. Background app using the Home button 
7. Stop the debugger in Xcode
8. Launch the app again
9. **Expect** page editor to be shown from where it left off

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
