### PR TITLE
Notifications: Don't dim the detail view when the filtered NRV is displayed.

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1275,6 +1275,10 @@ private extension NotificationsViewController {
         if splitViewController.wpPrimaryColumnWidth != columnWidth {
             splitViewController.wpPrimaryColumnWidth = columnWidth
         }
+
+        if columnWidth == .default {
+            splitViewController.dimDetailViewController(shouldDimDetailViewController, withAlpha: WPAlphaZero)
+        }
     }
 
     var noConnectionTitleText: String {
@@ -1307,6 +1311,10 @@ private extension NotificationsViewController {
 
     var shouldDisplayFullscreenNoResultsView: Bool {
         return shouldDisplayNoResultsView && filter == .none
+    }
+
+    var shouldDimDetailViewController: Bool {
+        return shouldDisplayNoResultsView && filter != .none
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1266,15 +1266,14 @@ private extension NotificationsViewController {
     }
 
     func updateSplitViewAppearanceForNoResultsView() {
-        if let splitViewController = splitViewController as? WPSplitViewController {
-            let columnWidth: WPSplitViewControllerPrimaryColumnWidth = (shouldDisplayFullscreenNoResultsView || shouldDisplayJetpackPrompt) ? .full : .default
-            if splitViewController.wpPrimaryColumnWidth != columnWidth {
-                splitViewController.wpPrimaryColumnWidth = columnWidth
-            }
+        guard let splitViewController = splitViewController as? WPSplitViewController else {
+            return
+        }
 
-            if columnWidth == .default {
-                splitViewController.dimDetailViewController(shouldDimDetailViewController)
-            }
+        let columnWidth: WPSplitViewControllerPrimaryColumnWidth = (shouldDisplayFullscreenNoResultsView || shouldDisplayJetpackPrompt) ? .full : .default
+
+        if splitViewController.wpPrimaryColumnWidth != columnWidth {
+            splitViewController.wpPrimaryColumnWidth = columnWidth
         }
     }
 
@@ -1310,9 +1309,6 @@ private extension NotificationsViewController {
         return shouldDisplayNoResultsView && filter == .none
     }
 
-    var shouldDimDetailViewController: Bool {
-        return shouldDisplayNoResultsView && filter != .none
-    }
 }
 
 // MARK: - NoResultsViewControllerDelegate

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -227,7 +227,7 @@ class WPSplitViewController: UISplitViewController {
     fileprivate let dimmingViewAlpha: CGFloat = 0.5
     fileprivate let dimmingViewAnimationDuration: TimeInterval = 0.3
 
-    @objc func dimDetailViewController(_ dimmed: Bool) {
+    func dimDetailViewController(_ dimmed: Bool, withAlpha alpha: CGFloat? = nil) {
         if dimmed {
             if dimmingView.superview == nil {
                 view.addSubview(dimmingView)
@@ -237,7 +237,7 @@ class WPSplitViewController: UISplitViewController {
                 // Dismiss the keyboard from the detail view controller if active
                 topDetailViewController?.navigationController?.view.endEditing(true)
                 UIView.animate(withDuration: dimmingViewAnimationDuration, animations: {
-                    self.dimmingView.alpha = self.dimmingViewAlpha
+                    self.dimmingView.alpha = alpha ?? self.dimmingViewAlpha
                 })
             }
         } else if dimmingView.superview != nil {


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/issues/14547

This removes the dimmed view when there are no Notifications to show for a selected filter.

Details:
I tried simply not showing the dimmed view. Without it, there is no detail view, so `WPSplitViewController` automatically creates one. Which was fine on iPad. However, on an iPhone that has single and split view, `collapseSecondary` adds it to the top of the view stack, covering the primary view. Not so fine. `WPSplitViewController` has behavior tied to the existence of the dimmed view. We want that behavior, but we don't want the view dimmed. So the solution ended up being to show the dimmed view with an alpha of 0. 

To test:
- Run the app on an iPad or an iPhone that has single and split view (ex: iPhone 11 Pro Max).
- Go to the Notifications tab.
- Select a filter that has no Notifications.
- Verify the detail view is no longer dimmed.

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/95254173-ba9d4280-07dc-11eb-93ea-8466fabe570f.png) | ![after](https://user-images.githubusercontent.com/1816888/95254490-2f707c80-07dd-11eb-96fb-7ac5b9a312d0.png) |
| ![iphone_before](https://user-images.githubusercontent.com/1816888/95256407-01406c00-07e0-11eb-8c80-6b9f3c544843.png) | ![iphone_after](https://user-images.githubusercontent.com/1816888/95256422-07364d00-07e0-11eb-9800-a38469660cb3.png) |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
