### PR TITLE
Replace instance of QuickStartTourGuide inside WPTabBarController with separate singleton

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -16,8 +16,7 @@ extension BlogDetailsViewController {
             self?.refreshSiteIcon()
             self?.configureTableViewData()
             self?.reloadTableViewPreservingSelection()
-            if let index = QuickStartTourGuide.find()?.currentElementInt(),
-                let element = QuickStartTourElement(rawValue: index) {
+            if let element = QuickStartTourElement(rawValue: QuickStartTourGuide.shared.currentElementInt()) {
                 self?.scroll(to: element)
             }
 
@@ -81,16 +80,13 @@ extension BlogDetailsViewController {
     }
 
     private func showNoticeOrAlertAsNeeded() {
-        guard let tourGuide = QuickStartTourGuide.find() else {
-            return
-        }
 
-        if tourGuide.shouldShowUpgradeToV2Notice(for: blog) {
+        if QuickStartTourGuide.shared.shouldShowUpgradeToV2Notice(for: blog) {
             showUpgradeToV2Alert(for: blog)
 
-            tourGuide.didShowUpgradeToV2Notice(for: blog)
-        } else if let tourToSuggest = tourGuide.tourToSuggest(for: blog) {
-            tourGuide.suggest(tourToSuggest, for: blog)
+            QuickStartTourGuide.shared.didShowUpgradeToV2Notice(for: blog)
+        } else if let tourToSuggest = QuickStartTourGuide.shared.tourToSuggest(for: blog) {
+            QuickStartTourGuide.shared.suggest(tourToSuggest, for: blog)
         }
     }
 
@@ -113,7 +109,7 @@ extension BlogDetailsViewController {
             self?.toggleSpotlightOnHeaderView()
         }
 
-        QuickStartTourGuide.find()?.visited(.checklist)
+        QuickStartTourGuide.shared.visited(.checklist)
     }
 
     @objc func quickStartSectionViewModel() -> BlogDetailsSection {
@@ -133,10 +129,9 @@ extension BlogDetailsViewController {
                                            }
         customizeRow.quickStartIdentifier = .checklist
         customizeRow.showsSelectionState = false
-         if let customizeDetailCount = QuickStartTourGuide.find()?.countChecklistCompleted(in: QuickStartTourGuide.customizeListTours, for: blog) {
-             customizeRow.detail = String(format: detailFormatStr, customizeDetailCount, QuickStartTourGuide.customizeListTours.count)
-             customizeRow.quickStartTitleState = customizeDetailCount == QuickStartTourGuide.customizeListTours.count ? .completed : .customizeIncomplete
-        }
+        let customizeDetailCount = QuickStartTourGuide.shared.countChecklistCompleted(in: QuickStartTourGuide.customizeListTours, for: blog)
+        customizeRow.detail = String(format: detailFormatStr, customizeDetailCount, QuickStartTourGuide.customizeListTours.count)
+        customizeRow.quickStartTitleState = customizeDetailCount == QuickStartTourGuide.customizeListTours.count ? .completed : .customizeIncomplete
 
         let growTitle = NSLocalizedString("Grow Your Audience",
                                           comment: "Name of the Quick Start list that guides users through a few tasks to customize their new website.")
@@ -151,10 +146,9 @@ extension BlogDetailsViewController {
                                      }
         growRow.quickStartIdentifier = .checklist
         growRow.showsSelectionState = false
-         if let growDetailCount = QuickStartTourGuide.find()?.countChecklistCompleted(in: QuickStartTourGuide.growListTours, for: blog) {
-             growRow.detail = String(format: detailFormatStr, growDetailCount, QuickStartTourGuide.growListTours.count)
-             growRow.quickStartTitleState = growDetailCount == QuickStartTourGuide.growListTours.count ? .completed : .growIncomplete
-        }
+        let growDetailCount = QuickStartTourGuide.shared.countChecklistCompleted(in: QuickStartTourGuide.growListTours, for: blog)
+        growRow.detail = String(format: detailFormatStr, growDetailCount, QuickStartTourGuide.growListTours.count)
+        growRow.quickStartTitleState = growDetailCount == QuickStartTourGuide.growListTours.count ? .completed : .growIncomplete
 
         let sectionTitle = NSLocalizedString("Next Steps", comment: "Table view title for the quick start section.")
         let section = BlogDetailsSection(title: sectionTitle, andRows: [customizeRow, growRow], category: .quickStart)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -394,7 +394,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewWillAppear:animated];
 
-    if ([[QuickStartTourGuide find] currentElementInt] != NSNotFound) {
+    if ([[QuickStartTourGuide shared] currentElementInt] != NSNotFound) {
         self.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
     } else {
         self.additionalSafeAreaInsets = UIEdgeInsetsZero;
@@ -1235,7 +1235,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         }
         [WPStyleGuide configureTableViewCell:cell];
     }
-    if ([[QuickStartTourGuide find] isCurrentElement:row.quickStartIdentifier]) {
+    if ([[QuickStartTourGuide shared] isCurrentElement:row.quickStartIdentifier]) {
         row.accessoryView = [QuickStartSpotlightView new];
     } else if ([row.accessoryView isKindOfClass:[QuickStartSpotlightView class]]) {
         row.accessoryView = nil;
@@ -1310,7 +1310,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
         [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped];
         
-        [[QuickStartTourGuide find] removeFrom:self.blog];
+        [[QuickStartTourGuide shared] removeFrom:self.blog];
     }];
     
     UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
@@ -1479,7 +1479,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     controller.blog = self.blog;
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showPostListFromSource:(BlogDetailsNavigationSource)source
@@ -1488,7 +1488,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     PostListViewController *controller = [PostListViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showPageListFromSource:(BlogDetailsNavigationSource)source
@@ -1497,7 +1497,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementPages];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementPages];
 }
 
 - (void)showMediaLibraryFromSource:(BlogDetailsNavigationSource)source
