### PR TITLE
Fixes a memory leak with ImageDimensionsFetcher

### DIFF
--- a/WordPress/Classes/Utility/Image Dimension Parser/ImageDimensionFetcher.swift
+++ b/WordPress/Classes/Utility/Image Dimension Parser/ImageDimensionFetcher.swift
@@ -12,6 +12,11 @@ class ImageDimensionsFetcher: NSObject, URLSessionDataDelegate {
     private let request: URLRequest
     private var task: URLSessionDataTask? = nil
     private let parser: ImageDimensionParser
+    private var session: URLSession? = nil
+
+    deinit {
+        cancel()
+    }
 
     init(request: URLRequest,
          success: @escaping CompletionHandler,
@@ -33,9 +38,11 @@ class ImageDimensionsFetcher: NSObject, URLSessionDataDelegate {
         task.resume()
 
         self.task = task
+        self.session = session
     }
 
     func cancel() {
+        session?.invalidateAndCancel()
         task?.cancel()
     }
 


### PR DESCRIPTION
### To test:
1. Launch the app
2. Tap on the Reader tab
3. Tap on the Discover
4. Locate a post with a featured image
5. Open it
6. Tap back
7. In Xcode: Tap on the memory graph button 
<img width="195" alt="Screen Shot 2020-10-14 at 2 49 09 PM" src="https://user-images.githubusercontent.com/793774/96032378-6d8c2280-0e13-11eb-9d2e-98a91a03ea40.png">
8. Search for `ImageDimensionsFetcher`


#### Expectation: No Results


### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
