### PR TITLE
Update Modal Layout Picker Preview Bar to use the Light Navigation Style

### DIFF
--- a/WordPress/Classes/Services/PageCoordinator.swift
+++ b/WordPress/Classes/Services/PageCoordinator.swift
@@ -23,7 +23,7 @@ class PageCoordinator {
 
         let container = CollapsableHeaderViewController(childViewController: childViewController)
         childViewController.headerContentsDelegate = container
-        let navigationController = UINavigationController(rootViewController: container)
+        let navigationController = GutenbergLightNavigationController(rootViewController: container)
 
         if #available(iOS 13.0, *) {
             navigationController.modalPresentationStyle = .pageSheet


### PR DESCRIPTION
## Description
This fixes an error found while doing some sanity testing. During the refactor as part of https://github.com/wordpress-mobile/WordPress-iOS/pull/15118, the navigation controller that was part of the Storyboard was removed and created programmatically. When this change was made we created it as UINavigationController (which has the WordPress Blue color in production) instead of using the GutenbergLightNavigationController which has different styling applied and which is what was used by the storyboard. 

## To test:
<details>
<summary><strong>To disable or enable the development version of Modal Layout Picker</strong></summary>

- Open the app from the build that allows FeatureFlags such as a PR build or a local development build
    - By default, the modal layout picker will be disabled.
    - From the site page:
        - Click on your Gravatar.
        - Click on App Settings.
        - Click on Debug.
        - Toggle "Gutenberg Modal Layout Picker" to enable or disable the picker
            <img width=300 src="https://user-images.githubusercontent.com/3384451/90816133-c8b10580-e2f9-11ea-8584-6bbfd7e523e2.gif" />
</details>

When enabled, the Layout Picker should show when creating a new page from My Site and from the Page list.

📓 You'll want to run this from the included installable build or by changing the [newNavBarAppearance](https://github.com/wordpress-mobile/WordPress-iOS/blob/8f89df64f37b89543274ab247267492ef6487646/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift#L47) flag to true. 

### Test
1. Start by navigating to the Modal Layout Picker
1. Select a Layout
1. Select Preview
- **Expect** to see a white navigation bar instead of the WordPress Blue

## Screenshots:

Before | After
--- | ---
<kdb><a href="https://user-images.githubusercontent.com/3384451/97325184-1772a280-1849-11eb-91ce-ff05b0c4cf07.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/97325184-1772a280-1849-11eb-91ce-ff05b0c4cf07.png"/></a></kdb> | <kdb><a href="https://user-images.githubusercontent.com/3384451/97325088-ff9b1e80-1848-11eb-961c-5e33068c84ac.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/97325088-ff9b1e80-1848-11eb-961c-5e33068c84ac.png"/></a></kdb>

## Additional Context: 

This is a continuation of the work done in  and will be followed up by other tickets as part of [Modal Layout Picker Project](https://github.com/wordpress-mobile/gutenberg-mobile/issues?q=is%3Aissue+is%3Aopen+%5BModal+Layout+Picker%5D)

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


