### PR TITLE
Fix force-unwrapped optional for SuggestionsTableView in NotificationDetailsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -529,7 +529,7 @@ private extension NotificationDetailsViewController {
 private extension NotificationDetailsViewController {
     func attachSuggestionsViewIfNeeded() {
         guard shouldAttachSuggestionsView, let suggestionsTableView = self.suggestionsTableView else {
-            self.suggestionsTableView?.removeFromSuperview()
+            suggestionsTableView.removeFromSuperview()
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -54,7 +54,7 @@ class NotificationDetailsViewController: UIViewController {
 
     /// Reply Suggestions
     ///
-    @IBOutlet var suggestionsTableView: SuggestionsTableView!
+    @IBOutlet var suggestionsTableView: SuggestionsTableView?
 
     /// Embedded Media Downloader
     ///
@@ -436,7 +436,7 @@ extension NotificationDetailsViewController {
     func setupSuggestionsView() {
         guard let siteID = note.metaSiteID else { return }
         suggestionsTableView = SuggestionsTableView(siteID: siteID, suggestionType: .mention, delegate: self)
-        suggestionsTableView.translatesAutoresizingMaskIntoConstraints = false
+        suggestionsTableView?.translatesAutoresizingMaskIntoConstraints = false
     }
 
     func setupKeyboardManager() {
@@ -528,8 +528,8 @@ private extension NotificationDetailsViewController {
 //
 private extension NotificationDetailsViewController {
     func attachSuggestionsViewIfNeeded() {
-        guard shouldAttachSuggestionsView else {
-            suggestionsTableView.removeFromSuperview()
+        guard shouldAttachSuggestionsView, let suggestionsTableView = self.suggestionsTableView else {
+            self.suggestionsTableView?.removeFromSuperview()
             return
         }
 
@@ -540,7 +540,7 @@ private extension NotificationDetailsViewController {
             suggestionsTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             suggestionsTableView.topAnchor.constraint(equalTo: view.topAnchor),
             suggestionsTableView.bottomAnchor.constraint(equalTo: replyTextView.topAnchor)
-            ])
+        ])
     }
 
     var shouldAttachSuggestionsView: Bool {
@@ -1180,11 +1180,11 @@ private extension NotificationDetailsViewController {
 //
 extension NotificationDetailsViewController: ReplyTextViewDelegate {
     func textView(_ textView: UITextView, didTypeWord word: String) {
-        suggestionsTableView.showSuggestions(forWord: word)
+        suggestionsTableView?.showSuggestions(forWord: word)
     }
 
     func replyTextView(_ replyTextView: ReplyTextView, willEnterFullScreen controller: FullScreenCommentReplyViewController) {
-        guard let siteID = note.metaSiteID else {
+        guard let siteID = note.metaSiteID, let suggestionsTableView = self.suggestionsTableView else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -529,7 +529,7 @@ private extension NotificationDetailsViewController {
 private extension NotificationDetailsViewController {
     func attachSuggestionsViewIfNeeded() {
         guard shouldAttachSuggestionsView, let suggestionsTableView = self.suggestionsTableView else {
-            suggestionsTableView.removeFromSuperview()
+            self.suggestionsTableView?.removeFromSuperview()
             return
         }
 


### PR DESCRIPTION
Fixes https://sentry.io/share/issue/02558ce4c4ee42f6bd3d3936da263663/ – a blocker for App Store release.

To test: This is a bit of a tricky bug – it's rather rare, so difficult to reproduce. However, the stack trace points to the line that's affected, and it seems like a safe bet that somehow the UI state is invalid, so allowing the `SuggestionsTableView` to be a real optional should prevent a crash, possibly at the expense of some missing UI in invalid states.

To be clear – this isn't necessarily a _fix_ for the problem – more of a band-aid to avoid it so that we can ship this release.

When looking at this, I was initially concerned this may be related to one of the IUOs for the constraints (ie – when the view is removed from the superview it's blowing up somewhere internal), but I don't _think_ that's the case – the stack trace doesn't go into UIKit internals which makes me think it's the view that's the problem, not the constraint. But feel free to check my work on that! :) 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
