### PR TITLE
Add initial A/B testing support

### DIFF
--- a/WordPress/Classes/Utility/ABTesting/ABTesting.swift
+++ b/WordPress/Classes/Utility/ABTesting/ABTesting.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// A protocol that defines a A/B Testing provider
+///
+protocol ABTesting {
+
+    /// Refresh the assigned experiments
+    func refresh()
+}

--- a/WordPress/Classes/Utility/ABTesting/ABTesting.swift
+++ b/WordPress/Classes/Utility/ABTesting/ABTesting.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+enum Variation: Equatable {
+    case control
+    case treatment
+    case other(String)
+    case unknown
+}
+
 /// A protocol that defines a A/B Testing provider
 ///
 protocol ABTesting {
@@ -8,5 +15,5 @@ protocol ABTesting {
     func refresh(completion: (() -> Void)?)
 
     /// Return an experiment variation
-    func experiment(_ name: String) -> String?
+    func experiment(_ name: String) -> Variation
 }

--- a/WordPress/Classes/Utility/ABTesting/ABTesting.swift
+++ b/WordPress/Classes/Utility/ABTesting/ABTesting.swift
@@ -5,7 +5,7 @@ import Foundation
 protocol ABTesting {
 
     /// Refresh the assigned experiments
-    func refresh()
+    func refresh(completion: (() -> Void)?)
 
     /// Return an experiment variation
     func experiment(_ name: String) -> String?

--- a/WordPress/Classes/Utility/ABTesting/ABTesting.swift
+++ b/WordPress/Classes/Utility/ABTesting/ABTesting.swift
@@ -6,4 +6,7 @@ protocol ABTesting {
 
     /// Refresh the assigned experiments
     func refresh()
+
+    /// Return an experiment variation
+    func experiment(_ name: String) -> String?
 }

--- a/WordPress/Classes/Utility/ABTesting/Assignments.swift
+++ b/WordPress/Classes/Utility/ABTesting/Assignments.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct Assignments: Decodable {
+    let ttl: Int
+    let variations: [String: String?]
+}

--- a/WordPress/Classes/Utility/ABTesting/Assignments.swift
+++ b/WordPress/Classes/Utility/ABTesting/Assignments.swift
@@ -1,6 +1,11 @@
 import Foundation
 
+/// Model that contains experiments variations and TTL
+///
 struct Assignments: Decodable {
+    /// Time in seconds until the `variations` should be considered stale.
     let ttl: Int
+
+    /// Mapping from experiment name to variation name.
     let variations: [String: String?]
 }

--- a/WordPress/Classes/Utility/ABTesting/ExPlat.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlat.swift
@@ -3,6 +3,8 @@ import Foundation
 class ExPlat: ABTesting {
     let service: ExPlatService
 
+    private let assignmentsKey = "ab-testing-assignments"
+
     init(service: ExPlatService = ExPlatService.withDefaultApi()) {
         self.service = service
     }
@@ -15,13 +17,13 @@ class ExPlat: ABTesting {
             }
 
             let validVariations = assignments.variations.filter { $0.value != nil }
-            UserDefaults.standard.setValue(validVariations, forKey: "ab-testing-assignments")
+            UserDefaults.standard.setValue(validVariations, forKey: self.assignmentsKey)
             completion?()
         }
     }
 
     func experiment(_ name: String) -> Variation {
-        guard let assignments = UserDefaults.standard.object(forKey: "ab-testing-assignments") as? [String: String?],
+        guard let assignments = UserDefaults.standard.object(forKey: assignmentsKey) as? [String: String?],
               case let variation?? = assignments[name] else {
             return .unknown
         }

--- a/WordPress/Classes/Utility/ABTesting/ExPlat.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlat.swift
@@ -14,7 +14,8 @@ class ExPlat: ABTesting {
                 return
             }
 
-            UserDefaults.standard.setValue(assignments.variations, forKey: "ab-testing-assignments")
+            let validVariations = assignments.variations.filter { $0.value != nil }
+            UserDefaults.standard.setValue(validVariations, forKey: "ab-testing-assignments")
             completion?()
         }
     }

--- a/WordPress/Classes/Utility/ABTesting/ExPlat.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlat.swift
@@ -7,13 +7,15 @@ class ExPlat: ABTesting {
         self.service = service
     }
 
