### PR TITLE
Improves MySitesCoordinator.

### DIFF
--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -320,7 +320,7 @@ fileprivate extension SearchManager {
     }
 
     func openSiteDetailsScreen(for blog: Blog) {
-        WPTabBarController.sharedInstance().switchMySitesTabToBlogDetails(for: blog)
+        WPTabBarController.sharedInstance()?.mySitesCoordinator.showBlogDetails(for: blog)
     }
 
     // MARK: Reader Tab Navigation

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -219,7 +219,7 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
                 return
             }
             WPAnalytics.track(.enhancedSiteCreationSuccessPreviewOkButtonTapped)
-            WPTabBarController.sharedInstance().switchMySitesTabToBlogDetails(for: blog)
+            WPTabBarController.sharedInstance()?.mySitesCoordinator.showBlogDetails(for: blog)
 
             self?.showQuickStartAlert(for: blog)
         }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -22,19 +22,15 @@ class MySitesCoordinator: NSObject {
         super.init()
     }
 
-    private func prepareToNavigate() {
+    func showMySites() {
         becomeActiveTab()
 
         mySitesNavigationController.viewControllers = [blogListViewController]
     }
 
-    func showMySites() {
-        prepareToNavigate()
-    }
-
     @objc
     func showBlogDetails(for blog: Blog) {
-        prepareToNavigate()
+        showMySites()
 
         blogListViewController.setSelectedBlog(blog, animated: false)
     }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -18,7 +18,7 @@ class MySitesCoordinator: NSObject {
         self.mySitesNavigationController = mySitesNavigationController
         self.blogListViewController = blogListViewController
         self.becomeActiveTab = becomeActiveTab
-        
+
         super.init()
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -27,11 +27,7 @@ class MySitesCoordinator: NSObject {
     private func prepareToNavigate() {
         becomeActiveTab()
 
-        if Feature.enabled(.newNavBarAppearance) {
-            mySitesNavigationController.viewControllers = [blogDetailsViewController]
-        } else {
-            mySitesNavigationController.viewControllers = [blogListViewController]
-        }
+        mySitesNavigationController.viewControllers = [blogListViewController]
     }
 
     func showMySites() {
@@ -42,11 +38,7 @@ class MySitesCoordinator: NSObject {
     func showBlogDetails(for blog: Blog) {
         prepareToNavigate()
 
-        if Feature.enabled(.newNavBarAppearance) {
-            blogDetailsViewController.blog = blog
-        } else {
-            blogListViewController.setSelectedBlog(blog, animated: false)
-        }
+        blogListViewController.setSelectedBlog(blog, animated: false)
     }
 
     func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection? = nil) {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -4,7 +4,6 @@ import UIKit
 class MySitesCoordinator: NSObject {
     let mySitesSplitViewController: WPSplitViewController
     let mySitesNavigationController: UINavigationController
-    let blogDetailsViewController: BlogDetailsViewController
     let blogListViewController: BlogListViewController
     let becomeActiveTab: () -> Void
 
@@ -18,7 +17,6 @@ class MySitesCoordinator: NSObject {
         self.mySitesSplitViewController = mySitesSplitViewController
         self.mySitesNavigationController = mySitesNavigationController
         self.blogListViewController = blogListViewController
-        self.blogDetailsViewController = BlogDetailsViewController(meScenePresenter: blogListViewController.meScenePresenter)
         self.becomeActiveTab = becomeActiveTab
         
         super.init()

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -4,33 +4,53 @@ import UIKit
 class MySitesCoordinator: NSObject {
     let mySitesSplitViewController: WPSplitViewController
     let mySitesNavigationController: UINavigationController
+    let blogDetailsViewController: BlogDetailsViewController
     let blogListViewController: BlogListViewController
+    let becomeActiveTab: () -> Void
 
     @objc
-    init(mySitesSplitViewController: WPSplitViewController,
-         mySitesNavigationController: UINavigationController,
-         blogListViewController: BlogListViewController) {
+    init(
+        mySitesSplitViewController: WPSplitViewController,
+        mySitesNavigationController: UINavigationController,
+        blogListViewController: BlogListViewController,
+        onBecomeActiveTab becomeActiveTab: @escaping () -> Void) {
+
         self.mySitesSplitViewController = mySitesSplitViewController
         self.mySitesNavigationController = mySitesNavigationController
         self.blogListViewController = blogListViewController
-
+        self.blogDetailsViewController = BlogDetailsViewController(meScenePresenter: blogListViewController.meScenePresenter)
+        self.becomeActiveTab = becomeActiveTab
+        
         super.init()
     }
 
     private func prepareToNavigate() {
-        WPTabBarController.sharedInstance().showMySitesTab()
+        becomeActiveTab()
 
-        mySitesNavigationController.viewControllers = [blogListViewController]
+        if Feature.enabled(.newNavBarAppearance) {
+            mySitesNavigationController.viewControllers = [blogDetailsViewController]
+        } else {
+            mySitesNavigationController.viewControllers = [blogListViewController]
+        }
     }
 
     func showMySites() {
         prepareToNavigate()
     }
 
-    func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection? = nil) {
+    @objc
+    func showBlogDetails(for blog: Blog) {
         prepareToNavigate()
 
-        blogListViewController.setSelectedBlog(blog, animated: false)
+        if Feature.enabled(.newNavBarAppearance) {
+            blogDetailsViewController.blog = blog
+        } else {
+            blogListViewController.setSelectedBlog(blog, animated: false)
+        }
+    }
+
+    func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection? = nil) {
+        showBlogDetails(for: blog)
 
         if let subsection = subsection,
             let blogDetailsViewController = mySitesNavigationController.topViewController as? BlogDetailsViewController {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -58,7 +58,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)switchMySitesTabToThemesViewForBlog:(Blog *)blog;
 - (void)switchTabToPostsListForPost:(AbstractPost *)post;
 - (void)switchTabToPagesListForPost:(AbstractPost *)post;
-- (void)switchMySitesTabToBlogDetailsForBlog:(Blog *)blog;
 
 - (void)popNotificationsTabToRoot;
 - (void)switchNotificationsTabToNotificationSettings;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -350,9 +350,14 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (MySitesCoordinator *)mySitesCoordinator
 {
+    __weak __typeof(self) weakSelf = self;
+    
     return [[MySitesCoordinator alloc] initWithMySitesSplitViewController:self.blogListSplitViewController
                                               mySitesNavigationController:self.blogListNavigationController
-                                                   blogListViewController:self.blogListViewController];
+                                                   blogListViewController:self.blogListViewController
+                                                        onBecomeActiveTab:^{
+        [weakSelf showMySitesTab];
+    }];
 }
 
 - (ReaderCoordinator *)readerCoordinator
@@ -501,7 +506,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         }
     }
 
-    [self switchMySitesTabToBlogDetailsForBlog:post.blog];
+    [self.mySitesCoordinator showBlogDetailsFor:post.blog];
 
     BlogDetailsViewController *blogDetailVC = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
     if ([blogDetailVC isKindOfClass:[BlogDetailsViewController class]]) {
@@ -521,7 +526,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         }
     }
 
-    [self switchMySitesTabToBlogDetailsForBlog:post.blog];
+    [self.mySitesCoordinator showBlogDetailsFor:post.blog];
 
     BlogDetailsViewController *blogDetailVC = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
     if ([blogDetailVC isKindOfClass:[BlogDetailsViewController class]]) {
@@ -537,7 +542,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog
 {
-    [self switchMySitesTabToBlogDetailsForBlog:blog];
+    [self.mySitesCoordinator showBlogDetailsFor:blog];
 
     BlogDetailsViewController *blogDetailVC = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
     if ([blogDetailVC isKindOfClass:[BlogDetailsViewController class]]) {
@@ -568,7 +573,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (void)switchMySitesTabToThemesViewForBlog:(Blog *)blog
 {
-    [self switchMySitesTabToBlogDetailsForBlog:blog];
+    [self.mySitesCoordinator showBlogDetailsFor:blog];
 
     BlogDetailsViewController *blogDetailVC = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
     if ([blogDetailVC isKindOfClass:[BlogDetailsViewController class]]) {

--- a/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
@@ -35,7 +35,7 @@ class ShareNoticeNavigationCoordinator {
     static func navigateToBlogDetails(with userInfo: NSDictionary) {
         fetchBlog(from: userInfo, onSuccess: { blog in
             if let blog = blog {
-                WPTabBarController.sharedInstance().switchMySitesTabToBlogDetails(for: blog)
+                WPTabBarController.sharedInstance()?.mySitesCoordinator.showBlogDetails(for: blog)
             }
         }, onFailure: {
             DDLogError("Could not fetch blog from share notification.")


### PR DESCRIPTION
This PR is part of a [larger upcoming PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/15130) that was broken up to make the review easier.

Improves MySitesCoordinator so that it:

- Implements the logic to show a blog's details screen.
- Doesn't really know or care about `WPTabBarController` so that we can avoid a circular dependency, which is good for maintainability of the code.

Also removes the code to show a blog's details from `WPTabBarController` (since it's now handled by `MySiteCoordinator` as mentioned above).

## To test:

When testing keep in mind that you should notice no visible differences between develop and this branch.  The changes in this PR are in preparation of upcoming work, and we should just make sure nothing is broken in the process.

### Test 1:

Use an account with existing blogs.

1. Launch the app and log in if needed.
2. Make sure "My Sites" is the first active tab, and that you can see the blog details for your default / selected blog.

### Test 2:

1. Using iOS's spotlight, search for the name of one of your blogs.
2. Spotlight should show you a result for your blog.  Tap on it.
3. The app will be  launched and you should see the details screen for the blog you searched.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
