### PR TITLE
Update CircleCI to use iOS 14 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,17 @@ parameters:
     type: string
     default: all-lang
 
+xcode_version: &xcode_version
+  xcode-version: "12.1.0"
+
+iphone_test_device: &iphone_test_device
+  device: iPhone 11
+  ios-version: "14.1"
+
+ipad_test_device: &ipad_test_device
+  device: iPad Air (4th generation)
+  ios-version: "14.1"
+
 commands:
   fix-image:
     steps:
@@ -42,7 +53,7 @@ jobs:
         type: string
     executor:
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     steps:
       - fix-image
       - git/shallow-checkout
@@ -72,7 +83,7 @@ jobs:
         type: string
     executor:
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     steps:
       - fix-image
       - git/shallow-checkout
@@ -101,7 +112,7 @@ jobs:
         default: false
     executor:
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     steps:
       - fix-image
       - git/shallow-checkout
@@ -137,7 +148,7 @@ jobs:
   Installable Build:
     executor:
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     steps:
       - fix-image
       - git/shallow-checkout
@@ -161,9 +172,9 @@ jobs:
           path: Artifacts
           destination: Artifacts
   Release Build:
-    executor: 
+    executor:
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -205,7 +216,7 @@ jobs:
   translation-review-build:
     executor: 
       name: ios/default
-      xcode-version: "12.0.0"
+      <<: *xcode_version
     environment:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
@@ -252,17 +263,14 @@ workflows:
     unless: << pipeline.parameters.translation_review_build >>
     jobs:
       - Build Tests:
-          device: iPhone 11
-          ios-version: "14.0"
+          <<: *iphone_test_device
       - Unit Tests:
-          device: iPhone 11
-          ios-version: "14.0"
+          <<: *iphone_test_device
           requires: [ "Build Tests" ]
       # Always run UI tests on develop and release branches
       - UI Tests:
           name: UI Tests (iPhone 11)
-          device: iPhone 11
-          ios-version: "14.0"
+          <<: *iphone_test_device
           post-to-slack: true
           requires: [ "Build Tests" ]
           filters:
@@ -291,13 +299,11 @@ workflows:
                 - /^release.*/
       - UI Tests:
           name: UI Tests (iPhone 11)
-          device: iPhone 11
-          ios-version: "14.0"
+          <<: *iphone_test_device
           requires: [ "Optional Tests" ]
       - UI Tests:
           name: UI Tests (iPad Air 4th generation)
-          device: iPad Air \\(4th generation\\)
-          ios-version: "14.0"
+          <<: *ipad_test_device
           requires: [ "Optional Tests" ]
   Installable Build:
     unless: << pipeline.parameters.translation_review_build >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,13 @@ commands:
 
 jobs:
   Build Tests:
+    parameters:
+      device:
+        type: string
+        description: The device (e.g. "iPhone 11") to use when compiling the build.
+      ios-version:
+        description: The iOS deployment target (e.g. "13.0") used to compile the build that will be used for testing.
+        type: string
     executor:
       name: ios/default
       xcode-version: "12.0.0"
@@ -48,7 +55,7 @@ jobs:
           command: rake dependencies
       - run:
           name: Build for Testing
-          command: cd ./Scripts && bundle exec fastlane build_for_testing
+          command: cd ./Scripts && bundle exec fastlane build_for_testing device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
       - persist_to_workspace:
           root: ./
           paths:
@@ -56,30 +63,37 @@ jobs:
             - Pods/WordPressMocks
             - vendor/bundle
   Unit Tests:
+    parameters:
+      device:
+        type: string
+        description: The device (e.g. "iPhone 11") to use when running unit tests.
+      ios-version:
+        description: The iOS version (e.g. "14.0") of the device used to run tests.
+        type: string
     executor:
       name: ios/default
       xcode-version: "12.0.0"
     steps:
       - fix-image
       - git/shallow-checkout
-      - ios/boot-simulator:
-          xcode-version: "12.0.0"
-          device: iPhone 11
       - attach_workspace:
           at: ./
       - run:
           name: Prepare Bundle
           command: bundle --path vendor/bundle
