### PR TITLE
Revert CropViewController manual update

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -34,7 +34,7 @@ PODS:
   - CocoaLumberjack (3.5.2):
     - CocoaLumberjack/Core (= 3.5.2)
   - CocoaLumberjack/Core (3.5.2)
-  - CropViewController (2.5.4)
+  - CropViewController (2.5.3)
   - DoubleConversion (1.1.5)
   - Down (0.6.6)
   - FBLazyVector (0.61.5)
@@ -688,7 +688,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
   CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
-  CropViewController: 980df34ffc499db89755b2f307f20eca00cd40c6
+  CropViewController: a5c143548a0fabcd6cc25f2d26e40460cfb8c78c
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   Down: 71bf4af3c04fa093e65dffa25c4b64fa61287373
   FBLazyVector: 47798d43f20e85af0d3cef09928b6e2d16dbbe4c


### PR DESCRIPTION
This PR removes the manual bump (from 2.5.3 to 2.5.4) in CropViewController that produces the huge warnings when running `bundle exec pod install`.

### How to test

1. `bundle exec pod install`
2. Check no warnings are generated

(You can also check the CI output instead of running the branch in your machine)