### PR TITLE
Fix translator builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,6 @@ jobs:
       - run: 
           name: Install other tools
           command: |
-            brew unlink python@2
             brew install imagemagick
             brew install ghostscript
             curl -sL https://sentry.io/get-cli/ | bash

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -464,11 +464,11 @@ import "./ScreenshotFastfile"
     ios_merge_translators_strings(strings_folder:"../WordPress/Resources/")
     sh("cd ../.. && ./Scripts/extract-framework-translations.swift")
 
-    xcbuild(
-        workspace: "../WordPress.xcworkspace",
+    gym(
         scheme: "WordPress",
+        workspace: "../WordPress.xcworkspace",
         configuration: "Debug",
-        xcargs: "-sdk iphonesimulator SYMROOT='/var/tmp/'"
+        destination: "platform=iOS Simulator,name=iPhone 11",
     )
 
     zip(path: "/var/tmp/Debug-iphonesimulator/WordPress.app", output_path: "/var/tmp/Debug-iphonesimulator/WordPress.zip")

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -470,6 +470,7 @@ import "./ScreenshotFastfile"
         configuration: "Debug",
         destination: "platform=iOS Simulator,name=iPhone 11",
         output_directory: "/var/tmp",
+        skip_codesigning: true,
     )
 
     zip(path: "/var/tmp/Debug-iphonesimulator/WordPress.app", output_path: "/var/tmp/Debug-iphonesimulator/WordPress.zip")

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -469,6 +469,7 @@ import "./ScreenshotFastfile"
         workspace: "../WordPress.xcworkspace",
         configuration: "Debug",
         destination: "platform=iOS Simulator,name=iPhone 11",
+        output_directory: "/var/tmp",
     )
 
     zip(path: "/var/tmp/Debug-iphonesimulator/WordPress.app", output_path: "/var/tmp/Debug-iphonesimulator/WordPress.zip")

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -14792,6 +14792,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
@@ -14859,6 +14860,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_BITCODE = NO;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (


### PR DESCRIPTION
Fixes an issue with translation release builds – it still tried to remove python 2 before starting, which caused it to fail.

**To Test:**
- Ensure that the translation review build worked