### PR TITLE
Removes a bad workaround for an issue that was introduced in 16.0

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -526,16 +526,6 @@ static NSInteger HideSearchMinSites = 3;
     UIRefreshControl *refreshControl = [[UIRefreshControl alloc] init];
     [refreshControl addTarget:self action:@selector(syncBlogs) forControlEvents:UIControlEventValueChanged];
     self.tableView.refreshControl = refreshControl;
-    
-    // Workaround: The refresh control was showing on top of the table view, apparently because
-    // iOS is failing to put it behind the table view contents (iOS bug).
-    //
-    // Ref: https://stackoverflow.com/a/59713642
-    //
-    // If you want to test if this workaround can be removed, simply comment it, run the app
-    // and check that when the blog list if first displayed, the refresh control is NOT visible
-    // at the front of the table view.
-    refreshControl.layer.zPosition = -1;
 
     self.tableView.tableFooterView = [UIView new];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];


### PR DESCRIPTION
Same as https://github.com/wordpress-mobile/WordPress-iOS/pull/15320, but targeting 16.2.

## To test:

Please check the referenced PR.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
