### PR TITLE
Ensure noto font is fully loaded before building attributed strings.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] Support contact email: fixed issue that prevented non-alpha characters from being entered. [#15210]
 * [*] Support contact information prompt: fixed issue that could cause the app to crash when entering email address. [#15210]
+* [*] Fixed an issue where comments viewed in the Reader would always be italicized.
 
 16.1
 -----

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -181,10 +181,8 @@ private extension WPRichContentView {
         "</style>"
         let html = styleString + string
 
-        // Request the font to ensure it's loaded. Otherwise NSAttributedString
-        // falls back to Times New Roman :o
-        // https://github.com/wordpress-mobile/WordPress-iOS/issues/6564
-        _ = WPFontManager.notoItalicFont(ofSize: 16)
+        // Ensure the noto font family is fully loaded or the font defaults to Times New Roman.
+        WPFontManager.loadNotoFontFamily()
         do {
             if let attrTxt = try NSAttributedString.attributedStringFromHTMLString(html, defaultAttributes: nil) {
                 return attrTxt


### PR DESCRIPTION
Fixes #14205 

This PR fixes an issue where comments in the reader were always appearing italic.  The all italic font behavior appears to have started with iOS 13 (12.4 appeared fine in my test). Previously the app was explicitly loading the Noto italic font to address the old issue in #6564. I'm guessing Apple has changed something under the hood about how font's are loaded.  As of iOS 13, if no other fonts in the Noto font family were loaded it was defaulting to the italic font for everything.  This change ensures all of the Noto fonts are loaded prior to use.

Note: Test this patch against iOS 12, 13 and 14 since the font handling under the hood appears to vary a bit with each version. 

To test:
Prep:
Leave a comment on a blog you follow. Make sure the comment has a mix of normal and rich text, including italics.

Scenario 1:
- View comments on a post in the reader.  Ensure they are not all italic.

Scenario 2:
- View the comment you prepared.  Confirm it looks correct. 
- Leave a break point and inspect the value of attrTxt on line 188.  Confirm that the correct font is being used.

@emilylaguna would you be game for a review? 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
