### PR TITLE
Extracts the header and footer container from Modal Layout Picker to be reusable for the upcoming Home Page Picker

### DIFF
--- a/WordPress/Classes/Models/PageTemplateCategory+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/PageTemplateCategory+CoreDataProperties.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreData
 
-extension PageTemplateCategory {
+extension PageTemplateCategory: CollabsableHeaderFilterOption {
 
     @nonobjc public class func fetchRequest() -> NSFetchRequest<PageTemplateCategory> {
         return NSFetchRequest<PageTemplateCategory>(entityName: "PageTemplateCategory")

--- a/WordPress/Classes/Services/PageCoordinator.swift
+++ b/WordPress/Classes/Services/PageCoordinator.swift
@@ -13,13 +13,17 @@ class PageCoordinator {
 
     private static func showLayoutPicker(from controller: UIViewController, forBlog blog: Blog, _ completion: @escaping TemplateSelectionCompletion) {
         let storyboard = UIStoryboard(name: "LayoutPickerStoryboard", bundle: Bundle.main)
-        guard let navigationController = storyboard.instantiateInitialViewController() as? UINavigationController,
-            let rootView = navigationController.topViewController as? GutenbergLayoutPickerViewController  else {
+        guard let childViewController = storyboard.instantiateInitialViewController() as? GutenbergLayoutPickerViewController else {
             completion(nil)
             return
         }
-        rootView.completion = completion
-        rootView.blog = blog
+
+        childViewController.completion = completion
+        childViewController.blog = blog
+
+        let container = CollapsableHeaderViewController(childViewController: childViewController)
+        childViewController.headerContentsDelegate = container
+        let navigationController = UINavigationController(rootViewController: container)
 
         if #available(iOS 13.0, *) {
             navigationController.modalPresentationStyle = .pageSheet

--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/Collabsable Header Filter Bar/CollabsableHeaderFilterCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/Collabsable Header Filter Bar/CollabsableHeaderFilterCollectionViewCell.swift
@@ -1,19 +1,24 @@
 import UIKit
 
-class LayoutPickerFilterCollectionViewCell: UICollectionViewCell {
+protocol CollabsableHeaderFilterOption: class {
+    var title: String { get }
+    var emoji: String? { get }
+}
 
-    static let cellReuseIdentifier = "LayoutPickerFilterCollectionViewCell"
-    static let nib = UINib(nibName: "LayoutPickerFilterCollectionViewCell", bundle: Bundle.main)
+class CollabsableHeaderFilterCollectionViewCell: UICollectionViewCell {
+
+    static let cellReuseIdentifier = "\(CollabsableHeaderFilterCollectionViewCell.self)"
+    static let nib = UINib(nibName: "\(CollabsableHeaderFilterCollectionViewCell.self)", bundle: Bundle.main)
 
     static var font: UIFont {
         return WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
     }
 
     private static let combinedLeftRightMargin: CGFloat = 32
-    static func estimatedWidth(forFilter filter: GutenbergLayoutSection) -> CGFloat {
+    static func estimatedWidth(forFilter filter: CollabsableHeaderFilterOption) -> CGFloat {
         /// The emoji below is used as a placeholder to estimate the size of the title. We don't use the actual emoji provided by the API because this could be nil
         /// and we want to allow space for a checkmark when the cell is selected.
-        let size = "👋 \(filter.section.title)".size(withAttributes: [
+        let size = "👋 \(filter.title)".size(withAttributes: [
             NSAttributedString.Key.font: font
         ])
 
@@ -24,18 +29,16 @@ class LayoutPickerFilterCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var pillBackgroundView: UIView!
     @IBOutlet weak var checkmark: UIImageView!
 
-    var filter: GutenbergLayoutSection? = nil {
+    var filter: CollabsableHeaderFilterOption? = nil {
         didSet {
-            let section = filter?.section
             filterLabel.text = filterTitle
-            filterLabel.accessibilityLabel = section?.title
+            filterLabel.accessibilityLabel = filter?.title
         }
     }
 
     var filterTitle: String {
-        let section = filter?.section
-        let emoji = isSelected ? nil : section?.emoji
-        return [emoji, section?.title].compactMap { $0 }.joined(separator: " ")
+        let emoji = isSelected ? nil : filter?.emoji
+        return [emoji, filter?.title].compactMap { $0 }.joined(separator: " ")
     }
 
     var checkmarkTintColor: UIColor {
@@ -62,7 +65,7 @@ class LayoutPickerFilterCollectionViewCell: UICollectionViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        filterLabel.font = LayoutPickerFilterCollectionViewCell.font
+        filterLabel.font = CollabsableHeaderFilterCollectionViewCell.font
         if #available(iOS 13.0, *) {
             checkmark.image = UIImage(systemName: "checkmark")
         } else {
@@ -108,7 +111,7 @@ class LayoutPickerFilterCollectionViewCell: UICollectionViewCell {
     }
 }
 
-extension LayoutPickerFilterCollectionViewCell: GhostableView {
+extension CollabsableHeaderFilterCollectionViewCell: GhostableView {
     func ghostAnimationWillStart() {
         filterLabel.text = ""
         pillBackgroundView.startGhostAnimation(style: GhostCellStyle.muriel)

--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/Collabsable Header Filter Bar/CollabsableHeaderFilterCollectionViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/Collabsable Header Filter Bar/CollabsableHeaderFilterCollectionViewCell.xib
@@ -11,7 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="LayoutPickerFilterCollectionViewCell" customModule="WordPress" customModuleProvider="target">
+        <collectionViewCell clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="CollabsableHeaderFilterCollectionViewCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="105" height="44"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">

--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/Collabsable Header Filter Bar/CollapsableHeaderFilterBar.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/Collabsable Header Filter Bar/CollapsableHeaderFilterBar.swift
@@ -1,14 +1,14 @@
 import UIKit
 
-protocol FilterBarDelegate {
+protocol CollapsableHeaderFilterBarDelegate: class {
     func numberOfFilters() -> Int
-    func filter(forIndex: Int) -> GutenbergLayoutSection
+    func filter(forIndex: Int) -> CollabsableHeaderFilterOption
     func didSelectFilter(withIndex selectedIndex: IndexPath, withSelectedIndexes selectedIndexes: [IndexPath])
     func didDeselectFilter(withIndex index: IndexPath, withSelectedIndexes selectedIndexes: [IndexPath])
 }
 
-class GutenbergLayoutFilterBar: UICollectionView {
-    var filterDelegate: FilterBarDelegate?
+class CollapsableHeaderFilterBar: UICollectionView {
+    var filterDelegate: CollapsableHeaderFilterBarDelegate?
     private let defaultCellHeight: CGFloat = 44
     private let defaultCellWidth: CGFloat = 105
     var shouldShowGhostContent: Bool = false {
@@ -19,7 +19,7 @@ class GutenbergLayoutFilterBar: UICollectionView {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        register(LayoutPickerFilterCollectionViewCell.nib, forCellWithReuseIdentifier: LayoutPickerFilterCollectionViewCell.cellReuseIdentifier)
+        register(CollabsableHeaderFilterCollectionViewCell.nib, forCellWithReuseIdentifier: CollabsableHeaderFilterCollectionViewCell.cellReuseIdentifier)
         self.delegate = self
         self.dataSource = self
     }
@@ -30,7 +30,7 @@ class GutenbergLayoutFilterBar: UICollectionView {
     }
 }
 
-extension GutenbergLayoutFilterBar: UICollectionViewDelegate {
+extension CollapsableHeaderFilterBar: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         if collectionView.cellForItem(at: indexPath)?.isSelected ?? false {
             deselectItem(indexPath)
@@ -49,26 +49,26 @@ extension GutenbergLayoutFilterBar: UICollectionViewDelegate {
     }
 }
 
-extension GutenbergLayoutFilterBar: UICollectionViewDelegateFlowLayout {
+extension CollapsableHeaderFilterBar: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         guard !shouldShowGhostContent, let filter = filterDelegate?.filter(forIndex: indexPath.item) else {
             return CGSize(width: defaultCellWidth, height: defaultCellHeight)
         }
 
-        let width = LayoutPickerFilterCollectionViewCell.estimatedWidth(forFilter: filter)
+        let width = CollabsableHeaderFilterCollectionViewCell.estimatedWidth(forFilter: filter)
         return CGSize(width: width, height: defaultCellHeight)
      }
 }
 
-extension GutenbergLayoutFilterBar: UICollectionViewDataSource {
+extension CollapsableHeaderFilterBar: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return shouldShowGhostContent ? 1 : (filterDelegate?.numberOfFilters() ?? 0)
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cellReuseIdentifier = LayoutPickerFilterCollectionViewCell.cellReuseIdentifier
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier, for: indexPath) as? LayoutPickerFilterCollectionViewCell else {
-            fatalError("Expected the cell with identifier \"\(cellReuseIdentifier)\" to be a \(LayoutPickerFilterCollectionViewCell.self). Please make sure the collection view is registering the correct nib before loading the data")
+        let cellReuseIdentifier = CollabsableHeaderFilterCollectionViewCell.cellReuseIdentifier
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier, for: indexPath) as? CollabsableHeaderFilterCollectionViewCell else {
+            fatalError("Expected the cell with identifier \"\(cellReuseIdentifier)\" to be a \(CollabsableHeaderFilterCollectionViewCell.self). Please make sure the collection view is registering the correct nib before loading the data")
         }
 
         if shouldShowGhostContent {

--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.swift
@@ -1,0 +1,406 @@
+import UIKit
+
+protocol CollapsableHeaderDataSource {
+
+    /// Used to populate the scrollable area of this container. 
+    var scrollView: UIScrollView { get }
+
+    /// Used to populate the Large title and small title in the header
+    var mainTitle: String { get }
+
+    /// Used to populate the subtitle/prompt in the header
+    var prompt: String { get }
+
+    /// Used to populate the button title for the button that is displayed when no item is selected
+    var defaultActionTitle: String { get }
+
+    /// Used to populate the button title for the right most button when an item is selected
+    var primaryActionTitle: String { get }
+
+    /// Used to populate the button title for the left most button when an item is selected
+    var secondaryActionTitle: String { get }
+
+    /// The estimated content size of the scroll view. This is used to adjust the content insests to allow the header to be scrollable to be collapsable still when
+    /// it's not populated with enough data. This is desirable to help maintain the header's state when the filtered options change and reduce the content size.
+    func estimatedContentSize() -> CGSize
+}
+
+protocol CollapsableHeaderDelegate: class {
+    /// Notifies the delegate that the button that is displayed when no item is selected was tapped
+    func defaultActionSelected()
+
+    /// Notifies the delegate that the right most button when an item is selected was tapped
+    func primaryActionSelected()
+
+    /// Notifies the delegate that the left most button when an item is selected was tapped
+    func secondaryActionSelected()
+}
+
+protocol CollapsableHeaderContentsDelegate: class {
+    /// A public interface to notify the container that the content size of the scroll view is about to change. This is useful in adjusting the bottom insets to allow the
+    /// view to still be scrollable with the content size is less than the total space of the expanded screen.
+    func contentSizeWillChange()
+
+    /// A public interface to notify the container that the selected state for an items has changed.
+    func itemSelectionChanged(_ hasSelectedItem: Bool)
+
+    /// A public interface to notify the container that the content view is loading content still
+    func loadingStateChanged(_ isLoading: Bool)
+}
+
+class CollapsableHeaderViewController: UIViewController {
+
+    let childViewController: (UIViewController & CollapsableHeaderDataSource)
+    weak var delegate: CollapsableHeaderDelegate?
+    weak var filterDelegate: CollapsableHeaderFilterBarDelegate?
+
+    var scrollView: UIScrollView {
+        childViewController.scrollView
+    }
+
+    @IBOutlet weak var containerView: UIView!
+    @IBOutlet weak var headerBar: UIView!
+    @IBOutlet weak var headerView: UIView!
+    @IBOutlet weak var closeButton: UIButton!
+    @IBOutlet weak var titleView: UILabel!
+    @IBOutlet weak var largeTitleView: UILabel!
+    @IBOutlet weak var promptView: UILabel!
+    @IBOutlet weak var filterBar: CollapsableHeaderFilterBar!
+    @IBOutlet weak var footerView: UIView!
+    @IBOutlet weak var createBlankPageBtn: UIButton!
+    @IBOutlet weak var previewBtn: UIButton!
+    @IBOutlet weak var createPageBtn: UIButton!
+    @IBOutlet weak var selectedStateButtonsContainer: UIView!
+
+    /// This  is used as a means to adapt to different text sizes to force the desired layout and then active `headerHeightConstraint`
+    /// when scrolling begins to allow pushing the non static items out of the scrollable area.
+    @IBOutlet weak var initialHeaderTopConstraint: NSLayoutConstraint!
+    @IBOutlet weak var headerHeightConstraint: NSLayoutConstraint!
+    @IBOutlet weak var titleToSubtitleSpacing: NSLayoutConstraint!
+    @IBOutlet weak var subtitleToCategoryBarSpacing: NSLayoutConstraint!
+    @IBOutlet weak var minHeaderBottomSpacing: NSLayoutConstraint!
+    @IBOutlet weak var maxHeaderBottomSpacing: NSLayoutConstraint!
+    @IBOutlet var visualEffects: [UIVisualEffectView]! {
+        didSet {
+            if #available(iOS 13.0, *) {
+                visualEffects.forEach { (visualEffect) in
+                    visualEffect.effect = UIBlurEffect.init(style: .systemChromeMaterial)
+                }
+            }
+        }
+    }
+
+    private var shouldUseCompactLayout: Bool {
+        return traitCollection.verticalSizeClass == .compact
+    }
+
+    private var _maxHeaderHeight: CGFloat = 0
+    private var maxHeaderHeight: CGFloat {
+        if shouldUseCompactLayout {
+            return minHeaderHeight
+        } else {
+            return _maxHeaderHeight
+        }
+    }
+
+    private var _midHeaderHeight: CGFloat = 0
+    private var midHeaderHeight: CGFloat {
+        if shouldUseCompactLayout {
+            return minHeaderHeight
+        } else {
+            return _midHeaderHeight
+        }
+    }
+    private var minHeaderHeight: CGFloat = 0
+
+    private var titleIsHidden: Bool = true {
+        didSet {
+            if oldValue != titleIsHidden {
+                titleView.isHidden = false
+                let alpha: CGFloat = titleIsHidden ? 0 : 1
+                UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCrossDissolve, animations: {
+                    self.titleView.alpha = alpha
+                }) { (_) in
+                    self.titleView.isHidden = self.titleIsHidden
+                }
+            }
+        }
+    }
+
+    var accentColor: UIColor {
+        if #available(iOS 13.0, *) {
+            return UIColor { (traitCollection: UITraitCollection) -> UIColor in
+                if traitCollection.userInterfaceStyle == .dark {
+                    return UIColor.muriel(color: .accent, .shade40)
+                } else {
+                    return UIColor.muriel(color: .accent, .shade50)
+                }
+            }
+        } else {
+            return UIColor.muriel(color: .accent, .shade50)
+        }
+    }
+
+    convenience init(childViewController: UIViewController & CollapsableHeaderDataSource & CollapsableHeaderDelegate & CollapsableHeaderFilterBarDelegate) {
+        self.init(childViewController: childViewController, delegate: childViewController, filterDelegate: childViewController)
+    }
+
+    init(childViewController: UIViewController & CollapsableHeaderDataSource, delegate: CollapsableHeaderDelegate?, filterDelegate: CollapsableHeaderFilterBarDelegate?) {
+        self.childViewController = childViewController
+        self.delegate = delegate
+        self.filterDelegate = filterDelegate
+        super.init(nibName: "\(CollapsableHeaderViewController.self)", bundle: .main)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        insertChildView()
+
+        largeTitleView.font = WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.largeTitle, fontWeight: .semibold)
+        titleView.font = WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.largeTitle, fontWeight: .semibold).withSize(17)
+        closeButton.setImage(UIImage.gridicon(.crossSmall), for: .normal)
+
+        styleButtons()
+        setStaticText()
+
+        scrollView.delegate = self
+        layoutHeader()
+        filterBar.filterDelegate = filterDelegate
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(true, animated: true)
+        super.viewWillAppear(animated)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        navigationController?.isNavigationBarHidden = false
+        super.viewDidDisappear(animated)
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if #available(iOS 13.0, *) {
+            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                styleButtons()
+            }
+        }
+
+        if let previousTraitCollection = previousTraitCollection, traitCollection.verticalSizeClass != previousTraitCollection.verticalSizeClass {
+            layoutHeaderInsets()
+        }
+    }
+
+    @IBAction func closeSelected(_ sender: Any) {
+        dismiss(animated: true, completion: nil)
+    }
+
+    @IBAction func defaultActionSelected(_ sender: Any) {
+        delegate?.defaultActionSelected()
+    }
+
+    @IBAction func primaryActionSelected(_ sender: Any) {
+        delegate?.primaryActionSelected()
+    }
+
+    @IBAction func secondaryActionSelected(_ sender: Any) {
+        delegate?.secondaryActionSelected()
+    }
+
+    private func setStaticText() {
+        closeButton.accessibilityLabel = NSLocalizedString("Close", comment: "Dismisses the current screen")
+        titleView.text = childViewController.mainTitle
+        largeTitleView.text = childViewController.mainTitle
+        promptView.text = childViewController.prompt
+        createBlankPageBtn.setTitle(childViewController.defaultActionTitle, for: .normal)
+        previewBtn.setTitle(childViewController.secondaryActionTitle, for: .normal)
+        createPageBtn.setTitle(childViewController.primaryActionTitle, for: .normal)
+    }
+
+    private func insertChildView() {
+        add(childViewController)
+        guard let childView = childViewController.view else { return }
+        childView.translatesAutoresizingMaskIntoConstraints = false
+        let top = NSLayoutConstraint(item: childView, attribute: .top, relatedBy: .equal, toItem: containerView, attribute: .top, multiplier: 1, constant: 1)
+        let bottom = NSLayoutConstraint(item: childView, attribute: .bottom, relatedBy: .equal, toItem: containerView, attribute: .bottom, multiplier: 1, constant: 1)
+        let leading = NSLayoutConstraint(item: childView, attribute: .leading, relatedBy: .equal, toItem: containerView, attribute: .leading, multiplier: 1, constant: 1)
+        let trailing = NSLayoutConstraint(item: childView, attribute: .trailing, relatedBy: .equal, toItem: containerView, attribute: .trailing, multiplier: 1, constant: 1)
+        containerView.addSubview(childView)
+        containerView.addConstraints([top, bottom, leading, trailing])
+    }
+
+    private func styleButtons() {
+        let seperator: UIColor
+        if #available(iOS 13.0, *) {
+            seperator = .separator
+        } else {
+            seperator = UIColor.muriel(color: .divider)
+        }
+
+        [createBlankPageBtn, previewBtn].forEach { (button) in
+            button?.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
+            button?.layer.borderColor = seperator.cgColor
+            button?.layer.borderWidth = 1
+            button?.layer.cornerRadius = 8
+        }
+
+        createPageBtn.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
+        createPageBtn.backgroundColor = accentColor
+        createPageBtn.layer.cornerRadius = 8
+
+        if #available(iOS 13.0, *) {
+            closeButton.backgroundColor = UIColor { (traitCollection: UITraitCollection) -> UIColor in
+                if traitCollection.userInterfaceStyle == .dark {
+                    return UIColor.systemFill
+                } else {
+                    return UIColor.quaternarySystemFill
+                }
+            }
+        }
+    }
+
+    private func calculateHeaderSnapPoints() {
+        minHeaderHeight = filterBar.frame.height + minHeaderBottomSpacing.constant
+        _midHeaderHeight = titleToSubtitleSpacing.constant + promptView.frame.height + subtitleToCategoryBarSpacing.constant + filterBar.frame.height + maxHeaderBottomSpacing.constant
+        _maxHeaderHeight = largeTitleView.frame.height + _midHeaderHeight
+    }
+
+    private func layoutHeaderInsets() {
+        let topInset = maxHeaderHeight + headerBar.frame.height
+
+        if let tableView = scrollView as? UITableView {
+            tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: topInset))
+            tableView.tableHeaderView?.backgroundColor = .clear
+        } else {
+            scrollView.contentInset.top = topInset
+        }
+
+        updateFooterInsets()
+    }
+
+    /*
+     * Calculates the needed space for the footer to allow the header to still collapse but also to prevent unneeded space
+     * at the bottome of the tableView when multiple cells are rendered.
+     */
+    private func updateFooterInsets() {
+        let minimumFooterSize = footerView.frame.size.height + (UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0)
+
+        /// The needed distance to fill the rest of the screen to allow the header to still collapse when scrolling (or to maintain a collapsed header if it was already collapsed when selecting a filter)
+        let estimatedContentSize = childViewController.estimatedContentSize()
+        let distanceToBottom = scrollView.frame.height - headerBar.frame.height - minHeaderHeight - estimatedContentSize.height
+        let newHeight: CGFloat = max(minimumFooterSize, distanceToBottom)
+
+        if let tableView = scrollView as? UITableView {
+            tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: newHeight))
+            tableView.tableFooterView?.isGhostableDisabled = true
+            tableView.tableFooterView?.backgroundColor = .clear
+        } else {
+            scrollView.contentInset.bottom = newHeight
+        }
+    }
+
+    private func layoutHeader() {
+        [headerBar, headerView, footerView].forEach({
+            $0?.setNeedsLayout()
+            $0?.layoutIfNeeded()
+        })
+
+        calculateHeaderSnapPoints()
+        layoutHeaderInsets()
+    }
+}
+
+extension CollapsableHeaderViewController: UIScrollViewDelegate {
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard !shouldUseCompactLayout else {
+            titleIsHidden = false
+            return
+        }
+
+        if !headerHeightConstraint.isActive {
+            initialHeaderTopConstraint.isActive = false
+            headerHeightConstraint.isActive = true
+        }
+
+        let scrollOffset = scrollView.contentOffset.y
+        let newHeaderViewHeight = maxHeaderHeight - scrollOffset
+
+        if newHeaderViewHeight < minHeaderHeight {
+            headerHeightConstraint.constant = minHeaderHeight
+        } else {
+            headerHeightConstraint.constant = newHeaderViewHeight
+        }
+
+        titleIsHidden = largeTitleView.frame.maxY > 0
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        snapToHeight(scrollView)
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if !decelerate {
+            snapToHeight(scrollView)
+        }
+    }
+
+    private func snapToHeight(_ scrollView: UIScrollView) {
+        guard !shouldUseCompactLayout else { return }
+
+        if largeTitleView.frame.midY > 0 {
+            snapToHeight(scrollView, height: maxHeaderHeight)
+        } else if promptView.frame.midY > 0 {
+            snapToHeight(scrollView, height: midHeaderHeight)
+        } else if headerHeightConstraint.constant != minHeaderHeight {
+            snapToHeight(scrollView, height: minHeaderHeight)
+        }
+    }
+
+    private func snapToHeight(_ scrollView: UIScrollView, height: CGFloat) {
+        scrollView.contentOffset.y = maxHeaderHeight - height
+        headerHeightConstraint.constant = height
+        titleIsHidden = (height >= maxHeaderHeight) && !shouldUseCompactLayout
+        UIView.animate(withDuration: 0.4, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0.5, options: .curveEaseInOut, animations: {
+            self.headerView.setNeedsLayout()
+            self.headerView.layoutIfNeeded()
+        }, completion: nil)
+    }
+}
+
+extension CollapsableHeaderViewController: CollapsableHeaderContentsDelegate {
+
+    func contentSizeWillChange() {
+        updateFooterInsets()
+    }
+
+    func itemSelectionChanged(_ hasSelectedItem: Bool) {
+        createBlankPageBtn.isHidden = false
+        selectedStateButtonsContainer.isHidden = false
+
+        createBlankPageBtn.alpha = hasSelectedItem ? 1 : 0
+        selectedStateButtonsContainer.alpha = hasSelectedItem ? 0 : 1
+
+        let alpha: CGFloat = hasSelectedItem ? 0 : 1
+        let selectedStateContainerAlpha: CGFloat = hasSelectedItem ? 1 : 0
+
+        UIView.animate(withDuration: LayoutPickerCollectionViewCell.selectionAnimationSpeed, delay: 0, options: .transitionCrossDissolve, animations: {
+            self.createBlankPageBtn.alpha = alpha
+            self.selectedStateButtonsContainer.alpha = selectedStateContainerAlpha
+        }) { (_) in
+            self.createBlankPageBtn.isHidden = hasSelectedItem
+            self.selectedStateButtonsContainer.isHidden = !hasSelectedItem
+        }
+    }
+
+    func loadingStateChanged(_ isLoading: Bool) {
+        filterBar.shouldShowGhostContent = isLoading
+        filterBar.allowsMultipleSelection = !isLoading
+        filterBar.reloadData()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.swift
@@ -67,9 +67,9 @@ class CollapsableHeaderViewController: UIViewController {
     @IBOutlet weak var promptView: UILabel!
     @IBOutlet weak var filterBar: CollapsableHeaderFilterBar!
     @IBOutlet weak var footerView: UIView!
-    @IBOutlet weak var createBlankPageBtn: UIButton!
-    @IBOutlet weak var previewBtn: UIButton!
-    @IBOutlet weak var createPageBtn: UIButton!
+    @IBOutlet weak var defaultActionButton: UIButton!
+    @IBOutlet weak var secondaryActionButton: UIButton!
+    @IBOutlet weak var primaryActionButton: UIButton!
     @IBOutlet weak var selectedStateButtonsContainer: UIView!
 
     /// This  is used as a means to adapt to different text sizes to force the desired layout and then active `headerHeightConstraint`
@@ -217,9 +217,9 @@ class CollapsableHeaderViewController: UIViewController {
         titleView.text = childViewController.mainTitle
         largeTitleView.text = childViewController.mainTitle
         promptView.text = childViewController.prompt
-        createBlankPageBtn.setTitle(childViewController.defaultActionTitle, for: .normal)
-        previewBtn.setTitle(childViewController.secondaryActionTitle, for: .normal)
-        createPageBtn.setTitle(childViewController.primaryActionTitle, for: .normal)
+        defaultActionButton.setTitle(childViewController.defaultActionTitle, for: .normal)
+        secondaryActionButton.setTitle(childViewController.secondaryActionTitle, for: .normal)
+        primaryActionButton.setTitle(childViewController.primaryActionTitle, for: .normal)
     }
 
     private func insertChildView() {
@@ -242,16 +242,16 @@ class CollapsableHeaderViewController: UIViewController {
             seperator = UIColor.muriel(color: .divider)
         }
 
-        [createBlankPageBtn, previewBtn].forEach { (button) in
+        [defaultActionButton, secondaryActionButton].forEach { (button) in
             button?.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
             button?.layer.borderColor = seperator.cgColor
             button?.layer.borderWidth = 1
             button?.layer.cornerRadius = 8
         }
 
-        createPageBtn.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
-        createPageBtn.backgroundColor = accentColor
-        createPageBtn.layer.cornerRadius = 8
+        primaryActionButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
+        primaryActionButton.backgroundColor = accentColor
+        primaryActionButton.layer.cornerRadius = 8
 
         if #available(iOS 13.0, *) {
             closeButton.backgroundColor = UIColor { (traitCollection: UITraitCollection) -> UIColor in
@@ -380,20 +380,20 @@ extension CollapsableHeaderViewController: CollapsableHeaderContentsDelegate {
     }
 
     func itemSelectionChanged(_ hasSelectedItem: Bool) {
-        createBlankPageBtn.isHidden = false
+        defaultActionButton.isHidden = false
         selectedStateButtonsContainer.isHidden = false
 
-        createBlankPageBtn.alpha = hasSelectedItem ? 1 : 0
+        defaultActionButton.alpha = hasSelectedItem ? 1 : 0
         selectedStateButtonsContainer.alpha = hasSelectedItem ? 0 : 1
 
         let alpha: CGFloat = hasSelectedItem ? 0 : 1
         let selectedStateContainerAlpha: CGFloat = hasSelectedItem ? 1 : 0
 
         UIView.animate(withDuration: LayoutPickerCollectionViewCell.selectionAnimationSpeed, delay: 0, options: .transitionCrossDissolve, animations: {
-            self.createBlankPageBtn.alpha = alpha
+            self.defaultActionButton.alpha = alpha
             self.selectedStateButtonsContainer.alpha = selectedStateContainerAlpha
         }) { (_) in
-            self.createBlankPageBtn.isHidden = hasSelectedItem
+            self.defaultActionButton.isHidden = hasSelectedItem
             self.selectedStateButtonsContainer.isHidden = !hasSelectedItem
         }
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.swift
@@ -170,6 +170,12 @@ class CollapsableHeaderViewController: UIViewController {
         scrollView.delegate = self
         layoutHeader()
         filterBar.filterDelegate = filterDelegate
+
+        if #available(iOS 13.0, *) {} else {
+            headerBar.backgroundColor = .basicBackground
+            headerView.backgroundColor = .basicBackground
+            footerView.backgroundColor = .basicBackground
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -271,7 +277,13 @@ class CollapsableHeaderViewController: UIViewController {
     }
 
     private func layoutHeaderInsets() {
-        let topInset = maxHeaderHeight + headerBar.frame.height
+        let topInset: CGFloat
+
+        if #available(iOS 13.0, *) {
+            topInset = maxHeaderHeight + headerBar.frame.height
+        } else {
+            topInset = maxHeaderHeight + headerBar.frame.height + UIApplication.shared.statusBarFrame.height
+        }
 
         if let tableView = scrollView as? UITableView {
             tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: topInset))

--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.xib
@@ -200,7 +200,7 @@
                                 <constraint firstAttribute="height" constant="0.5" id="DKq-so-Z8k"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dmc-kV-0d8">
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dmc-kV-0d8" userLabel="Default Action">
                             <rect key="frame" x="20" y="16" width="374" height="44"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
@@ -214,10 +214,10 @@
                                 <action selector="defaultActionSelected:" destination="-1" eventType="touchUpInside" id="d2H-aW-Shz"/>
                             </connections>
                         </button>
-                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xLP-0m-3rr">
+                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xLP-0m-3rr" userLabel="Selected State Container">
                             <rect key="frame" x="20" y="16" width="374" height="44"/>
                             <subviews>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HeJ-NR-hHA">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HeJ-NR-hHA" userLabel="Secondry Action">
                                     <rect key="frame" x="0.0" y="0.0" width="182" height="44"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
@@ -228,7 +228,7 @@
                                         <action selector="secondaryActionSelected:" destination="-1" eventType="touchUpInside" id="fGK-R9-pK4"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cck-0Q-rBD">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cck-0Q-rBD" userLabel="Primary Action">
                                     <rect key="frame" x="192" y="0.0" width="182" height="44"/>
                                     <color key="backgroundColor" name="Pink50"/>
                                     <state key="normal" title="Create Page">

--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.xib
@@ -14,8 +14,7 @@
             <connections>
                 <outlet property="closeButton" destination="uxA-nG-zFs" id="Pp0-9y-rhJ"/>
                 <outlet property="containerView" destination="WmP-bw-ceT" id="lul-gs-fMI"/>
-                <outlet property="createBlankPageBtn" destination="dmc-kV-0d8" id="NfO-bU-Zl7"/>
-                <outlet property="createPageBtn" destination="cck-0Q-rBD" id="Y0w-MZ-C18"/>
+                <outlet property="defaultActionButton" destination="dmc-kV-0d8" id="NfO-bU-Zl7"/>
                 <outlet property="filterBar" destination="DE5-R9-8tB" id="IAj-gK-2g6"/>
                 <outlet property="footerView" destination="UfV-hu-KZx" id="LZu-HT-o4b"/>
                 <outlet property="headerBar" destination="UZ7-wW-FYi" id="4aa-pG-O4U"/>
@@ -25,8 +24,9 @@
                 <outlet property="largeTitleView" destination="nio-Wp-Ebw" id="cep-fi-6vl"/>
                 <outlet property="maxHeaderBottomSpacing" destination="MbU-Zk-mLK" id="LVn-jl-g9N"/>
                 <outlet property="minHeaderBottomSpacing" destination="wOf-4J-lXq" id="8Pp-zi-ErG"/>
-                <outlet property="previewBtn" destination="HeJ-NR-hHA" id="afV-HA-5GH"/>
+                <outlet property="primaryActionButton" destination="cck-0Q-rBD" id="Y0w-MZ-C18"/>
                 <outlet property="promptView" destination="bxz-wi-I73" id="O9L-j8-Peu"/>
+                <outlet property="secondaryActionButton" destination="HeJ-NR-hHA" id="afV-HA-5GH"/>
                 <outlet property="selectedStateButtonsContainer" destination="xLP-0m-3rr" id="mPa-xF-Hff"/>
                 <outlet property="subtitleToCategoryBarSpacing" destination="LOU-MU-PJx" id="jgY-Bn-wH6"/>
                 <outlet property="titleToSubtitleSpacing" destination="yo1-TE-BW8" id="uQ6-LG-Y3O"/>

--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.xib
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CollapsableHeaderViewController" customModule="WordPress" customModuleProvider="target">
+            <connections>
+                <outlet property="closeButton" destination="uxA-nG-zFs" id="Pp0-9y-rhJ"/>
+                <outlet property="containerView" destination="WmP-bw-ceT" id="lul-gs-fMI"/>
+                <outlet property="createBlankPageBtn" destination="dmc-kV-0d8" id="NfO-bU-Zl7"/>
+                <outlet property="createPageBtn" destination="cck-0Q-rBD" id="Y0w-MZ-C18"/>
+                <outlet property="filterBar" destination="DE5-R9-8tB" id="IAj-gK-2g6"/>
+                <outlet property="footerView" destination="UfV-hu-KZx" id="LZu-HT-o4b"/>
+                <outlet property="headerBar" destination="UZ7-wW-FYi" id="4aa-pG-O4U"/>
+                <outlet property="headerHeightConstraint" destination="dks-Bz-gRQ" id="PfP-C9-RWM"/>
+                <outlet property="headerView" destination="LGN-fD-c9Q" id="sXv-v4-bqj"/>
+                <outlet property="initialHeaderTopConstraint" destination="tcz-y3-AwH" id="Vs9-Bf-urr"/>
+                <outlet property="largeTitleView" destination="nio-Wp-Ebw" id="cep-fi-6vl"/>
+                <outlet property="maxHeaderBottomSpacing" destination="MbU-Zk-mLK" id="LVn-jl-g9N"/>
+                <outlet property="minHeaderBottomSpacing" destination="wOf-4J-lXq" id="8Pp-zi-ErG"/>
+                <outlet property="previewBtn" destination="HeJ-NR-hHA" id="afV-HA-5GH"/>
+                <outlet property="promptView" destination="bxz-wi-I73" id="O9L-j8-Peu"/>
+                <outlet property="selectedStateButtonsContainer" destination="xLP-0m-3rr" id="mPa-xF-Hff"/>
+                <outlet property="subtitleToCategoryBarSpacing" destination="LOU-MU-PJx" id="jgY-Bn-wH6"/>
+                <outlet property="titleToSubtitleSpacing" destination="yo1-TE-BW8" id="uQ6-LG-Y3O"/>
+                <outlet property="titleView" destination="ZLd-6x-CZD" id="bsF-wj-Rdu"/>
+                <outlet property="view" destination="U3M-sT-nKQ" id="MUQ-Hw-DWi"/>
+                <outletCollection property="visualEffects" destination="0Qq-k5-kWr" collectionClass="NSMutableArray" id="O3m-zF-fOy"/>
+                <outletCollection property="visualEffects" destination="qxH-Si-bGn" collectionClass="NSMutableArray" id="vFL-eT-78Y"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="U3M-sT-nKQ">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WmP-bw-ceT" userLabel="Child Container">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </view>
+                <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Qq-k5-kWr">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="305.5"/>
+                    <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.69999998807907104" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="JJ1-pb-5F1">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="305.5"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <color key="tintColor" systemColor="systemBackgroundColor"/>
+                    <vibrancyEffect style="fill">
+                        <blurEffect style="systemChromeMaterial"/>
+                    </vibrancyEffect>
+                </visualEffectView>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UZ7-wW-FYi" userLabel="Header Bar">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
+                    <subviews>
+                        <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose a Layout" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZLd-6x-CZD">
+                            <rect key="frame" x="143.5" y="62" width="127.5" height="20.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                            <variation key="heightClass=compact" hidden="NO"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uxA-nG-zFs" userLabel="Close">
+                            <rect key="frame" x="371" y="57" width="30" height="30"/>
+                            <color key="backgroundColor" systemColor="systemFillColor"/>
+                            <accessibility key="accessibilityConfiguration" label="Close"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="30" id="8cI-NP-F53"/>
+                                <constraint firstAttribute="width" secondItem="uxA-nG-zFs" secondAttribute="height" multiplier="1:1" id="KqJ-Nc-00B"/>
+                            </constraints>
+                            <color key="tintColor" systemColor="secondaryLabelColor"/>
+                            <inset key="contentEdgeInsets" minX="2" minY="2" maxX="2" maxY="2"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                    <integer key="value" value="15"/>
+                                </userDefinedRuntimeAttribute>
+                            </userDefinedRuntimeAttributes>
+                            <connections>
+                                <action selector="closeSelected:" destination="-1" eventType="touchUpInside" id="1pT-l2-z6W"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="ZLd-6x-CZD" firstAttribute="top" relation="greaterThanOrEqual" secondItem="UZ7-wW-FYi" secondAttribute="top" id="2Xs-UD-gf1"/>
+                        <constraint firstItem="ZLd-6x-CZD" firstAttribute="centerX" secondItem="UZ7-wW-FYi" secondAttribute="centerX" id="UWU-OH-B6J"/>
+                        <constraint firstItem="ZLd-6x-CZD" firstAttribute="centerY" secondItem="uxA-nG-zFs" secondAttribute="centerY" id="Y6L-97-Huh"/>
+                        <constraint firstItem="uxA-nG-zFs" firstAttribute="top" relation="greaterThanOrEqual" secondItem="UZ7-wW-FYi" secondAttribute="top" constant="13" id="gSh-Kw-Z03"/>
+                        <constraint firstAttribute="bottom" secondItem="uxA-nG-zFs" secondAttribute="bottom" constant="13" id="qDy-4y-t1r"/>
+                        <constraint firstItem="uxA-nG-zFs" firstAttribute="width" secondItem="uxA-nG-zFs" secondAttribute="height" multiplier="1:1" id="r29-jf-HGj"/>
+                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ZLd-6x-CZD" secondAttribute="bottom" id="sff-7j-JoX"/>
+                    </constraints>
+                </view>
+                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LGN-fD-c9Q" userLabel="Header View">
+                    <rect key="frame" x="0.0" y="100" width="414" height="205.5"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Get started by choosing from a wide variety of pre-made page layouts. Or just start with a blank page." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bxz-wi-I73">
+                            <rect key="frame" x="67" y="53" width="280" height="64.5"/>
+                            <constraints>
+                                <constraint firstAttribute="width" priority="750" constant="280" id="bav-Si-etZ"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <color key="textColor" systemColor="secondaryLabelColor"/>
+                            <nil key="highlightedColor"/>
+                            <variation key="heightClass=compact" hidden="YES"/>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Choose a Layout" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nio-Wp-Ebw">
+                            <rect key="frame" x="84.5" y="0.0" width="245" height="41"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                            <variation key="heightClass=compact" hidden="YES"/>
+                        </label>
+                        <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="DE5-R9-8tB" customClass="CollapsableHeaderFilterBar" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="137.5" width="414" height="44"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="44" id="Eej-Tm-ddy"/>
+                            </constraints>
+                            <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="12" id="2U8-JP-Gbh">
+                                <size key="itemSize" width="105" height="44"/>
+                                <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                <inset key="sectionInset" minX="20" minY="0.0" maxX="20" maxY="0.0"/>
+                            </collectionViewFlowLayout>
+                            <cells/>
+                        </collectionView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9w9-KC-2W9" userLabel="Seperator">
+                            <rect key="frame" x="0.0" y="205" width="414" height="0.5"/>
+                            <color key="backgroundColor" systemColor="separatorColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="0.5" id="Q9V-Av-JqM"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="DE5-R9-8tB" firstAttribute="top" secondItem="bxz-wi-I73" secondAttribute="bottom" constant="20" id="LOU-MU-PJx"/>
+                        <constraint firstAttribute="bottom" secondItem="DE5-R9-8tB" secondAttribute="bottom" priority="750" constant="24" id="MbU-Zk-mLK"/>
+                        <constraint firstItem="nio-Wp-Ebw" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="LGN-fD-c9Q" secondAttribute="leading" constant="5" id="Naz-hw-4xT"/>
+                        <constraint firstItem="bxz-wi-I73" firstAttribute="centerX" secondItem="LGN-fD-c9Q" secondAttribute="centerX" id="NvC-eg-qbU"/>
+                        <constraint firstItem="nio-Wp-Ebw" firstAttribute="centerX" secondItem="LGN-fD-c9Q" secondAttribute="centerX" id="UNn-H7-WWo"/>
+                        <constraint firstItem="9w9-KC-2W9" firstAttribute="leading" secondItem="LGN-fD-c9Q" secondAttribute="leading" id="X3f-jY-uff"/>
+                        <constraint firstAttribute="trailing" secondItem="DE5-R9-8tB" secondAttribute="trailing" id="a3z-v1-Ujv"/>
+                        <constraint firstAttribute="trailing" secondItem="9w9-KC-2W9" secondAttribute="trailing" id="bqi-CI-mnl"/>
+                        <constraint firstAttribute="height" constant="205.5" id="dks-Bz-gRQ"/>
+                        <constraint firstItem="bxz-wi-I73" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="LGN-fD-c9Q" secondAttribute="leading" constant="20" id="guA-LW-Zer">
+                            <variation key="widthClass=regular" constant="170"/>
+                        </constraint>
+                        <constraint firstAttribute="bottom" secondItem="9w9-KC-2W9" secondAttribute="bottom" id="ntw-Of-ryN"/>
+                        <constraint firstItem="DE5-R9-8tB" firstAttribute="leading" secondItem="LGN-fD-c9Q" secondAttribute="leading" id="qOR-nT-mJQ"/>
+                        <constraint firstItem="nio-Wp-Ebw" firstAttribute="top" secondItem="LGN-fD-c9Q" secondAttribute="top" id="tcz-y3-AwH"/>
+                        <constraint firstItem="DE5-R9-8tB" firstAttribute="top" secondItem="LGN-fD-c9Q" secondAttribute="top" id="uVe-Ze-eIF"/>
+                        <constraint firstItem="DE5-R9-8tB" firstAttribute="top" relation="greaterThanOrEqual" secondItem="LGN-fD-c9Q" secondAttribute="top" id="wKv-4h-bvX"/>
+                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="DE5-R9-8tB" secondAttribute="bottom" constant="9" id="wOf-4J-lXq"/>
+                        <constraint firstItem="bxz-wi-I73" firstAttribute="top" secondItem="nio-Wp-Ebw" secondAttribute="bottom" constant="12" id="yo1-TE-BW8"/>
+                    </constraints>
+                    <variation key="default">
+                        <mask key="constraints">
+                            <exclude reference="dks-Bz-gRQ"/>
+                            <exclude reference="uVe-Ze-eIF"/>
+                        </mask>
+                    </variation>
+                    <variation key="heightClass=compact">
+                        <mask key="constraints">
+                            <exclude reference="dks-Bz-gRQ"/>
+                            <exclude reference="yo1-TE-BW8"/>
+                            <include reference="LOU-MU-PJx"/>
+                            <exclude reference="MbU-Zk-mLK"/>
+                            <include reference="uVe-Ze-eIF"/>
+                        </mask>
+                    </variation>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UfV-hu-KZx" userLabel="Footer View">
+                    <rect key="frame" x="0.0" y="786" width="414" height="110"/>
+                    <subviews>
+                        <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qxH-Si-bGn">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="110"/>
+                            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.69999998807907104" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="X8b-Ge-Itm">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="110"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
+                            <color key="tintColor" systemColor="systemBackgroundColor"/>
+                            <vibrancyEffect style="fill">
+                                <blurEffect style="systemChromeMaterial"/>
+                            </vibrancyEffect>
+                        </visualEffectView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jCA-DJ-MgS" userLabel="Seperator">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
+                            <color key="backgroundColor" systemColor="separatorColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="0.5" id="DKq-so-Z8k"/>
+                            </constraints>
+                        </view>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dmc-kV-0d8">
+                            <rect key="frame" x="20" y="16" width="374" height="44"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="44" id="9bL-Jo-3aw"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                            <state key="normal" title="Create Blank Page">
+                                <color key="titleColor" systemColor="labelColor"/>
+                            </state>
+                            <connections>
+                                <action selector="defaultActionSelected:" destination="-1" eventType="touchUpInside" id="d2H-aW-Shz"/>
+                            </connections>
+                        </button>
+                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xLP-0m-3rr">
+                            <rect key="frame" x="20" y="16" width="374" height="44"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HeJ-NR-hHA">
+                                    <rect key="frame" x="0.0" y="0.0" width="182" height="44"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
+                                    <state key="normal" title="Preview">
+                                        <color key="titleColor" systemColor="labelColor"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="secondaryActionSelected:" destination="-1" eventType="touchUpInside" id="fGK-R9-pK4"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cck-0Q-rBD">
+                                    <rect key="frame" x="192" y="0.0" width="182" height="44"/>
+                                    <color key="backgroundColor" name="Pink50"/>
+                                    <state key="normal" title="Create Page">
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="primaryActionSelected:" destination="-1" eventType="touchUpInside" id="YUD-TB-HxA"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstItem="cck-0Q-rBD" firstAttribute="width" secondItem="xLP-0m-3rr" secondAttribute="width" multiplier="0.5" constant="-5" id="26X-1h-3jp"/>
+                                <constraint firstAttribute="height" constant="44" id="AUa-es-Pw9"/>
+                                <constraint firstItem="HeJ-NR-hHA" firstAttribute="leading" secondItem="xLP-0m-3rr" secondAttribute="leading" id="E6P-f3-kf7"/>
+                                <constraint firstItem="HeJ-NR-hHA" firstAttribute="width" secondItem="xLP-0m-3rr" secondAttribute="width" multiplier="0.5" constant="-5" id="F49-9j-ilB"/>
+                                <constraint firstItem="cck-0Q-rBD" firstAttribute="top" secondItem="xLP-0m-3rr" secondAttribute="top" id="amE-U6-15J"/>
+                                <constraint firstAttribute="trailing" secondItem="cck-0Q-rBD" secondAttribute="trailing" id="k26-u8-QNP"/>
+                                <constraint firstAttribute="bottom" secondItem="cck-0Q-rBD" secondAttribute="bottom" id="kw6-8R-EPs"/>
+                                <constraint firstItem="HeJ-NR-hHA" firstAttribute="top" secondItem="xLP-0m-3rr" secondAttribute="top" id="kyb-gD-SeS"/>
+                                <constraint firstAttribute="bottom" secondItem="HeJ-NR-hHA" secondAttribute="bottom" id="ntG-KY-0Eg"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="qxH-Si-bGn" firstAttribute="leading" secondItem="UfV-hu-KZx" secondAttribute="leading" id="4y3-db-p8j"/>
+                        <constraint firstAttribute="trailing" secondItem="jCA-DJ-MgS" secondAttribute="trailing" id="Msd-NV-Dt9"/>
+                        <constraint firstItem="qxH-Si-bGn" firstAttribute="top" secondItem="UfV-hu-KZx" secondAttribute="top" id="Sdv-Fh-3JR"/>
+                        <constraint firstItem="xLP-0m-3rr" firstAttribute="top" secondItem="UfV-hu-KZx" secondAttribute="top" constant="16" id="UKO-gp-8A5"/>
+                        <constraint firstAttribute="bottom" secondItem="qxH-Si-bGn" secondAttribute="bottom" id="ZsV-Vw-hdo"/>
+                        <constraint firstItem="jCA-DJ-MgS" firstAttribute="leading" secondItem="UfV-hu-KZx" secondAttribute="leading" id="jdx-th-4uc"/>
+                        <constraint firstItem="dmc-kV-0d8" firstAttribute="top" secondItem="UfV-hu-KZx" secondAttribute="top" constant="16" id="lU4-Sj-dcL"/>
+                        <constraint firstItem="jCA-DJ-MgS" firstAttribute="top" secondItem="UfV-hu-KZx" secondAttribute="top" id="v6p-Jz-Saz"/>
+                        <constraint firstAttribute="trailing" secondItem="qxH-Si-bGn" secondAttribute="trailing" id="yT0-ne-uGv"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="0a4-LI-57Y"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstAttribute="bottom" secondItem="UfV-hu-KZx" secondAttribute="bottom" id="18E-U6-772"/>
+                <constraint firstAttribute="trailing" secondItem="UZ7-wW-FYi" secondAttribute="trailing" id="3R4-ls-twS"/>
+                <constraint firstItem="WmP-bw-ceT" firstAttribute="leading" secondItem="0a4-LI-57Y" secondAttribute="leading" id="E8Q-Ya-VH2"/>
+                <constraint firstItem="0a4-LI-57Y" firstAttribute="trailing" secondItem="uxA-nG-zFs" secondAttribute="trailing" constant="13" id="G5L-Lz-8Bh"/>
+                <constraint firstItem="0Qq-k5-kWr" firstAttribute="leading" secondItem="U3M-sT-nKQ" secondAttribute="leading" id="Gbb-Mc-Rbf"/>
+                <constraint firstItem="WmP-bw-ceT" firstAttribute="trailing" secondItem="0a4-LI-57Y" secondAttribute="trailing" id="IEC-aq-Jdg"/>
+                <constraint firstItem="LGN-fD-c9Q" firstAttribute="top" secondItem="UZ7-wW-FYi" secondAttribute="bottom" id="Icl-E5-W4j"/>
+                <constraint firstAttribute="bottom" secondItem="WmP-bw-ceT" secondAttribute="bottom" id="Nhd-PS-v0n"/>
+                <constraint firstItem="UfV-hu-KZx" firstAttribute="trailing" secondItem="U3M-sT-nKQ" secondAttribute="trailing" id="NjJ-wX-zxg"/>
+                <constraint firstItem="0a4-LI-57Y" firstAttribute="trailing" secondItem="xLP-0m-3rr" secondAttribute="trailing" constant="20" id="Ocz-OA-dkn"/>
+                <constraint firstItem="uxA-nG-zFs" firstAttribute="top" secondItem="0a4-LI-57Y" secondAttribute="top" constant="13" id="TnA-93-Oo9"/>
+                <constraint firstItem="LGN-fD-c9Q" firstAttribute="trailing" secondItem="U3M-sT-nKQ" secondAttribute="trailing" id="USb-Ex-vxP"/>
+                <constraint firstItem="UZ7-wW-FYi" firstAttribute="top" secondItem="U3M-sT-nKQ" secondAttribute="top" id="Wkr-ux-jJa"/>
+                <constraint firstItem="0a4-LI-57Y" firstAttribute="bottom" secondItem="xLP-0m-3rr" secondAttribute="bottom" constant="16" id="XTi-C4-Mxf"/>
+                <constraint firstAttribute="trailing" secondItem="0Qq-k5-kWr" secondAttribute="trailing" id="XxU-6u-RcX"/>
+                <constraint firstItem="xLP-0m-3rr" firstAttribute="leading" secondItem="0a4-LI-57Y" secondAttribute="leading" constant="20" id="caz-IN-HQX"/>
+                <constraint firstItem="0a4-LI-57Y" firstAttribute="trailing" secondItem="dmc-kV-0d8" secondAttribute="trailing" constant="20" id="cxE-O8-ska"/>
+                <constraint firstItem="0Qq-k5-kWr" firstAttribute="top" secondItem="UZ7-wW-FYi" secondAttribute="top" id="fJ8-nE-fRq"/>
+                <constraint firstItem="dmc-kV-0d8" firstAttribute="leading" secondItem="0a4-LI-57Y" secondAttribute="leading" constant="20" id="gMc-5F-M6S"/>
+                <constraint firstItem="UZ7-wW-FYi" firstAttribute="leading" secondItem="U3M-sT-nKQ" secondAttribute="leading" id="i7c-8T-4PJ"/>
+                <constraint firstItem="0a4-LI-57Y" firstAttribute="bottom" secondItem="dmc-kV-0d8" secondAttribute="bottom" constant="16" id="l61-SQ-FeO"/>
+                <constraint firstItem="UfV-hu-KZx" firstAttribute="leading" secondItem="U3M-sT-nKQ" secondAttribute="leading" id="msf-aW-ktk"/>
+                <constraint firstItem="0Qq-k5-kWr" firstAttribute="bottom" secondItem="LGN-fD-c9Q" secondAttribute="bottom" id="p8r-IQ-pZK"/>
+                <constraint firstItem="LGN-fD-c9Q" firstAttribute="leading" secondItem="U3M-sT-nKQ" secondAttribute="leading" id="uNo-VY-vcT"/>
+                <constraint firstItem="WmP-bw-ceT" firstAttribute="top" secondItem="U3M-sT-nKQ" secondAttribute="top" id="yIx-Dt-kfa"/>
+            </constraints>
+            <point key="canvasLocation" x="-230.43478260869566" y="-881.25"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="Pink50">
+            <color red="0.78823529411764703" green="0.20784313725490197" blue="0.43137254901960786" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="separatorColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemFillColor">
+            <color red="0.47058823529411764" green="0.47058823529411764" blue="0.50196078431372548" alpha="0.20000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
@@ -15,95 +15,23 @@ class GutenbergLayoutSection {
     }
 }
 
-class GutenbergLayoutPickerViewController: UIViewController {
+class GutenbergLayoutPickerViewController: UIViewController, CollapsableHeaderDataSource, CollapsableHeaderDelegate {
+    let defaultActionTitle = NSLocalizedString("Create Blank Page", comment: "Title for button to make a blank page")
+    let primaryActionTitle = NSLocalizedString("Create Page", comment: "Title for button to make a page with the contents of the selected layout")
+    let secondaryActionTitle = NSLocalizedString("Preview", comment: "Title for button to preview a selected layout")
+    let mainTitle = NSLocalizedString("Choose a Layout", comment: "Title for the screen to pick a template for a page")
+    let prompt = NSLocalizedString("Get started by choosing from a wide variety of pre-made page layouts. Or just start with a blank page.", comment: "Prompt for the screen to pick a template for a page")
+    weak var headerContentsDelegate: CollapsableHeaderContentsDelegate?
 
-    @IBOutlet weak var headerBar: UIView!
-    @IBOutlet weak var headerView: UIView!
-    @IBOutlet weak var closeButton: UIButton!
-    @IBOutlet weak var titleView: UILabel!
-    @IBOutlet weak var largeTitleView: UILabel!
-    @IBOutlet weak var promptView: UILabel!
-    @IBOutlet weak var filterBar: GutenbergLayoutFilterBar!
     @IBOutlet weak var tableView: UITableView!
-    @IBOutlet weak var footerView: UIView!
-    @IBOutlet weak var createBlankPageBtn: UIButton!
-    @IBOutlet weak var previewBtn: UIButton!
-    @IBOutlet weak var createPageBtn: UIButton!
-    @IBOutlet weak var selectedStateButtonsContainer: UIView!
-
-    /// This  is used as a means to adapt to different text sizes to force the desired layout and then active `headerHeightConstraint`
-    /// when scrolling begins to allow pushing the non static items out of the scrollable area.
-    @IBOutlet weak var initialHeaderTopConstraint: NSLayoutConstraint!
-    @IBOutlet weak var headerHeightConstraint: NSLayoutConstraint!
-    @IBOutlet weak var titleToSubtitleSpacing: NSLayoutConstraint!
-    @IBOutlet weak var subtitleToCategoryBarSpacing: NSLayoutConstraint!
-    @IBOutlet weak var minHeaderBottomSpacing: NSLayoutConstraint!
-    @IBOutlet weak var maxHeaderBottomSpacing: NSLayoutConstraint!
-    @IBOutlet var visualEffects: [UIVisualEffectView]! {
-        didSet {
-            if #available(iOS 13.0, *) {
-                visualEffects.forEach { (visualEffect) in
-                    visualEffect.effect = UIBlurEffect.init(style: .systemChromeMaterial)
-                }
-            }
-        }
-    }
-
-    private var shouldUseCompactLayout: Bool {
-        return traitCollection.verticalSizeClass == .compact
-    }
-
-    private var _maxHeaderHeight: CGFloat = 0
-    private var maxHeaderHeight: CGFloat {
-        if shouldUseCompactLayout {
-            return minHeaderHeight
-        } else {
-            return _maxHeaderHeight
-        }
-    }
-
-    private var _midHeaderHeight: CGFloat = 0
-    private var midHeaderHeight: CGFloat {
-        if shouldUseCompactLayout {
-            return minHeaderHeight
-        } else {
-            return _midHeaderHeight
-        }
-    }
-    private var minHeaderHeight: CGFloat = 0
-
-    private var titleIsHidden: Bool = true {
-        didSet {
-            if oldValue != titleIsHidden {
-                titleView.isHidden = false
-                let alpha: CGFloat = titleIsHidden ? 0 : 1
-                UIView.animate(withDuration: 0.4, delay: 0, options: .transitionCrossDissolve, animations: {
-                    self.titleView.alpha = alpha
-                }) { (_) in
-                    self.titleView.isHidden = self.titleIsHidden
-                }
-            }
-        }
-    }
-
-    var accentColor: UIColor {
-        if #available(iOS 13.0, *) {
-            return UIColor { (traitCollection: UITraitCollection) -> UIColor in
-                if traitCollection.userInterfaceStyle == .dark {
-                    return UIColor.muriel(color: .accent, .shade40)
-                } else {
-                    return UIColor.muriel(color: .accent, .shade50)
-                }
-            }
-        } else {
-            return UIColor.muriel(color: .accent, .shade50)
-        }
+    var scrollView: UIScrollView {
+        return tableView
     }
 
     private var selectedLayout: IndexPath? = nil {
         didSet {
             if !(oldValue != nil && selectedLayout != nil) {
-                layoutSelected(selectedLayout != nil)
+                headerContentsDelegate?.itemSelectionChanged(selectedLayout != nil)
             }
         }
     }
@@ -118,8 +46,7 @@ class GutenbergLayoutPickerViewController: UIViewController {
 
     private var isLoading: Bool = true {
         didSet {
-            filterBar.shouldShowGhostContent = isLoading
-            filterBar.allowsMultipleSelection = !isLoading
+            headerContentsDelegate?.loadingStateChanged(isLoading)
             if isLoading {
                 tableView.startGhostAnimation(style: GhostCellStyle.muriel)
             } else {
@@ -127,45 +54,16 @@ class GutenbergLayoutPickerViewController: UIViewController {
             }
 
             tableView.reloadData()
-            filterBar.reloadData()
         }
     }
 
     var completion: PageCoordinator.TemplateSelectionCompletion? = nil
     var blog: Blog? = nil
 
-    private func setStaticText() {
-        closeButton.accessibilityLabel = NSLocalizedString("Close", comment: "Dismisses the current screen")
-
-        let translatedTitle = NSLocalizedString("Choose a Layout", comment: "Title for the screen to pick a template for a page")
-        titleView.text = translatedTitle
-        largeTitleView.text = translatedTitle
-
-        promptView.text = NSLocalizedString("Get started by choosing from a wide variety of pre-made page layouts. Or just start with a blank page.", comment: "Prompt for the screen to pick a template for a page")
-        createBlankPageBtn.setTitle(NSLocalizedString("Create Blank Page", comment: "Title for button to make a blank page"), for: .normal)
-        previewBtn.setTitle(NSLocalizedString("Preview", comment: "Title for button to preview a selected layout"), for: .normal)
-        createPageBtn.setTitle(NSLocalizedString("Create Page", comment: "Title for button to make a page with the contents of the selected layout"), for: .normal)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.register(LayoutPickerSectionTableViewCell.nib, forCellReuseIdentifier: LayoutPickerSectionTableViewCell.cellReuseIdentifier)
         fetchLayouts()
-        filterBar.filterDelegate = self
-        setStaticText()
-        closeButton.setImage(UIImage.gridicon(.crossSmall), for: .normal)
-        styleButtons()
-        layoutHeader()
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        navigationController?.setNavigationBarHidden(true, animated: true)
-        super.viewWillAppear(animated)
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        navigationController?.isNavigationBarHidden = false
-        super.viewDidDisappear(animated)
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -186,37 +84,11 @@ class GutenbergLayoutPickerViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if #available(iOS 13.0, *) {
-            if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-                styleButtons()
-            }
-        }
-
         if let previousTraitCollection = previousTraitCollection, traitCollection.verticalSizeClass != previousTraitCollection.verticalSizeClass {
-            layoutTableViewHeader()
             if let visibleRow = tableView.indexPathsForVisibleRows?.first {
                 tableView.scrollToRow(at: visibleRow, at: .top, animated: true)
             }
         }
-    }
-
-    @IBAction func closeModal(_ sender: Any) {
-        dismiss(animated: true, completion: nil)
-    }
-
-    @IBAction func createBlankPageTapped(_ sender: Any) {
-        createPage(layout: nil)
-    }
-
-    @IBAction func createPageTapped(_ sender: Any) {
-        guard let sectionIndex = selectedLayout?.section, let position = selectedLayout?.item else {
-            createPage(layout: nil)
-            return
-        }
-
-        let layout = sections[sectionIndex].layouts[position]
-        LayoutPickerAnalyticsEvent.templateApplied(slug: layout.slug)
-        createPage(layout: layout)
     }
 
     private func createPage(layout: PageTemplateLayout?) {
@@ -227,101 +99,6 @@ class GutenbergLayoutPickerViewController: UIViewController {
 
         dismiss(animated: true) {
             completion(layout)
-        }
-    }
-
-    private func styleButtons() {
-        let seperator: UIColor
-        if #available(iOS 13.0, *) {
-            seperator = .separator
-        } else {
-            seperator = UIColor.muriel(color: .divider)
-        }
-
-        [createBlankPageBtn, previewBtn].forEach { (button) in
-            button?.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
-            button?.layer.borderColor = seperator.cgColor
-            button?.layer.borderWidth = 1
-            button?.layer.cornerRadius = 8
-        }
-
-        createPageBtn.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
-        createPageBtn.backgroundColor = accentColor
-        createPageBtn.layer.cornerRadius = 8
-
-        if #available(iOS 13.0, *) {
-            closeButton.backgroundColor = UIColor { (traitCollection: UITraitCollection) -> UIColor in
-                if traitCollection.userInterfaceStyle == .dark {
-                    return UIColor.systemFill
-                } else {
-                    return UIColor.quaternarySystemFill
-                }
-            }
-        }
-    }
-
-    private func layoutTableViewHeader() {
-        let topInset = maxHeaderHeight + headerBar.frame.height
-        tableView.tableHeaderView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: topInset))
-        updateTableViewFooter()
-    }
-
-    /*
-     * Calculates the needed space for the footer to allow the header to still collapse but also to prevent unneeded space
-     * at the bottome of the tableView when multiple cells are rendered.
-     */
-    private func updateTableViewFooter() {
-        let estimatedRowHeight: CGFloat = LayoutPickerSectionTableViewCell.estimatedCellHeight
-        let minimumFooterSize = footerView.frame.size.height + (UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0)
-        let rowCount = CGFloat(max((filteredSections ?? sections).count, 1))
-
-        /// The needed distance to fill the rest of the screen to allow the header to still collapse when scrolling (or to maintain a collapsed header if it was already collapsed when selecting a filter)
-        let distanceToBottom = tableView.frame.height - headerBar.frame.height - minHeaderHeight - (estimatedRowHeight * rowCount)
-        let newHeight: CGFloat = max(minimumFooterSize, distanceToBottom)
-
-        tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: newHeight))
-        tableView.tableFooterView?.isGhostableDisabled = true
-    }
-
-    private func calculateHeaderSnapPoints() {
-        minHeaderHeight = filterBar.frame.height + minHeaderBottomSpacing.constant
-        _midHeaderHeight = titleToSubtitleSpacing.constant + promptView.frame.height + subtitleToCategoryBarSpacing.constant + filterBar.frame.height + maxHeaderBottomSpacing.constant
-        _maxHeaderHeight = largeTitleView.frame.height + _midHeaderHeight
-    }
-
-    private func layoutHeader() {
-        largeTitleView.font = WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.largeTitle, fontWeight: .semibold)
-        titleView.font = WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.largeTitle, fontWeight: .semibold).withSize(17)
-
-        headerView.setNeedsLayout()
-        headerView.layoutIfNeeded()
-        footerView.setNeedsLayout()
-        footerView.layoutIfNeeded()
-
-        calculateHeaderSnapPoints()
-        layoutTableViewHeader()
-
-        tableView.tableHeaderView?.backgroundColor = .clear
-        tableView.tableFooterView?.backgroundColor = .clear
-    }
-
-    private func layoutSelected(_ isSelected: Bool) {
-        createBlankPageBtn.isHidden = false
-        selectedStateButtonsContainer.isHidden = false
-
-        createBlankPageBtn.alpha = isSelected ? 1 : 0
-        selectedStateButtonsContainer.alpha = isSelected ? 0 : 1
-
-        let alpha: CGFloat = isSelected ? 0 : 1
-        let selectedStateContainerAlpha: CGFloat = isSelected ? 1 : 0
-
-
-        UIView.animate(withDuration: LayoutPickerCollectionViewCell.selectionAnimationSpeed, delay: 0, options: .transitionCrossDissolve, animations: {
-            self.createBlankPageBtn.alpha = alpha
-            self.selectedStateButtonsContainer.alpha = selectedStateContainerAlpha
-        }) { (_) in
-            self.createBlankPageBtn.isHidden = isSelected
-            self.selectedStateButtonsContainer.isHidden = !isSelected
         }
     }
 
@@ -337,69 +114,24 @@ class GutenbergLayoutPickerViewController: UIViewController {
             return GutenbergLayoutSection(category)
         }) ?? []
     }
-}
 
-extension GutenbergLayoutPickerViewController: UITableViewDelegate {
+    func defaultActionSelected() {
+        createPage(layout: nil)
+    }
 
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard !shouldUseCompactLayout else {
-            titleIsHidden = false
+    func primaryActionSelected() {
+        guard let sectionIndex = selectedLayout?.section, let position = selectedLayout?.item else {
+            createPage(layout: nil)
             return
         }
 
-        if !headerHeightConstraint.isActive {
-            initialHeaderTopConstraint.isActive = false
-            headerHeightConstraint.isActive = true
-        }
-
-        let scrollOffset = scrollView.contentOffset.y
-        let newHeaderViewHeight = maxHeaderHeight - scrollOffset
-
-        if newHeaderViewHeight < minHeaderHeight {
-            headerHeightConstraint.constant = minHeaderHeight
-        } else {
-            headerHeightConstraint.constant = newHeaderViewHeight
-        }
-
-        titleIsHidden = largeTitleView.frame.maxY > 0
+        let layout = sections[sectionIndex].layouts[position]
+        LayoutPickerAnalyticsEvent.templateApplied(slug: layout.slug)
+        createPage(layout: layout)
     }
 
-    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        snapToHeight(scrollView)
-    }
-
-    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
-        if !decelerate {
-            snapToHeight(scrollView)
-        }
-    }
-
-    private func snapToHeight(_ scrollView: UIScrollView) {
-        guard !shouldUseCompactLayout else { return }
-
-        if largeTitleView.frame.midY > 0 {
-            snapToHeight(scrollView, height: maxHeaderHeight)
-        } else if promptView.frame.midY > 0 {
-            snapToHeight(scrollView, height: midHeaderHeight)
-        } else if headerHeightConstraint.constant != minHeaderHeight {
-            snapToHeight(scrollView, height: minHeaderHeight)
-        }
-    }
-
-    private func snapToHeight(_ scrollView: UIScrollView, height: CGFloat) {
-        scrollView.contentOffset.y = maxHeaderHeight - height
-        headerHeightConstraint.constant = height
-        titleIsHidden = (height >= maxHeaderHeight) && !shouldUseCompactLayout
-        UIView.animate(withDuration: 0.4, delay: 0, usingSpringWithDamping: 0.7, initialSpringVelocity: 0.5, options: .curveEaseInOut, animations: {
-            self.headerView.setNeedsLayout()
-            self.headerView.layoutIfNeeded()
-        }, completion: nil)
-    }
-
-    private func containsSelectedLayout(_ selectedIndexPath: IndexPath, atIndexPath indexPath: IndexPath) -> Bool {
-        let rowSection = (filteredSections ?? sections)[indexPath.row]
-        let sectionSlug = sections[selectedIndexPath.section].section.slug
-        return (sectionSlug == rowSection.section.slug)
+    func secondaryActionSelected() {
+        performSegue(withIdentifier: "preview", sender: nil)
     }
 }
 
@@ -430,6 +162,19 @@ extension GutenbergLayoutPickerViewController: UITableViewDataSource {
         }
 
         return cell
+    }
+
+    private func containsSelectedLayout(_ selectedIndexPath: IndexPath, atIndexPath indexPath: IndexPath) -> Bool {
+        let rowSection = (filteredSections ?? sections)[indexPath.row]
+        let sectionSlug = sections[selectedIndexPath.section].section.slug
+        return (sectionSlug == rowSection.section.slug)
+    }
+
+    func estimatedContentSize() -> CGSize {
+        let rowCount = CGFloat(max((filteredSections ?? sections).count, 1))
+        let estimatedRowHeight: CGFloat = LayoutPickerSectionTableViewCell.estimatedCellHeight
+        let estimatedHeight = (estimatedRowHeight * rowCount)
+        return CGSize(width: tableView.contentSize.width, height: estimatedHeight)
     }
 }
 
@@ -466,13 +211,13 @@ extension GutenbergLayoutPickerViewController: LayoutPickerSectionTableViewCellD
     }
 }
 
