### PR TITLE
Plugins: Attempts to resolve a crash by adding an extra session count check

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
@@ -95,8 +95,12 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
         case .replace:
             tableView.reloadData()
         case .selective(let changedRows):
-            let tableViewSectionsCount = tableViewModel.sections.count
-            guard tableViewSectionsCount > 0 else {
+            guard
+                // There is a strange scenario where the view model has multiple sections
+                // defined but the tableView thinks it has only zero, so check for both.
+                // See https://github.com/wordpress-mobile/WordPress-iOS/issues/14790
+                tableViewModel.sections.count > 0 && tableView.numberOfSections > 0
+            else {
                 tableView.reloadData()
                 return
             }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
@@ -96,10 +96,11 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
             tableView.reloadData()
         case .selective(let changedRows):
             guard
-                // There is a strange scenario where the view model has multiple sections
-                // defined but the tableView thinks it has only zero, so check for both.
+                // There is a strange scenario where the view model has multiple
+                // sections defined but the tableView thinks it has only zero,
+                // so make sure they are in agreement.
                 // See https://github.com/wordpress-mobile/WordPress-iOS/issues/14790
-                tableViewModel.sections.count > 0 && tableView.numberOfSections > 0
+                tableViewModel.sections.count == tableView.numberOfSections
             else {
                 tableView.reloadData()
                 return


### PR DESCRIPTION
Fixes #14790 

This is an attempt to fix a crash reported by Sentry with the Plugins feature.  I haven't been able to duplicate the crash myself, but as the crash reports suggests the issue is the relevant data model and the tableView disagree on the number of existing sections, ensuring both are in agreement seems like a reasonable fix.

To test:
Since reproducing the crash itself might be difficult, just ensure there are no regressions in the feature.
1. Use a wpcom site with a business plan so you have access to the plugins feature.
2. Go to the Site Details > Plugins screen. 
3. Click the Manage button
4. In the list of plugins, click on one of the ones that is not auto managed.
5. Toggle its activation status, then again to restore it.
6. Tap back to the list.
7. Confirm nothing goes 💥 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@chipsnyder could I trouble you for a review of this one? 