### PR TITLE
Issues/15352 comment analytics

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -90,6 +90,18 @@ import Foundation
     case jetpackDisconnectTapped
     case jetpackDisconnectRequested
 
+    // Comments
+    case commentViewed
+    case commentApproved
+    case commentUnApproved
+    case commentLiked
+    case commentUnliked
+    case commentTrashed
+    case commentSpammed
+    case commentEditorOpened
+    case commentEdited
+    case commentRepliedTo
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -236,6 +248,29 @@ import Foundation
             return "jetpack_disconnect_tapped"
         case .jetpackDisconnectRequested:
             return "jetpack_disconnect_requested"
+
+        // Comments
+        case .commentViewed:
+            return "comment_viewed"
+        case .commentApproved:
+            return "comment_approved"
+        case .commentUnApproved:
+            return "comment_unapproved"
+        case .commentLiked:
+            return "comment_liked"
+        case .commentUnliked:
+            return "comment_unliked"
+        case .commentTrashed:
+            return "comment_trashed"
+        case .commentSpammed:
+            return "comment_spammed"
+        case .commentEditorOpened:
+            return "comment_editor_opened"
+        case .commentEdited:
+            return "comment_edited"
+        case .commentRepliedTo:
+            return "comment_replied_to"
+
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -21,6 +21,7 @@ extern NSString * const WPAppAnalyticsKeyFollowAction;
 extern NSString * const WPAppAnalyticsKeySource;
 extern NSString * const WPAppAnalyticsKeyPostType;
 extern NSString * const WPAppAnalyticsKeyTapSource;
