### PR TITLE
Fix UI test media dialog handling on iOS 14

### DIFF
--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -74,7 +74,7 @@ extension XCTestCase {
         app.activate()
 
         // Media permissions alert handler
-        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: "OK")
+        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: "Allow Access to All Photos")
     }
 
     public func takeScreenshotOfFailedTest() {


### PR DESCRIPTION
Restores PR #15233 
Fixes #15224

From iOS 14 onwards, the system media permission dialog no longer has an "OK" button. The closest option now is "Allow Access to All Photos".

For some reason, the changes here were not propagated to the other PR, #15225  

To test:
Ensure CI ui tests pass on develop.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
