### PR TITLE
Reader Improvements: Adds comment action to the bottom of the content

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,11 +21,11 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="768"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xyq-y6-zPR">
-                                        <rect key="frame" x="0.0" y="0.0" width="446" height="243"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="446" height="222.5"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
                                     <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iSu-TI-yew" customClass="ReaderWebView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="259" width="414" height="0.0"/>
+                                        <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
                                         <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="414" placeholder="YES" id="akw-kl-dl7"/>
@@ -37,14 +38,40 @@
                                         </wkWebViewConfiguration>
                                     </wkWebView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="O4e-BA-8jp">
-                                        <rect key="frame" x="16" y="259" width="414" height="0.0"/>
+                                        <rect key="frame" x="16" y="238.5" width="414" height="20.5"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TWq-e0-xZe">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="0.0"/>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ewc-f7-89P" customClass="ReaderCardDiscoverAttributionView" customModule="WordPress">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="20.5"/>
+                                                <subviews>
+                                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="NEe-UN-zaj" customClass="CircularImageView" customModule="WordPress">
+                                                        <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" priority="999" constant="20" id="LME-RR-daf"/>
+                                                            <constraint firstAttribute="width" constant="20" id="NrG-FK-J1s"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="740" verticalCompressionResistancePriority="1000" text="Attribution" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="D7G-k1-H0E">
+                                                        <rect key="frame" x="28" y="0.0" width="386" height="20.5"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <color key="textColor" red="0.66666666669999997" green="0.66666666669999997" blue="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" id="dx7-H0-Hns"/>
+                                                    <constraint firstItem="NEe-UN-zaj" firstAttribute="leading" secondItem="Ewc-f7-89P" secondAttribute="leading" id="GKo-Xg-pwk"/>
+                                                    <constraint firstAttribute="trailing" secondItem="D7G-k1-H0E" secondAttribute="trailing" id="Hwq-jr-GrU"/>
+                                                    <constraint firstItem="D7G-k1-H0E" firstAttribute="top" secondItem="Ewc-f7-89P" secondAttribute="top" id="WUy-M3-Hb6"/>
+                                                    <constraint firstItem="D7G-k1-H0E" firstAttribute="height" relation="greaterThanOrEqual" secondItem="NEe-UN-zaj" secondAttribute="height" id="iqj-BZ-ezI"/>
+                                                    <constraint firstItem="NEe-UN-zaj" firstAttribute="top" secondItem="Ewc-f7-89P" secondAttribute="top" id="lFz-U6-ykF"/>
+                                                    <constraint firstItem="D7G-k1-H0E" firstAttribute="leading" secondItem="NEe-UN-zaj" secondAttribute="trailing" constant="8" id="wYe-dA-TcC"/>
+                                                    <constraint firstAttribute="bottom" secondItem="D7G-k1-H0E" secondAttribute="bottom" id="xYY-66-i2k"/>
                                                 </constraints>
+                                                <connections>
+                                                    <outlet property="imageView" destination="NEe-UN-zaj" id="9sM-RI-9rU"/>
+                                                    <outlet property="textLabel" destination="D7G-k1-H0E" id="437-Ec-cHF"/>
+                                                </connections>
                                             </view>
                                         </subviews>
                                     </stackView>
@@ -77,7 +104,7 @@
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ERb-e0-U8L">
                                 <rect key="frame" x="0.0" y="862" width="414" height="34"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qnQ-Ld-x9K">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
@@ -98,7 +125,7 @@
                                                     </imageView>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wMZ-jx-Iu5">
                                                         <rect key="frame" x="42" y="17" width="372" height="32"/>
-                                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                     </view>
                                                 </subviews>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -221,7 +248,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="bottom" secondItem="Jvg-nM-lV9" secondAttribute="bottom" id="05b-PA-2Gv"/>
                                                     <constraint firstItem="Jvg-nM-lV9" firstAttribute="top" secondItem="xrm-JQ-hpv" secondAttribute="top" id="2sk-af-ZIb"/>
