### PR TITLE
Use correct analytics event for save draft action

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -308,7 +308,9 @@ extension PostEditor where Self: UIViewController {
 
             // The post is a local or remote draft
             alertController.addDefaultActionWithTitle(title) { _ in
-                self.publishPost(action: self.editorAction(), dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
+                let action = self.editorAction()
+                self.postEditorStateContext.action = action
+                self.publishPost(action: action, dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
             }
         }
 
@@ -327,7 +329,11 @@ extension PostEditor where Self: UIViewController {
             return .save
         }
 
-        return post.status == .draft ? .saveAsDraft : .publish
+        if post.isLocalDraft {
+            return .save
+        }
+
+        return post.status == .draft ? .update : .publish
     }
 }
 


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-iOS/issues/13729

When selecting the ✖️ then selecting save as draft the action that was being sent along to `publishPost` was being sent as `save` however the analytics stat was being sent as `publish` to get the desired outcome this should be `save`. Updated the `postEditorStateContext` action to match the change from the user's selection. 

This also affects when a user opens an existing post and updates. The flow for `update` and `save` appear to be the same in `postEditorStateContext` so I added that metric to the list as well.

🗒️ This is another take on the research and work that @guarani did as part of https://github.com/wordpress-mobile/WordPress-iOS/pull/14274

### To test:

An easy way to test for these events is to run the app locally through XCode and filter the console to look for the string `🔵 Tracked:`

1. Create a new Page or Post
1. Make a few edits Set title and content
1. Select "X" in the top left-hand corner
     - **Expect:** To see a dialog with "You have unsaved changes." and "Save Draft"
1. Select Save

**Expect** The editor should fire the analytics event `editor_draft_saved`


---
### Additional Sanity Tests

#### Updates via ✖️ 
1. Open an existing draft
1. Make an edit
1. Select the ✖️ to back out
1. Select "Update Draft"
**Expect** The editor should fire the analytics event `editor_post_update`

#### Create a draft and update via ✖️ 
1. Create a new page or post
1. Make an edit
1. Select `...` in the top right corner
1. Select "Save as Draft"
    - The editor should fire the analytics event `editor_quick_draft_saved`
1. Make another edit
1. Select the ✖️ to back out
1. Select "Update Draft"
**Expect** The editor should fire the analytics event `editor_post_update`

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
