### PR TITLE
Reader: Moves Select Interests to be displayed under the Discover tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 16.0
 -----
- 
+ * [*] Reader: Select interests is now displayed under the Discover tab. [#15097]
+
 15.9
 -----
 * [*] Fixed issue that caused duplicate views to be displayed when requesting a login link. [#14975]

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -59,7 +59,6 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementStats = 18,
     QuickStartTourElementPlans = 19,
     QuickStartTourElementSiteTitle = 20,
-    QuickStartTourElementSelectInterests = 21
 };
 
 typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -178,7 +178,7 @@ open class QuickStartTourGuide: NSObject {
         }
         if element != currentElement {
             let blogDetailEvents: [QuickStartTourElement] = [.blogDetailNavigation, .checklist, .themes, .viewSite, .sharing]
-            let readerElements: [QuickStartTourElement] = [.readerTab, .selectInterests, .readerSearch]
+            let readerElements: [QuickStartTourElement] = [.readerTab, .readerSearch]
 
             if blogDetailEvents.contains(element) {
                 endCurrentTour()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -208,13 +208,11 @@ struct QuickStartFollowTour: QuickStartTour {
         let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .readerTab, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.reader)))
 
-        let step2: WayPoint = (element: .selectInterests, description: NSAttributedString(string: ""))
-
         let step2DescriptionBase = NSLocalizedString("Select %@ to look for sites with similar interests", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let step2DescriptionTarget = NSLocalizedString("Search", comment: "The menu item to select during a guided tour.")
-        let step3: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.search)))
+        let step2: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.search)))
 
-        return [step1, step2, step3]
+        return [step1, step2]
     }()
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of following other sites.", comment: "This value is used to set the accessibility hint text for following the sites of other users.")

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
@@ -1,3 +1,7 @@
+extension NSNotification.Name {
+    static let readerManageControllerWasDismissed = NSNotification.Name("ReaderManageControllerWasDismissed")
+}
+
 class ReaderManageScenePresenter: ScenePresenter {
 
     enum TabbedSection {
@@ -59,6 +63,7 @@ private extension ReaderManageScenePresenter {
 
         let tabbedViewController = TabbedViewController(items: tabbedItems, onDismiss: {
             self.delegate?.didDismiss(presenter: self)
+            NotificationCenter.default.post(name: .readerManageControllerWasDismissed, object: self)
         })
         tabbedViewController.title =  NSLocalizedString("Manage", comment: "Title for the Reader Manage screen.")
         if let section = selectedSection, let firstSelection = sections.firstIndex(of: section) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -179,6 +179,7 @@ private extension ReaderCardsStreamViewController {
     func hideSelectInterestsView() {
         guard selectInterestsViewController.parent != nil else {
             if shouldForceRefresh {
+                scrollViewToTop()
                 displayLoadingStream()
                 super.syncIfAppropriate(forceSync: true)
                 shouldForceRefresh = false
@@ -187,8 +188,9 @@ private extension ReaderCardsStreamViewController {
             return
         }
 
+        scrollViewToTop()
         displayLoadingStream()
-        syncIfAppropriate(forceSync: true)
+        super.syncIfAppropriate(forceSync: true)
 
         UIView.animate(withDuration: 0.2, animations: {
             self.selectInterestsViewController.view.alpha = 0

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -194,6 +194,7 @@ private extension ReaderCardsStreamViewController {
             self.selectInterestsViewController.view.alpha = 0
         }) { [unowned self] _ in
             self.selectInterestsViewController.remove()
+            self.selectInterestsViewController.view.alpha = 1
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -180,7 +180,7 @@ private extension ReaderCardsStreamViewController {
         guard selectInterestsViewController.parent != nil else {
             if shouldForceRefresh {
                 displayLoadingStream()
-                syncIfAppropriate(forceSync: true)
+                super.syncIfAppropriate(forceSync: true)
                 shouldForceRefresh = false
             }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -900,7 +900,7 @@ import WordPressFlux
     /// - The app must be running on the foreground.
     /// - The current time must be greater than the last sync interval.
     ///
-    func syncIfAppropriate() {
+    func syncIfAppropriate(forceSync: Bool = false) {
         guard UIApplication.shared.isRunningTestSuite() == false else {
             return
         }
@@ -925,7 +925,7 @@ import WordPressFlux
         let lastSynced = topic.lastSynced ?? Date(timeIntervalSince1970: 0)
         let interval = Int( Date().timeIntervalSince(lastSynced))
 
-        if canSync() && (interval >= refreshInterval || topicPostsCount == 0) {
+        if forceSync || (canSync() && (interval >= refreshInterval || topicPostsCount == 0)) {
             syncHelper?.syncContentWithUserInteraction(false)
         } else {
             handleConnectionError()


### PR DESCRIPTION
### Screenshots
<img src="https://user-images.githubusercontent.com/793774/95925480-b8079380-0d6e-11eb-812e-20a70d826ca2.png" width="30%" />

### To test:
1. Launch the app
2. Tap on the Reader tab
3. Tap on the Cog
4. Delete all your followed topics, if any
5. Close the Cog
6. Tap on the Discover tab

**Expectation:** You see the Select interests view

7. Select some interests
8. Tap the Continue button

**Expectation:** You should see the loading view, that fades away and displays the reader cards feed

9. Stay on the Discover tab
10. Tap on the settings Cog to manage your topics
11. Tap on Manage Topics
12. Delete all your topics again
13. Tap the Done button to dismiss

**Expectation:** You see the Select interests view

14. Stay on the Discover tab
15. Tap on the settings Cog to manage your topics
16. Delete the followed topics again
17. Add a different topic
18. Tap done to dismiss

**Expectation:** You see the loading view, then a feed for the new topic you entered


### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
