### PR TITLE
Feature announcements improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -308,6 +308,7 @@ class AppSettingsViewController: UITableViewController {
             guard let self = self else {
                 return
             }
+            self.tableView.deselectSelectedRowWithAnimation(true)
             WPTabBarController.sharedInstance().presentWhatIsNew(on: self)
         }
     }

--- a/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
@@ -35,9 +35,12 @@ class WhatIsNewScenePresenter: ScenePresenter {
         }
 
         startPresenting = { [weak viewController, weak self] in
-            guard let self = self, let viewController = viewController, viewController.isViewOnScreen() else {
-                return
-            }
+            guard let self = self,
+                let viewController = viewController,
+                viewController.isViewOnScreen(),
+                (viewController is AppSettingsViewController || self.store.announcements.first?.isLocalized == true) else {
+                    return
+                }
             let controller = self.makeWhatIsNewViewController()
 
             self.trackAccess(from: viewController)

--- a/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
@@ -32,11 +32,8 @@ class FindOutMoreCell: UITableViewCell {
     }
 
     func configure(with url: URL?) {
-        guard let url = url else {
-            findOutMoreButton.isHidden = true
-            return
-        }
-        self.findOutMoreUrl = url
+        findOutMoreUrl = url
+        findOutMoreButton.isHidden = url == nil
     }
 }
 

--- a/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
@@ -32,6 +32,10 @@ class FindOutMoreCell: UITableViewCell {
     }
 
     func configure(with url: URL?) {
+        guard let url = url else {
+            findOutMoreButton.isHidden = true
+            return
+        }
         self.findOutMoreUrl = url
     }
 }


### PR DESCRIPTION
Fixes #NA

This PR adds the following improvements to Feature announcements:

1. Hide the "Find out more" button if there is no valid URL to point to
2. Do not present announcements at app update if they are not localized for the current language/region, but still allow users to retrieve them from App Settings/What's New in WordPress

To test:

**Test case 1**
- Build/run and make sure no announcements show up and that "What's New in WordPress" does not show up in App settings
- manually update the version to 16.9, relaunch and make sure announcements show up, and they do not have a "Find out more" button
- manually update the version to 17.0, relaunch and make sure that announcements show up and they do have the "Find out more" button, and it points to WordPress.org

**Test case 2**
- Start from scratch (discard local changes from test case 1 and delete/reinstall the app)
- change language/locale on the device to a non-English language (e.g. Italiano/Italia)
- Build/run and make sure that no announcements show up at startup, and that "What's New in WordPress" does not show up in App settings
- manually update to either 16.9 or 17.0 and make sure that announcements do not show up at startup, but the "What's New in WordPress" (with the properly translated title)  is indeed available in App settings and that tapping it presents the announcements non localized (in English)

**example screenshots for targeted test versions**

16.9 | 17.0
--- | ---
<img height="400" src="https://user-images.githubusercontent.com/34376330/95389697-d0346a00-08b9-11eb-82b1-5b2916350b81.png"> | <img height="400" src="https://user-images.githubusercontent.com/34376330/95389235-27860a80-08b9-11eb-8856-181d201cc569.png">


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
