### PR TITLE
Add translations download on new beta releases

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -164,6 +164,7 @@ import "./ScreenshotFastfile"
   lane :new_beta_release do | options |
     ios_betabuild_prechecks(options)
     ios_bump_version_beta()
+    ios_update_metadata(options)
     ios_tag_build()
   end
 


### PR DESCRIPTION
This PR adds a step to download the translations to the new_beta_release lane. This way, we can start to test available translations a little bit earlier in the release process.

To Test:
Testing is a bit hack-y.
- Checkout a new test branch from this one.
- Comment out the `ios_betabuild_prechecks` line. This is important because otherwise you'll push stuff to the current release branch.
- Comment out the `ios_tag_build` step, otherwise you'll push tags to GitHub and start the build.
- Commit the new Fastfile to your test branch.
- Run `bundle exec fastlane new_beta_release`.
- Verify that the translations are downloaded, committed and pushed.
- Delete your local test branch.
- Delete your test branch from GitHub (it has been automatically pushed).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