-    func refresh() {
+    func refresh(completion: (() -> Void)? = nil) {
         service.getAssignments { assignments in
             guard let assignments = assignments else {
+                completion?()
                 return
             }
 
             UserDefaults.standard.setValue(assignments.variations, forKey: "ab-testing-assignments")
+            completion?()
         }
     }
 

--- a/WordPress/Classes/Utility/ABTesting/ExPlat.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlat.swift
@@ -20,11 +20,19 @@ class ExPlat: ABTesting {
         }
     }
 
-    func experiment(_ name: String) -> String? {
-        guard let assignments = UserDefaults.standard.object(forKey: "ab-testing-assignments") as? [String: String?] else {
-            return nil
+    func experiment(_ name: String) -> Variation {
+        guard let assignments = UserDefaults.standard.object(forKey: "ab-testing-assignments") as? [String: String?],
+              case let variation?? = assignments[name] else {
+            return .unknown
         }
 
-        return assignments[name] ?? nil
+        switch variation {
+        case "control":
+            return .control
+        case "treatment":
+            return .treatment
+        default:
+            return .other(variation)
+        }
     }
 }

--- a/WordPress/Classes/Utility/ABTesting/ExPlat.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlat.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+class ExPlat: ABTesting {
+    let wordPressComRestApi: WordPressComRestApi
+
+    init(wordPressComRestApi: WordPressComRestApi) {
+        self.wordPressComRestApi = wordPressComRestApi
+    }
+
+    func refresh() {
+        let assignmentsPath = "wpcom/v2/experiments/0.1.0/assignments/calypso"
+
+        wordPressComRestApi.GET(assignmentsPath,
+                                parameters: nil,
+                                success: { responseObject, httpResponse in
+                                    do {
+                                        let decoder = JSONDecoder()
+                                        let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])
+                                        let assignments = try decoder.decode(Assignments.self, from: data)
+                                        UserDefaults.standard.setValue(assignments.variations, forKey: "explat")
+                                    } catch {
+                                        DDLogError("Error parsing the experiment response: \(error)")
+                                    }
+        }, failure: { error, _ in
+
+        })
+    }
+}
+
+extension ExPlat {
+    class func withDefaultApi() -> ExPlat {
+        let accountService = AccountService(managedObjectContext: ContextManager.shared.mainContext)
+        let defaultAccount = accountService.defaultWordPressComAccount()
+        let token: String? = defaultAccount?.authToken
+
+        let api = WordPressComRestApi.defaultApi(oAuthToken: token,
+                                              userAgent: WPUserAgent.wordPress(),
+                                              localeKey: WordPressComRestApi.LocaleKeyV2)
+        return ExPlat(wordPressComRestApi: api)
+    }
+}

--- a/WordPress/Classes/Utility/ABTesting/ExPlat.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlat.swift
@@ -16,4 +16,12 @@ class ExPlat: ABTesting {
             UserDefaults.standard.setValue(assignments.variations, forKey: "ab-testing-assignments")
         }
     }
+
+    func experiment(_ name: String) -> String? {
+        guard let assignments = UserDefaults.standard.object(forKey: "ab-testing-assignments") as? [String: String?] else {
+            return nil
+        }
+
+        return assignments[name] ?? nil
+    }
 }

--- a/WordPress/Classes/Utility/ABTesting/ExPlatService.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlatService.swift
@@ -12,7 +12,7 @@ class ExPlatService {
     func getAssignments(completion: @escaping (Assignments?) -> Void) {
         wordPressComRestApi.GET(assignmentsPath,
                                 parameters: nil,
-                                success: { responseObject, httpResponse in
+                                success: { responseObject, _ in
                                     do {
                                         let decoder = JSONDecoder()
                                         let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1196,6 +1196,8 @@
 		8BE25F202551B8C9002E52E4 /* ExPlatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25F1F2551B8C9002E52E4 /* ExPlatTests.swift */; };
 		8BE25F642551C579002E52E4 /* Assignments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25F3B2551C497002E52E4 /* Assignments.swift */; };
 		8BE25F732551C8A0002E52E4 /* explat-assignments.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BE25F722551C8A0002E52E4 /* explat-assignments.json */; };
+		8BE25F9D2551D5BD002E52E4 /* ExPlatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25F812551D52C002E52E4 /* ExPlatService.swift */; };
+		8BE25FAC2551D6E7002E52E4 /* ExPlatServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25FAB2551D6E7002E52E4 /* ExPlatServiceTests.swift */; };
 		8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BF0B607247D88EB009A7457 /* UITableViewCell+enableDisable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */; };
