### PR TITLE
Bug Fix to Stock Photo Library Selection

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -6,15 +6,13 @@ final class MediaLibraryMediaPickingCoordinator {
     typealias PickersDelegate = StockPhotosPickerDelegate & WPMediaPickerViewControllerDelegate & TenorPickerDelegate
     private weak var delegate: PickersDelegate?
     private var tenor: TenorPicker?
-
-    private let stockPhotos = StockPhotosPicker()
+    private var stockPhotos: StockPhotosPicker?
     private let cameraCapture = CameraCaptureCoordinator()
     private let mediaLibrary = MediaLibraryPicker()
 
     init(delegate: PickersDelegate) {
         self.delegate = delegate
 
-        stockPhotos.delegate = delegate
         mediaLibrary.delegate = delegate
     }
 
@@ -90,7 +88,12 @@ final class MediaLibraryMediaPickingCoordinator {
     }
 
     private func showStockPhotos(origin: UIViewController, blog: Blog) {
-        stockPhotos.presentPicker(origin: origin, blog: blog)
+        let picker = StockPhotosPicker()
+        // add delegate conformance, allow release of picker in the same manner as the tenor picker
+        // in order to prevent duplicated uploads and botched de-selection on second upload
+        picker.delegate = self
+        picker.presentPicker(origin: origin, blog: blog)
+        stockPhotos = picker
     }
 
     private func showTenor(origin: UIViewController, blog: Blog) {
@@ -119,5 +122,12 @@ extension MediaLibraryMediaPickingCoordinator: TenorPickerDelegate {
     func tenorPicker(_ picker: TenorPicker, didFinishPicking assets: [TenorMedia]) {
         delegate?.tenorPicker(picker, didFinishPicking: assets)
         tenor = nil
+    }
+}
+
+extension MediaLibraryMediaPickingCoordinator: StockPhotosPickerDelegate {
+    func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia]) {
+        delegate?.stockPhotosPicker(picker, didFinishPicking: assets)
+        stockPhotos = nil
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -654,11 +654,10 @@ extension MediaLibraryViewController: StockPhotosPickerDelegate {
         guard assets.count > 0 else {
             return
         }
-
         let mediaCoordinator = MediaCoordinator.shared
-        assets.forEach {
+        assets.forEach { stockMedia in
             let info = MediaAnalyticsInfo(origin: .mediaLibrary(.stockPhotos), selectionMethod: .fullScreenPicker)
-            mediaCoordinator.addMedia(from: $0, to: blog, analyticsInfo: info)
+            mediaCoordinator.addMedia(from: stockMedia, to: blog, analyticsInfo: info)
             WPAnalytics.track(.stockMediaUploaded)
         }
     }

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosDataSource.swift
@@ -140,8 +140,10 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
 
 extension StockPhotosDataSource {
     private func notifyObservers(incremental: Bool = false, inserted: IndexSet = IndexSet()) {
-        observers.forEach {
-            $0.value(incremental, IndexSet(), inserted, IndexSet(), [])
+        DispatchQueue.main.async {
+            self.observers.forEach {
+                $0.value(incremental, IndexSet(), inserted, IndexSet(), [])
+            }
         }
     }
 }
@@ -165,7 +167,7 @@ extension StockPhotosDataSource: StockPhotosDataLoaderDelegate {
             onStopLoading?()
         }
 
-        guard media.count > 0 && searchQuery.count > 0 else {
+        guard media.count > 0, searchQuery.count > 0 else {
             clearSearch(notifyObservers: true)
             return
         }
@@ -176,7 +178,6 @@ extension StockPhotosDataSource: StockPhotosDataLoaderDelegate {
             appendMedia(with: media)
         }
     }
-
     private func overwriteMedia(with media: [StockPhotosMedia]) {
         photosMedia = media
         notifyObservers(incremental: false)

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosPicker.swift
@@ -6,7 +6,11 @@ protocol StockPhotosPickerDelegate: AnyObject {
 
 /// Presents the Stock Photos main interface
 final class StockPhotosPicker: NSObject {
-    var allowMultipleSelection = true
+    var allowMultipleSelection = true {
+        didSet {
+            pickerOptions.allowMultipleSelection = allowMultipleSelection
+        }
+    }
 
     private lazy var dataSource: StockPhotosDataSource = {
         return StockPhotosDataSource(service: stockPhotosService)
@@ -66,9 +70,10 @@ final class StockPhotosPicker: NSObject {
             self?.updateHintView()
         }
         dataSource.onStartLoading = { [weak self] in
-            if let searchHint = self?.searchHint {
-                NoResultsStockPhotosConfiguration.configureAsLoading(searchHint)
+            guard let strongSelf = self else {
+                return
             }
+            NoResultsStockPhotosConfiguration.configureAsLoading(strongSelf.searchHint)
         }
         dataSource.onStopLoading = { [weak self] in
             self?.updateHintView()

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -140,8 +140,17 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
         // Single Section Mode: A single section will contain all of the rows
         if singleSectionMode {
-            return [Section(rows: rows)]
+            // Switch on stream type to provide descriptive text in footer for more context
+            switch stream.kind {
+            case .Device:
+                return [Section(rows: rows, footerText: NSLocalizedString("Settings for push notifications that appear on your mobile device.", comment: "Descriptive text for the Push Notifications Settings"))]
+            case .Email:
+                return [Section(rows: rows, footerText: NSLocalizedString("Settings for notifications that are sent to the email tied to your account.", comment: "Descriptive text for the Email Notifications Settings"))]
+            case .Timeline:
+                return [Section(rows: rows, footerText: NSLocalizedString("Settings for notifications that appear in the Notifications tab.", comment: "Descriptive text for the Notifications Tab Settings"))]
+            }
         }
+
 
         // Multi Section Mode: We'll have one Section per Row
         var sections = [Section]()


### PR DESCRIPTION
Fixes #14646 

Added missing delegate conformance - without the delegate, the stock photo picker did not have its data cleared when it was next viewed. Also added small edits for great consistency of function across stock photo and gif pickers.

To test: Go to the Media Library and select + to add media. Choose the Free Photo Library. Search for any photo and upload it, then return to search the free photos again. Note that no items are selected, and when you search for media and upload another image, the previous image is not uploaded in its place, as before.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@mindgraffiti Would you be able to check this one for me please? Thanks a bunch!