### PR TITLE
Workaround for a crashing bug with Bulgarian keyboards.

### DIFF
--- a/WordPress/Classes/Extensions/UITextField+WorkaroundContinueIssue.swift
+++ b/WordPress/Classes/Extensions/UITextField+WorkaroundContinueIssue.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+@objc
+extension UITextField {
+
+    /// This method takes care of resolving whether the iOS version is vulnerable to the Bulgarian / Icelandic keyboard crash issue
+    /// by Apple.  Once the issue is resolved by Apple we should consider setting an upper iOS version to limit this workaround.
+    ///
+    /// Once we drop support for iOS 14, we could remove this extension entirely.
+    ///
+    public class func shouldActivateWorkaroundForBulgarianKeyboardCrash() -> Bool {
+        if #available(iOS 14.0, *) {
+            return true
+        }
+
+        return false
+    }
+
+    /// We're swizzling `UITextField.becomeFirstResponder()` so that we can fix an issue with
+    /// Bulgarian and Icelandic keyboards when appropriate.
+    ///
+    /// Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15187
+    ///
+    @objc
+    class func activateWorkaroundForBulgarianKeyboardCrash() {
+        let original = class_getInstanceMethod(
+            UITextField.self,
+            #selector(UITextField.becomeFirstResponder))!
+        let new = class_getInstanceMethod(
+            UITextField.self,
+            #selector(UITextField.swizzledBecomeFirstResponder))!
+
+        method_exchangeImplementations(original, new)
+    }
+
+    /// This method simply replaces the `returnKeyType == .continue` with
+    /// `returnKeyType == .next`when the Bulgarian Keyboard crash workaround is needed.
+    ///
+    public func swizzledBecomeFirstResponder() {
+        if UITextField.shouldActivateWorkaroundForBulgarianKeyboardCrash(),
+           returnKeyType == .continue {
+            returnKeyType = .next
+        }
+
+        // This can look confusing - it's basically calling the original method to
+        // make sure we don't disrupt anything.
+        swizzledBecomeFirstResponder()
+    }
+}

--- a/WordPress/Classes/Extensions/UITextField+WorkaroundContinueIssue.swift
+++ b/WordPress/Classes/Extensions/UITextField+WorkaroundContinueIssue.swift
@@ -23,12 +23,17 @@ extension UITextField {
     ///
     @objc
     class func activateWorkaroundForBulgarianKeyboardCrash() {
-        let original = class_getInstanceMethod(
-            UITextField.self,
-            #selector(UITextField.becomeFirstResponder))!
-        let new = class_getInstanceMethod(
-            UITextField.self,
-            #selector(UITextField.swizzledBecomeFirstResponder))!
+        guard let original = class_getInstanceMethod(
+                UITextField.self,
+                #selector(UITextField.becomeFirstResponder)),
+              let new = class_getInstanceMethod(
+                UITextField.self,
+                #selector(UITextField.swizzledBecomeFirstResponder)) else {
+
+            DDLogError("Could not activate workaround for Bulgarian keyboard crash.")
+
+            return
+        }
 
         method_exchangeImplementations(original, new)
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -108,6 +108,13 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         DDLogInfo("didFinishLaunchingWithOptions state: \(application.applicationState)")
 
+        if UITextField.shouldActivateWorkaroundForBulgarianKeyboardCrash() {
+            // WORKAROUND: this is a workaround for an issue with UITextField in iOS 14.
+            // Please refer to the documentation of the called method to learn the details and know
+            // how to tell if this call can be removed.
+            UITextField.activateWorkaroundForBulgarianKeyboardCrash()
+        }
+
         InteractiveNotificationsManager.shared.registerForUserNotifications()
         showWelcomeScreenIfNeeded(animated: false)
         setupPingHub()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2168,6 +2168,7 @@
 		F17A2A2023BFBD84001E96AC /* UIView+ExistingConstraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17A2A1F23BFBD84001E96AC /* UIView+ExistingConstraints.swift */; };
 		F1863716253E49B8003D4BEF /* AddSiteAlertFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1863715253E49B8003D4BEF /* AddSiteAlertFactory.swift */; };
 		F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B43771F849F580089B817 /* PostAttachmentTests.swift */; };
+		F19153BD2549ED0800629EC4 /* UITextField+WorkaroundContinueIssue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19153BC2549ED0800629EC4 /* UITextField+WorkaroundContinueIssue.swift */; };
 		F1ADCAF7241FEF0C00F150D2 /* AtomicAuthenticationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1ADCAF6241FEF0C00F150D2 /* AtomicAuthenticationService.swift */; };
 		F1B1E7A324098FA100549E2A /* BlogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B1E7A224098FA100549E2A /* BlogTests.swift */; };
 		F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