-      - ios/wait-for-simulator
       - run:
           name: Run Unit Tests
           working_directory: Scripts
-          command: bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
+          command: bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3 device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
   UI Tests:
     parameters:
       device:
+        type: string
+        description: The device (e.g. "iPhone 11") to use when running tests.
+      ios-version:
+        description: The iOS version (e.g. "14.0") of the device used to run tests.
         type: string
       post-to-slack:
         description: Post to Slack when tests fail. SLACK_WEBHOOK ENV variable must be set.
@@ -91,9 +105,6 @@ jobs:
     steps:
       - fix-image
       - git/shallow-checkout
-      - ios/boot-simulator:
-          xcode-version: "12.0.0"
-          device: << parameters.device >>
       - attach_workspace:
           at: ./
       - run:
@@ -103,11 +114,10 @@ jobs:
           name: Run mocks
           command: ./Pods/WordPressMocks/scripts/start.sh 8282
           background: true
-      - ios/wait-for-simulator
       - run:
           name: Run UI Tests
           working_directory: Scripts
-          command: bundle exec fastlane test_without_building name:WordPressUITests try_count:3
+          command: bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
       - when:
@@ -117,9 +127,8 @@ jobs:
                 name: Prepare Slack message
                 when: always
                 command: |
-                  # Get the name of the device that is running. Using "<< parameters.device >>" can cause slack formatting errors.
-                  DEVICE_NAME=$(xcrun simctl list -j | jq -r --arg UDID $SIMULATOR_UDID '.devices[] | .[] | select(.udid == "\($UDID)") | .name')
-                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: WordPress iOS UI tests failed on ${DEVICE_NAME} in \`${CIRCLE_BRANCH}\` branch by ${CIRCLE_USERNAME}.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'" >> $BASH_ENV
+                  # Get the name of the device that is running.
+                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: WordPress iOS UI tests failed on '<< parameters.device >>' in \`${CIRCLE_BRANCH}\` branch by ${CIRCLE_USERNAME}.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'" >> $BASH_ENV
             - slack/status:
                 fail_only: true
                 include_job_number_field: false
@@ -242,13 +251,18 @@ workflows:
   wordpress_ios:
     unless: << pipeline.parameters.translation_review_build >>
     jobs:
-      - Build Tests
+      - Build Tests:
+          device: iPhone 11
+          ios-version: "14.0"
       - Unit Tests:
+          device: iPhone 11
+          ios-version: "14.0"
           requires: [ "Build Tests" ]
       # Always run UI tests on develop and release branches
       - UI Tests:
           name: UI Tests (iPhone 11)
           device: iPhone 11
+          ios-version: "14.0"
           post-to-slack: true
           requires: [ "Build Tests" ]
           filters:
@@ -257,8 +271,8 @@ workflows:
                 - develop
                 - /^release.*/
       - UI Tests:
-          name: UI Tests (iPad Air 3rd generation)
-          device: iPad Air \\(3rd generation\\)
+          name: UI Tests (iPad Air 4th generation)
+          <<: *ipad_test_device
           post-to-slack: true
           requires: [ "Build Tests" ]
           filters:
@@ -278,10 +292,12 @@ workflows:
       - UI Tests:
           name: UI Tests (iPhone 11)
           device: iPhone 11
+          ios-version: "14.0"
           requires: [ "Optional Tests" ]
       - UI Tests:
           name: UI Tests (iPad Air 4th generation)
           device: iPad Air \\(4th generation\\)
+          ios-version: "14.0"
           requires: [ "Optional Tests" ]
   Installable Build:
     unless: << pipeline.parameters.translation_review_build >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
                 when: always
                 command: |
                   # Get the name of the device that is running.
-                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: WordPress iOS UI tests failed on '<< parameters.device >>' in \`${CIRCLE_BRANCH}\` branch by ${CIRCLE_USERNAME}.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'" >> $BASH_ENV
+                  echo "export SLACK_FAILURE_MESSAGE=':red_circle: WordPress iOS UI tests failed on << parameters.device >> in \`${CIRCLE_BRANCH}\` branch by ${CIRCLE_USERNAME}.\n\nPlease reach out in #platform9 if you think this failure is not caused by your changes, so we can investigate.'" >> $BASH_ENV
             - slack/status:
                 fail_only: true
                 include_job_number_field: false

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -481,6 +481,8 @@ import "./ScreenshotFastfile"
       scheme: "WordPress",
       derived_data_path: "../DerivedData",
       build_for_testing: true,
+      device: options[:device],
+      deployment_target_version: options[:ios_version],
     )
   end
   #####################################################################################
@@ -634,6 +636,8 @@ import "./ScreenshotFastfile"
     multi_scan(
       workspace: "../WordPress.xcworkspace",
       scheme: "WordPress",
+      device: options[:device],
+      deployment_target_version: options[:ios_version],
       test_without_building: true,
       xctestrun: testPlanPath,
       try_count: options[:try_count],

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -74,7 +74,13 @@ extension XCTestCase {
         app.activate()
 
         // Media permissions alert handler
-        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: "OK")
+        let alertButtonTitle: String
+        if #available(iOS 14.0, *) {
+            alertButtonTitle = "Allow Access to All Photos"
+        } else {
+            alertButtonTitle = "OK"
+        }
+        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: alertButtonTitle)
     }
 
     public func takeScreenshotOfFailedTest() {


### PR DESCRIPTION
Now that [we've updated CircleCI to run Xcode 12](https://github.com/wordpress-mobile/WordPress-iOS/pull/14848), tests should be run on iOS 14 simulators — but currently, iOS 13 simulators are used in (likely) all tests:

```
[19:19:38]: Found simulator "iPhone 8 (13.5)"
[19:19:52]: Starting test run 1
```
<sub>Source: "UI Tests (iPad Air 4th generation)", step "Run UI tests"</sub>

## Approach

We're currently using [a `boot-simulator` command](https://github.com/wordpress-mobile/circleci-orbs/blob/72e11900f381d2389c9339a3def26b65b029f5bf/src/ios/orb.yml#L268) to locate and pre-boot a simulator in preparation for tests. 

Pre-booting was needed because ["xcodebuild can behave unpredictably if the simulator is not already booted"](https://github.com/wordpress-mobile/circleci-orbs/blob/72e11900f381d2389c9339a3def26b65b029f5bf/src/ios/orb.yml#L361). Now however, we're [no longer using xcodebuild directly](https://github.com/wordpress-mobile/WordPress-iOS/pull/14848) - we're using Fastlane, which might behave normally even if the simulator is not pre-booted.

If we determine that pre-boot the simulator is beneficial (note that [CircleCI still recommends it](https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator)), instead of going back to the current implementation of `boot-simulator`, we could instead try `xcrun instruments -w` as described in the aforementioned CircleCI article.

## To test

#### Check the Build Tests job

1. Open the link to the Build Tests job
2. Open the "Build for Testing" step
3. Under the `Summary for scan` section, ensure that **the `device` parameter is `iPhone 11`**
4. Ensure the job completes successfully 🟢

#### Check the Unit Tests job

1. Open the link to the Unit Tests job
2. Expect to **no longer see "Boot simulator" or "Wait for simulator" steps**
3. Open the "Run Unit Tests" step
4. Expect to see "iOS 14.1, Booted" in the log output
5. Ensure the job completes successfully 🟢

#### Check the UI Tests job

1. Approve the optional UI Tests if they haven't been approved yet
2. Open each of the two "UI Tests" job links, for each:
  a. Expect to **no longer see "Boot simulator" or "Wait for simulator" steps**
  b. Open the "Run UI Tests" step
  c. Expect to see "iOS 14.1, Booted" in the log output
  d. Ensure the job completes successfully 🟢

#### Check the Installable Build job

1. Approve the optional Installable Build job if it hasn't been approved yet
2. Ensure the job completes successfully 🟢

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
