### PR TITLE
Reader: Select Interests: Update UI

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 16.0
 -----
- 
+ * [*] Reader: Select interests is now displayed under the Discover tab. [#15097]
+
 15.9
 -----
 * [*] Fixed issue that caused duplicate views to be displayed when requesting a login link. [#14975]

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -59,7 +59,6 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementStats = 18,
     QuickStartTourElementPlans = 19,
     QuickStartTourElementSiteTitle = 20,
-    QuickStartTourElementSelectInterests = 21
 };
 
 typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -178,7 +178,7 @@ open class QuickStartTourGuide: NSObject {
         }
         if element != currentElement {
             let blogDetailEvents: [QuickStartTourElement] = [.blogDetailNavigation, .checklist, .themes, .viewSite, .sharing]
-            let readerElements: [QuickStartTourElement] = [.readerTab, .selectInterests, .readerSearch]
+            let readerElements: [QuickStartTourElement] = [.readerTab, .readerSearch]
 
             if blogDetailEvents.contains(element) {
                 endCurrentTour()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -208,13 +208,11 @@ struct QuickStartFollowTour: QuickStartTour {
         let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .readerTab, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.reader)))
 
-        let step2: WayPoint = (element: .selectInterests, description: NSAttributedString(string: ""))
-
         let step2DescriptionBase = NSLocalizedString("Select %@ to look for sites with similar interests", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let step2DescriptionTarget = NSLocalizedString("Search", comment: "The menu item to select during a guided tour.")
-        let step3: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.search)))
+        let step2: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.search)))
 