@@ -3745,6 +3747,8 @@
 		8BE25F1F2551B8C9002E52E4 /* ExPlatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExPlatTests.swift; sourceTree = "<group>"; };
 		8BE25F3B2551C497002E52E4 /* Assignments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assignments.swift; sourceTree = "<group>"; };
 		8BE25F722551C8A0002E52E4 /* explat-assignments.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "explat-assignments.json"; sourceTree = "<group>"; };
+		8BE25F812551D52C002E52E4 /* ExPlatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExPlatService.swift; sourceTree = "<group>"; };
+		8BE25FAB2551D6E7002E52E4 /* ExPlatServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExPlatServiceTests.swift; sourceTree = "<group>"; };
 		8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrepublishingHeaderViewTests.swift; path = WordPressTest/PrepublishingHeaderViewTests.swift; sourceTree = SOURCE_ROOT; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+enableDisable.swift"; sourceTree = "<group>"; };
@@ -8192,6 +8196,7 @@
 				8BE25F3B2551C497002E52E4 /* Assignments.swift */,
 				8BE25EFE2551B78B002E52E4 /* ABTesting.swift */,
 				8BE25F0D2551B885002E52E4 /* ExPlat.swift */,
+				8BE25F812551D52C002E52E4 /* ExPlatService.swift */,
 			);
 			path = ABTesting;
 			sourceTree = "<group>";
@@ -8200,6 +8205,7 @@
 			isa = PBXGroup;
 			children = (
 				8BE25F1F2551B8C9002E52E4 /* ExPlatTests.swift */,
+				8BE25FAB2551D6E7002E52E4 /* ExPlatServiceTests.swift */,
 			);
 			path = ABTesting;
 			sourceTree = "<group>";
@@ -13402,6 +13408,7 @@
 				57BAD50C225CCE1A006139EC /* WPTabBarController+Swift.swift in Sources */,
 				E1468DE71E794A4D0044D80F /* LanguageSelectorViewController.swift in Sources */,
 				E14694071F3459E2004052C8 /* PluginListViewController.swift in Sources */,
+				8BE25F9D2551D5BD002E52E4 /* ExPlatService.swift in Sources */,
 				FF0D8146205809C8000EE505 /* PostCoordinator.swift in Sources */,
 				7EA30DB621ADA20F0092F894 /* AztecAttachmentDelegate.swift in Sources */,
 				82B67B361FC726CD006FB593 /* Memoize.swift in Sources */,
@@ -14254,6 +14261,7 @@
 				40EE948222132F5800CD264F /* PublicizeConectionStatsRecordValueTests.swift in Sources */,
 				577C2AAB22936DCB00AD1F03 /* PostCardCellGhostableTests.swift in Sources */,
 				02761EC4227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift in Sources */,
+				8BE25FAC2551D6E7002E52E4 /* ExPlatServiceTests.swift in Sources */,
 				732A473D218787500015DA74 /* WPRichTextFormatterTests.swift in Sources */,
 				1ABA150822AE5F870039311A /* WordPressUIBundleTests.swift in Sources */,
 				57569CF2230485680052EE14 /* PostAutoUploadInteractorTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1192,6 +1192,10 @@
 		8BDA5A75247C63F300AB124C /* ReaderDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5A71247C5E5800AB124C /* ReaderDetailCoordinator.swift */; };
 		8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */; };
 		8BE25EFF2551B78B002E52E4 /* ABTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25EFE2551B78B002E52E4 /* ABTesting.swift */; };
+		8BE25F0E2551B885002E52E4 /* ExPlat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25F0D2551B885002E52E4 /* ExPlat.swift */; };
+		8BE25F202551B8C9002E52E4 /* ExPlatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25F1F2551B8C9002E52E4 /* ExPlatTests.swift */; };
+		8BE25F642551C579002E52E4 /* Assignments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25F3B2551C497002E52E4 /* Assignments.swift */; };
+		8BE25F732551C8A0002E52E4 /* explat-assignments.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BE25F722551C8A0002E52E4 /* explat-assignments.json */; };
 		8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BF0B607247D88EB009A7457 /* UITableViewCell+enableDisable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */; };
