### PR TITLE
Prologue Carousel: Disable the feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -47,7 +47,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .newNavBarAppearance:
             return BuildConfiguration.current == .localDeveloper
         case .unifiedPrologueCarousel:
-            return BuildConfiguration.current == .localDeveloper
+            return false
         case .stories:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .siteCreationHomePagePicker:


### PR DESCRIPTION
Project Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/15056

It may be a while before this project is picked up again. Disable the feature flag so the changes aren't distracting to devs logging in with a debug build.

### To test
1. Log out if logged in.
2. See the usual carousel displayed.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
