### PR TITLE
Track Cards API response

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -74,7 +74,7 @@ import Foundation
     case readerSharedItem
     case readerSuggestedSiteVisited
     case readerSuggestedSiteToggleFollow
-    case readerCardsFetched
+    case readerCardsDidRespond
 
     // What's New - Feature announcements
     case featureAnnouncementShown
@@ -206,8 +206,8 @@ import Foundation
             return "reader_suggested_site_visited"
         case .readerSuggestedSiteToggleFollow:
             return "reader_suggested_site_toggle_follow"
-        case .readerCardsFetched:
-            return "reader_cards_fetched"
+        case .readerCardsDidRespond:
+            return "reader_cards_did_respond"
         // What's New - Feature announcements
         case .featureAnnouncementShown:
             return "feature_announcement_shown"

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -74,6 +74,7 @@ import Foundation
     case readerSharedItem
     case readerSuggestedSiteVisited
     case readerSuggestedSiteToggleFollow
+    case readerCardsFetched
 
     // What's New - Feature announcements
     case featureAnnouncementShown
@@ -205,6 +206,8 @@ import Foundation
             return "reader_suggested_site_visited"
         case .readerSuggestedSiteToggleFollow:
             return "reader_suggested_site_toggle_follow"
+        case .readerCardsFetched:
+            return "reader_cards_fetched"
         // What's New - Feature announcements
         case .featureAnnouncementShown:
             return "feature_announcement_shown"

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -74,7 +74,7 @@ import Foundation
     case readerSharedItem
     case readerSuggestedSiteVisited
     case readerSuggestedSiteToggleFollow
-    case readerCardsDidRespond
+    case readerDiscoverContentPresented
 
     // What's New - Feature announcements
     case featureAnnouncementShown
@@ -206,8 +206,8 @@ import Foundation
             return "reader_suggested_site_visited"
         case .readerSuggestedSiteToggleFollow:
             return "reader_suggested_site_toggle_follow"
-        case .readerCardsDidRespond:
-            return "reader_cards_did_respond"
+        case .readerDiscoverContentPresented:
+            return "reader_discover_content_presented"
         // What's New - Feature announcements
         case .featureAnnouncementShown:
             return "feature_announcement_shown"

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -25,7 +25,9 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     private var selectInterestsViewController: ReaderSelectInterestsViewController = ReaderSelectInterestsViewController()
 
     /// Whether the current view controller is visible
-    private var isVisible = false
+    private var isVisible: Bool {
+        return isViewLoaded && view.window != nil
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -39,16 +41,6 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         displaySelectInterestsIfNeeded()
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        isVisible = true
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        isVisible = false
     }
 
     // MARK: - TableView Related

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -115,7 +115,10 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         cardsService.fetch(isFirstPage: true, refreshCount: refreshCount, success: { [weak self] cardsCount, hasMore in
             self?.trackApiResponse()
             success(cardsCount, hasMore)
-        }, failure: failure)
+        }, failure: { [weak self] error in
+            self?.trackApiResponse()
+            failure(error)
+        })
     }
 
     override func loadMoreItems(_ success: ((Bool) -> Void)?, failure: ((NSError) -> Void)?) {
@@ -154,7 +157,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
             return
         }
 
-        WPAnalytics.track(.readerCardsFetched)
+        WPAnalytics.track(.readerCardsDidRespond)
     }
 
     // MARK: - TableViewHandler

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -157,7 +157,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
             return
         }
 
-        WPAnalytics.track(.readerCardsDidRespond)
+        WPAnalytics.track(.readerDiscoverContentPresented)
     }
 
     // MARK: - TableViewHandler


### PR DESCRIPTION
This PR tracks if:

1) The API response has arrived
2) The user is still waiting for the content/error to be presented (aka didn't left Discover)

The event fired is intended to be used in a funnel, to check how many users are leaving Discover due to the API taking too long to respond.

### To test

Launch the app:

1. Open Discover
2. Wait for the cards to appear
3. Check that `reader_discover_content_presented` is fired

Launch the app again (to clear cache):

1. Open Discover
2. Immediately switch to other section (like Following)
3. Check that `reader_discover_content_presented` is *not* fired

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
