### PR TITLE
Fixes a bug with the background of the blog details view.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -94,9 +94,6 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
 
         self.init(frame: .zero)
 
-        // Temporary so we can differentiate between this and the old blog details in the PR review.
-        backgroundColor = .white
-
         siteIconView.tapped = { [weak self] in
             QuickStartTourGuide.shared.visited(.siteIcon)
             self?.siteIconView.spotlightIsShown = false


### PR DESCRIPTION
Fixed a bug that caused the blog details background to be white in black mode.

## To test:

Ensure flag `newNavBarAppearance` is ON.

1. Launch the app in dark mode.
2. Go to the list of sites, and select a site
3. In the blog details screen ensure the header view is not white.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