@@ -3737,6 +3741,10 @@
 		8BDA5A73247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailCoordinatorTests.swift; sourceTree = "<group>"; };
 		8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCSS.swift; sourceTree = "<group>"; };
 		8BE25EFE2551B78B002E52E4 /* ABTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTesting.swift; sourceTree = "<group>"; };
+		8BE25F0D2551B885002E52E4 /* ExPlat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExPlat.swift; sourceTree = "<group>"; };
+		8BE25F1F2551B8C9002E52E4 /* ExPlatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExPlatTests.swift; sourceTree = "<group>"; };
+		8BE25F3B2551C497002E52E4 /* Assignments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assignments.swift; sourceTree = "<group>"; };
+		8BE25F722551C8A0002E52E4 /* explat-assignments.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "explat-assignments.json"; sourceTree = "<group>"; };
 		8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrepublishingHeaderViewTests.swift; path = WordPressTest/PrepublishingHeaderViewTests.swift; sourceTree = SOURCE_ROOT; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+enableDisable.swift"; sourceTree = "<group>"; };
@@ -8181,7 +8189,17 @@
 		8BE25EFD2551B777002E52E4 /* ABTesting */ = {
 			isa = PBXGroup;
 			children = (
+				8BE25F3B2551C497002E52E4 /* Assignments.swift */,
 				8BE25EFE2551B78B002E52E4 /* ABTesting.swift */,
+				8BE25F0D2551B885002E52E4 /* ExPlat.swift */,
+			);
+			path = ABTesting;
+			sourceTree = "<group>";
+		};
+		8BE25F1E2551B8B2002E52E4 /* ABTesting */ = {
+			isa = PBXGroup;
+			children = (
+				8BE25F1F2551B8C9002E52E4 /* ExPlatTests.swift */,
 			);
 			path = ABTesting;
 			sourceTree = "<group>";
@@ -10192,6 +10210,7 @@
 			isa = PBXGroup;
 			children = (
 				32110548250BFC5A0048446F /* Image Dimension Parser */,
+				8BE25F1E2551B8B2002E52E4 /* ABTesting */,
 				7EC9FE0822C6275900C5A888 /* Analytics */,
 				572FB3FE223A800500933C76 /* Classes */,
 				FF9A6E6F21F9359200D36D14 /* Gutenberg */,
@@ -10421,6 +10440,7 @@
 				D88A64A5208D92B1008AE9BC /* stock-photos-media.json */,
 				D88A64A9208D974D008AE9BC /* thumbnail-collection.json */,
 				D88A64AD208D9CF5008AE9BC /* stock-photos-pageable.json */,
+				8BE25F722551C8A0002E52E4 /* explat-assignments.json */,
 			);
 			name = "Mock Data";
 			path = "Test Data";
@@ -11731,6 +11751,7 @@
 				D848CC0520FF062100A9038F /* notifications-user-content-meta.json in Resources */,
 				8BB185CF24B62D7600A4CCE8 /* reader-cards-success.json in Resources */,
 				7E4A772320F7BE94001C706D /* activity-log-comment-content.json in Resources */,
+				8BE25F732551C8A0002E52E4 /* explat-assignments.json in Resources */,
 				E12BE5EE1C5235DB000FD5CA /* get-me-settings-v1.1.json in Resources */,
 				933D1F6C1EA7A3AB009FB462 /* TestingMode.storyboard in Resources */,
 				08F8CD371EBD2AA80049D0C0 /* test-image-device-photo-gps.jpg in Resources */,
@@ -12966,6 +12987,7 @@
 				08CC67801C49B65A00153AD7 /* MenuLocation.m in Sources */,
 				4349B0AF218A477F0034118A /* RevisionsTableViewCell.swift in Sources */,
 				738B9A5921B85CF20005062B /* KeyboardInfo.swift in Sources */,
+				8BE25F642551C579002E52E4 /* Assignments.swift in Sources */,
 				E15644F31CE0E5A500D96E64 /* PlanDetailViewModel.swift in Sources */,
 				17E4CD0C238C33F300C56916 /* DebugMenuViewController.swift in Sources */,
 				08D978571CD2AF7D0054F19A /* MenuItemCheckButtonView.m in Sources */,
@@ -13065,6 +13087,7 @@
 				98A437AE20069098004A8A57 /* DomainSuggestionsTableViewController.swift in Sources */,
 				3F3087C424EDB7040087B548 /* AnnouncementCell.swift in Sources */,
 				5D1D04761B7A50B100CDE646 /* ReaderStreamViewController.swift in Sources */,
+				8BE25F0E2551B885002E52E4 /* ExPlat.swift in Sources */,
 				B57B92BD1B73B08100DFF00B /* SeparatorsView.swift in Sources */,
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,
 				7E4123C320F4097B00DF8486 /* FormattableContentStyles.swift in Sources */,
@@ -14339,6 +14362,7 @@
 				E1B921BC1C0ED5A3003EA3CB /* MediaSizeSliderCellTest.swift in Sources */,
 				40F50B80221310D400CBBB73 /* FollowersStatsRecordValueTests.swift in Sources */,
 				3F50945F245537A700C4470B /* ReaderTabViewModelTests.swift in Sources */,
+				8BE25F202551B8C9002E52E4 /* ExPlatTests.swift in Sources */,
 				0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */,
 				D848CBF920FEF82100A9038F /* NotificationsContentFactoryTests.swift in Sources */,
 				575802132357C41200E4C63C /* MediaCoordinatorTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1191,6 +1191,7 @@
 		8BDA5A74247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5A73247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift */; };
 		8BDA5A75247C63F300AB124C /* ReaderDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5A71247C5E5800AB124C /* ReaderDetailCoordinator.swift */; };
 		8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */; };