+extern NSString * const WPAppAnalyticsKeyReplyingTo;
 
 /**
  *  @class      WPAppAnalytics

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -25,7 +25,8 @@ NSString * const WPAppAnalyticsKeyQuickAction                       = @"quick_ac
 NSString * const WPAppAnalyticsKeyFollowAction                      = @"follow_action";
 NSString * const WPAppAnalyticsKeySource                            = @"source";
 NSString * const WPAppAnalyticsKeyPostType                          = @"post_type";
-NSString * const WPAppAnalyticsKeyTapSource                          = @"tap_source";
+NSString * const WPAppAnalyticsKeyTapSource                         = @"tap_source";
+NSString * const WPAppAnalyticsKeyReplyingTo                        = @"replying_to";
 
 NSString * const WPAppAnalyticsKeyHasGutenbergBlocks                = @"has_gutenberg_blocks";
 static NSString * const WPAppAnalyticsKeyLastVisibleScreen          = @"last_visible_screen";

--- a/WordPress/Classes/ViewRelated/Comments/CommentAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentAnalytics.swift
@@ -1,0 +1,9 @@
+//
+//  CommentAnalytics.swift
+//  WordPress
+//
+//  Created by aerych on 11/22/20.
+//  Copyright © 2020 WordPress. All rights reserved.
+//
+
+import Foundation

--- a/WordPress/Classes/ViewRelated/Comments/CommentAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentAnalytics.swift
@@ -1,26 +1,34 @@
 import Foundation
 
-@objc class CommentAnalytics: NSObject{
+@objc class CommentAnalytics: NSObject {
+
+    struct Constants {
+        static let sites = "sites"
+        static let reader = "reader"
+        static let notifications = "notifications"
+        static let unknown = "unknown"
+        static let context = "context"
+    }
 
     static func trackingContext() -> String {
-        let screen = WPTabBarController.sharedInstance()?.currentlySelectedScreen() ?? "unknown"
+        let screen = WPTabBarController.sharedInstance()?.currentlySelectedScreen() ?? Constants.unknown
         switch screen {
         case WPTabBarCurrentlySelectedScreenSites:
-            return "sites"
+            return Constants.sites
         case WPTabBarCurrentlySelectedScreenReader:
-            return "reader"
+            return Constants.reader
         case WPTabBarCurrentlySelectedScreenNotifications:
-            return "notifications"
+            return Constants.notifications
         default:
-            return "unknown"
+            return Constants.unknown
         }
     }
 
     static func defaultProperties(comment: Comment) -> [AnyHashable: Any] {
         return [
-            "context": trackingContext(),
-            "post_id": comment.postID.intValue,
-            "comment_id": comment.commentID.intValue
+            Constants.context: trackingContext(),
+            WPAppAnalyticsKeyPostID: comment.postID.intValue,
+            WPAppAnalyticsKeyCommentID: comment.commentID.intValue
         ]
     }
 
@@ -72,6 +80,22 @@ import Foundation
     @objc static func trackCommentRepliedTo(comment: Comment) {
         let properties = defaultProperties(comment: comment)
         WPAnalytics.track(.commentRepliedTo, properties: properties, blog: comment.blog)
+    }
+
+    static func trackCommentEditorOpened(block: FormattableCommentContent) {
+        WPAnalytics.track(.commentEditorOpened, properties: [
+            Constants.context: CommentAnalytics.trackingContext(),
+            WPAppAnalyticsKeyBlogID: block.metaSiteID?.intValue ?? 0,
+            WPAppAnalyticsKeyCommentID: block.metaCommentID?.intValue ?? 0
+        ])
+    }
+
+    static func trackCommentEdited(block: FormattableCommentContent) {
+        WPAnalytics.track(.commentEdited, properties: [
+            Constants.context: CommentAnalytics.trackingContext(),
+            WPAppAnalyticsKeyBlogID: block.metaSiteID?.intValue ?? 0,
+            WPAppAnalyticsKeyCommentID: block.metaCommentID?.intValue ?? 0
+        ])
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentAnalytics.swift
@@ -1,9 +1,77 @@
-//
-//  CommentAnalytics.swift
-//  WordPress
-//
-//  Created by aerych on 11/22/20.
-//  Copyright © 2020 WordPress. All rights reserved.
-//
-
 import Foundation
+
+@objc class CommentAnalytics: NSObject{
+
+    static func trackingContext() -> String {
+        let screen = WPTabBarController.sharedInstance()?.currentlySelectedScreen() ?? "unknown"
+        switch screen {
+        case WPTabBarCurrentlySelectedScreenSites:
+            return "sites"
+        case WPTabBarCurrentlySelectedScreenReader:
+            return "reader"
+        case WPTabBarCurrentlySelectedScreenNotifications:
+            return "notifications"
+        default:
+            return "unknown"
+        }
+    }
+
+    static func defaultProperties(comment: Comment) -> [AnyHashable: Any] {
+        return [
+            "context": trackingContext(),
+            "post_id": comment.postID.intValue,
+            "comment_id": comment.commentID.intValue
+        ]
+    }
+
+    @objc static func trackCommentViewed(comment: Comment) {
+        let properties = defaultProperties(comment: comment)
+        WPAnalytics.track(.commentViewed, properties: properties, blog: comment.blog)
+    }
+
+    @objc static func trackCommentEditorOpened(comment: Comment) {
+        let properties = defaultProperties(comment: comment)
+        WPAnalytics.track(.commentEditorOpened, properties: properties, blog: comment.blog)
+    }
+
+    @objc static func trackCommentEdited(comment: Comment) {
+        let properties = defaultProperties(comment: comment)
+        WPAnalytics.track(.commentEdited, properties: properties, blog: comment.blog)
+    }
+
+    @objc static func trackCommentApproved(comment: Comment) {
+        let properties = defaultProperties(comment: comment)
+        WPAnalytics.track(.commentApproved, properties: properties, blog: comment.blog)
+    }
+
+    @objc static func trackCommentUnApproved(comment: Comment) {
+        let properties = defaultProperties(comment: comment)
+        WPAnalytics.track(.commentUnApproved, properties: properties, blog: comment.blog)
+    }
+
+    @objc static func trackCommentTrashed(comment: Comment) {
+        let properties = defaultProperties(comment: comment)
+        WPAnalytics.track(.commentTrashed, properties: properties, blog: comment.blog)
+    }
+
+    @objc static func trackCommentSpammed(comment: Comment) {
+        let properties = defaultProperties(comment: comment)
+        WPAnalytics.track(.commentSpammed, properties: properties, blog: comment.blog)
+    }
+
+    @objc static func trackCommentLiked(comment: Comment) {
+        let properties = defaultProperties(comment: comment)
+        WPAnalytics.track(.commentLiked, properties: properties, blog: comment.blog)
+    }
+
+    @objc static func trackCommentUnLiked(comment: Comment) {
+        let properties = defaultProperties(comment: comment)
+        WPAnalytics.track(.commentUnliked, properties: properties, blog: comment.blog)
+    }
+
+    @objc static func trackCommentRepliedTo(comment: Comment) {
+        let properties = defaultProperties(comment: comment)
+        WPAnalytics.track(.commentRepliedTo, properties: properties, blog: comment.blog)
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -438,7 +438,10 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 {
     __typeof(self) __weak weakSelf = self;
 
-    if (!self.comment.isLiked) {
+    if (self.comment.isLiked) {
+        [CommentAnalytics trackCommentLikedWithComment:[self comment]];
+    } else {
+        [CommentAnalytics trackCommentUnLikedWithComment:[self comment]];
         [[UINotificationFeedbackGenerator new] notificationOccurred:UINotificationFeedbackTypeSuccess];
     }
 
@@ -450,12 +453,14 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
                                        failure:^(NSError *error) {
                                            [weakSelf reloadData];
                                        }];
+
 }
 
 - (void)approveComment
 {
     __typeof(self) __weak weakSelf = self;
 
+    [CommentAnalytics trackCommentApprovedWithComment:[self comment]];
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
     [commentService approveComment:self.comment success:nil failure:^(NSError *error) {
@@ -469,6 +474,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 {
     __typeof(self) __weak weakSelf = self;
 
+    [CommentAnalytics trackCommentUnApprovedWithComment:[self comment]];
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
     [commentService unapproveComment:self.comment success:nil failure:^(NSError *error) {
@@ -481,7 +487,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 - (void)trashComment
 {
     __typeof(self) __weak weakSelf = self;
-    
+
     NSString *message = NSLocalizedString(@"Are you sure you want to delete this comment?",
                                           @"Message asking for confirmation on comment deletion");
     
@@ -495,7 +501,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     
     UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Delete", @"Delete")
                                                            style:UIAlertActionStyleDestructive
-                                                         handler:^(UIAlertAction *action){
+                                                         handler:^(UIAlertAction *action) {
                                                              NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
                                                              CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
                                                              
@@ -506,7 +512,8 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
                                                                  DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
                                                                  return;
                                                              }
-                                                             
+
+                                                             [CommentAnalytics trackCommentTrashedWithComment:[weakSelf comment]];
                                                              [commentService deleteComment:reloadedComment success:nil failure:nil];
                                                              
                                                              // Note: the parent class of CommentsViewController will pop this as a result of NSFetchedResultsChangeDelete
@@ -534,18 +541,19 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     
     UIAlertAction *spamAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Spam", @"Spam")
                                                          style:UIAlertActionStyleDestructive
-                                                       handler:^(UIAlertAction *action){
+                                                       handler:^(UIAlertAction *action) {
                                                            NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
                                                            CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
                                                            
                                                            NSError *error = nil;
                                                            Comment *reloadedComment = (Comment *)[context existingObjectWithID:weakSelf.comment.objectID error:&error];
-                                                           
+
                                                            if (error) {
                                                                DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
                                                                return;
                                                            }
-                                                           
+
+                                                           [CommentAnalytics trackCommentSpammedWithComment:reloadedComment];
                                                            [commentService spamComment:reloadedComment success:nil failure:nil];
                                                        }];
     [alertController addAction:cancelAction];
@@ -576,6 +584,8 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     navController.navigationBar.translucent = NO;
 
     [self presentViewController:navController animated:true completion:nil];
+
+    [CommentAnalytics trackCommentEditorOpenedWithComment:[self comment]];
 }
 
 - (void)updateCommentForNewContent:(NSString *)content
@@ -583,6 +593,9 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     // Set the new Content Data
     self.comment.content = content;
     [self reloadData];
+
+    // Regardless of success or failure track the user's intent to save a change.
+    [CommentAnalytics trackCommentEditedWithComment:[self comment]];
     
     // Hit the backend
     __typeof(self) __weak weakSelf = self;
@@ -630,6 +643,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     Comment *reply = [commentService createReplyForComment:self.comment];
     reply.content = content;
     [commentService uploadComment:reply success:successBlock failure:failureBlock];
+    [CommentAnalytics trackCommentRepliedToComment:[self comment]];
 }
 
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -231,8 +231,9 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     Comment *comment            = [self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
     CommentViewController *vc   = [CommentViewController new];
     vc.comment                  = comment;
-        
+
     [self.navigationController pushViewController:vc animated:YES];
+    [CommentAnalytics trackCommentViewedWithComment:comment];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
@@ -303,6 +304,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (void)approveComment:(Comment *)comment
 {
+    [CommentAnalytics trackCommentUnApprovedWithComment:comment];
     CommentService *service = [[CommentService alloc] initWithManagedObjectContext:self.managedObjectContext];
         
     [self.tableView setEditing:NO animated:YES];
@@ -313,6 +315,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (void)unapproveComment:(Comment *)comment
 {
+    [CommentAnalytics trackCommentUnApprovedWithComment:comment];
     CommentService *service = [[CommentService alloc] initWithManagedObjectContext:self.managedObjectContext];
     
     [self.tableView setEditing:NO animated:YES];
@@ -323,6 +326,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (void)deleteComment:(Comment *)comment
 {
+    [CommentAnalytics trackCommentTrashedWithComment:comment];
     CommentService *service = [[CommentService alloc] initWithManagedObjectContext:self.managedObjectContext];
     
     [self.tableView setEditing:NO animated:YES];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -785,7 +785,6 @@ private extension NotificationDetailsViewController {
         // Setup: Callbacks
         cell.onReplyClick = { [weak self] _ in
             self?.focusOnReplyTextViewWithBlock(commentBlock)
-            WPAppAnalytics.track(.notificationsCommentRepliedTo)
         }
 
         cell.onLikeClick = { [weak self] _ in
@@ -1077,6 +1076,7 @@ private extension NotificationDetailsViewController {
 
         let actionContext = ActionContext(block: block, content: content) { [weak self] (request, success) in
             if success {
+                WPAppAnalytics.track(.notificationsCommentRepliedTo)
                 let message = NSLocalizedString("Reply Sent!", comment: "The app successfully sent a comment")
                 self?.displayNotice(title: message)
             } else {
@@ -1099,6 +1099,7 @@ private extension NotificationDetailsViewController {
 
         let actionContext = ActionContext(block: block, content: content) { [weak self] (request, success) in
             guard success == false else {
+                CommentAnalytics.trackCommentEdited(block: block)
                 return
             }
 
@@ -1151,6 +1152,7 @@ private extension NotificationDetailsViewController {
         navController.modalTransitionStyle = .coverVertical
         navController.navigationBar.isTranslucent = false
 
+        CommentAnalytics.trackCommentEditorOpened(block: block)
         present(navController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -2,6 +2,9 @@
 
 extern NSString * const WPNewPostURLParamContentKey;
 extern NSString * const WPNewPostURLParamTagsKey;
+extern NSString * const WPTabBarCurrentlySelectedScreenSites;
+extern NSString * const WPTabBarCurrentlySelectedScreenReader;
+extern NSString * const WPTabBarCurrentlySelectedScreenNotifications;
 
 typedef NS_ENUM(NSUInteger, WPTabType) {
     WPTabMySites,

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -39,6 +39,10 @@ NSString * const WPNewPostURLParamContentKey = @"content";
 NSString * const WPNewPostURLParamTagsKey = @"tags";
 NSString * const WPNewPostURLParamImageKey = @"image";
 
+static NSString * const WPTabBarCurrentlySelectedScreenSites = @"Blog List";
+static NSString * const WPTabBarCurrentlySelectedScreenReader = @"Reader";
+static NSString * const WPTabBarCurrentlySelectedScreenNotifications = @"Notifications";
+
 static NSInteger const WPTabBarIconOffsetiPad = 7;
 static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
@@ -558,13 +562,13 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     NSString *currentlySelectedScreen = @"";
     switch (self.selectedIndex) {
         case WPTabMySites:
-            currentlySelectedScreen = @"Blog List";
+            currentlySelectedScreen = WPTabBarCurrentlySelectedScreenSites;
             break;
         case WPTabReader:
-            currentlySelectedScreen = @"Reader";
+            currentlySelectedScreen = WPTabBarCurrentlySelectedScreenReader;
             break;
         case WPTabNotifications:
-            currentlySelectedScreen = @"Notifications";
+            currentlySelectedScreen = WPTabBarCurrentlySelectedScreenNotifications;
             break;
         default:
             break;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -39,9 +39,9 @@ NSString * const WPNewPostURLParamContentKey = @"content";
 NSString * const WPNewPostURLParamTagsKey = @"tags";
 NSString * const WPNewPostURLParamImageKey = @"image";
 
-static NSString * const WPTabBarCurrentlySelectedScreenSites = @"Blog List";
-static NSString * const WPTabBarCurrentlySelectedScreenReader = @"Reader";
-static NSString * const WPTabBarCurrentlySelectedScreenNotifications = @"Notifications";
+NSString * const WPTabBarCurrentlySelectedScreenSites = @"Blog List";
+NSString * const WPTabBarCurrentlySelectedScreenReader = @"Reader";
+NSString * const WPTabBarCurrentlySelectedScreenNotifications = @"Notifications";
 
 static NSInteger const WPTabBarIconOffsetiPad = 7;
 static NSInteger const WPTabBarIconOffsetiPhone = 5;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2078,6 +2078,7 @@
 		E6431DE61C4E892900FD8D90 /* SharingDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E6431DE21C4E892900FD8D90 /* SharingDetailViewController.m */; };
 		E6431DE71C4E892900FD8D90 /* SharingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E6431DE41C4E892900FD8D90 /* SharingViewController.m */; };
 		E64384831C628FCC0052ADB5 /* WPStyleGuide+Sharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64384821C628FCC0052ADB5 /* WPStyleGuide+Sharing.swift */; };
