### PR TITLE
Fix crash where UIBarButtonItem is not a UIView

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -576,7 +576,6 @@ private extension ReaderDetailViewController {
 
         let button = barButtonItem(with: icon, action: #selector(didTapMenuButton(_:)))
         button.accessibilityLabel = Strings.moreButtonAccessibilityLabel
-        button.width = 44
         return button
     }
 
@@ -589,8 +588,11 @@ private extension ReaderDetailViewController {
 
     func barButtonItem(with image: UIImage, action: Selector) -> UIBarButtonItem {
         let image = image.withRenderingMode(.alwaysTemplate)
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 44.0, height: image.size.height))
+        button.setImage(image, for: UIControl.State())
+        button.addTarget(self, action: action, for: .touchUpInside)
 
-        return UIBarButtonItem(image: image, style: .plain, target: self, action: action)
+        return UIBarButtonItem(customView: button)
     }
 }
 


### PR DESCRIPTION
Sentry crash - https://sentry.io/share/issue/dcf3dbd9e962429d92512da13c9256f9/

UiBarButtonItem does not subclass a UIView hence the crash when trying to set the presentation controller source view to it.

Reverting the barItem's image initialization with a button one

To test:
1. Open a reader article on iPad 
2. Tap on the More menu - 3 vertical dots
3. See the popover and no crash

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
