### PR TITLE
Page Settings: set display titles to "Page Settings" if a page is being editing.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1260,7 +1260,9 @@ private extension AztecPostViewController {
             }
         }
 
-        alert.addDefaultActionWithTitle(MoreSheetAlert.postSettingsTitle) { [unowned self] _ in
+        let settingsTitle = self.post is Page ? MoreSheetAlert.pageSettingsTitle : MoreSheetAlert.postSettingsTitle
+
+        alert.addDefaultActionWithTitle(settingsTitle) { [unowned self] _ in
             self.displayPostSettings()
         }
 
@@ -3396,6 +3398,7 @@ extension AztecPostViewController {
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
         static let historyTitle = NSLocalizedString("History", comment: "Displays the History screen from the editor's alert sheet")
         static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
+        static let pageSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
         static let accessibilityIdentifier = "MoreSheetAccessibilityIdentifier"
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -53,7 +53,10 @@ extension GutenbergViewController {
             }
         }
 
-        alert.addDefaultActionWithTitle(MoreSheetAlert.postSettingsTitle) { [weak self] _ in
+
+        let settingsTitle = self.post is Page ? MoreSheetAlert.pageSettingsTitle : MoreSheetAlert.postSettingsTitle
+
+        alert.addDefaultActionWithTitle(settingsTitle) { [weak self] _ in
             self?.displayPostSettings()
         }
 
@@ -111,6 +114,7 @@ extension GutenbergViewController {
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
         static let historyTitle = NSLocalizedString("History", comment: "Displays the History screen from the editor's alert sheet")
         static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
+        static let pageSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
         static let accessibilityIdentifier = "MoreSheetAccessibilityIdentifier"
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -128,8 +128,12 @@ FeaturedImageViewControllerDelegate>
 {
     [super viewDidLoad];
     
-    self.title = NSLocalizedString(@"Post Settings", @"The title of the Post Settings screen.");
-
+    if ([self.apost isKindOfClass:[Page class]]) {
+        self.title = NSLocalizedString(@"Page Settings", @"The title of the Page Settings screen.");
+    } else {
+        self.title = NSLocalizedString(@"Post Settings", @"The title of the Post Settings screen.");
+    }
+    
     DDLogInfo(@"%@ %@", self, NSStringFromSelector(_cmd));
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];


### PR DESCRIPTION
Fixes #12374 

When editing a page, change settings titles to `Page Settings` instead of `Post Settings`.

To test:
- Edit a Page.
  - Select `...` on the nav bar.
  - Verify the settings option is `Page Settings`.
- Switch to classic editor.
  - Select `...` on the nav bar.
  - Verify the settings option is `Page Settings`.
- Select `Page Settings`.
  - Verify the view title is `Page Settings`.

| Gutenberg menu | Classic menu | Settings view |
|--------|-------|-------|
| <img width="425" alt="gutenberg_menu" src="https://user-images.githubusercontent.com/1816888/97933011-c3772a80-1d2e-11eb-8814-ff8e8fb8c500.png"> | <img width="420" alt="aztec_menu" src="https://user-images.githubusercontent.com/1816888/97933027-d1c54680-1d2e-11eb-9fcc-7a60176248c0.png"> | <img width="426" alt="settings_title" src="https://user-images.githubusercontent.com/1816888/97933039-d984eb00-1d2e-11eb-97ef-71df4fc5327f.png"> |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
