### PR TITLE
Reader: change copy tags to topics

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -146,14 +146,14 @@ extension ReaderTagTopic {
         let titleFunction: (FilterProvider.State?) -> String = { state in
             switch state {
             case .loading, .error, .none:
-                return NSLocalizedString("Tags", comment: "Tags Filter Tab Title")
+                return NSLocalizedString("Topics", comment: "Topics Filter Tab Title")
             case .ready(let items):
-                return String(format: NSLocalizedString("Tags (%lu)", comment: "Tags Filter Tab Title with Count"), items.count)
+                return String(format: NSLocalizedString("Topics (%lu)", comment: "Topics Filter Tab Title with Count"), items.count)
             }
         }
 
-        let emptyTitle = NSLocalizedString("Add a tag", comment: "No Tags View Button Label")
-        let emptyActionTitle = NSLocalizedString("You can follow posts on a specific subject by adding a tag.", comment: "No Tags View Label")
+        let emptyTitle = NSLocalizedString("Add a topic", comment: "No Topics View Button Label")
+        let emptyActionTitle = NSLocalizedString("You can follow posts on a specific subject by adding a topic.", comment: "No Topics View Label")
 
         return FilterProvider(title: titleFunction,
                               accessibilityIdentifier: "TagsFilterTab",

--- a/WordPress/Classes/ViewRelated/Reader/Manage/OffsetTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/OffsetTableViewHandler.swift
@@ -1,4 +1,4 @@
-// A table view handler offset by 1 (for Add a Tag in Reader Tags)
+// A table view handler offset by 1 (for Add a Topic in Reader Tags)
 class OffsetTableViewHandler: WPTableViewHandler {
 
     func object(at indexPath: IndexPath) -> NSFetchRequestResult? {

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
@@ -16,7 +16,7 @@ class ReaderManageScenePresenter: ScenePresenter {
         var tabbedItem: TabbedViewController.TabbedItem {
             switch self {
             case .tags:
-                return TabbedViewController.TabbedItem(title: NSLocalizedString("Followed Tags", comment: "Followed Tags Title"),
+                return TabbedViewController.TabbedItem(title: NSLocalizedString("Followed Topics", comment: "Followed Topics Title"),
                                                                viewController: makeViewController(),
                                                                accessibilityIdentifier: "FollowedTags")
             case .sites:

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewController+Cells.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewController+Cells.swift
@@ -16,7 +16,7 @@ extension ReaderTagsTableViewModel {
     }
 
     private func configureAddTag(cell: UITableViewCell) {
-        cell.textLabel?.text = NSLocalizedString("Add a Tag", comment: "Title of a feature to add a new tag to the tags subscribed by the user.")
+        cell.textLabel?.text = NSLocalizedString("Add a Topic", comment: "Title of a feature to add a new topic to the topics subscribed by the user.")
         cell.accessoryView = UIImageView(image: UIImage.gridicon(.plusSmall))
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -115,11 +115,11 @@ extension ReaderTagsTableViewModel {
                 self?.scrollToTag(tag)
             }
         }, failure: { (error) in
-            DDLogError("Could not follow tag named \(tagName) : \(String(describing: error))")
+            DDLogError("Could not follow topic named \(tagName) : \(String(describing: error))")
 
             generator.notificationOccurred(.error)
 
-            let title = NSLocalizedString("Could Not Follow Tag", comment: "Title of a prompt informing the user there was a probem unsubscribing from a tag in the reader.")
+            let title = NSLocalizedString("Could Not Follow Topic", comment: "Title of a prompt informing the user there was a probem unsubscribing from a topic in the reader.")
             let message = error?.localizedDescription
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alert.addCancelActionWithTitle(NSLocalizedString("OK", comment: "Button title. An acknowledgement of the message displayed in a prompt."))
@@ -136,7 +136,7 @@ extension ReaderTagsTableViewModel {
         service.unfollowTag(topic, withSuccess: nil) { (error) in
             DDLogError("Could not unfollow topic \(topic), \(String(describing: error))")
 
-            let title = NSLocalizedString("Could Not Remove Tag", comment: "Title of a prompt informing the user there was a probem unsubscribing from a tag in the reader.")
+            let title = NSLocalizedString("Could Not Remove Topic", comment: "Title of a prompt informing the user there was a probem unsubscribing from a topic in the reader.")
             let message = error?.localizedDescription
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alert.addCancelActionWithTitle(NSLocalizedString("OK", comment: "Button title. An acknowledgement of the message displayed in a prompt."))

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -29,7 +29,7 @@ extension ReaderTagsTableViewModel: WPTableViewHandlerDelegate {
         return ReaderTagTopic.tagsFetchRequest
     }
 
-    /// Disable highlighting for all rows but "Add a tag" this allows the rows to be "flashed" but not show taps
+    /// Disable highlighting for all rows but "Add a Topic" this allows the rows to be "flashed" but not show taps
     func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
         let adjustedPath = tableViewHandler.adjusted(indexPath: indexPath)
         return adjustedPath == nil
@@ -65,15 +65,15 @@ extension ReaderTagsTableViewModel {
     /// Presents a new view controller for subscribing to a new tag.
     private func showAddTag() {
 
-        let placeholder = NSLocalizedString("Add any tag", comment: "Placeholder text. A call to action for the user to type any tag to which they would like to subscribe.")
+        let placeholder = NSLocalizedString("Add any topic", comment: "Placeholder text. A call to action for the user to type any topic to which they would like to subscribe.")
         let controller = SettingsTextViewController(text: nil, placeholder: placeholder, hint: nil)
-        controller.title = NSLocalizedString("Add a Tag", comment: "Title of a feature to add a new tag to the tags subscribed by the user.")
+        controller.title = NSLocalizedString("Add a Topic", comment: "Title of a feature to add a new topic to the topics subscribed by the user.")
         controller.onValueChanged = { [weak self] value in
             self?.follow(tagName: value)
         }
         controller.mode = .lowerCaseText
         controller.displaysActionButton = true
-        controller.actionText = NSLocalizedString("Add Tag", comment: "Button Title. Tapping subscribes the user to a new tag.")
+        controller.actionText = NSLocalizedString("Add Topic", comment: "Button Title. Tapping subscribes the user to a new topic.")
         controller.onActionPress = { [weak self] in
             self?.dismissModal()
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -374,9 +374,9 @@ import WordPressShared
     /// Presents a new view controller for subscribing to a new tag.
     ///
     @objc func showAddTag() {
-        let placeholder = NSLocalizedString("Add any tag", comment: "Placeholder text. A call to action for the user to type any tag to which they would like to subscribe.")
+        let placeholder = NSLocalizedString("Add any topic", comment: "Placeholder text. A call to action for the user to type any topic to which they would like to subscribe.")
         let controller = SettingsTextViewController(text: nil, placeholder: placeholder, hint: nil)
-        controller.title = NSLocalizedString("Add a Tag", comment: "Title of a feature to add a new tag to the tags subscribed by the user.")
+        controller.title = NSLocalizedString("Add a Topic", comment: "Title of a feature to add a new topic to the topics subscribed by the user.")
         controller.onValueChanged = { value in
             if value.trim().count > 0 {
                 self.followTagNamed(value.trim())
@@ -384,7 +384,7 @@ import WordPressShared
         }
         controller.mode = .lowerCaseText
         controller.displaysActionButton = true
-        controller.actionText = NSLocalizedString("Add Tag", comment: "Button Title. Tapping subscribes the user to a new tag.")
+        controller.actionText = NSLocalizedString("Add Topic", comment: "Button Title. Tapping subscribes the user to a new topic.")
         controller.onActionPress = {
             self.dismissModal()
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -420,7 +420,7 @@ import WordPressShared
     ///
     @objc func promptUnfollowTagTopic(_ topic: ReaderTagTopic) {
         let title = NSLocalizedString("Remove", comment: "Title of a prompt asking the user to confirm they no longer wish to subscribe to a certain tag.")
-        let template = NSLocalizedString("Are you sure you wish to remove the tag '%@'?", comment: "A short message asking the user if they wish to unfollow the specified tag. The %@ is a placeholder for the name of the tag.")
+        let template = NSLocalizedString("Are you sure you wish to remove the topic '%@'?", comment: "A short message asking the user if they wish to unfollow the specified topic. The %@ is a placeholder for the name of the topic.")
         let message = String(format: template, topic.title)
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Title of a cancel button.")) { (action) in
@@ -443,7 +443,7 @@ import WordPressShared
         service.unfollowTag(topic, withSuccess: nil) { (error) in
             DDLogError("Could not unfollow topic \(topic), \(String(describing: error))")
 
-            let title = NSLocalizedString("Could Not Remove Tag", comment: "Title of a prompt informing the user there was a probem unsubscribing from a tag in the reader.")
+            let title = NSLocalizedString("Could Not Remove Topic", comment: "Title of a prompt informing the user there was a probem unsubscribing from a topic in the reader.")
             let message = error?.localizedDescription
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alert.addCancelActionWithTitle(NSLocalizedString("OK", comment: "Button title. An acknowledgement of the message displayed in a prompt."))
@@ -476,7 +476,7 @@ import WordPressShared
 
                 generator.notificationOccurred(.error)
 
-                let title = NSLocalizedString("Could Not Follow Tag", comment: "Title of a prompt informing the user there was a probem unsubscribing from a tag in the reader.")
+                let title = NSLocalizedString("Could Not Follow Topic", comment: "Title of a prompt informing the user there was a probem unsubscribing from a topic in the reader.")
                 let message = error?.localizedDescription
                 let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
                 alert.addCancelActionWithTitle(NSLocalizedString("OK", comment: "Button title. An acknowledgement of the message displayed in a prompt."))

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewModel.swift
@@ -510,7 +510,7 @@ enum ReaderDefaultMenuItemOrder: Int {
         var fetchedIndex = index
         if ReaderHelpers.isLoggedIn() {
             if fetchedIndex == 0 {
-                let title = NSLocalizedString("Add a Tag", comment: "Title. Lets the user know that they can use this feature to subscribe to new tags.")
+                let title = NSLocalizedString("Add a Topic", comment: "Title. Lets the user know that they can use this feature to subscribe to new topics.")
                 return ReaderMenuItem(title: title, type: .addItem)
             } else {
                 // Adjust the index by one to account for AddItem


### PR DESCRIPTION
Fixes #14837
Fixes #14838

## To test

### Filtering

1. Go to Reader
2. Tap the filter
3. Check that the text read "Topics (X)"

### Managing

1. Go to Reader
2. Tap the cog icon
3. Check that the section is now "Followed Topics"
4. Tap "Add a Topic"
5. Check the labels

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
