### PR TITLE
Update LayoutChanged notification

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenusSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusSelectionView.m
@@ -128,8 +128,7 @@
 
         self.detailView.showsDesignActive = selectionItemsExpanded;
         [self prepareForVoiceOver];
-        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification,
-                                        [self.stackView.arrangedSubviews firstObject]);
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
     }
 }
 


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-iOS/issues/12881#issuecomment-704332412

After expanding the menu item the app fires the accessibility notification `UIAccessibilityLayoutChangedNotification` with the parameter `[self.stackView.arrangedSubviews firstObject]`. From my testing, this seems to do two things.
1. Lets the app know that some of the accessible items have changed.
1. Schedules an event to update the focused item back to the first item of the stack view. In these cases, it's the header with the expansion button.

The first part seems to happen right away because I'm able to swipe to the new nested items. The second step seems delayed though because I'm able to swipe to a new item but then my focus is reverted.

Removing the second parameter allows part 1 (update the list of accessible elements) to still occur but prevents the focus change.

## To Test

1. Go to Settings > General > Accessibility > VoiceOver and toggle the setting on.
1. In the WordPress app, go to Menus.
1. Highlight a menu 
1. Double-tap to expand the areas option
1. While VoiceOver is still speaking the first couple of words ~"Menu area primary" swipe right to navigate to the next item
- **Expect** your focus to not be reverted from the selected item.

| Before | After |
| --- | --- |
| <kbd>![Voice-Over 2020-10-06 11_00_14](https://user-images.githubusercontent.com/3384451/95219578-89644880-07c3-11eb-8475-755b98e998ef.gif)</kbd> | <kbd>![VoiceOver-after 2020-10-06 14_22_44](https://user-images.githubusercontent.com/3384451/95244045-73648100-07df-11eb-9137-b003fa7ce188.gif)</kbd> | 

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
