### PR TITLE
Moves settings button to the navigation bar from the tab bar

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -7,8 +7,6 @@ class ReaderTabView: UIView {
     private let tabBar: FilterTabBar
     private let filterButton: PostMetaButton
     private let resetFilterButton: UIButton
-    private let settingsButton: UIButton
-    private let verticalDivider: UIView
     private let horizontalDivider: UIView
     private let containerView: UIView
     private var loadingView: UIView?
@@ -22,8 +20,6 @@ class ReaderTabView: UIView {
         tabBar = FilterTabBar()
         filterButton = PostMetaButton(type: .custom)
         resetFilterButton = UIButton(type: .custom)
-        settingsButton = UIButton(type: .custom)
-        verticalDivider = UIView()
         horizontalDivider = UIView()
         containerView = UIView()
 
@@ -76,9 +72,7 @@ extension ReaderTabView {
         setupButtonsView()
         setupFilterButton()
         setupResetFilterButton()
-        setupVerticalDivider(verticalDivider)
         setupHorizontalDivider(horizontalDivider)
-        setupSettingsButton()
         activateConstraints()
     }
 
@@ -105,8 +99,6 @@ extension ReaderTabView {
         }
         buttonsStackView.isHidden = tabItem.shouldHideButtonsView
         horizontalDivider.isHidden = tabItem.shouldHideButtonsView
-        settingsButton.isHidden = tabItem.shouldHideSettingsButton
-        verticalDivider.isHidden = tabItem.shouldHideSettingsButton
     }
 
     private func setupButtonsView() {
@@ -116,8 +108,6 @@ extension ReaderTabView {
         buttonsStackView.alignment = .fill
         buttonsStackView.addArrangedSubview(filterButton)
         buttonsStackView.addArrangedSubview(resetFilterButton)
-        buttonsStackView.addArrangedSubview(verticalDivider)
-        buttonsStackView.addArrangedSubview(settingsButton)
         buttonsStackView.isHidden = true
     }
 
@@ -145,33 +135,9 @@ extension ReaderTabView {
         resetFilterButton.accessibilityLabel = Accessibility.resetFilterButtonLabel
     }
 
-    private func setupVerticalDivider(_ divider: UIView) {
-        divider.translatesAutoresizingMaskIntoConstraints = false
-        let dividerView = UIView()
-        dividerView.translatesAutoresizingMaskIntoConstraints = false
-        dividerView.backgroundColor = Appearance.dividerColor
-        divider.addSubview(dividerView)
-        NSLayoutConstraint.activate([
-            dividerView.centerYAnchor.constraint(equalTo: divider.centerYAnchor),
-            dividerView.heightAnchor.constraint(equalTo: divider.heightAnchor, multiplier: Appearance.verticalDividerHeightMultiplier),
-            dividerView.leadingAnchor.constraint(equalTo: divider.leadingAnchor),
-            dividerView.trailingAnchor.constraint(equalTo: divider.trailingAnchor)
-        ])
-    }
-
     private func setupHorizontalDivider(_ divider: UIView) {
         divider.translatesAutoresizingMaskIntoConstraints = false
         divider.backgroundColor = Appearance.dividerColor
-    }
-
-    private func setupSettingsButton() {
-        settingsButton.accessibilityLabel = Appearance.settingsButtonAccessibilitylabel
-        settingsButton.translatesAutoresizingMaskIntoConstraints = false
-        settingsButton.addTarget(self, action: #selector(didTapSettingsButton), for: .touchUpInside)
-        WPStyleGuide.applyReaderSettingsButtonStyle(settingsButton)
-        settingsButton.accessibilityIdentifier = Accessibility.settingsButtonIdentifier
-        settingsButton.accessibilityLabel = Accessibility.settingsButtonLabel
-        settingsButton.accessibilityHint = Accessibility.settingsButtonHint
     }
 
     private func addContentToContainerView() {
@@ -195,10 +161,8 @@ extension ReaderTabView {
         NSLayoutConstraint.activate([
             buttonsStackView.heightAnchor.constraint(equalToConstant: Appearance.barHeight),
             resetFilterButton.widthAnchor.constraint(equalToConstant: Appearance.resetButtonWidth),
-            verticalDivider.widthAnchor.constraint(equalToConstant: Appearance.dividerWidth),
             horizontalDivider.heightAnchor.constraint(equalToConstant: Appearance.dividerWidth),
-            horizontalDivider.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
-            settingsButton.widthAnchor.constraint(equalToConstant: Appearance.settingsButtonWidth)
+            horizontalDivider.widthAnchor.constraint(equalTo: mainStackView.widthAnchor)
         ])
     }
 }
@@ -244,10 +208,6 @@ extension ReaderTabView {
             return
         }
         viewModel.resetFilter(selectedItem: tabItem)
-    }
-
-    @objc private func didTapSettingsButton() {
-        viewModel.presentSettings(from: settingsButton)
     }
 }
 
@@ -302,7 +262,6 @@ private extension ReaderTabView {
 
         static let tabBarAnimationsDuration = 0.2
 
-        static let settingsButtonAccessibilitylabel = NSLocalizedString("Manage", comment: "Label for managing sites and filters in the Reader tab")
         static let defaultFilterButtonTitle = NSLocalizedString("Filter", comment: "Title of the filter button in the Reader")
         static let filterButtonMaxFontSize: CGFloat = 28.0
         static let filterButtonFont = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .regular)
@@ -312,11 +271,9 @@ private extension ReaderTabView {
 
         static let resetButtonWidth: CGFloat = 32
         static let resetButtonInsets = UIEdgeInsets(top: 1, left: -4, bottom: -1, right: 4)
-        static let settingsButtonWidth: CGFloat = 56
 
         static let dividerWidth: CGFloat = .hairlineBorderWidth
         static let dividerColor: UIColor = .divider
-        static let verticalDividerHeightMultiplier: CGFloat = 0.6
         // "ghost" titles are set to the default english titles, as they won't be visible anyway
         static let ghostTabItems = [GhostTabItem(title: "Following"), GhostTabItem(title: "Discover"), GhostTabItem(title: "Likes"), GhostTabItem(title: "Saved")]
     }
@@ -329,8 +286,5 @@ extension ReaderTabView {
         static let filterButtonIdentifier = "ReaderFilterButton"
         static let resetButtonIdentifier = "ReaderResetButton"
         static let resetFilterButtonLabel = NSLocalizedString("Reset filter", comment: "Accessibility label for the reset filter button in the reader.")
-        static let settingsButtonIdentifier = "ReaderSettingsButton"
-        static let settingsButtonLabel = NSLocalizedString("Manage", comment: "Accessibility label for the settings button in the reader.")
-        static let settingsButtonHint = NSLocalizedString("Manage followed sites and tags", comment: "Accessibility hint for the settings button in the reader.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -18,7 +18,7 @@ class ReaderTabViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         title = ReaderTabConstants.title
-        setupSearchButton()
+        setupNavigationButtons()
 
         ReaderTabViewController.configureRestoration(on: self)
 
@@ -32,13 +32,6 @@ class ReaderTabViewController: UIViewController {
                 self?.dismiss(animated: true, completion: nil)
                 completion(title)
             })
-        }
-
-        viewModel.settingsTapped = { [weak self] fromView in
-            guard let self = self else {
-                return
-            }
-            viewModel.presentManage(from: self)
         }
 
         NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountDidChange(_:)), name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged, object: nil)