-extension GutenbergLayoutPickerViewController: FilterBarDelegate {
+extension GutenbergLayoutPickerViewController: CollapsableHeaderFilterBarDelegate {
     func numberOfFilters() -> Int {
         return sections.count
     }
 
-    func filter(forIndex index: Int) -> GutenbergLayoutSection {
-        return sections[index]
+    func filter(forIndex index: Int) -> CollabsableHeaderFilterOption {
+        return sections[index].section
     }
 
     func didSelectFilter(withIndex selectedIndex: IndexPath, withSelectedIndexes selectedIndexes: [IndexPath]) {
@@ -485,7 +230,7 @@ extension GutenbergLayoutPickerViewController: FilterBarDelegate {
 
         filteredSections = [sections[selectedIndex.item]]
         tableView.performBatchUpdates({
-            updateTableViewFooter()
+            headerContentsDelegate?.contentSizeWillChange()
             tableView.deleteRows(at: rowsToRemove, with: .fade)
         })
     }
@@ -501,7 +246,7 @@ extension GutenbergLayoutPickerViewController: FilterBarDelegate {
 
         tableView.performBatchUpdates({
             if selectedIndexes.count == 2 {
-                updateTableViewFooter()
+                headerContentsDelegate?.contentSizeWillChange()
             }
             tableView.reloadSections([0], with: .automatic)
         })
@@ -515,7 +260,7 @@ extension GutenbergLayoutPickerViewController: FilterBarDelegate {
 
         filteredSections = nil
         tableView.performBatchUpdates({
-            updateTableViewFooter()
+            headerContentsDelegate?.contentSizeWillChange()
             tableView.reloadSections([0], with: .fade)
         })
     }
@@ -536,7 +281,7 @@ extension GutenbergLayoutPickerViewController: FilterBarDelegate {
 
         guard let rowToRemove = row else { return }
         tableView.performBatchUpdates({
-            updateTableViewFooter()
+            headerContentsDelegate?.contentSizeWillChange()
             tableView.deleteRows(at: [rowToRemove], with: .fade)
         })
     }
@@ -548,6 +293,5 @@ extension GutenbergLayoutPickerViewController: NSFetchedResultsControllerDelegat
         sections = makeSectionData(with: resultsController)
         isLoading = resultsController.isEmpty()
         tableView.reloadData()
-        filterBar.reloadData()
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/LayoutPickerStoryboard.storyboard
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/LayoutPickerStoryboard.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aWE-F8-w6T">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="6uO-HR-ECX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -10,33 +10,16 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Gutenberg Light Navigation Controller-->
-        <scene sceneID="SGh-Er-MmG">
-            <objects>
-                <navigationController modalPresentationStyle="pageSheet" id="aWE-F8-w6T" customClass="GutenbergLightNavigationController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <modalPageSheetSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="fJE-kp-n4d">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="6uO-HR-ECX" kind="relationship" relationship="rootViewController" id="ljr-5Y-xox"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="R6x-45-g0O" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-858" y="-236"/>
-        </scene>
         <!--Gutenberg Layout Picker View Controller-->
         <scene sceneID="rwi-t4-8K6">
             <objects>
                 <viewController id="6uO-HR-ECX" customClass="GutenbergLayoutPickerViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="1ZG-pe-aDl">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" dataMode="prototypes" style="plain" separatorInsetReference="fromAutomaticInsets" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="eiU-pw-Xq6">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <connections>
@@ -44,256 +27,14 @@
                                     <outlet property="delegate" destination="6uO-HR-ECX" id="gWb-yc-zee"/>
                                 </connections>
                             </tableView>
-                            <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sUr-lt-a0R">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="261.5"/>
-                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.69999999999999996" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="r2i-Qw-xq3">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="261.5"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                </view>
-                                <color key="tintColor" systemColor="systemBackgroundColor"/>
-                                <vibrancyEffect style="fill">
-                                    <blurEffect style="systemChromeMaterial"/>
-                                </vibrancyEffect>
-                            </visualEffectView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uh3-j1-P0D">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
-                                <subviews>
-                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose a Layout" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Irb-2L-Gsp">
-                                        <rect key="frame" x="143.5" y="18" width="127.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                        <variation key="heightClass=compact" hidden="NO"/>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jOR-Cu-uXg" userLabel="Close">
-                                        <rect key="frame" x="371" y="13" width="30" height="30"/>
-                                        <color key="backgroundColor" systemColor="systemFillColor"/>
-                                        <accessibility key="accessibilityConfiguration" label="Close"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="jOR-Cu-uXg" secondAttribute="height" multiplier="1:1" id="6pg-Tz-WAp"/>
-                                            <constraint firstAttribute="width" constant="30" id="IBh-fH-Vyz"/>
-                                        </constraints>
-                                        <color key="tintColor" systemColor="secondaryLabelColor"/>
-                                        <inset key="contentEdgeInsets" minX="2" minY="2" maxX="2" maxY="2"/>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                <integer key="value" value="15"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <action selector="closeModal:" destination="6uO-HR-ECX" eventType="touchUpInside" id="I7L-ZE-mnH"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="Irb-2L-Gsp" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Uh3-j1-P0D" secondAttribute="top" id="2BV-R1-xth"/>
-                                    <constraint firstItem="Irb-2L-Gsp" firstAttribute="centerY" secondItem="jOR-Cu-uXg" secondAttribute="centerY" id="3fn-bf-ODB"/>
-                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Irb-2L-Gsp" secondAttribute="bottom" id="EA4-Ha-TPp"/>
-                                    <constraint firstItem="jOR-Cu-uXg" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Uh3-j1-P0D" secondAttribute="top" constant="13" id="J5v-Ec-gJ7"/>
-                                    <constraint firstItem="Irb-2L-Gsp" firstAttribute="centerX" secondItem="Uh3-j1-P0D" secondAttribute="centerX" id="UOb-Xb-XWn"/>
-                                    <constraint firstItem="jOR-Cu-uXg" firstAttribute="width" secondItem="jOR-Cu-uXg" secondAttribute="height" multiplier="1:1" id="aS9-dr-vpA"/>
-                                    <constraint firstAttribute="bottom" secondItem="jOR-Cu-uXg" secondAttribute="bottom" constant="13" id="pUu-vg-esB"/>
-                                </constraints>
-                            </view>
-                            <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DTZ-MR-Eqm">
-                                <rect key="frame" x="0.0" y="56" width="414" height="205.5"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Get started by choosing from a wide variety of pre-made page layouts. Or just start with a blank page." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yqC-YH-PXy">
-                                        <rect key="frame" x="67" y="53" width="280" height="64.5"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" priority="750" constant="280" id="uXu-Ky-l0r"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <color key="textColor" systemColor="secondaryLabelColor"/>
-                                        <nil key="highlightedColor"/>
-                                        <variation key="heightClass=compact" hidden="YES"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Choose a Layout" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S74-AK-pHd">
-                                        <rect key="frame" x="84.5" y="0.0" width="245" height="41"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                        <variation key="heightClass=compact" hidden="YES"/>
-                                    </label>
-                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="fhN-6z-taa" customClass="GutenbergLayoutFilterBar" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="137.5" width="414" height="44"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="Zmw-89-cy2"/>
-                                        </constraints>
-                                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="12" id="IPj-9L-w95">
-                                            <size key="itemSize" width="105" height="44"/>
-                                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                            <inset key="sectionInset" minX="20" minY="0.0" maxX="20" maxY="0.0"/>
-                                        </collectionViewFlowLayout>
-                                        <cells/>
-                                    </collectionView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4ff-7z-VN8" userLabel="Seperator">
-                                        <rect key="frame" x="0.0" y="205" width="414" height="0.5"/>
-                                        <color key="backgroundColor" systemColor="separatorColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="0.5" id="Gkn-GA-ugR"/>
-                                        </constraints>
-                                    </view>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="fhN-6z-taa" secondAttribute="trailing" id="3Zj-xu-kOK"/>
-                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="fhN-6z-taa" secondAttribute="bottom" constant="9" id="3wZ-NV-ETZ"/>
-                                    <constraint firstItem="S74-AK-pHd" firstAttribute="top" secondItem="DTZ-MR-Eqm" secondAttribute="top" id="4pf-bx-DHy"/>
-                                    <constraint firstItem="4ff-7z-VN8" firstAttribute="leading" secondItem="DTZ-MR-Eqm" secondAttribute="leading" id="Ckj-L2-I9f"/>
-                                    <constraint firstItem="S74-AK-pHd" firstAttribute="centerX" secondItem="DTZ-MR-Eqm" secondAttribute="centerX" id="D5r-df-4Ke"/>
-                                    <constraint firstAttribute="bottom" secondItem="4ff-7z-VN8" secondAttribute="bottom" id="GwS-lS-4cI"/>
-                                    <constraint firstItem="yqC-YH-PXy" firstAttribute="centerX" secondItem="DTZ-MR-Eqm" secondAttribute="centerX" id="NW7-GP-Ix1"/>
-                                    <constraint firstItem="fhN-6z-taa" firstAttribute="top" relation="greaterThanOrEqual" secondItem="DTZ-MR-Eqm" secondAttribute="top" id="OQo-1y-GIH"/>
-                                    <constraint firstItem="fhN-6z-taa" firstAttribute="top" secondItem="yqC-YH-PXy" secondAttribute="bottom" constant="20" id="TWT-Wj-G1p"/>
-                                    <constraint firstItem="S74-AK-pHd" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="DTZ-MR-Eqm" secondAttribute="leading" constant="5" id="Uqh-1Y-Vt5"/>
-                                    <constraint firstItem="fhN-6z-taa" firstAttribute="top" secondItem="DTZ-MR-Eqm" secondAttribute="top" id="X0m-zz-UO3"/>
-                                    <constraint firstItem="yqC-YH-PXy" firstAttribute="top" secondItem="S74-AK-pHd" secondAttribute="bottom" constant="12" id="h5U-Rb-Tvs"/>
-                                    <constraint firstAttribute="trailing" secondItem="4ff-7z-VN8" secondAttribute="trailing" id="lHV-hQ-Tyq"/>
-                                    <constraint firstItem="yqC-YH-PXy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="DTZ-MR-Eqm" secondAttribute="leading" constant="20" id="nEd-ak-pA5">
-                                        <variation key="widthClass=regular" constant="170"/>
-                                    </constraint>
-                                    <constraint firstItem="fhN-6z-taa" firstAttribute="leading" secondItem="DTZ-MR-Eqm" secondAttribute="leading" id="q90-Gh-IhP"/>
-                                    <constraint firstAttribute="bottom" secondItem="fhN-6z-taa" secondAttribute="bottom" priority="750" constant="24" id="vJ5-2N-JfP"/>
-                                    <constraint firstAttribute="height" constant="205.5" id="yrU-yj-SJL"/>
-                                </constraints>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="yrU-yj-SJL"/>
-                                        <exclude reference="X0m-zz-UO3"/>
-                                    </mask>
-                                </variation>
-                                <variation key="heightClass=compact">
-                                    <mask key="constraints">
-                                        <exclude reference="yrU-yj-SJL"/>
-                                        <exclude reference="h5U-Rb-Tvs"/>
-                                        <include reference="TWT-Wj-G1p"/>
-                                        <include reference="X0m-zz-UO3"/>
-                                        <exclude reference="vJ5-2N-JfP"/>
-                                    </mask>
-                                </variation>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Hj-mT-YmE">
-                                <rect key="frame" x="0.0" y="732" width="414" height="110"/>
-                                <subviews>
-                                    <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="23P-EU-wmp">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="110"/>
-                                        <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" alpha="0.69999999999999996" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="bI9-Jh-RnP">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="110"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        </view>
-                                        <color key="tintColor" systemColor="systemBackgroundColor"/>
-                                        <vibrancyEffect style="fill">
-                                            <blurEffect style="systemChromeMaterial"/>
-                                        </vibrancyEffect>
-                                    </visualEffectView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4d5-b5-WY5" userLabel="Seperator">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
-                                        <color key="backgroundColor" systemColor="separatorColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="0.5" id="FyD-HZ-iYi"/>
-                                        </constraints>
-                                    </view>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zm3-8S-slr">
-                                        <rect key="frame" x="20" y="16" width="374" height="44"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="vsh-Og-z49"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                                        <state key="normal" title="Create Blank Page">
-                                            <color key="titleColor" systemColor="labelColor"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="createBlankPageTapped:" destination="6uO-HR-ECX" eventType="touchUpInside" id="p28-fq-nCl"/>
-                                        </connections>
-                                    </button>
-                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xgi-q4-Faa">
-                                        <rect key="frame" x="20" y="16" width="374" height="44"/>
-                                        <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yt3-Sv-2ZO">
-                                                <rect key="frame" x="0.0" y="0.0" width="182" height="44"/>
-                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
-                                                <state key="normal" title="Preview">
-                                                    <color key="titleColor" systemColor="labelColor"/>
-                                                </state>
-                                                <connections>
-                                                    <segue destination="Ppr-up-cWw" kind="show" identifier="" id="5jQ-d2-6qd"/>
-                                                </connections>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CcO-r6-GJK">
-                                                <rect key="frame" x="192" y="0.0" width="182" height="44"/>
-                                                <color key="backgroundColor" name="Pink50"/>
-                                                <state key="normal" title="Create Page">
-                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                </state>
-                                                <connections>
-                                                    <action selector="createPageTapped:" destination="6uO-HR-ECX" eventType="touchUpInside" id="qf8-DI-GRX"/>
-                                                </connections>
-                                            </button>
-                                        </subviews>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="Yt3-Sv-2ZO" secondAttribute="bottom" id="6EV-Jo-H1F"/>
-                                            <constraint firstItem="Yt3-Sv-2ZO" firstAttribute="top" secondItem="xgi-q4-Faa" secondAttribute="top" id="7ie-xO-Gh6"/>
-                                            <constraint firstItem="Yt3-Sv-2ZO" firstAttribute="width" secondItem="xgi-q4-Faa" secondAttribute="width" multiplier="0.5" constant="-5" id="JNZ-Vq-aud"/>
-                                            <constraint firstAttribute="trailing" secondItem="CcO-r6-GJK" secondAttribute="trailing" id="Nef-23-98F"/>
-                                            <constraint firstItem="Yt3-Sv-2ZO" firstAttribute="leading" secondItem="xgi-q4-Faa" secondAttribute="leading" id="Pvu-N0-d5Q"/>
-                                            <constraint firstAttribute="bottom" secondItem="CcO-r6-GJK" secondAttribute="bottom" id="bUx-29-J6P"/>
-                                            <constraint firstItem="CcO-r6-GJK" firstAttribute="width" secondItem="xgi-q4-Faa" secondAttribute="width" multiplier="0.5" constant="-5" id="fWy-BS-DJ4"/>
-                                            <constraint firstItem="CcO-r6-GJK" firstAttribute="top" secondItem="xgi-q4-Faa" secondAttribute="top" id="hxx-pc-6rL"/>
-                                            <constraint firstAttribute="height" constant="44" id="oLf-XH-dwy"/>
-                                        </constraints>
-                                    </view>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="xgi-q4-Faa" firstAttribute="top" secondItem="2Hj-mT-YmE" secondAttribute="top" constant="16" id="Dw8-Dr-wEC"/>
-                                    <constraint firstItem="23P-EU-wmp" firstAttribute="top" secondItem="2Hj-mT-YmE" secondAttribute="top" id="GNM-KC-RD1"/>
-                                    <constraint firstAttribute="trailing" secondItem="23P-EU-wmp" secondAttribute="trailing" id="NhP-tv-4D3"/>
-                                    <constraint firstAttribute="bottom" secondItem="23P-EU-wmp" secondAttribute="bottom" id="YJo-ib-KjJ"/>
-                                    <constraint firstItem="23P-EU-wmp" firstAttribute="leading" secondItem="2Hj-mT-YmE" secondAttribute="leading" id="mZs-uU-veX"/>
-                                    <constraint firstItem="zm3-8S-slr" firstAttribute="top" secondItem="2Hj-mT-YmE" secondAttribute="top" constant="16" id="nbw-U1-qqx"/>
-                                    <constraint firstItem="4d5-b5-WY5" firstAttribute="leading" secondItem="2Hj-mT-YmE" secondAttribute="leading" id="trb-MF-1tH"/>
-                                    <constraint firstAttribute="trailing" secondItem="4d5-b5-WY5" secondAttribute="trailing" id="ycn-K0-U6M"/>
-                                    <constraint firstItem="4d5-b5-WY5" firstAttribute="top" secondItem="2Hj-mT-YmE" secondAttribute="top" id="yqZ-0P-CpH"/>
-                                </constraints>
-                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ad1-6E-LbB"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="DTZ-MR-Eqm" firstAttribute="trailing" secondItem="1ZG-pe-aDl" secondAttribute="trailing" id="6f9-t5-YPi"/>
-                            <constraint firstItem="eiU-pw-Xq6" firstAttribute="top" secondItem="ad1-6E-LbB" secondAttribute="top" id="9L6-zi-h3z"/>
-                            <constraint firstItem="ad1-6E-LbB" firstAttribute="trailing" secondItem="zm3-8S-slr" secondAttribute="trailing" constant="20" id="AV6-1Z-QAk"/>
-                            <constraint firstItem="ad1-6E-LbB" firstAttribute="trailing" secondItem="xgi-q4-Faa" secondAttribute="trailing" constant="20" id="CMG-TG-7Bt"/>
-                            <constraint firstAttribute="trailing" secondItem="Uh3-j1-P0D" secondAttribute="trailing" id="J6b-ze-7EX"/>
-                            <constraint firstItem="2Hj-mT-YmE" firstAttribute="trailing" secondItem="1ZG-pe-aDl" secondAttribute="trailing" id="JLC-Iz-eF0"/>
-                            <constraint firstItem="ad1-6E-LbB" firstAttribute="trailing" secondItem="jOR-Cu-uXg" secondAttribute="trailing" constant="13" id="LRF-0t-d4A"/>
-                            <constraint firstItem="DTZ-MR-Eqm" firstAttribute="leading" secondItem="1ZG-pe-aDl" secondAttribute="leading" id="MGa-PL-qLp"/>
-                            <constraint firstItem="xgi-q4-Faa" firstAttribute="leading" secondItem="ad1-6E-LbB" secondAttribute="leading" constant="20" id="Wvf-bv-jL9"/>
-                            <constraint firstItem="Uh3-j1-P0D" firstAttribute="leading" secondItem="1ZG-pe-aDl" secondAttribute="leading" id="X70-T3-BYM"/>
-                            <constraint firstItem="DTZ-MR-Eqm" firstAttribute="top" secondItem="Uh3-j1-P0D" secondAttribute="bottom" id="YoB-vl-hiJ"/>
-                            <constraint firstItem="eiU-pw-Xq6" firstAttribute="trailing" secondItem="ad1-6E-LbB" secondAttribute="trailing" id="e1a-xF-B0G"/>
-                            <constraint firstItem="sUr-lt-a0R" firstAttribute="top" secondItem="Uh3-j1-P0D" secondAttribute="top" id="e2X-Tl-Nfa"/>
-                            <constraint firstItem="ad1-6E-LbB" firstAttribute="bottom" secondItem="zm3-8S-slr" secondAttribute="bottom" constant="16" id="fcm-u4-u4T"/>
-                            <constraint firstAttribute="trailing" secondItem="sUr-lt-a0R" secondAttribute="trailing" id="gYK-e6-5sr"/>
-                            <constraint firstAttribute="bottom" secondItem="2Hj-mT-YmE" secondAttribute="bottom" id="gu4-Iy-a0x"/>
-                            <constraint firstItem="Uh3-j1-P0D" firstAttribute="top" secondItem="1ZG-pe-aDl" secondAttribute="top" id="hW9-t5-sTL"/>
-                            <constraint firstItem="sUr-lt-a0R" firstAttribute="leading" secondItem="1ZG-pe-aDl" secondAttribute="leading" id="oPB-J3-LLV"/>
-                            <constraint firstItem="eiU-pw-Xq6" firstAttribute="leading" secondItem="ad1-6E-LbB" secondAttribute="leading" id="oph-yf-8ZF"/>
-                            <constraint firstItem="jOR-Cu-uXg" firstAttribute="top" secondItem="ad1-6E-LbB" secondAttribute="top" constant="13" id="pMF-KH-URM"/>
-                            <constraint firstItem="ad1-6E-LbB" firstAttribute="bottom" secondItem="xgi-q4-Faa" secondAttribute="bottom" constant="16" id="rJy-Xq-e5q"/>
-                            <constraint firstItem="sUr-lt-a0R" firstAttribute="bottom" secondItem="DTZ-MR-Eqm" secondAttribute="bottom" id="tqr-ky-YM7"/>
-                            <constraint firstItem="2Hj-mT-YmE" firstAttribute="leading" secondItem="1ZG-pe-aDl" secondAttribute="leading" id="uqK-Wk-nWk"/>
+                            <constraint firstItem="eiU-pw-Xq6" firstAttribute="top" secondItem="1ZG-pe-aDl" secondAttribute="top" id="9L6-zi-h3z"/>
+                            <constraint firstItem="eiU-pw-Xq6" firstAttribute="trailing" secondItem="1ZG-pe-aDl" secondAttribute="trailing" id="e1a-xF-B0G"/>
+                            <constraint firstItem="eiU-pw-Xq6" firstAttribute="leading" secondItem="1ZG-pe-aDl" secondAttribute="leading" id="oph-yf-8ZF"/>
                             <constraint firstAttribute="bottom" secondItem="eiU-pw-Xq6" secondAttribute="bottom" id="w7N-g8-juX"/>
-                            <constraint firstItem="zm3-8S-slr" firstAttribute="leading" secondItem="ad1-6E-LbB" secondAttribute="leading" constant="20" id="xmh-RB-Bds"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="hnp-yV-O4V">
@@ -302,27 +43,8 @@
                     </navigationItem>
                     <nil key="simulatedTopBarMetrics"/>
                     <connections>
-                        <outlet property="closeButton" destination="jOR-Cu-uXg" id="JYm-hS-Ov6"/>
-                        <outlet property="createBlankPageBtn" destination="zm3-8S-slr" id="KLr-3l-vzg"/>
-                        <outlet property="createPageBtn" destination="CcO-r6-GJK" id="rBK-hn-WsJ"/>
-                        <outlet property="filterBar" destination="fhN-6z-taa" id="SWq-vJ-HXY"/>
-                        <outlet property="footerView" destination="2Hj-mT-YmE" id="q1B-dG-UTq"/>
-                        <outlet property="headerBar" destination="Uh3-j1-P0D" id="1Ra-RG-uNE"/>
-                        <outlet property="headerHeightConstraint" destination="yrU-yj-SJL" id="n1e-gV-ZH4"/>
-                        <outlet property="headerView" destination="DTZ-MR-Eqm" id="pgP-hd-zPq"/>
-                        <outlet property="initialHeaderTopConstraint" destination="4pf-bx-DHy" id="7iv-2m-zD3"/>
-                        <outlet property="largeTitleView" destination="S74-AK-pHd" id="N2V-CK-Nng"/>
-                        <outlet property="maxHeaderBottomSpacing" destination="vJ5-2N-JfP" id="7Kz-K6-waN"/>
-                        <outlet property="minHeaderBottomSpacing" destination="3wZ-NV-ETZ" id="OhI-lZ-ARC"/>
-                        <outlet property="previewBtn" destination="Yt3-Sv-2ZO" id="bTE-wA-RbY"/>
-                        <outlet property="promptView" destination="yqC-YH-PXy" id="gxZ-Pj-Rdj"/>
-                        <outlet property="selectedStateButtonsContainer" destination="xgi-q4-Faa" id="LCI-7T-1iQ"/>
-                        <outlet property="subtitleToCategoryBarSpacing" destination="TWT-Wj-G1p" id="OfT-Wy-xkZ"/>
                         <outlet property="tableView" destination="eiU-pw-Xq6" id="blQ-fQ-0HC"/>
-                        <outlet property="titleToSubtitleSpacing" destination="h5U-Rb-Tvs" id="cKq-4h-p0K"/>
-                        <outlet property="titleView" destination="Irb-2L-Gsp" id="Rko-Ov-kDK"/>
-                        <outletCollection property="visualEffects" destination="23P-EU-wmp" collectionClass="NSMutableArray" id="fpg-Qd-4N1"/>
-                        <outletCollection property="visualEffects" destination="sUr-lt-a0R" collectionClass="NSMutableArray" id="4Yu-YQ-PFc"/>
+                        <segue destination="Ppr-up-cWw" kind="show" identifier="preview" id="rC3-HN-3FP"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Tb5-bl-pjs" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -334,20 +56,20 @@
             <objects>
                 <viewController title="Preview" id="Ppr-up-cWw" customClass="LayoutPreviewViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="u02-GK-Tp6">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="786"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sDy-Xm-faX">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="710"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="698"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dZv-T8-D8c">
-                                <rect key="frame" x="0.0" y="710" width="414" height="76"/>
+                                <rect key="frame" x="0.0" y="698" width="414" height="110"/>
                                 <subviews>
                                     <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TgS-cX-N2D">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="76"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="110"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="xlP-zH-ho5">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="76"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="110"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </view>
@@ -405,7 +127,7 @@
                     <navigationItem key="navigationItem" title="Preview" id="yl7-1R-9yC">
                         <barButtonItem key="rightBarButtonItem" style="plain" id="a9M-Fe-sUg">
                             <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="3Uh-3L-aYL" userLabel="Close">
-                                <rect key="frame" x="364" y="13" width="30" height="30"/>
+                                <rect key="frame" x="364" y="7" width="30" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" systemColor="systemFillColor"/>
                                 <accessibility key="accessibilityConfiguration" label="Close"/>
@@ -442,9 +164,6 @@
         <namedColor name="Pink50">
             <color red="0.78823529411764703" green="0.20784313725490197" blue="0.43137254901960786" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -614,6 +614,8 @@
 		46183CF5251BD658004F9AFD /* PageTemplateLayout+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46183CF3251BD658004F9AFD /* PageTemplateLayout+CoreDataProperties.swift */; };
 		46183D1F251BD6A0004F9AFD /* PageTemplateCategory+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46183D1D251BD6A0004F9AFD /* PageTemplateCategory+CoreDataClass.swift */; };
 		46183D20251BD6A0004F9AFD /* PageTemplateCategory+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46183D1E251BD6A0004F9AFD /* PageTemplateCategory+CoreDataProperties.swift */; };
+		4625B556253789C000C04AAD /* CollapsableHeaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4625B555253789C000C04AAD /* CollapsableHeaderViewController.swift */; };
+		4625B6342538B53700C04AAD /* CollapsableHeaderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4625B6332538B53700C04AAD /* CollapsableHeaderViewController.xib */; };
 		4629E41D243D21400002E15C /* EditorThemeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4629E41C243D21400002E15C /* EditorThemeStore.swift */; };
 		4629E4212440C5B20002E15C /* GutenbergCoverUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4629E4202440C5B20002E15C /* GutenbergCoverUploadProcessor.swift */; };
 		4629E4232440C8160002E15C /* GutenbergCoverUploadProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4629E4222440C8160002E15C /* GutenbergCoverUploadProcessorTests.swift */; };
