### PR TITLE
Remove the FAB + Me feature flags

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -6,8 +6,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case debugMenu
     case readerCSS
     case unifiedAuth
-    case meMove
-    case floatingCreateButton
     case newReaderNavigation
     case swiftCoreData
     case homepageSettings
@@ -31,10 +29,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .readerCSS:
             return false
         case .unifiedAuth:
-            return true
-        case .meMove:
-            return true
-        case .floatingCreateButton:
             return true
         case .newReaderNavigation:
             return true
@@ -88,10 +82,6 @@ extension FeatureFlag {
             return "Ignore Reader CSS Cache"
         case .unifiedAuth:
             return "Unified Auth"
-        case .meMove:
-            return "Move the Me Scene to My Site"
-        case .floatingCreateButton:
-            return "Floating Create Button"
         case .newReaderNavigation:
             return "New Reader Navigation"
         case .swiftCoreData:
@@ -114,8 +104,6 @@ extension FeatureFlag {
     var canOverride: Bool {
         switch self {
         case .debugMenu:
-            return false
-        case .floatingCreateButton:
             return false
         case .newReaderNavigation:
             return false

--- a/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
@@ -24,9 +24,6 @@ enum MeNavigationAction: NavigationAction {
         switch self {
         case .root:
             WPTabBarController.sharedInstance().showMeScene()
-            if !FeatureFlag.meMove.enabled {
-                WPTabBarController.sharedInstance().popMeTabToRoot()
-            }
         case .accountSettings:
             WPTabBarController.sharedInstance().navigateToAccountSettings()
         case .notificationSettings:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -368,13 +368,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self configureBlogDetailHeader];
     [self.headerView setBlog:_blog];
     [self startObservingQuickStart];
-    if([Feature enabled:FeatureFlagMeMove]) {
-        [self addMeButtonToNavigationBar];
-    }
+    [self addMeButtonToNavigationBar];
     
-    if ([Feature enabled:FeatureFlagFloatingCreateButton]) {
-        [self.createButtonCoordinator addTo:self.view trailingAnchor:self.view.safeAreaLayoutGuide.trailingAnchor bottomAnchor:self.view.safeAreaLayoutGuide.bottomAnchor];
-    }
+    [self.createButtonCoordinator addTo:self.view trailingAnchor:self.view.safeAreaLayoutGuide.trailingAnchor bottomAnchor:self.view.safeAreaLayoutGuide.bottomAnchor];
 }
 
 /// Resizes the `tableHeaderView` as necessary whenever its size changes.
@@ -421,7 +417,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    if ([self.tabBarController isKindOfClass:[WPTabBarController class]] && [Feature enabled:FeatureFlagFloatingCreateButton]) {
+    if ([self.tabBarController isKindOfClass:[WPTabBarController class]]) {
         [self.createButtonCoordinator showCreateButton];
     }
     [self createUserActivity];

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -885,11 +885,7 @@ static NSInteger HideSearchMinSites = 3;
 - (void)setAddSiteBarButtonItem
 {
     if (self.dataSource.allBlogsCount == 0) {
-        if([Feature enabled:FeatureFlagMeMove]) {
-            [self addMeButtonToNavigationBarWith:[[self defaultWordPressComAccount] email]];
-        } else {
-            self.navigationItem.rightBarButtonItem = nil;
-        }
+        [self addMeButtonToNavigationBarWith:[[self defaultWordPressComAccount] email]];
     }
     else {
         self.navigationItem.rightBarButtonItem = self.addSiteButton;

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController+UIViewControllerRestoration.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController+UIViewControllerRestoration.swift
@@ -8,23 +8,17 @@ extension MeViewController: UIViewControllerRestoration {
 
     static func viewController(withRestorationIdentifierPath identifierComponents: [String],
                                coder: NSCoder) -> UIViewController? {
-        if FeatureFlag.meMove.enabled {
-            return MeViewController()
-        } else {
-            return WPTabBarController.sharedInstance().meViewController
-        }
+       return MeViewController()
     }
 
     override func decodeRestorableState(with coder: NSCoder) {
         super.decodeRestorableState(with: coder)
-        if FeatureFlag.meMove.enabled {
-            // needs to be done after self has been initialized, so we do it in this method
-            let doneButton = UIBarButtonItem(target: self, action: #selector(dismissHandler))
-            navigationItem.rightBarButtonItem = doneButton
-            if WPDeviceIdentification.isiPad() {
-                navigationController?.modalPresentationStyle = .formSheet
-                navigationController?.modalTransitionStyle = .coverVertical
-            }
+        // needs to be done after self has been initialized, so we do it in this method
+        let doneButton = UIBarButtonItem(target: self, action: #selector(dismissHandler))
+        navigationItem.rightBarButtonItem = doneButton
+        if WPDeviceIdentification.isiPad() {
+            navigationController?.modalPresentationStyle = .formSheet
+            navigationController?.modalTransitionStyle = .coverVertical
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -87,14 +87,6 @@ class MeViewController: UITableViewController {
         // based on if there's a header or not.
         tableView.tableHeaderView = account.map { headerViewForAccount($0) }
 
-        // After we've reloaded the view model we should maintain the current
-        // table row selection, or if the split view we're in is not compact
-        // then we'll just select the first item in the table.
-
-        // First, we'll grab the appropriate index path so we can reselect it
-        // after reloading the table
-        let selectedIndexPath = tableView.indexPathForSelectedRow ?? IndexPath(row: 0, section: 0)
-
         // Then we'll reload the table view model (prompting a table reload)
         handler.viewModel = tableViewModel(loggedIn)
     }

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -71,27 +71,9 @@ class MeViewController: UITableViewController {
 
         registerUserActivity()
     }
-    //TODO: Remove when the new Me scene is shipped
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard !FeatureFlag.meMove.enabled else {
-            return
-        }
-        // Required to update the tableview cell disclosure indicators
-        reloadViewModel()
-    }
 
     @objc fileprivate func accountDidChange() {
         reloadViewModel()
-        guard !FeatureFlag.meMove.enabled else {
-            return
-        }
-        //TODO: Remove when the new Me scene is scipped
-        // Reload the detail pane if the split view isn't compact
-        if let splitViewController = splitViewController as? WPSplitViewController,
-            let detailViewController = initialDetailViewControllerForSplitView(splitViewController), !splitViewControllerIsHorizontallyCompact {
-            showDetailViewController(detailViewController, sender: self)
-        }
     }
 
     @objc fileprivate func reloadViewModel() {
@@ -115,11 +97,6 @@ class MeViewController: UITableViewController {
 
         // Then we'll reload the table view model (prompting a table reload)
         handler.viewModel = tableViewModel(loggedIn)
-        //TODO: remove this after the new Me scene has shipped
-        if !splitViewControllerIsHorizontallyCompact, !FeatureFlag.meMove.enabled {
-            // And finally we'll reselect the selected row, if there is one
-            tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .none)
-        }
     }
 
     fileprivate func headerViewForAccount(_ account: WPAccount) -> MeHeaderView {
@@ -131,13 +108,7 @@ class MeViewController: UITableViewController {
     }
 
     private var appSettingsRow: NavigationItemRow {
-        var accessoryType: UITableViewCell.AccessoryType
-        if FeatureFlag.meMove.enabled {
-            accessoryType = .disclosureIndicator
-        } else {
-            accessoryType = (splitViewControllerIsHorizontallyCompact) ? .disclosureIndicator : .none
-        }
-
+        let accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator
 
         return NavigationItemRow(
             title: RowTitles.appSettings,
@@ -148,12 +119,7 @@ class MeViewController: UITableViewController {
     }
 
     fileprivate func tableViewModel(_ loggedIn: Bool) -> ImmuTable {
-        var accessoryType: UITableViewCell.AccessoryType
-        if FeatureFlag.meMove.enabled {
-            accessoryType = .disclosureIndicator
-        } else {
-            accessoryType = (splitViewControllerIsHorizontallyCompact) ? .disclosureIndicator : .none
-        }
+        let accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator
 
         let myProfile = NavigationItemRow(
             title: RowTitles.myProfile,
@@ -247,14 +213,9 @@ class MeViewController: UITableViewController {
         return { [unowned self] row in
             if let myProfileViewController = self.myProfileViewController {
                 WPAppAnalytics.track(.openedMyProfile)
-                if FeatureFlag.meMove.enabled {
-                    self.navigationController?.pushViewController(myProfileViewController,
-                                                                  animated: true,
-                                                                  rightBarButton: self.navigationItem.rightBarButtonItem)
-                } else {
-                    self.showDetailViewController(myProfileViewController, sender: self)
-                }
-
+                self.navigationController?.pushViewController(myProfileViewController,
+                                                              animated: true,
+                                                              rightBarButton: self.navigationItem.rightBarButtonItem)
             }
         }
     }
@@ -266,13 +227,9 @@ class MeViewController: UITableViewController {
                 guard let controller = AccountSettingsViewController(account: account) else {
                     return
                 }
-                if FeatureFlag.meMove.enabled {
-                    self.navigationController?.pushViewController(controller,
-                                                                  animated: true,
-                                                                  rightBarButton: self.navigationItem.rightBarButtonItem)
-                } else {
-                    self.showDetailViewController(controller, sender: self)
-                }
+                self.navigationController?.pushViewController(controller,
+                                                              animated: true,
+                                                              rightBarButton: self.navigationItem.rightBarButtonItem)
 
             }
         }
@@ -282,32 +239,18 @@ class MeViewController: UITableViewController {
         return { [unowned self] row in
             WPAppAnalytics.track(.openedAppSettings)
             let controller = AppSettingsViewController()
-            if FeatureFlag.meMove.enabled {
-                self.navigationController?.pushViewController(controller,
-                                                              animated: true,
-                                                              rightBarButton: self.navigationItem.rightBarButtonItem)
-            } else {
-                self.showDetailViewController(controller, sender: self)
-            }
+            self.navigationController?.pushViewController(controller,
+                                                          animated: true,
+                                                          rightBarButton: self.navigationItem.rightBarButtonItem)
         }
     }
 
     func pushHelp() -> ImmuTableAction {
         return { [unowned self] row in
             let controller = SupportTableViewController()
-
-            if FeatureFlag.meMove.enabled {
-                self.navigationController?.pushViewController(controller,
-                                                              animated: true,
-                                                              rightBarButton: self.navigationItem.rightBarButtonItem)
-            } else {
-                // If iPad, show Support from Me view controller instead of navigation controller.
-                if !self.splitViewControllerIsHorizontallyCompact {
-                    controller.showHelpFromViewController = self
-                }
-
-                self.showDetailViewController(controller, sender: self)
-            }
+            self.navigationController?.pushViewController(controller,
+                                                          animated: true,
+                                                          rightBarButton: self.navigationItem.rightBarButtonItem)
         }
     }
 
@@ -457,19 +400,6 @@ class MeViewController: UITableViewController {
     ///
     fileprivate func promptForLoginOrSignup() {
         WordPressAuthenticator.showLogin(from: self, animated: true, showCancel: true, restrictToWPCom: true)
-    }
-}
-
-// MARK: - WPSplitViewControllerDetailProvider Conformance
-//TODO: remove this extension when the new Me scene is shipped
-extension MeViewController: WPSplitViewControllerDetailProvider {
-    func initialDetailViewControllerForSplitView(_ splitView: WPSplitViewController) -> UIViewController? {
-        // If we're not logged in yet, return app settings
-        guard let _ = defaultAccount() else {
-            return AppSettingsViewController()
-        }
-
-        return myProfileViewController
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+MeNavigation.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+MeNavigation.swift
@@ -5,64 +5,31 @@ import UIKit
 extension WPTabBarController {
     /// removes all but the primary viewControllers from the stack
     @objc func popMeTabToRoot() {
-        if FeatureFlag.meMove.enabled {
-            getNavigationController()?.popToRootViewController(animated: false)
-        } else {
-            self.meNavigationController.popToRootViewController(animated: false)
-        }
-
+        getNavigationController()?.popToRootViewController(animated: false)
     }
     /// presents the Me scene. If the feature flag is disabled, replaces the previously defined `showMeTab`
     @objc func showMeScene(animated: Bool = true, completion: (() -> Void)? = nil) {
-        if FeatureFlag.meMove.enabled {
-            meScenePresenter.present(on: self, animated: animated, completion: completion)
-        } else {
-            showTab(for: Int(WPTabType.me.rawValue))
-        }
+        meScenePresenter.present(on: self, animated: animated, completion: completion)
     }
     /// access to sub levels
     @objc func navigateToAccountSettings() {
-        if FeatureFlag.meMove.enabled {
-            showMeScene(animated: false) {
-                self.popMeTabToRoot()
-                self.getMeViewController()?.navigateToAccountSettings()
-            }
-        } else {
-            showMeScene()
-            popMeTabToRoot()
-            DispatchQueue.main.async {
-                self.meViewController.navigateToAccountSettings()
-            }
+        showMeScene(animated: false) {
+            self.popMeTabToRoot()
+            self.getMeViewController()?.navigateToAccountSettings()
         }
     }
 
     @objc func navigateToAppSettings() {
-        if FeatureFlag.meMove.enabled {
-            showMeScene() {
-                self.popMeTabToRoot()
-                self.getMeViewController()?.navigateToAppSettings()
-            }
-        } else {
-            showMeScene()
-            popMeTabToRoot()
-            DispatchQueue.main.async {
-                self.meViewController.navigateToAppSettings()
-            }
+        showMeScene() {
+            self.popMeTabToRoot()
+            self.getMeViewController()?.navigateToAppSettings()
         }
     }
 
     @objc func navigateToSupport() {
-        if FeatureFlag.meMove.enabled {
-            showMeScene() {
-                self.popMeTabToRoot()
-                self.getMeViewController()?.navigateToHelpAndSupport()
-            }
-        } else {
-            showMeScene()
-            popMeTabToRoot()
-            DispatchQueue.main.async {
-                self.meViewController.navigateToHelpAndSupport()
-            }
+        showMeScene() {
+            self.popMeTabToRoot()
+            self.getMeViewController()?.navigateToHelpAndSupport()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -2,9 +2,7 @@
 // MARK: - Tab Access Tracking
 
 extension WPTabBarController {
-    private static let tabIndexToStatMap: [WPTabType: WPAnalyticsStat] = FeatureFlag.meMove.enabled ?
-        [.mySites: .mySitesTabAccessed, .reader: .readerAccessed] :
-        [.mySites: .mySitesTabAccessed, .reader: .readerAccessed, .me: .meTabAccessed]
+    private static let tabIndexToStatMap: [WPTabType: WPAnalyticsStat] = [.mySites: .mySitesTabAccessed, .reader: .readerAccessed]
 
     private struct AssociatedKeys {
         static var shouldTrackTabAccessOnViewDidAppear = 0

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -2,12 +2,10 @@
 
 extern NSString * const WPNewPostURLParamContentKey;
 extern NSString * const WPNewPostURLParamTagsKey;
-//TODO: Remove WPTabMe and WPTabNewPost when the new Me page and FAB are released
+
 typedef NS_ENUM(NSUInteger, WPTabType) {
     WPTabMySites,
     WPTabReader,
-    WPTabNewPost,
-    WPTabMe,
     WPTabNotifications
 };
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -29,10 +29,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 @property (nonatomic, strong, readonly) UINavigationController *blogListNavigationController;
 @property (nonatomic, strong, readonly) ReaderMenuViewController *readerMenuViewController;
 @property (nonatomic, strong, readonly) NotificationsViewController *notificationsViewController;
-// will be removed when the new IA implementation completes
-@property (nonatomic, strong, readonly) MeViewController *meViewController;
-// will be removed when the new IA implementation completes
-@property (nonatomic, strong, readonly) UINavigationController *meNavigationController;
 @property (nonatomic, strong, readonly) UINavigationController *readerNavigationController;
 @property (nonatomic, strong, readonly) QuickStartTourGuide *tourGuide;
 @property (nonatomic, strong, readonly) MySitesCoordinator *mySitesCoordinator;
@@ -52,8 +48,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)showPostTab;
 - (void)showPostTabWithCompletion:(void (^)(void))afterDismiss;
 - (void)showPostTabForBlog:(Blog *)blog;
-// will be removed when the new IA implementation completes
-- (void)showMeTab;
 - (void)showNotificationsTab;
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia;
 - (void)showReaderTabForPost:(NSNumber *)postId onBlog:(NSNumber *)blogId;
@@ -73,8 +67,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 
 - (void)showNotificationsTabForNoteWithID:(NSString *)notificationID;
 - (void)updateNotificationBadgeVisibility;
-// will be removed when the new IA implementation completes
-- (void)showTabForIndex:(NSInteger)tabIndex;
 
 - (Blog *)currentOrLastBlog;
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -21,7 +21,6 @@ static NSString * const WPTabBarRestorationID = @"WPTabBarID";
 
 static NSString * const WPBlogListSplitViewRestorationID = @"WPBlogListSplitViewRestorationID";
 static NSString * const WPReaderSplitViewRestorationID = @"WPReaderSplitViewRestorationID";
-static NSString * const WPMeSplitViewRestorationID = @"WPMeSplitViewRestorationID";
 static NSString * const WPNotificationsSplitViewRestorationID = @"WPNotificationsSplitViewRestorationID";
 
 static NSString * const WPBlogListNavigationRestorationID = @"WPBlogListNavigationID";
@@ -42,25 +41,20 @@ NSString * const WPNewPostURLParamImageKey = @"image";
 
 static NSInteger const WPTabBarIconOffsetiPad = 7;
 static NSInteger const WPTabBarIconOffsetiPhone = 5;
-static CGFloat const WPTabBarIconSize = 32.0f;
 
 @interface WPTabBarController () <UITabBarControllerDelegate, UIViewControllerRestoration>
 
 @property (nonatomic, strong) BlogListViewController *blogListViewController;
 @property (nonatomic, strong) NotificationsViewController *notificationsViewController;
 @property (nonatomic, strong) ReaderMenuViewController *readerMenuViewController;
-@property (nonatomic, strong) MeViewController *meViewController;
 @property (nonatomic, strong) QuickStartTourGuide *tourGuide;
-@property (nonatomic, strong) UIViewController *newPostViewController;
 
 @property (nonatomic, strong) UINavigationController *blogListNavigationController;
 @property (nonatomic, strong) UINavigationController *readerNavigationController;
 @property (nonatomic, strong) UINavigationController *notificationsNavigationController;
-@property (nonatomic, strong) UINavigationController *meNavigationController;
 
 @property (nonatomic, strong) WPSplitViewController *blogListSplitViewController;
 @property (nonatomic, strong) WPSplitViewController *readerSplitViewController;
-@property (nonatomic, strong) WPSplitViewController *meSplitViewController;
 @property (nonatomic, strong) WPSplitViewController *notificationsSplitViewController;
 @property (nonatomic, strong) ReaderTabViewModel *readerTabViewModel;
 
@@ -226,39 +220,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     return _readerMenuViewController;
 }
 
-- (UIViewController *)newPostViewController
-{
-    if (_newPostViewController) {
-        return _newPostViewController;
-    }
-
-    _newPostViewController = [[UIViewController alloc] init];
-    _newPostViewController.tabBarItem.accessibilityIdentifier = @"Write";
-    _newPostViewController.tabBarItem.title = NSLocalizedString(@"Write", @"The accessibility value of the post tab.");
-
-    [self updateWriteButtonAppearance];
-
-    return _newPostViewController;
-}
-
-- (UINavigationController *)meNavigationController
-{
-    if (!_meNavigationController) {
-        _meNavigationController = [[UINavigationController alloc] initWithRootViewController:self.meViewController];
-        self.meTabBarImage = [UIImage imageNamed:@"icon-tab-me"];
-        self.meTabBarImageUnreadUnselected = [UIImage imageNamed:@"icon-tab-me-unread-unselected"];
-        self.meTabBarImageUnreadSelected = [UIImage imageNamed:@"icon-tab-me-unread-selected"];
-        _meNavigationController.tabBarItem.image = self.meTabBarImage;
-        _meNavigationController.tabBarItem.selectedImage = self.meTabBarImage;
-        _meNavigationController.restorationIdentifier = WPMeNavigationRestorationID;
-        _meNavigationController.tabBarItem.accessibilityLabel = NSLocalizedString(@"Me", @"The accessibility value of the me tab.");
-        _meNavigationController.tabBarItem.accessibilityIdentifier = @"meTabButton";
-        _meNavigationController.tabBarItem.title = NSLocalizedString(@"Me", @"The accessibility value of the me tab.");
-    }
-    
-    return _meNavigationController;
-}
-
 - (UINavigationController *)notificationsNavigationController
 {
     if (_notificationsNavigationController) {
@@ -279,33 +240,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     _notificationsNavigationController.tabBarItem.title = NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label");
 
     return _notificationsNavigationController;
-}
-
-- (void)updateWriteButtonAppearance
-{
-    CGSize size = self.view.bounds.size;
-    CGFloat screenWidth = [[UIScreen mainScreen] bounds].size.width;
-
-    // Try and determine whether the app is displayed at a size which will result in a tab
-    // bar with button titles and images horizontally stacked, instead of vertically
-    BOOL iPhoneLandscape = [WPDeviceIdentification isiPhone] && UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]);
-    BOOL iPadPortraitFullscreen = [WPDeviceIdentification isiPad] &&
-    UIInterfaceOrientationIsPortrait([[UIApplication sharedApplication] statusBarOrientation]) &&
-    size.width == screenWidth;
-    BOOL iPadLandscapeGreaterThanHalfSplit = [WPDeviceIdentification isiPad] &&
-    UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation]) &&
-    size.width > screenWidth / 2;
-
-    if (iPhoneLandscape || iPadPortraitFullscreen || iPadLandscapeGreaterThanHalfSplit) {
-        self.newPostViewController.tabBarItem.imageInsets = UIEdgeInsetsZero;
-        self.newPostViewController.tabBarItem.titlePositionAdjustment = UIOffsetZero;
-        self.newPostViewController.tabBarItem.image = [UIImage gridiconOfType:GridiconTypeCreate withSize:CGSizeMake(WPTabBarIconSize, WPTabBarIconSize)];
-    } else {
-        self.newPostViewController.tabBarItem.imageInsets = [self tabBarIconImageInsets];
-        self.newPostViewController.tabBarItem.titlePositionAdjustment = UIOffsetMake(0, 99999.0);
-
-        self.newPostViewController.tabBarItem.image = [UIImage imageNamed:@"icon-tab-newpost"];
-    }
 }
 
 - (UIEdgeInsets)tabBarIconImageInsets
@@ -372,20 +306,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     return _readerTabViewModel;
 }
 
-- (UISplitViewController *)meSplitViewController
-{
-    if (!_meSplitViewController) {
-        _meSplitViewController = [WPSplitViewController new];
-        _meSplitViewController.restorationIdentifier = WPMeSplitViewRestorationID;
-        [_meSplitViewController setInitialPrimaryViewController:self.meNavigationController];
-        _meSplitViewController.wpPrimaryColumnWidth = WPSplitViewControllerPrimaryColumnWidthNarrow;
-
-        _meSplitViewController.tabBarItem = self.meNavigationController.tabBarItem;
-    }
-    
-    return _meSplitViewController;
-}
-
 - (UISplitViewController *)notificationsSplitViewController
 {
     if (!_notificationsSplitViewController) {
@@ -408,7 +328,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     _readerNavigationController = nil;
     _readerMenuViewController = nil;
     _readerSplitViewController = nil;
-    _meSplitViewController = nil;
     _notificationsNavigationController = nil;
     _notificationsSplitViewController = nil;
     
@@ -452,41 +371,24 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     if ([Feature enabled:FeatureFlagNewReaderNavigation]) {
         allViewControllers = [NSMutableArray arrayWithArray:@[self.blogListSplitViewController,
         self.readerNavigationController,
-        self.newPostViewController,
-        self.meSplitViewController,
         self.notificationsSplitViewController]];
     } else {
         allViewControllers = [NSMutableArray arrayWithArray:@[self.blogListSplitViewController,
         self.readerSplitViewController,
-        self.newPostViewController,
-        self.meSplitViewController,
         self.notificationsSplitViewController]];
     }
-
-    
-    [allViewControllers removeObject:self.newPostViewController];
-
-    [allViewControllers removeObject:self.meSplitViewController];
-    self.meSplitViewController = nil;
-    self.meNavigationController = nil;
-    self.meViewController = nil;
 
     return allViewControllers;
 }
 
-- (void)showTabForIndex:(NSInteger)tabIndex
-{
-    [self setSelectedIndex:tabIndex];
-}
-
 - (void)showMySitesTab
 {
-    [self showTabForIndex:WPTabMySites];
+    [self setSelectedIndex:WPTabMySites];
 }
 
 - (void)showReaderTab
 {
-    [self showTabForIndex:WPTabReader];
+    [self setSelectedIndex:WPTabReader];
 }
 
 - (void)showPostTab
@@ -519,7 +421,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)showNotificationsTab
 {
-    [self showTabForIndex:WPTabNotifications];
+    [self setSelectedIndex:WPTabNotifications];
 }
 
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia
@@ -629,7 +531,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)switchMySitesTabToAddNewSite
 {
-    [self showTabForIndex:WPTabMySites];
+    [self setSelectedIndex:WPTabMySites];
     [self.blogListViewController presentInterfaceForAddingNewSiteFrom:self.tabBar];
 }
 
@@ -676,7 +578,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)switchMySitesTabToBlogDetailsForBlog:(Blog *)blog
 {
-    [self showTabForIndex:WPTabMySites];
+    [self setSelectedIndex:WPTabMySites];
 
     BlogListViewController *blogListVC = self.blogListViewController;
     self.blogListNavigationController.viewControllers = @[blogListVC];
@@ -807,7 +709,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)showNotificationsTabForNoteWithID:(NSString *)notificationID
 {
-    [self showTabForIndex:WPTabNotifications];
+    [self setSelectedIndex:WPTabNotifications];
     [self.notificationsViewController showDetailsForNotificationWithID:notificationID];
 }
 
@@ -829,7 +731,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 {
     if (notification.object == nil) {
         [self.readerNavigationController popToRootViewControllerAnimated:NO];
-        [self.meNavigationController popToRootViewControllerAnimated:NO];
         [self.notificationsNavigationController popToRootViewControllerAnimated:NO];
     }
     if ([Feature enabled:FeatureFlagNewReaderNavigation]) {
@@ -908,11 +809,8 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     }
 
     return @[
-             [UIKeyCommand keyCommandWithInput:@"N" modifierFlags:UIKeyModifierCommand action:@selector(showPostTab) discoverabilityTitle:NSLocalizedString(@"New Post", @"The accessibility value of the post tab.")],
              [UIKeyCommand keyCommandWithInput:@"1" modifierFlags:UIKeyModifierCommand action:@selector(showMySitesTab) discoverabilityTitle:NSLocalizedString(@"My Site", @"The accessibility value of the my site tab.")],
              [UIKeyCommand keyCommandWithInput:@"2" modifierFlags:UIKeyModifierCommand action:@selector(showReaderTab) discoverabilityTitle:NSLocalizedString(@"Reader", @"The accessibility value of the reader tab.")],
-             // will be removed when the new IA implementation completes
-             [UIKeyCommand keyCommandWithInput:@"3" modifierFlags:UIKeyModifierCommand action:@selector(showMeTab) discoverabilityTitle:NSLocalizedString(@"Me", @"The accessibility value of the me tab.")],
              [UIKeyCommand keyCommandWithInput:@"4" modifierFlags:UIKeyModifierCommand action:@selector(showNotificationsTab) discoverabilityTitle:NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label")],
              ];
 }
@@ -936,13 +834,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (void)viewDidLayoutSubviews
 {
     [super viewDidLayoutSubviews];
-}
-
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
-{
-    [super traitCollectionDidChange:previousTraitCollection];
-
-    [self updateWriteButtonAppearance];
 }
 
 #pragma mark - UIViewControllerTransitioningDelegate


### PR DESCRIPTION
Removes the feature flags for the Floating Action Button and Me tab move.

## Testing

### Tab Bar and Buttons
- Floating Action Button shows in the lower right of the blog details screen.
- Me button shows in the upper right of the blog details screen.
- No Me tab in the tab bar
- No Create tab in the tab bar

### Links
- Test the 3D shortcut to create a new post
- Test deep links:
	- `xcrun simctl openurl booted "wpdebug://newpost?content=test"`
	- `xcrun simctl openurl booted "wpdebug://newpage?content=test"`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
