### PR TITLE
Pages: add Edit to options menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -610,6 +610,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                     strongSelf.retryPage(page)
                 })
             } else {
+                addEditAction(to: alertController, for: page)
+
                 alertController.addActionWithTitle(viewButtonTitle, style: .default, handler: { [weak self] (action) in
                     guard let strongSelf = self,
                         let page = strongSelf.pageForObjectID(objectID) else {
@@ -652,6 +654,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                     strongSelf.retryPage(page)
                 })
             } else {
+                addEditAction(to: alertController, for: page)
+
                 alertController.addActionWithTitle(viewButtonTitle, style: .default, handler: { [weak self] (action) in
                     guard let strongSelf = self,
                         let page = strongSelf.pageForObjectID(objectID) else {
@@ -693,6 +697,19 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             presentationController.sourceView = button
             presentationController.sourceRect = button.bounds
         }
+    }
+
+    private func addEditAction(to controller: UIAlertController, for page: AbstractPost) {
+        if page.status == .trash {
+            return
+        }
+
+        let buttonTitle = NSLocalizedString("Edit", comment: "Label for a button that opens the Edit Page view controller")
+        controller.addActionWithTitle(buttonTitle, style: .default, handler: { [weak self] _ in
+            if let page = self?.pageForObjectID(page.objectID) {
+                self?.editPage(page)
+            }
+        })
     }
 
     private func addSetParentAction(to controller: UIAlertController, for page: AbstractPost, at index: IndexPath?) {


### PR DESCRIPTION
Fixes #8224 

This adds an `Edit` option to the ellipsis menu on a Page.

To test:
- Go to Pages.
- Tap the ellipsis button on a page.
  - For Published, Drafts, and Scheduled, there is now an `Edit` option.
  - For Trashed, there is not.

| ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-04 at 16 38 30](https://user-images.githubusercontent.com/1816888/98179592-58f3f500-1ebc-11eb-9edc-a86683efb2c4.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2020-11-04 at 16 38 52](https://user-images.githubusercontent.com/1816888/98179617-64472080-1ebc-11eb-867b-516647aaa3c5.png) |
|--------|-------|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
