### PR TITLE
Some changes to BlogDetailsViewController+MeButtonTests for reusability

### DIFF
--- a/WordPress/Classes/Utility/Gesture Recognizer/BindableTapGestureRecognizer.swift
+++ b/WordPress/Classes/Utility/Gesture Recognizer/BindableTapGestureRecognizer.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+class BindableTapGestureRecognizer: UITapGestureRecognizer {
+    typealias Action = (_ sender: BindableTapGestureRecognizer) -> Void
+
+    let action: Action
+
+    init(action: @escaping Action) {
+        self.action = action
+
+        super.init(target: nil, action: nil)
+
+        addTarget(self, action: #selector(actionHandler))
+    }
+
+    @objc
+    private func actionHandler() {
+        action(self)
+    }
+}

--- a/WordPress/Classes/Utility/Gesture Recognizer/BindableTapGestureRecognizer.swift
+++ b/WordPress/Classes/Utility/Gesture Recognizer/BindableTapGestureRecognizer.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// A tap gesture recognizer that works with a closure, instead of an action and target.
+///
 class BindableTapGestureRecognizer: UITapGestureRecognizer {
     typealias Action = (_ sender: BindableTapGestureRecognizer) -> Void
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
@@ -1,39 +1,22 @@
 import Gridicons
 import UIKit
 
-
 /// Add a UIBarButtonItem to the navigation bar that  presents the Me scene.
-extension BlogDetailsViewController {
+extension UIViewController {
     @objc
-    func presentHandler() {
-        meScenePresenter.present(on: self, animated: true, completion: nil)
-    }
-
-    @objc
-    func addMeButtonToNavigationBar() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(email: blog.account?.email,
-                                                            target: self,
-                                                            action: #selector(presentHandler))
+    func addMeButtonToNavigationBar(email: String?, meScenePresenter: ScenePresenter) {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            email: email,
+            action: {
+                meScenePresenter.present(on: self, animated: true, completion: nil)
+            })
     }
 }
-
-extension BlogListViewController {
-    @objc
-    private func presentHandler() {
-        meScenePresenter.present(on: self, animated: true, completion: nil)
-    }
-
-    @objc
-    func addMeButtonToNavigationBar(with email: String) {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(email: email,
-                                                            target: self,
-                                                            action: #selector(presentHandler))
-    }
-}
-
 
 /// methods to set the gravatar image on the me button
 private extension UIBarButtonItem {
+    typealias TapAction = () -> Void
+
     /// gravatar configuration parameters
     struct GravatarConfiguration {
         static let radius: CGFloat = 32
@@ -44,15 +27,19 @@ private extension UIBarButtonItem {
     }
 
     /// Assign the gravatar CircularImageView to the customView property and attach the passed target/action.
-    convenience init(email: String?, style: UIBarButtonItem.Style = .plain, target: Any?, action: Selector?) {
+     convenience init(
+        email: String?,
+        style: UIBarButtonItem.Style = .plain,
+        action: @escaping TapAction) {
+
         self.init()
         makeMeButtonAccessible()
-        customView = makeGravatarTappableView(with: email, target: target, action: action)
-    }
+        customView = makeGravatarTappableView(with: email, action: action)
+     }
 
     /// Create the gravatar CircluarImageView with a fade animation on tap.
     /// If no valid email is provided, fall back to the circled user icon
-    func makeGravatarTappableView(with email: String?, target: Any?, action: Selector?) -> UIView {
+    func makeGravatarTappableView(with email: String?, action: @escaping TapAction) -> UIView {
         let gravatarImageView = GravatarButtonView(tappableWidth: GravatarConfiguration.tappableWidth)
 
         gravatarImageView.adjustView = { [weak self] view in
@@ -77,7 +64,7 @@ private extension UIBarButtonItem {
             gravatarImageView.image = GravatarConfiguration.fallBackImage
         }
 
-        let tapRecognizer = UITapGestureRecognizer(target: target, action: action)
+        let tapRecognizer = BindableTapGestureRecognizer(action: { _ in action() })
         gravatarImageView.addGestureRecognizer(tapRecognizer)
 
         return embedInView(gravatarImageView)

--- a/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog + Me/UIBarButtonItem+MeBarButton.swift
@@ -7,7 +7,11 @@ extension UIViewController {
     func addMeButtonToNavigationBar(email: String?, meScenePresenter: ScenePresenter) {
         navigationItem.rightBarButtonItem = UIBarButtonItem(
             email: email,
-            action: {
+            action: { [weak self] in
+                guard let self = self else {
+                    return
+                }
+
                 meScenePresenter.present(on: self, animated: true, completion: nil)
             })
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -368,7 +368,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self configureBlogDetailHeader];
     [self.headerView setBlog:_blog];
     [self startObservingQuickStart];
-    [self addMeButtonToNavigationBar];
+    [self addMeButtonToNavigationBarWithEmail:self.blog.account.email meScenePresenter:self.meScenePresenter];
     
     [self.createButtonCoordinator addTo:self.view trailingAnchor:self.view.safeAreaLayoutGuide.trailingAnchor bottomAnchor:self.view.safeAreaLayoutGuide.bottomAnchor];
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -899,7 +899,7 @@ static NSInteger HideSearchMinSites = 3;
 - (void)setAddSiteBarButtonItem
 {
     if (self.dataSource.allBlogsCount == 0) {
-        [self addMeButtonToNavigationBarWith:[[self defaultWordPressComAccount] email]];
+        [self addMeButtonToNavigationBarWithEmail:[[self defaultWordPressComAccount] email] meScenePresenter:self.meScenePresenter];
     }
     else {
         self.navigationItem.rightBarButtonItem = self.addSiteButton;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2144,6 +2144,7 @@
 		E6F2788421BC1A4A008B4DB5 /* PlanFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F2787E21BC1A49008B4DB5 /* PlanFeature.swift */; };
 		E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */; };
 		E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B921F5DD9A1F257C792EC225 /* Pods_WordPressTest.framework */; };
+		F10465142554260600655194 /* BindableTapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10465132554260600655194 /* BindableTapGestureRecognizer.swift */; };
 		F10E655021B0613A007AB2EE /* GutenbergViewController+MoreActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10E654F21B06139007AB2EE /* GutenbergViewController+MoreActions.swift */; };
 		F110239B2318479000C4E84A /* Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = F110239A2318479000C4E84A /* Media.swift */; };
 		F11023A1231863CE00C4E84A /* MediaServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11023A0231863CE00C4E84A /* MediaServiceTests.swift */; };
@@ -4871,6 +4872,7 @@
 		E9BAA39DBCC9B24D1C785074 /* Pods-WordPressScreenshotGeneration.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressScreenshotGeneration.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressScreenshotGeneration/Pods-WordPressScreenshotGeneration.release-internal.xcconfig"; sourceTree = "<group>"; };
 		EEF80689364FA9CAE10405E8 /* Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationServiceExtension/Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		EF379F0A70B6AC45330EE287 /* Pods-WordPressTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release.xcconfig"; sourceTree = "<group>"; };
+		F10465132554260600655194 /* BindableTapGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BindableTapGestureRecognizer.swift; sourceTree = "<group>"; };
 		F10E654F21B06139007AB2EE /* GutenbergViewController+MoreActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "GutenbergViewController+MoreActions.swift"; sourceTree = "<group>"; };
 		F110239A2318479000C4E84A /* Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Media.swift; sourceTree = "<group>"; };
 		F11023A0231863CE00C4E84A /* MediaServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaServiceTests.swift; sourceTree = "<group>"; };
@@ -7962,6 +7964,7 @@
 		8584FDB4192437160019C02E /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				F10465122554260600655194 /* Gesture Recognizer */,
 				326E2818250AC4610029EBF0 /* Image Dimension Parser */,
 				1A433B1B2254CBC300AE7910 /* Networking */,
 				40247E002120FE2300AE1C3C /* Automated Transfer */,
@@ -10716,6 +10719,14 @@
 			path = Pages;
 			sourceTree = "<group>";
 		};
+		F10465122554260600655194 /* Gesture Recognizer */ = {
+			isa = PBXGroup;
+			children = (
+				F10465132554260600655194 /* BindableTapGestureRecognizer.swift */,
+			);
+			path = "Gesture Recognizer";
+			sourceTree = "<group>";
+		};
 		F126FDFC20A33BDB0010EB6E /* Processors */ = {
 			isa = PBXGroup;
 			children = (
@@ -13401,6 +13412,7 @@
 				4631359624AD068B0017E65C /* GutenbergLayoutPickerViewController.swift in Sources */,
 				D8225409219AB2030014D0E2 /* SiteInformation.swift in Sources */,
 				D83CA3A920842D190060E310 /* StockPhotosPageable.swift in Sources */,
+				F10465142554260600655194 /* BindableTapGestureRecognizer.swift in Sources */,
 				E62079DF1CF79FC200F5CD46 /* ReaderSearchSuggestion.swift in Sources */,
 				E64ECA4D1CE62041000188A0 /* ReaderSearchViewController.swift in Sources */,
 				98F537A722496CF300B334F9 /* SiteStatsTableHeaderView.swift in Sources */,

--- a/WordPress/WordPressTest/BlogDetailsViewController+MeButtonTests.swift
+++ b/WordPress/WordPressTest/BlogDetailsViewController+MeButtonTests.swift
@@ -47,8 +47,12 @@ class BlogDetailsViewControllerTests: XCTestCase {
             XCTFail("Blog details viewController not initialized")
             return
         }
+
+        let email = controller.blog.account?.email
+        let scenePresenter = controller.meScenePresenter
+
         // When
-        controller.addMeButtonToNavigationBar()
+        controller.addMeButtonToNavigationBar(email: email, meScenePresenter: scenePresenter)
         // Then
         guard let meButton = controller.navigationItem.rightBarButtonItem else {
             XCTFail("Me Button not installed")
@@ -57,41 +61,5 @@ class BlogDetailsViewControllerTests: XCTestCase {
 
         XCTAssertEqual(meButton.accessibilityLabel, TestConstants.meButtonLabel)
         XCTAssertEqual(meButton.accessibilityHint, TestConstants.meButtonHint)
-    }
-
-    func testPresentMeOnButtonTap() {
-        // Given
-        guard let controller = blogDetailsViewController else {
-            XCTFail("Blog details viewController not initialized")
-            return
-        }
-        controller.addMeButtonToNavigationBar()
-        guard controller.navigationItem.rightBarButtonItem != nil else {
-            XCTFail("Me Button not installed")
-            return
-        }
-        scenePresenter?.presentExpectation = expectation(description: "Me was presented")
-        // When
-
-        guard let target = blogDetailsViewController?.target(forAction: #selector(BlogDetailsViewController.presentHandler),
-                                                             withSender: blogDetailsViewController) else {
-            XCTFail("Target not found")
-            return
-        }
-
-        let actionableTarget = target as AnyObject
-        _ = actionableTarget.perform(#selector(BlogDetailsViewController.presentHandler))
-
-        // Then
-        guard let presentedController = scenePresenter?.presentedViewController else {
-            XCTFail("Presented controller was not instantiated")
-            return
-        }
-        XCTAssertEqual(presentedController.accessibilityLabel, "testController")
-        waitForExpectations(timeout: 4) { error in
-            if let error = error {
-                XCTFail("waitForExpectationsWithTimeout errored: \(error)")
-            }
-        }
     }
 }


### PR DESCRIPTION
This is part of [a much larger upcoming PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/15199) that was split to make the reviews more atomic.

Makes some changes to BlogDetailsViewController+MeButtonTests.swift for reusability.

The reason I'm doing these changes is because I'll be needing to show the Me scene from a new view controller, and I wanted to avoid having to duplicate this snippet a third time:

https://github.com/wordpress-mobile/WordPress-iOS/blob/00f6ac4ee88b2631e0302e644acf44b4f2ed9e9b/WordPress/Classes/ViewRelated/Blog/Blog%20%2B%20Me/UIBarButtonItem%2BMeBarButton.swift#L5-L32

To do so, I just made a generic extension for any `UIViewController` to be able to call `addMeButtonToNavigationBar` instead.

## Important:

Please read my inline comment in the sources.

## To test:

### Test 1:

Make sure you're logged in with an account that has at least 1 blog.

1. Launch the App
2. Go to the details for a blog

Make sure the user's icon is loaded and visible in the top-right corner as always.

3. Tap on the user's icon.

Make sure the Me scene is shown.

### Test 2:

Make sure you're logged with an account that has no blogs.

1. Launch the App
2. Go to the list of sites.

Make sure the user's icon is loaded and visible in the top-right corner as always.

3. Tap on the user's icon.

Make sure the Me scene is shown.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