@@ -1506,7 +1506,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     MediaLibraryViewController *controller = [[MediaLibraryViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showPeople
@@ -1515,7 +1515,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     PeopleViewController *controller = [PeopleViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showPlugins
@@ -1524,7 +1524,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     PluginDirectoryViewController *controller = [[PluginDirectoryViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showPlans
@@ -1533,7 +1533,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     PlanListViewController *controller = [[PlanListViewController alloc] initWithStyle:UITableViewStyleGrouped];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementPlans];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementPlans];
 }
 
 - (void)showSettings
@@ -1542,7 +1542,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     SiteSettingsViewController *controller = [[SiteSettingsViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showSharing
@@ -1559,7 +1559,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedSharingManagement withBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementSharing];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementSharing];
 }
 
 - (void)showStatsFromSource:(BlogDetailsNavigationSource)source
@@ -1579,7 +1579,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self showDetailViewController:statsView sender:self];
     }
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementStats];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementStats];
 }
 
 - (void)showActivity
@@ -1587,7 +1587,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     ActivityListViewController *controller = [[ActivityListViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showThemes
@@ -1599,7 +1599,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     };
     [self showDetailViewController:viewController sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementThemes];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementThemes];
 }
 
 - (void)showMenus
@@ -1608,7 +1608,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     MenusViewController *viewController = [MenusViewController controllerWithBlog:self.blog];
     [self showDetailViewController:viewController sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showViewSite
@@ -1632,7 +1632,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self toggleSpotlightOnHeaderView];
     }];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementViewSite];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementViewSite];
     self.additionalSafeAreaInsets = UIEdgeInsetsZero;
 }
 
