### PR TITLE
Fix some tracks events having user_id=0

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -499,6 +499,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 
             [NotificationSupportService insertServiceExtensionToken:defaultAccount.authToken];
             [NotificationSupportService insertServiceExtensionUsername:defaultAccount.username];
+            [NotificationSupportService insertServiceExtensionUserID:defaultAccount.userID.stringValue];
         });
     }
     

--- a/WordPress/Classes/Services/NotificationSupportService.swift
+++ b/WordPress/Classes/Services/NotificationSupportService.swift
@@ -70,6 +70,23 @@ open class NotificationSupportService: NSObject {
         }
     }
 
+    /// Sets the UserID  that should be used by the Notification Service Extension to access WPCOM.
+    ///
+    /// - Parameter userID: WordPress.com userID
+    ///
+    @objc
+    class func insertServiceExtensionUserID(_ userID: String) {
+        do {
+            try SFHFKeychainUtils.storeUsername(WPNotificationServiceExtensionKeychainUserIDKey,
+                                                andPassword: userID,
+                                                forServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                                                accessGroup: WPAppKeychainAccessGroup,
+                                                updateExisting: true)
+        } catch {
+            DDLogDebug("Error while saving Notification Service Extension userID: \(error)")
+        }
+    }
+
     /// Attempts to delete the current WPCOM OAuth Token used by the Notification Content Extension.
     ///
     @objc
@@ -119,6 +136,19 @@ open class NotificationSupportService: NSObject {
                                              accessGroup: WPAppKeychainAccessGroup)
         } catch {
             DDLogDebug("Error while removing Notification Service Extension username: \(error)")
+        }
+    }
+
+    /// Attempts to delete the current WPCOM Username used by the Notification Service Extension.
+    ///
+    @objc
+    class func deleteServiceExtensionUserID() {
+        do {
+            try SFHFKeychainUtils.deleteItem(forUsername: WPNotificationServiceExtensionKeychainUserIDKey,
+                                             andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                                             accessGroup: WPAppKeychainAccessGroup)
+        } catch {
+            DDLogDebug("Error while removing Notification Service Extension userID: \(error)")
         }
     }
 }

--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -43,6 +43,7 @@ extern NSString *const WPNotificationContentExtensionKeychainUsernameKey;
 extern NSString *const WPNotificationServiceExtensionKeychainServiceName;
 extern NSString *const WPNotificationServiceExtensionKeychainTokenKey;
 extern NSString *const WPNotificationServiceExtensionKeychainUsernameKey;
+extern NSString *const WPNotificationServiceExtensionKeychainUserIDKey;
 
 /// Share Extension Constants
 ///

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -55,6 +55,7 @@ NSString *const WPNotificationContentExtensionKeychainUsernameKey   = @"Username
 NSString *const WPNotificationServiceExtensionKeychainServiceName   = @"NotificationServiceExtension";
 NSString *const WPNotificationServiceExtensionKeychainTokenKey      = @"OAuth2Token";
 NSString *const WPNotificationServiceExtensionKeychainUsernameKey   = @"Username";
+NSString *const WPNotificationServiceExtensionKeychainUserIDKey     = @"UserID";
 
 /// Share Extension Constants
 ///

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -800,6 +800,7 @@ extension WordPressAppDelegate {
 
             NotificationSupportService.insertServiceExtensionToken(authToken)
             NotificationSupportService.insertServiceExtensionUsername(account.username)
+            NotificationSupportService.insertServiceExtensionUserID(account.userID.stringValue)
         }
     }
 
@@ -809,6 +810,7 @@ extension WordPressAppDelegate {
 
         NotificationSupportService.deleteServiceExtensionToken()
         NotificationSupportService.deleteServiceExtensionUsername()
+        NotificationSupportService.deleteServiceExtensionUserID()
     }
 }
 

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -30,6 +30,9 @@ class NotificationService: UNNotificationServiceExtension {
         let username = readExtensionUsername()
         tracks.wpcomUsername = username
 
+        let userID = readExtensionUserID()
+        tracks.wpcomUserID = userID
+
         let token = readExtensionToken()
         tracks.trackExtensionLaunched(token != nil)
 
@@ -155,5 +158,20 @@ private extension NotificationService {
         }
 
         return username
+    }
+
+    /// Retrieves the WPCOM userID, meant for Extension usage.
+    ///
+    /// - Returns: the userID if found; `nil` otherwise
+    ///
+    func readExtensionUserID() -> String? {
+        guard let userID = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainUserIDKey,
+                                                                         andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                                                                            accessGroup: WPAppKeychainAccessGroup) else {
+            debugPrint("Unable to retrieve Notification Service Extension userID")
+            return nil
+        }
+
+        return userID
     }
 }

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -3,6 +3,7 @@ import UIKit
 open class Tracks {
     // MARK: - Public Properties
     open var wpcomUsername: String?
+    open var wpcomUserID: String?
 
     // MARK: - Private Properties
     fileprivate let uploader: Uploader
@@ -31,7 +32,7 @@ open class Tracks {
     // MARK: - Private Helpers
     fileprivate func payloadWithEventName(_ eventName: String, properties: [String: Any]?) -> [String: Any] {
         let timestamp   = NSNumber(value: Int64(Date().timeIntervalSince1970 * 1000) as Int64)
-        let userID      = UUID().uuidString
+        let anonUserID  = UUID().uuidString
         let device      = UIDevice.current
         let bundle      = Bundle.main
         let appName     = bundle.object(forInfoDictionaryKey: "CFBundleName") as? String
@@ -55,8 +56,11 @@ open class Tracks {
         if let username = wpcomUsername {
             payload["_ul"] = username
             payload["_ut"] = "wpcom:user_id"
+            if let userID = wpcomUserID {
+                payload["_ui"] = userID
+            }
         } else {
-            payload["_ui"] = userID
+            payload["_ui"] = anonUserID
             payload["_ut"] = "anon"
         }
 


### PR DESCRIPTION
Related to: https://github.com/wordpress-mobile/WordPress-iOS/issues/14775

Majority part of the events seemed to be related to `wpios_notification_service_extension_`. Tried to add the `userID` parameter to events in the `WordPressNotificationServiceExtension` extension.

To test:

1. Launch the app from Xcode
1. In Xcode, select `Attach To Process` from the `Debug` menu
1. Select notification extension Xcode Debug menu, select `WordPressNotificationServiceExtension`
1. Add a breakpoint [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/15080/files#diff-2e69385331678eae7b4d9d869fa8c115R57)
1. Trigger a notification (by sending a push, etc.).
1. Breakpoint should be triggered
1. Check if userID is correct

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
