### PR TITLE
[Gutenberg] Adding upload processor for File block

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -304,6 +304,10 @@ class PostCoordinator: NSObject {
         var gutenbergProcessors = [Processor]()
         var aztecProcessors = [Processor]()
 
+        // File block can upload any kind of media.
+        let gutenbergFileProcessor = GutenbergFileUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
+        gutenbergProcessors.append(gutenbergFileProcessor)
+
         if media.mediaType == .image {
             let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
             gutenbergProcessors.append(gutenbergImgPostUploadProcessor)

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergFileUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergFileUploadProcessor.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Aztec
+
+class GutenbergFileUploadProcessor: Processor {
+    private struct FileBlockKeys {
+        static var name = "wp:file"
+        static var id = "id"
+        static var href = "href"
+    }
+
+    let mediaUploadID: Int32
+    let remoteURLString: String
+    let serverMediaID: Int
+
+    init(mediaUploadID: Int32, serverMediaID: Int, remoteURLString: String) {
+        self.mediaUploadID = mediaUploadID
+        self.serverMediaID = serverMediaID
+        self.remoteURLString = remoteURLString
+    }
+
+    lazy var fileHtmlProcessor = HTMLProcessor(for: "a", replacer: { (file) in
+        var attributes = file.attributes
+
+        attributes.set(.string(self.remoteURLString), forKey: FileBlockKeys.href)
+
+        var html = "<a "
+        let attributeSerializer = ShortcodeAttributeSerializer()
+        html += attributeSerializer.serialize(attributes)
+        html += ">\(file.content ?? "")</a>"
+        return html
+    })
+
+    lazy var fileBlockProcessor = GutenbergBlockProcessor(for: FileBlockKeys.name, replacer: { fileBlock in
+        guard let mediaID = fileBlock.attributes[FileBlockKeys.id] as? Int,
+            mediaID == self.mediaUploadID else {
+                return nil
+        }
+        var block = "<!-- \(FileBlockKeys.name) "
+        var attributes = fileBlock.attributes
+        attributes[FileBlockKeys.id] = self.serverMediaID
+        attributes[FileBlockKeys.href] = self.remoteURLString
+        if let jsonData = try? JSONSerialization.data(withJSONObject: attributes, options: .sortedKeys),
+            let jsonString = String(data: jsonData, encoding: .utf8) {
+            block += jsonString
+        }
+        block += " -->"
+        block += self.fileHtmlProcessor.process(fileBlock.content)
+        block += "<!-- /\(FileBlockKeys.name) -->"
+        return block
+    })
+
+    func process(_ text: String) -> String {
+        return fileBlockProcessor.process(text)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		1AED7239229D2E260036C5B8 /* WireMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE0F2B02297F7E9000BDD7F /* WireMock.swift */; };
 		1D36FCB53C05724865D41F7A /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
+		1E0462162566938300EB98EF /* GutenbergFileUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0462152566938300EB98EF /* GutenbergFileUploadProcessor.swift */; };
 		1E0FF01E242BC572008DA898 /* GutenbergWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0FF01D242BC572008DA898 /* GutenbergWebViewController.swift */; };
 		1E485A90249B61440000A253 /* GutenbergRequestAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E485A8F249B61440000A253 /* GutenbergRequestAuthenticator.swift */; };
 		1E4F2E712458AF8500EB73E7 /* GutenbergWebNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4F2E702458AF8500EB73E7 /* GutenbergWebNavigationViewController.swift */; };
@@ -2777,6 +2778,7 @@
 		1B77149F6C65D343E7E3AD09 /* Pods-WordPressUITests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressUITests.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressUITests/Pods-WordPressUITests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1E0462152566938300EB98EF /* GutenbergFileUploadProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergFileUploadProcessor.swift; sourceTree = "<group>"; };
 		1E0FF01D242BC572008DA898 /* GutenbergWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergWebViewController.swift; sourceTree = "<group>"; };
 		1E485A8F249B61440000A253 /* GutenbergRequestAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergRequestAuthenticator.swift; sourceTree = "<group>"; };
 		1E4F2E702458AF8500EB73E7 /* GutenbergWebNavigationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergWebNavigationViewController.swift; sourceTree = "<group>"; };
@@ -5742,7 +5744,7 @@
 			path = GutenbergWeb;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				98D31BBF239720E4009CFF43 /* MainInterface.storyboard */,
@@ -10952,6 +10954,7 @@
 			isa = PBXGroup;
 			children = (
 				FF2EC3BF2209A144006176E1 /* GutenbergImgUploadProcessor.swift */,
+				1E0462152566938300EB98EF /* GutenbergFileUploadProcessor.swift */,
 				FF1B11E4238FDFE70038B93E /* GutenbergGalleryUploadProcessor.swift */,
 				91138454228373EB00FB02B7 /* GutenbergVideoUploadProcessor.swift */,
 				4629E4202440C5B20002E15C /* GutenbergCoverUploadProcessor.swift */,
@@ -11407,7 +11410,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -12729,6 +12732,7 @@
 				B0AC50B4251E959B0039E022 /* CommentViewController.swift in Sources */,
 				086E1FE01BBB35D2002D86CA /* MenusViewController.m in Sources */,
 				9F3EFCA3208E308A00268758 /* UIViewController+Notice.swift in Sources */,
+				1E0462162566938300EB98EF /* GutenbergFileUploadProcessor.swift in Sources */,
 				F913BB1024B3C5CE00C19032 /* EventLoggingDataProvider.swift in Sources */,
 				8B93856E22DC08060010BF02 /* PageListSectionHeaderView.swift in Sources */,
 				59E1D46F1CEF77B500126697 /* Page+CoreDataProperties.swift in Sources */,


### PR DESCRIPTION
This PR adds an Upload Processor for the new File block.
This allows file uploads to finish and update the HTML content without the need of Gutenberg running.

To test:

- Add a file block to a new post.
- Upload a file to the block (big enough to have the time to close the editor).
- Close the editor selecting `Update Draft`.
- Let the upload to finish in the background.
- When the file is uploaded and the post saved, open the post again (on web or mobile).
  - Check that the block renders properly.
  - Check that all references to `href` are updated to the remote URL.
  - Check that the file ID has been updated to the remote one.

cc @jd-alexander 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
