### PR TITLE
Stories: Feature Flag

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -72,7 +72,9 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     /// Does the blog support Stock Photos feature (free photos library)
     BlogFeatureStockPhotos,
     /// Does the blog support setting the homepage type and pages?
-    BlogFeatureHomepageSettings
+    BlogFeatureHomepageSettings,
+    /// Does the blog support stories?
+    BlogFeatureStories
 };
 
 typedef NS_ENUM(NSInteger, SiteVisibility) {

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -516,6 +516,8 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
             return [self isAdmin];
         case BlogFeatureHomepageSettings:
             return [self supportsRestApi] && [self isAdmin];
+        case BlogFeatureStories:
+            return [self supportsStories];
     }
 }
 
@@ -582,6 +584,12 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         && self.isAdmin;
 
     return isTransferrable || hasRequiredJetpack;
+}
+
+- (BOOL)supportsStories
+{
+    BOOL hasRequiredJetpack = [self hasRequiredJetpackVersion:@"8.9"];
+    return hasRequiredJetpack || self.isHostedAtWPcom;
 }
 
 - (BOOL)accountIsDefaultAccount

--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -150,7 +150,7 @@ import AutomatticTracks
 
         WPTabBarController.sharedInstance()?.present(postVC, animated: true, completion: nil)
 
-        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "url_scheme", WPAppAnalyticsKeyPostType: "post"])
+        WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: "url_scheme", WPAppAnalyticsKeyPostType: "post"])
 
         return true
     }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -20,6 +20,7 @@ extern NSString * const WPAppAnalyticsKeyQuickAction;
 extern NSString * const WPAppAnalyticsKeyFollowAction;
 extern NSString * const WPAppAnalyticsKeySource;
 extern NSString * const WPAppAnalyticsKeyPostType;