+		8BE25EFF2551B78B002E52E4 /* ABTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25EFE2551B78B002E52E4 /* ABTesting.swift */; };
 		8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BF0B607247D88EB009A7457 /* UITableViewCell+enableDisable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */; };
@@ -3735,6 +3736,7 @@
 		8BDA5A71247C5E5800AB124C /* ReaderDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailCoordinator.swift; sourceTree = "<group>"; };
 		8BDA5A73247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailCoordinatorTests.swift; sourceTree = "<group>"; };
 		8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCSS.swift; sourceTree = "<group>"; };
+		8BE25EFE2551B78B002E52E4 /* ABTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ABTesting.swift; sourceTree = "<group>"; };
 		8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrepublishingHeaderViewTests.swift; path = WordPressTest/PrepublishingHeaderViewTests.swift; sourceTree = SOURCE_ROOT; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+enableDisable.swift"; sourceTree = "<group>"; };
@@ -5694,7 +5696,7 @@
 			path = GutenbergWeb;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				98D31BBF239720E4009CFF43 /* MainInterface.storyboard */,
@@ -7958,6 +7960,7 @@
 				7E21C763202BBE9F00837CF5 /* iAds */,
 				B5C9401B1DB901120079D4FF /* Account */,
 				85A1B6721742E7DB00BA5E35 /* Analytics */,
+				8BE25EFD2551B777002E52E4 /* ABTesting */,
 				F1D690131F828FF000200E30 /* BuildInformation */,
 				B5ECA6CB1DBAA0110062D7E0 /* CoreData */,
 				B5DB8AF51C949DC70059196A /* ImmuTable */,
@@ -8173,6 +8176,14 @@
 				3278D4A82524F46F008080AA /* ReaderDetailCommentsView.xib */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		8BE25EFD2551B777002E52E4 /* ABTesting */ = {
+			isa = PBXGroup;
+			children = (
+				8BE25EFE2551B78B002E52E4 /* ABTesting.swift */,
+			);
+			path = ABTesting;
 			sourceTree = "<group>";
 		};
 		8BE69514243E676C00FF492F /* Prepublishing Nudges */ = {
@@ -11326,7 +11337,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -12580,6 +12591,7 @@
 				46183D1F251BD6A0004F9AFD /* PageTemplateCategory+CoreDataClass.swift in Sources */,
 				40E7FED02211FFBC0032834E /* AllTimeStatsRecordValue+CoreDataProperties.swift in Sources */,
 				4054F45F2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataClass.swift in Sources */,
+				8BE25EFF2551B78B002E52E4 /* ABTesting.swift in Sources */,
 				174C9697205A846E00CEEF6E /* PostNoticeViewModel.swift in Sources */,
 				9A2D0B25225CB980009E585F /* JetpackInstallStore.swift in Sources */,
 				738B9A5421B85CF20005062B /* WizardNavigation.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1198,6 +1198,7 @@
 		8BE25F732551C8A0002E52E4 /* explat-assignments.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BE25F722551C8A0002E52E4 /* explat-assignments.json */; };
 		8BE25F9D2551D5BD002E52E4 /* ExPlatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25F812551D52C002E52E4 /* ExPlatService.swift */; };
 		8BE25FAC2551D6E7002E52E4 /* ExPlatServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE25FAB2551D6E7002E52E4 /* ExPlatServiceTests.swift */; };
