### PR TITLE
Reader cross post card: Add border to avatar images.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -73,6 +73,7 @@ private extension ReaderCrossPostCell {
     struct Constants {
         static let blavatarPlaceholderImage: UIImage? = UIImage(named: "post-blavatar-placeholder")
         static let avatarPlaceholderImage: UIImage? = UIImage(named: "gravatar")
+        static let imageBorderWidth: CGFloat = 1
         static let xPostTitlePrefix = "X-post: "
         static let commentTemplate = "%@ left a comment on %@, cross-posted to %@"
         static let siteTemplate = "%@ cross-posted from %@ to %@"
@@ -106,7 +107,7 @@ private extension ReaderCrossPostCell {
     // MARK: - Configuration
 
     func configureBlavatarImage() {
-
+        configureAvatarBorder(blavatarImageView)
         let placeholder = Constants.blavatarPlaceholderImage
         let size = blavatarImageView.frame.size.width * UIScreen.main.scale
 
@@ -132,6 +133,7 @@ private extension ReaderCrossPostCell {
     }
 
     func configureAvatarImageView() {
+        configureAvatarBorder(avatarImageView)
         let placeholder = Constants.avatarPlaceholderImage
 
         // Always reset
@@ -140,6 +142,12 @@ private extension ReaderCrossPostCell {
         if let url = contentProvider?.avatarURLForDisplay() {
             avatarImageView.downloadImage(from: url, placeholderImage: placeholder)
         }
+    }
+
+    func configureAvatarBorder(_ imageView: UIImageView) {
+        imageView.layer.borderColor = WPStyleGuide.readerCardBlogIconBorderColor().cgColor
+        imageView.layer.borderWidth = Constants.imageBorderWidth
+        imageView.layer.masksToBounds = true
     }
 
     func configureTitleLabel() {


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/15315#discussion_r525527946

This adds a border to the avatars on the Reader cross post card.

To test:
- Go to the Reader.
- Find a cross post card.
- Verify the site and author avatars have a border.

| Before | After |
|--------|-------|
| <img width="433" alt="before" src="https://user-images.githubusercontent.com/1816888/99465991-be060c80-28f8-11eb-91ed-11e20ee4cf70.png"> | <img width="432" alt="after" src="https://user-images.githubusercontent.com/1816888/99465996-c3fbed80-28f8-11eb-9933-572db09c2174.png"> |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
