### PR TITLE
Reader: Fixes anchor links not responding to taps

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] Fixed issue that caused duplicate views to be displayed when requesting a login link. [#14975]
 * [internal] Modified feature flags that show unified Site Address, Google, Apple, WordPress views and iCloud keychain login. Could cause regressions. [#14954, #14969, #14970, #14971, #14972]
 * [*] Fixed an issue that caused page editor to become an invisible overlay. [#15012]
+* [*] Reader: Fixed an issue that resulted in no action when tapping a link with an anchor. [#15027]
 
 15.8
 -----

--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -145,6 +145,24 @@ extension URL {
         let components = pathComponents.filter({ $0 != "/" })
         return components.count == 4 && isHostedAtWPCom
     }
+
+
+    /// Does a quick test to see if 2 urls are equal to each other by
+    /// using just the hosts and paths. This ignores any query items, or hashes
+    /// on the urls
+    func isHostAndPathEqual(to url: URL) -> Bool {
+        guard
+            let components1 = URLComponents(url: self, resolvingAgainstBaseURL: true),
+            let components2 = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        else {
+            return false
+        }
+
+        let check1 = (components1.host ?? "") + components1.path
+        let check2 = (components2.host ?? "") + components2.path
+
+        return check1 == check2
+    }
 }
 
 extension NSURL {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -220,7 +220,8 @@ class ReaderDetailCoordinator {
         service.fetchPost(at: url,
                           success: { [weak self] post in
                             self?.post = post
-                            self?.renderPostAndBumpStats(with: url)
+                            self?.renderPostAndBumpStats()
+                            self?.scrollToHashIfNeeded(with: url)
                             self?.view?.show(title: post?.postTitle)
         }, failure: { [weak self] error in
             DDLogError("Error fetching post for detail: \(String(describing: error?.localizedDescription))")
@@ -229,13 +230,12 @@ class ReaderDetailCoordinator {
         })
     }
 
-    private func renderPostAndBumpStats(with url: URL? = nil) {
+    private func renderPostAndBumpStats() {
         guard let post = post else {
             return
         }
 
         view?.render(post)
-        scrollToHashIfNeeded(with: url)
 
         bumpStats()
         bumpPageViewsForPost()

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -212,6 +212,7 @@ class ReaderDetailCoordinator {
         })
     }
 
+
     /// Requests a ReaderPost from the service and updates the View.
     ///
     /// Use this method to fetch a ReaderPost from a URL.
@@ -221,7 +222,6 @@ class ReaderDetailCoordinator {
                           success: { [weak self] post in
                             self?.post = post
                             self?.renderPostAndBumpStats()
-                            self?.scrollToHashIfNeeded(with: url)
                             self?.view?.show(title: post?.postTitle)
         }, failure: { [weak self] error in
             DDLogError("Error fetching post for detail: \(String(describing: error?.localizedDescription))")
@@ -244,9 +244,9 @@ class ReaderDetailCoordinator {
     /// If the loaded URL contains a hash/anchor then jump to that spot in the post content
     /// once it loads
     ///
-    private func scrollToHashIfNeeded(with url: URL? = nil) {
+    private func scrollToHashIfNeeded() {
         guard
-            let url = url,
+            let url = postURL,
             let hash = URLComponents(url: url, resolvingAgainstBaseURL: true)?.fragment
         else {
             return
@@ -327,6 +327,12 @@ class ReaderDetailCoordinator {
         } else {
             presentWebViewController(url)
         }
+    }
+
+
+    /// Called after the webView fully loads
+    func webViewDidLoad() {
+        scrollToHashIfNeeded()
     }
 
     /// Show the featured image fullscreen

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -440,7 +440,7 @@ extension ReaderDetailViewController: WKNavigationDelegate {
         if let hash = pendingHashString {
             // This fixes an issue where sometimes jumping to the anchor would go to the wrong place
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                self.scroll(to: hash)
+                self.scroll(to: hash, animated: false)
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -174,16 +174,12 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Scroll the content to a given #hash
     ///
     func scroll(to hash: String) {
-        scroll(to: hash, animated: true)
-    }
-
-    func scroll(to hash: String, animated: Bool = true) {
         webView.evaluateJavaScript("document.getElementById('\(hash)').offsetTop", completionHandler: { [unowned self] height, _ in
             guard let height = height as? CGFloat else {
                 return
             }
 
-            self.scrollView.setContentOffset(CGPoint(x: 0, y: height + self.webView.frame.origin.y), animated: animated)
+            self.scrollView.setContentOffset(CGPoint(x: 0, y: height + self.webView.frame.origin.y), animated: true)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -10,6 +10,8 @@ class ReaderWebView: WKWebView {
 
     let jsToRemoveSrcSet = "document.querySelectorAll('img, img-placeholder').forEach((el) => {el.removeAttribute('srcset')})"
 
+    var postURL: URL? = nil
+
     /// Make the webview transparent
     ///
     override func awakeFromNib() {
@@ -50,6 +52,31 @@ class ReaderWebView: WKWebView {
                 \(additionalJavaScript)
                 // Remove autoplay to avoid media autoplaying
                 document.querySelectorAll('video-placeholder, audio-placeholder').forEach((el) => {el.removeAttribute('autoplay')})
+
+                // Replaces the bundle URL with the post URL for each "blank" anchor tag (<a href="#anchor"></a>).
+                // this fixes an issue where tapping on one would return a file url with the anchor attached to it
+                let baseURL = "\(Bundle.wordPressSharedBundle.bundleURL)"
+                let postURL = "\(postURL?.absoluteString ?? "")"
+
+                if(postURL.length > 0){
+                    let anchors = document.querySelectorAll('a')
+
+                    anchors.forEach(function(elem){
+                      // Ignore any regular links that don't have hashes
+                      if(!elem.hash || elem.hash.length < 0) {
+                        return
+                      }
+
+                      let href = elem.href;
+
+                      // Skip any links that aren't the base URL
+                      if(href.substr(0, baseURL.length) != baseURL){
+                        return
+                      }
+
+                      elem.href = postURL + elem.hash;
+                    });
+                }
             })
         </script>
         </html>

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -265,11 +265,10 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
         coordinator.post = post
 
-        coordinator.handle(URL(string: "#hash")!)
+        coordinator.handle(URL(string: "https://wordpress.com#hash")!)
 
         expect(viewMock.didCallScrollToWith).to(equal("hash"))
     }
-
 }
 
 private class ReaderPostServiceMock: ReaderPostService {

--- a/WordPress/WordPressTest/ReaderDetailViewControllerTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailViewControllerTests.swift
@@ -57,6 +57,7 @@ class ReaderPostBuilder: PostBuilder {
 
     func build() -> ReaderPost {
         post.blogURL = "https://wordpress.com"
+        post.permaLink = "https://wordpress.com"
         return post
     }
 }


### PR DESCRIPTION
Fixes #15017

### Demo
<img src="https://user-images.githubusercontent.com/793774/94742725-078b9f80-032b-11eb-93a7-b64e13a83927.gif" width="30%" />

### To test:

#### Loading of posts with anchors
1. Open a post with a link to a post with an anchor in the reader, example URL: https://emilylaguna.wordpress.com/2020/09/30/anchor-1/
2. Tap on the link
3. If it's a WP.com post you should be directed to the post in the app, and sent to the anchor once the post loads

#### Loading of a post with internal anchors
1. Open a post that has anchors to other areas in the same post, example: https://emilylaguna.wordpress.com/2020/09/30/anchor-2/
2. Scroll to the anchor
3. Tap on it
4. You should be brought to the location in the post for that anchor

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
