### PR TITLE
Login Prologue button view: make constraints optional.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -198,9 +198,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.2-beta.1'
 
-    # pod 'WordPressAuthenticator', '~> 1.29.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.29.0-beta'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/prologue_button_contraints'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -198,9 +198,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.2-beta.1'
 
-    pod 'WordPressAuthenticator', '~> 1.27.0'
+    # pod 'WordPressAuthenticator', '~> 1.29.0-beta'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/prologue_button_contraints'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -506,7 +506,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/prologue_button_contraints`)
+  - WordPressAuthenticator (~> 1.29.0-beta)
   - WordPressKit (~> 4.21.0-beta.1)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.12.0)
@@ -556,6 +556,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -657,9 +658,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.40.0
-  WordPressAuthenticator:
-    :branch: fix/prologue_button_contraints
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.40.0/third-party-podspecs/Yoga.podspec.json
 
@@ -678,9 +676,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.40.0
-  WordPressAuthenticator:
-    :commit: cf9ce987d17f9856fb9b8f90d9f4cee17751289d
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -778,6 +773,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: f94dc050f61518f13a6e6d830ec219a44f4880af
+PODFILE CHECKSUM: b7bf48931a3f51045431e3f83d4eb20b0f32151e
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -68,11 +68,11 @@ PODS:
   - GTMAppAuth (1.1.0):
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher (~> 1.4)
-  - GTMSessionFetcher (1.4.0):
-    - GTMSessionFetcher/Full (= 1.4.0)
-  - GTMSessionFetcher/Core (1.4.0)
-  - GTMSessionFetcher/Full (1.4.0):
-    - GTMSessionFetcher/Core (= 1.4.0)
+  - GTMSessionFetcher (1.5.0):
+    - GTMSessionFetcher/Full (= 1.5.0)
+  - GTMSessionFetcher/Core (1.5.0)
+  - GTMSessionFetcher/Full (1.5.0):
+    - GTMSessionFetcher/Core (= 1.5.0)
   - Gutenberg (1.40.0):
     - React (= 0.61.5)
     - React-CoreModules (= 0.61.5)
@@ -395,7 +395,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.27.0):
+  - WordPressAuthenticator (1.29.0-beta.1):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -506,7 +506,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.27.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/prologue_button_contraints`)
   - WordPressKit (~> 4.21.0-beta.1)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.12.0)
@@ -556,7 +556,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -658,6 +657,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.40.0
+  WordPressAuthenticator:
+    :branch: fix/prologue_button_contraints
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.40.0/third-party-podspecs/Yoga.podspec.json
 
@@ -676,6 +678,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.40.0
+  WordPressAuthenticator:
+    :commit: cf9ce987d17f9856fb9b8f90d9f4cee17751289d
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -702,7 +707,7 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   Gridicons: eaddc89f7210f38722de4c4c32c121da3e9738d9
   GTMAppAuth: 197a8dabfea5d665224aa00d17f164fc2248dab9
-  GTMSessionFetcher: 6f5c8abbab8a9bce4bb3f057e317728ec6182b10
+  GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   Gutenberg: 36d982421b1fee7e77d7259184398afb022714dd
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   lottie-ios: 85ce835dd8c53e02509f20729fc7d6a4e6645a0a
@@ -756,7 +761,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 2808ae2692e9e5ded6780c7bfb74e6a1571a1906
+  WordPressAuthenticator: af62de7e961bdb71e15be2557f7d1a6240cd2bbb
   WordPressKit: 98b1b095e3e312b49af0d3db5ec3c6272416eda6
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
@@ -773,6 +778,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 8fd22e6297511af0a3db44495f46b5173bea72cb
+PODFILE CHECKSUM: f94dc050f61518f13a6e6d830ec219a44f4880af
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/WordPress-iOS/issues/15094
Auth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/511

This uses the Auth changes that makes the constraints on the Login Prologue button view optional.

This is an attempt to fix the crash as noted on #15094 . There shouldn't be a noticeable difference, so just some smoke testing should do it.

To test:
- Run the app on an iPad.
- Log out if necessary.
- Rotate the device.
- Verify the prologue buttons are sized correctly.

| ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-11-05 at 17 15 59](https://user-images.githubusercontent.com/1816888/98310607-a76fc500-1f8a-11eb-8d6a-df9375c421b5.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-11-05 at 17 16 03](https://user-images.githubusercontent.com/1816888/98310622-ae96d300-1f8a-11eb-9cc3-0be1a6c9014b.png) |
|--------|-------|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
