### PR TITLE
Remove two unused methods.

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -54,8 +54,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)switchMySitesTabToAddNewSite;
 - (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog;
 - (void)switchMySitesTabToMediaForBlog:(Blog *)blog;
-- (void)switchMySitesTabToCustomizeViewForBlog:(Blog *)blog;
-- (void)switchMySitesTabToThemesViewForBlog:(Blog *)blog;
 
 - (void)popNotificationsTabToRoot;
 - (void)switchNotificationsTabToNotificationSettings;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -519,28 +519,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         [blogDetailVC showDetailViewForSubsection:BlogDetailsSubsectionMedia];
     }
 }
-
-- (void)switchMySitesTabToCustomizeViewForBlog:(Blog *)blog
-{
-    [self switchMySitesTabToThemesViewForBlog:blog];
-
-    UIViewController *topVC = [self.blogListSplitViewController topDetailViewController];
-    if ([topVC isKindOfClass:[ThemeBrowserViewController class]]) {
-        ThemeBrowserViewController *themeViewController = (ThemeBrowserViewController *)topVC;
-        [themeViewController presentCustomizeForTheme:[themeViewController currentTheme]];
-    }
-}
-
-- (void)switchMySitesTabToThemesViewForBlog:(Blog *)blog
-{
-    [self.mySitesCoordinator showBlogDetailsFor:blog];
-
-    BlogDetailsViewController *blogDetailVC = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
-    if ([blogDetailVC isKindOfClass:[BlogDetailsViewController class]]) {
-        [blogDetailVC showDetailViewForSubsection:BlogDetailsSubsectionThemes];
-    }
-}
-
+ 
 - (void)switchMySitesTabToBlogDetailsForBlog:(Blog *)blog
 {
     [self setSelectedIndex:WPTabMySites];


### PR DESCRIPTION
This PR is part of my ongoing work for Big Titles, White Headers.

The reason I'm removing them is due to some upcoming changes in the view controller hierarchy of the "My Sites" tab.  The changes I'm planning to push required me to move these two methods to `MySiteCoordinator.swift` - but since I noticed they're not being used, I decided to just remove them for now.

They're fairly easy to reimplement (if we need them) within `MySiteCoordinator`.  But again since they're not being used I think it's not a big loss to just remove them for now.

## To test:

Simply make sure the app builds, and that the changes look fine in code.  There's nothing to test since it's just a code removal for unused code.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
