### PR TITLE
Account Settings Email: show indicator if pending email change

### DIFF
--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -68,12 +68,23 @@ struct EditableTextRow: ImmuTableRow {
 
     let title: String
     let value: String
+    let accessoryImage: UIImage?
     let action: ImmuTableAction?
 
+    init(title: String, value: String, accessoryImage: UIImage? = nil, action: ImmuTableAction?) {
+        self.title = title
+        self.value = value
+        self.accessoryImage = accessoryImage
+        self.action = action
+    }
+    
     func configureCell(_ cell: UITableViewCell) {
         cell.textLabel?.text = title
         cell.detailTextLabel?.text = value
         cell.accessoryType = .disclosureIndicator
+        if accessoryImage != nil {
+            cell.accessoryView = UIImageView(image: accessoryImage)
+        }
 
         WPStyleGuide.configureTableViewCell(cell)
     }

--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -77,7 +77,7 @@ struct EditableTextRow: ImmuTableRow {
         self.accessoryImage = accessoryImage
         self.action = action
     }
-    
+
     func configureCell(_ cell: UITableViewCell) {
         cell.textLabel?.text = title
         cell.detailTextLabel?.text = value

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -90,6 +90,7 @@ private class AccountSettingsController: SettingsController {
         let email = EditableTextRow(
             title: NSLocalizedString("Email", comment: "Account Settings Email label"),
             value: settings?.emailForDisplay ?? "",
+            accessoryImage: emailAccessoryImage(),
             action: presenter.push(editEmailAddress(settings, service: service))
         )
 
@@ -238,7 +239,8 @@ private class AccountSettingsController: SettingsController {
     // MARK: - Private Helpers
 
     fileprivate func noticeForAccountSettings(_ settings: AccountSettings?) -> String? {
-        guard let pendingAddress = settings?.emailPendingAddress, settings?.emailPendingChange == true else {
+        guard settings?.emailPendingChange == true,
+              let pendingAddress = settings?.emailPendingAddress else {
             return nil
         }
 
@@ -248,6 +250,13 @@ private class AccountSettingsController: SettingsController {
         return String(format: localizedNotice, pendingAddress)
     }
 
+    fileprivate func emailAccessoryImage() -> UIImage? {
+        guard settings?.emailPendingChange == true else {
+            return nil
+        }
+
+        return UIImage.gridicon(.noticeOutline).imageWithTintColor(.error)
+    }
 
     // MARK: - Constants
 


### PR DESCRIPTION
Fixes #10104 

This displays an indicator on the Email row if there is a pending email change.

To test:
- Go to Me > Account Settings.
- Tap the Email row.
  - Change your email, and return to Account Settings.
  - An indicator now appears on the Email row.
- Tap the Email row.
  - Revert Pending Changes.
  - On Account Settings, the indicator is no longer displayed.

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/98291867-0886a100-1f69-11eb-9ff7-43c37abfcfcb.png) | ![after](https://user-images.githubusercontent.com/1816888/98291886-0e7c8200-1f69-11eb-8da5-6c8a99949db0.png) |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
