### PR TITLE
Support contact info: Fix text entry issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 16.2
 -----
- 
+* [**] Support contact email: fixed issue that prevented non-alpha characters from being entered. [#15210]
+* [*] Support contact information prompt: fixed issue that could cause the app to crash when entering email address. [#15210]
+
 16.1
 -----
 * [***] Block Editor: Adds new option to select from a variety of predefined page templates when creating a new page for a Gutenberg site.

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -847,14 +847,20 @@ private extension ZendeskUtils {
         }
     }
 
-    static func generateDisplayName(from rawEmail: String) -> String {
-
+    static func generateDisplayName(from rawEmail: String) -> String? {
         // Generate Name, using the same format as Signup.
 
         // step 1: lower case
         let email = rawEmail.lowercased()
+
         // step 2: remove the @ and everything after
-        let localPart = email.split(separator: "@")[0]
+
+        // Verify something exists before the @.
+        guard email.first != "@",
+              let localPart = email.split(separator: "@").first else {
+            return nil
+        }
+
         // step 3: remove all non-alpha characters
         let localCleaned = localPart.replacingOccurrences(of: "[^A-Za-z/.]", with: "", options: .regularExpression)
         // step 4: turn periods into spaces

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -828,12 +828,15 @@ private extension ZendeskUtils {
     }
 
     static func updateNameFieldForEmail(_ email: String) {
-        guard let alertController = ZendeskUtils.sharedInstance.presentInController?.presentedViewController as? UIAlertController,
-            let nameField = alertController.textFields?.last else {
-                return
+        guard !email.isEmpty else {
+            return
         }
 
-        guard !email.isEmpty else {
+        // Find the name text field if it's being displayed.
+        guard let alertController = ZendeskUtils.sharedInstance.presentInController?.presentedViewController as? UIAlertController,
+              let textFields = alertController.textFields,
+              textFields.count > 1,
+              let nameField = textFields.last else {
             return
         }
 

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -788,6 +788,7 @@ private extension ZendeskUtils {
             textField.text = ZendeskUtils.sharedInstance.userEmail
             textField.delegate = ZendeskUtils.sharedInstance
             textField.isEnabled = false
+            textField.keyboardType = .emailAddress
 
             textField.addTarget(self,
                                 action: #selector(emailTextFieldDidChange),


### PR DESCRIPTION
Fixes #n/a
Ref: https://github.com/wordpress-mobile/WordPress-iOS/pull/15204#pullrequestreview-522089318

This fixes two issues with the Support contact information:
- Contact Email > email address prompt: Unable to enter non-alpha characters in the email address field.
- Contact Support > contact info prompt: The app crashed when @ was the first character in the email field.

**To test:**

Prerequisite: Start with a fresh install so the app doesn't have any Support contact information saved in Me > Help & Support.

<img width="400" alt="no_info" src="https://user-images.githubusercontent.com/1816888/98044073-8a4cc200-1de3-11eb-89de-7e273d1b5f80.png">

**Contact Email:**
- Tap the `Contact Email` row.
- Verify you can enter non-alpha characters (namely the @ symbol 😄 ).

<img width="294" alt="email" src="https://user-images.githubusercontent.com/1816888/98044936-f1b74180-1de4-11eb-8a12-711ed405ca99.png">

**Contact Support:**
- Tap the `Contact Support` row.
- Enter an @ symbol as the first character in the email field.
  - Verify the app doesn't crash.
  - Verify the Name field is not populated (it only uses text preceding the @).

<img width="298" alt="email_name" src="https://user-images.githubusercontent.com/1816888/98044672-79e91700-1de4-11eb-9904-dd673cca9186.png">


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
