### PR TITLE
Accessibility: add VoiceOver description to trash button in Media Details

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -161,6 +161,7 @@ class MediaItemViewController: UITableViewController {
                                             style: .plain,
                                             target: self,
                                             action: #selector(trashTapped(_:)))
+            trashItem.accessibilityLabel = NSLocalizedString("Trash", comment: "Accessibility label for trash buttons in nav bars")
 
             if media.blog.supports(.mediaDeletion) {
                 navigationItem.rightBarButtonItems = [ shareItem, trashItem ]


### PR DESCRIPTION
Fixes #15002 

This PR adds an accessibility label to the trash button so that VoiceOver will read it as "Trash. Button." (We use the term "trash" for deleting posts too, which is why I did not set this to "delete".)

### To test
1. Build and run this branch on a device.
2. Enable VoiceOver 
3. Navigate to My Site > Pick a site > Media > Select one image > Swipe left twice (to reach the delete icon in the navigation bar)

The trash icon should be read as "Trash, button." 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
