### PR TITLE
Fix failing UI tests in block editor

### DIFF
--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -49,7 +49,7 @@ class BlockEditorScreen: BaseScreen {
      - Parameter withText: the text to enter in the paragraph block
      */
     func addParagraphBlock(withText text: String) -> BlockEditorScreen {
-        addBlock("Paragraph")
+        addBlock("Paragraph block")
         paragraphView.typeText(text)
 
         return self
@@ -59,7 +59,7 @@ class BlockEditorScreen: BaseScreen {
      Adds an image block with latest image from device.
      */
     func addImage() -> BlockEditorScreen {
-        addBlock("Image")
+        addBlock("Image block")
         addImageByOrder(id: 0)
 
         return self
@@ -121,7 +121,7 @@ class BlockEditorScreen: BaseScreen {
 
     private func addBlock(_ blockLabel: String) {
         addBlockButton.tap()
-        XCUIApplication().otherElements[blockLabel].tap()
+        XCUIApplication().buttons[blockLabel].tap()
     }
 
     /*

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -74,7 +74,7 @@ extension XCTestCase {
         app.activate()
 
         // Media permissions alert handler
-        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: "Allow Access to All Photos")
+        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: "OK")
     }
 
     public func takeScreenshotOfFailedTest() {

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -74,7 +74,7 @@ extension XCTestCase {
         app.activate()
 
         // Media permissions alert handler
-        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: "OK")
+        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: "Allow Access to All Photos")
     }
 
     public func takeScreenshotOfFailedTest() {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/15224

When adding a block (e.g. Paragraph) in Gutenberg via the block inserter, UI tests break seemingly because identifiers for the buttons in the block inserter have changed format. UI tests previously looked for a "static text" element (named "Paragraph" for example) and raised the following error when not found:
```
        /Users/paulvonschrottky/projects/WordPress-iOS/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift:124: error: -[WordPressUITests.EditorGutenbergTests testBasicPostPublish] : Failed to get matching snapshot: No matches found for Elements matching predicate '"Paragraph" IN identifiers' from input {(
```

**Testing locally:**
1. If testing locally, run `rake mocks` and then run UI tests from Xcode (see [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/WordPressUITests/README.md) for details on running UI tests) **important: run locally with an iOS 13.5 simulator to match CircleCI, otherwise tests will fail due to iOS 14 media permissions dialog changes**
2. Ensure all UI tests pass

**Testing on CircleCI:**
1. Ensure all UI tests pass on CircleCI for this PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
