### PR TITLE
Add null check around date fetching in ReaderCommentCell

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -194,8 +194,8 @@ class ReaderCommentCell: UITableViewCell {
         guard let comment = comment else {
             return
         }
-
-        timeLabel.text = (comment.dateForDisplay() as NSDate).mediumString()
+        let commentDate = (comment.dateForDisplay() as NSDate?) ?? NSDate()
+        timeLabel.text = commentDate.mediumString()
         timeLabel.isUserInteractionEnabled = true
         timeLabel.longPressAction = { [weak self] in self?.onTimeStampLongPress?() }
     }


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-iOS/issues/13738

### Description
The location of the error was calling `dateForDisplay` on a [Comment](https://github.com/wordpress-mobile/WordPress-iOS/blob/b83aaaf67dc80e296871f805077ffc72accac018/WordPress/Classes/Models/Comment.m) and then cast that to a non-optional `NSDate`. Walking down the code trail  [Comment.dateForDisplay](https://github.com/wordpress-mobile/WordPress-iOS/blob/b83aaaf67dc80e296871f805077ffc72accac018/WordPress/Classes/Models/Comment.m#L176-L179) references [dateCreated](https://github.com/wordpress-mobile/WordPress-iOS/blob/b83aaaf67dc80e296871f805077ffc72accac018/WordPress/Classes/Models/Comment.m#L89-L98) which is then stored in CoreData as an [optional value](https://github.com/wordpress-mobile/WordPress-iOS/blob/b83aaaf67dc80e296871f805077ffc72accac018/WordPress/Classes/WordPress.xcdatamodeld/WordPress%2099.xcdatamodel/contents#L281). I believe I was able to recreate the crash once but I wasn't able to find a reference to my crash in sentry so the steps below were my best approximation.

### To test:
This bug is difficult to recreate and as such the testing steps here is just sanity:
1. Open the app and Navigate to the Reader
1. View the comments on a post
Expect things to work 🤷 

Steps that were common in the bug report to try first:
- Try liking different comments and posts
- Try replying
- Change tabs between the reader and notifications
- Reply, Like, and view comments from both tabs

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
