### PR TITLE
iOS14 Today widget: combine stat title and value in accessibility label

### DIFF
--- a/WordPress/WordPressHomeWidgetToday/Views/Cards/VerticalCard.swift
+++ b/WordPress/WordPressHomeWidgetToday/Views/Cards/VerticalCard.swift
@@ -10,16 +10,22 @@ struct VerticalCard: View {
         largeText ? Appearance.largeTextFont : Appearance.textFont
     }
 
+    private var accessibilityLabel: Text {
+        // The colon makes VoiceOver pause between elements
+        Text(title) + Text(": ") + Text(value)
+    }
+
     var body: some View {
         VStack(alignment: .leading) {
             Text(title)
                 .font(Appearance.titleFont)
                 .fontWeight(Appearance.titleFontWeight)
                 .foregroundColor(Appearance.titleColor)
-
+                .accessibility(hidden: true)
             Text(value)
                 .font(titleFont)
                 .foregroundColor(Appearance.textColor)
+                .accessibility(label: accessibilityLabel)
         }
         .flipsForRightToLeftLayoutDirection(true)
     }


### PR DESCRIPTION
Fixes #15159 

When a stat is selected with VoiceOver enabled, the title and value are now read together instead of independent elements.

Specifically:
- Accessibility is disabled on the title label.(ex: "Views")
- The accessibility label for the value is title + value. (ex: "Views 5,980")

To test:
- Run the app.
- Add both widgets to the Home view.
- Enable VoiceOver.
  - Selecting the site title will read the site title.
  - Selecting the widget title (i.e. "Today") will read the widget title.
  - Selecting a stat will read both the title and value (ex: "Views 5,980").

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
