### PR TITLE
Localization: translation key exceeds character limit for GlotPress

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,8 +3,8 @@
 * [***] Site Creation: Adds an option to pick a home page design when creating a WordPress.com site. [multiple PRs](https://github.com/search?q=repo%3Awordpress-mobile%2FWordPress-iOS+++repo%3Awordpress-mobile%2FWordPress-iOS-Shared+repo%3Awordpress-mobile%2FWordPressUI-iOS+repo%3Awordpress-mobile%2FWordPressKit-iOS+repo%3Awordpress-mobile%2FAztecEditor-iOS+is%3Apr+closed%3A%3C2020-11-30+%22Home+Page+Picker%22&type=Issues)
 * [*] Fixed an issue where `tel:` and `mailto:` links weren't launching actions in the webview found in Reader > post > more > Visit. [#15310]
 * [*] Reader bug fix: tapping a telephone, sms or email link in a detail post in Reader will now respond with the correct action. [#15307]
-
-
+* [*] My Site > Settings > Start Over. Correcting a translation error in the detailed instructions on the Start Over view. [#15358]
+ 
 16.2
 -----
 * [**] Support contact email: fixed issue that prevented non-alpha characters from being entered. [#15210]

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
@@ -15,6 +15,9 @@ open class StartOverViewController: UITableViewController, MFMailComposeViewCont
 
     @objc let headerView: TableViewHeaderDetailView = {
         let header = NSLocalizedString("Let Us Help", comment: "Heading for instructions on Start Over settings page")
+        /// GlotPress breaks if iOS keys are longer than 256 characters, and additionally if a string reaches
+        /// 256 characters in English, it does not leave any flexibility for languages with longer words.
+        /// So lets support our translators and keep GlotPress happy :) 
         let detail1 = NSLocalizedString("If you want a site but do not want any of the posts and pages you have now, " +
                                         "our support team can delete your posts, pages, media, and comments for you.",
                                         comment: "Detailed instructions on Start Over settings page. This is the first paragraph.")

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
@@ -15,9 +15,10 @@ open class StartOverViewController: UITableViewController, MFMailComposeViewCont
 
     @objc let headerView: TableViewHeaderDetailView = {
         let header = NSLocalizedString("Let Us Help", comment: "Heading for instructions on Start Over settings page")
-        /// GlotPress breaks if iOS keys are longer than 256 characters, and additionally if a string reaches
-        /// 256 characters in English, it does not leave any flexibility for languages with longer words.
-        /// So lets support our translators and keep GlotPress happy :) 
+        /// GlotPress breaks if iOS keys are longer than 256 characters.
+        /// Additionally, if a string reaches 256 characters in English,
+        /// it does not leave any flexibility for languages with longer words.
+        /// So lets support our translators and keep GlotPress happy :) GH: #15353
         let detail1 = NSLocalizedString("If you want a site but do not want any of the posts and pages you have now, " +
                                         "our support team can delete your posts, pages, media, and comments for you.",
                                         comment: "Detailed instructions on Start Over settings page. This is the first paragraph.")

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
@@ -15,7 +15,7 @@ open class StartOverViewController: UITableViewController, MFMailComposeViewCont
 
     @objc let headerView: TableViewHeaderDetailView = {
         let header = NSLocalizedString("Let Us Help", comment: "Heading for instructions on Start Over settings page")
-        let detail1 = NSLocalizedString("If you want a site but don't want any of the posts and pages you have now, " +
+        let detail1 = NSLocalizedString("If you want a site but do not want any of the posts and pages you have now, " +
                                         "our support team can delete your posts, pages, media, and comments for you.",
                                         comment: "Detailed instructions on Start Over settings page. This is the first paragraph.")
         let doubleNewline = "\n\n"

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
@@ -15,7 +15,15 @@ open class StartOverViewController: UITableViewController, MFMailComposeViewCont
 
     @objc let headerView: TableViewHeaderDetailView = {
         let header = NSLocalizedString("Let Us Help", comment: "Heading for instructions on Start Over settings page")
-        let detail = NSLocalizedString("If you want a site but don't want any of the posts and pages you have now, our support team can delete your posts, pages, media, and comments for you.\n\nThis will keep your site and URL active, but give you a fresh start on your content creation. Just contact us to have your current content cleared out.", comment: "Detail for instructions on Start Over settings page")
+        let detail1 = NSLocalizedString("If you want a site but don't want any of the posts and pages you have now, " +
+                                        "our support team can delete your posts, pages, media, and comments for you.",
+                                        comment: "Detailed instructions on Start Over settings page. This is the first paragraph.")
+        let doubleNewline = "\n\n"
+        let detail2 = NSLocalizedString("This will keep your site and URL active, " +
+                                        "but give you a fresh start on your content creation. " +
+                                        "Just contact us to have your current content cleared out.",
+                                        comment: "Detailed instructions on Start Over settings page. This is the second paragraph.")
+        let detail = String.localizedStringWithFormat("%@%@%@", detail1, doubleNewline, detail2)
 
        return TableViewHeaderDetailView(title: header, detail: detail)
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
@@ -16,9 +16,7 @@ open class StartOverViewController: UITableViewController, MFMailComposeViewCont
     @objc let headerView: TableViewHeaderDetailView = {
         let header = NSLocalizedString("Let Us Help", comment: "Heading for instructions on Start Over settings page")
         /// GlotPress breaks if iOS keys are longer than 256 characters.
-        /// Additionally, if a string reaches 256 characters in English,
-        /// it does not leave any flexibility for languages with longer words.
-        /// So lets support our translators and keep GlotPress happy :) GH: #15353
+        /// So lets split it to keep GlotPress happy :) GH: #15353
         let detail1 = NSLocalizedString("If you want a site but do not want any of the posts and pages you have now, " +
                                         "our support team can delete your posts, pages, media, and comments for you.",
                                         comment: "Detailed instructions on Start Over settings page. This is the first paragraph.")


### PR DESCRIPTION
Fixes #15353 

### To test
It can't really be tested until the new translation strings are available. So the only thing to look for is: ensure the localized strings do not exceed 255 characters in English.

1. Change device language to a language that uses words that have more characters than English, such as German or Dutch. 
2. Navigate to My Site > Settings > Start Over. The detailed instructions text should now to be translated instead of falling back to English.

### Screenshots
Proof of bug:
<a href="https://user-images.githubusercontent.com/1062444/99831606-f38f3d80-2b24-11eb-8d14-6d202045ee59.png"><img src="https://user-images.githubusercontent.com/1062444/99831606-f38f3d80-2b24-11eb-8d14-6d202045ee59.png" width="350" /></a>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