@@ -1653,7 +1653,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:dashboardUrl] options:nil completionHandler:nil];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 #pragma mark - Remove Site

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -75,11 +75,11 @@ class BlogDetailHeaderView: UIView {
     }
 
     @objc func toggleSpotlightOnSiteTitle() {
-        titleButton.shouldShowSpotlight = QuickStartTourGuide.find()?.isCurrentElement(.siteTitle) == true
+        titleButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.siteTitle)
     }
 
     @objc func toggleSpotlightOnSiteIcon() {
-        siteIconView.spotlightIsShown = QuickStartTourGuide.find()?.isCurrentElement(.siteIcon) == true
+        siteIconView.spotlightIsShown = QuickStartTourGuide.shared.isCurrentElement(.siteIcon)
     }
 
     private enum Constants {
@@ -96,7 +96,7 @@ class BlogDetailHeaderView: UIView {
         self.init(frame: .zero)
 
         siteIconView.tapped = { [weak self] in
-            QuickStartTourGuide.find()?.visited(.siteIcon)
+            QuickStartTourGuide.shared.visited(.siteIcon)
             self?.siteIconView.spotlightIsShown = false
 
             self?.delegate?.siteIconTapped()
@@ -165,7 +165,7 @@ class BlogDetailHeaderView: UIView {
     }
 
     @objc private func titleButtonTapped() {
-        QuickStartTourGuide.find()?.visited(.siteTitle)
+        QuickStartTourGuide.shared.visited(.siteTitle)
         titleButton.shouldShowSpotlight = false
 
         delegate?.siteTitleTapped()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
@@ -190,9 +190,6 @@ private extension QuickStartChecklistManager {
     }
 
     func tableView(_ tableView: UITableView, completeTourAt indexPath: IndexPath) {
-        guard let tourGuide = QuickStartTourGuide.find() else {
-            return
-        }
         let tour = todoTours[indexPath.row]
         todoTours.remove(at: indexPath.row)
         completedTours.append(tour)
@@ -213,7 +210,7 @@ private extension QuickStartChecklistManager {
                 if self.shouldShowCompleteTasksScreen() {
                     self.didTapHeader(self.completedSectionCollapse)
                 }
-                tourGuide.complete(tour: tour, for: self.blog, postNotification: false)
+                QuickStartTourGuide.shared.complete(tour: tour, for: self.blog, postNotification: false)
                 let sections = IndexSet(integer: Sections.todo.rawValue)
                 tableView.reloadSections(sections, with: .automatic)
             }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -99,11 +99,10 @@ class QuickStartChecklistViewController: UITableViewController {
                     return
                 }
 
-                let tourGuide = QuickStartTourGuide.find()
-                tourGuide?.prepare(tour: tour, for: self.blog)
+                QuickStartTourGuide.shared.prepare(tour: tour, for: self.blog)
 
                 self.dismiss(animated: true) {
-                    tourGuide?.begin()
+                    QuickStartTourGuide.shared.begin()
                 }
             }
         }, didTapHeader: { [unowned self] expand in

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationSettings.swift
@@ -3,14 +3,11 @@ class QuickStartNavigationSettings: NSObject {
     private var spotlightView: QuickStartSpotlightView?
 
     func updateWith(navigationController: UINavigationController, andViewController viewController: UIViewController) {
-        guard let tourGuide = QuickStartTourGuide.find() else {
-            return
-        }
 
         switch viewController {
         case is BlogListViewController:
-            tourGuide.visited(.noSuchElement)
-            tourGuide.endCurrentTour()
+            QuickStartTourGuide.shared.visited(.noSuchElement)
+            QuickStartTourGuide.shared.endCurrentTour()
         default:
             break
         }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -11,13 +11,10 @@ open class QuickStartTourGuide: NSObject {
     static let notificationElementKey = "QuickStartElementKey"
     static let notificationDescriptionKey = "QuickStartDescriptionKey"
 
-    @objc static func find() -> QuickStartTourGuide? {
-        guard let tabBarController = WPTabBarController.sharedInstance(),
-            let tourGuide = tabBarController.tourGuide else {
-            return nil
-        }
-        return tourGuide
-    }
+
+    @objc static let shared = QuickStartTourGuide()
+
+    private override init() {}
 
     func setup(for blog: Blog) {
         didShowUpgradeToV2Notice(for: blog)

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -137,7 +137,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     [WPStyleGuide configureTableViewCell:cell];
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-    if (indexPath == [NSIndexPath indexPathForRow:0 inSection:0] && [[QuickStartTourGuide find] isCurrentElement:QuickStartTourElementConnections]) {
+    if (indexPath == [NSIndexPath indexPathForRow:0 inSection:0] && [[QuickStartTourGuide shared] isCurrentElement:QuickStartTourElementConnections]) {
         cell.accessoryView = [QuickStartSpotlightView new];
     } else {
         cell.accessoryView = nil;
@@ -205,7 +205,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         controller = [[SharingConnectionsViewController alloc] initWithBlog:self.blog publicizeService:publicizer];
         [WPAppAnalytics track:WPAnalyticsStatSharingOpenedPublicize withBlog:self.blog];
 
-        [[QuickStartTourGuide find] visited:QuickStartTourElementConnections];
+        [[QuickStartTourGuide shared] visited:QuickStartTourElementConnections];
     } else {
         controller = [[SharingButtonsViewController alloc] initWithBlog:self.blog];
         [WPAppAnalytics track:WPAnalyticsStatSharingOpenedSharingButtonSettings withBlog:self.blog];

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -127,7 +127,7 @@ class DebugMenuViewController: UITableViewController {
     }
 
     private func enableQuickStart(for blog: Blog) {
-        QuickStartTourGuide.find()?.setup(for: blog)
+        QuickStartTourGuide.shared.setup(for: blog)
     }
 
     // MARK: Reader

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -119,7 +119,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if QuickStartTourGuide.find()?.isCurrentElement(.newPage) ?? false {
+        if QuickStartTourGuide.shared.isCurrentElement(.newPage) {
             updateFilterWithPostStatus(.publish)
         }
 
@@ -477,7 +477,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let editorViewController = EditPageViewController(blog: blog, postTitle: starterLayout?.title, content: starterLayout?.content, appliedTemplate: starterLayout?.slug)
         present(editorViewController, animated: false)
 
-        QuickStartTourGuide.find()?.visited(.newPage)
+        QuickStartTourGuide.shared.visited(.newPage)
     }
 
     fileprivate func editPage(_ page: Page) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -538,7 +538,7 @@ import WordPressShared
         }
 
         if menuItem.type == .search {
-            QuickStartTourGuide.find()?.visited(.readerSearch)
+            QuickStartTourGuide.shared.visited(.readerSearch)
         }
 
         if menuItem.type == .addItem {
@@ -591,7 +591,7 @@ import WordPressShared
         WPStyleGuide.configureTableViewCell(cell)
         cell.accessoryView = nil
         cell.accessoryType = (splitViewControllerIsHorizontallyCompact) ? .disclosureIndicator : .none
-        if menuItem.type == .search && QuickStartTourGuide.find()?.isCurrentElement(.readerSearch) ?? false {
+        if menuItem.type == .search && QuickStartTourGuide.shared.isCurrentElement(.readerSearch) {
             cell.accessoryView = QuickStartSpotlightView()
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -148,7 +148,7 @@ import Gridicons
             return
         }
 
-        QuickStartTourGuide.find()?.visited(.readerSearch)
+        QuickStartTourGuide.shared.visited(.readerSearch)
         WPAppAnalytics.track(.readerSearchLoaded)
         didBumpStats = true
     }

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
@@ -26,11 +26,7 @@ extension FancyAlertViewController {
         let allowButton = ButtonConfig(Strings.allowButtonText) { controller, _ in
             controller.dismiss(animated: true)
 
-            guard let tourGuide = QuickStartTourGuide.find() else {
-                return
-            }
-
-            tourGuide.setup(for: blog)
+            QuickStartTourGuide.shared.setup(for: blog)
 
             WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "positive"])
         }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -126,7 +126,7 @@ import WordPressFlux
             let actionSheetVC = actionSheetController(with: viewController.traitCollection)
             viewController.present(actionSheetVC, animated: true, completion: {
                 WPAnalytics.track(.createSheetShown)
-                QuickStartTourGuide.find()?.visited(.newpost)
+                QuickStartTourGuide.shared.visited(.newpost)
             })
         }
     }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
@@ -4,7 +4,7 @@ struct PostAction: ActionSheetItem {
     let handler: () -> Void
 
     func makeButton() -> ActionSheetButton {
-        let highlight: Bool = QuickStartTourGuide.find()?.shouldSpotlight(.newpost) ?? false
+        let highlight: Bool = QuickStartTourGuide.shared.shouldSpotlight(.newpost)
         return ActionSheetButton(title: NSLocalizedString("Blog post", comment: "Create new Blog Post button title"),
                                  image: .gridicon(.posts),
                                  identifier: "blogPostButton",

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -36,11 +36,11 @@ extension WPTabBarController {
     }
 
     @objc func alertQuickStartThatReaderWasTapped() {
-        tourGuide.visited(.readerTab)
+        QuickStartTourGuide.shared.visited(.readerTab)
     }
 
     @objc func alertQuickStartThatOtherTabWasTapped() {
-        tourGuide.visited(.tabFlipped)
+        QuickStartTourGuide.shared.visited(.tabFlipped)
     }
 
     @objc func stopWatchingQuickTours() {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -19,7 +19,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 @class ReaderMenuViewController;
 @class ReaderTabViewModel;
 @class WPSplitViewController;
-@class QuickStartTourGuide;
 @protocol ScenePresenter;
 
 @interface WPTabBarController : UITabBarController <UIViewControllerTransitioningDelegate>
@@ -30,7 +29,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 @property (nonatomic, strong, readonly) ReaderMenuViewController *readerMenuViewController;
 @property (nonatomic, strong, readonly) NotificationsViewController *notificationsViewController;
 @property (nonatomic, strong, readonly) UINavigationController *readerNavigationController;
-@property (nonatomic, strong, readonly) QuickStartTourGuide *tourGuide;
 @property (nonatomic, strong, readonly) MySitesCoordinator *mySitesCoordinator;
 @property (nonatomic, strong, readonly) ReaderCoordinator *readerCoordinator;
 @property (nonatomic, strong) id<ScenePresenter> meScenePresenter;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -47,7 +47,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 @property (nonatomic, strong) BlogListViewController *blogListViewController;
 @property (nonatomic, strong) NotificationsViewController *notificationsViewController;
 @property (nonatomic, strong) ReaderMenuViewController *readerMenuViewController;
-@property (nonatomic, strong) QuickStartTourGuide *tourGuide;
 
 @property (nonatomic, strong) UINavigationController *blogListNavigationController;
 @property (nonatomic, strong) UINavigationController *readerNavigationController;
@@ -92,8 +91,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     self = [super init];
     if (self) {
         [self setDelegate:self];
-        self.tourGuide = [[QuickStartTourGuide alloc] init];
-
         [self setRestorationIdentifier:WPTabBarRestorationID];
         [self setRestorationClass:[WPTabBarController class]];
         [[self tabBar] setAccessibilityIdentifier:@"Main Navigation"];

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
@@ -107,11 +107,8 @@ open class ThemeBrowserHeaderView: UICollectionReusableView {
     }
 
     private func spotlightCustomizeButtonIfTourIsActive() {
-        guard let tourGuide = QuickStartTourGuide.find() else {
-            return
-        }
 
-        if tourGuide.isCurrentElement(.customize) {
+        if QuickStartTourGuide.shared.isCurrentElement(.customize) {
             customizeButton.addSubview(quickStartSpotlightView)
             quickStartSpotlightView.translatesAutoresizingMaskIntoConstraints = false
             addConstraints([

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -814,7 +814,7 @@ public protocol ThemePresenter: class {
 
     @objc open func presentCustomizeForTheme(_ theme: Theme?) {
         WPAppAnalytics.track(.themesCustomizeAccessed, with: self.blog)
-        QuickStartTourGuide.find()?.visited(.customize)
+        QuickStartTourGuide.shared.visited(.customize)
 
         presentUrlForTheme(theme, url: theme?.customizeUrl(), activeButton: false, modalStyle: .fullScreen)
     }


### PR DESCRIPTION
Ref #15238

the above referenced crash shows two calls to `[WPTabBarController sharedInstance]` in the same stack trace. The crash is possibly caused because the second call happens when the singleton is not yet fully initialized.

The second call to `[WPTabBarController sharedInstance]` is made by `QuickStartTourGuide`, which has an instance in the `WPTabBarController` singleton.

To avoid this, and in general to reduce calls to `[WPTabBarController sharedInstance]`, this PR separates `QuickStartTourGuide` in its own singleton. Singletons are less than ideal and should be avoided when possible, but separating `QuickStartTourGuide` at this stage might make simpler a future (quasi)singleton-free redesign.

To test:

- Add a new site
- when prompted for help, tap "Yes help me"
- Go through all the steps of the quick start guide and make sure they work as expected

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
