### PR TITLE
Added `Block site` and `Report post` to more menu in `Following` feed (only for sites you don't follow)

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -13,7 +13,7 @@ final class ReaderShowMenuAction {
 
 
         // Block button
-        if shouldShowBlockSiteMenuItem(readerTopic: readerTopic) {
+        if shouldShowBlockSiteMenuItem(readerTopic: readerTopic, post: post) {
             alertController.addActionWithTitle(ReaderPostMenuButtonTitles.blockSite,
                                                style: .destructive,
                                                handler: { (action: UIAlertAction) in
@@ -24,7 +24,7 @@ final class ReaderShowMenuAction {
         }
 
         // Report button
-        if shouldShowReportPostMenuItem(readerTopic: readerTopic) {
+        if shouldShowReportPostMenuItem(readerTopic: readerTopic, post: post) {
             alertController.addActionWithTitle(ReaderPostMenuButtonTitles.reportPost,
                                                style: .default,
                                                handler: { (action: UIAlertAction) in
@@ -94,18 +94,18 @@ final class ReaderShowMenuAction {
         WPAnalytics.track(.postCardMoreTapped)
     }
 
-    fileprivate func shouldShowBlockSiteMenuItem(readerTopic: ReaderAbstractTopic?) -> Bool {
+    fileprivate func shouldShowBlockSiteMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {
         guard let topic = readerTopic else {
             return false
         }
         if isLoggedIn {
             return ReaderHelpers.isTopicTag(topic) || (ReaderHelpers.topicIsDiscover(topic) && FeatureFlag.readerImprovementsPhase2.enabled)
-                || ReaderHelpers.topicIsFreshlyPressed(topic)
+                || ReaderHelpers.topicIsFreshlyPressed(topic) || (ReaderHelpers.topicIsFollowing(topic) && !post.isFollowing)
         }
         return false
     }
 
-    fileprivate func shouldShowReportPostMenuItem(readerTopic: ReaderAbstractTopic?) -> Bool {
-        return shouldShowBlockSiteMenuItem(readerTopic: readerTopic)
+    fileprivate func shouldShowReportPostMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {
+        return shouldShowBlockSiteMenuItem(readerTopic: readerTopic, post: post)
     }
 }


### PR DESCRIPTION
`Block site` and `Report post` options are now available from the overflow menu in Following post cards, only for sites you don't follow (mimicking .com)

To test:

### For followed sites 
1. Got to Reader
2. Go to Following tab
3. Tap on the more menu (3 vertical dots) on a post card of a site you **follow**.
4. See that `Report post` and `Block site` options are **not available** 

### For sites not followed 
1. Go to Reader
2. Go to Following tab
3. Tap Filter
4. Choose a tag 
5. Gp back to Following feed 
6. Tap on the more menu (3 vertical dots) on a post card of a site you **do not follow**.
7. See the `Report post` and `Block site` options **available** 

![Screen Shot 2020-09-30 at 4 34 29 PM](https://user-images.githubusercontent.com/1335657/94750924-1464bf00-033c-11eb-9e65-4e4ebc197c15.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