+extern NSString * const WPAppAnalyticsKeyTapSource;
 
 /**
  *  @class      WPAppAnalytics

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -25,6 +25,7 @@ NSString * const WPAppAnalyticsKeyQuickAction                       = @"quick_ac
 NSString * const WPAppAnalyticsKeyFollowAction                      = @"follow_action";
 NSString * const WPAppAnalyticsKeySource                            = @"source";
 NSString * const WPAppAnalyticsKeyPostType                          = @"post_type";
+NSString * const WPAppAnalyticsKeyTapSource                          = @"tap_source";
 
 NSString * const WPAppAnalyticsKeyHasGutenbergBlocks                = @"has_gutenberg_blocks";
 static NSString * const WPAppAnalyticsKeyLastVisibleScreen          = @"last_visible_screen";

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -15,6 +15,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case whatIsNew
     case newNavBarAppearance
     case unifiedPrologueCarousel
+    case stories
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -49,6 +50,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return BuildConfiguration.current == .localDeveloper
         case .unifiedPrologueCarousel:
             return BuildConfiguration.current == .localDeveloper
+        case .stories:
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 
@@ -103,6 +106,8 @@ extension FeatureFlag {
             return "New Navigation Bar Appearance"
         case .unifiedPrologueCarousel:
             return "Unified Prologue Carousel"
+        case .stories:
+            return "Stories"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
@@ -1,0 +1,35 @@
+
+extension BlogDetailsViewController {
+
+    /// Make a create button coordinator with
+    /// - Returns: CreateButtonCoordinator with new post, page, and story actions.
+    @objc func makeCreateButtonCoordinator() -> CreateButtonCoordinator {
+
+        let newPage = { [weak self] in
+            let controller = self?.tabBarController as? WPTabBarController
+            let blog = controller?.currentOrLastBlog()
+            controller?.showPageEditor(forBlog: blog)
+        }
+
+        let newPost = { [weak self] in
+            let controller = self?.tabBarController as? WPTabBarController
+            controller?.showPostTab(completion: {
+                self?.startAlertTimer()
+            })
+        }
+
+        let newStory = { [weak self] in
+            let controller = self?.tabBarController as? WPTabBarController
+            let blog = controller?.currentOrLastBlog()
+            controller?.showStoryEditor(forBlog: blog)
+        }
+
+        let coordinator = CreateButtonCoordinator(self, newPost: newPost, newPage: newPage, newStory: shouldShowNewStory ? newStory : nil)
+        return coordinator
+    }
+
+    //TODO: Can be removed after stories launches
+    private var shouldShowNewStory: Bool {
+        return Feature.enabled(.stories) && blog.supports(.stories)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -436,6 +436,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     if (!_createButtonCoordinator) {
         __weak __typeof(self) weakSelf = self;
+
+        BOOL showNewStory = [Feature enabled:FeatureFlagStories] && [self.blog supports:BlogFeatureStories];
+        void (^newStory)(void) = ^void() {
+            WPTabBarController *controller = (WPTabBarController *)weakSelf.tabBarController;
+            Blog *blog = [controller currentOrLastBlog];
+            [controller showStoryEditorForBlog:blog];
+        };
+
         _createButtonCoordinator = [[CreateButtonCoordinator alloc] init:self newPost:^{
             [((WPTabBarController *)weakSelf.tabBarController) showPostTabWithCompletion:^(void) {
                 [weakSelf startAlertTimer];
@@ -444,7 +452,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             WPTabBarController *controller = (WPTabBarController *)weakSelf.tabBarController;
             Blog *blog = [controller currentOrLastBlog];
             [controller showPageEditorForBlog:blog];
-        }];
+        } newStory: (showNewStory) ? newStory : nil];
     }
     
     return _createButtonCoordinator;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -435,24 +435,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (CreateButtonCoordinator *)createButtonCoordinator
 {
     if (!_createButtonCoordinator) {
-        __weak __typeof(self) weakSelf = self;
-
-        BOOL showNewStory = [Feature enabled:FeatureFlagStories] && [self.blog supports:BlogFeatureStories];
-        void (^newStory)(void) = ^void() {
-            WPTabBarController *controller = (WPTabBarController *)weakSelf.tabBarController;
-            Blog *blog = [controller currentOrLastBlog];
-            [controller showStoryEditorForBlog:blog];
-        };
-
-        _createButtonCoordinator = [[CreateButtonCoordinator alloc] init:self newPost:^{
-            [((WPTabBarController *)weakSelf.tabBarController) showPostTabWithCompletion:^(void) {
-                [weakSelf startAlertTimer];
-            }];
-        } newPage:^{
-            WPTabBarController *controller = (WPTabBarController *)weakSelf.tabBarController;
-            Blog *blog = [controller currentOrLastBlog];
-            [controller showPageEditorForBlog:blog];
-        } newStory: (showNewStory) ? newStory : nil];
+        _createButtonCoordinator = [self makeCreateButtonCoordinator];
     }
     
     return _createButtonCoordinator;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1357,7 +1357,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             break;
     }
     
-    [WPAppAnalytics track:event withProperties:@{@"tap_source": sourceString} withBlog:self.blog];
+    [WPAppAnalytics track:event withProperties:@{WPAppAnalyticsKeyTapSource: sourceString} withBlog:self.blog];
 }
 
 - (void)preloadBlogData

--- a/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
@@ -17,7 +17,7 @@ class MediaNoticeNavigationCoordinator {
         editor.modalPresentationStyle = .fullScreen
         editor.insertedMedia = media
         WPTabBarController.sharedInstance().present(editor, animated: false)
-        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": source, WPAppAnalyticsKeyPostType: "post"], with: blog)
+        WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: source, WPAppAnalyticsKeyPostType: "post"], with: blog)
     }
 
     static func navigateToMediaLibrary(with userInfo: NSDictionary) {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -442,7 +442,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     // MARK: - Post Actions
 
     override func createPost() {
-        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "posts_view", WPAppAnalyticsKeyPostType: "page"], with: blog)
+        WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: "posts_view", WPAppAnalyticsKeyPostType: "page"], with: blog)
 
         PageCoordinator.showLayoutPickerIfNeeded(from: self, forBlog: blog) { [weak self] (selectedLayout) in
             self?.createPage(selectedLayout)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -523,7 +523,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         let editor = EditPostViewController(blog: blog)
         editor.modalPresentationStyle = .fullScreen
         present(editor, animated: false, completion: nil)
-        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "posts_view", WPAppAnalyticsKeyPostType: "post"], with: blog)
+        WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: "posts_view", WPAppAnalyticsKeyPostType: "post"], with: blog)
     }
 
     private func editPost(apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -4,8 +4,12 @@ extension WPTabBarController {
         showPageEditor(blog: forBlog)
     }
 
+    @objc func showStoryEditor(forBlog: Blog? = nil) {
+        showStoryEditor(blog: forBlog)
+    }
+
     /// Show the page tab
-    /// - Parameter inBlog: Blog to a add a page to. Uses the current or last blog if not provided
+    /// - Parameter blog: Blog to a add a page to. Uses the current or last blog if not provided
     func showPageEditor(blog inBlog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
 
         // If we are already showing a view controller, dismiss and show the editor afterward
@@ -32,5 +36,25 @@ extension WPTabBarController {
     private func showEditor(blog: Blog, title: String?, content: String?, templateKey: String?) {
         let editorViewController = EditPageViewController(blog: blog, postTitle: title, content: content, appliedTemplate: templateKey)
         present(editorViewController, animated: false)
+    }
+
+    /// Show the story editor
+    /// - Parameter blog: Blog to a add a story to. Uses the current or last blog if not provided
+    func showStoryEditor(blog inBlog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
+        // If we are already showing a view controller, dismiss and show the editor afterward
+        guard presentedViewController == nil else {
+            dismiss(animated: true) { [weak self] in
+                self?.showStoryEditor(blog: inBlog, title: title, content: content, source: source)
+            }
+            return
+        }
+
+        guard let blog = inBlog ?? self.currentOrLastBlog() else { return }
+        let blogID = blog.dotComID?.intValue ?? 0 as Any
+        WPAnalytics.track(WPAnalyticsEvent.editorCreatedPage, properties: ["tap_source": source, WPAppAnalyticsKeyBlogID: blogID, WPAppAnalyticsKeyPostType: "story"])
+
+        let controller = UIViewController()
+        controller.view.backgroundColor = .white
+        present(controller, animated: true, completion: nil)
     }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -26,7 +26,7 @@ extension WPTabBarController {
         }
 
         let blogID = blog.dotComID?.intValue ?? 0 as Any
-        WPAnalytics.track(WPAnalyticsEvent.editorCreatedPage, properties: ["tap_source": source, WPAppAnalyticsKeyBlogID: blogID, WPAppAnalyticsKeyPostType: "page"])
+        WPAnalytics.track(WPAnalyticsEvent.editorCreatedPage, properties: [WPAppAnalyticsKeyTapSource: source, WPAppAnalyticsKeyBlogID: blogID, WPAppAnalyticsKeyPostType: "page"])
 
         PageCoordinator.showLayoutPickerIfNeeded(from: self, forBlog: blog) { [weak self] (selectedLayout) in
             self?.showEditor(blog: blog, title: selectedLayout?.title, content: selectedLayout?.content, templateKey: selectedLayout?.slug)
@@ -51,7 +51,7 @@ extension WPTabBarController {
 
         guard let blog = inBlog ?? self.currentOrLastBlog() else { return }
         let blogID = blog.dotComID?.intValue ?? 0 as Any
-        WPAnalytics.track(WPAnalyticsEvent.editorCreatedPage, properties: ["tap_source": source, WPAppAnalyticsKeyBlogID: blogID, WPAppAnalyticsKeyPostType: "story"])
+        WPAnalytics.track(WPAnalyticsEvent.editorCreatedPage, properties: [WPAppAnalyticsKeyTapSource: source, WPAppAnalyticsKeyBlogID: blogID, WPAppAnalyticsKeyPostType: "story"])
 
         let controller = UIViewController()
         controller.view.backgroundColor = .white

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -451,7 +451,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     editor.afterDismiss = afterDismiss;
     
     NSString *tapSource = @"create_button";
-    [WPAppAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ @"tap_source": tapSource, WPAppAnalyticsKeyPostType: @"post"} withBlog:blog];
+    [WPAppAnalytics track:WPAnalyticsStatEditorCreatedPost withProperties:@{ WPAppAnalyticsKeyTapSource: tapSource, WPAppAnalyticsKeyPostType: @"post"} withBlog:blog];
     [self presentViewController:editor animated:NO completion:nil];
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2187,6 +2187,7 @@
 		F5660D03235CF73800020B1E /* SchedulingCalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */; };
 		F5660D07235D114500020B1E /* CalendarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D06235D114500020B1E /* CalendarCollectionView.swift */; };
 		F5660D09235D1CDD00020B1E /* CalendarMonthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5660D08235D1CDD00020B1E /* CalendarMonthView.swift */; };
