### PR TITLE
Update CircleCI to iOS 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # Using 1.0 of the Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
-  ios: wordpress-mobile/ios@1.0
+  ios: wordpress-mobile/ios@dev:add/select-simulator-command
   git: wordpress-mobile/git@1.0
   slack: circleci/slack@3.4.2
 
@@ -39,6 +39,9 @@ jobs:
     steps:
       - fix-image
       - git/shallow-checkout
+      - ios/select-simulator:
+          xcode-version: "12.0.0"
+          device: iPhone 11
       - ios/install-dependencies:
             bundle-install: true
             pod-install: true
@@ -48,7 +51,7 @@ jobs:
           command: rake dependencies
       - run:
           name: Build for Testing
-          command: cd ./Scripts && bundle exec fastlane build_for_testing
+          command: cd ./Scripts && bundle exec fastlane build_for_testing device:"$SIMULATOR_NAME ($SIMULATOR_IOS_VERSION)"
       - persist_to_workspace:
           root: ./
           paths:
@@ -74,7 +77,7 @@ jobs:
       - run:
           name: Run Unit Tests
           working_directory: Scripts
-          command: bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
+          command: bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3 device:"$SIMULATOR_NAME ($SIMULATOR_IOS_VERSION)"
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
   UI Tests:
@@ -107,7 +110,7 @@ jobs:
       - run:
           name: Run UI Tests
           working_directory: Scripts
-          command: bundle exec fastlane test_without_building name:WordPressUITests try_count:3
+          command: bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"$SIMULATOR_NAME ($SIMULATOR_IOS_VERSION)"
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
       - when:

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -480,6 +480,7 @@ import "./ScreenshotFastfile"
       workspace: "../WordPress.xcworkspace",
       scheme: "WordPress",
       derived_data_path: "../DerivedData",
+      device: options[:device],
       build_for_testing: true,
     )
   end
@@ -637,6 +638,7 @@ import "./ScreenshotFastfile"
       test_without_building: true,
       xctestrun: testPlanPath,
       try_count: options[:try_count],
+      device: options[:device],
       output_directory: "../build/results",
       result_bundle: true
     )

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -74,7 +74,13 @@ extension XCTestCase {
         app.activate()
 
         // Media permissions alert handler
-        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: "OK")
+        let alertButtonTitle: String
+        if #available(iOS 14.0, *) {
+            alertButtonTitle = "Allow Access to All Photos"
+        } else {
+            alertButtonTitle = "OK"
+        }
+        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: alertButtonTitle)
     }
 
     public func takeScreenshotOfFailedTest() {


### PR DESCRIPTION
**Note: Do not merge until https://github.com/wordpress-mobile/circleci-orbs/pull/63 is merged and the orb reference is updated.**

Now that [we've updated CircleCI to run Xcode 12](https://github.com/wordpress-mobile/WordPress-iOS/pull/14848), tests should be run on iOS 14 simulators — but currently, iOS 13.5 simulators are used in (likely) all tests:

```
[19:19:38]: Found simulator "iPhone 8 (13.5)"
[19:19:52]: Starting test run 1
```
<sub>Source: "UI Tests (iPad Air 4th generation)", step "Run UI tests"</sub>

## Approach

We were not telling Fastlane which simulator to use, what this change does is explicitly pass in a `device` parameter to invocations of our Fastlane commands that run tests (`scan` and `multi_scan`).

This relies on https://github.com/wordpress-mobile/circleci-orbs/pull/63, which adds a new `select-simulator` command to our iOS orb. We then execute this new command and use the simulator details it provides to construct a string such as "iPhone 11 (14.0)" which is passed in to Fastlane.

## To test

#### Check the Build Tests job

1. Open the link to the Build Tests job
2. Expect to see a new step named "Select simulator"
3. Open the "Build for Testing" step
4. Under the `Summary for scan 2.162.0` section, ensure that the `device` parameter is `iPhone 11 (14.0)`
5. Ensure the job completes successfully 🟢

#### Check the Unit Tests job

1. Open the link to the Unit Tests job
2. Expect to see a new step named "Select simulator" right before "Boot simulator"
3. Open the "Run Unit Tests" step
4. Expect to see "iOS 14.0, Booted" in the log output
5. Ensure the job completes successfully 🟢

#### Check the UI Tests job

1. Approve the optional UI Tests if they haven't been approved yet
2. Open each of the two "UI Tests" job links, for each:
  a. Expect to see a new step named "Select simulator" right before "Boot simulator"
  b. Open the "Run UI Tests" step
  c. Expect to see "iOS 14.0, Booted" in the log output
  d. Ensure the job completes successfully 🟢

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
