### PR TITLE
What's New - Use pre-uploaded base64 image, if it exists

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -38,9 +38,9 @@ end
 
 def wordpress_kit
 
-    #pod 'WordPressKit', '~> 4.18.0-beta'
+    pod 'WordPressKit', '~> 4.18.0-beta'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/15014-base64-images-in-features'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -38,9 +38,9 @@ end
 
 def wordpress_kit
 
-    pod 'WordPressKit', '~> 4.18.0-beta'
+    #pod 'WordPressKit', '~> 4.18.0-beta'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/15014-base64-images-in-features'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -407,7 +407,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.11-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.18.0-beta.1):
+  - WordPressKit (4.18.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -506,7 +506,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.26.0-beta)
-  - WordPressKit (~> 4.18.0-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/15014-base64-images-in-features`)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
   - WordPressUI (~> 1.7.1)
@@ -556,7 +556,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -657,6 +656,9 @@ EXTERNAL SOURCES:
     :commit: a0a5353efe8560ccca572b6a15165b5608df7ee1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressKit:
+    :branch: feature/15014-base64-images-in-features
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/a0a5353efe8560ccca572b6a15165b5608df7ee1/third-party-podspecs/Yoga.podspec.json
 
@@ -675,6 +677,9 @@ CHECKOUT OPTIONS:
     :commit: a0a5353efe8560ccca572b6a15165b5608df7ee1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
+  WordPressKit:
+    :commit: c8f0b888489c6d4015885c041da18a6395ccc7eb
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -756,7 +761,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: e44d5f80a6f02c3491414d24c5e09ef0dc666b40
-  WordPressKit: 35574a223dd23320866813677d908cf81c8a4750
+  WordPressKit: 7fb381043697d3f1ec7c0f52407aa0fd54b544db
   WordPressMocks: b4064b99a073117bbc304abe82df78f2fbe60992
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: 9da5d966b8beb091950cd96880db398d7f30e246
@@ -772,6 +777,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: caba36b01d2e3ecf68f096e7e2c8ebb58452fb5e
+PODFILE CHECKSUM: 96d51c9f8370a53adaa68433fc433c0294a1f0a3
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -506,7 +506,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.26.0-beta)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/15014-base64-images-in-features`)
+  - WordPressKit (~> 4.18.0-beta)
   - WordPressMocks (~> 0.0.8)
   - WordPressShared (~> 1.12.0)
   - WordPressUI (~> 1.7.1)
@@ -556,6 +556,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -656,9 +657,6 @@ EXTERNAL SOURCES:
     :commit: a0a5353efe8560ccca572b6a15165b5608df7ee1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
-  WordPressKit:
-    :branch: feature/15014-base64-images-in-features
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/a0a5353efe8560ccca572b6a15165b5608df7ee1/third-party-podspecs/Yoga.podspec.json
 
@@ -677,9 +675,6 @@ CHECKOUT OPTIONS:
     :commit: a0a5353efe8560ccca572b6a15165b5608df7ee1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
-  WordPressKit:
-    :commit: c8f0b888489c6d4015885c041da18a6395ccc7eb
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -777,6 +772,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: a87ab1e4badace92c75eb11dc77ede1e995b2adc
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 96d51c9f8370a53adaa68433fc433c0294a1f0a3
+PODFILE CHECKSUM: caba36b01d2e3ecf68f096e7e2c8ebb58452fb5e
 
 COCOAPODS: 1.9.3

--- a/WordPress/Classes/ViewRelated/What's New/Views/AnnouncementCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/AnnouncementCell.swift
@@ -48,11 +48,13 @@ class AnnouncementCell: UITableViewCell {
     }
 
     func configure(feature: WordPressKit.Feature) {
-        if let iconBase64 = feature.iconBase64,
-            !iconBase64.isEmpty,
-            let imageData = Data(base64Encoded: iconBase64),
+
+        if let iconBase64Components = feature.iconBase64,
+            !iconBase64Components.isEmpty,
+            let base64Image = iconBase64Components.components(separatedBy: ";base64,")[safe: 1],
+            let imageData = Data(base64Encoded: base64Image, options: .ignoreUnknownCharacters),
             let icon = UIImage(data: imageData) {
-            announcementImageView.image = icon
+                announcementImageView.image = icon
         }
 
         else if let url = URL(string: feature.iconUrl) {

--- a/WordPress/Classes/ViewRelated/What's New/Views/AnnouncementCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/AnnouncementCell.swift
@@ -48,13 +48,18 @@ class AnnouncementCell: UITableViewCell {
     }
 
     func configure(feature: WordPressKit.Feature) {
-        if let url = URL(string: feature.iconUrl) {
+        if let iconBase64 = feature.iconBase64,
+            !iconBase64.isEmpty,
+            let imageData = Data(base64Encoded: iconBase64),
+            let icon = UIImage(data: imageData) {
+            announcementImageView.image = icon
+        }
+
+        else if let url = URL(string: feature.iconUrl) {
             announcementImageView.af_setImage(withURL: url)
         }
         headingLabel.text = feature.title
         subHeadingLabel.text = feature.subtitle
-        // TODO - WHATSNEW: - remove when images will be passed
-        announcementImageView.backgroundColor = .accent
     }
 }
 


### PR DESCRIPTION
Fixes #15014

WordPressKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/287

To test:
- fresh install to make sure to clean up `UserDefaults`
- Go to Me/App Settings/What's New in WordPress
- make sure that the first announcements has the icon displayed below
- to double check, set a breakpoint at line 55 in `AnnouncementCell.swift` and make sure that, for the first row of the table view, the `announcementImageView` is set from the `iconBase64` property.
<p align=center>
<img width=120 src=https://user-images.githubusercontent.com/34376330/94624022-2e8a9880-027b-11eb-8b89-99bd93d8cf2d.png>
</p>


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
