### PR TITLE
Activity Log: adds pagination and fix NoResultsController

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.21.0-beta.1'
+    pod 'WordPressKit', '~> 4.21.0-beta.2'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -407,7 +407,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.21.0-beta.1):
+  - WordPressKit (4.21.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -507,7 +507,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.29.0-beta)
-  - WordPressKit (~> 4.21.0-beta.1)
+  - WordPressKit (~> 4.21.0-beta.2)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.12.0)
   - WordPressUI (~> 1.7.1)
@@ -757,7 +757,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: af62de7e961bdb71e15be2557f7d1a6240cd2bbb
-  WordPressKit: 98b1b095e3e312b49af0d3db5ec3c6272416eda6
+  WordPressKit: a019d4353b09c91f63c274302c7f0dca29da6890
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 38cb62e9cb998d4dc3c1611f17934c6875a6b3e8
   WordPressUI: 9da5d966b8beb091950cd96880db398d7f30e246
@@ -773,6 +773,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: b7bf48931a3f51045431e3f83d4eb20b0f32151e
+PODFILE CHECKSUM: c879e960f44306d90f1a93f29c11a73861f25d3d
 
 COCOAPODS: 1.9.3

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -61,15 +61,18 @@ private enum ActivityStoreError: Error {
 
 class ActivityStore: QueryStore<ActivityStoreState, ActivityQuery> {
 
-    fileprivate let refreshInterval: TimeInterval = 60 // seconds
+    private let refreshInterval: TimeInterval = 60 // seconds
+
+    private let activityServiceRemote: ActivityServiceRemote?
 
     override func queriesChanged() {
         super.queriesChanged()
         processQueries()
     }
 
-    init() {
-        super.init(initialState: ActivityStoreState())
+    init(dispatcher: ActionDispatcher = .global, activityServiceRemote: ActivityServiceRemote? = nil) {
+        self.activityServiceRemote = activityServiceRemote
+        super.init(initialState: ActivityStoreState(), dispatcher: dispatcher)
     }
 
     override func logError(_ error: String) {
@@ -392,6 +395,10 @@ private extension ActivityStore {
     // MARK: - Helpers
 
     func remote(site: JetpackSiteRef) -> ActivityServiceRemote? {
+        guard activityServiceRemote == nil else {
+            return activityServiceRemote!
+        }
+
         guard let token = CredentialsService().getOAuthToken(site: site) else {
             return nil
         }

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -396,7 +396,7 @@ private extension ActivityStore {
 
     func remote(site: JetpackSiteRef) -> ActivityServiceRemote? {
         guard activityServiceRemote == nil else {
-            return activityServiceRemote!
+            return activityServiceRemote
         }
 
         guard let token = CredentialsService().getOAuthToken(site: site) else {

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -61,7 +61,7 @@ private enum ActivityStoreError: Error {
 
 class ActivityStore: QueryStore<ActivityStoreState, ActivityQuery> {
 
-    private let refreshInterval: TimeInterval = 60 // seconds
+    private let refreshInterval: TimeInterval = 60
 
     private let activityServiceRemote: ActivityServiceRemote?
 

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -5,8 +5,9 @@ import WordPressFlux
 // MARK: - Store helper types
 
 enum ActivityAction: Action {
-    case refreshActivities(site: JetpackSiteRef)
-    case receiveActivities(site: JetpackSiteRef, activities: [Activity])
+    case refreshActivities(site: JetpackSiteRef, quantity: Int)
+    case loadMoreActivities(site: JetpackSiteRef, quantity: Int, offset: Int)
+    case receiveActivities(site: JetpackSiteRef, activities: [Activity], hasMore: Bool, loadingMore: Bool)
     case receiveActivitiesFailed(site: JetpackSiteRef, error: Error)
 
     case rewind(site: JetpackSiteRef, rewindID: String)
@@ -38,6 +39,7 @@ struct ActivityStoreState {
     var activities = [JetpackSiteRef: [Activity]]()
     var lastFetch = [JetpackSiteRef: Date]()
     var fetchingActivities = [JetpackSiteRef: Bool]()
+    var hasMore = false
 
     var rewindStatus = [JetpackSiteRef: RewindStatus]()
     var fetchingRewindStatus = [JetpackSiteRef: Bool]()
@@ -144,12 +146,14 @@ class ActivityStore: QueryStore<ActivityStoreState, ActivityQuery> {
         }
 
         switch activityAction {
-        case .receiveActivities(let site, let activities):
-            receiveActivities(site: site, activities: activities)
+        case .receiveActivities(let site, let activities, let hasMore, let loadingMore):
+            receiveActivities(site: site, activities: activities, hasMore: hasMore, loadingMore: loadingMore)
+        case .loadMoreActivities(let site, let quantity, let offset):
+            loadMoreActivities(site: site, quantity: quantity, offset: offset)
         case .receiveActivitiesFailed(let site, let error):
             receiveActivitiesFailed(site: site, error: error)
-        case .refreshActivities(let site):
-            refreshActivities(site: site)
+        case .refreshActivities(let site, let quantity):
+            refreshActivities(site: site, quantity: quantity)
         case .rewind(let site, let rewindID):
             rewind(site: site, rewindID: rewindID)
         case .rewindStarted(let site, let rewindID, let restoreID):
@@ -193,25 +197,29 @@ extension ActivityStore {
 }
 
 private extension ActivityStore {
-    func fetchActivities(site: JetpackSiteRef, count: Int = 1000) {
+    func fetchActivities(site: JetpackSiteRef, count: Int = 20, offset: Int = 0) {
         state.fetchingActivities[site] = true
 
         remote(site: site)?.getActivityForSite(
             site.siteID,
+            offset: offset,
             count: count,
-            success: { [actionDispatcher] (activities, _ /* hasMore */) in
-                actionDispatcher.dispatch(ActivityAction.receiveActivities(site: site, activities: activities))
+            success: { [actionDispatcher] (activities, hasMore) in
+                let loadingMore = offset > 0
+                actionDispatcher.dispatch(ActivityAction.receiveActivities(site: site, activities: activities, hasMore: hasMore, loadingMore: loadingMore))
         },
             failure: { [actionDispatcher] error in
                 actionDispatcher.dispatch(ActivityAction.receiveActivitiesFailed(site: site, error: error))
         })
     }
 
-    func receiveActivities(site: JetpackSiteRef, activities: [Activity]) {
+    func receiveActivities(site: JetpackSiteRef, activities: [Activity], hasMore: Bool = false, loadingMore: Bool = false) {
         transaction { state in
-            state.activities[site] = activities
+            let allActivities = loadingMore ? (state.activities[site] ?? []) + activities : activities
+            state.activities[site] = allActivities
             state.fetchingActivities[site] = false
             state.lastFetch[site] = Date()
+            state.hasMore = hasMore
         }
     }
 
@@ -222,12 +230,20 @@ private extension ActivityStore {
         }
     }
 
-    func refreshActivities(site: JetpackSiteRef) {
+    func refreshActivities(site: JetpackSiteRef, quantity: Int) {
         guard !isFetching(site: site) else {
             DDLogInfo("Activity Log refresh triggered while one was in progress")
             return
         }
-        fetchActivities(site: site)
+        fetchActivities(site: site, count: quantity)
+    }
+
+    func loadMoreActivities(site: JetpackSiteRef, quantity: Int, offset: Int) {
+        guard !isFetching(site: site) else {
+            DDLogInfo("Activity Log refresh triggered while one was in progress")
+            return
+        }
+        fetchActivities(site: site, count: quantity, offset: offset)
     }
 
     func rewind(site: JetpackSiteRef, rewindID: String) {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -293,13 +293,14 @@ private extension ActivityListViewController {
         noResultsViewController.bindViewModel(viewModel)
 
         if noResultsViewController.view.superview != tableView {
-            noResultsViewController.view.frame = tableView.frame
             tableView.addSubview(withFadeAnimation: noResultsViewController.view)
         }
 
         addChild(noResultsViewController)
         noResultsViewController.didMove(toParent: self)
 
+        noResultsViewController.view.frame = tableView.frame
+        noResultsViewController.view.frame.origin.y = 0
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -84,6 +84,7 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
         ImmuTable.registerRows([ActivityListRow.self, RewindStatusRow.self], tableView: tableView)
 
         tableView.tableFooterView = spinner
+        tableView.tableFooterView?.isHidden = true
 
         WPAnalytics.track(.activityLogViewed)
     }
@@ -113,8 +114,9 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
             if isUserTriggeredRefresh {
                 refreshControl.beginRefreshing()
                 isUserTriggeredRefresh = false
+            } else if tableView.numberOfSections > 0 {
+                tableView.tableFooterView?.isHidden = false
             }
-            tableView.tableFooterView?.isHidden = false
         case (false, true):
             refreshControl.endRefreshing()
         default:
@@ -291,6 +293,7 @@ private extension ActivityListViewController {
         noResultsViewController.bindViewModel(viewModel)
 
         if noResultsViewController.view.superview != tableView {
+            noResultsViewController.view.frame = tableView.frame
             tableView.addSubview(withFadeAnimation: noResultsViewController.view)
         }
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -57,8 +57,10 @@ class ActivityListViewModel: Observable {
     }
 
     public func loadMore() {
-        offset = store.state.activities[site]?.count ?? 0
-        ActionDispatcher.dispatch(ActivityAction.loadMoreActivities(site: site, quantity: count, offset: offset))
+        if !store.isFetching(site: site) {
+            offset = store.state.activities[site]?.count ?? 0
+            ActionDispatcher.dispatch(ActivityAction.loadMoreActivities(site: site, quantity: count, offset: offset))
+        }
     }
 
     func noResultsViewModel() -> NoResultsViewController.Model? {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -19,6 +19,9 @@ class ActivityListViewModel: Observable {
     private let rewindStatusReceipt: Receipt
     private var storeReceipt: Receipt?
 
+    private let count = 20
+    private var offset = 0
+
     var errorViewModel: NoResultsViewController.Model?
     private(set) var refreshing = false {
         didSet {
@@ -26,6 +29,10 @@ class ActivityListViewModel: Observable {
                 emitChange()
             }
         }
+    }
+
+    var hasMore: Bool {
+        store.state.hasMore
     }
 
     init(site: JetpackSiteRef, store: ActivityStore = StoreContainer.shared.activity) {
@@ -46,7 +53,12 @@ class ActivityListViewModel: Observable {
     }
 
     public func refresh() {
-        ActionDispatcher.dispatch(ActivityAction.refreshActivities(site: site))
+        ActionDispatcher.dispatch(ActivityAction.refreshActivities(site: site, quantity: count))
+    }
+
+    public func loadMore() {
+        offset = store.state.activities[site]?.count ?? 0
+        ActionDispatcher.dispatch(ActivityAction.loadMoreActivities(site: site, quantity: count, offset: offset))
     }
 
     func noResultsViewModel() -> NoResultsViewController.Model? {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1147,6 +1147,7 @@
 		8B260D7E2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
+		8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */; };
 		8B6BD55024293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6BD54F24293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift */; };
 		8B6EA62323FDE50B004BA312 /* PostServiceUploadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */; };
 		8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */; };
@@ -3691,6 +3692,7 @@
 		8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostVisibilitySelectorViewController.swift; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
+		8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListViewModelTests.swift; sourceTree = "<group>"; };
 		8B6BD54F24293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingNudgesViewControllerTests.swift; sourceTree = "<group>"; };
 		8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceUploadingList.swift; sourceTree = "<group>"; };
 		8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewControllerTests.swift; sourceTree = "<group>"; };
@@ -8144,6 +8146,14 @@
 			name = "Recovered References";
 			sourceTree = "<group>";
 		};
+		8B69F0E2255C2BC0006B1CEF /* Activity */ = {
+			isa = PBXGroup;
+			children = (
+				8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */,
+			);
+			path = Activity;
+			sourceTree = "<group>";
+		};
 		8B7623352384372200AB3EE7 /* Pages */ = {
 			isa = PBXGroup;
 			children = (
@@ -9717,6 +9727,7 @@
 		BE20F5E11B2F738E0020694C /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				8B69F0E2255C2BC0006B1CEF /* Activity */,
 				32F1A6D123F710A300AB8CA9 /* NUX */,
 				8BD36E042395CC2F00EFFF1C /* Aztec */,
 				325D3B3A23A8372500766DF6 /* Comments */,
@@ -14179,6 +14190,7 @@
 				8BDA5A6D247C2F8400AB124C /* ReaderDetailViewControllerTests.swift in Sources */,
 				82301B8F1E787420009C9C4E /* AppRatingUtilityTests.swift in Sources */,
 				D81C2F5420F85DB1002AE1F1 /* ApproveCommentActionTests.swift in Sources */,
+				8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */,
 				8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */,
 				F1B1E7A324098FA100549E2A /* BlogTests.swift in Sources */,
 				57889AB823589DF100DAE56D /* PageBuilder.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1148,6 +1148,7 @@
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
 		8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */; };
+		8B69F100255C4870006B1CEF /* ActivityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */; };
 		8B6BD55024293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6BD54F24293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift */; };
 		8B6EA62323FDE50B004BA312 /* PostServiceUploadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */; };
 		8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */; };
@@ -3693,6 +3694,7 @@
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
 		8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListViewModelTests.swift; sourceTree = "<group>"; };
+		8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStoreTests.swift; sourceTree = "<group>"; };
 		8B6BD54F24293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingNudgesViewControllerTests.swift; sourceTree = "<group>"; };
 		8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceUploadingList.swift; sourceTree = "<group>"; };
 		8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewControllerTests.swift; sourceTree = "<group>"; };
@@ -6811,6 +6813,7 @@
 		572FB3FF223A802900933C76 /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */,
 				572FB400223A806000933C76 /* NoticeStoreTests.swift */,
 			);
 			path = Stores;
@@ -14263,6 +14266,7 @@
 				8B8C814D2318073300A0E620 /* BasePostTests.swift in Sources */,
 				F1F083F6241FFE930056D3B1 /* AtomicAuthenticationServiceTests.swift in Sources */,
 				FF8CD625214184EE00A33A8D /* MediaAssetExporterTests.swift in Sources */,
+				8B69F100255C4870006B1CEF /* ActivityStoreTests.swift in Sources */,
 				B5C0CF3F204DB92F00DB0362 /* NotificationReplyStoreTests.swift in Sources */,
 				575E126322973EBB0041B3EB /* PostCompactCellGhostableTests.swift in Sources */,
 				40ACCF14224E167900190713 /* FlagsTest.swift in Sources */,

--- a/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
+++ b/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
@@ -10,7 +10,7 @@ class ActivityListViewModelTests: XCTestCase {
     func testLoadMore() {
         let jetpackSiteRef = JetpackSiteRef.mock(siteID: 0, username: "")
         let activityStoreMock = ActivityStoreMock()
-        let activityListViewModel = ActivityListViewModel.init(site: jetpackSiteRef, store: activityStoreMock)
+        let activityListViewModel = ActivityListViewModel(site: jetpackSiteRef, store: activityStoreMock)
 
         activityListViewModel.loadMore()
 
@@ -24,19 +24,14 @@ class ActivityListViewModelTests: XCTestCase {
     func testLoadMoreOffset() {
         let jetpackSiteRef = JetpackSiteRef.mock(siteID: 0, username: "")
         let activityStoreMock = ActivityStoreMock()
-        let activityListViewModel = ActivityListViewModel.init(site: jetpackSiteRef, store: activityStoreMock)
-        activityStoreMock.state.activities[jetpackSiteRef] = [mockedActivity(), mockedActivity(), mockedActivity()]
+        let activityListViewModel = ActivityListViewModel(site: jetpackSiteRef, store: activityStoreMock)
+        activityStoreMock.state.activities[jetpackSiteRef] = [Activity.mock(), Activity.mock(), Activity.mock()]
 
         activityListViewModel.loadMore()
 
         XCTAssertEqual(activityStoreMock.dispatchedAction, "loadMoreActivities")
         XCTAssertEqual(activityStoreMock.quantity, 20)
         XCTAssertEqual(activityStoreMock.offset, 3)
-    }
-
-    private func mockedActivity() -> Activity {
-        let dictionary = ["activity_id": "1", "summary": "", "content": ["text": ""], "published": "2020-11-09T13:16:43.701+00:00"] as [String : AnyObject]
-        return try! Activity(dictionary: dictionary)
     }
 }
 
@@ -60,5 +55,12 @@ class ActivityStoreMock: ActivityStore {
         default:
             break
         }
+    }
+}
+
+extension Activity {
+    static func mock() -> Activity {
+        let dictionary = ["activity_id": "1", "summary": "", "content": ["text": ""], "published": "2020-11-09T13:16:43.701+00:00"] as [String : AnyObject]
+        return try! Activity(dictionary: dictionary)
     }
 }

--- a/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
+++ b/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
@@ -60,7 +60,7 @@ class ActivityStoreMock: ActivityStore {
 
 extension Activity {
     static func mock() -> Activity {
-        let dictionary = ["activity_id": "1", "summary": "", "content": ["text": ""], "published": "2020-11-09T13:16:43.701+00:00"] as [String : AnyObject]
+        let dictionary = ["activity_id": "1", "summary": "", "content": ["text": ""], "published": "2020-11-09T13:16:43.701+00:00"] as [String: AnyObject]
         return try! Activity(dictionary: dictionary)
     }
 }

--- a/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
+++ b/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import WordPressFlux
+
+@testable import WordPress
+
+class ActivityListViewModelTests: XCTestCase {
+
+    // Check if `loadMore` dispatchs the correct action and params
+    //
+    func testLoadMore() {
+        let jetpackSiteRef = JetpackSiteRef.mock(siteID: 0, username: "")
+        let activityStoreMock = ActivityStoreMock()
+        let activityListViewModel = ActivityListViewModel.init(site: jetpackSiteRef, store: activityStoreMock)
+
+        activityListViewModel.loadMore()
+
+        XCTAssertEqual(activityStoreMock.dispatchedAction, "loadMoreActivities")
+        XCTAssertEqual(activityStoreMock.quantity, 20)
+        XCTAssertEqual(activityStoreMock.offset, 0)
+    }
+
+    // Check if `loadMore` dispatchs the correct offset
+    //
+    func testLoadMoreOffset() {
+        let jetpackSiteRef = JetpackSiteRef.mock(siteID: 0, username: "")
+        let activityStoreMock = ActivityStoreMock()
+        let activityListViewModel = ActivityListViewModel.init(site: jetpackSiteRef, store: activityStoreMock)
+        activityStoreMock.state.activities[jetpackSiteRef] = [mockedActivity(), mockedActivity(), mockedActivity()]
+
+        activityListViewModel.loadMore()
+
+        XCTAssertEqual(activityStoreMock.dispatchedAction, "loadMoreActivities")
+        XCTAssertEqual(activityStoreMock.quantity, 20)
+        XCTAssertEqual(activityStoreMock.offset, 3)
+    }
+
+    private func mockedActivity() -> Activity {
+        let dictionary = ["activity_id": "1", "summary": "", "content": ["text": ""], "published": "2020-11-09T13:16:43.701+00:00"] as [String : AnyObject]
+        return try! Activity(dictionary: dictionary)
+    }
+}
+
+class ActivityStoreMock: ActivityStore {
+    var dispatchedAction: String?
+    var site: JetpackSiteRef?
+    var quantity: Int?
+    var offset: Int?
+
+    override func onDispatch(_ action: Action) {
+        guard let activityAction = action as? ActivityAction else {
+            return
+        }
+
+        switch activityAction {
+        case .loadMoreActivities(let site, let quantity, let offset):
+            dispatchedAction = "loadMoreActivities"
+            self.site = site
+            self.quantity = quantity
+            self.offset = offset
+        default:
+            break
+        }
+    }
+}

--- a/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
+++ b/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
@@ -33,6 +33,19 @@ class ActivityListViewModelTests: XCTestCase {
         XCTAssertEqual(activityStoreMock.quantity, 20)
         XCTAssertEqual(activityStoreMock.offset, 3)
     }
+
+    // Should not load more if already loading
+    //
+    func testLoadMoreDoesntTriggeredWhenAlreadyFetching() {
+        let jetpackSiteRef = JetpackSiteRef.mock(siteID: 0, username: "")
+        let activityStoreMock = ActivityStoreMock()
+        let activityListViewModel = ActivityListViewModel(site: jetpackSiteRef, store: activityStoreMock)
+        activityStoreMock.isFetching = true
+
+        activityListViewModel.loadMore()
+
+        XCTAssertNil(activityStoreMock.dispatchedAction)
+    }
 }
 
 class ActivityStoreMock: ActivityStore {
@@ -40,6 +53,11 @@ class ActivityStoreMock: ActivityStore {
     var site: JetpackSiteRef?
     var quantity: Int?
     var offset: Int?
+    var isFetching = false
+
+    override func isFetching(site: JetpackSiteRef) -> Bool {
+        return isFetching
+    }
 
     override func onDispatch(_ action: Action) {
         guard let activityAction = action as? ActivityAction else {

--- a/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
@@ -1,0 +1,83 @@
+import WordPressFlux
+import XCTest
+
+@testable import WordPress
+
+class ActivityStoreTests: XCTestCase {
+    private var dispatcher: ActionDispatcher!
+    private var store: ActivityStore!
+    private var activityServiceMock: ActivityServiceRemoteMock!
+
+    override func setUp() {
+        super.setUp()
+
+        dispatcher = ActionDispatcher()
+        activityServiceMock = ActivityServiceRemoteMock()
+        store = ActivityStore.init(dispatcher: dispatcher, activityServiceRemote: activityServiceMock)
+    }
+
+    override func tearDown() {
+        dispatcher = nil
+        store = nil
+
+        super.tearDown()
+    }
+
+    // Check if loadMoreActivities call the service with the correct params
+    //
+    func testLoadMoreActivities() {
+        let jetpackSiteRef = JetpackSiteRef.mock(siteID: 9, username: "foo")
+
+        dispatch(.loadMoreActivities(site: jetpackSiteRef, quantity: 10, offset: 20))
+
+        XCTAssertEqual(activityServiceMock.getActivityForSiteCalledWithSiteID, 9)
+        XCTAssertEqual(activityServiceMock.getActivityForSiteCalledWithCount, 10)
+        XCTAssertEqual(activityServiceMock.getActivityForSiteCalledWithOffset, 20)
+    }
+
+    // Check if loadMoreActivities keep the activies and add the new retrieved ones
+    //
+    func testLoadMoreActivitiesKeepTheExistent() {
+        let jetpackSiteRef = JetpackSiteRef.mock(siteID: 9, username: "foo")
+        store.state.activities[jetpackSiteRef] = [Activity.mock()]
+        activityServiceMock.activitiesToReturn = [Activity.mock(), Activity.mock()]
+        activityServiceMock.hasMore = true
+
+        dispatch(.loadMoreActivities(site: jetpackSiteRef, quantity: 10, offset: 20))
+
+        XCTAssertEqual(store.state.activities[jetpackSiteRef]?.count, 3)
+        XCTAssertTrue(store.state.hasMore)
+    }
+
+    // MARK: - Helpers
+
+    private func dispatch(_ action: ActivityAction) {
+        dispatcher.dispatch(action)
+    }
+}
+
+class ActivityServiceRemoteMock: ActivityServiceRemote {
+    var getActivityForSiteCalledWithSiteID: Int?
+    var getActivityForSiteCalledWithOffset: Int?
+    var getActivityForSiteCalledWithCount: Int?
+
+    var activitiesToReturn: [Activity]?
+    var hasMore = false
+
+    override func getActivityForSite(_ siteID: Int,
+                                     offset: Int = 0,
+                                     count: Int,
+                                     after: Date? = nil,
+                                     before: Date? = nil,
+                                     group: [String] = [],
+                                     success: @escaping (_ activities: [Activity], _ hasMore: Bool) -> Void,
+                                     failure: @escaping (Error) -> Void) {
+        getActivityForSiteCalledWithSiteID = siteID
+        getActivityForSiteCalledWithCount = count
+        getActivityForSiteCalledWithOffset = offset
+
+        if let activitiesToReturn = activitiesToReturn {
+            success(activitiesToReturn, hasMore)
+        }
+    }
+}

--- a/WordPress/WordPressTest/RegisterDomainDetailsViewModelTests.swift
+++ b/WordPress/WordPressTest/RegisterDomainDetailsViewModelTests.swift
@@ -2,13 +2,13 @@
 import XCTest
 
 extension JetpackSiteRef {
-    static func mock(siteID: Int, username: String) -> JetpackSiteRef {
+    static func mock(siteID: Int = 9001, username: String = "test") -> JetpackSiteRef {
         let payload: NSString = """
         {
-            "siteID": 9001,
-            "username": "test"
+            "siteID": \(siteID),
+            "username": "\(username)"
         }
-        """
+        """ as NSString
 
 
         return try! JSONDecoder().decode(JetpackSiteRef.self, from: payload.data(using: 8)!)


### PR DESCRIPTION
Part of #15192

* Fix the NoResultsController
* Adds pagination to the Activity Log

<p align="center"><img src="https://user-images.githubusercontent.com/7040243/98845741-eb504780-242c-11eb-9d97-ab18bc4b2685.gif" width="300"></p>

### To test

1. Open the Activity Log
2. make sure the "Loading Activities" message appears
3. When the activities appears scroll down
4. Make sure new activities are correctly loaded and in order (you can compare with web)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
