### PR TITLE
only show Jetpack Section title as "Jetpack" if it's a paid Jetpack site

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -843,8 +843,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
         [rows addObject:settingsRow];
     }
+    NSString *title = @"";
 
-    NSString *title = NSLocalizedString(@"Jetpack", @"Section title for the publish table section in the blog details screen");
+    if ([self.blog supports:BlogFeatureJetpackSettings]) {
+        title = NSLocalizedString(@"Jetpack", @"Section title for the publish table section in the blog details screen");
+    }
+
     return [[BlogDetailsSection alloc] initWithTitle:title andRows:rows category:BlogDetailsSectionCategoryJetpack];
 }
 


### PR DESCRIPTION
only show Jetpack Section title as "Jetpack" if it's a paid Jetpack site, otherwise the section will remain without a title as it was before

To test:
1. Go to a .com site, see that there is not title for Stats and Activity log 
2. Go to a site with Jetpack, see the section title as "jetpack"

Site with Jetpack             |  wpcom
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/1335657/100029286-d026f580-2da5-11eb-817b-4986c3787e2f.png)  |  ![](https://user-images.githubusercontent.com/1335657/100029290-d2894f80-2da5-11eb-92ac-093993c38994.png)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
