### PR TITLE
Update stats in the iOS 14 today widget from the app

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -991,28 +991,28 @@ private extension InsightStoreState {
 
     private func saveHomeWidgetTodayData(stats: TodayWidgetStats) {
 
-        guard let siteID = SiteStatsInformation.sharedInstance.siteID as? Int else {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID else {
             return
         }
 
         var homeWidgetTodayCache = HomeWidgetTodayData.read() ?? initializeHomeWidgetTodayData()
 
-        guard let oldData = homeWidgetTodayCache[siteID] else {
+        guard let oldData = homeWidgetTodayCache[siteID.intValue] else {
             DDLogError("HomeWidgetToday: Failed to find a matching site")
             return
         }
         // TODO - TODAYWIDGET: it might be better to move the blog updates in SiteStatsInformation
         let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
 
-        guard let blog = blogService.blog(byBlogId: NSNumber(value: siteID)) else {
+        guard let blog = blogService.blog(byBlogId: siteID) else {
             DDLogError("HomeWidgetToday: the site does not exist anymore")
             // if for any reason that site does not exist anymore, remove it from the cache.
-            homeWidgetTodayCache.removeValue(forKey: siteID)
+            homeWidgetTodayCache.removeValue(forKey: siteID.intValue)
             HomeWidgetTodayData.write(data: homeWidgetTodayCache)
             return
         }
         // refresh stats and update any blog info, if they had changed
-        homeWidgetTodayCache[siteID] = HomeWidgetTodayData(siteID: siteID,
+        homeWidgetTodayCache[siteID.intValue] = HomeWidgetTodayData(siteID: siteID.intValue,
                                                            siteName: blog.title ?? oldData.siteName,
                                                            url: blog.url ?? oldData.url,
                                                            timeZoneName: blogService.timeZone(for: blog).identifier,
@@ -1038,7 +1038,7 @@ private extension InsightStoreState {
                 let title = ($1.title ?? url).isEmpty ? url : $1.title ?? url
                 let timeZoneName = blogService.timeZone(for: blog).identifier
 
-                $0[Int(truncating: blogID)] = HomeWidgetTodayData(siteID: Int(truncating: blogID),
+                $0[blogID.intValue] = HomeWidgetTodayData(siteID: blogID.intValue,
                                                                   siteName: title,
                                                                   url: url,
                                                                   timeZoneName: timeZoneName,

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -1001,7 +1001,7 @@ private extension InsightStoreState {
             DDLogError("HomeWidgetToday: Failed to find a matching site")
             return
         }
-
+        // TODO - TODAYWIDGET: it might be better to move the blog updates in SiteStatsInformation
         let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
 
         guard let blog = blogService.blog(byBlogId: NSNumber(value: siteID)) else {

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -1032,7 +1032,7 @@ private extension InsightStoreState {
             if let blogID = element.dotComID,
                let url = element.url,
                let blog = blogService.blog(byBlogId: blogID) {
-
+                // set the title to the site title, if it's not nil and not empty; otherwise use the site url
                 let title = (element.title ?? url).isEmpty ? url : element.title ?? url
                 let timeZoneName = blogService.timeZone(for: blog).identifier
 

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -947,15 +947,34 @@ extension StatsInsightsStore {
 private extension InsightStoreState {
 
     func storeTodayWidgetData() {
-        guard widgetUsingCurrentSite() else {
-            return
-        }
+
 
         let data = TodayWidgetStats(views: todaysStats?.viewsCount,
                                     visitors: todaysStats?.visitorsCount,
                                     likes: todaysStats?.likesCount,
                                     comments: todaysStats?.commentsCount)
+        saveHomeWidgetTodayData(stats: data)
+
+        guard widgetUsingCurrentSite() else {
+            return
+        }
         data.saveData()
+    }
+
+    private func saveHomeWidgetTodayData(stats: TodayWidgetStats) {
+
+
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID as? Int, let timeZoneName = SiteStatsInformation.sharedInstance.siteTimeZone?.identifier else {
+            return
+        }
+
+        var homeWidgetTodayCache = HomeWidgetTodayData.read() ?? [Int: HomeWidgetTodayData]()
+
+        let newData = HomeWidgetTodayData(siteID: siteID, siteName: "", url: "", timeZoneName: timeZoneName, date: Date(), stats: stats)
+
+        homeWidgetTodayCache[newData.siteID] = newData
+
+        HomeWidgetTodayData.write(data: homeWidgetTodayCache)
     }
 
     func storeAllTimeWidgetData() {

--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -66,6 +66,9 @@ extern NSString *const WPStatsTodayWidgetUserDefaultsSiteNameKey;
 extern NSString *const WPStatsTodayWidgetUserDefaultsSiteUrlKey;
 extern NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey;
 
+/// iOS 14 Widget Constants
+extern NSString *const WPHomeWidgetTodayKind;
+
 /// Apple ID Constants
 ///
 extern NSString *const WPAppleIDKeychainUsernameKey;

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -78,6 +78,9 @@ NSString *const WPStatsTodayWidgetUserDefaultsSiteNameKey           = @"WordPres
 NSString *const WPStatsTodayWidgetUserDefaultsSiteUrlKey            = @"WordPressTodayWidgetSiteUrl";
 NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey       = @"WordPressTodayWidgetTimeZone";
 
+/// iOS 14 Widget Constants
+NSString *const WPHomeWidgetTodayKind                               =@"WordPressHomeWidgetToday";
+
 /// Apple ID Constants
 ///
 NSString *const WPAppleIDKeychainUsernameKey                        = @"Username";

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/HomeWidgetCache.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/HomeWidgetCache.swift
@@ -1,0 +1,40 @@
+/// Cache manager that stores `HomeWidgetData` values in a plist file, contained in the specified security application group and with the specified file name.
+/// The corresponding dictionary is always in the form `[Int: T]`, where the `Int` key is the SiteID, and the `T` value is any `HomeWidgetData` instance.
+struct HomeWidgetCache<T: HomeWidgetData> {
+
+    let fileName: String
+    let appGroup: String
+
+    private var fileURL: URL? {
+        FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup)?.appendingPathComponent(fileName)
+    }
+
+    func read() throws -> [Int: T]? {
+
+        guard let fileURL = fileURL,
+            FileManager.default.fileExists(atPath: fileURL.path) else {
+                return nil
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        return try PropertyListDecoder().decode([Int: T].self, from: data)
+    }
+
+    func write(widgetData: [Int: T]) throws {
+
+        guard let fileURL = fileURL else {
+                return
+        }
+
+        let encodedData = try PropertyListEncoder().encode(widgetData)
+        try encodedData.write(to: fileURL)
+    }
+
+    func delete() throws {
+
+        guard let fileURL = fileURL else {
+                return
+        }
+        try FileManager.default.removeItem(at: fileURL)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/HomeWidgetTodayData.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/HomeWidgetTodayData.swift
@@ -1,0 +1,61 @@
+
+// TODO - TODAYWIDGET: we might change this and use only one type for all three widgets
+/// protocol that generalizes home widgets data
+protocol HomeWidgetData: Codable {
+
+    associatedtype WidgetStats
+
+    var siteID: Int { get }
+    var url: String { get }
+    var timeZoneName: String { get }
+    var stats: WidgetStats { get }
+}
+
+
+// TODO - TODAYWIDGET: we might change this and use only one type for all three widgets
+/// Type that contains all the relevant data of a Today Home Wifget
+struct HomeWidgetTodayData: HomeWidgetData {
+
+    typealias WidgetStats = TodayWidgetStats
+
+    let siteID: Int
+    let siteName: String
+    let url: String
+    let timeZoneName: String
+    let date: Date
+    let stats: WidgetStats
+}
+
+
+// MARK: - Local cache
+extension HomeWidgetTodayData {
+
+    static func readData(from cache: HomeWidgetCache<Self>? = nil) -> [Int: HomeWidgetTodayData]? {
+        let cache = cache ?? HomeWidgetCache<HomeWidgetTodayData>(fileName: Constants.fileName, appGroup: WPAppGroupName)
+        do {
+            return try cache.read()
+        } catch {
+            DDLogError("HomeWidgetToday: Failed loading data: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    static func write(data: [Int: HomeWidgetTodayData], to cache: HomeWidgetCache<Self>? = nil) {
+        let cache = cache ?? HomeWidgetCache<HomeWidgetTodayData>(fileName: Constants.fileName, appGroup: WPAppGroupName)
+
+        do {
+            try cache.write(widgetData: data)
+        } catch {
+            DDLogError("HomeWidgetToday: Failed writing data: \(error.localizedDescription)")
+        }
+    }
+}
+
+
+// MARK: - Constants
+private extension HomeWidgetTodayData {
+
+    enum Constants {
+        static let fileName = "HomeWidgetTodayData.plist"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/HomeWidgetTodayData.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/HomeWidgetTodayData.swift
@@ -8,7 +8,7 @@ protocol HomeWidgetData: Codable {
     var siteID: Int { get }
     var url: String { get }
     var timeZoneName: String { get }
-    var stats: WidgetStats { get }
+    var stats: WidgetStats? { get }
 }
 
 
@@ -23,15 +23,17 @@ struct HomeWidgetTodayData: HomeWidgetData {
     let url: String
     let timeZoneName: String
     let date: Date
-    let stats: WidgetStats
+    let stats: WidgetStats?
 }
 
 
 // MARK: - Local cache
 extension HomeWidgetTodayData {
 
-    static func readData(from cache: HomeWidgetCache<Self>? = nil) -> [Int: HomeWidgetTodayData]? {
-        let cache = cache ?? HomeWidgetCache<HomeWidgetTodayData>(fileName: Constants.fileName, appGroup: WPAppGroupName)
+    static func read(from cache: HomeWidgetCache<Self>? = nil) -> [Int: HomeWidgetTodayData]? {
+
+        let cache = cache ?? HomeWidgetCache<HomeWidgetTodayData>(fileName: Constants.fileName,
+                                                                  appGroup: WPAppGroupName)
         do {
             return try cache.read()
         } catch {
@@ -41,7 +43,9 @@ extension HomeWidgetTodayData {
     }
 
     static func write(data: [Int: HomeWidgetTodayData], to cache: HomeWidgetCache<Self>? = nil) {
-        let cache = cache ?? HomeWidgetCache<HomeWidgetTodayData>(fileName: Constants.fileName, appGroup: WPAppGroupName)
+
+        let cache = cache ?? HomeWidgetCache<HomeWidgetTodayData>(fileName: Constants.fileName,
+                                                                  appGroup: WPAppGroupName)
 
         do {
             try cache.write(widgetData: data)

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/HomeWidgetTodayData.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/HomeWidgetTodayData.swift
@@ -1,14 +1,17 @@
+import WidgetKit
 
 // TODO - TODAYWIDGET: we might change this and use only one type for all three widgets
 /// protocol that generalizes home widgets data
-protocol HomeWidgetData: Codable {
+protocol HomeWidgetData: Codable, TimelineEntry {
 
     associatedtype WidgetStats
 
     var siteID: Int { get }
+    var siteName: String { get }
     var url: String { get }
     var timeZoneName: String { get }
-    var stats: WidgetStats? { get }
+    var date: Date { get }
+    var stats: WidgetStats { get }
 }
 
 
@@ -23,7 +26,7 @@ struct HomeWidgetTodayData: HomeWidgetData {
     let url: String
     let timeZoneName: String
     let date: Date
-    let stats: WidgetStats?
+    let stats: WidgetStats
 }
 
 
@@ -51,6 +54,17 @@ extension HomeWidgetTodayData {
             try cache.write(widgetData: data)
         } catch {
             DDLogError("HomeWidgetToday: Failed writing data: \(error.localizedDescription)")
+        }
+    }
+
+    static func delete(cache: HomeWidgetCache<Self>? = nil) {
+        let cache = cache ?? HomeWidgetCache<HomeWidgetTodayData>(fileName: Constants.fileName,
+                                                                  appGroup: WPAppGroupName)
+
+        do {
+            try cache.delete()
+        } catch {
+            DDLogError("HomeWidgetToday: Failed deleting data: \(error.localizedDescription)")
         }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -421,13 +421,11 @@
 		3F526C582538CF2B0069706C /* WordPressHomeWidgetToday.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 3F526C542538CF2A0069706C /* WordPressHomeWidgetToday.intentdefinition */; };
 		3F526C592538CF2B0069706C /* WordPressHomeWidgetToday.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 3F526C542538CF2A0069706C /* WordPressHomeWidgetToday.intentdefinition */; };
 		3F526C5C2538CF2B0069706C /* WordPressHomeWidgetToday.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 3F526C4C2538CF2A0069706C /* WordPressHomeWidgetToday.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		3F526CF12539F85F0069706C /* TodayWidgetContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F526CEF2539F85F0069706C /* TodayWidgetContent.swift */; };
 		3F526D572539FAC60069706C /* TodayWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F526D562539FAC60069706C /* TodayWidgetView.swift */; };
 		3F5689F0254209790048A9E4 /* TodayWidgetSmallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5689EF254209790048A9E4 /* TodayWidgetSmallView.swift */; };
 		3F568A0025420DE80048A9E4 /* TodayWidgetMediumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5689FF25420DE80048A9E4 /* TodayWidgetMediumView.swift */; };
 		3F568A1F254213B60048A9E4 /* VerticalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F568A1E254213B60048A9E4 /* VerticalCard.swift */; };
 		3F568A2F254216550048A9E4 /* FlexibleCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F568A2E254216550048A9E4 /* FlexibleCard.swift */; };
-		3F5B2D372540BECB009DEED1 /* TodayWidgetContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F526CEF2539F85F0069706C /* TodayWidgetContent.swift */; };
 		3F5B3EAF23A851330060FF1F /* ReaderReblogPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */; };
 		3F5B3EB123A851480060FF1F /* ReaderReblogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B3EB023A851480060FF1F /* ReaderReblogFormatter.swift */; };
 		3F662C4A24DC9FAC00CAEA95 /* WhatIsNewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F662C4924DC9FAC00CAEA95 /* WhatIsNewViewController.swift */; };
@@ -2948,7 +2946,6 @@
 		3F526C542538CF2A0069706C /* WordPressHomeWidgetToday.intentdefinition */ = {isa = PBXFileReference; lastKnownFileType = file.intentdefinition; path = WordPressHomeWidgetToday.intentdefinition; sourceTree = "<group>"; };
 		3F526C552538CF2B0069706C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3F526C572538CF2B0069706C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		3F526CEF2539F85F0069706C /* TodayWidgetContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWidgetContent.swift; sourceTree = "<group>"; };
 		3F526D562539FAC60069706C /* TodayWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWidgetView.swift; sourceTree = "<group>"; };
 		3F5689EF254209790048A9E4 /* TodayWidgetSmallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWidgetSmallView.swift; sourceTree = "<group>"; };
 		3F5689FF25420DE80048A9E4 /* TodayWidgetMediumView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWidgetMediumView.swift; sourceTree = "<group>"; };
@@ -6474,7 +6471,6 @@
 			isa = PBXGroup;
 			children = (
 				3F526D2B2539F9D60069706C /* Views */,
-				3F526D1C2539F9C80069706C /* Model */,
 				3F526C522538CF2A0069706C /* WordPressHomeWidgetToday.swift */,
 				98390AC2254C984700868F0A /* Tracks+TodayHomeWidget.swift */,
 				3F526CA82538E0ED0069706C /* Supporting Files */,
@@ -6494,14 +6490,6 @@
 				3F1FD31C2548B30D0060C53A /* WordPressHomeWidgetToday-Bridging-Header.h */,
 			);
 			path = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		3F526D1C2539F9C80069706C /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				3F526CEF2539F85F0069706C /* TodayWidgetContent.swift */,
-			);
-			path = Model;
 			sourceTree = "<group>";
 		};
 		3F526D2B2539F9D60069706C /* Views */ = {
@@ -14008,7 +13996,6 @@
 				7E7947A9210BAC1D005BB851 /* NotificationContentRange.swift in Sources */,
 				8B6EA62323FDE50B004BA312 /* PostServiceUploadingList.swift in Sources */,
 				E1EBC36F1C118EA500F638E0 /* ImmuTable.swift in Sources */,
-				3F5B2D372540BECB009DEED1 /* TodayWidgetContent.swift in Sources */,
 				B59B18751CC7FB8D0055EB7C /* PersonViewController.swift in Sources */,
 				4054F4602214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataProperties.swift in Sources */,
 				9A8ECE122254A3260043C8DA /* JetpackRemoteInstallState.swift in Sources */,
@@ -14059,7 +14046,6 @@
 				3F568A0025420DE80048A9E4 /* TodayWidgetMediumView.swift in Sources */,
 				3F568A2F254216550048A9E4 /* FlexibleCard.swift in Sources */,
 				3F568A1F254213B60048A9E4 /* VerticalCard.swift in Sources */,
-				3F526CF12539F85F0069706C /* TodayWidgetContent.swift in Sources */,
 				3F526C532538CF2A0069706C /* WordPressHomeWidgetToday.swift in Sources */,
 				3F1FD27B2548AE900060C53A /* CocoaLumberjack.swift in Sources */,
 				3F5689F0254209790048A9E4 /* TodayWidgetSmallView.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -434,6 +434,8 @@
 		3F6975FF242D941E001F1807 /* ReaderTabViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6975FE242D941E001F1807 /* ReaderTabViewModel.swift */; };
 		3F6A7E92251BC1DC005B6A61 /* WPTabBarController+WhatIsNew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6A7E91251BC1DC005B6A61 /* WPTabBarController+WhatIsNew.swift */; };
 		3F6AD0562502A91400080F3B /* AnnouncementsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6AD0552502A91400080F3B /* AnnouncementsCache.swift */; };
+		3F6DA04125646F96002AB88F /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6DA04025646F96002AB88F /* HomeWidgetTodayData.swift */; };
+		3F6DA05E2564710C002AB88F /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6DA04025646F96002AB88F /* HomeWidgetTodayData.swift */; };
 		3F71D5302548C2B200A4BA93 /* Double+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C82B52193A7B900A06E84 /* Double+Stats.swift */; };
 		3F73BE5D24EB38E200BE99FF /* WhatIsNewScenePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F73BE5C24EB38E200BE99FF /* WhatIsNewScenePresenter.swift */; };
 		3F73BE5F24EB3B4400BE99FF /* WhatIsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F73BE5E24EB3B4400BE99FF /* WhatIsNewView.swift */; };
@@ -444,6 +446,8 @@
 		3F8CB10623A07B17007627BF /* ReaderReblogAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CB10523A07B17007627BF /* ReaderReblogAction.swift */; };
 		3F8CBE0B24EEB0EA00F71234 /* AnnouncementsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CBE0A24EEB0EA00F71234 /* AnnouncementsDataSource.swift */; };
 		3F8CBE0D24EED2CB00F71234 /* FindOutMoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CBE0C24EED2CB00F71234 /* FindOutMoreCell.swift */; };
+		3FA53E9C256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA53E9B256571D800F4D9A2 /* HomeWidgetCache.swift */; };
+		3FA53E9D256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA53E9B256571D800F4D9A2 /* HomeWidgetCache.swift */; };
 		3FC8D19B244F43B500495820 /* ReaderTabItemsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */; };
 		3FCCAA1523F4A1A3004064C0 /* UIBarButtonItem+MeBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCCAA1423F4A1A3004064C0 /* UIBarButtonItem+MeBarButton.swift */; };
 		3FD0316F24201E08005C0993 /* GravatarButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD0316E24201E08005C0993 /* GravatarButtonView.swift */; };
