### PR TITLE
ios 14 today widget refresh policy

### DIFF
--- a/WordPress/WordPressHomeWidgetToday/Model/TodayWidgetContent.swift
+++ b/WordPress/WordPressHomeWidgetToday/Model/TodayWidgetContent.swift
@@ -2,7 +2,7 @@ import WidgetKit
 
 
 struct TodayWidgetContent: TimelineEntry {
-    let date = Date()
+    let date: Date
     let siteTitle: String
     let stats: TodayWidgetStats
 }

--- a/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetView.swift
+++ b/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetView.swift
@@ -43,6 +43,13 @@ extension TodayWidgetView {
 }
 
 struct TodayWidgetView_Previews: PreviewProvider {
+    // TODO - TODAYWIDGET: this has been added here for preview purposes only. 
+    static let staticContent = TodayWidgetContent(date: Date(),
+                                           siteTitle: "Places you should visit",
+                                           stats: TodayWidgetStats(views: 5980,
+                                                                   visitors: 4208,
+                                                                   likes: 107,
+                                                                   comments: 5))
     static var previews: some View {
         TodayWidgetView(content: staticContent)
             .previewContext(WidgetPreviewContext(family: .systemSmall))

--- a/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetView.swift
+++ b/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetView.swift
@@ -44,10 +44,10 @@ extension TodayWidgetView {
 
 struct TodayWidgetView_Previews: PreviewProvider {
     static var previews: some View {
-        TodayWidgetView(content: staticModel)
+        TodayWidgetView(content: staticContent)
             .previewContext(WidgetPreviewContext(family: .systemSmall))
 
-        TodayWidgetView(content: staticModel)
+        TodayWidgetView(content: staticContent)
             .previewContext(WidgetPreviewContext(family: .systemMedium))
     }
 }

--- a/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
+++ b/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
@@ -1,33 +1,34 @@
 import WidgetKit
 import SwiftUI
 
-// TODO - TODAYWIDGET: remove this static model when real data come in.
-let staticModel = TodayWidgetContent(siteTitle: "Places you should visit",
-                                     stats: TodayWidgetStats(views: 5980,
-                                                            visitors: 4208,
-                                                            likes: 107,
-                                                            comments: 5))
+// TODO - TODAYWIDGET: This can serve as static content to display in the preview if no data are yet available
+// we should define what to put in here
+let staticContent = TodayWidgetContent(date: Date(),
+                                       siteTitle: "Places you should visit",
+                                       stats: TodayWidgetStats(views: 5980,
+                                                               visitors: 4208,
+                                                               likes: 107,
+                                                               comments: 5))
 
 struct Provider: TimelineProvider {
-
+    // TODO - TODAYWIDGET: Kept these methods simple on purpose, for now.
+    // They might complicate depending on Context
     func placeholder(in context: Context) -> TodayWidgetContent {
-        staticModel
+        staticContent
     }
 
     func getSnapshot(in context: Context, completion: @escaping (TodayWidgetContent) -> ()) {
-        completion(staticModel)
+        getSnapshotData(completion: completion)
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
-        // TODO - TODAYWIDGET: Using the "old widget" configuration, for now.
-        guard let initialStats = TodayWidgetStats.loadSavedData() else {
-            return
-        }
-
-        let entries = [TodayWidgetContent(siteTitle: siteName, stats: initialStats)]
-        let timeline = Timeline(entries: entries, policy: .atEnd)
-        completion(timeline)
+        getTimelineData(completion: completion)
     }
+}
+
+// MARK: - Widget data
+private extension Provider {
+
     // TODO - TODAYWIDGET: Using the "old widget" configuration, for now.
     var siteName: String {
         let defaults = UserDefaults(suiteName: WPAppGroupName)
@@ -42,6 +43,31 @@ struct Provider: TimelineProvider {
             return url
         }
         return "Site not found"
+    }
+
+    func getSnapshotData(completion: @escaping (TodayWidgetContent) -> ()) {
+        // TODO - TODAYWIDGET: Using the "old widget" configuration, for now.
+        guard let initialStats = TodayWidgetStats.loadSavedData() else {
+            completion(staticContent)
+            return
+        }
+        completion(TodayWidgetContent(date: Date(), siteTitle: siteName, stats: initialStats))
+    }
+
+    func getTimelineData(completion: @escaping (Timeline<Entry>) -> ()) {
+
+        let date = Date()
+        let nextRefreshDate = Calendar.current.date(byAdding: .hour, value: 1, to: date)
+        // TODO - TODAYWIDGET: This is a sample data set to test timeline updates
+        let entries = [TodayWidgetContent(date: date,
+                                          siteTitle: "My Site + \(Int.random(in: 4 ... 100))",
+                                          stats: TodayWidgetStats(views: 5980,
+                                                                  visitors: 4208,
+                                                                  likes: 107,
+                                                                  comments: 5))]
+
+        let timeline = Timeline(entries: entries, policy: .after(nextRefreshDate!))
+        completion(timeline)
     }
 }
 

--- a/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
+++ b/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
@@ -50,13 +50,14 @@ private extension Provider {
 
         let date = Date()
         let nextRefreshDate = Calendar.current.date(byAdding: .minute, value: Constants.refreshInterval, to: date)
-        // TODO - TODAYWIDGET: This is a sample data set to test timeline updates
+        // TODO - TODAYWIDGET: This is just a sample data set to test timeline updates
+        let randomNumber = Int.random(in: 4 ... 100)
         let entries = [TodayWidgetContent(date: date,
-                                          siteTitle: "My Site + \(Int.random(in: 4 ... 100))",
-                                          stats: TodayWidgetStats(views: 5980,
-                                                                  visitors: 4208,
-                                                                  likes: 107,
-                                                                  comments: 5))]
+                                          siteTitle: "My Site + \(randomNumber)",
+                                          stats: TodayWidgetStats(views: randomNumber,
+                                                                  visitors: randomNumber,
+                                                                  likes: randomNumber,
+                                                                  comments: randomNumber))]
 
         let timeline = Timeline(entries: entries, policy: .after(nextRefreshDate!))
         completion(timeline)

--- a/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
+++ b/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
@@ -49,7 +49,7 @@ private extension Provider {
     func getTimelineData(completion: @escaping (Timeline<Entry>) -> ()) {
 
         let date = Date()
-        let nextRefreshDate = Calendar.current.date(byAdding: .minute, value: Constants.refreshInterval, to: date)
+        let nextRefreshDate = Calendar.current.date(byAdding: .minute, value: Constants.refreshInterval, to: date) ?? date
         // TODO - TODAYWIDGET: This is just a sample data set to test timeline updates
         let randomNumber = Int.random(in: 4 ... 100)
         let entries = [TodayWidgetContent(date: date,
@@ -59,7 +59,7 @@ private extension Provider {
                                                                   likes: randomNumber,
                                                                   comments: randomNumber))]
 
-        let timeline = Timeline(entries: entries, policy: .after(nextRefreshDate!))
+        let timeline = Timeline(entries: entries, policy: .after(nextRefreshDate))
         completion(timeline)
     }
 }

--- a/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
+++ b/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
@@ -1,20 +1,12 @@
 import WidgetKit
 import SwiftUI
 
-// TODO - TODAYWIDGET: This can serve as static content to display in the preview if no data are yet available
-// we should define what to put in here
-let staticContent = TodayWidgetContent(date: Date(),
-                                       siteTitle: "Places you should visit",
-                                       stats: TodayWidgetStats(views: 5980,
-                                                               visitors: 4208,
-                                                               likes: 107,
-                                                               comments: 5))
 
 struct Provider: TimelineProvider {
     // TODO - TODAYWIDGET: Kept these methods simple on purpose, for now.
     // They might complicate depending on Context
     func placeholder(in context: Context) -> TodayWidgetContent {
-        staticContent
+        Constants.staticContent
     }
 
     func getSnapshot(in context: Context, completion: @escaping (TodayWidgetContent) -> ()) {
@@ -48,7 +40,7 @@ private extension Provider {
     func getSnapshotData(completion: @escaping (TodayWidgetContent) -> ()) {
         // TODO - TODAYWIDGET: Using the "old widget" configuration, for now.
         guard let initialStats = TodayWidgetStats.loadSavedData() else {
-            completion(staticContent)
+            completion(Constants.staticContent)
             return
         }
         completion(TodayWidgetContent(date: Date(), siteTitle: siteName, stats: initialStats))
@@ -57,7 +49,7 @@ private extension Provider {
     func getTimelineData(completion: @escaping (Timeline<Entry>) -> ()) {
 
         let date = Date()
-        let nextRefreshDate = Calendar.current.date(byAdding: .hour, value: 1, to: date)
+        let nextRefreshDate = Calendar.current.date(byAdding: .minute, value: Constants.refreshInterval, to: date)
         // TODO - TODAYWIDGET: This is a sample data set to test timeline updates
         let entries = [TodayWidgetContent(date: date,
                                           siteTitle: "My Site + \(Int.random(in: 4 ... 100))",
@@ -68,6 +60,22 @@ private extension Provider {
 
         let timeline = Timeline(entries: entries, policy: .after(nextRefreshDate!))
         completion(timeline)
+    }
+}
+
+// MARK: - Constants
+private extension Provider {
+    enum Constants {
+        // TODO - TODAYWIDGET: This can serve as static content to display in the preview if no data are yet available
+        // we should define what to put in here
+        static let staticContent = TodayWidgetContent(date: Date(),
+                                                      siteTitle: "Places you should visit",
+                                                      stats: TodayWidgetStats(views: 5980,
+                                                                              visitors: 4208,
+                                                                              likes: 107,
+                                                                              comments: 5))
+        // refresh interval of the widget, in minutes
+        static let refreshInterval = 60
     }
 }
 


### PR DESCRIPTION
Fixes #15289 

Adds a refresh policy to the new Today Widget for iOS 14

To test:
- Install one or more instances of the widget
- make sure that the random number used for testing (`WordPressHomeWidgetToday.swift`, line 54) updates after the set time interval. This will be the only number showing multiple times in the widget (see example below)

<p align=center>
<img width="400" src="https://user-images.githubusercontent.com/34376330/99098512-b19f4e00-259e-11eb-8b3d-00d6e3062dd4.png">
</p>

**Notes**
1. The current refresh interval is set to 1 hour (`WordPressHomeWidgetToday.swift`, line 79). To test more efficiently, set this interval to a reasonable value. Consider that if it's too low (e.g. 1 minute) iOS will probably not update that often. There seems to be a lower limit of a few minutes at least
2. According to the documentation https://developer.apple.com/documentation/widgetkit/timelineprovider, to test more precisely, the widgets should be detached from Xcode

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
