### PR TITLE
Remove the Story Post option from Blog Posts list screen with feature flag is off

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -164,18 +164,23 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     private lazy var createButtonCoordinator: CreateButtonCoordinator = {
-        return CreateButtonCoordinator(self, actions: [
+        var actions: [ActionSheetItem] = [
             PostAction(handler: { [weak self] in
                     self?.dismiss(animated: false, completion: nil)
                     self?.createPost()
-            }),
-            StoryAction(handler: { [weak self] in
-                guard let self = self else {
-                    return
-                }
-                (self.tabBarController as? WPTabBarController)?.showStoryEditor(blog: self.blog, title: nil, content: nil, source: "post_list")
             })
-        ])
+        ]
+        if Feature.enabled(.stories) && blog.supports(.stories) {
+            actions.append(
+                StoryAction(handler: { [weak self] in
+                    guard let self = self else {
+                        return
+                    }
+                    (self.tabBarController as? WPTabBarController)?.showStoryEditor(blog: self.blog, title: nil, content: nil, source: "post_list")
+                })
+            )
+        }
+        return CreateButtonCoordinator(self, actions: actions)
     }()
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
The story post option was showing in the Blog Posts screen even when the feature flag was off or the blog didn't support it. These two criteria were added in this PR.

### Testing

#### Feature Flag
- Navigate to the Blog Posts screen (Blog Details / My Site > Blog Posts) 
- Verify that the Story Post option shows upon tapping the FAB when the stories feature flag is enabled (default in development builds)
<img width="413" alt="Screen Shot 2020-11-04 at 3 32 53 PM" src="https://user-images.githubusercontent.com/3250/98175005-06620b00-1eb3-11eb-89f3-d0f080af186b.png">

- Turn off the Feature Flag from App Settings > Debug > Stories
<img width="413" alt="Screen Shot 2020-11-04 at 3 28 26 PM" src="https://user-images.githubusercontent.com/3250/98174902-d9155d00-1eb2-11eb-9f44-97ccfd0018d8.png">

- Return to the Blog Posts screen
- Check that tapping the FAB opens the Post Editor.

#### Blog Support
- Use a site with Jetpack < 8.9 (ping me if you need a site to test with)
- Navigate to the Blog Posts screen (Blog Details / My Site > Blog Posts) 
- Verify that tapping the FAB opens the Post Editor.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