@@ -2956,6 +2960,7 @@
 		3F6975FE242D941E001F1807 /* ReaderTabViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabViewModel.swift; sourceTree = "<group>"; };
 		3F6A7E91251BC1DC005B6A61 /* WPTabBarController+WhatIsNew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPTabBarController+WhatIsNew.swift"; sourceTree = "<group>"; };
 		3F6AD0552502A91400080F3B /* AnnouncementsCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsCache.swift; sourceTree = "<group>"; };
+		3F6DA04025646F96002AB88F /* HomeWidgetTodayData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWidgetTodayData.swift; sourceTree = "<group>"; };
 		3F73BE5C24EB38E200BE99FF /* WhatIsNewScenePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewScenePresenter.swift; sourceTree = "<group>"; };
 		3F73BE5E24EB3B4400BE99FF /* WhatIsNewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewView.swift; sourceTree = "<group>"; };
 		3F751D452491A93D0008A2B1 /* ZendeskUtilsTests+Plans.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZendeskUtilsTests+Plans.swift"; sourceTree = "<group>"; };
@@ -2964,6 +2969,7 @@
 		3F8CB10523A07B17007627BF /* ReaderReblogAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogAction.swift; sourceTree = "<group>"; };
 		3F8CBE0A24EEB0EA00F71234 /* AnnouncementsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsDataSource.swift; sourceTree = "<group>"; };
 		3F8CBE0C24EED2CB00F71234 /* FindOutMoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindOutMoreCell.swift; sourceTree = "<group>"; };
+		3FA53E9B256571D800F4D9A2 /* HomeWidgetCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWidgetCache.swift; sourceTree = "<group>"; };
 		3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabItemsStore.swift; sourceTree = "<group>"; };
 		3FCCAA1423F4A1A3004064C0 /* UIBarButtonItem+MeBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+MeBarButton.swift"; sourceTree = "<group>"; };
 		3FD0316E24201E08005C0993 /* GravatarButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GravatarButtonView.swift; sourceTree = "<group>"; };
@@ -6545,6 +6551,15 @@
 			path = Cache;
 			sourceTree = "<group>";
 		};
+		3F6DA03F25646F59002AB88F /* iOS 14 Widgets */ = {
+			isa = PBXGroup;
+			children = (
+				3F6DA04025646F96002AB88F /* HomeWidgetTodayData.swift */,
+				3FA53E9B256571D800F4D9A2 /* HomeWidgetCache.swift */,
+			);
+			path = "iOS 14 Widgets";
+			sourceTree = "<group>";
+		};
 		3F751D442491A8B20008A2B1 /* Zendesk */ = {
 			isa = PBXGroup;
 			children = (
@@ -8844,6 +8859,7 @@
 		98E58A2D2360D1FD00E5534B /* Today Widgets */ = {
 			isa = PBXGroup;
 			children = (
+				3F6DA03F25646F59002AB88F /* iOS 14 Widgets */,
 				989064F9237CC1A300218CD2 /* Data */,
 				9890650C237CC1E700218CD2 /* Shared Views */,
 				985ED0E323C6950600B8D06A /* WidgetStyles.swift */,
@@ -12939,6 +12955,7 @@
 				822D60B91F4CCC7A0016C46D /* BlogJetpackSettingsService.swift in Sources */,
 				08216FD51CDBF96000304BA7 /* MenuItemTypeViewController.m in Sources */,
 				B526DC291B1E47FC002A8C5F /* WPStyleGuide+WebView.m in Sources */,
+				3F6DA04125646F96002AB88F /* HomeWidgetTodayData.swift in Sources */,
 				82FC61271FA8ADAD00A1757E /* WPStyleGuide+Activity.swift in Sources */,
 				98BFF57E23984345008A1DCB /* AllTimeWidgetStats.swift in Sources */,
 				7E40713A2372AD54003627FA /* GutenbergFilesAppMediaSource.swift in Sources */,
@@ -13074,6 +13091,7 @@
 				3234BB172530DFCA0068DA40 /* ReaderTableCardCell.swift in Sources */,
 				7462BFD42028CD4400B552D8 /* ShareNoticeNavigationCoordinator.swift in Sources */,
 				D80BC7A02074722000614A59 /* CameraCaptureCoordinator.swift in Sources */,
+				3FA53E9C256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */,
 				F913BB0E24B3C58B00C19032 /* EventLoggingDelegate.swift in Sources */,
 				4089C51022371B120031CE78 /* TodayStatsRecordValue+CoreDataClass.swift in Sources */,
 				988F073523D0CE8800AC67A6 /* WidgetUrlCell.swift in Sources */,
@@ -14035,6 +14053,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F1FD30D2548B0A80060C53A /* Constants.m in Sources */,
+				3FA53E9D256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */,
 				3F1FD2502548AD8B0060C53A /* TodayWidgetStats.swift in Sources */,
 				3F526D572539FAC60069706C /* TodayWidgetView.swift in Sources */,
 				3F568A0025420DE80048A9E4 /* TodayWidgetMediumView.swift in Sources */,
@@ -14047,6 +14066,7 @@
 				98390AC3254C984700868F0A /* Tracks+TodayHomeWidget.swift in Sources */,
 				3F71D5302548C2B200A4BA93 /* Double+Stats.swift in Sources */,
 				3F526C582538CF2B0069706C /* WordPressHomeWidgetToday.intentdefinition in Sources */,
+				3F6DA05E2564710C002AB88F /* HomeWidgetTodayData.swift in Sources */,
 				98390AD2254C985F00868F0A /* Tracks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -435,7 +435,6 @@
 		3F6A7E92251BC1DC005B6A61 /* WPTabBarController+WhatIsNew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6A7E91251BC1DC005B6A61 /* WPTabBarController+WhatIsNew.swift */; };
 		3F6AD0562502A91400080F3B /* AnnouncementsCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6AD0552502A91400080F3B /* AnnouncementsCache.swift */; };
 		3F6DA04125646F96002AB88F /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6DA04025646F96002AB88F /* HomeWidgetTodayData.swift */; };
-		3F6DA05E2564710C002AB88F /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6DA04025646F96002AB88F /* HomeWidgetTodayData.swift */; };
 		3F71D5302548C2B200A4BA93 /* Double+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C82B52193A7B900A06E84 /* Double+Stats.swift */; };
 		3F73BE5D24EB38E200BE99FF /* WhatIsNewScenePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F73BE5C24EB38E200BE99FF /* WhatIsNewScenePresenter.swift */; };
 		3F73BE5F24EB3B4400BE99FF /* WhatIsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F73BE5E24EB3B4400BE99FF /* WhatIsNewView.swift */; };
