### PR TITLE
Small changes to try and fix a Media issue.

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -574,25 +574,18 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 - (void)syncMediaLibraryForBlog:(Blog *)blog
                         success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure
-{
-    // This has been added temporarily to try and track the source of a nil object exception
-    // Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/14960
-    //
-    // It's already crashing below inside performBlock.  This assertion just makes sure it crashes
-    // a bit earlier so we can get a better stack trace.
-    //
-    // - Diego Rey Mendez, 2 October 2020
-    if (blog == nil || blog.objectID == nil) {
-        DDLogInfo(@"Blog: %@", blog);
-        DDLogInfo(@"BlogID: %@", blog.objectID);
-        DDLogInfo(@"Blog MOC: %@", blog.managedObjectContext);
-        @throw NSInternalInconsistencyException;
-    }
-    
+{    
     __block BOOL onePageLoad = NO;
     NSManagedObjectID *blogObjectID = [blog objectID];
     [self.managedObjectContext performBlock:^{
-        Blog *blogInContext = (Blog *)[self.managedObjectContext objectWithID:blogObjectID];
+        NSError *error = nil;
+        Blog *blogInContext = (Blog *)[self.managedObjectContext existingObjectWithID:blogObjectID error:&error];
+        
+        if (!blogInContext) {
+            failure(error);
+            return;
+        }
+        
         NSSet *originalLocalMedia = blogInContext.media;
         id<MediaServiceRemote> remote = [self remoteForBlog:blogInContext];
         [remote getMediaLibraryWithPageLoad:^(NSArray *media) {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -28,14 +28,6 @@
 
 - (instancetype)initWithBlog:(Blog *)blog
 {
-    // This has been added temporarily to try and track the source of a nil object exception
-    // Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/14960
-    //
-    // - Diego Rey Mendez, 2 October 2020
-    if (blog == nil) {
-        DDLogError(@"MediaLibraryPickerDataSource initializing with nil blog");
-    }
-    
     self = [super init];
     if (self) {
         _mediaGroup = [[MediaLibraryGroup alloc] initWithBlog:blog];
@@ -52,16 +44,7 @@
 }
 
 - (instancetype)initWithPost:(AbstractPost *)post
-{
-    // This has been added temporarily to try and track the source of a nil object exception
-    // Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/14960
-    //
-    // - Diego Rey Mendez, 2 October 2020
-    if (post == nil || post.blog == nil) {
-        DDLogError(@"MediaLibraryPickerDataSource initializing with a post with a nil blog");
-        DDLogError(@"Post MOC: %@", post.managedObjectContext);
-    }
-    
+{    
     self = [self initWithBlog:post.blog];
     if (self) {
         _post = post;

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -164,16 +164,16 @@ struct MediaProgressCoordinatorNoticeViewModel {
 
         let context = ContextManager.sharedInstance().mainContext
         var blog: Blog? = nil
-        
+
         context.performAndWait {
             guard let mediaInContext = try? context.existingObject(with: media.objectID) as? Media else {
                 DDLogError("The media object no longer exists")
                 return
             }
-            
+
             blog = mediaInContext.blog
         }
-        
+
         return blog
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -163,14 +163,17 @@ struct MediaProgressCoordinatorNoticeViewModel {
         }
 
         let context = ContextManager.sharedInstance().mainContext
-
-        var blog = media.blog
-        if blog.managedObjectContext != context,
-            let objectInContext = try? context.existingObject(with: blog.objectID),
-            let blogInContext = objectInContext as? Blog {
-            blog = blogInContext
+        var blog: Blog? = nil
+        
+        context.performAndWait {
+            guard let mediaInContext = try? context.existingObject(with: media.objectID) as? Media else {
+                DDLogError("The media object no longer exists")
+                return
+            }
+            
+            blog = mediaInContext.blog
         }
-
+        
         return blog
     }
 }


### PR DESCRIPTION
This change aims fo fix:
- https://github.com/wordpress-mobile/WordPress-iOS/issues/14963
- https://github.com/wordpress-mobile/WordPress-iOS/issues/14960

We're now retrieving the media object from the main context (which is consistent with what we were doing with the blog object).

I'm also removing some logging code I added for 15.8, since no reports came up in Sentry.  I'm instead assuming that the call to `objectWithID` should be replaced with `existingObjectWithID` to make sure the blog exists, and reporting an error if it doesn't.

I'm optimistic this could be the culprit behind a large number of bugs we've been seeing, where `media.blog` was `nil`.

## To test:

1. Launch the App from a new installation.
2. Go into the Media Library for one of your sites.  Make sure it loads perfectly.
3. Upload media.
4. Make sure the upload doesn't fail.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
