### PR TITLE
Removes a bad workaround for an issue that was introduced in 16.0

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -526,16 +526,6 @@ static NSInteger HideSearchMinSites = 3;
     UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
     [refreshControl addTarget:self action:@selector(syncBlogs) forControlEvents:UIControlEventValueChanged];
     self.tableView.refreshControl = refreshControl;
-    
-    // Workaround: The refresh control was showing on top of the table view, apparently because
-    // iOS is failing to put it behind the table view contents (iOS bug).
-    //
-    // Ref: https://stackoverflow.com/a/59713642
-    //
-    // If you want to test if this workaround can be removed, simply comment it, run the app
-    // and check that when the blog list if first displayed, the refresh control is NOT visible
-    // at the front of the table view.
-    refreshControl.layer.zPosition = -1;
 
     self.tableView.tableFooterView = [UIView new];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];


### PR DESCRIPTION
This is the first step to fixing: https://github.com/wordpress-mobile/WordPress-iOS/issues/15256

Rolls back [a workaround](https://github.com/wordpress-mobile/WordPress-iOS/pull/15136) I added for an issue with the refresh control in the list of sites.

My workaround was only hiding the refresh wheel, but it wasn't a proper fix for the problem, as the first row in the list of sites couldn't be selected by users.

## Additional information

After rolling back these changes, we still need to fix the issue, which was introduced in this PR:

https://github.com/wordpress-mobile/WordPress-iOS/pull/15081

And specifically by this commit:

https://github.com/wordpress-mobile/WordPress-iOS/pull/15081/commits/3a9543c74ef4c3b340ae53aacd236416c54ab7cb

## To test:

1. Run the App.
2. Switch to the "My Sites" tab.
3. If the refreshing activity wheel isn't visible on top of the first row, just tap on a site to see it's details, and go back to the list of sites.

Make sure you can see the refresh activity wheel on top of the first site (in the list of sites).  As mentioned above, we need another PR to fix the underlying issue.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