@@ -3066,6 +3068,8 @@
 		46183CF3251BD658004F9AFD /* PageTemplateLayout+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PageTemplateLayout+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		46183D1D251BD6A0004F9AFD /* PageTemplateCategory+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PageTemplateCategory+CoreDataClass.swift"; sourceTree = "<group>"; };
 		46183D1E251BD6A0004F9AFD /* PageTemplateCategory+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PageTemplateCategory+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		4625B555253789C000C04AAD /* CollapsableHeaderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsableHeaderViewController.swift; sourceTree = "<group>"; };
+		4625B6332538B53700C04AAD /* CollapsableHeaderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollapsableHeaderViewController.xib; sourceTree = "<group>"; };
 		4629E41C243D21400002E15C /* EditorThemeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorThemeStore.swift; sourceTree = "<group>"; };
 		4629E4202440C5B20002E15C /* GutenbergCoverUploadProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergCoverUploadProcessor.swift; sourceTree = "<group>"; };
 		4629E4222440C8160002E15C /* GutenbergCoverUploadProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergCoverUploadProcessorTests.swift; sourceTree = "<group>"; };
@@ -6651,16 +6655,33 @@
 			name = "Resources-iPad";
 			sourceTree = "<group>";
 		};
+		4625B5472537875E00C04AAD /* CollapsableHeader */ = {
+			isa = PBXGroup;
+			children = (
+				4625B70A2539F35000C04AAD /* Collabsable Header Filter Bar */,
+				4625B555253789C000C04AAD /* CollapsableHeaderViewController.swift */,
+				4625B6332538B53700C04AAD /* CollapsableHeaderViewController.xib */,
+			);
+			path = CollapsableHeader;
+			sourceTree = "<group>";
+		};
+		4625B70A2539F35000C04AAD /* Collabsable Header Filter Bar */ = {
+			isa = PBXGroup;
+			children = (
+				469EB16724D9AD8B00C764CB /* CollapsableHeaderFilterBar.swift */,
+				469EB16324D8B12700C764CB /* CollabsableHeaderFilterCollectionViewCell.swift */,
+				469EB16424D8B12700C764CB /* CollabsableHeaderFilterCollectionViewCell.xib */,
+			);
+			path = "Collabsable Header Filter Bar";
+			sourceTree = "<group>";
+		};
 		4631359224AD057E0017E65C /* Layout Picker */ = {
 			isa = PBXGroup;
 			children = (
-				469EB16724D9AD8B00C764CB /* GutenbergLayoutFilterBar.swift */,
 				4631359524AD068B0017E65C /* GutenbergLayoutPickerViewController.swift */,
 				465B097924C877E500336B6C /* GutenbergLightNavigationController.swift */,
 				469CE06F24BCFB04003BDC8B /* LayoutPickerCollectionViewCell.swift */,
 				469CE07024BCFB04003BDC8B /* LayoutPickerCollectionViewCell.xib */,
-				469EB16324D8B12700C764CB /* LayoutPickerFilterCollectionViewCell.swift */,
-				469EB16424D8B12700C764CB /* LayoutPickerFilterCollectionViewCell.xib */,
 				469CE06B24BCED75003BDC8B /* LayoutPickerSectionTableViewCell.swift */,
 				469CE06C24BCED75003BDC8B /* LayoutPickerSectionTableViewCell.xib */,
 				4631359324AD05A60017E65C /* LayoutPickerStoryboard.storyboard */,
@@ -7521,6 +7542,7 @@
 				912347752216E27200BD9F97 /* GutenbergViewController+Localization.swift */,
 				FFC02B82222687BF00E64FDE /* GutenbergImageLoader.swift */,
 				FF4DEAD52448FFC900ACA032 /* GutenbergMentionsViewController.swift */,
+				4625B5472537875E00C04AAD /* CollapsableHeader */,
 			);
 			path = Gutenberg;
 			sourceTree = "<group>";
@@ -13307,6 +13329,7 @@
 				FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */,
 				D8A3A5B5206A4C7800992576 /* StockPhotosPicker.swift in Sources */,
 				E60C2ED71DE5075100488630 /* ReaderCommentCell.swift in Sources */,
+				4625B556253789C000C04AAD /* CollapsableHeaderViewController.swift in Sources */,
 				5DBCD9D518F35D7500B32229 /* ReaderTopicService.m in Sources */,
 				2F09D134245223D300956257 /* HeaderDetailsContentStyles.swift in Sources */,
 				403F57BC20E5CA6A004E889A /* RewindStatusRow.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -629,9 +629,9 @@
 		469CE06E24BCED75003BDC8B /* LayoutPickerSectionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 469CE06C24BCED75003BDC8B /* LayoutPickerSectionTableViewCell.xib */; };
 		469CE07124BCFB04003BDC8B /* LayoutPickerCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469CE06F24BCFB04003BDC8B /* LayoutPickerCollectionViewCell.swift */; };
 		469CE07224BCFB04003BDC8B /* LayoutPickerCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 469CE07024BCFB04003BDC8B /* LayoutPickerCollectionViewCell.xib */; };
