### PR TITLE
Reader: As a precaution, cancel previous downloads when configuring cells

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -160,7 +160,7 @@ class ReaderCommentCell: UITableViewCell {
         guard let comment = comment else {
             return
         }
-
+        avatarImageView.cancelImageDownload()
         let placeholder = UIImage(named: "gravatar")
         if let url = comment.avatarURLForDisplay() {
             avatarImageView.downloadImage(from: url, placeholderImage: placeholder)


### PR DESCRIPTION
Refs #15285 

This PR attempts to address the curious issue reported in #15285 by canceling any inflight image downloads when configuring a reader cell for a new comment.  I remain somewhat suspicious of [the download code](https://github.com/wordpress-mobile/WordPressUI-iOS/blob/98b454a912e5f2b7e39525bc7442efaafbeb04a2/WordPressUI/Extensions/UIImageView%2BNetworking.swift#L82) in the UI pod but haven't been able to suss out the issue with its logic (assuming there is one).  We should leave #15285 open to track future reports in case this patch doesn't do the trick. 

To test:
Apply the patch. 
Smoke test reader comments.  Confirm avatars still load as expected.

@ScoutHarris could I trouble you for a quick peek at this one? 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