@@ -4930,6 +4931,7 @@
 		F17A2A1F23BFBD84001E96AC /* UIView+ExistingConstraints.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+ExistingConstraints.swift"; sourceTree = "<group>"; };
 		F1863715253E49B8003D4BEF /* AddSiteAlertFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddSiteAlertFactory.swift; sourceTree = "<group>"; };
 		F18B43771F849F580089B817 /* PostAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAttachmentTests.swift; path = Posts/PostAttachmentTests.swift; sourceTree = "<group>"; };
+		F19153BC2549ED0800629EC4 /* UITextField+WorkaroundContinueIssue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+WorkaroundContinueIssue.swift"; sourceTree = "<group>"; };
 		F1ADCAF6241FEF0C00F150D2 /* AtomicAuthenticationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicAuthenticationService.swift; sourceTree = "<group>"; };
 		F1B1E7A224098FA100549E2A /* BlogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogTests.swift; sourceTree = "<group>"; };
 		F1BBA95E243BEFC500E9E5E6 /* WordPress 95.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 95.xcdatamodel"; sourceTree = "<group>"; };
@@ -9391,6 +9393,7 @@
 				171CC15724FCEBF7008B7180 /* UINavigationBar+Appearance.swift */,
 				7326A4A7221C8F4100B4EB8C /* UIStackView+Subviews.swift */,
 				8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */,
+				F19153BC2549ED0800629EC4 /* UITextField+WorkaroundContinueIssue.swift */,
 				D829C33A21B12EFE00B09F12 /* UIView+Borders.swift */,
 				F17A2A1D23BFBD72001E96AC /* UIView+ExistingConstraints.swift */,
 				9A162F2421C26F5F00FDC035 /* UIViewController+ChildViewController.swift */,
@@ -13673,6 +13676,7 @@
 				E148362F1C6DF7D8005ACF53 /* Product.swift in Sources */,
 				082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */,
 				82FC612A1FA8B6F000A1757E /* ActivityListViewModel.swift in Sources */,
+				F19153BD2549ED0800629EC4 /* UITextField+WorkaroundContinueIssue.swift in Sources */,
 				E17780801C97FA9500FA7E14 /* StoreKit+Debug.swift in Sources */,
 				E1ADE0EB20A9EF6200D6AADC /* PrivacySettingsViewController.swift in Sources */,
 				E6431DE61C4E892900FD8D90 /* SharingDetailViewController.m in Sources */,


### PR DESCRIPTION
Fixes #15187 

Adds a workaround to avoid the crash by replacing text field's `returnKeyType == .continue` with `returnKeyType == .next`.

# Reproducing the original issue

If you want to reproduce the original issue, comment the call to `UITextField.activateWorkaroundForBulgarianKeyboardCrash()` and following the testing steps below.

# To test the fix

Be logged out (this issue can be reproduced in any text field, but being logged out is necessary for the proposed reproduction steps below).

1. Add the Bulgarian or Icelandic keyboard in your devices settings.
2. Launch WPiOS
3. Tap "Continue with WordPress.com"
4. Tap on the email field to start writing. If the Bulgarian / Icelandic keyboard is the selected one you should be able to use it normally and the App should not crash.
5. If the selected keyboard is not Bulgarian / Icelandic, tap on the globe icon in your keyboard until you switch to it.  Make sure it works fine and doesn't crash the App.

# PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