@@ -448,6 +447,7 @@
 		3F8CBE0D24EED2CB00F71234 /* FindOutMoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CBE0C24EED2CB00F71234 /* FindOutMoreCell.swift */; };
 		3FA53E9C256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA53E9B256571D800F4D9A2 /* HomeWidgetCache.swift */; };
 		3FA53E9D256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA53E9B256571D800F4D9A2 /* HomeWidgetCache.swift */; };
+		3FA53ED62565860900F4D9A2 /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6DA04025646F96002AB88F /* HomeWidgetTodayData.swift */; };
 		3FC8D19B244F43B500495820 /* ReaderTabItemsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */; };
 		3FCCAA1523F4A1A3004064C0 /* UIBarButtonItem+MeBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCCAA1423F4A1A3004064C0 /* UIBarButtonItem+MeBarButton.swift */; };
 		3FD0316F24201E08005C0993 /* GravatarButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD0316E24201E08005C0993 /* GravatarButtonView.swift */; };
@@ -14064,9 +14064,9 @@
 				3F1FD27B2548AE900060C53A /* CocoaLumberjack.swift in Sources */,
 				3F5689F0254209790048A9E4 /* TodayWidgetSmallView.swift in Sources */,
 				98390AC3254C984700868F0A /* Tracks+TodayHomeWidget.swift in Sources */,