-		469EB16524D8B12700C764CB /* LayoutPickerFilterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469EB16324D8B12700C764CB /* LayoutPickerFilterCollectionViewCell.swift */; };
-		469EB16624D8B12700C764CB /* LayoutPickerFilterCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 469EB16424D8B12700C764CB /* LayoutPickerFilterCollectionViewCell.xib */; };
-		469EB16824D9AD8B00C764CB /* GutenbergLayoutFilterBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469EB16724D9AD8B00C764CB /* GutenbergLayoutFilterBar.swift */; };
+		469EB16524D8B12700C764CB /* CollabsableHeaderFilterCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469EB16324D8B12700C764CB /* CollabsableHeaderFilterCollectionViewCell.swift */; };
+		469EB16624D8B12700C764CB /* CollabsableHeaderFilterCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 469EB16424D8B12700C764CB /* CollabsableHeaderFilterCollectionViewCell.xib */; };
+		469EB16824D9AD8B00C764CB /* CollapsableHeaderFilterBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 469EB16724D9AD8B00C764CB /* CollapsableHeaderFilterBar.swift */; };
 		46C984682527863E00988BB9 /* LayoutPickerAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C984672527863E00988BB9 /* LayoutPickerAnalyticsEvent.swift */; };
 		46E327D124E705C7000944B3 /* PageLayoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E327D024E705C7000944B3 /* PageLayoutService.swift */; };
 		46E327D324E71B18000944B3 /* GutenbergLayouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E327D224E71B17000944B3 /* GutenbergLayouts.swift */; };
