### PR TITLE
Change Password: update placeholder text.

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Account Settings/ChangePasswordViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/ChangePasswordViewController.swift
@@ -13,7 +13,7 @@ class ChangePasswordViewController: SettingsTextViewController, UITextFieldDeleg
     }()
 
     convenience init(username: String, onSaveActionPress: @escaping ChangePasswordSaveAction) {
-        self.init(text: "", placeholder: "\(Constants.title)...", hint: Constants.description)
+        self.init(text: "", placeholder: "\(Constants.placeholder)", hint: Constants.description)
         self.onSaveActionPress = onSaveActionPress
         self.username = username
     }
@@ -79,6 +79,7 @@ class ChangePasswordViewController: SettingsTextViewController, UITextFieldDeleg
         static let title = NSLocalizedString("Change Password", comment: "Main title")
         static let description = NSLocalizedString("Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & ).", comment: "Help text that describes how the password should be. It appears while editing the password")
         static let actionButtonTitle = NSLocalizedString("Save", comment: "Settings Text save button title")
+        static let placeholder = NSLocalizedString("New password", comment: "Placeholder text for password field")
     }
 }
 


### PR DESCRIPTION
Fixes #10855 

To test:

- Go to Me > Account Settings > Change Password.
- Verify placeholder is `New password`.

<img width="432" alt="Screen Shot 2020-11-06 at 3 49 26 PM" src="https://user-images.githubusercontent.com/1816888/98422051-f9c2eb80-2047-11eb-9129-1a9b1430a46f.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
