### PR TITLE
Use a default timestamp for custom Sentry event

### DIFF
--- a/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
+++ b/WordPress/Classes/Utility/Logging/SentryStartupEvent.swift
@@ -62,6 +62,7 @@ extension CrashLogging {
         let event = Event(level: .error)
         event.message = error.localizedDescription
         event.extra = userInfo ?? (error as NSError).userInfo
+        event.timestamp = Date()
 
         Client.shared?.snapshotStacktrace {
             Client.shared?.appendStacktrace(to: event)


### PR DESCRIPTION
This fixes a potential crash that could happen if the `Event` object is later used for encrypted logging

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
