### PR TITLE
enable what's new feature flag for all

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -49,7 +49,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .gutenbergModalLayoutPicker:
             return false
         case .whatIsNew:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .newNavBarAppearance:
             return BuildConfiguration.current == .localDeveloper
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -85,9 +85,7 @@ extension BlogDetailsViewController {
             return
         }
 
-        if shouldShowCreateButtonAnnouncement() {
-            showCreateButtonAnnouncementAlert()
-        } else if tourGuide.shouldShowUpgradeToV2Notice(for: blog) {
+        if tourGuide.shouldShowUpgradeToV2Notice(for: blog) {
             showUpgradeToV2Alert(for: blog)
 
             tourGuide.didShowUpgradeToV2Notice(for: blog)
@@ -162,30 +160,6 @@ extension BlogDetailsViewController {
         let section = BlogDetailsSection(title: sectionTitle, andRows: [customizeRow, growRow], category: .quickStart)
         section.showQuickStartMenu = true
         return section
-    }
-
-    private func shouldShowCreateButtonAnnouncement() -> Bool {
-        return AppRatingUtility.shared.didUpgradeVersion && !UserDefaults.standard.createButtonAlertWasDisplayed && !FeatureFlag.whatIsNew.enabled
-    }
-
-    private func showCreateButtonAnnouncementAlert() {
-        guard noPresentedViewControllers else {
-            return
-        }
-
-        UserDefaults.standard.createButtonAlertWasDisplayed = true
-
-        let alert = FancyAlertViewController.makeCreateButtonAnnouncementAlertController { [weak self] (controller) in
-            controller.dismiss(animated: true)
-            if let url = URL(string: "https://wordpress.com/blog/2020/06/01/improved-navigation-in-the-wordpress-apps/") {
-                let webViewController = WebViewControllerFactory.controller(url: url)
-                let navController = LightNavigationController(rootViewController: webViewController)
-                self?.tabBarController?.present(navController, animated: true)
-            }
-        }
-        alert.modalPresentationStyle = .custom
-        alert.transitioningDelegate = self
-        tabBarController?.present(alert, animated: true)
     }
 
     private func showUpgradeToV2Alert(for blog: Blog) {


### PR DESCRIPTION
Fixes #15033
This also removes the **Streamlined navigation** alert that appeared at app update

To test:
- update the app (either manually or from a previous version to this one) and make sure that the **Streamlined navigation** alert does not appear. See an example of this alert in the screenshot below

<p align=center>
<img height=400 src=https://user-images.githubusercontent.com/34376330/94940239-d9c46900-0498-11eb-86fd-445d9de3f20b.PNG>
</p>



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~ Since users won't see feature announcements until they are actually added on the backend, I would not add release notes for this feature at this moment.
