### PR TITLE
WebView: Configure WKWebView to support inline media playback on iPhones

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -94,7 +94,11 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     }
 
     @objc init(configuration: WebViewControllerConfiguration) {
-        webView = WKWebView()
+        let config = WKWebViewConfiguration()
+        // The default on iPad is true. We want the iPhone to be true as well.
+        config.allowsInlineMediaPlayback = true
+
+        webView = WKWebView(frame: .zero, configuration: config)
         url = configuration.url
         customOptionsButton = configuration.optionsButton
         secureInteraction = configuration.secureInteraction


### PR DESCRIPTION
Refs #15026 

This PR adds a WKWebViewConfiguration to the WebKitViewController. This allows web-based videos to be played inline on the iPhone if they are coded to do so.  This is the default behavior on the iPad, and desired for WPStories regardless of the platform on which they are viewed.

With this change video tags that define the `playsinline` attribute will now play inline on the iPhone and iPad, while video tags that do not specify this attribute will continue to play full screen in the native player.

See comments below and the referenced issue for more details.

@aforcier, @leandroalonso would either of you care to review? 😁 

To test:
View a WPStory with a video slide. Confirm the video plays inline vs opening the native viewer. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