+		8BE25FBB2551F6CC002E52E4 /* explat-malformed-assignments.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BE25FBA2551F6CC002E52E4 /* explat-malformed-assignments.json */; };
 		8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BF0B607247D88EB009A7457 /* UITableViewCell+enableDisable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */; };
@@ -3749,6 +3750,7 @@
 		8BE25F722551C8A0002E52E4 /* explat-assignments.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "explat-assignments.json"; sourceTree = "<group>"; };
 		8BE25F812551D52C002E52E4 /* ExPlatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExPlatService.swift; sourceTree = "<group>"; };
 		8BE25FAB2551D6E7002E52E4 /* ExPlatServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExPlatServiceTests.swift; sourceTree = "<group>"; };
+		8BE25FBA2551F6CC002E52E4 /* explat-malformed-assignments.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "explat-malformed-assignments.json"; sourceTree = "<group>"; };
 		8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrepublishingHeaderViewTests.swift; path = WordPressTest/PrepublishingHeaderViewTests.swift; sourceTree = SOURCE_ROOT; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+enableDisable.swift"; sourceTree = "<group>"; };
@@ -10447,6 +10449,7 @@
 				D88A64A9208D974D008AE9BC /* thumbnail-collection.json */,
 				D88A64AD208D9CF5008AE9BC /* stock-photos-pageable.json */,
 				8BE25F722551C8A0002E52E4 /* explat-assignments.json */,
+				8BE25FBA2551F6CC002E52E4 /* explat-malformed-assignments.json */,
 			);
 			name = "Mock Data";
 			path = "Test Data";
@@ -11771,6 +11774,7 @@
 				3211056B250C0F750048446F /* valid-png-header in Resources */,
 				748BD8851F19234300813F9A /* notifications-mark-as-read.json in Resources */,
 				7E442FCA20F678D100DEACA5 /* activity-log-pingback-content.json in Resources */,
+				8BE25FBB2551F6CC002E52E4 /* explat-malformed-assignments.json in Resources */,
 				F127FFD824213B5600B9D41A /* atomic-get-authentication-cookie-success.json in Resources */,
 				D848CC0120FF030C00A9038F /* notifications-comment-meta.json in Resources */,
 				93594BD5191D2F5A0079E6B2 /* stats-batch.json in Resources */,

--- a/WordPress/WordPressTest/ABTesting/ExPlatServiceTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatServiceTests.swift
@@ -4,11 +4,6 @@ import OHHTTPStubs
 @testable import WordPress
 
 class ExPlatServiceTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        stubDomainsResponseWithFile("explat-assignments.json")
