### PR TITLE
NotificationDetailsViewController: Suggestions is now Optional

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -54,7 +54,7 @@ class NotificationDetailsViewController: UIViewController {
 
     /// Reply Suggestions
     ///
-    @IBOutlet var suggestionsTableView: SuggestionsTableView!
+    @IBOutlet var suggestionsTableView: SuggestionsTableView?
 
     /// Embedded Media Downloader
     ///
@@ -434,9 +434,12 @@ extension NotificationDetailsViewController {
     }
 
     func setupSuggestionsView() {
-        guard let siteID = note.metaSiteID else { return }
+        guard let siteID = note.metaSiteID else {
+            return
+        }
+
         suggestionsTableView = SuggestionsTableView(siteID: siteID, suggestionType: .mention, delegate: self)
-        suggestionsTableView.translatesAutoresizingMaskIntoConstraints = false
+        suggestionsTableView?.translatesAutoresizingMaskIntoConstraints = false
     }
 
     func setupKeyboardManager() {
@@ -528,6 +531,10 @@ private extension NotificationDetailsViewController {
 //
 private extension NotificationDetailsViewController {
     func attachSuggestionsViewIfNeeded() {
+        guard let suggestionsTableView = suggestionsTableView else {
+            return
+        }
+
         guard shouldAttachSuggestionsView else {
             suggestionsTableView.removeFromSuperview()
             return
@@ -1180,11 +1187,11 @@ private extension NotificationDetailsViewController {
 //
 extension NotificationDetailsViewController: ReplyTextViewDelegate {
     func textView(_ textView: UITextView, didTypeWord word: String) {
-        suggestionsTableView.showSuggestions(forWord: word)
+        suggestionsTableView?.showSuggestions(forWord: word)
     }
 
     func replyTextView(_ replyTextView: ReplyTextView, willEnterFullScreen controller: FullScreenCommentReplyViewController) {
-        guard let siteID = note.metaSiteID else {
+        guard let siteID = note.metaSiteID, let suggestionsTableView = suggestionsTableView else {
             return
         }
 


### PR DESCRIPTION
Fixes #15246

@guarani Sir!! can I trouble you with this one?
cc @AliSoftware

To test:

1. Log into WordPress iOS with our AAPL iTC demo account
2. Press over the Notifications tab
3. Press over the first row: `Happy Anniversary!`

- [ ] Verify the app doesn't crash!

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