+		E64595F0256B5D7800F7F90C /* CommentAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64595EF256B5D7800F7F90C /* CommentAnalytics.swift */; };
 		E64ECA4D1CE62041000188A0 /* ReaderSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E64ECA4C1CE62041000188A0 /* ReaderSearchViewController.swift */; };
 		E65219F91B8D10C2000B1217 /* ReaderBlockedSiteCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65219F81B8D10C2000B1217 /* ReaderBlockedSiteCell.xib */; };
 		E65219FB1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65219FA1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift */; };
@@ -4827,6 +4828,7 @@
 		E6431DE41C4E892900FD8D90 /* SharingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SharingViewController.m; sourceTree = "<group>"; };
 		E64384821C628FCC0052ADB5 /* WPStyleGuide+Sharing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Sharing.swift"; sourceTree = "<group>"; };
 		E6452B7C1FEAF4DC00D21BF1 /* WordPress 69.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 69.xcdatamodel"; sourceTree = "<group>"; };
+		E64595EF256B5D7800F7F90C /* CommentAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentAnalytics.swift; sourceTree = "<group>"; };
 		E64ECA4C1CE62041000188A0 /* ReaderSearchViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSearchViewController.swift; sourceTree = "<group>"; };
 		E65219F81B8D10C2000B1217 /* ReaderBlockedSiteCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderBlockedSiteCell.xib; sourceTree = "<group>"; };
 		E65219FA1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderBlockedSiteCell.swift; sourceTree = "<group>"; };
@@ -5740,7 +5742,7 @@
 			path = GutenbergWeb;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				98D31BBF239720E4009CFF43 /* MainInterface.storyboard */,