@@ -3082,9 +3082,9 @@
 		469CE06C24BCED75003BDC8B /* LayoutPickerSectionTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LayoutPickerSectionTableViewCell.xib; sourceTree = "<group>"; };
 		469CE06F24BCFB04003BDC8B /* LayoutPickerCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutPickerCollectionViewCell.swift; sourceTree = "<group>"; };
 		469CE07024BCFB04003BDC8B /* LayoutPickerCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LayoutPickerCollectionViewCell.xib; sourceTree = "<group>"; };
-		469EB16324D8B12700C764CB /* LayoutPickerFilterCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutPickerFilterCollectionViewCell.swift; sourceTree = "<group>"; };
-		469EB16424D8B12700C764CB /* LayoutPickerFilterCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LayoutPickerFilterCollectionViewCell.xib; sourceTree = "<group>"; };
-		469EB16724D9AD8B00C764CB /* GutenbergLayoutFilterBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergLayoutFilterBar.swift; sourceTree = "<group>"; };
+		469EB16324D8B12700C764CB /* CollabsableHeaderFilterCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollabsableHeaderFilterCollectionViewCell.swift; sourceTree = "<group>"; };
+		469EB16424D8B12700C764CB /* CollabsableHeaderFilterCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollabsableHeaderFilterCollectionViewCell.xib; sourceTree = "<group>"; };
+		469EB16724D9AD8B00C764CB /* CollapsableHeaderFilterBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsableHeaderFilterBar.swift; sourceTree = "<group>"; };
 		46C984672527863E00988BB9 /* LayoutPickerAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutPickerAnalyticsEvent.swift; sourceTree = "<group>"; };
 		46E327D024E705C7000944B3 /* PageLayoutService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageLayoutService.swift; sourceTree = "<group>"; };
 		46E327D224E71B17000944B3 /* GutenbergLayouts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenbergLayouts.swift; sourceTree = "<group>"; };
@@ -11382,10 +11382,11 @@
 				8BA77BCD248340CE00E1EBBF /* ReaderDetailToolbar.xib in Resources */,
 				4070D75C20E5F55A007CEBDA /* RewindStatusTableViewCell.xib in Resources */,
 				5D13FA571AF99C2100F06492 /* PageListSectionHeaderView.xib in Resources */,