+		F56A33332538C0ED00E2AEF3 /* BlogDetailsViewController+FAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56A33322538C0ED00E2AEF3 /* BlogDetailsViewController+FAB.swift */; };
 		F57402A7235FF9C300374346 /* SchedulingDate+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57402A6235FF9C300374346 /* SchedulingDate+Helpers.swift */; };
 		F574416E242569CA00E150A8 /* Route+Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = F574416C2425697D00E150A8 /* Route+Page.swift */; };
 		F580C3C123D22E2D0038E243 /* PreviewDeviceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F580C3C023D22E2D0038E243 /* PreviewDeviceLabel.swift */; };
@@ -4915,6 +4916,7 @@
 		F5660CFF235CE82100020B1E /* SchedulingCalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulingCalendarViewController.swift; sourceTree = "<group>"; };
 		F5660D06235D114500020B1E /* CalendarCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarCollectionView.swift; sourceTree = "<group>"; };
 		F5660D08235D1CDD00020B1E /* CalendarMonthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarMonthView.swift; sourceTree = "<group>"; };
+		F56A33322538C0ED00E2AEF3 /* BlogDetailsViewController+FAB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+FAB.swift"; sourceTree = "<group>"; };
 		F57402A6235FF9C300374346 /* SchedulingDate+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SchedulingDate+Helpers.swift"; sourceTree = "<group>"; };
 		F574416C2425697D00E150A8 /* Route+Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route+Page.swift"; sourceTree = "<group>"; };
 		F580C3C023D22E2D0038E243 /* PreviewDeviceLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDeviceLabel.swift; sourceTree = "<group>"; };
@@ -6242,6 +6244,7 @@
 			children = (
 				462F4E0618369F0B0028D2F8 /* BlogDetailsViewController.h */,
 				462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */,
