### PR TITLE
Analytics: Adds property to flag sites as blogs or p2s

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -293,6 +293,7 @@ extension WPAnalytics {
     static func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any], blog: Blog) {
         var props = properties
         props[WPAppAnalyticsKeyBlogID] = blog.dotComID
+        props[WPAppAnalyticsKeySiteType] = blog.isWPForTeams() ? WPAppAnalyticsValueSiteTypeP2 : WPAppAnalyticsValueSiteTypeBlog
         WPAnalytics.track(event, properties: props)
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -56,6 +56,11 @@ extern NSString * const WPAppAnalyticsKeyTapSource;
  */
 + (NSInteger)sessionCount;
 
+/**
+ *  @brief      Returns the site type for the blogID. Default is "blog".
+ */
++ (NSString *)siteTypeForBlogWithID:(NSNumber *)blogID;
+
 #pragma mark - User Opt Out
 
 /**

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -21,7 +21,9 @@ extern NSString * const WPAppAnalyticsKeyFollowAction;
 extern NSString * const WPAppAnalyticsKeySource;
 extern NSString * const WPAppAnalyticsKeyPostType;
 extern NSString * const WPAppAnalyticsKeyTapSource;
-
+extern NSString * const WPAppAnalyticsKeySiteType;
+extern NSString * const WPAppAnalyticsValueSiteTypeBlog;
+extern NSString * const WPAppAnalyticsValueSiteTypeP2;
 /**
  *  @class      WPAppAnalytics
  *  @brief      This is a container for the app-specific analytics logic.

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -6,6 +6,7 @@
 #import "WPTabBarController.h"
 #import "ApiCredentials.h"
 #import "AccountService.h"
+#import "BlogService.h"
 #import "Blog.h"
 #import "AbstractPost.h"
 #import "WordPress-Swift.h"
@@ -26,10 +27,15 @@ NSString * const WPAppAnalyticsKeyFollowAction                      = @"follow_a
 NSString * const WPAppAnalyticsKeySource                            = @"source";
 NSString * const WPAppAnalyticsKeyPostType                          = @"post_type";
 NSString * const WPAppAnalyticsKeyTapSource                          = @"tap_source";
+NSString * const WPAppAnalyticsKeySiteType                          = @"site_type";
 
 NSString * const WPAppAnalyticsKeyHasGutenbergBlocks                = @"has_gutenberg_blocks";
 static NSString * const WPAppAnalyticsKeyLastVisibleScreen          = @"last_visible_screen";
 static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_app";
+
+NSString * const WPAppAnalyticsValueSiteTypeBlog                    = @"blog";
+NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
+
 
 @interface WPAppAnalytics ()
 
@@ -102,6 +108,13 @@ static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_
 {
     [WPAnalytics clearQueuedEvents];
     [WPAnalytics clearTrackers];
+}
+
++ (NSString *)siteTypeForBlogWithID:(NSNumber *)blogID
+{
+    BlogService *service = [[BlogService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
+    Blog *blog = [service blogByBlogId:blogID];
+    return [blog isWPForTeams] ? WPAppAnalyticsValueSiteTypeP2 : WPAppAnalyticsValueSiteTypeBlog;
 }
 
 #pragma mark - Notifications
@@ -257,6 +270,9 @@ static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_
     
     if (blogID) {
         [mutableProperties setObject:blogID forKey:WPAppAnalyticsKeyBlogID];
+
+        NSString *siteType = [self siteTypeForBlogWithID:blogID];
+        [mutableProperties setObject:siteType forKey:WPAppAnalyticsKeySiteType];
     }
     
     if ([mutableProperties count] > 0) {

--- a/WordPress/WordPressTest/WPAppAnalyticsTests.m
+++ b/WordPress/WordPressTest/WPAppAnalyticsTests.m
@@ -156,4 +156,11 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     XCTAssertTrue([WPAppAnalytics userHasOptedOut]);
 }
 
+- (void)testSiteTypeForBlog
+{
+    NSString *siteType = [WPAppAnalytics siteTypeForBlogWithID: @99999999];
+    XCTAssertNotNil(siteType);
+    XCTAssertTrue([siteType isEqualToString:@"blog"]);
+}
+
 @end


### PR DESCRIPTION
Closes #15344 

This PR adds a new property to site events. If the event records a blogID, another property will be added to flag whether that event's site is a blog or a p2. 
Adding this directly to WPAppAnalytics seemed to be the lightest touch but I'd be game for another solution that avoids importing BlogService to re-fetch the blog here.

To test:
Confirm tests pass.
Run this branch and set breakpoints where the property is added. 
Trigger an event that records a blog ID, e.g. viewing Site Details > Blog Posts for a site that is a new P2, and another wpcom site.  Confirm the correct values are recorded.

@ScoutHarris could I trouble you with this one? 

cc @khaykov for the Android version of this.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
