### PR TITLE
Reader: Do not override images that already have an anchor link

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -98,8 +98,11 @@ class ReaderWebView: WKWebView {
 
             // Make all images tappable
             // Exception for images in Stories, which have their own link structure
+            // and images that already have a link
             document.querySelectorAll('img:not(.wp-story-image)').forEach((el) => {
-                el.outerHTML = `<a href="${el.src}">${el.outerHTML}</a>`
+                if (el.parentNode.nodeName.toLowerCase() !== 'a') {
+                    el.outerHTML = `<a href="${el.src}">${el.outerHTML}</a>`;
+                }
             })
 
             // Only display images after they have fully loaded, to have a native feel


### PR DESCRIPTION
Fixes #15009 

### To test

1. Open a post in Reader that contains an image with a link (eg.: https://charlietest12345.blog/2020/10/15/image-with-link/)
2. Tap the first image and checks that it opens https://wordpress.org/
3. Tap the 2nd image and checks that it shows itself fullscreen

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
