### PR TITLE
[Home Page Picker] Add the WP custom user agent to site creation webviews

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/Preview/SiteDesignPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/Preview/SiteDesignPreviewViewController.swift
@@ -71,6 +71,7 @@ class SiteDesignPreviewViewController: UIViewController, NoResultsViewHost {
     private func configureWebView() {
         guard let demoURL = URL(string: siteDesign.demoURL) else { return }
         let request = URLRequest(url: demoURL)
+        webView.customUserAgent = WPUserAgent.wordPress()
         webView.load(request)
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -140,7 +140,7 @@ final class AssembledSiteView: UIView {
         self.initialSiteRequest = siteRequest
 
         generator.prepare()
-
+        webView.customUserAgent = WPUserAgent.wordPress()
         webView.load(siteRequest)
     }
 


### PR DESCRIPTION
Adds the custom WP app user agent string to the Webview's user agent. This will hide the Cookie prompt on larger devices like an iPad 

## To test:
1. Navigate to the Create WordPress.com site
    - My Sites > ➕ > Create WordPress.com site
1.  Complete the site creation flow
1. Expect the cookie bar to be hidden

## Screenshots:

Before | After
--- | ---
<kdb><a href="https://user-images.githubusercontent.com/3384451/100007008-5db01880-2d99-11eb-8ea2-c53e77373c68.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/100007008-5db01880-2d99-11eb-8ea2-c53e77373c68.png"/></a></kdb> | <kdb><a href="https://user-images.githubusercontent.com/3384451/100006965-4f61fc80-2d99-11eb-8f73-c21dda18109b.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/100006965-4f61fc80-2d99-11eb-8f73-c21dda18109b.png"/></a></kdb>


## Additional Context: 

This is a continuation of the work done in the [Home Page Picker Project](https://github.com/wordpress-mobile/gutenberg-mobile/labels/Project%3A%20Home%20Page%20Picker). 

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.



