### PR TITLE
Notifications > Jetpack install prompt: show view on rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -999,18 +999,24 @@ extension NotificationsViewController {
     }
 
     @objc func selectFirstNotificationIfAppropriate() {
-        // If we don't currently have a selected notification and there is a notification
-        // in the list, then select it.
-        if !splitViewControllerIsHorizontallyCompact && selectedNotification == nil {
-            if let firstNotification = tableViewHandler.resultsController.fetchedObjects?.first as? Notification,
-                let indexPath = tableViewHandler.resultsController.indexPath(forObject: firstNotification) {
-                selectRow(for: firstNotification, animated: false, scrollPosition: .none)
-                self.tableView(tableView, didSelectRowAt: indexPath)
-            } else {
-                // If there's no notification to select, we should wipe out
-                // any detail view controller that may be present.
-                showDetailViewController(UIViewController(), sender: nil)
-            }
+        guard !splitViewControllerIsHorizontallyCompact && selectedNotification == nil else {
+            return
+        }
+
+        // If we don't currently have a selected notification and there is a notification in the list, then select it.
+        if let firstNotification = tableViewHandler.resultsController.fetchedObjects?.first as? Notification,
+            let indexPath = tableViewHandler.resultsController.indexPath(forObject: firstNotification) {
+            selectRow(for: firstNotification, animated: false, scrollPosition: .none)
+            self.tableView(tableView, didSelectRowAt: indexPath)
+            return
+        }
+
+        // If we're not showing the Jetpack prompt or the fullscreen No Results View,
+        // then clear any detail view controller that may be present.
+        // (i.e. don't add an empty detail VC if the primary is full width)
+        if let splitViewController = splitViewController as? WPSplitViewController,
+            splitViewController.wpPrimaryColumnWidth != WPSplitViewControllerPrimaryColumnWidth.full {
+            showDetailViewController(UIViewController(), sender: nil)
         }
     }
 


### PR DESCRIPTION
Fixes #15067 

This fixes an issue where the Jetpack install prompt would disappear on rotation.

Details:
The problem was caused by the empty details view being rendered on top of the primary view (which displays the Jetpack prompt). Now, if the primary view is full width, an empty details view is _not_ added to the stack. 
This takes advantage of the fix for https://github.com/wordpress-mobile/WordPress-iOS/pull/15053 (when the view is split in the `separateSecondaryFrom` method, the details is just not shown).

To test:
- On an iPhone that switches between single and split view (ex: iPhone 11 Pro Max), select a site that does not have Jetpack installed.
- Go to the Notifications tab.
- Rotate the device to landscape and back to portrait.
- Verify the view is still displayed.

![jetpack_prompt_rotation](https://user-images.githubusercontent.com/1816888/95397311-23a9b680-08c0-11eb-9a45-97cc5fcbe594.gif)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
