### PR TITLE
Bug fix to stock photo selection

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -7,14 +7,13 @@ final class MediaLibraryMediaPickingCoordinator {
     private weak var delegate: PickersDelegate?
     private var tenor: TenorPicker?
 
-    private let stockPhotos = StockPhotosPicker()
+    private var stockPhotos: StockPhotosPicker?
     private let cameraCapture = CameraCaptureCoordinator()
     private let mediaLibrary = MediaLibraryPicker()
 
     init(delegate: PickersDelegate) {
         self.delegate = delegate
 
-        stockPhotos.delegate = delegate
         mediaLibrary.delegate = delegate
     }
 
@@ -90,7 +89,12 @@ final class MediaLibraryMediaPickingCoordinator {
     }
 
     private func showStockPhotos(origin: UIViewController, blog: Blog) {
-        stockPhotos.presentPicker(origin: origin, blog: blog)
+        let picker = StockPhotosPicker()
+        // add delegate conformance, allow release of picker in the same manner as the tenor picker
+        // in order to prevent duplicated uploads and botched de-selection on second upload
+        picker.delegate = self
+        picker.presentPicker(origin: origin, blog: blog)
+        stockPhotos = picker
     }
 
     private func showTenor(origin: UIViewController, blog: Blog) {
@@ -119,5 +123,12 @@ extension MediaLibraryMediaPickingCoordinator: TenorPickerDelegate {
     func tenorPicker(_ picker: TenorPicker, didFinishPicking assets: [TenorMedia]) {
         delegate?.tenorPicker(picker, didFinishPicking: assets)
         tenor = nil
+    }
+}
+
+extension MediaLibraryMediaPickingCoordinator: StockPhotosPickerDelegate {
+    func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia]) {
+        delegate?.stockPhotosPicker(picker, didFinishPicking: assets)
+        stockPhotos = nil
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -656,9 +656,9 @@ extension MediaLibraryViewController: StockPhotosPickerDelegate {
         }
 
         let mediaCoordinator = MediaCoordinator.shared
-        assets.forEach {
+        assets.forEach { stockPhoto in
             let info = MediaAnalyticsInfo(origin: .mediaLibrary(.stockPhotos), selectionMethod: .fullScreenPicker)
-            mediaCoordinator.addMedia(from: $0, to: blog, analyticsInfo: info)
+            mediaCoordinator.addMedia(from: stockPhoto, to: blog, analyticsInfo: info)
             WPAnalytics.track(.stockMediaUploaded)
         }
     }

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosPicker.swift
@@ -6,7 +6,11 @@ protocol StockPhotosPickerDelegate: AnyObject {
 
 /// Presents the Stock Photos main interface
 final class StockPhotosPicker: NSObject {
-    var allowMultipleSelection = true
+    var allowMultipleSelection = true {
+        didSet {
+            pickerOptions.allowMultipleSelection = allowMultipleSelection
+        }
+    }
 
     private lazy var dataSource: StockPhotosDataSource = {
         return StockPhotosDataSource(service: stockPhotosService)


### PR DESCRIPTION
Fixes #14646 

To test: Go to the Media Library and select + to add media. Choose the Free Photo Library. Search for any photo and upload it, then return to search the free photos again. Note that no items are selected, and when you search for media and upload another image, the previous image is not uploaded in its place, as before.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

I've updated the branch so this should merge ok now. @guarani would you be able to take a look, since you were checking over the initial PR for me?