@@ -9907,6 +9909,7 @@
 		C533CF320E6D3AB3000C3DE8 /* Comments */ = {
 			isa = PBXGroup;
 			children = (
+				E64595EE256B5D5000F7F90C /* Analytics */,
 				B56994461B7A82A300FF26FA /* Style */,
 				B56994471B7A82CD00FF26FA /* Controllers */,
 				B56994481B7A82D400FF26FA /* Views */,
@@ -10681,6 +10684,14 @@
 			name = Sharing;
 			sourceTree = "<group>";
 		};
+		E64595EE256B5D5000F7F90C /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				E64595EF256B5D7800F7F90C /* CommentAnalytics.swift */,
+			);
+			name = Analytics;
+			sourceTree = "<group>";
+		};
 		E66969D01B9E3D5000EC9C00 /* 37-38 */ = {
 			isa = PBXGroup;
 			children = (
@@ -11412,7 +11423,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -13258,6 +13269,7 @@
 				73BFDA8A211D054800907245 /* Notifiable.swift in Sources */,
 				404B35D322E9BA0800AD0B37 /* RegisterDomainDetailsViewModel+CountryDialCodes.swift in Sources */,
 				D8EB1FD121900810002AE1C4 /* BlogListViewController+SiteCreation.swift in Sources */,
+				E64595F0256B5D7800F7F90C /* CommentAnalytics.swift in Sources */,
 				FA5C740F1C599BA7000B528C /* TableViewHeaderDetailView.swift in Sources */,
 				0857C2771CE5375F0014AE99 /* MenuItemAbstractView.m in Sources */,
 				D800D86420997BA100E7C7E5 /* ReaderMenuItemCreator.swift in Sources */,


### PR DESCRIPTION
Closes #15352 

This PR adds analytics tracking to the My Sites > Comments feature, and makes a few smaller updates to Reader and Notification comments.  See 15352 for full details. 

Note that in most cases, these events are optimistically dispatched -- i.e. bumped when the associated action is performed, not necessarily when the action is successfully completed. 

To test:
There are a couple of options for testing.
Option one: Set breakpoints and confirm the new events are being dispatched as their related actions are performed.  
Option two: Perform the associated actions and monitor tracks live events to confirm they are dispatched. 

@ScoutHarris Game for one more? 

cc @khaykov for the Android version

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
