### PR TITLE
New P2s: hide Activity Log and Themes

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -769,7 +769,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     statsRow.quickStartIdentifier = QuickStartTourElementStats;
     [rows addObject:statsRow];
 
-    if ([self.blog supports:BlogFeatureActivity]) {
+    if ([self.blog supports:BlogFeatureActivity] && ![self.blog isWPForTeams]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Activity", @"Noun. Links to a blog's Activity screen.")
                                                         image:[UIImage gridiconOfType:GridiconTypeHistory]
                                                      callback:^{
@@ -778,7 +778,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
 
 // Temporarily disabled
-//    if ([self.blog supports:BlogFeaturePlans]) {
+//    if ([self.blog supports:BlogFeaturePlans] && ![self.blog isWPForTeams]) {
 //        BlogDetailsRow *plansRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plans", @"Action title. Noun. Links to a blog's Plans screen.")
 //                                                         identifier:BlogDetailsPlanCellIdentifier
 //                                                              image:[UIImage gridiconOfType:GridiconTypePlans]
@@ -842,7 +842,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
-    if ([self.blog supports:BlogFeatureThemeBrowsing]) {
+    if ([self.blog supports:BlogFeatureThemeBrowsing] && ![self.blog isWPForTeams]) {
         BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Themes", @"Themes option in the blog details")
                                                               image:[UIImage gridiconOfType:GridiconTypeThemes]
                                                            callback:^{


### PR DESCRIPTION
Ref: #15263 

This hides the `Activity` and `Themes` options for new P2s. 

`Plans` is already hidden, but I put the P2 check there as well in case it's re-enabled in the future.

To test:
- On a new P2 site, go to My Site.
  - Verify Activity Log and Themes do not appear.
- Select a non-P2 site.
  - Verify Activity Log and Themes do appear.

| Site | P2 |
|--------|-------|
| ![non-p2](https://user-images.githubusercontent.com/1816888/98749308-8f2beb80-2378-11eb-9f86-a536ed1861bf.png) | ![p2](https://user-images.githubusercontent.com/1816888/98749317-9652f980-2378-11eb-855b-a43a9e6f19e0.png) |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
