### PR TITLE
Removing unnecessary print statements

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -343,9 +343,8 @@ class GutenbergViewController: UIViewController, PostEditor {
 
         service?.syncJetpackSettingsForBlog(post.blog, success: { [weak self] in
             self?.gutenberg.updateCapabilities()
-            print("---> Success syncing JETPACK: Enabled=\(self!.post.blog.settings!.jetpackSSOEnabled)")
         }, failure: { (error) in
-            print("---> ERROR syncking JETPACK")
+            DDLogError("Error syncing JETPACK: \(String(describing: error))")
         })
     }
 


### PR DESCRIPTION
Fixes a crash due to force unwraps on print statements.

To test:
- Smoke test Gutenberg editor init.

cc @loremattei @yaelirub 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