@@ -79,12 +72,20 @@ class ReaderTabViewController: UIViewController {
         ReaderTracker.shared.stop(.main)
     }
 
-    func setupSearchButton() {
+    func setupNavigationButtons() {
+        // Settings Button
+        let settingsButton = UIBarButtonItem(image: UIImage.gridicon(.cog),
+                                             style: .plain,
+                                             target: self,
+                                             action: #selector(didTapSettingsButton))
+        settingsButton.accessibilityIdentifier = ReaderTabConstants.settingsButtonIdentifier
+
+        // Search Button
         let searchButton = UIBarButtonItem(barButtonSystemItem: .search,
                                            target: self,
                                            action: #selector(didTapSearchButton))
         searchButton.accessibilityIdentifier = ReaderTabConstants.searchButtonAccessibilityIdentifier
-        navigationItem.rightBarButtonItem = searchButton
+        navigationItem.rightBarButtonItems = [searchButton, settingsButton]
     }
 
     override func loadView() {
@@ -101,8 +102,11 @@ class ReaderTabViewController: UIViewController {
 }
 
 
-// MARK: - Search
+// MARK: - Navigation Buttons
 extension ReaderTabViewController {
+    @objc private func didTapSettingsButton() {
+        viewModel.presentManage(from: self)
+    }
 
     @objc private func didTapSearchButton() {
         viewModel.navigateToSearch()
@@ -192,6 +196,7 @@ extension ReaderTabViewController {
 extension ReaderTabViewController {
     private enum ReaderTabConstants {
         static let title = NSLocalizedString("Reader", comment: "The default title of the Reader")
+        static let settingsButtonIdentifier = "ReaderSettingsButton"
         static let searchButtonAccessibilityIdentifier = "ReaderSearchBarButton"
         static let storyBoardInitError = "Storyboard instantiation not supported"
         static let restorationIdentifier = "WPReaderTabControllerRestorationID"

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -36,7 +36,6 @@ import WordPressFlux
 
     /// Settings
     private let settingsPresenter: ScenePresenter
-    var settingsTapped: ((UIView) -> Void)?
 
     init(readerContentFactory: @escaping (ReaderContent) -> ReaderContentViewController,
          searchNavigationFactory: @escaping () -> Void,
@@ -141,16 +140,6 @@ extension ReaderTabViewModel {
         }
     }
 }
-
-
-// MARK: - Settings
-extension ReaderTabViewModel {
-
-    func presentSettings(from: UIView) {
-        settingsTapped?(from)
-    }
-}
-
 
 // MARK: - Bottom Sheet
 extension ReaderTabViewModel {

--- a/WordPress/WordPressTest/ReaderTabViewModelTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewModelTests.swift
@@ -96,25 +96,6 @@ class ReaderTabViewModelTests: XCTestCase {
         }
     }
 
-    func testSettingsTapped() {
-        // Given
-        let settingsTappedExpectation = expectation(description: "Settings button was tapped")
-        viewModel.settingsTapped = { view in
-            settingsTappedExpectation.fulfill()
-            XCTAssertEqual("test view", view.accessibilityIdentifier!)
-        }
-        let view = UIView()
-        view.accessibilityIdentifier = "test view"
-        // When
-        viewModel.presentSettings(from: view)
-        // Then
-        waitForExpectations(timeout: 4) { error in
-            if let error = error {
-                XCTFail("waitForExpectationsWithTimeout errored: \(error)")
-            }
-        }
-    }
-
     func testPresentFilterFromView() {
         // Given
         let filterTappedExpectation = expectation(description: "Filter button was tapped")

--- a/WordPress/WordPressTest/ReaderTabViewTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewTests.swift
@@ -95,7 +95,7 @@ extension ReaderTabViewTests {
 
     private func validateButtonsStackView(_ view: UIView) {
         XCTAssert(view is UIStackView)
-        XCTAssertEqual(view.subviews.count, 4)
+        XCTAssertEqual(view.subviews.count, 2)
         XCTAssertTrue(view.subviews.contains(where: { $0 is PostMetaButton }))
     }
 


### PR DESCRIPTION
Fixes #14835

### Screenshots
| iPhone 11.4 | iPad 12.4 | iPhone 14.0 |
|:---:|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/793774/95111909-0c6a9d80-06f5-11eb-9a20-6c9a2356ff0e.png" width="" />|<img src="https://user-images.githubusercontent.com/793774/95111908-0bd20700-06f5-11eb-9adc-26d59cab3c9b.png" width="50%" />|<img src="https://user-images.githubusercontent.com/793774/95111910-0c6a9d80-06f5-11eb-9c75-79bcb72ae9e9.png" width="50%" />|

### To test:
1. Launch the app
2. Tap on the Reader tab
3. Tap on the Settings icon
4. Go through the flows of the manage screen, unfollowing, following, etc.

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
