### PR TITLE
Fix reader_article_detail_more_tapped event

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -288,8 +288,6 @@ class ReaderDetailCoordinator {
         let siteTopic: ReaderSiteTopic? = service.findSiteTopic(withSiteID: post.siteID)
 
         ReaderPostMenu.showMenuForPost(post, topic: siteTopic, fromView: anchorView, inViewController: viewController)
-
-        WPAnalytics.track(.readerArticleDetailMoreTapped)
     }
 
     private func showTopic(_ topic: String) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -89,6 +89,8 @@ open class ReaderPostMenu {
         } else {
             viewController.present(alertController, animated: true)
         }
+
+        WPAnalytics.track(.readerArticleDetailMoreTapped)
     }
 
     fileprivate class func existingObject<T>(for objectID: NSManagedObjectID?, context: NSManagedObjectContext?) -> T? {


### PR DESCRIPTION
This PR fixes the event `reader_article_detail_more_tapped`.

In some circumstances, this event was not being triggered.

### To test

1. Open a post in Reader
2. Tap the More button
3. Check that the event is firing