### PR TITLE
Enable @-mentions on Atomic sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 16.3
 -----
+* [**] Fixed a bug where @-mentions didn't work on WordPress.com sites with plugins enabled [#14844]
  
 16.2
 -----

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -478,7 +478,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         case BlogFeatureOAuth2Login:
             return [self isHostedAtWPcom];
         case BlogFeatureMentions:
-            return [self isHostedAtWPcom];
+            return [self isAccessibleThroughWPCom];
         case BlogFeatureReblog:
         case BlogFeaturePlans:
             return [self isHostedAtWPcom] && [self isAdmin];

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -876,14 +876,9 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 extension GutenbergViewController {
 
     private func showSuggestions(type: SuggestionType, callback: @escaping (Swift.Result<String, NSError>) -> Void) {
-        guard let siteID = post.blog.dotComID, let blog = SuggestionService.shared.persistedBlog(for: siteID) else {
+        guard let siteID = post.blog.dotComID else {
             callback(.failure(GutenbergSuggestionsViewController.SuggestionError.notAvailable as NSError))
             return
-        }
-
-        switch type {
-        case .mention:
-            guard SuggestionService.shared.shouldShowSuggestions(for: blog) else { return }
         }
 
         previousFirstResponder = view.findFirstResponder()
@@ -956,7 +951,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
 
     func gutenbergCapabilities() -> [Capabilities: Bool] {
         return [
-            .mentions: post.blog.isAccessibleThroughWPCom() && FeatureFlag.gutenbergMentions.enabled,
+            .mentions: FeatureFlag.gutenbergMentions.enabled && SuggestionService.shared.shouldShowSuggestions(for: post.blog),
             .unsupportedBlockEditor: isUnsupportedBlockEditorEnabled,
             .canEnableUnsupportedBlockEditor: post.blog.jetpack?.isConnected ?? false,
             .modalLayoutPicker: FeatureFlag.gutenbergModalLayoutPicker.enabled,


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/14844

@-mentions was (inadvertently) disabled on Atomic sites on WordPress for iOS - although it is enabled on WordPress for Android. This PR enables @-mentions for Atomic sites by turning the feature on if `isAccessibleThroughWPCom` is `true`, which means at the time of writing only non-Jetpack self-hosted sites will have @-mentions disabled.

I've also updated the code to ensure that when @-mentions is disabled, the `@` toolbar button in Gutenberg is hidden.

### To test

Smoke test @-mentions in each of the following:

```
- [ ] @-mentions is enabled on WordPress.com simple sites
- [ ] @-mentions is enabled on WordPress.com Atomic sites
- [ ] @-mentions is enabled on Jetpack-connected self-hosted sites
- [ ] @-mentions is **disabled** on non-Jetpack self-hosted sites
```

<details>
<summary>Test details</summary>
<br>

**What you'll need**: You'll need one of each type of site listed above (ping me if you'd like to use my sites that I have already created).
<br>

Run through the below steps for each of the four site types above, ensuring that @-mentions is enabled/disabled as stated above.

<ol>
<li>Open the block editor</li>
<li>In the &quot;Start writing...&quot; section, type <code>@</code> and verify that the list of suggestions is shown</li>
<li>Verify that the toolbar shows a `@` button (it might be off-screen, if so just scroll the toolbar to see it) and tapping it triggers the suggestions UI</li>
</ol>
</details>

To be extra sure, you may want to add an @-mention and ensure the recipient receives a notification.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
