### PR TITLE
Improves some initializers.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -301,21 +301,22 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self stopObservingQuickStart];
 }
 
-- (id)initWithMeScenePresenter:(id<ScenePresenter>)meScenePresenter
+- (instancetype)initWithMeScenePresenter:(id<ScenePresenter>)meScenePresenter
 {
-    self = [self init];
-    self.meScenePresenter = meScenePresenter;
+    self = [super init];
+    
+    if (self) {
+        self.restorationIdentifier = WPBlogDetailsRestorationID;
+        self.restorationClass = [self class];
+        _meScenePresenter = meScenePresenter;
+    }
+    
     return self;
 }
 
 - (instancetype)init
 {
-    self = [super init];
-    if (self) {
-        self.restorationIdentifier = WPBlogDetailsRestorationID;
-        self.restorationClass = [self class];
-    }
-    return self;
+    return [self initWithMeScenePresenter:[MeScenePresenter new]];
 }
 
 - (void)viewDidLoad

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -42,22 +42,22 @@ static NSInteger HideSearchMinSites = 3;
 
 - (instancetype)init
 {
+    return [self initWithMeScenePresenter:[MeScenePresenter new]];
+}
+
+- (instancetype)initWithMeScenePresenter:(id<ScenePresenter>)meScenePresenter
+{
     self = [super init];
+    
     if (self) {
         self.restorationIdentifier = NSStringFromClass([self class]);
         self.restorationClass = [self class];
+        _meScenePresenter = meScenePresenter;
+        
         [self configureDataSource];
         [self configureNavigationBar];
     }
-    return self;
-}
-
-- (id)initWithMeScenePresenter:(id<ScenePresenter>)meScenePresenter
-{
-    self = [self init];
-    if (self) {
-        self.meScenePresenter = meScenePresenter;
-    }
+    
     return self;
 }
 


### PR DESCRIPTION
@Gio2018 had found a scenario in which the App was crashing when tapping on the Me button.

I could not reproduce the crasher, but I did identify that the default initializer for `BlogListViewController` and `BlogDetailsViewController` are never setting property `meScenePresenter`.

This PR improves the initializers so that it's always set.

## To test:

Couldn't reproduce the original issue, but I suggest attempting to launch the app:

a. With an account with several blogs, and tapping on the user's icon in a site details.
b. With an account with no blogs and tapping on the user's icon in the sites list.
c. Trying to do state restoration in both scenarios A and B.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
