### PR TITLE
[Home Page Picker] Add Template to Preview analytics

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/Preview/SiteDesignPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/Preview/SiteDesignPreviewViewController.swift
@@ -107,7 +107,7 @@ class SiteDesignPreviewViewController: UIViewController, NoResultsViewHost {
 extension SiteDesignPreviewViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        SiteCreationAnalyticsHelper.trackSiteDesignPreviewLoading()
+        SiteCreationAnalyticsHelper.trackSiteDesignPreviewLoading(siteDesign)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
@@ -119,7 +119,7 @@ extension SiteDesignPreviewViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        SiteCreationAnalyticsHelper.trackSiteDesignPreviewLoaded()
+        SiteCreationAnalyticsHelper.trackSiteDesignPreviewLoaded(siteDesign)
         progressBar.animatableSetIsHidden(true)
         removeProgressObserver()
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -14,20 +14,20 @@ class SiteCreationAnalyticsHelper {
     }
 
     static func trackSiteDesignSelected(_ siteDesign: RemoteSiteDesign) {
-        WPAnalytics.track(.enhancedSiteCreationSiteDesignSelected, withProperties: [siteDesignKey: siteDesign.slug])
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignSelected, withProperties: commonProperties(siteDesign))
     }
 
     // MARK: - Site Design Preview
     static func trackSiteDesignPreviewViewed(_ siteDesign: RemoteSiteDesign) {
-        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewViewed, withProperties: [siteDesignKey: siteDesign.slug])
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewViewed, withProperties: commonProperties(siteDesign))
     }
 
-    static func trackSiteDesignPreviewLoading() {
-        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewLoading)
+    static func trackSiteDesignPreviewLoading(_ siteDesign: RemoteSiteDesign) {
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewLoading, withProperties: commonProperties(siteDesign))
     }
 
-    static func trackSiteDesignPreviewLoaded() {
-        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewLoaded)
+    static func trackSiteDesignPreviewLoaded(_ siteDesign: RemoteSiteDesign) {
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewLoaded, withProperties: commonProperties(siteDesign))
     }
 
     // MARK: - Error
@@ -37,5 +37,10 @@ class SiteCreationAnalyticsHelper {
         ]
 
         WPAnalytics.track(.enhancedSiteCreationErrorShown, withProperties: errorProperties)
+    }
+
+    // MARK: - Common
+    private static func commonProperties(_ siteDesign: RemoteSiteDesign) -> [AnyHashable: Any] {
+        return  [siteDesignKey: siteDesign.slug]
     }
 }


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/2720
📓 This helps align the approach taken on iOS and Android to include the `template` property in the loading preview analytics

📓 This does not include any of the changes in https://github.com/wordpress-mobile/WordPress-iOS/pull/15360 

## To test:
📓 This was branched off of the enable PR so no need to enable HPP unless you have it overridden

<details>
<summary><strong>To disable or enable the development version of Home Page Picker</strong></summary>

- Open the app from the build that allows FeatureFlags such as a PR build or a local development build
    - By default, the modal layout picker will be disabled.
    - From the site page:
        - Click on your Gravatar.
        - Click on App Settings.
        - Click on Debug.
        - Toggle "Site Creation: Home Page Picker" to enable or disable the picker
        - <kdb><a href="https://user-images.githubusercontent.com/3384451/97343011-5f032980-185d-11eb-9030-06c17f732fec.gif"><img width="300" src="https://user-images.githubusercontent.com/3384451/97343011-5f032980-185d-11eb-9030-06c17f732fec.gif"/></a></kdb>

</details>

📓 To help with testing these you can filter the console logs on `Tracked:`

1. Navigate to the Create WordPress.com site
    - My Sites > ➕ > Create WordPress.com site
1.  Select a site design
1. Select Preview
    - **Expect** to see the event `enhanced_site_creation_site_design_preview_viewed` fire with the parameter `template` populated with the selected design's `slug`
1. When the URL starts loading
    -  **Expect** to see the event `enhanced_site_creation_site_design_preview_loading` fire with the parameter `template` 
1. When the URL successfully loads
    -  **Expect** to see the event `enhanced_site_creation_site_design_preview_loaded` fire with the parameter `template` 
1. Select Choose
    - **Expect** to see the event `enhanced_site_creation_site_design_selected` fire with the parameter `template` 

## Additional Context: 

This is a continuation of the work done in the [Home Page Picker Project](https://github.com/wordpress-mobile/gutenberg-mobile/labels/Project%3A%20Home%20Page%20Picker) and is part of the [Round 2 requirements](https://github.com/wordpress-mobile/gutenberg-mobile/labels/Project%3A%20Home%20Page%20Picker%20Round%202).  

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

