### PR TITLE
AB testing: schedule a refresh based on TTL

### DIFF
--- a/WordPress/Classes/Utility/ABTesting/ExPlat.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlat.swift
@@ -22,6 +22,11 @@ class ExPlat: ABTesting {
         subscribeToNotifications()
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
     /// Only refresh if the TTL has expired
     ///
     func refreshIfNeeded(completion: (() -> Void)? = nil) {

--- a/WordPress/Classes/Utility/ABTesting/ExPlat.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlat.swift
@@ -16,8 +16,9 @@ class ExPlat: ABTesting {
 
     private(set) var scheduleTimer: Timer?
 
-    init(service: ExPlatService = ExPlatService.withDefaultApi()) {
-        self.service = service
+    init(configuration: ExPlatConfiguration,
+         service: ExPlatService? = nil) {
+        self.service = service ?? ExPlatService(configuration: configuration)
     }
 
     /// Only refresh if the TTL has expired

--- a/WordPress/Classes/Utility/ABTesting/ExPlat.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlat.swift
@@ -26,6 +26,7 @@ class ExPlat: ABTesting {
     func refreshIfNeeded(completion: (() -> Void)? = nil) {
         guard ttl > 0 else {
             completion?()
+            scheduleRefresh()
             return
         }
 

--- a/WordPress/Classes/Utility/ABTesting/ExPlat.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlat.swift
@@ -73,10 +73,22 @@ class ExPlat: ABTesting {
     private func scheduleRefresh() {
         if ttl > 0 {
             scheduleTimer?.invalidate()
-            scheduleTimer = Timer.scheduledTimer(withTimeInterval: ttl, repeats: true) { [weak self] timer in
-                self?.refresh()
-                timer.invalidate()
+
+            /// Schedule the refresh on a background thread
+            DispatchQueue.global(qos: .background).async { [weak self] in
+                guard let `self` = self else {
+                    return
+                }
+
+                self.scheduleTimer = Timer.scheduledTimer(withTimeInterval: self.ttl, repeats: true) { [weak self] timer in
+                    self?.refresh()
+                    timer.invalidate()
+                }
+
+                RunLoop.current.run()
             }
+
+
         } else {
             refresh()
         }

--- a/WordPress/Classes/Utility/ABTesting/ExPlatService.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlatService.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+protocol ExPlatConfiguration {
+    var platform: String { get }
+    var oAuthToken: String? { get }
+    var userAgent: String? { get }
+    var anonId: String? { get }
+}
+
 class ExPlatService {
     let platform: String
     let oAuthToken: String?
@@ -10,14 +17,11 @@ class ExPlatService {
         return "https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/\(platform)"
     }
 
-    init(platform: String,
-         oAuthToken: String? = nil,
-         userAgent: String? = nil,
-         anonId: String? = nil) {
-        self.platform = platform
-        self.oAuthToken = oAuthToken
-        self.userAgent = userAgent
-        self.anonId = anonId
+    init(configuration: ExPlatConfiguration) {
+        self.platform = configuration.platform
+        self.oAuthToken = configuration.oAuthToken
+        self.userAgent = configuration.userAgent
+        self.anonId = configuration.anonId
     }
 
     func getAssignments(completion: @escaping (Assignments?) -> Void) {
@@ -71,15 +75,5 @@ class ExPlatService {
         }
 
         task.resume()
-    }
-}
-
-extension ExPlatService {
-    class func withDefaultApi() -> ExPlatService {
-        let accountService = AccountService(managedObjectContext: ContextManager.shared.mainContext)
-        let defaultAccount = accountService.defaultWordPressComAccount()
-        let token: String? = defaultAccount?.authToken
-
-        return ExPlatService(platform: "calypso", oAuthToken: token, userAgent: WPUserAgent.wordPress())
     }
 }

--- a/WordPress/Classes/Utility/ABTesting/ExPlatService.swift
+++ b/WordPress/Classes/Utility/ABTesting/ExPlatService.swift
@@ -1,30 +1,76 @@
 import Foundation
 
 class ExPlatService {
-    let wordPressComRestApi: WordPressComRestApi
+    let platform: String
+    let oAuthToken: String?
+    let userAgent: String?
+    let anonId: String?
 
-    let assignmentsPath = "wpcom/v2/experiments/0.1.0/assignments/calypso"
+    var assignmentsEndpoint: String {
+        return "https://public-api.wordpress.com/wpcom/v2/experiments/0.1.0/assignments/\(platform)"
+    }
 
-    init(wordPressComRestApi: WordPressComRestApi) {
-        self.wordPressComRestApi = wordPressComRestApi
+    init(platform: String,
+         oAuthToken: String? = nil,
+         userAgent: String? = nil,
+         anonId: String? = nil) {
+        self.platform = platform
+        self.oAuthToken = oAuthToken
+        self.userAgent = userAgent
+        self.anonId = anonId
     }
 
     func getAssignments(completion: @escaping (Assignments?) -> Void) {
-        wordPressComRestApi.GET(assignmentsPath,
-                                parameters: nil,
-                                success: { responseObject, _ in
-                                    do {
-                                        let decoder = JSONDecoder()
-                                        let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])
-                                        let assignments = try decoder.decode(Assignments.self, from: data)
-                                        completion(assignments)
-                                    } catch {
-                                        DDLogError("Error parsing the experiment response: \(error)")
-                                        completion(nil)
-                                    }
-        }, failure: { error, _ in
+        guard var urlComponents = URLComponents(string: assignmentsEndpoint) else {
             completion(nil)
-        })
+            return
+        }
+
+        // Query items
+        urlComponents.queryItems = [URLQueryItem(name: "_locale", value: Locale.current.languageCode)]
+
+        if let anonId = anonId {
+            urlComponents.queryItems?.append(URLQueryItem.init(name: "anon_id", value: anonId))
+        }
+
+        guard let url = urlComponents.url else {
+            completion(nil)
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        // HTTP fields (including oAuthToken if provided)
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let oAuthToken = oAuthToken {
+            request.setValue( "Bearer \(oAuthToken)", forHTTPHeaderField: "Authorization")
+        }
+
+        // User-Agent
+        if let userAgent = userAgent {
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        }
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            guard let data = data, error == nil else {
+                completion(nil)
+                return
+            }
+
+            do {
+                let decoder = JSONDecoder()
+                let assignments = try decoder.decode(Assignments.self, from: data)
+                completion(assignments)
+            } catch {
+                DDLogError("Error parsing the experiment response: \(error)")
+                completion(nil)
+            }
+        }
+
+        task.resume()
     }
 }
 
@@ -34,9 +80,6 @@ extension ExPlatService {
         let defaultAccount = accountService.defaultWordPressComAccount()
         let token: String? = defaultAccount?.authToken
 
-        let api = WordPressComRestApi.defaultApi(oAuthToken: token,
-                                              userAgent: WPUserAgent.wordPress(),
-                                              localeKey: WordPressComRestApi.LocaleKeyV2)
-        return ExPlatService(wordPressComRestApi: api)
+        return ExPlatService(platform: "calypso", oAuthToken: token, userAgent: WPUserAgent.wordPress())
     }
 }

--- a/WordPress/WordPressTest/ABTesting/ExPlatServiceTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatServiceTests.swift
@@ -61,7 +61,7 @@ class ExPlatServiceTests: XCTestCase {
     }
 
     private func stubAssignmentsResponseWithError() {
-        stubAssignments(withStatus: 503)
+        stubAssignments(withFile: "explat-malformed-assignments.json", withStatus: 503)
     }
 
     private func stubAssignments(withFile file: String = "explat-assignments.json", withStatus status: Int32? = nil) {

--- a/WordPress/WordPressTest/ABTesting/ExPlatServiceTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatServiceTests.swift
@@ -15,7 +15,7 @@ class ExPlatServiceTests: XCTestCase {
     func testRefresh() {
         let expectation = XCTestExpectation(description: "Return assignments")
         stubAssignmentsResponseWithFile("explat-assignments.json")
-        let service = ExPlatService.withDefaultApi()
+        let service = ExPlatService(configuration: ExPlatTestConfiguration())
 
         service.getAssignments { assignments in
             XCTAssertEqual(assignments?.ttl, 60)
@@ -31,7 +31,7 @@ class ExPlatServiceTests: XCTestCase {
     func testRefreshDecodeFails() {
         let expectation = XCTestExpectation(description: "Do not return assignments")
         stubAssignmentsResponseWithFile("explat-malformed-assignments.json")
-        let service = ExPlatService.withDefaultApi()
+        let service = ExPlatService(configuration: ExPlatTestConfiguration())
 
         service.getAssignments { assignments in
             XCTAssertNil(assignments)
@@ -46,7 +46,7 @@ class ExPlatServiceTests: XCTestCase {
     func testRefreshServerFails() {
         let expectation = XCTestExpectation(description: "Do not return assignments")
         stubAssignmentsResponseWithError()
-        let service = ExPlatService.withDefaultApi()
+        let service = ExPlatService(configuration: ExPlatTestConfiguration())
 
         service.getAssignments { assignments in
             XCTAssertNil(assignments)
@@ -65,7 +65,7 @@ class ExPlatServiceTests: XCTestCase {
     }
 
     private func stubAssignments(withFile file: String = "explat-assignments.json", withStatus status: Int32? = nil) {
-        let endpoint = "wpcom/v2/experiments/0.1.0/assignments/calypso"
+        let endpoint = "wpcom/v2/experiments/0.1.0/assignments/wpios_test"
         stub(condition: { request in
             return (request.url!.absoluteString as NSString).contains(endpoint) && request.httpMethod! == "GET"
         }) { _ in
@@ -73,4 +73,14 @@ class ExPlatServiceTests: XCTestCase {
             return fixture(filePath: stubPath!, status: status ?? 200, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
     }
+}
+
+class ExPlatTestConfiguration: ExPlatConfiguration {
+    var platform = "wpios_test"
+
+    var oAuthToken: String?
+
+    var userAgent: String?
+
+    var anonId: String?
 }

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -47,8 +47,8 @@ class ExPlatTests: XCTestCase {
         abTesting.refresh {
 
             DispatchQueue.main.async {
-                XCTAssertTrue(abTesting.scheduleTimer!.isValid)
-                XCTAssertEqual(round(abTesting.scheduleTimer!.timeInterval), 60)
+                XCTAssertTrue(abTesting.scheduledTimer!.isValid)
+                XCTAssertEqual(round(abTesting.scheduledTimer!.timeInterval), 60)
                 expectation.fulfill()
             }
 

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -60,7 +60,7 @@ private class ExPlatServiceMock: ExPlatService {
     var returnAssignments = true
 
     init() {
-        super.init(wordPressComRestApi: WordPressComMockRestApi())
+        super.init(platform: "wpios")
     }
 
     override func getAssignments(completion: @escaping (Assignments?) -> Void) {

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -46,9 +46,11 @@ class ExPlatTests: XCTestCase {
         let abTesting = ExPlat(configuration: ExPlatTestConfiguration(), service: serviceMock)
         abTesting.refresh {
 
-            XCTAssertTrue(abTesting.scheduleTimer!.isValid)
-            XCTAssertEqual(round(abTesting.scheduleTimer!.timeInterval), 60)
-            expectation.fulfill()
+            DispatchQueue.main.async {
+                XCTAssertTrue(abTesting.scheduleTimer!.isValid)
+                XCTAssertEqual(round(abTesting.scheduleTimer!.timeInterval), 60)
+                expectation.fulfill()
+            }
 
         }
 

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -37,6 +37,23 @@ class ExPlatTests: XCTestCase {
 
         wait(for: [expectation], timeout: 2.0)
     }
+
+    // Schedule a timer to automatically refresh
+    //
+    func testScheduleRefresh() {
+        let expectation = XCTestExpectation(description: "Automatically refresh")
+        let serviceMock = ExPlatServiceMock()
+        let abTesting = ExPlat(service: serviceMock)
+        abTesting.refresh {
+
+            XCTAssertTrue(abTesting.scheduleTimer!.isValid)
+            XCTAssertEqual(round(abTesting.scheduleTimer!.timeInterval), 60)
+            expectation.fulfill()
+
+        }
+
+        wait(for: [expectation], timeout: 2.0)
+    }
 }
 
 private class ExPlatServiceMock: ExPlatService {

--- a/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
+++ b/WordPress/WordPressTest/ABTesting/ExPlatTests.swift
@@ -7,7 +7,7 @@ class ExPlatTests: XCTestCase {
     //
     func testRefresh() {
         let expectation = XCTestExpectation(description: "Save experiments")
-        let abTesting = ExPlat(service: ExPlatServiceMock())
+        let abTesting = ExPlat(configuration: ExPlatTestConfiguration(), service: ExPlatServiceMock())
 
         abTesting.refresh {
             XCTAssertEqual(abTesting.experiment("experiment"), .control)
@@ -23,7 +23,7 @@ class ExPlatTests: XCTestCase {
     func testError() {
         let expectation = XCTestExpectation(description: "Keep experiments")
         let serviceMock = ExPlatServiceMock()
-        let abTesting = ExPlat(service: serviceMock)
+        let abTesting = ExPlat(configuration: ExPlatTestConfiguration(), service: serviceMock)
         abTesting.refresh {
 
             serviceMock.returnAssignments = false
@@ -43,7 +43,7 @@ class ExPlatTests: XCTestCase {
     func testScheduleRefresh() {
         let expectation = XCTestExpectation(description: "Automatically refresh")
         let serviceMock = ExPlatServiceMock()
-        let abTesting = ExPlat(service: serviceMock)
+        let abTesting = ExPlat(configuration: ExPlatTestConfiguration(), service: serviceMock)
         abTesting.refresh {
 
             XCTAssertTrue(abTesting.scheduleTimer!.isValid)
@@ -60,7 +60,7 @@ private class ExPlatServiceMock: ExPlatService {
     var returnAssignments = true
 
     init() {
-        super.init(platform: "wpios")
+        super.init(configuration: ExPlatTestConfiguration())
     }
 
     override func getAssignments(completion: @escaping (Assignments?) -> Void) {


### PR DESCRIPTION
Part of wordpress-mobile/WordPress-iOS-Shared#278

This PR:

* Adds the feature to schedule a refresh given the `tll` that the ExPlat response returns
* Uses `URLSession` instead of `WordPressComRestApi`
* Has an object configuration, so it is completely decoupled from WPiOS

The latter two will help to extract it to https://github.com/Automattic/Automattic-Tracks-iOS 

### To test

Again, rely on the code/tests. :)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