@@ -232,7 +259,8 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <viewLayoutGuide key="safeArea" id="EtS-rx-pLc"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstItem="EKd-IB-Upn" firstAttribute="width" secondItem="vGc-hu-x5V" secondAttribute="width" id="aRu-Sg-NTM"/>
                                     <constraint firstItem="vGc-hu-x5V" firstAttribute="top" secondItem="EtS-rx-pLc" secondAttribute="top" id="kf9-7G-BWF"/>
@@ -240,10 +268,10 @@
                                     <constraint firstItem="EKd-IB-Upn" firstAttribute="top" secondItem="vGc-hu-x5V" secondAttribute="bottom" constant="32" id="p5l-dZ-qKp"/>
                                     <constraint firstItem="vGc-hu-x5V" firstAttribute="centerX" secondItem="qnQ-Ld-x9K" secondAttribute="centerX" id="pMy-9R-nWF"/>
                                 </constraints>
-                                <viewLayoutGuide key="safeArea" id="EtS-rx-pLc"/>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="Tqp-x3-yXv"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Tqp-x3-yXv" firstAttribute="trailing" secondItem="qnQ-Ld-x9K" secondAttribute="trailing" id="7q2-Rq-Wbt"/>
                             <constraint firstItem="ERb-e0-U8L" firstAttribute="top" secondItem="Qzd-gm-oIu" secondAttribute="bottom" id="AWw-Um-NsT"/>
@@ -262,10 +290,9 @@
                             <constraint firstItem="Tqp-x3-yXv" firstAttribute="trailing" secondItem="Qzd-gm-oIu" secondAttribute="trailing" id="zR2-IL-BwU"/>
                             <constraint firstItem="qnQ-Ld-x9K" firstAttribute="top" secondItem="HkO-UB-8qv" secondAttribute="top" id="zgv-gp-j1Q"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="Tqp-x3-yXv"/>
                     </view>
                     <connections>
-                        <outlet property="attributionViewContainer" destination="TWq-e0-xZe" id="0Bb-jI-gSy"/>
+                        <outlet property="attributionView" destination="Ewc-f7-89P" id="Pwq-Hm-VfQ"/>
                         <outlet property="headerContainerView" destination="Xyq-y6-zPR" id="duy-5z-Fdl"/>
                         <outlet property="loadingView" destination="qnQ-Ld-x9K" id="D1T-sa-IvL"/>
                         <outlet property="scrollView" destination="9JA-VQ-zzw" id="lCO-o1-bLB"/>
@@ -283,5 +310,8 @@
     <resources>
         <image name="gravatar" width="85" height="85"/>
         <image name="post-blavatar-placeholder" width="32" height="32"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
@@ -107,7 +107,7 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qnQ-Ld-x9K">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="250" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="vGc-hu-x5V">
                                         <rect key="frame" x="0.0" y="44" width="414" height="135"/>
@@ -281,7 +281,7 @@
                             <constraint firstItem="9JA-VQ-zzw" firstAttribute="leading" secondItem="Tqp-x3-yXv" secondAttribute="leading" id="KOc-Yv-UWy"/>
                             <constraint firstItem="Qzd-gm-oIu" firstAttribute="leading" secondItem="Tqp-x3-yXv" secondAttribute="leading" id="PNw-Cb-AvC"/>
                             <constraint firstAttribute="bottom" secondItem="ERb-e0-U8L" secondAttribute="bottom" id="fPU-nx-gzV"/>
-                            <constraint firstItem="Tqp-x3-yXv" firstAttribute="bottom" secondItem="qnQ-Ld-x9K" secondAttribute="bottom" id="jDb-2v-GlQ"/>
+                            <constraint firstAttribute="bottom" secondItem="qnQ-Ld-x9K" secondAttribute="bottom" id="jDb-2v-GlQ"/>
                             <constraint firstItem="ERb-e0-U8L" firstAttribute="centerX" secondItem="Qzd-gm-oIu" secondAttribute="centerX" id="kuZ-bk-VtY"/>
                             <constraint firstItem="qnQ-Ld-x9K" firstAttribute="leading" secondItem="Tqp-x3-yXv" secondAttribute="leading" id="mRn-49-Gms"/>
                             <constraint firstItem="Tqp-x3-yXv" firstAttribute="bottom" secondItem="Qzd-gm-oIu" secondAttribute="bottom" id="p2r-l3-0Mh"/>
