### PR TITLE
Restore previous post preview functionality

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewNonceHandler.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewNonceHandler.swift
@@ -33,7 +33,7 @@ struct PreviewNonceHandler {
         else {
             return url
         }
-        let queryItems = components.queryItems ?? []
+        let queryItems = components.queryItems
         components.queryItems = addPreviewIfNecessary(items: queryItems)
         components.scheme = unmappedSiteURL.scheme
         components.host = unmappedSiteURL.host
@@ -41,8 +41,8 @@ struct PreviewNonceHandler {
         return components.url
     }
 
-    private static func addPreviewIfNecessary(items: [URLQueryItem]) -> [URLQueryItem] {
-        var queryItems = items
+    private static func addPreviewIfNecessary(items: [URLQueryItem]?) -> [URLQueryItem]? {
+        guard var queryItems = items else { return nil }
         // Only add the preview query param if it doesn't exist.
         if !(queryItems.map { $0.name }).contains("preview") {
             queryItems.append(URLQueryItem(name: "preview", value: "true"))


### PR DESCRIPTION
Fixes #15266

Prior to https://github.com/wordpress-mobile/WordPress-iOS/pull/15061 (or https://github.com/wordpress-mobile/WordPress-iOS/commit/b01f2e62352c836254b7e1a867c939490085e5ce to be specific), post previews on sites with custom domains used the sites public URL (not the mapped `*.wordpress.com` one).

This PR restores the previous behavior by reverting a small change that led to the `preview=true` query parameter being added to post preview URLs.

To test:

1. Log into the app and choose a site with a custom domain (not a `*.wordpress.com` domain)
2. Go to the posts list screen and tap "View" on a published post
3. When the post preview model screen opens, tap the share button on the bottom-left corner of the screen
4. Copy the URL and verify it contains the custom domain. For example, if the site's custom domain is pschrottkyicloud.com, the URL should be similar to https://pschrottkyicloud.com/2020/11/03/a-post-of-mine

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