+				3FA53ED62565860900F4D9A2 /* HomeWidgetTodayData.swift in Sources */,
 				3F71D5302548C2B200A4BA93 /* Double+Stats.swift in Sources */,
 				3F526C582538CF2B0069706C /* WordPressHomeWidgetToday.intentdefinition in Sources */,
-				3F6DA05E2564710C002AB88F /* HomeWidgetTodayData.swift in Sources */,
 				98390AD2254C985F00868F0A /* Tracks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPress/WordPressHomeWidgetToday/Model/TodayWidgetContent.swift
+++ b/WordPress/WordPressHomeWidgetToday/Model/TodayWidgetContent.swift
@@ -1,8 +1,0 @@
-import WidgetKit
-
-
-struct TodayWidgetContent: TimelineEntry {
-    let date: Date
-    let siteTitle: String
-    let stats: TodayWidgetStats
-}

--- a/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetMediumView.swift
+++ b/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetMediumView.swift
@@ -1,7 +1,7 @@
  import SwiftUI
 
  struct TodayWidgetMediumView: View {
-    let content: TodayWidgetContent
+    let content: HomeWidgetTodayData
     let widgetTitle: LocalizedStringKey
     let viewsTitle: LocalizedStringKey
     let visitorsTitle: LocalizedStringKey
@@ -12,7 +12,7 @@
         VStack(alignment: .leading) {
             FlexibleCard(axis: .horizontal,
                          title: widgetTitle,
-                         value: content.siteTitle)
+                         value: content.siteName)
             Spacer()
             HStack {
                 makeColumn(upperTitle: viewsTitle,

--- a/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetSmallView.swift
+++ b/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetSmallView.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
 struct TodayWidgetSmallView: View {
-    let content: TodayWidgetContent
+    let content: HomeWidgetTodayData
     let widgetTitle: LocalizedStringKey
     let viewsTitle: LocalizedStringKey
 
     var body: some View {
         HStack {
             VStack(alignment: .leading) {
-                FlexibleCard(axis: .vertical, title: widgetTitle, value: content.siteTitle)
+                FlexibleCard(axis: .vertical, title: widgetTitle, value: content.siteName)
 
                 Spacer()
                 VerticalCard(title: viewsTitle, value: "\(content.stats.views.abbreviatedString())", largeText: true)

--- a/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetView.swift
+++ b/WordPress/WordPressHomeWidgetToday/Views/TodayWidgetView.swift
@@ -4,7 +4,7 @@ import WidgetKit
 struct TodayWidgetView: View {
     @Environment(\.widgetFamily) var family: WidgetFamily
 
-    let content: TodayWidgetContent
+    let content: HomeWidgetTodayData
 
     @ViewBuilder
     var body: some View {
@@ -44,12 +44,15 @@ extension TodayWidgetView {
 
 struct TodayWidgetView_Previews: PreviewProvider {
     // TODO - TODAYWIDGET: this has been added here for preview purposes only. 
-    static let staticContent = TodayWidgetContent(date: Date(),
-                                           siteTitle: "Places you should visit",
-                                           stats: TodayWidgetStats(views: 5980,
-                                                                   visitors: 4208,
-                                                                   likes: 107,
-                                                                   comments: 5))
+    static let staticContent = HomeWidgetTodayData(siteID: 0,
+                                                   siteName: "Places you should visit",
+                                                   url: "",
+                                                   timeZoneName: "GMT",
+                                                   date: Date(),
+                                                   stats: TodayWidgetStats(views: 5980,
+                                                                           visitors: 4208,
+                                                                           likes: 107,
+                                                                           comments: 5))
     static var previews: some View {
         TodayWidgetView(content: staticContent)
             .previewContext(WidgetPreviewContext(family: .systemSmall))

--- a/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
+++ b/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
@@ -5,11 +5,11 @@ import SwiftUI
 struct Provider: TimelineProvider {
     // TODO - TODAYWIDGET: Kept these methods simple on purpose, for now.
     // They might complicate depending on Context
-    func placeholder(in context: Context) -> TodayWidgetContent {
+    func placeholder(in context: Context) -> HomeWidgetTodayData {
         Constants.staticContent
     }
 
-    func getSnapshot(in context: Context, completion: @escaping (TodayWidgetContent) -> ()) {
+    func getSnapshot(in context: Context, completion: @escaping (HomeWidgetTodayData) -> ()) {
         getSnapshotData(completion: completion)
     }
 
@@ -21,46 +21,32 @@ struct Provider: TimelineProvider {
 // MARK: - Widget data
 private extension Provider {
 
-    // TODO - TODAYWIDGET: Using the "old widget" configuration, for now.
-    var siteName: String {
-        let defaults = UserDefaults(suiteName: WPAppGroupName)
+    func getSnapshotData(completion: @escaping (HomeWidgetTodayData) -> ()) {
 
-        if let title = defaults?.string(forKey: WPStatsTodayWidgetUserDefaultsSiteNameKey),
-           !title.isEmpty {
-            return title
-        }
-
-        if let url = defaults?.string(forKey: WPStatsTodayWidgetUserDefaultsSiteUrlKey),
-                  !url.isEmpty {
-            return url
-        }
-        return "Site not found"
-    }
-
-    func getSnapshotData(completion: @escaping (TodayWidgetContent) -> ()) {
-        // TODO - TODAYWIDGET: Using the "old widget" configuration, for now.
-        guard let initialStats = TodayWidgetStats.loadSavedData() else {
-            completion(Constants.staticContent)
-            return
-        }
-        completion(TodayWidgetContent(date: Date(), siteTitle: siteName, stats: initialStats))
+        completion(widgetData ?? Constants.staticContent)
     }
 
     func getTimelineData(completion: @escaping (Timeline<Entry>) -> ()) {
 
         let date = Date()
         let nextRefreshDate = Calendar.current.date(byAdding: .minute, value: Constants.refreshInterval, to: date) ?? date
-        // TODO - TODAYWIDGET: This is just a sample data set to test timeline updates
-        let randomNumber = Int.random(in: 4 ... 100)
-        let entries = [TodayWidgetContent(date: date,
-                                          siteTitle: "My Site + \(randomNumber)",
-                                          stats: TodayWidgetStats(views: randomNumber,
-                                                                  visitors: randomNumber,
-                                                                  likes: randomNumber,
-                                                                  comments: randomNumber))]
 
-        let timeline = Timeline(entries: entries, policy: .after(nextRefreshDate))
+        let entry = widgetData ?? Constants.staticContent
+
+        let timeline = Timeline(entries: [entry], policy: .after(nextRefreshDate))
         completion(timeline)
+    }
+
+    private var defaultSiteID: Int? {
+        // TODO - TODAYWIDGET: taking the default site id from user defaults for now.
+        // This would change if the old widget gets reconfigured to a different site than the default.
+        // This will be updated with the configuration intent.
+        UserDefaults(suiteName: WPAppGroupName)?.object(forKey: WPStatsTodayWidgetUserDefaultsSiteIdKey) as? Int
+    }
+
+    private var widgetData: HomeWidgetTodayData? {
+        // TODO - TODAYWIDGET: we might change this, but for now an ID equal to zero should not return any valid data
+        HomeWidgetTodayData.read()?[defaultSiteID ?? 0]
     }
 }
 
@@ -69,12 +55,15 @@ private extension Provider {
     enum Constants {
         // TODO - TODAYWIDGET: This can serve as static content to display in the preview if no data are yet available
         // we should define what to put in here
-        static let staticContent = TodayWidgetContent(date: Date(),
-                                                      siteTitle: "Places you should visit",
-                                                      stats: TodayWidgetStats(views: 5980,
-                                                                              visitors: 4208,
-                                                                              likes: 107,
-                                                                              comments: 5))
+        static let staticContent = HomeWidgetTodayData(siteID: 0,
+                                                       siteName: "Places you should visit",
+                                                       url: "",
+                                                       timeZoneName: "GMT",
+                                                       date: Date(),
+                                                       stats: TodayWidgetStats(views: 5980,
+                                                                               visitors: 4208,
+                                                                               likes: 107,
+                                                                               comments: 5))
         // refresh interval of the widget, in minutes
         static let refreshInterval = 60
     }

--- a/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
+++ b/WordPress/WordPressHomeWidgetToday/WordPressHomeWidgetToday.swift
@@ -72,10 +72,9 @@ private extension Provider {
 
 @main
 struct WordPressHomeWidgetToday: Widget {
-    private let kind: String = "WordPressHomeWidgetToday"
 
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+        StaticConfiguration(kind: WPHomeWidgetTodayKind, provider: Provider()) { entry in
             TodayWidgetView(content: entry)
         }
         .configurationDisplayName("Today")


### PR DESCRIPTION
Fixes #15104

Using the existing Stats logic to update the new Today Widget when the stats in the app are updated.

Known issues:

- at the moment, the logic takes as "default" site whatever site has been set for the old widgets (using the "Widgets" button in the Stats scene). If none was set, this will be the default site for the current user
- at the moment the logout and re-login with a different user is not handled, so it should be tested with only one user

To test:
- run the app and login on the testing device with a user that has at least one site, and possibly some daily stats that are not all zero
- background the app, Install the widget (any size would do, but medium size visualizes more info) and verify that the info look correct
- trigger some stats updates (e.g. do some visits, likes, comments from another device or browser, with another user that is following the site you are testing)
- go back to the app, then choose the site that is shown in the widget and then go to Stats, making sure that the updates you triggered appear
- background the app and go to the widget, and make sure that the same updates are reported in the widget.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
