### PR TITLE
Requests a larger site icon in the site stream header

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -99,7 +99,6 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
             return
         }
 
-        print("Found:", url.absoluteString)
         avatarImageView.downloadImage(from: url, placeholderImage: placeholder)
     }
 
@@ -142,8 +141,7 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
             return nil
         }
 
-        // WP.com uses `w` and Gravatar uses `s`
-        // for the resizing query key
+        // WP.com uses `w` and Gravatar uses `s` for the resizing query key
         let widthKey = host.contains("gravatar") ? "s" : "w"
         let width = Int(avatarImageView.bounds.width * UIScreen.main.scale)
         let item = URLQueryItem(name: widthKey, value: "\(width)")

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -90,20 +90,20 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     }
 
     @objc func configureHeaderImage(_ siteBlavatar: String?) {
-        let placeholder = UIImage(named: defaultBlavatar)
+        let placeholder = UIImage.siteIconPlaceholder
 
-        var path = ""
-        if siteBlavatar != nil {
-            path = siteBlavatar!
-        }
-
-        let url = URL(string: path)
-        if url != nil {
-            avatarImageView.downloadImage(from: url, placeholderImage: placeholder)
-        } else {
+        guard
+            let path = siteBlavatar,
+            let url = upscaledImageURL(urlString: path) else {
             avatarImageView.image = placeholder
+            return
         }
+
+        print("Found:", url.absoluteString)
+        avatarImageView.downloadImage(from: url, placeholderImage: placeholder)
     }
+
+
 
     @objc func formattedFollowerCountForTopic(_ topic: ReaderSiteTopic) -> String {
         let numberFormatter = NumberFormatter()
@@ -128,5 +128,34 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 
     @IBAction func didTapFollowButton(_ sender: UIButton) {
         delegate?.handleFollowActionForHeader(self)
+    }
+
+    // MARK: - Private: Helpers
+
+    /// Replaces the width query item (w) with an upscaled one for the image view
+    private func upscaledImageURL(urlString: String) -> URL? {
+        guard
+            let url = URL(string: urlString),
+            var components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+            let host = components.host
+        else {
+            return nil
+        }
+
+        // WP.com uses `w` and Gravatar uses `s`
+        // for the resizing query key
+        let widthKey = host.contains("gravatar") ? "s" : "w"
+        let width = Int(avatarImageView.bounds.width * UIScreen.main.scale)
+        let item = URLQueryItem(name: widthKey, value: "\(width)")
+
+        var queryItems = components.queryItems ?? []
+
+        // Remove any existing size queries
+        queryItems.removeAll(where: { $0.name == widthKey})
+
+        queryItems.append(item)
+        components.queryItems = queryItems
+
+        return components.url
     }
 }


### PR DESCRIPTION
Fixes #14856

### Screenshots
| Before | After |
|:---:|:---:|
|![Simulator Screen Shot - iPhone 11 Pro - 2020-10-02 at 17 55 17](https://user-images.githubusercontent.com/793774/94972954-58340180-04bf-11eb-9f88-d9a67d056dc1.png)|![Simulator Screen Shot - iPhone 11 Pro - 2020-10-02 at 17 53 39](https://user-images.githubusercontent.com/793774/94972867-215deb80-04bf-11eb-984c-52ebf4a84b7f.png)|

### To test:
1. Launch the app
2. Tap on the Reader
3. Tap on a the site section of a post that has an image
4. Notice the icon is a higher resolution

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