-				469EB16624D8B12700C764CB /* LayoutPickerFilterCollectionViewCell.xib in Resources */,
+				469EB16624D8B12700C764CB /* CollabsableHeaderFilterCollectionViewCell.xib in Resources */,
 				B54E1DF21A0A7BAA00807537 /* ReplyTextView.xib in Resources */,
 				9881296F219CF1310075FF33 /* StatsCellHeader.xib in Resources */,
 				3249615323F20111004C7733 /* PostSignUpInterstitialViewController.xib in Resources */,
+				4625B6342538B53700C04AAD /* CollapsableHeaderViewController.xib in Resources */,
 				9826AE8C21B5CC8D00C851FA /* PostingActivityMonth.xib in Resources */,
 				08D499671CDD20450004809A /* Menus.storyboard in Resources */,
 				9A3BDA1022944F4D00FBF510 /* CountriesMapView.xib in Resources */,
@@ -12413,7 +12414,7 @@
 				5D2B30B91B7411C700DA15F3 /* ReaderCardDiscoverAttributionView.swift in Sources */,
 				E1E89C6C1FD80E74006E7A33 /* Plugin.swift in Sources */,
 				7E4123BD20F4097B00DF8486 /* FormattableMediaContent.swift in Sources */,
-				469EB16524D8B12700C764CB /* LayoutPickerFilterCollectionViewCell.swift in Sources */,
+				469EB16524D8B12700C764CB /* CollabsableHeaderFilterCollectionViewCell.swift in Sources */,
 				40C403EB2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift in Sources */,
 				D87A329620ABD60700F4726F /* ReaderTableContent.swift in Sources */,
 				738B9A5A21B85CF20005062B /* SiteCreationHeaderData.swift in Sources */,
