### PR TITLE
Stories: Removes "Story" Tooltip Notice & A11y stories hint of FAB

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -418,7 +418,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewDidAppear:animated];
     if ([self.tabBarController isKindOfClass:[WPTabBarController class]]) {
-        [self.createButtonCoordinator showCreateButton];
+        [self.createButtonCoordinator showCreateButtonFor:self.blog];
     }
     [self createUserActivity];
     [self startAlertTimer];

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -204,7 +204,7 @@ import WordPressFlux
 
     @objc func showCreateButton(for blog: Blog) {
         let showsStories = Feature.enabled(.stories) && blog.supports(.stories)
-        button.accessibilityHint = showsStories ? NSLocalizedString("Creates new post, page, or story", comment: " Accessibility hint for create floating action button") : NSLocalizedString("Creates new post, or page", comment: " Accessibility hint for create floating action button")
+        button.accessibilityHint = showsStories ? NSLocalizedString("Creates new post, page, or story", comment: " Accessibility hint for create floating action button") : NSLocalizedString("Create a post or page", comment: " Accessibility hint for create floating action button")
         showCreateButton(notice: notice(for: blog))
     }
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -14,7 +14,6 @@ import WordPressFlux
         let button = FloatingActionButton(image: .gridicon(.create))
         button.accessibilityLabel = NSLocalizedString("Create", comment: "Accessibility label for create floating action button")
         button.accessibilityIdentifier = "floatingCreateButton"
-        button.accessibilityHint = NSLocalizedString("Creates new post, page, or story", comment: " Accessibility hint for create floating action button")
         return button
     }()
 
@@ -26,15 +25,17 @@ import WordPressFlux
 
     private let noticeAnimator = NoticeAnimator(duration: 0.5, springDampening: 0.7, springVelocity: 0.0)
 
-    private lazy var notice: Notice = {
-        let notice = Notice(title: NSLocalizedString("Create a post, page, or story", comment: "The tooltip title for the Floating Create Button"),
+    private func notice(for blog: Blog) -> Notice {
+        let showsStories = Feature.enabled(.stories) && blog.supports(.stories)
+        let title = showsStories ? NSLocalizedString("Create a post, page, or story", comment: "The tooltip title for the Floating Create Button") : NSLocalizedString("Creates new post, or page", comment: " Accessibility hint for create floating action button")
+        let notice = Notice(title: title,
                             message: "",
                             style: ToolTipNoticeStyle()) { [weak self] _ in
                 self?.didDismissTooltip = true
                 self?.hideNotice()
         }
         return notice
-    }()
+    }
 
     // Once this reaches `maximumTooltipViews` we won't show the tooltip again
     private var shownTooltipCount: Int {
@@ -201,13 +202,13 @@ import WordPressFlux
         }
     }
 
-    @objc func showCreateButton() {
-        showCreateButton(notice: nil)
+    @objc func showCreateButton(for blog: Blog) {
+        let showsStories = Feature.enabled(.stories) && blog.supports(.stories)
+        button.accessibilityHint = showsStories ? NSLocalizedString("Creates new post, page, or story", comment: " Accessibility hint for create floating action button") : NSLocalizedString("Creates new post, or page", comment: " Accessibility hint for create floating action button")
+        showCreateButton(notice: notice(for: blog))
     }
 
-    func showCreateButton(notice: Notice? = nil) {
-        let notice = notice ?? self.notice
-
+    func showCreateButton(notice: Notice) {
         if !didDismissTooltip {
             noticeContainerView = noticeAnimator.present(notice: notice, in: viewController!.view, sourceView: button)
             shownTooltipCount += 1


### PR DESCRIPTION
This fixes a bug where the Story option would show up in the tooltip notice & accessibility hint of the FAB.

- Removes "story" from the tooltip notice when the feature flag is disabled or the blog doesn't support it.
- Removes "story" from the A11y hint when the Feature flag is disabled or the blog doesn't support it.

### Testing

#### Tooltip Notice

- Install a new version of the application (or pause the debugger, run the following LLDB command, and switch away from and back to the My Sites tab):
`e -l swift -- import WordPress; UserDefaults.standard.createButtonTooltipWasDisplayed = false`
- Ensure that the Notice Tooltip says "Create a post, page, or story":
<img width="188" alt="Screen Shot 2020-10-19 at 2 48 08 PM" src="https://user-images.githubusercontent.com/3250/96510024-268a9c80-121a-11eb-8255-c42f81b597cf.png">

- Re-install or use step 1 to reset the state + re-launch the app.
- Turn off the Stories feature flag.
- Ensure that the Notice Tooltip says "Create a post, or page":
<img width="188" alt="Screen Shot 2020-10-19 at 3 09 31 PM" src="https://user-images.githubusercontent.com/3250/96512021-2049ef80-121d-11eb-95dc-9a9d9743ff21.png">

#### Accessibility Hint

- Install a new version of the application (or pause the debugger, run the following LLDB command, and switch away from and back to the My Sites tab):
`e -l swift -- import WordPress; UserDefaults.standard.createButtonTooltipWasDisplayed = false`
- Ensure that Voice Over speaks or the View Hierarchy Debugger shows "Creates new post, page, or story":
<img width="272" alt="Screen Shot 2020-10-19 at 3 26 44 PM" src="https://user-images.githubusercontent.com/3250/96513581-8c2d5780-121f-11eb-9d2f-a185e6ab9c3c.png">

- Re-install or use step 1 to reset the state + re-launch the app.
- Turn off the Stories feature flag.
- Ensure that the Notice Tooltip says "Create a post, or page":
<img width="272" alt="Screen Shot 2020-10-19 at 3 30 43 PM" src="https://user-images.githubusercontent.com/3250/96513880-11187100-1220-11eb-854c-c0bb675b13ed.png">

Switching between a Blog with Jetpack > 8.9 (or WordPress.com) and a Jetpack blog with < 8.9 should also trigger these changes.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