-        return [step1, step2, step3]
+        return [step1, step2]
     }()
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of following other sites.", comment: "This value is used to set the accessibility hint text for following the sites of other users.")

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
@@ -1,3 +1,7 @@
+extension NSNotification.Name {
+    static let readerManageControllerWasDismissed = NSNotification.Name("ReaderManageControllerWasDismissed")
+}
+
 class ReaderManageScenePresenter: ScenePresenter {
 
     enum TabbedSection {
@@ -59,6 +63,7 @@ private extension ReaderManageScenePresenter {
 
         let tabbedViewController = TabbedViewController(items: tabbedItems, onDismiss: {
             self.delegate?.didDismiss(presenter: self)
+            NotificationCenter.default.post(name: .readerManageControllerWasDismissed, object: self)
         })
         tabbedViewController.title =  NSLocalizedString("Manage", comment: "Title for the Reader Manage screen.")
         if let section = selectedSection, let firstSelection = sections.firstIndex(of: section) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -179,6 +179,7 @@ private extension ReaderCardsStreamViewController {
     func hideSelectInterestsView() {
         guard selectInterestsViewController.parent != nil else {
             if shouldForceRefresh {
+                scrollViewToTop()
                 displayLoadingStream()
                 super.syncIfAppropriate(forceSync: true)
                 shouldForceRefresh = false
@@ -187,8 +188,9 @@ private extension ReaderCardsStreamViewController {
             return
         }
 
+        scrollViewToTop()
         displayLoadingStream()
-        syncIfAppropriate(forceSync: true)
+        super.syncIfAppropriate(forceSync: true)
 
         UIView.animate(withDuration: 0.2, animations: {
             self.selectInterestsViewController.view.alpha = 0

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -194,6 +194,7 @@ private extension ReaderCardsStreamViewController {
             self.selectInterestsViewController.view.alpha = 0
         }) { [unowned self] _ in
             self.selectInterestsViewController.remove()
+            self.selectInterestsViewController.view.alpha = 1
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -180,7 +180,7 @@ private extension ReaderCardsStreamViewController {
         guard selectInterestsViewController.parent != nil else {
             if shouldForceRefresh {
                 displayLoadingStream()
-                syncIfAppropriate(forceSync: true)
+                super.syncIfAppropriate(forceSync: true)
                 shouldForceRefresh = false
             }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -900,7 +900,7 @@ import WordPressFlux
     /// - The app must be running on the foreground.
     /// - The current time must be greater than the last sync interval.
     ///
-    func syncIfAppropriate() {
+    func syncIfAppropriate(forceSync: Bool = false) {
         guard UIApplication.shared.isRunningTestSuite() == false else {
             return
         }
@@ -925,7 +925,7 @@ import WordPressFlux
         let lastSynced = topic.lastSynced ?? Date(timeIntervalSince1970: 0)
         let interval = Int( Date().timeIntervalSince(lastSynced))
 
-        if canSync() && (interval >= refreshInterval || topicPostsCount == 0) {
+        if forceSync || (canSync() && (interval >= refreshInterval || topicPostsCount == 0)) {
             syncHelper?.syncContentWithUserInteraction(false)
         } else {
             handleConnectionError()

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewFlowLayout.swift
@@ -11,6 +11,9 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
     @IBInspectable var cellHeight: CGFloat = 40
     @IBInspectable var allowsCentering: Bool = true
 
+    /// Whether or not the layout should be force centered
+    @IBInspectable var isCentered: Bool = false
+
     // Collapsing/Expanding support
     static let overflowItemKind = "InterestsOverflowItem"
     var maxNumberOfDisplayedLines: Int?
@@ -169,8 +172,7 @@ class ReaderInterestsCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
 
     override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        if allowsCentering,
-            collectionView?.traitCollection.horizontalSizeClass == .regular {
+        if allowsCentering, isCentered || collectionView?.traitCollection.horizontalSizeClass == .regular {
             return centeredLayoutAttributesForElements(in: rect)
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -9,6 +9,7 @@ class ReaderSelectInterestsViewController: UIViewController {
         static let cellSpacing: CGFloat = 6
         static let cellHeight: CGFloat = 40
         static let animationDuration: TimeInterval = 0.2
+        static let isCentered: Bool = true
     }
 
     private struct Strings {
@@ -115,6 +116,7 @@ class ReaderSelectInterestsViewController: UIViewController {
 
         layout.itemSpacing = Constants.cellSpacing
         layout.cellHeight = Constants.cellHeight
+        layout.isCentered = Constants.isCentered
     }
 
     private func configureNoResultsViewController() {

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -34,8 +35,8 @@
                         <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="2ka-fB-oWM">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="670"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="rOi-KY-muX">
-                                    <rect key="frame" x="20" y="8" width="374" height="110"/>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="rOi-KY-muX">
+                                    <rect key="frame" x="20" y="8" width="374" height="121"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discover and follow blogs you love" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sln-01-DYL" userLabel="Header Label">
                                             <rect key="frame" x="0.0" y="0.0" width="374" height="81.666666666666671"/>
@@ -44,7 +45,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose your interests" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Efr-XO-GjF" userLabel="Subtitle Label">
-                                            <rect key="frame" x="0.0" y="89.666666666666671" width="374" height="20.333333333333329"/>
+                                            <rect key="frame" x="0.0" y="100.66666666666667" width="374" height="20.333333333333329"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -52,8 +53,8 @@
                                     </subviews>
                                 </stackView>
                                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="fUq-vV-Pah">
-                                    <rect key="frame" x="20" y="128" width="374" height="542"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                    <rect key="frame" x="20" y="139" width="374" height="531"/>
+                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="IKi-eM-O1E" customClass="ReaderInterestsCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target">
                                         <size key="itemSize" width="128" height="128"/>
                                         <size key="headerReferenceSize" width="0.0" height="0.0"/>
@@ -85,7 +86,7 @@
                                     </connections>
                                 </button>
                             </subviews>
-                            <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="66" id="012-kS-ALd"/>
                                 <constraint firstAttribute="bottom" secondItem="5kh-rf-B5P" secondAttribute="bottom" constant="10" id="LUO-CS-zZF"/>
@@ -96,13 +97,13 @@
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="be9-lX-CD7">
                             <rect key="frame" x="0.0" y="736" width="414" height="0.0"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" id="XCs-b1-Ce2"/>
                             </constraints>
                         </view>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="trailing" secondItem="be9-lX-CD7" secondAttribute="trailing" id="0de-fR-YWW"/>
                         <constraint firstItem="be9-lX-CD7" firstAttribute="top" secondItem="X4F-fc-WqY" secondAttribute="bottom" id="67o-fb-UOy"/>
@@ -131,7 +132,8 @@
                     </subviews>
                 </stackView>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="y7t-k2-AgA" secondAttribute="bottom" id="1eg-oJ-DKt"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="DIz-pa-QD0" secondAttribute="trailing" constant="20" id="LAe-0c-dgq"/>
@@ -142,8 +144,15 @@
                 <constraint firstItem="DIz-pa-QD0" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="oBH-mC-Zzj"/>
                 <constraint firstItem="y7t-k2-AgA" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="w4M-aZ-bPI"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="-577" y="155"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="tertiarySystemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
@@ -38,13 +38,13 @@
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="rOi-KY-muX">
                                     <rect key="frame" x="20" y="8" width="374" height="121"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discover and follow blogs you love" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sln-01-DYL" userLabel="Header Label">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discover and follow blogs you love" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sln-01-DYL" userLabel="Header Label">
                                             <rect key="frame" x="0.0" y="0.0" width="374" height="81.666666666666671"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose your interests" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Efr-XO-GjF" userLabel="Subtitle Label">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose your interests" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Efr-XO-GjF" userLabel="Subtitle Label">
                                             <rect key="frame" x="0.0" y="100.66666666666667" width="374" height="20.333333333333329"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <nil key="textColor"/>

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
@@ -36,7 +36,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="414" height="670"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="rOi-KY-muX">
-                                    <rect key="frame" x="20" y="8" width="374" height="121"/>
+                                    <rect key="frame" x="20" y="12" width="374" height="121"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discover and follow blogs you love" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sln-01-DYL" userLabel="Header Label">
                                             <rect key="frame" x="0.0" y="0.0" width="374" height="81.666666666666671"/>
@@ -53,7 +53,7 @@
                                     </subviews>
                                 </stackView>
                                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="fUq-vV-Pah">
-                                    <rect key="frame" x="20" y="139" width="374" height="531"/>
+                                    <rect key="frame" x="20" y="143" width="374" height="527"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="IKi-eM-O1E" customClass="ReaderInterestsCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target">
                                         <size key="itemSize" width="128" height="128"/>
@@ -67,7 +67,7 @@
                                     </connections>
                                 </collectionView>
                             </subviews>
-                            <edgeInsets key="layoutMargins" top="8" left="20" bottom="0.0" right="20"/>
+                            <edgeInsets key="layoutMargins" top="12" left="20" bottom="0.0" right="20"/>
                         </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X4F-fc-WqY" userLabel="Button Container View">
                             <rect key="frame" x="0.0" y="670" width="414" height="66"/>
@@ -144,7 +144,7 @@
                 <constraint firstItem="DIz-pa-QD0" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="oBH-mC-Zzj"/>
                 <constraint firstItem="y7t-k2-AgA" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="w4M-aZ-bPI"/>
             </constraints>
-            <point key="canvasLocation" x="-577" y="155"/>
+            <point key="canvasLocation" x="-794" y="135"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
Depends on: https://github.com/wordpress-mobile/WordPress-iOS/pull/15097

Fixes #15088

- Increased spacing between title and subtitle to 32px
- Centered the title and subtitle
- Centered the interests collection view

### Screenshots
<img src="https://user-images.githubusercontent.com/793774/96023645-96a6b600-0e07-11eb-88d4-34899bf8ba7e.png" width="30%" />

### To test:
1. Launch app
3. Delete all your interests if needed
2. Tap Reader tab

**Expectation:**  See screenshot above

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
