### PR TITLE
Fix direct call to CoreDataManager

### DIFF
--- a/WordPress/Classes/ViewRelated/What's New/Dependency container/WPTabBarController+WhatIsNew.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Dependency container/WPTabBarController+WhatIsNew.swift
@@ -29,7 +29,7 @@ extension WPTabBarController {
     }
 
     private func makeApi() -> WordPressComRestApi {
-        let accountService = AccountService(managedObjectContext: CoreDataManager.shared.mainContext)
+        let accountService = AccountService(managedObjectContext: ContextManager.shared.mainContext)
         let defaultAccount = accountService.defaultWordPressComAccount()
         let token: String? = defaultAccount?.authToken
 


### PR DESCRIPTION
CoreDataManager should not be referenced directly until we have the Swift Core Data stack feature flagged, otherwise in a scenario where the feature flag is turned off, there will be duplicated stacks.
Fixes #NA

To test:
- Build with Xcode and verify that the memory graph does not contain more than two `NSManagedObjectModel` instances
- verify that the console does not contain logs like the following one:
`CoreData: warning: Multiple NSEntityDescriptions claim the NSManagedObject subclass 'Notification' so +entity is unable to disambiguate.`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
