### PR TITLE
Add accessibility label for media share button

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -155,6 +155,7 @@ class MediaItemViewController: UITableViewController {
                                             style: .plain,
                                             target: self,
                                             action: #selector(shareTapped(_:)))
+            shareItem.accessibilityLabel = NSLocalizedString("Share", comment: "Accessibility label for share buttons in nav bars")
 
             let trashItem = UIBarButtonItem(image: .gridicon(.trash),
                                             style: .plain,


### PR DESCRIPTION
Fixes #15003

Related to https://github.com/wordpress-mobile/WordPress-iOS/issues/12954

To test:

I used my IPad with Voiceover enabled to test this PR.

Notes: 
- The trash button also doesn't have an accessibility label. The related issue mentions this.
- Github doesn't support .mov files so I couldn't attach videos of the Voiceovers :(

PR submission checklist:

- [ x ] I have considered adding unit tests where possible.
- [ x ] I have considered adding accessibility improvements for my changes.
- [ x ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
