### PR TITLE
My Sites: fix first site not selectable

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -241,7 +241,6 @@ static NSInteger HideSearchMinSites = 3;
     
     // Ensure No Results VC is not shown. Will be shown later if necessary.
     [self.noResultsViewController removeFromView];
-    [self.tableView.refreshControl setHidden: NO];
     
     // If the user has sites, but they're all hidden...
     if (count > 0 && visibleSitesCount == 0 && !self.isEditing) {
@@ -289,8 +288,6 @@ static NSInteger HideSearchMinSites = 3;
                                                    image:@"mysites-nosites"
                                            subtitleImage:nil
                                            accessoryView:nil];
-
-        [self.tableView.refreshControl setHidden: YES];
         [self addNoResultsToView];
     }
 }
@@ -335,7 +332,6 @@ static NSInteger HideSearchMinSites = 3;
                                            accessoryView:nil];
     }
 
-    [self.tableView.refreshControl setHidden: YES];
     [self addNoResultsToView];
     
 }


### PR DESCRIPTION
Fixes #15256 

This removes showing/hiding the refresh control that was done in https://github.com/wordpress-mobile/WordPress-iOS/pull/15081. This fixes the refresh control appearing on top of the sites list.

To test:
- Go to My Sites.
- Verify the refresh control does not appear on top of the site list.
- Verify the first site is selectable.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
