### PR TITLE
Add "New" badge for Story post

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -159,19 +159,12 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         updateGhostableTableViewOptions()
 
         configureNavigationButtons()
-
-        createButtonCoordinator.add(to: view, trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor, bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor)
     }
-
-    lazy var createButtonCoordinator: CreateButtonCoordinator = { return CreateButtonCoordinator(self, newPost: {}, newPage: {}, newStory: {})
-    }()
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         configureCompactOrDefault()
-
-        createButtonCoordinator.showCreateButton()
     }
 
     func configureNavigationButtons() {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -159,12 +159,19 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         updateGhostableTableViewOptions()
 
         configureNavigationButtons()
+
+        createButtonCoordinator.add(to: view, trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor, bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor)
     }
+
+    lazy var createButtonCoordinator: CreateButtonCoordinator = { return CreateButtonCoordinator(self, newPost: {}, newPage: {}, newStory: {})
+    }()
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         configureCompactOrDefault()
+
+        createButtonCoordinator.showCreateButton()
     }
 
     func configureNavigationButtons() {

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -2,17 +2,17 @@ struct ActionSheetButton {
     let title: String
     let image: UIImage
     let identifier: String
-    let target: Any?
-    let selector: Selector
     let highlight: Bool
+    let badge: UIView?
+    let action: () -> Void
 
-    init(title: String, image: UIImage, identifier: String, target: Any?, selector: Selector, highlight: Bool = false) {
+    init(title: String, image: UIImage, identifier: String, highlight: Bool = false, badge: UIView? = nil, action: @escaping () -> Void) {
         self.title = title
         self.image = image
         self.identifier = identifier
-        self.target = target
-        self.selector = selector
         self.highlight = highlight
+        self.badge = badge
+        self.action = action
     }
 }
 
@@ -37,6 +37,7 @@ class ActionSheetViewController: UIViewController {
             static let imageTintColor: UIColor = .neutral(.shade30)
             static let font: UIFont = .preferredFont(forTextStyle: .callout)
             static let textColor: UIColor = .text
+            static let badgeHorizontalPadding: CGFloat = 10
         }
 
         enum Stack {
@@ -129,21 +130,42 @@ class ActionSheetViewController: UIViewController {
         NSLayoutConstraint.activate(stackViewConstraints + [bottomAnchor])
     }
 
-    func button(_ info: ActionSheetButton) -> UIButton {
-        let button = UIButton(type: .custom)
-        button.setTitle(info.title, for: .normal)
+    private func createButton(_ handler: @escaping () -> Void) -> UIButton {
+        let button: UIButton
+        if #available(iOS 14.0, *) {
+            button = UIButton(type: .custom, primaryAction: UIAction(handler: { _ in handler() }))
+        } else {
+            button = ClosureButton(frame: .zero, closure: {
+                handler()
+            })
+        }
+
         button.titleLabel?.font = Constants.Button.font
         button.setTitleColor(Constants.Button.textColor, for: .normal)
-        button.setImage(info.image, for: .normal)
         button.imageView?.tintColor = Constants.Button.imageTintColor
         button.setBackgroundImage(UIImage(color: .divider), for: .highlighted)
         button.titleEdgeInsets = Constants.Button.titleInsets
         button.naturalContentHorizontalAlignment = .leading
         button.contentEdgeInsets = Constants.Button.contentInsets
-        button.addTarget(info.target, action: info.selector, for: .touchUpInside)
-        button.accessibilityIdentifier = info.identifier
         button.translatesAutoresizingMaskIntoConstraints = false
         button.flipInsetsForRightToLeftLayoutDirection()
+        return button
+    }
+
+    private func button(_ info: ActionSheetButton) -> UIButton {
+        let button = createButton(info.action)
+
+        button.setTitle(info.title, for: .normal)
+        button.setImage(info.image, for: .normal)
+        button.accessibilityIdentifier = info.identifier
+
+        if let badge = info.badge {
+            button.addSubview(badge)
+            button.addConstraints([
+                badge.constrain(attribute: .left, toAttribute: .right, ofView: button.titleLabel!, relatedBy: .equal, constant: Constants.Button.badgeHorizontalPadding),
+                badge.constrainToSuperview(attribute: .centerY, relatedBy: .equal, constant: 0)
+            ])
+        }
 
         if info.highlight {
             addSpotlight(to: button)

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
@@ -1,0 +1,68 @@
+/// The Action Sheet containing action buttons to create new content to be displayed from the Create Button.
+class CreateButtonActionSheet: ActionSheetViewController {
+
+    enum Constants {
+        static let title = NSLocalizedString("Create New", comment: "Create New header text")
+
+        enum Badge {
+            static let font = UIFont.preferredFont(forTextStyle: .caption1)
+            static let insets = UIEdgeInsets(top: 2, left: 8, bottom: 2, right: 8)
+            static let cornerRadius: CGFloat = 2
+            static let backgroundColor = UIColor.muriel(color: MurielColor(name: .red, shade: .shade50))
+        }
+    }
+
+    init(newPost: @escaping () -> Void, newPage: @escaping () -> Void, newStory: (() -> Void)?) {
+        let postsButton = CreateButtonActionSheet.makePostsButton(handler: newPost)
+        let pagesButton = CreateButtonActionSheet.makePagesButton(handler: newPage)
+        let storiesButton = CreateButtonActionSheet.makeStoriesButton(handler: { newStory?() })
+        let shouldShowStories = newStory != nil
+        let buttons = shouldShowStories ? [postsButton, pagesButton, storiesButton] : [postsButton, pagesButton]
+
+        super.init(headerTitle: Constants.title, buttons: buttons)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Button Constructors
+
+    private static func makePostsButton(handler: @escaping () -> Void) -> ActionSheetButton {
+        let highlight: Bool = QuickStartTourGuide.find()?.shouldSpotlight(.newpost) ?? false
+
+        return ActionSheetButton(title: NSLocalizedString("Blog post", comment: "Create new Blog Post button title"),
+                                 image: .gridicon(.posts),
+                                 identifier: "blogPostButton",
+                                 highlight: highlight,
+                                 action: handler)
+    }
+
+    private static func makePagesButton(handler: @escaping () -> Void) -> ActionSheetButton {
+        return ActionSheetButton(title: NSLocalizedString("Site page", comment: "Create new Site Page button title"),
+                                            image: .gridicon(.pages),
+                                            identifier: "sitePageButton",
+                                            action: handler)
+    }
+
+    private static func makeStoriesButton(handler: @escaping () -> Void) -> ActionSheetButton {
+        let badge = CreateButtonActionSheet.newBadge(title: NSLocalizedString("New", comment: "New button badge on Stories Post button"))
+        return ActionSheetButton(title: NSLocalizedString("Story post", comment: "Create new Story button title"),
+                                            image: .gridicon(.book),
+                                            identifier: "storyButton",
+                                            badge: badge,
+                                            action: handler)
+    }
+
+    private static func newBadge(title: String) -> UIButton {
+        let badge = UIButton(type: .custom)
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.setTitle(title, for: .normal)
+        badge.titleLabel?.font = Constants.Badge.font
+        badge.contentEdgeInsets = Constants.Badge.insets
+        badge.layer.cornerRadius = Constants.Badge.cornerRadius
+        badge.isUserInteractionEnabled = false
+        badge.backgroundColor = Constants.Badge.backgroundColor
+        return badge
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -123,54 +123,12 @@ import WordPressFlux
         guard let viewController = viewController else {
             return
         }
-        let actionSheetVC = actionSheetController(with: viewController.traitCollection)
+        let actionSheetVC = CreateButtonActionSheet(newPost: newPost, newPage: newPage, newStory: newStory)
+        setupPresentation(on: actionSheetVC, for: viewController.traitCollection)
         viewController.present(actionSheetVC, animated: true, completion: {
             WPAnalytics.track(.createSheetShown)
             QuickStartTourGuide.find()?.visited(.newpost)
         })
-    }
-
-    private func actionSheetController(with traitCollection: UITraitCollection) -> UIViewController {
-        let postsButton = makePostsButton()
-        let pagesButton = makePagesButton()
-        let storiesButton = makeStoriesButton()
-        let shouldShowStories = newStory != nil
-        let buttons = shouldShowStories ? [postsButton, pagesButton, storiesButton] : [postsButton, pagesButton]
-        let actionSheetController = ActionSheetViewController(headerTitle: NSLocalizedString("Create New", comment: "Create New header text"),
-                                                              buttons: buttons)
-
-        setupPresentation(on: actionSheetController, for: traitCollection)
-
-        return actionSheetController
-    }
-
-    private func makePostsButton() -> ActionSheetButton {
-        let highlight: Bool = QuickStartTourGuide.find()?.shouldSpotlight(.newpost) ?? false
-
-        return ActionSheetButton(title: NSLocalizedString("Blog post", comment: "Create new Blog Post button title"),
-                                 image: .gridicon(.posts),
-                                 identifier: "blogPostButton",
-                                 target: self,
-                                 selector: #selector(showNewPost),
-                                 highlight: highlight)
-    }
-
-    // MARK: Button Constructors
-
-    private func makePagesButton() -> ActionSheetButton {
-        return ActionSheetButton(title: NSLocalizedString("Site page", comment: "Create new Site Page button title"),
-                                            image: .gridicon(.pages),
-                                            identifier: "sitePageButton",
-                                            target: self,
-                                            selector: #selector(showNewPage))
-    }
-
-    private func makeStoriesButton() -> ActionSheetButton {
-        return ActionSheetButton(title: NSLocalizedString("Story post", comment: "Create new Story button title"),
-                                            image: .gridicon(.book),
-                                            identifier: "storyButton",
-                                            target: self,
-                                            selector: #selector(showNewStory))
     }
 
     private func setupPresentation(on viewController: UIViewController, for traitCollection: UITraitCollection) {
@@ -218,18 +176,6 @@ import WordPressFlux
         } else {
             button.springAnimation(toShow: true)
         }
-    }
-
-    @objc func showNewPost() {
-        newPost()
-    }
-
-    @objc func showNewPage() {
-        newPage()
-    }
-
-    @objc func showNewStory() {
-        newStory?()
     }
 
     // MARK: - Quick Start

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2178,6 +2178,7 @@
 		F52CACCA244FA7AA00661380 /* ReaderManageScenePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52CACC9244FA7AA00661380 /* ReaderManageScenePresenter.swift */; };
 		F52CACCC24512EA700661380 /* EmptyActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52CACCB24512EA700661380 /* EmptyActionView.swift */; };
 		F532AD61253B81320013B42E /* StoriesIntroDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F532AD60253B81320013B42E /* StoriesIntroDataSource.swift */; };
+		F532AE1C253E55D40013B42E /* CreateButtonActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F532AE1B253E55D40013B42E /* CreateButtonActionSheet.swift */; };
 		F53FF3A123E2377E001AD596 /* BlogDetailHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A023E2377E001AD596 /* BlogDetailHeaderView.swift */; };
 		F53FF3A323EA3E45001AD596 /* BlogDetailsViewController+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A223EA3E45001AD596 /* BlogDetailsViewController+Header.swift */; };
 		F53FF3A823EA723D001AD596 /* ActionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A723EA723D001AD596 /* ActionRow.swift */; };
@@ -4940,6 +4941,7 @@
 		F52CACC9244FA7AA00661380 /* ReaderManageScenePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderManageScenePresenter.swift; sourceTree = "<group>"; };
 		F52CACCB24512EA700661380 /* EmptyActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyActionView.swift; sourceTree = "<group>"; };
 		F532AD60253B81320013B42E /* StoriesIntroDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoriesIntroDataSource.swift; sourceTree = "<group>"; };
+		F532AE1B253E55D40013B42E /* CreateButtonActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateButtonActionSheet.swift; sourceTree = "<group>"; };
 		F53FF3A023E2377E001AD596 /* BlogDetailHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailHeaderView.swift; sourceTree = "<group>"; };
 		F53FF3A223EA3E45001AD596 /* BlogDetailsViewController+Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+Header.swift"; sourceTree = "<group>"; };
 		F53FF3A723EA723D001AD596 /* ActionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionRow.swift; sourceTree = "<group>"; };
@@ -10775,6 +10777,7 @@
 				F551E7F423F6EA3100751212 /* FloatingActionButton.swift */,
 				F5E032DA24088F44003AF350 /* UIView+SpringAnimations.swift */,
 				F5E032D5240889EB003AF350 /* CreateButtonCoordinator.swift */,
+				F532AE1B253E55D40013B42E /* CreateButtonActionSheet.swift */,
 				F5B9D7EF245BA938002BB2C7 /* FancyAlertViewController+CreateButtonAnnouncement.swift */,
 			);
 			path = "Floating Create Button";