-    }
-
     override func tearDown() {
         super.tearDown()
 
@@ -19,11 +14,27 @@ class ExPlatServiceTests: XCTestCase {
     //
     func testRefresh() {
         let expectation = XCTestExpectation(description: "Return assignments")
+        stubDomainsResponseWithFile("explat-assignments.json")
         let service = ExPlatService.withDefaultApi()
 
         service.getAssignments { assignments in
             XCTAssertEqual(assignments?.ttl, 60)
             XCTAssertEqual(assignments?.variations, ["experiment": "control"])
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    // Do not return assignments when the decoding fails
+    //
+    func testRefreshDecodeFails() {
+        let expectation = XCTestExpectation(description: "Do not return assignments")
+        stubDomainsResponseWithFile("explat-malformed-assignments.json")
+        let service = ExPlatService.withDefaultApi()
+
+        service.getAssignments { assignments in
+            XCTAssertNil(assignments)
             expectation.fulfill()
         }
 

--- a/WordPress/WordPressTest/ABTesting/ExPlatServiceTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatServiceTests.swift
@@ -1,10 +1,9 @@
 import XCTest
 import OHHTTPStubs
-import Nimble
 
 @testable import WordPress
 
-class ExPlatTests: XCTestCase {
+class ExPlatServiceTests: XCTestCase {
     override func setUp() {
         super.setUp()
         stubDomainsResponseWithFile("explat-assignments.json")
@@ -16,12 +15,19 @@ class ExPlatTests: XCTestCase {
         OHHTTPStubs.removeAllStubs()
     }
 
+    // Return TTL and variations
+    //
     func testRefresh() {
-        let abTesting = ExPlat.withDefaultApi()
+        let expectation = XCTestExpectation(description: "Return assignments")
+        let service = ExPlatService.withDefaultApi()
 
-        abTesting.refresh()
+        service.getAssignments { assignments in
+            XCTAssertEqual(assignments?.ttl, 60)
+            XCTAssertEqual(assignments?.variations, ["experiment": "control"])
+            expectation.fulfill()
+        }
 
-        expect(UserDefaults.standard.object(forKey: "ab-testing-assignments") as? [String: String?]).toEventually(equal(["experiment": "control"]))
+        wait(for: [expectation], timeout: 2.0)
     }
 
     private func stubDomainsResponseWithFile(_ filename: String) {

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -11,7 +11,7 @@ class ExPlatTests: XCTestCase {
 
         abTesting.refresh()
 
-        expect(UserDefaults.standard.object(forKey: "ab-testing-assignments") as? [String: String?]).toEventually(equal(["experiment": "control"]))
+        expect(abTesting.experiment("experiment")).to(equal("control"))
     }
 }
 

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -57,7 +57,8 @@ private class ExPlatServiceMock: ExPlatService {
                 ttl: 60,
                 variations: [
                     "experiment": "control",
-                    "another_experiment": "treatment"
+                    "another_experiment": "treatment",
+                    "expired_experiment": nil
                 ]
             )
         )

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -4,19 +4,32 @@ import Nimble
 @testable import WordPress
 
 class ExPlatTests: XCTestCase {
-    // Save the returned assignments
+    // Save the returned experiments variation
     //
     func testRefresh() {
-        let abTesting = ExPlat(service: ExPlatServiceMock.withDefaultApi())
+        let abTesting = ExPlat(service: ExPlatServiceMock())
 
         abTesting.refresh()
 
-        expect(abTesting.experiment("experiment")).to(equal("control"))
+        expect(abTesting.experiment("experiment")).toEventually(equal("control"))
+        expect(abTesting.experiment("another_experiment")).toEventually(equal("treatment"))
     }
 }
 
 private class ExPlatServiceMock: ExPlatService {
+    init() {
+        super.init(wordPressComRestApi: WordPressComMockRestApi())
+    }
+
     override func getAssignments(completion: @escaping (Assignments?) -> Void) {
-        completion(Assignments.init(ttl: 60, variations: ["experiment": "control"]))
+        completion(
+            Assignments(
+                ttl: 60,
+                variations: [
+                    "experiment": "control",
+                    "another_experiment": "treatment"
+                ]
+            )
+        )
     }
 }

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+import OHHTTPStubs
+import Nimble
+
+@testable import WordPress
+
+class ExPlatTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        stubDomainsResponseWithFile("explat-assignments.json")
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        OHHTTPStubs.removeAllStubs()
+    }
+
+    func testRefresh() {
+        let abTesting = ExPlat.withDefaultApi()
+
+        abTesting.refresh()
+
+        expect(UserDefaults.standard.object(forKey: "explat") as? [String: String?]).toEventually(equal(["experiment": "control"]))
+    }
+
+    private func stubDomainsResponseWithFile(_ filename: String) {
+        stub(condition: { request in
+            return (request.url!.absoluteString as NSString).contains("wpcom/v2/experiments/0.1.0/assignments/calypso") && request.httpMethod! == "GET"
+        }) { _ in
+            let stubPath = OHPathForFile(filename, type(of: self))
+            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
+        }
+    }
+}

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -1,36 +1,22 @@
 import XCTest
-import OHHTTPStubs
 import Nimble
 
 @testable import WordPress
 
 class ExPlatTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        stubDomainsResponseWithFile("explat-assignments.json")
-    }
-
-    override func tearDown() {
-        super.tearDown()
-
-        OHHTTPStubs.removeAllStubs()
-    }
-
+    // Save the returned assignments
+    //
     func testRefresh() {
-        let abTesting = ExPlat.withDefaultApi()
+        let abTesting = ExPlat(service: ExPlatServiceMock.withDefaultApi())
 
         abTesting.refresh()
 
         expect(UserDefaults.standard.object(forKey: "ab-testing-assignments") as? [String: String?]).toEventually(equal(["experiment": "control"]))
     }
+}
 
-    private func stubDomainsResponseWithFile(_ filename: String) {
-        let endpoint = "wpcom/v2/experiments/0.1.0/assignments/calypso"
-        stub(condition: { request in
-            return (request.url!.absoluteString as NSString).contains(endpoint) && request.httpMethod! == "GET"
-        }) { _ in
-            let stubPath = OHPathForFile(filename, type(of: self))
-            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
-        }
+private class ExPlatServiceMock: ExPlatService {
+    override func getAssignments(completion: @escaping (Assignments?) -> Void) {
+        completion(Assignments.init(ttl: 60, variations: ["experiment": "control"]))
     }
 }

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -10,8 +10,8 @@ class ExPlatTests: XCTestCase {
         let abTesting = ExPlat(service: ExPlatServiceMock())
 
         abTesting.refresh {
-            XCTAssertEqual(abTesting.experiment("experiment"), "control")
-            XCTAssertEqual(abTesting.experiment("another_experiment"), "treatment")
+            XCTAssertEqual(abTesting.experiment("experiment"), .control)
+            XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment)
             expectation.fulfill()
         }
 
@@ -28,8 +28,8 @@ class ExPlatTests: XCTestCase {
 
             serviceMock.returnAssignments = false
             abTesting.refresh {
-                XCTAssertEqual(abTesting.experiment("experiment"), "control")
-                XCTAssertEqual(abTesting.experiment("another_experiment"), "treatment")
+                XCTAssertEqual(abTesting.experiment("experiment"), .control)
+                XCTAssertEqual(abTesting.experiment("another_experiment"), .treatment)
                 expectation.fulfill()
             }
 

--- a/WordPress/WordPressTest/Test Data/explat-assignments.json
+++ b/WordPress/WordPressTest/Test Data/explat-assignments.json
@@ -1,0 +1,6 @@
+{
+    "variations": {
+        "experiment": "control"
+    },
+    "ttl": 60
+}

--- a/WordPress/WordPressTest/Test Data/explat-malformed-assignments.json
+++ b/WordPress/WordPressTest/Test Data/explat-malformed-assignments.json
@@ -1,0 +1,3 @@
+{
+    malformed
+}


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS-Shared/issues/278

This PR adds a basic API to retrieve experiments and their variations from the ExPlat.

(TTL, Anonymization, Deanonymization are coming in subsequent PRs)

### To test

There are no visual changes, so you can rely on the tests (or debugging) to make sure it's working and please propose any changes you have in mind. :)

Also, you can just add `ExPlat().refresh()` in `WordPressAppDelegate`.

### Usage

My idea is to use it like:

```swift
switch abTesting.experiment("reader") {
    case .treatment:
        // Show treatment option
    case .control:
        // Show control option
    case .unknown:
        // Experiment doesn't exist or wasn't retrieved
    case .other(let value) where value == "my-value":
        // any other value 
}
```

Overall, usage should be way more simpler, like:

```swift
switch abTesting.experiment("reader") {
    case .treatment:
        // Show treatment option
    default:
        // Show control option
}
```

### Wait, shouldn't that be on WordPress-iOS-Shared/Kit?

Yes. My plan is to have that in a separate library so both WPiOS and WooiOS (and any other app) can make use of it. But we have a few issues:

- Tracks protocol is on Shared
- `WPAnalyticsTrackerAutomatticTracks` on the other hand is in WPiOS (and Woo have its own implementation)
- The logic to request a V2 endpoint is in another library, WordPress-Kit
- I don't want to create a dependency between Shared and Kit neither rely on the implementation of the `WPAnalyticsTrackerAutomatticTracks` here

Given this would require a lot more discussion I decided to just go ahead and implement it in WPiOS, then we can manage the better way to extract it. (@astralbodies I could really use your expertise here)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
