### PR TITLE
Support contact email: update with email from contact info prompt

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -191,7 +191,11 @@ private extension SupportTableViewController {
                 guard let controllerToShowFrom = self.controllerToShowFrom() else {
                     return
                 }
-                ZendeskUtils.sharedInstance.showNewRequestIfPossible(from: controllerToShowFrom, with: self.sourceTag)
+                ZendeskUtils.sharedInstance.showNewRequestIfPossible(from: controllerToShowFrom, with: self.sourceTag) { identityUpdated in
+                    if identityUpdated {
+                        reloadViewModel()
+                    }
+                }
             } else {
                 guard let url = Constants.forumsURL else {
                     return
@@ -209,7 +213,11 @@ private extension SupportTableViewController {
             guard let controllerToShowFrom = self.controllerToShowFrom() else {
                 return
             }
-            ZendeskUtils.sharedInstance.showTicketListIfPossible(from: controllerToShowFrom, with: self.sourceTag)
+            ZendeskUtils.sharedInstance.showTicketListIfPossible(from: controllerToShowFrom, with: self.sourceTag) { identityUpdated in
+                if identityUpdated {
+                    reloadViewModel()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #n/a
Ref: https://github.com/wordpress-mobile/WordPress-iOS/pull/15204#pullrequestreview-522089318

This fixes an issue where the `Contact Email` field did not immediately update after contact information was entered via `Contact Support` or `My Tickets`.

Optional completion blocks have been added to `showNewRequestIfPossible` and `showTicketListIfPossible` to inform the caller when the user sets their contact information. In this case, the caller being `SupportTableViewController`. The Support table is reloaded if the user's identity has been updated. 

To test:

Contact Support:
- Start with a fresh install.
- Go to Me > Help & Support.
- Tap the `Contact Support` row.
- In the prompt, enter an email address, and `OK`.
- After the prompt is dismissed, the `Contact Email` is updated to what was entered.

My Tickets:
- Start with a fresh install.
- Go to Me > Help & Support.
- Tap the `My Tickets` row.
- In the prompt, enter an email address, and `OK`.
- After the prompt is dismissed, the `Contact Email` is updated to what was entered.

![update_email](https://user-images.githubusercontent.com/1816888/98174404-13322f00-1eb2-11eb-9dd8-413afae506e6.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