@@ -13304,6 +13307,7 @@
 				C81CCD70243AFAE600A83E27 /* TenorResponse.swift in Sources */,
 				9872CB30203B8A730066A293 /* SignupEpilogueTableViewController.swift in Sources */,
 				E1B23B081BFB3B370006559B /* MyProfileViewController.swift in Sources */,
+				F532AE1C253E55D40013B42E /* CreateButtonActionSheet.swift in Sources */,
 				8BCB83D124C21063001581BD /* ReaderStreamViewController+Ghost.swift in Sources */,
 				B5CC05F61962150600975CAC /* Constants.m in Sources */,
 				4326191522FCB9DC003C7642 /* MurielColor.swift in Sources */,


### PR DESCRIPTION
This adds a red "New" badge to the Story post button in the Action Sheet which appears when tapping the FAB.

ActionSheetViewController was refactored a bit as part of this to keep `CreateButtonCoordinator` a little more focused on the presentation and configuration of the FAB instead of configuring the Action Sheet.

### Testing

* Open the Blog Details page on a wordpress.com blog with the Stories feature flag enabled (it's enabled by default in Debug builds).
* Tap the FAB in the bottom right.
* Check the "Story post" button for the "New" badge
<img width="178" alt="Screen Shot 2020-10-21 at 12 25 17 PM" src="https://user-images.githubusercontent.com/3250/96767208-70e65780-1399-11eb-87c2-3a3fc510fe7c.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