@@ -292,6 +292,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="actionStackView" destination="O4e-BA-8jp" id="Ro3-aL-ekY"/>
                         <outlet property="attributionView" destination="Ewc-f7-89P" id="Pwq-Hm-VfQ"/>
                         <outlet property="headerContainerView" destination="Xyq-y6-zPR" id="duy-5z-Fdl"/>
                         <outlet property="loadingView" destination="qnQ-Ld-x9K" id="D1T-sa-IvL"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -335,7 +335,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     private func configureCommentAction() {
         actionStackView.insertArrangedSubview(commentAction, at: 0)
-        commentAction.backgroundColor = view.backgroundColor
+        commentAction.backgroundColor = .clear
     }
 
     private func configureDiscoverAttribution(_ post: ReaderPost) {
@@ -346,7 +346,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             attributionView.translatesAutoresizingMaskIntoConstraints = false
             attributionView.configureViewWithVerboseSiteAttribution(post)
             attributionView.delegate = self
-            attributionView.backgroundColor = view.backgroundColor
+            attributionView.backgroundColor = .clear
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -23,9 +23,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Header container
     @IBOutlet weak var headerContainerView: UIView!
 
-    /// Wrapper for the attribution view
-    @IBOutlet weak var attributionViewContainer: UIStackView!
-
     /// Wrapper for the toolbar
     @IBOutlet weak var toolbarContainerView: UIView!
 
@@ -33,7 +30,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     @IBOutlet weak var loadingView: UIView!
 
     /// Attribution view for Discovery posts
-    private let attributionView: ReaderCardDiscoverAttributionView = .loadFromNib()
+    @IBOutlet weak var attributionView: ReaderCardDiscoverAttributionView!
 
     /// The actual header
     private let featuredImage: ReaderDetailFeaturedImageView = .loadFromNib()
@@ -52,9 +49,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// An observer of the content size of the webview
     private var scrollObserver: NSKeyValueObservation?
-
-    /// If we're following the scrollview to hide/show nav and toolbar
-    private var isFollowingScrollView = false
 
     /// The coordinator, responsible for the logic
     var coordinator: ReaderDetailCoordinator?
@@ -335,11 +329,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             attributionView.isHidden = true
         } else {
             attributionView.displayAsLink = true
-            attributionViewContainer.addSubview(attributionView)
-            attributionViewContainer.pinSubviewToAllEdges(attributionView)
             attributionView.translatesAutoresizingMaskIntoConstraints = false
             attributionView.configureViewWithVerboseSiteAttribution(post)
             attributionView.delegate = self
+            attributionView.backgroundColor = view.backgroundColor
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -29,6 +29,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// The loading view, which contains all the ghost views
     @IBOutlet weak var loadingView: UIView!
 
+    /// The loading view, which contains all the ghost views
+    @IBOutlet weak var actionStackView: UIStackView!
+
     /// Attribution view for Discovery posts
     @IBOutlet weak var attributionView: ReaderCardDiscoverAttributionView!
 
@@ -40,6 +43,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// Bottom toolbar
     private let toolbar: ReaderDetailToolbar = .loadFromNib()
+
+    /// Comment view, add action bar
+    private let commentAction: ReaderDetailCommentsView = .loadFromNib()
 
     /// A view that fills the bottom portion outside of the safe area
     @IBOutlet weak var toolbarSafeAreaView: UIView!
@@ -102,6 +108,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         configureNoResultsViewController()
         observeWebViewHeight()
         configureNotifications()
+        configureCommentAction()
+
         coordinator?.start()
 
         // Fixes swipe to go back not working when leftBarButtonItem is set
@@ -162,6 +170,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         featuredImage.configure(for: post, with: self)
         toolbar.configure(for: post, in: self)
         header.configure(for: post)
+        commentAction.configure(for: post, in: self)
 
         coordinator?.storeAuthenticationCookies(in: webView) { [weak self] in
             self?.webView.loadHTMLString(post.contentForDisplay())
@@ -322,6 +331,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         toolbarContainerView.pinSubviewToAllEdges(toolbar)
         toolbarContainerView.translatesAutoresizingMaskIntoConstraints = false
         toolbarSafeAreaView.backgroundColor = toolbar.backgroundColor
+    }
+
+    private func configureCommentAction() {
+        actionStackView.insertArrangedSubview(commentAction, at: 0)
+        commentAction.backgroundColor = view.backgroundColor
     }
 
     private func configureDiscoverAttribution(_ post: ReaderPost) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -335,7 +335,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     private func configureCommentAction() {
         actionStackView.insertArrangedSubview(commentAction, at: 0)
-        commentAction.backgroundColor = .clear
     }
 
     private func configureDiscoverAttribution(_ post: ReaderPost) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsView.swift
@@ -1,0 +1,110 @@
+import UIKit
+import Gridicons
+
+class ReaderDetailCommentsView: UIView, NibLoadable {
+    @IBOutlet weak var viewCommentsButton: UIButton!
+    @IBOutlet weak var commentsLabel: UILabel!
+    @IBOutlet weak var disclosureImageView: UIImageView!
+    @IBOutlet weak var addButton: UIButton!
+
+    /// The reader post that the toolbar interacts with
+    private var post: ReaderPost?
+
+    /// The VC where the toolbar is inserted
+    private weak var viewController: UIViewController?
+
+    /// An observer of the number of likes of the post
+    private var commentCountObserver: NSKeyValueObservation?
+
+    /// Returns the current comment count
+    private var commentCount: Int {
+        return post?.commentCount()?.intValue ?? 0
+    }
+
+    /// Configures the view for the given post
+    func configure(for post: ReaderPost, in viewController: UIViewController) {
+        self.post = post
+        self.viewController = viewController
+
+        guard shouldShowCommentAction else {
+            isHidden = true
+            return
+        }
+
+        commentsLabel.text = commentTitle()
+        addButton.setTitle(Strings.addComment, for: .normal)
+
+        applyStyles()
+        isHidden = false
+    }
+
+    // MARK: - IBAction's
+    @IBAction func didTapViewCommentsButton(_ sender: Any) {
+        guard let post = post, let viewController = viewController else {
+            return
+        }
+
+        ReaderCommentAction().execute(post: post, origin: viewController)
+    }
+
+    @IBAction func didTapAddCommentButton(_ sender: Any) {
+        guard let post = post, let viewController = viewController else {
+            return
+        }
+
+        ReaderCommentAction().execute(post: post,
+                                      origin: viewController,
+                                      promptToAddComment: true)
+    }
+
+    // MARK: - Private: Helpers
+    private func commentTitle() -> String {
+        let format = commentCount != 1 ? Strings.commentFormatPlural : Strings.commentFormat
+
+        return String(format: format, "\(commentCount)")
+    }
+
+    private var shouldShowCommentAction: Bool {
+        // Show comments if logged in and comments are enabled, or if comments exist.
+        // But only if it is from wpcom (jetpack and external is not yet supported).
+        // Nesting this conditional cos it seems clearer that way
+        guard let post = post else {
+            return false
+        }
+
+        if (post.isWPCom || post.isJetpack) {
+            let commentCount = post.commentCount?.intValue ?? 0
+            if (ReaderHelpers.isLoggedIn() && post.commentsOpen) || commentCount > 0 {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    // MARK: - Styles
+    private func applyStyles() {
+        commentsLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
+        commentsLabel.textColor = .text
+        addButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body)
+        addButton.titleLabel?.textColor = UIColor.muriel(color: .primary, .shade40)
+
+        let iconColor = UIColor(light: .lightGray, dark: .white)
+
+        let icon: UIImage = UIImage.gridicon(.chevronRight, size: CGSize(width: 20, height: 20))
+        disclosureImageView.image = icon.imageWithTintColor(iconColor)
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        applyStyles()
+    }
+
+    // MARK: - Constants
+    private struct Strings {
+        static let commentFormat = NSLocalizedString("%@ comment", comment: "Accessibility label for comments button (singular)")
+        static let commentFormatPlural = NSLocalizedString("%@ comments", comment: "Accessibility label for comments button (plural)")
+        static let addComment = NSLocalizedString("Add Comment", comment: "Accessibility label for add comment button")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsView.swift
@@ -72,7 +72,7 @@ class ReaderDetailCommentsView: UIView, NibLoadable {
             return false
         }
 
-        if (post.isWPCom || post.isJetpack) {
+        if post.isWPCom || post.isJetpack {
             let commentCount = post.commentCount?.intValue ?? 0
             if (ReaderHelpers.isLoggedIn() && post.commentsOpen) || commentCount > 0 {
                 return true

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsView.xib
@@ -12,11 +12,11 @@
         <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XHZ-A5-1VK" customClass="ReaderDetailCommentsView" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="CqH-7n-yCg">
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="CqH-7n-yCg">
                     <rect key="frame" x="-2" y="0.0" width="416" height="24"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tNq-SU-bHU">
-                            <rect key="frame" x="0.0" y="0.0" width="208" height="24"/>
+                            <rect key="frame" x="0.0" y="0.0" width="203" height="24"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GeG-xx-Hjc">
                                     <rect key="frame" x="0.0" y="0.0" width="83" height="24"/>
@@ -32,7 +32,7 @@
                                     </constraints>
                                 </imageView>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ucZ-Od-AwP" userLabel="Overlay Button">
-                                    <rect key="frame" x="0.0" y="0.0" width="208" height="24"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="203" height="24"/>
                                     <connections>
                                         <action selector="didTapViewCommentsButton:" destination="XHZ-A5-1VK" eventType="touchUpInside" id="3qG-Bc-nht"/>
                                     </connections>
@@ -42,6 +42,7 @@
                             <constraints>
                                 <constraint firstAttribute="bottom" secondItem="fl5-Kc-zxf" secondAttribute="bottom" constant="1" id="ERr-OS-ODd"/>
                                 <constraint firstItem="GeG-xx-Hjc" firstAttribute="leading" secondItem="tNq-SU-bHU" secondAttribute="leading" id="Et8-xQ-9e7"/>
+                                <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="fl5-Kc-zxf" secondAttribute="trailing" constant="97" id="KXQ-gE-OeJ"/>
                                 <constraint firstAttribute="trailing" secondItem="ucZ-Od-AwP" secondAttribute="trailing" id="Kmp-VN-5R3"/>
                                 <constraint firstItem="GeG-xx-Hjc" firstAttribute="top" secondItem="tNq-SU-bHU" secondAttribute="top" id="NZc-6x-Ewp"/>
                                 <constraint firstAttribute="bottom" secondItem="GeG-xx-Hjc" secondAttribute="bottom" id="SBP-PE-pbj"/>
@@ -49,10 +50,11 @@
                                 <constraint firstAttribute="bottom" secondItem="ucZ-Od-AwP" secondAttribute="bottom" id="cd4-ip-dRk"/>
                                 <constraint firstItem="ucZ-Od-AwP" firstAttribute="top" secondItem="tNq-SU-bHU" secondAttribute="top" id="cmB-vc-cBq"/>
                                 <constraint firstItem="fl5-Kc-zxf" firstAttribute="leading" secondItem="GeG-xx-Hjc" secondAttribute="trailing" constant="3" id="iN0-ln-EDv"/>
+                                <constraint firstItem="GeG-xx-Hjc" firstAttribute="width" relation="lessThanOrEqual" secondItem="tNq-SU-bHU" secondAttribute="width" multiplier="0.9" id="nlh-kX-VpU"/>
                             </constraints>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Aec-C8-RtP">
-                            <rect key="frame" x="208" y="0.0" width="208" height="24"/>
+                            <rect key="frame" x="213" y="0.0" width="203" height="24"/>
                             <state key="normal" title="Add Comment"/>
                             <connections>
                                 <action selector="didTapAddCommentButton:" destination="XHZ-A5-1VK" eventType="touchUpInside" id="BbW-Ls-t5e"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsView.xib
@@ -10,7 +10,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XHZ-A5-1VK" customClass="ReaderDetailCommentsView" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="32"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="CqH-7n-yCg">
                     <rect key="frame" x="-2" y="0.0" width="416" height="24"/>
@@ -69,7 +69,7 @@
                 <constraint firstAttribute="trailing" secondItem="CqH-7n-yCg" secondAttribute="trailing" id="OcB-3b-WJH"/>
                 <constraint firstItem="CqH-7n-yCg" firstAttribute="leading" secondItem="XHZ-A5-1VK" secondAttribute="leading" constant="-2" id="UO5-Tl-oZG"/>
                 <constraint firstItem="CqH-7n-yCg" firstAttribute="top" secondItem="XHZ-A5-1VK" secondAttribute="top" id="drF-bl-37Y"/>
-                <constraint firstAttribute="height" constant="32" id="ote-Ol-7Ou"/>
+                <constraint firstAttribute="height" constant="43" id="ote-Ol-7Ou"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsView.xib
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_5" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XHZ-A5-1VK" customClass="ReaderDetailCommentsView" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="32"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="CqH-7n-yCg">
+                    <rect key="frame" x="-2" y="0.0" width="416" height="24"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tNq-SU-bHU">
+                            <rect key="frame" x="0.0" y="0.0" width="208" height="24"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GeG-xx-Hjc">
+                                    <rect key="frame" x="0.0" y="0.0" width="83" height="24"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="fl5-Kc-zxf">
+                                    <rect key="frame" x="86" y="3" width="20" height="20"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="20" id="Rma-qH-85f"/>
+                                        <constraint firstAttribute="width" constant="20" id="UoQ-ax-kyC"/>
+                                    </constraints>
+                                </imageView>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ucZ-Od-AwP" userLabel="Overlay Button">
+                                    <rect key="frame" x="0.0" y="0.0" width="208" height="24"/>
+                                    <connections>
+                                        <action selector="didTapViewCommentsButton:" destination="XHZ-A5-1VK" eventType="touchUpInside" id="3qG-Bc-nht"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="bottom" secondItem="fl5-Kc-zxf" secondAttribute="bottom" constant="1" id="ERr-OS-ODd"/>
+                                <constraint firstItem="GeG-xx-Hjc" firstAttribute="leading" secondItem="tNq-SU-bHU" secondAttribute="leading" id="Et8-xQ-9e7"/>
+                                <constraint firstAttribute="trailing" secondItem="ucZ-Od-AwP" secondAttribute="trailing" id="Kmp-VN-5R3"/>
+                                <constraint firstItem="GeG-xx-Hjc" firstAttribute="top" secondItem="tNq-SU-bHU" secondAttribute="top" id="NZc-6x-Ewp"/>
+                                <constraint firstAttribute="bottom" secondItem="GeG-xx-Hjc" secondAttribute="bottom" id="SBP-PE-pbj"/>
+                                <constraint firstItem="ucZ-Od-AwP" firstAttribute="leading" secondItem="tNq-SU-bHU" secondAttribute="leading" id="c2B-XC-3rm"/>
+                                <constraint firstAttribute="bottom" secondItem="ucZ-Od-AwP" secondAttribute="bottom" id="cd4-ip-dRk"/>
+                                <constraint firstItem="ucZ-Od-AwP" firstAttribute="top" secondItem="tNq-SU-bHU" secondAttribute="top" id="cmB-vc-cBq"/>
+                                <constraint firstItem="fl5-Kc-zxf" firstAttribute="leading" secondItem="GeG-xx-Hjc" secondAttribute="trailing" constant="3" id="iN0-ln-EDv"/>
+                            </constraints>
+                        </view>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Aec-C8-RtP">
+                            <rect key="frame" x="208" y="0.0" width="208" height="24"/>
+                            <state key="normal" title="Add Comment"/>
+                            <connections>
+                                <action selector="didTapAddCommentButton:" destination="XHZ-A5-1VK" eventType="touchUpInside" id="BbW-Ls-t5e"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="24" id="SeS-ae-KTI"/>
+                    </constraints>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="CqH-7n-yCg" secondAttribute="trailing" id="OcB-3b-WJH"/>
+                <constraint firstItem="CqH-7n-yCg" firstAttribute="leading" secondItem="XHZ-A5-1VK" secondAttribute="leading" constant="-2" id="UO5-Tl-oZG"/>
+                <constraint firstItem="CqH-7n-yCg" firstAttribute="top" secondItem="XHZ-A5-1VK" secondAttribute="top" id="drF-bl-37Y"/>
+                <constraint firstAttribute="height" constant="32" id="ote-Ol-7Ou"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="addButton" destination="Aec-C8-RtP" id="9j3-yJ-z8g"/>
+                <outlet property="commentsLabel" destination="GeG-xx-Hjc" id="qCI-xV-Q4m"/>
+                <outlet property="disclosureImageView" destination="fl5-Kc-zxf" id="LEG-Ly-JAL"/>
+                <outlet property="viewCommentsButton" destination="ucZ-Od-AwP" id="JFA-FP-K6R"/>
+            </connections>
+            <point key="canvasLocation" x="-51" y="-52"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="disclosure-chevron" width="8" height="13"/>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentAction.swift
@@ -1,11 +1,12 @@
 /// Encapsulates a command to navigate to a post's comments
 final class ReaderCommentAction {
-    func execute(post: ReaderPost, origin: UIViewController) {
+    func execute(post: ReaderPost, origin: UIViewController, promptToAddComment: Bool = false) {
         guard let postInMainContext = ReaderActionHelpers.postInMainContext(post),
             let controller = ReaderCommentsViewController(post: postInMainContext) else {
             return
         }
 
+        controller.promptToAddComment = promptToAddComment
         origin.navigationController?.pushViewController(controller, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.h
@@ -4,7 +4,7 @@
 
 @interface ReaderCommentsViewController : UIViewController
 
-@property (nonatomic, strong,  readonly) ReaderPost *post;
+@property (nonatomic, strong, readonly) ReaderPost *post;
 @property (nonatomic, assign, readwrite) BOOL allowsPushingPostDetails;
 
 - (void)setupWithPostID:(NSNumber *)postID siteID:(NSNumber *)siteID;
@@ -12,4 +12,6 @@
 + (instancetype)controllerWithPost:(ReaderPost *)post;
 + (instancetype)controllerWithPostID:(NSNumber *)postID siteID:(NSNumber *)siteID;
 
+/// Opens the Add Comment when the view appears
+@property (nonatomic) BOOL promptToAddComment;
 @end

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -161,8 +161,14 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     [super viewDidAppear:animated];
     [self.tableView reloadData];
-}
 
+    if(self.promptToAddComment){
+        [self.replyTextView becomeFirstResponder];
+
+        // Reset the value to prevent prompting again if the user leaves and comes back
+        self.promptToAddComment = NO;
+    }
+}
 
 - (void)viewWillDisappear:(BOOL)animated
 {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -363,6 +363,8 @@
 		325D3B3D23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 325D3B3C23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift */; };
 		326E281B250AC4A50029EBF0 /* ImageDimensionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E2819250AC4A50029EBF0 /* ImageDimensionFetcher.swift */; };
 		326E281C250AC4A50029EBF0 /* ImageDimensionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E281A250AC4A50029EBF0 /* ImageDimensionParser.swift */; };
+		3278D49A2524F438008080AA /* ReaderDetailCommentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3278D4992524F438008080AA /* ReaderDetailCommentsView.swift */; };
+		3278D4A92524F46F008080AA /* ReaderDetailCommentsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3278D4A82524F46F008080AA /* ReaderDetailCommentsView.xib */; };
 		327B48C3247CC7E000C3DE61 /* ReaderRelativeTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327B48C2247CC7E000C3DE61 /* ReaderRelativeTimeFormatter.swift */; };
 		327B48C5247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327B48C4247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift */; };
 		329F8E5624DDAC61002A5311 /* DynamicHeightCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 329F8E5524DDAC61002A5311 /* DynamicHeightCollectionView.swift */; };
@@ -2810,6 +2812,8 @@
 		325D3B3C23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewControllerTests.swift; sourceTree = "<group>"; };
 		326E2819250AC4A50029EBF0 /* ImageDimensionFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageDimensionFetcher.swift; sourceTree = "<group>"; };
 		326E281A250AC4A50029EBF0 /* ImageDimensionParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageDimensionParser.swift; sourceTree = "<group>"; };
+		3278D4992524F438008080AA /* ReaderDetailCommentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailCommentsView.swift; sourceTree = "<group>"; };
+		3278D4A82524F46F008080AA /* ReaderDetailCommentsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderDetailCommentsView.xib; sourceTree = "<group>"; };
 		327B48C2247CC7E000C3DE61 /* ReaderRelativeTimeFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderRelativeTimeFormatter.swift; sourceTree = "<group>"; };
 		327B48C4247CC9F300C3DE61 /* ReaderRelativeTimeFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderRelativeTimeFormatterTests.swift; sourceTree = "<group>"; };
 		328CEC5D23A532BA00A6899E /* FullScreenCommentReplyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewController.swift; sourceTree = "<group>"; };
@@ -8058,6 +8062,8 @@
 				8BA77BCC248340CE00E1EBBF /* ReaderDetailToolbar.xib */,
 				3223393B24FEC18000BDD4BF /* ReaderDetailFeaturedImageView.swift */,
 				3223393D24FEC2A700BDD4BF /* ReaderDetailFeaturedImageView.xib */,
+				3278D4992524F438008080AA /* ReaderDetailCommentsView.swift */,
+				3278D4A82524F46F008080AA /* ReaderDetailCommentsView.xib */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -11282,6 +11288,7 @@
 				5D5A6E941B613CA400DAF819 /* ReaderPostCardCell.xib in Resources */,
 				17E3634622C417F0000E0C79 /* jetpack_green_icon_76pt@2x.png in Resources */,
 				4349B0B0218A477F0034118A /* RevisionsTableViewCell.xib in Resources */,
+				3278D4A92524F46F008080AA /* ReaderDetailCommentsView.xib in Resources */,
 				17DC4C3322C5E6910059CA11 /* open_source_dark_icon_40pt.png in Resources */,
 				439F4F38219B636500F8D0C7 /* Revisions.storyboard in Resources */,
 				4019B27120885AB900A0C7EB /* Activity.storyboard in Resources */,
@@ -12933,6 +12940,7 @@
 				08F8CD2F1EBD29440049D0C0 /* MediaImageExporter.swift in Sources */,
 				912347192213484300BD9F97 /* GutenbergViewController+InformativeDialog.swift in Sources */,
 				2FA6511721F26A24009AA935 /* ChangePasswordViewController.swift in Sources */,
+				3278D49A2524F438008080AA /* ReaderDetailCommentsView.swift in Sources */,
 				D816C1F020E0893A00C4D82F /* LikeComment.swift in Sources */,
 				59E1D46E1CEF77B500126697 /* Page.swift in Sources */,
 				321955BF24BE234C00E3F316 /* ReaderInterestsCoordinator.swift in Sources */,


### PR DESCRIPTION
Part of #14767

### Screenshots:
| Dark | Light |
|:---:|:---:|
|![simulator_screenshot_F439C092-1531-47B3-8486-E8A81FD494C6](https://user-images.githubusercontent.com/793774/94959728-82c59080-04a6-11eb-8c59-bfdda8218800.png)|![simulator_screenshot_A21253B5-997A-47B2-8F5F-FFF3A3F0C40C](https://user-images.githubusercontent.com/793774/94959752-8ce78f00-04a6-11eb-8462-fe1ffe278f8e.png)|

### To test:

#### Singular comment
1. Launch the app
2. Tap on the Reader 
3. Tap on a post with 1 comments
4. Scroll to the bottom of the content
5. You should see an action bar with 2 buttons: <kbd>1 comment</kbd> and <kbd>Add Comment</kbd>

#### 0 or more than 1 comment
1. Launch the app
2. Tap on the Reader 
3. Tap on a post with no comments
4. Scroll to the bottom of the content
5. You should see an action bar with 2 buttons for <kbd>X comments</kbd> and <kbd>Add Comment</kbd> where x is the number of comments for the post

#### Comments disabled
1. Launch the app
2. Tap on the Reader 
3. Tap on a post with comments disabled
4. Scroll to the bottom of the content
5. You should not see the comment actions

#### View Comments Action
1. Launch the app
2. Tap on the Reader 
3. Tap on a post with comments
4. Scroll to the bottom of the content
5. Tap the X comments button
6. You should be brought to the comments for the post

#### Add Comment Action
1. Launch the app
2. Tap on the Reader 
3. Tap on a post with comments
4. Scroll to the bottom of the content
5. Tap the Add Comment button
6. You should be brought to the comments for the post, and the reply textfield should become active after the view loads


### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
