### PR TITLE
iOS14 Today widget: add localizations and RTL support

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1423,6 +1423,7 @@
 		98C0CE9B23C559C800D0F27C /* Double+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C82B52193A7B900A06E84 /* Double+Stats.swift */; };
 		98C0CE9C23C559C800D0F27C /* Double+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C82B52193A7B900A06E84 /* Double+Stats.swift */; };
 		98CAD296221B4ED2003E8F45 /* StatSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CAD295221B4ED1003E8F45 /* StatSection.swift */; };
+		98CE3D25254A22B500CEA7B9 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E1D91454134A853D0089019C /* Localizable.strings */; };
 		98D31B8F2396ED7F009CFF43 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93E5283B19A7741A003A1A9C /* NotificationCenter.framework */; };
 		98D31B992396ED7F009CFF43 /* WordPressAllTimeWidget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 98D31B8E2396ED7E009CFF43 /* WordPressAllTimeWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		98D31BA72396F7E2009CFF43 /* AllTimeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D31BA52396F7BF009CFF43 /* AllTimeViewController.swift */; };
@@ -11780,6 +11781,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F526C562538CF2B0069706C /* Assets.xcassets in Resources */,
+				98CE3D25254A22B500CEA7B9 /* Localizable.strings in Resources */,
 				3F8A087D253E4337000F35ED /* ColorPalette.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPress/WordPressHomeWidgetToday/Views/Cards/VerticalCard.swift
+++ b/WordPress/WordPressHomeWidgetToday/Views/Cards/VerticalCard.swift
@@ -21,6 +21,7 @@ struct VerticalCard: View {
                 .font(titleFont)
                 .foregroundColor(Appearance.textColor)
         }
+        .flipsForRightToLeftLayoutDirection(true)
     }
 }
 

--- a/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetSmallView.swift
+++ b/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetSmallView.swift
@@ -15,5 +15,6 @@ struct TodayWidgetSmallView: View {
             }
             Spacer()
         }
+        .flipsForRightToLeftLayoutDirection(true)
     }
 }


### PR DESCRIPTION
Fixes #15157 

This adds localizations for the Home Today widget, and finishes RTL support.

- `WordPress\Resources\Localizable.strings` - added `WordPressHomeWidgetToday` target. (Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/15185)
- Added `flipsForRightToLeftLayoutDirection` for a couple views that were missing it.

Note: the Site Title is still static, so it will appear in English for now. In the future, it will display the actual native site title.

To test:
- Run the app.
- Add both WP Home widgets to your Home view.
- Change the device language.
- Verify the text is translated.

| <img width="378" alt="english" src="https://user-images.githubusercontent.com/1816888/97509437-ea58e980-1947-11eb-9567-89fdff6e3ab7.png"> | <img width="380" alt="spanish" src="https://user-images.githubusercontent.com/1816888/97509451-f17ff780-1947-11eb-9167-4862edf96ad1.png"> |
|--------|-------|

- Change the device to a RTL language.
- Verify the text is RTL.

<img width="380" alt="arabic" src="https://user-images.githubusercontent.com/1816888/97509551-3572fc80-1948-11eb-89e9-5b6bd033c265.png">


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
