### PR TITLE
Resolves issue where extra space was being added to the scrollable area

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.swift
@@ -212,6 +212,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
+        guard isShowingNoResults else { return }
         coordinator.animate { (_) in
             self.updateHeaderDisplay()
             if self.shouldHideFilterBar {

--- a/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/CollapsableHeader/CollapsableHeaderViewController.swift
@@ -188,7 +188,6 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         setStaticText()
 
         scrollView.delegate = self
-        layoutHeader()
 
         if #available(iOS 13.0, *) {} else {
             headerBar.backgroundColor = .basicBackground
@@ -199,6 +198,9 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
 
     override func viewWillAppear(_ animated: Bool) {
         navigationController?.setNavigationBarHidden(true, animated: true)
+        if !isViewOnScreen() {
+            layoutHeader()
+        }
         super.viewWillAppear(animated)
     }
 


### PR DESCRIPTION
## Description

This resolves an error where on iPads the initial calculations were happening before the view would finish laying out. This resulted in extra spacing like:

Portrait | Landscape
--- | ---
<kdb><a href="https://user-images.githubusercontent.com/3384451/97042490-1f77cd00-153f-11eb-87bf-f7e7ce498a45.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/97042490-1f77cd00-153f-11eb-87bf-f7e7ce498a45.png"/></a></kdb> | <kdb><a href="https://user-images.githubusercontent.com/3384451/97042529-2dc5e900-153f-11eb-9d43-992d3fe9d103.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/97042529-2dc5e900-153f-11eb-9d43-992d3fe9d103.png"/></a></kdb>


## To test:
<details>
<summary><strong>To disable or enable the development version of Modal Layout Picker</strong></summary>

- Open the app from the build that allows FeatureFlags such as a PR build or a local development build
    - By default, the modal layout picker will be disabled.
    - From the site page:
        - Click on your Gravatar.
        - Click on App Settings.
        - Click on Debug.
        - Toggle "Gutenberg Modal Layout Picker" to enable or disable the picker
            <img width=300 src="https://user-images.githubusercontent.com/3384451/90816133-c8b10580-e2f9-11ea-8584-6bbfd7e523e2.gif" />
</details>

When enabled, the Layout Picker should show when creating a new page from My Site and from the Page list.

Start by navigating to the Modal Layout Picker

### Test
1. On iPad running iOS 13+ open MLP
1. Verify the screen layouts correctly
1. Try rotating
1. Verify the screen layouts correctly

Portrait | Landscape
--- | ---
<kdb><a href="https://user-images.githubusercontent.com/3384451/97042897-ba70a700-153f-11eb-8fdb-f4c4c030571e.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/97042897-ba70a700-153f-11eb-8fdb-f4c4c030571e.png"/></a></kdb> | <kdb><a href="https://user-images.githubusercontent.com/3384451/97042948-cbb9b380-153f-11eb-9efa-4cd25a379e89.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/97042948-cbb9b380-153f-11eb-9efa-4cd25a379e89.png"/></a></kdb>

## Additional Context: 

This is a continuation of the work done in  and will be followed up by other tickets as part of [Modal Layout Picker Project](https://github.com/wordpress-mobile/gutenberg-mobile/issues?q=is%3Aissue+is%3Aopen+%5BModal+Layout+Picker%5D)

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