+				F56A33322538C0ED00E2AEF3 /* BlogDetailsViewController+FAB.swift */,
 				74989B8B2088E3650054290B /* BlogDetailsViewController+Activity.swift */,
 				02AC3091226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift */,
 				435D10192130C2AB00BB2AA8 /* BlogDetailsViewController+FancyAlerts.swift */,
@@ -12423,6 +12426,7 @@
 				7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */,
 				B03B9234250BC593000A40AF /* SuggestionService.swift in Sources */,
 				B555E1151C04A68D00CEC81B /* WordPress-41-42.xcmappingmodel in Sources */,
+				F56A33332538C0ED00E2AEF3 /* BlogDetailsViewController+FAB.swift in Sources */,
 				F12FA5D92428FA8F0054DA21 /* AuthenticationService.swift in Sources */,
 				E16A76F11FC4758300A661E3 /* JetpackSiteRef.swift in Sources */,
 				B5B56D3219AFB68800B4E29B /* WPStyleGuide+Reply.swift in Sources */,


### PR DESCRIPTION
Adds a feature flag, blog requirement, and FAB menu option for the Stories project.

Future PRs will add a "New" label to the Story post menu item, a new icon once added to Gridicons, an onboarding screen, Kanvas library, and Story posting logic.

### Changes

* Adds the `.stories` feature flag
* Adds a `BlogFeatureStories` feature check to ensure that the blog is Jetpack >= 8.9 or is WordPress.com hosted
* Adds a "Story post" menu option to the FAB menu

### Testing

* Ensure that the "Story post" option shows up in the FAB menu in debug builds. (Blog Details > FAB > "Story post")

  * "Story post" should show up on Sites with Jetpack >= 8.9
  * "Story post" should show up on Wordpress.com blogs
  * "Story post" should not show on sites without Jetpack or with version lower than <8.9.

![Screen Shot 2020-10-14 at 4 14 14 PM](https://user-images.githubusercontent.com/3250/96051272-63c8e600-0e38-11eb-91a6-16ea405bc5d4.png)

* Ensure that the "Stories" flag option shows up in the Debug Settings (Me > App Settings > Debug)

![Screen Shot 2020-10-14 at 4 13 19 PM](https://user-images.githubusercontent.com/3250/96051215-45fb8100-0e38-11eb-9386-0caee5b56a7a.png)

* Tapping the "Story post" button should bring up a blank view controller (swipe down to dismiss). This is temporary

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
