### PR TITLE
Reader Improvements Detail: Fixes some small issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -175,7 +175,6 @@ class ReaderDetailCoordinator {
         }
 
         presentWebViewController(postURL)
-        viewController?.navigationController?.popViewController(animated: true)
     }
 
     /// Some posts have content from private sites that need special cookies

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -598,7 +598,7 @@ private extension ReaderDetailViewController {
     }
 
     func shareButtonItem() -> UIBarButtonItem? {
-        let button = barButtonItem(with: .gridicon(.shareiOS), action: #selector(didTapBrowserButton(_:)))
+        let button = barButtonItem(with: .gridicon(.shareiOS), action: #selector(didTapShareButton(_:)))
         button.accessibilityLabel = Strings.shareButtonAccessibilityLabel
 
         return button

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -237,12 +237,15 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     ///
     /// - Parameter title: a optional String containing the title
     func show(title: String?) {
-
         let placeholder = NSLocalizedString("Post", comment: "Placeholder title for ReaderPostDetails.")
         let titleView = UILabel()
 
         titleView.attributedText = NSAttributedString(string: title ?? placeholder, attributes: UINavigationBar.standardTitleTextAttributes())
         navigationItem.titleView = titleView
+        titleView.isHidden = true
+
+        // Allow the title to appear in the back button tap and hold in iOS 14+
+        self.title = title
     }
 
 


### PR DESCRIPTION
### Description
- Hides the title from the Reader Detail screen
- Fixes share button action in the nav bar 
- No longer pops when tapping the open in browser action

### To test:
1. Open the Reader
2. Tap on a post

**Expectation:** The title is hidden

3. Tap the share button in the nav bar

**Expectation:** The share sheet is displayed

4. Tap the browser button in the nav bar

**Expectation:** The browser is opened and you stay on the detail view

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