@@ -13226,7 +13227,7 @@
 				D8212CC120AA7C58008E8AE8 /* ReaderShowMenuAction.swift in Sources */,
 				B5BE31C41CB825A100BDF770 /* NSURLCache+Helpers.swift in Sources */,
 				B5552D831CD1062400B26DF6 /* String+Extensions.swift in Sources */,
-				469EB16824D9AD8B00C764CB /* GutenbergLayoutFilterBar.swift in Sources */,
+				469EB16824D9AD8B00C764CB /* CollapsableHeaderFilterBar.swift in Sources */,
 				40247E022120FE3600AE1C3C /* AutomatedTransferHelper.swift in Sources */,
 				082AB9D91C4EEEF4000CA523 /* PostTagService.m in Sources */,
 				3F6975FF242D941E001F1807 /* ReaderTabViewModel.swift in Sources */,


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2725

## To test:
<details>
<summary><strong>To disable or enable the development version of Modal Layout Picker</strong></summary>

- Open the app from the build that allows FeatureFlags such as a PR build or a local development build
    - By default, the modal layout picker will be disabled.
    - From the site page:
        - Click on your Gravatar.
        - Click on App Settings.
        - Click on Debug.
        - Toggle "Gutenberg Modal Layout Picker" to enable or disable the picker
            <img width=300 src="https://user-images.githubusercontent.com/3384451/90816133-c8b10580-e2f9-11ea-8584-6bbfd7e523e2.gif" />
</details>

When enabled, the Layout Picker should show when creating a new page from My Site and from the Page list.

Start by navigating to the Modal Layout Picker

### Sanity test Layout Picker
- Navigate to the Modal Layout Picker and scroll around a bit to make sure everything looks right

### Sanity test Create Blank Page
1. Navigate to Modal Layout Picker
1. Select Create Blank Page
**Expect** to be taken to the Editor with a blank page

### Sanity test Create Page
1. Navigate to Modal Layout Picker
1. Select a layout
1. Select Create Page
**Expect** to be taken to the Editor with the contents of the layout loaded

### Sanity test Preview
1. Navigate to Modal Layout Picker
1. Select a layout
1. Select Preview
**Expect** to be taken to a Read-Only Editor with the contents of the layout loaded

### Sanity test Preview > Create Page
1. Navigate to Modal Layout Picker
1. Select a layout
1. Select Preview
1. Select Create Page
**Expect** to be taken to the Editor with the contents of the layout loaded

## Additional Context: 
This is a refactor moving some code around in preparation for the home page picker project.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
