### PR TITLE
[iPad] No Sites: fix view sizes on rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -241,7 +241,7 @@ static NSInteger HideSearchMinSites = 3;
     
     // Ensure No Results VC is not shown. Will be shown later if necessary.
     [self.noResultsViewController removeFromView];
-    [self.tableView.refreshControl setHidden: false];
+    [self.tableView.refreshControl setHidden: NO];
     
     // If the user has sites, but they're all hidden...
     if (count > 0 && visibleSitesCount == 0 && !self.isEditing) {
@@ -290,7 +290,7 @@ static NSInteger HideSearchMinSites = 3;
                                            subtitleImage:nil
                                            accessoryView:nil];
 
-        [self.tableView.refreshControl setHidden: true];
+        [self.tableView.refreshControl setHidden: YES];
         [self addNoResultsToView];
     }
 }
@@ -335,7 +335,7 @@ static NSInteger HideSearchMinSites = 3;
                                            accessoryView:nil];
     }
 
-    [self.tableView.refreshControl setHidden: true];
+    [self.tableView.refreshControl setHidden: YES];
     [self addNoResultsToView];
     
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -241,6 +241,7 @@ static NSInteger HideSearchMinSites = 3;
     
     // Ensure No Results VC is not shown. Will be shown later if necessary.
     [self.noResultsViewController removeFromView];
+    [self.tableView.refreshControl setHidden: false];
     
     // If the user has sites, but they're all hidden...
     if (count > 0 && visibleSitesCount == 0 && !self.isEditing) {
@@ -288,6 +289,8 @@ static NSInteger HideSearchMinSites = 3;
                                                    image:@"mysites-nosites"
                                            subtitleImage:nil
                                            accessoryView:nil];
+
+        [self.tableView.refreshControl setHidden: true];
         [self addNoResultsToView];
     }
 }
@@ -332,6 +335,7 @@ static NSInteger HideSearchMinSites = 3;
                                            accessoryView:nil];
     }
 
+    [self.tableView.refreshControl setHidden: true];
     [self addNoResultsToView];
     
 }

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -67,7 +67,7 @@ class WPSplitViewController: UISplitViewController {
             preferredPrimaryColumnWidthFraction = columnWidth / size.width
         case .full:
             break
-            
+
             // Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/14547
             // Due to a bug where the column widths are not updating correctly when the primary column
             // is set to full width, the empty views are not sized correctly on rotation. As a workaround,

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -62,13 +62,19 @@ class WPSplitViewController: UISplitViewController {
             preferredPrimaryColumnWidthFraction = UISplitViewController.automaticDimension
         case .narrow:
             let columnWidth = WPSplitViewControllerNarrowPrimaryColumnWidth.width(for: size)
-
             minimumPrimaryColumnWidth = columnWidth
             maximumPrimaryColumnWidth = columnWidth
-            preferredPrimaryColumnWidthFraction = size.width / columnWidth
+            preferredPrimaryColumnWidthFraction = columnWidth / size.width
         case .full:
-            maximumPrimaryColumnWidth = size.width
-            preferredPrimaryColumnWidthFraction = 1.0
+            break
+            
+            // Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/14547
+            // Due to a bug where the column widths are not updating correctly when the primary column
+            // is set to full width, the empty views are not sized correctly on rotation. As a workaround,
+            // don't attempt to resize the columns for full width. These lines should be restored when
+            // the full width issue is resolved.
+            // maximumPrimaryColumnWidth = size.width
+            // preferredPrimaryColumnWidthFraction = 1.0
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -20,7 +20,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="30" y="100" width="315" height="456.5"/>
+                                        <rect key="frame" x="30" y="105.5" width="315" height="456.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
                                                 <rect key="frame" x="38" y="0.0" width="239" height="234"/>
@@ -91,8 +91,8 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="leading" secondItem="0Ae-eX-ae9" secondAttribute="leading" constant="30" id="Gn9-QB-PCu"/>
+                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerY" secondItem="0Ae-eX-ae9" secondAttribute="centerY" id="awy-Qw-qAb"/>
                                     <constraint firstAttribute="trailing" secondItem="Mkl-mm-wtH" secondAttribute="trailing" constant="30" id="gZv-Ze-rOt"/>
-                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="top" secondItem="0Ae-eX-ae9" secondAttribute="top" constant="100" id="kju-zT-gzN"/>
                                 </constraints>
                             </view>
                         </subviews>


### PR DESCRIPTION
Ref: #14547 
Fixes: #14342

**TL;DR:** 
This puts in a workaround so the 'No Sites' views are sized correctly on rotation. ([master issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/14547), [example](https://github.com/wordpress-mobile/WordPress-iOS/issues/14547#issuecomment-667410591) of incorrect views, [discussion](https://github.com/wordpress-mobile/WordPress-iOS/issues/14547#issuecomment-702217917).)

**Details:**
This issue is a direct result of the split view widths not updating when the primary width is set to `full`. After some headbanging, the only way I could "fix" it was to just not update the column widths for `full`. _This as a workaround, and should be removed when the split view width issue is resolved._ I just figured until the root cause is fixed, we could at least get the views to look decent.

I put the workaround in the `WPSplitViewController` directly, instead of each VC that uses `full` width. Because those VCs have other logic around the `full` width, that would require more hacking and possible regressions. This was the most straightforward workaround, and the easiest to undo later.

@frosty - if this is an acceptable workaround, I'll add a note to https://github.com/wordpress-mobile/WordPress-iOS/issues/14547 to remove it later.

In addition, because of this workaround, I was also able to fix the NRV being vertically off center. This is a permanent fix, and should continue to work correctly once the split view widths are fixed. (This is what fixes #14342, and every other instance of the NRV being too high.)

**To test:**

---

No Sites view:
- On an iPad, log in with an account that has no sites.
- Rotate the device. 
  - Verify both views are sized correctly (i.e. there are no grey areas).
  - Verify the No Sites view is vertically centered in the left pane.

| Before | After |
|--------|-------|
| ![ipad_before](https://user-images.githubusercontent.com/1816888/95631379-d6088780-0a40-11eb-8d1e-d377699b4c5e.gif) | ![ipad_after](https://user-images.githubusercontent.com/1816888/95632292-90e55500-0a42-11eb-84f7-b661ba66ff5a.gif) |

---

NRV vertical placement:
- On an iPhone, log in with an account that has no sites.
  - Verify the No Sites view is vertically centered in the view.
- On an iPhone, log in with an account that has sites.
  - Go to Media > + > Free Photo Library or Free GIF Library.
  - Tap the search field to make that field active.
  - Verify the NRV no longer appears under the search bar.

| Before | After |
|--------|-------|
| ![iphone_no_sites_before](https://user-images.githubusercontent.com/1816888/95631490-10722480-0a41-11eb-875d-6fbaec9a6c30.png) | ![iphone_no_sites_after](https://user-images.githubusercontent.com/1816888/95632019-fe44b600-0a41-11eb-9d8b-c34d55ab5338.png) |
| ![iphone_media_before](https://user-images.githubusercontent.com/1816888/95631505-1831c900-0a41-11eb-9420-18738d7e90ed.png) | ![iphone_media_after](https://user-images.githubusercontent.com/1816888/95631907-c0479200-0a41-11eb-8c6f-851d40c09461.png) |

---

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
