### PR TITLE
Adds the FAB to the Post and Page List screens

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 16.1
 -----
 * [*] Fixed an issue that was causing the refresh control to show up on top of the list of sites. [https://github.com/wordpress-mobile/WordPress-iOS/pull/15136]
+* [***] The "Floating Action Button" now appears on the list of posts and pages for quick and convenient creation. [https://github.com/wordpress-mobile/WordPress-iOS/pull/15149l]
 
  
 16.0

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
@@ -24,7 +24,10 @@ extension BlogDetailsViewController {
             controller?.showStoryEditor(forBlog: blog)
         }
 
-        let actions: [ActionSheetItem] = shouldShowNewStory ? [PostAction(handler: newPost), PageAction(handler: newPage), StoryAction(handler: newStory)] : [PostAction(handler: newPost), PageAction(handler: newPage)]
+        var actions: [ActionSheetItem] = [PostAction(handler: newPost), PageAction(handler: newPage)]
+        if shouldShowNewStory {
+            actions.append(StoryAction(handler: newStory))
+        }
         let coordinator = CreateButtonCoordinator(self, actions: actions)
         return coordinator
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
@@ -24,7 +24,8 @@ extension BlogDetailsViewController {
             controller?.showStoryEditor(forBlog: blog)
         }
 
-        let coordinator = CreateButtonCoordinator(self, newPost: newPost, newPage: newPage, newStory: shouldShowNewStory ? newStory : nil)
+        let actions: [ActionSheetItem] = shouldShowNewStory ? [PostAction(handler: newPost), PageAction(handler: newPage), StoryAction(handler: newStory)] : [PostAction(handler: newPost), PageAction(handler: newPage)]
+        let coordinator = CreateButtonCoordinator(self, actions: actions)
         return coordinator
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -50,6 +50,12 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         return HomepageSettingsService(blog: blog, context: blog.managedObjectContext ?? ContextManager.shared.mainContext)
     }()
 
+    private lazy var createButtonCoordinator: CreateButtonCoordinator = {
+        return CreateButtonCoordinator(self, actions: [PageAction(handler: { [weak self] in
+            self?.createPost()
+        })])
+    }()
+
     // MARK: - GUI
 
     @IBOutlet weak var filterTabBarTopConstraint: NSLayoutConstraint!
@@ -122,6 +128,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         title = NSLocalizedString("Site Pages", comment: "Title of the screen showing the list of pages for a blog.")
 
         configureFilterBarTopConstraint()
+
+        createButtonCoordinator.add(to: view, trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor, bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -131,6 +139,22 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         _tableViewHandler.refreshTableView()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if traitCollection.horizontalSizeClass == .compact {
+            createButtonCoordinator.showCreateButton()
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.horizontalSizeClass == .compact {
+            createButtonCoordinator.showCreateButton()
+        } else {
+            createButtonCoordinator.hideCreateButton()
+        }
+    }
 
     // MARK: - Configuration
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -128,12 +128,6 @@ class AbstractPostListViewController: UIViewController,
 
     @IBOutlet var filterTabBar: FilterTabBar!
 
-    @objc lazy var addButton: UIBarButtonItem = {
-        let addButton = UIBarButtonItem(image: .gridicon(.plus), style: .plain, target: self, action: #selector(handleAddButtonTapped))
-        addButton.accessibilityLabel = NSLocalizedString("Add", comment: "Button to create a new post.")
-        return addButton
-    }()
-
     @objc var searchController: UISearchController!
     @objc var recentlyTrashedPostObjectIDs = [NSManagedObjectID]() // IDs of trashed posts. Cleared on refresh or when filter changes.
 
@@ -229,7 +223,6 @@ class AbstractPostListViewController: UIViewController,
         //
         let backButton = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
         navigationItem.backBarButtonItem = backButton
-        navigationItem.rightBarButtonItem = addButton
     }
 
     func configureFilterBar() {
@@ -569,10 +562,6 @@ class AbstractPostListViewController: UIViewController,
         syncItemsWithUserInteraction(true)
 
         WPAnalytics.track(.postListPullToRefresh, withProperties: propertiesForAnalytics())
-    }
-
-    @objc func handleAddButtonTapped() {
-        createPost()
     }
 
     // MARK: - Synching

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -159,6 +159,31 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         updateGhostableTableViewOptions()
 
         configureNavigationButtons()
+
+        createButtonCoordinator.add(to: view, trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor, bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor)
+    }
+
+    private lazy var createButtonCoordinator: CreateButtonCoordinator = {
+        return CreateButtonCoordinator(self, actions: [
+            PostAction(handler: { [weak self] in
+                    self?.dismiss(animated: false, completion: nil)
+                    self?.createPost()
+            }),
+            StoryAction(handler: { [weak self] in
+                guard let self = self else {
+                    return
+                }
+                (self.tabBarController as? WPTabBarController)?.showStoryEditor(blog: self.blog, title: nil, content: nil, source: "post_list")
+            })
+        ])
+    }()
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if traitCollection.horizontalSizeClass == .compact {
+            createButtonCoordinator.showCreateButton()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -167,8 +192,17 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         configureCompactOrDefault()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.horizontalSizeClass == .compact {
+            createButtonCoordinator.showCreateButton()
+        } else {
+            createButtonCoordinator.hideCreateButton()
+        }
+    }
+
     func configureNavigationButtons() {
-        navigationItem.rightBarButtonItems = [addButton, postsViewButtonItem]
+        navigationItem.rightBarButtonItems = [postsViewButtonItem]
     }
 
     @objc func togglePostsView() {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
@@ -11,7 +11,7 @@ class CreateButtonActionSheet: ActionSheetViewController {
     }
 
     init(actions: [ActionSheetItem]) {
-        let buttons = actions.map({ return $0.makeButton() })
+        let buttons = actions.map { $0.makeButton() }
         super.init(headerTitle: Constants.title, buttons: buttons)
     }
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
@@ -1,68 +1,21 @@
+protocol ActionSheetItem {
+    var handler: () -> Void { get }
+    func makeButton() -> ActionSheetButton
+}
+
 /// The Action Sheet containing action buttons to create new content to be displayed from the Create Button.
 class CreateButtonActionSheet: ActionSheetViewController {
 
     enum Constants {
         static let title = NSLocalizedString("Create New", comment: "Create New header text")
-
-        enum Badge {
-            static let font = UIFont.preferredFont(forTextStyle: .caption1)
-            static let insets = UIEdgeInsets(top: 2, left: 8, bottom: 2, right: 8)
-            static let cornerRadius: CGFloat = 2
-            static let backgroundColor = UIColor.muriel(color: MurielColor(name: .red, shade: .shade50))
-        }
     }
 
-    init(newPost: @escaping () -> Void, newPage: @escaping () -> Void, newStory: (() -> Void)?) {
-        let postsButton = CreateButtonActionSheet.makePostsButton(handler: newPost)
-        let pagesButton = CreateButtonActionSheet.makePagesButton(handler: newPage)
-        let storiesButton = CreateButtonActionSheet.makeStoriesButton(handler: { newStory?() })
-        let shouldShowStories = newStory != nil
-        let buttons = shouldShowStories ? [postsButton, pagesButton, storiesButton] : [postsButton, pagesButton]
-
+    init(actions: [ActionSheetItem]) {
+        let buttons = actions.map({ return $0.makeButton() })
         super.init(headerTitle: Constants.title, buttons: buttons)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: Button Constructors
-
-    private static func makePostsButton(handler: @escaping () -> Void) -> ActionSheetButton {
-        let highlight: Bool = QuickStartTourGuide.find()?.shouldSpotlight(.newpost) ?? false
-
-        return ActionSheetButton(title: NSLocalizedString("Blog post", comment: "Create new Blog Post button title"),
-                                 image: .gridicon(.posts),
-                                 identifier: "blogPostButton",
-                                 highlight: highlight,
-                                 action: handler)
-    }
-
-    private static func makePagesButton(handler: @escaping () -> Void) -> ActionSheetButton {
-        return ActionSheetButton(title: NSLocalizedString("Site page", comment: "Create new Site Page button title"),
-                                            image: .gridicon(.pages),
-                                            identifier: "sitePageButton",
-                                            action: handler)
-    }
-
-    private static func makeStoriesButton(handler: @escaping () -> Void) -> ActionSheetButton {
-        let badge = CreateButtonActionSheet.newBadge(title: NSLocalizedString("New", comment: "New button badge on Stories Post button"))
-        return ActionSheetButton(title: NSLocalizedString("Story post", comment: "Create new Story button title"),
-                                            image: .gridicon(.book),
-                                            identifier: "storyButton",
-                                            badge: badge,
-                                            action: handler)
-    }
-
-    private static func newBadge(title: String) -> UIButton {
-        let badge = UIButton(type: .custom)
-        badge.translatesAutoresizingMaskIntoConstraints = false
-        badge.setTitle(title, for: .normal)
-        badge.titleLabel?.font = Constants.Badge.font
-        badge.contentEdgeInsets = Constants.Badge.insets
-        badge.layer.cornerRadius = Constants.Badge.cornerRadius
-        badge.isUserInteractionEnabled = false
-        badge.backgroundColor = Constants.Badge.backgroundColor
-        return badge
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -20,10 +20,6 @@ import WordPressFlux
 
     private weak var viewController: UIViewController?
 
-    let newPost: () -> Void
-    let newPage: () -> Void
-    let newStory: (() -> Void)?
-
     private let noticeAnimator = NoticeAnimator(duration: 0.5, springDampening: 0.7, springVelocity: 0.0)
 
     private lazy var notice: Notice = {
@@ -60,6 +56,7 @@ import WordPressFlux
     }
 
     private weak var noticeContainerView: NoticeContainerView?
+    private let actions: [ActionSheetItem]
 
     /// Returns a newly initialized CreateButtonCoordinator
     /// - Parameters:
@@ -67,11 +64,9 @@ import WordPressFlux
     ///   - newPost: A closure to call when the New Post button is tapped.
     ///   - newPage: A closure to call when the New Page button is tapped.
     ///   - newStory: A closure to call when the New Story button is tapped. The New Story button is hidden when value is `nil`.
-    @objc init(_ viewController: UIViewController, newPost: @escaping () -> Void, newPage: @escaping () -> Void, newStory: (() -> Void)?) {
+    init(_ viewController: UIViewController, actions: [ActionSheetItem]) {
         self.viewController = viewController
-        self.newPost = newPost
-        self.newPage = newPage
-        self.newStory = newStory
+        self.actions = actions
 
         super.init()
 
@@ -123,12 +118,22 @@ import WordPressFlux
         guard let viewController = viewController else {
             return
         }
-        let actionSheetVC = CreateButtonActionSheet(newPost: newPost, newPage: newPage, newStory: newStory)
-        setupPresentation(on: actionSheetVC, for: viewController.traitCollection)
-        viewController.present(actionSheetVC, animated: true, completion: {
-            WPAnalytics.track(.createSheetShown)
-            QuickStartTourGuide.find()?.visited(.newpost)
-        })
+
+        if actions.count == 1 {
+            actions.first?.handler()
+        } else {
+            let actionSheetVC = actionSheetController(with: viewController.traitCollection)
+            viewController.present(actionSheetVC, animated: true, completion: {
+                WPAnalytics.track(.createSheetShown)
+                QuickStartTourGuide.find()?.visited(.newpost)
+            })
+        }
+    }
+
+    private func actionSheetController(with traitCollection: UITraitCollection) -> UIViewController {
+        let actionSheetVC = CreateButtonActionSheet(actions: actions)
+        setupPresentation(on: actionSheetVC, for: traitCollection)
+        return actionSheetVC
     }
 
     private func setupPresentation(on viewController: UIViewController, for traitCollection: UITraitCollection) {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
@@ -1,0 +1,59 @@
+/// Common Actions used by CreateButtonActionSheet
+
+struct PostAction: ActionSheetItem {
+    let handler: () -> Void
+
+    func makeButton() -> ActionSheetButton {
+        let highlight: Bool = QuickStartTourGuide.find()?.shouldSpotlight(.newpost) ?? false
+        return ActionSheetButton(title: NSLocalizedString("Blog post", comment: "Create new Blog Post button title"),
+                                 image: .gridicon(.posts),
+                                 identifier: "blogPostButton",
+                                 highlight: highlight,
+                                 action: handler)
+    }
+}
+
+struct PageAction: ActionSheetItem {
+    let handler: () -> Void
+
+    func makeButton() -> ActionSheetButton {
+        return ActionSheetButton(title: NSLocalizedString("Site page", comment: "Create new Site Page button title"),
+                                            image: .gridicon(.pages),
+                                            identifier: "sitePageButton",
+                                            action: handler)
+    }
+}
+
+struct StoryAction: ActionSheetItem {
+
+    private enum Constants {
+        enum Badge {
+            static let font = UIFont.preferredFont(forTextStyle: .caption1)
+            static let insets = UIEdgeInsets(top: 2, left: 8, bottom: 2, right: 8)
+            static let cornerRadius: CGFloat = 2
+            static let backgroundColor = UIColor.muriel(color: MurielColor(name: .red, shade: .shade50))
+        }
+    }
+
+    let handler: () -> Void
+    func makeButton() -> ActionSheetButton {
+        let badge = StoryAction.newBadge(title: NSLocalizedString("New", comment: "New button badge on Stories Post button"))
+        return ActionSheetButton(title: NSLocalizedString("Story post", comment: "Create new Story button title"),
+                                            image: .gridicon(.book),
+                                            identifier: "storyButton",
+                                            badge: badge,
+                                            action: handler)
+    }
+
+    static func newBadge(title: String) -> UIButton {
+        let badge = UIButton(type: .custom)
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.setTitle(title, for: .normal)
+        badge.titleLabel?.font = Constants.Badge.font
+        badge.contentEdgeInsets = Constants.Badge.insets
+        badge.layer.cornerRadius = Constants.Badge.cornerRadius
+        badge.isUserInteractionEnabled = false
+        badge.backgroundColor = Constants.Badge.backgroundColor
+        return badge
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2217,6 +2217,7 @@
 		F5D0A64E23CC159400B20D27 /* PreviewWebKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D0A64D23CC159400B20D27 /* PreviewWebKitViewController.swift */; };
 		F5D0A65023CC15A800B20D27 /* PreviewNonceHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D0A64F23CC15A800B20D27 /* PreviewNonceHandler.swift */; };
 		F5D0A65223CCD3B600B20D27 /* PreviewWebKitViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D0A65123CCD3B600B20D27 /* PreviewWebKitViewControllerTests.swift */; };
+		F5D399302541F25B0058D0AB /* SheetActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3992F2541F25B0058D0AB /* SheetActions.swift */; };
 		F5E032D6240889EB003AF350 /* CreateButtonCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E032D5240889EB003AF350 /* CreateButtonCoordinator.swift */; };
 		F5E032DB24088F44003AF350 /* UIView+SpringAnimations.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E032DA24088F44003AF350 /* UIView+SpringAnimations.swift */; };
 		F5E032DF2408D1F1003AF350 /* WPTabBarController+ShowTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E032DE2408D1F1003AF350 /* WPTabBarController+ShowTab.swift */; };
@@ -4978,6 +4979,7 @@
 		F5D0A64D23CC159400B20D27 /* PreviewWebKitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewWebKitViewController.swift; sourceTree = "<group>"; };
 		F5D0A64F23CC15A800B20D27 /* PreviewNonceHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewNonceHandler.swift; sourceTree = "<group>"; };
 		F5D0A65123CCD3B600B20D27 /* PreviewWebKitViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewWebKitViewControllerTests.swift; sourceTree = "<group>"; };
+		F5D3992F2541F25B0058D0AB /* SheetActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetActions.swift; sourceTree = "<group>"; };
 		F5E032D5240889EB003AF350 /* CreateButtonCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateButtonCoordinator.swift; sourceTree = "<group>"; };
 		F5E032DA24088F44003AF350 /* UIView+SpringAnimations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SpringAnimations.swift"; sourceTree = "<group>"; };
 		F5E032DE2408D1F1003AF350 /* WPTabBarController+ShowTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPTabBarController+ShowTab.swift"; sourceTree = "<group>"; };
@@ -10777,6 +10779,7 @@
 				F551E7F423F6EA3100751212 /* FloatingActionButton.swift */,
 				F5E032DA24088F44003AF350 /* UIView+SpringAnimations.swift */,
 				F5E032D5240889EB003AF350 /* CreateButtonCoordinator.swift */,
+				F5D3992F2541F25B0058D0AB /* SheetActions.swift */,
 				F532AE1B253E55D40013B42E /* CreateButtonActionSheet.swift */,
 				F5B9D7EF245BA938002BB2C7 /* FancyAlertViewController+CreateButtonAnnouncement.swift */,
 			);
@@ -12991,6 +12994,7 @@
 				937D9A1119F838C2007B9D5F /* AccountToAccount22to23.swift in Sources */,
 				400A2C772217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift in Sources */,
 				D8212CB320AA6861008E8AE8 /* ReaderFollowAction.swift in Sources */,
+				F5D399302541F25B0058D0AB /* SheetActions.swift in Sources */,
 				8B7F51C924EED804008CF5B5 /* ReaderTracker.swift in Sources */,
 				E6F2788421BC1A4A008B4DB5 /* PlanFeature.swift in Sources */,
 				3F421DF524A3EC2B00CA9B9E /* Spotlightable.swift in Sources */,


### PR DESCRIPTION
Replaces the + Navigation Bar button with the FAB to the Post and Page list screens.

See pbD5rk-mp-p2 for more information about this change.

### Testing

#### iPhone
* Ensure that the FAB shows up on the Blog Details screen
* Ensure that the FAB shows up on the Posts List Screen
* Ensure that the FAB shows up on the Page List Screen
* FAB should not show on Media or other details screens.

#### iPad
* Ensure that the FAB shows up on the Blog Details screen when the split view controller is shown
* Ensure that the FAB shows/hides when changing the size of the app using split screen (should show on Posts list when split view controller is gone).

![CleanShot 2020-10-22 at 12 15 11](https://user-images.githubusercontent.com/3250/96913213-95593700-1460-11eb-95c4-93494ce177da.gif)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
