### PR TITLE
Remove `newReaderNavigation` feature flag.

### DIFF
--- a/WordPress/Classes/Extensions/Notifications/NotificationName+Names.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationName+Names.swift
@@ -6,14 +6,9 @@ extension Foundation.Notification.Name {
     static var reachabilityChanged: Foundation.NSNotification.Name {
         return Foundation.Notification.Name("org.wordpress.reachability.changed")
     }
-
-    static var showAllSavedForLaterPosts: Foundation.NSNotification.Name {
-        return Foundation.Notification.Name("org.wordpress.reader.savedforlaterposts.showall")
-    }
 }
 
 @objc extension NSNotification {
-    public static let ShowAllSavedForLaterPostsNotification = Foundation.Notification.Name.showAllSavedForLaterPosts
     public static let ReachabilityChangedNotification = Foundation.Notification.Name.reachabilityChanged
 }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -6,7 +6,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case debugMenu
     case readerCSS
     case unifiedAuth
-    case newReaderNavigation
     case swiftCoreData
     case homepageSettings
     case gutenbergMentions
@@ -31,8 +30,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .readerCSS:
             return false
         case .unifiedAuth:
-            return true
-        case .newReaderNavigation:
             return true
         case .swiftCoreData:
             return BuildConfiguration.current == .localDeveloper
@@ -88,8 +85,6 @@ extension FeatureFlag {
             return "Ignore Reader CSS Cache"
         case .unifiedAuth:
             return "Unified Auth"
-        case .newReaderNavigation:
-            return "New Reader Navigation"
         case .swiftCoreData:
             return "Migrate Core Data Stack to Swift"
         case .homepageSettings:
@@ -114,8 +109,6 @@ extension FeatureFlag {
     var canOverride: Bool {
         switch self {
         case .debugMenu:
-            return false
-        case .newReaderNavigation:
             return false
         case .swiftCoreData:
             return false

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -56,14 +56,9 @@ extension ReaderRoute: NavigationAction {
             return
         }
 
-        coordinator.source = source
-
-        if source == nil {
-            // If we're not navigating internally,
-            // we want to bounce back to Safari on failure
-            coordinator.failureBlock = {
-                self.failAndBounce(values)
-            }
+        // Bounce back to Safari on failure
+        coordinator.failureBlock = {
+            self.failAndBounce(values)
         }
 
         switch self {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -124,9 +124,8 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         // TODO: - READERNAV - Update this check once the old reader is removed
         if origin is ReaderSavedPostsViewController {
             actionOrigin = .savedStream
-        } else if let origin = origin as? ReaderStreamViewController, origin.contentType == .saved, FeatureFlag.newReaderNavigation.enabled {
+        } else if let origin = origin as? ReaderStreamViewController, origin.contentType == .saved {
             actionOrigin = .savedStream
-
         } else {
             actionOrigin = .otherStream
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -76,6 +76,7 @@ extension ReaderMenuViewController {
     }
 }
 
+// TODO: - READERNAV - nix this with ReaderSavedPostsViewController.
 extension ReaderSavedPostsViewController {
     func trackSavedPostNavigation() {
         WPAppAnalytics.track(.readerSavedPostOpened, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.savedStream.openPostValue ])
@@ -84,10 +85,13 @@ extension ReaderSavedPostsViewController {
 
 extension ReaderStreamViewController {
     func trackSavedPostNavigation() {
-        if FeatureFlag.newReaderNavigation.enabled, contentType == .saved {
-            WPAppAnalytics.track(.readerSavedPostOpened, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.savedStream.openPostValue ])
+        if contentType == .saved {
+            WPAppAnalytics.track(.readerSavedPostOpened,
+                                 withProperties: [readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.savedStream.openPostValue])
         } else {
-            WPAppAnalytics.track(.readerSavedPostOpened, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.otherStream.openPostValue ])
+            // TODO: - READERNAV - See refactor note in ReaderSaveForLater+Analytics.viewAllPostsValue.
+            WPAppAnalytics.track(.readerSavedPostOpened,
+                                 withProperties: [readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.otherStream.openPostValue])
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
@@ -61,11 +61,7 @@ final class ReaderSaveForLaterAction {
                             actionTitle: Strings.viewAll,
                             actionHandler: { _ in
                                 self.trackViewAllSavedPostsAction(origin: origin)
-                                guard !FeatureFlag.newReaderNavigation.enabled else {
                                     WPTabBarController.sharedInstance().switchToSavedPosts()
-                                    return
-                                }
-                                self.showAll()
         })
 
         present(notice)
@@ -103,7 +99,4 @@ final class ReaderSaveForLaterAction {
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
-    private func showAll() {
-        NotificationCenter.default.post(name: .showAllSavedForLaterPosts, object: self, userInfo: nil)
-    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -34,26 +34,18 @@ extension ReaderStreamViewController {
 
     func headerForStream(_ topic: ReaderAbstractTopic) -> ReaderHeader? {
 
-        if ReaderHelpers.topicIsFollowing(topic), !FeatureFlag.newReaderNavigation.enabled {
-            return Bundle.main.loadNibNamed("ReaderFollowedSitesStreamHeader", owner: nil, options: nil)!.first as! ReaderFollowedSitesStreamHeader
-        }
-
-        // if tag
         if ReaderHelpers.isTopicTag(topic) && !isContentFiltered {
             return Bundle.main.loadNibNamed("ReaderTagStreamHeader", owner: nil, options: nil)!.first as! ReaderTagStreamHeader
         }
 
-        // if list
         if ReaderHelpers.isTopicList(topic) {
             return Bundle.main.loadNibNamed("ReaderListStreamHeader", owner: nil, options: nil)!.first as! ReaderListStreamHeader
         }
 
-        // if site
         if ReaderHelpers.isTopicSite(topic) {
             return Bundle.main.loadNibNamed("ReaderSiteStreamHeader", owner: nil, options: nil)!.first as! ReaderSiteStreamHeader
         }
 
-        // if anything else return nil
         return nil
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -35,15 +35,15 @@ extension ReaderStreamViewController {
     func headerForStream(_ topic: ReaderAbstractTopic) -> ReaderHeader? {
 
         if ReaderHelpers.isTopicTag(topic) && !isContentFiltered {
-            return Bundle.main.loadNibNamed("ReaderTagStreamHeader", owner: nil, options: nil)!.first as! ReaderTagStreamHeader
+            return Bundle.main.loadNibNamed("ReaderTagStreamHeader", owner: nil, options: nil)?.first as? ReaderTagStreamHeader
         }
 
         if ReaderHelpers.isTopicList(topic) {
-            return Bundle.main.loadNibNamed("ReaderListStreamHeader", owner: nil, options: nil)!.first as! ReaderListStreamHeader
+            return Bundle.main.loadNibNamed("ReaderListStreamHeader", owner: nil, options: nil)?.first as? ReaderListStreamHeader
         }
 
         if ReaderHelpers.isTopicSite(topic) {
-            return Bundle.main.loadNibNamed("ReaderSiteStreamHeader", owner: nil, options: nil)!.first as! ReaderSiteStreamHeader
+            return Bundle.main.loadNibNamed("ReaderSiteStreamHeader", owner: nil, options: nil)?.first as? ReaderSiteStreamHeader
         }
 
         return nil

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -132,8 +132,7 @@ import WordPressFlux
     }
 
     private var isLoadingDiscover: Bool {
-        return FeatureFlag.newReaderNavigation.enabled &&
-            readerTopic == nil &&
+        return readerTopic == nil &&
             contentType == .topic &&
             siteID == ReaderHelpers.discoverSiteID
     }
@@ -198,7 +197,7 @@ import WordPressFlux
     ///
     @objc class func controllerWithTopic(_ topic: ReaderAbstractTopic) -> ReaderStreamViewController {
         // if a default discover topic is provided, treat it as a site to retrieve the header
-        if ReaderHelpers.topicIsDiscover(topic) && FeatureFlag.newReaderNavigation.enabled {
+        if ReaderHelpers.topicIsDiscover(topic) {
             return controllerWithSiteID(ReaderHelpers.discoverSiteID, isFeed: false)
         }
 
@@ -572,8 +571,9 @@ import WordPressFlux
             // need to refresh.
             tableViewController.refreshControl = nil
         }
+
         // saved posts are local so do not need a pull to refresh
-        if FeatureFlag.newReaderNavigation.enabled, contentType == .saved {
+        if contentType == .saved {
             tableViewController.refreshControl = nil
         }
 
@@ -1874,9 +1874,6 @@ extension ReaderStreamViewController: ReaderPostUndoCellDelegate {
 private extension ReaderStreamViewController {
 
     var shouldDisplayNoTopicController: Bool {
-        guard FeatureFlag.newReaderNavigation.enabled else {
-            return false
-        }
         switch contentType {
         case .selfHostedFollowing:
             displaySelfHostedFollowingController()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -531,13 +531,11 @@ import WordPressFlux
         }
 
         tableView.tableHeaderView = header
-            // This feels somewhat hacky, but it is the only way I found to insert a stack view into the header without breaking the autolayout constraints.
+        // This feels somewhat hacky, but it is the only way I found to insert a stack view into the header without breaking the autolayout constraints.
         let centerConstraint = header.centerXAnchor.constraint(equalTo: tableView.centerXAnchor)
         let topConstraint = header.topAnchor.constraint(equalTo: tableView.topAnchor)
         let headerWidthConstraint = header.widthAnchor.constraint(equalTo: tableView.widthAnchor)
-        if FeatureFlag.newReaderNavigation.enabled {
-            headerWidthConstraint.priority = UILayoutPriority(999)
-        }
+        headerWidthConstraint.priority = UILayoutPriority(999)
 
         NSLayoutConstraint.activate([
             centerConstraint,
@@ -750,15 +748,7 @@ import WordPressFlux
     }
 
     private func showFollowing() {
-        guard !FeatureFlag.newReaderNavigation.enabled else {
-            WPTabBarController.sharedInstance().switchToFollowedSites()
-            return
-        }
-        guard let readerMenuViewController = WPTabBarController.sharedInstance().readerMenuViewController else {
-            return
-        }
-
-        readerMenuViewController.showSectionForDefaultMenuItem(withOrder: .followed, animated: true)
+        WPTabBarController.sharedInstance().switchToFollowedSites()
     }
 
     // MARK: - Blocking

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -40,65 +40,28 @@ class ReaderCoordinator: NSObject {
     }
 
     func showDiscover() {
-        guard !FeatureFlag.newReaderNavigation.enabled else {
-            WPTabBarController.sharedInstance().switchToDiscover()
-            return
-        }
-        prepareToNavigate()
-
-        readerMenuViewController.showSectionForDefaultMenuItem(withOrder: .discover,
-                                                               animated: isNavigatingFromSource)
+        WPTabBarController.sharedInstance().switchToDiscover()
     }
-
+    
     func showSearch() {
-        guard !FeatureFlag.newReaderNavigation.enabled else {
-            WPTabBarController.sharedInstance().navigateToReaderSearch()
-            return
-        }
-        prepareToNavigate()
-
-        readerMenuViewController.showSectionForDefaultMenuItem(withOrder: .search,
-                                                               animated: isNavigatingFromSource)
+        WPTabBarController.sharedInstance().navigateToReaderSearch()
     }
 
     func showA8CTeam() {
-        guard !FeatureFlag.newReaderNavigation.enabled else {
-            WPTabBarController.sharedInstance()?.switchToTopic(where: { topic in
-                guard (topic as? ReaderTeamTopic)?.slug == ReaderTeamTopic.a8cTeamSlug else {
-                    return false
-                }
-                return true
-            })
-            return
-        }
-        prepareToNavigate()
-
-        readerMenuViewController.showSectionForTeam(withSlug: ReaderTeamTopic.a8cTeamSlug, animated: isNavigatingFromSource)
+        WPTabBarController.sharedInstance()?.switchToTopic(where: { topic in
+            guard (topic as? ReaderTeamTopic)?.slug == ReaderTeamTopic.a8cTeamSlug else {
+                return false
+            }
+            return true
+        })
     }
 
     func showMyLikes() {
-        guard !FeatureFlag.newReaderNavigation.enabled else {
-            WPTabBarController.sharedInstance().switchToMyLikes()
-            return
-        }
-        prepareToNavigate()
-
-        readerMenuViewController.showSectionForDefaultMenuItem(withOrder: .likes,
-                                                               animated: isNavigatingFromSource)
+        WPTabBarController.sharedInstance().switchToMyLikes()
     }
 
     func showManageFollowing() {
-        guard !FeatureFlag.newReaderNavigation.enabled else {
-            WPTabBarController.sharedInstance()?.switchToFollowedSites()
-            return
-        }
-        prepareToNavigate()
-
-        readerMenuViewController.showSectionForDefaultMenuItem(withOrder: .followed, animated: false)
-
-        if let followedViewController = topNavigationController?.topViewController as? ReaderStreamViewController {
-            followedViewController.showManageSites(animated: isNavigatingFromSource)
-        }
+        WPTabBarController.sharedInstance()?.switchToFollowedSites()
     }
 
     func showList(named listName: String, forUser user: String) {
@@ -110,23 +73,10 @@ class ReaderCoordinator: NSObject {
             return
         }
 
-        guard !FeatureFlag.newReaderNavigation.enabled else {
-            WPTabBarController.sharedInstance()?.switchToTopic(where: { $0 == topic })
-            return
-        }
-
-        if !isNavigatingFromSource {
-            prepareToNavigate()
-        }
-
-        let streamViewController = ReaderStreamViewController.controllerWithTopic(topic)
-
-        streamViewController.streamLoadFailureBlock = failureBlock
-
-        readerSplitViewController.showDetailViewController(streamViewController, sender: nil)
-        readerMenuViewController.deselectSelectedRow(animated: false)
+        WPTabBarController.sharedInstance()?.switchToTopic(where: { $0 == topic })
     }
 
+    // here
     func showTag(named tagName: String) {
         if !isNavigatingFromSource, !FeatureFlag.newReaderNavigation.enabled {
             prepareToNavigate()
@@ -168,25 +118,12 @@ class ReaderCoordinator: NSObject {
     }
 
     func showStream(with siteID: Int, isFeed: Bool) {
-
-        guard !FeatureFlag.newReaderNavigation.enabled else {
-            getSiteTopic(siteID: NSNumber(value: siteID), isFeed: isFeed) { result in
-                guard let topic = try? result.get() else { return }
-                WPTabBarController.sharedInstance()?.navigateToReaderSite(topic)
+        getSiteTopic(siteID: NSNumber(value: siteID), isFeed: isFeed) { result in
+            guard let topic = try? result.get() else {
+                return
             }
-            return
-        }
-
-        let controller = ReaderStreamViewController.controllerWithSiteID(NSNumber(value: siteID), isFeed: isFeed)
-        controller.streamLoadFailureBlock = failureBlock
-
-        if isNavigatingFromSource {
-            topNavigationController?.pushViewController(controller, animated: true)
-        } else {
-            prepareToNavigate()
-
-            readerSplitViewController.showDetailViewController(controller, sender: nil)
-            readerMenuViewController.deselectSelectedRow(animated: false)
+            
+            WPTabBarController.sharedInstance()?.navigateToReaderSite(topic)
         }
     }
 
@@ -212,11 +149,7 @@ class ReaderCoordinator: NSObject {
 
     func showPost(with postID: Int, for feedID: Int, isFeed: Bool) {
         let postLoadFailureBlock = { [weak self, failureBlock] in
-            if FeatureFlag.newReaderNavigation.enabled {
-                self?.readerNavigationController.popToRootViewController(animated: false)
-            } else {
-                self?.topNavigationController?.popViewController(animated: false)
-            }
+            self?.readerNavigationController.popToRootViewController(animated: false)
             failureBlock?()
         }
 
@@ -225,20 +158,7 @@ class ReaderCoordinator: NSObject {
                                                                                    isFeed: isFeed)
 
         detailViewController.postLoadFailureBlock = postLoadFailureBlock
-
-        guard !FeatureFlag.newReaderNavigation.enabled else {
-            WPTabBarController.sharedInstance().navigateToReader(detailViewController)
-            return
-        }
-
-        if isNavigatingFromSource {
-            topNavigationController?.pushFullscreenViewController(detailViewController, animated: isNavigatingFromSource)
-        } else {
-            prepareToNavigate()
-
-            topNavigationController?.pushFullscreenViewController(detailViewController, animated: isNavigatingFromSource)
-            readerMenuViewController.deselectSelectedRow(animated: false)
-        }
+        WPTabBarController.sharedInstance().navigateToReader(detailViewController)
     }
 
     private var topNavigationController: UINavigationController? {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -3,19 +3,12 @@ import UIKit
 @objc
 class ReaderCoordinator: NSObject {
     let readerNavigationController: UINavigationController
-    let readerSplitViewController: WPSplitViewController
-    let readerMenuViewController: ReaderMenuViewController
 
     var failureBlock: (() -> Void)? = nil
 
     @objc
-    init(readerNavigationController: UINavigationController,
-         readerSplitViewController: WPSplitViewController,
-         readerMenuViewController: ReaderMenuViewController) {
+    init(readerNavigationController: UINavigationController) {
         self.readerNavigationController = readerNavigationController
-        self.readerSplitViewController = readerSplitViewController
-        self.readerMenuViewController = readerMenuViewController
-
         super.init()
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -8,17 +8,6 @@ class ReaderCoordinator: NSObject {
 
     var failureBlock: (() -> Void)? = nil
 
-    var source: UIViewController? = nil {
-        didSet {
-            let hasSource = source != nil
-            let sourceIsTopViewController = source == topNavigationController?.topViewController
-
-            isNavigatingFromSource = hasSource && (sourceIsTopViewController || readerIsNotCurrentlySelected)
-        }
-    }
-
-    private var isNavigatingFromSource = false
-
     @objc
     init(readerNavigationController: UINavigationController,
          readerSplitViewController: WPSplitViewController,
@@ -28,12 +17,6 @@ class ReaderCoordinator: NSObject {
         self.readerMenuViewController = readerMenuViewController
 
         super.init()
-    }
-
-    private func prepareToNavigate() {
-        WPTabBarController.sharedInstance().showReaderTab()
-
-        topNavigationController?.popToRootViewController(animated: isNavigatingFromSource)
     }
 
     func showReaderTab() {
@@ -150,22 +133,6 @@ class ReaderCoordinator: NSObject {
         WPTabBarController.sharedInstance().navigateToReader(detailViewController)
     }
 
-    private var topNavigationController: UINavigationController? {
-        guard readerIsNotCurrentlySelected == false else {
-            return source?.navigationController
-        }
-
-        if readerMenuViewController.splitViewControllerIsHorizontallyCompact == false,
-            let navigationController = readerSplitViewController.topDetailViewController?.navigationController {
-            return navigationController
-        }
-
-        return readerNavigationController
-    }
-
-    private var readerIsNotCurrentlySelected: Bool {
-        return WPTabBarController.sharedInstance().selectedViewController != readerSplitViewController
-    }
 }
 
 extension ReaderTopicService {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -29,6 +29,7 @@ class ReaderCoordinator: NSObject {
 
         super.init()
     }
+
     private func prepareToNavigate() {
         WPTabBarController.sharedInstance().showReaderTab()
 
@@ -42,7 +43,7 @@ class ReaderCoordinator: NSObject {
     func showDiscover() {
         WPTabBarController.sharedInstance().switchToDiscover()
     }
-    
+
     func showSearch() {
         WPTabBarController.sharedInstance().navigateToReaderSearch()
     }
@@ -76,26 +77,14 @@ class ReaderCoordinator: NSObject {
         WPTabBarController.sharedInstance()?.switchToTopic(where: { $0 == topic })
     }
 
-    // here
     func showTag(named tagName: String) {
-        if !isNavigatingFromSource, !FeatureFlag.newReaderNavigation.enabled {
-            prepareToNavigate()
-        }
-
         let remote = ReaderTopicServiceRemote(wordPressComRestApi: WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress()))
         let slug = remote.slug(forTopicName: tagName) ?? tagName.lowercased()
-        guard !FeatureFlag.newReaderNavigation.enabled else {
-            getTagTopic(tagSlug: slug) { result in
-                guard let topic = try? result.get() else { return }
-                WPTabBarController.sharedInstance()?.navigateToReaderTag(topic)
-            }
-            return
-        }
-        let controller = ReaderStreamViewController.controllerWithTagSlug(slug)
-        controller.streamLoadFailureBlock = failureBlock
 
-        readerSplitViewController.showDetailViewController(controller, sender: nil)
-        readerMenuViewController.deselectSelectedRow(animated: false)
+        getTagTopic(tagSlug: slug) { result in
+            guard let topic = try? result.get() else { return }
+            WPTabBarController.sharedInstance()?.navigateToReaderTag(topic)
+        }
     }
 
     private func getTagTopic(tagSlug: String, completion: @escaping (Result<ReaderTagTopic, Error>) -> Void) {
@@ -122,7 +111,7 @@ class ReaderCoordinator: NSObject {
             guard let topic = try? result.get() else {
                 return
             }
-            
+
             WPTabBarController.sharedInstance()?.navigateToReaderSite(topic)
         }
     }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -26,10 +26,7 @@ class ReaderCoordinator: NSObject {
 
     func showA8CTeam() {
         WPTabBarController.sharedInstance()?.switchToTopic(where: { topic in
-            guard (topic as? ReaderTeamTopic)?.slug == ReaderTeamTopic.a8cTeamSlug else {
-                return false
-            }
-            return true
+            return (topic as? ReaderTeamTopic)?.slug == ReaderTeamTopic.a8cTeamSlug
         })
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -59,8 +59,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)popNotificationsTabToRoot;
 - (void)switchNotificationsTabToNotificationSettings;
 
-- (void)switchReaderTabToSavedPosts;
-
 - (void)showNotificationsTabForNoteWithID:(NSString *)notificationID;
 - (void)updateNotificationBadgeVisibility;
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -121,11 +121,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
                                                      name:WordPressAuthenticator.WPSigninDidFinishNotification
                                                    object:nil];
 
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(switchReaderTabToSavedPosts)
-                                                     name:NSNotification.ShowAllSavedForLaterPostsNotification
-                                                   object:nil];
-
         // Watch for application badge number changes
         [[UIApplication sharedApplication] addObserver:self
                                             forKeyPath:WPApplicationIconBadgeNumberKeyPath
@@ -465,11 +460,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [self.notificationsNavigationController popToRootViewControllerAnimated:NO];
 
     [self.notificationsViewController showNotificationSettings];
-}
-
-- (void)switchReaderTabToSavedPosts
-{
-    [self switchToSavedPosts];
 }
 
 - (NSString *)currentlySelectedScreen

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -53,6 +53,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 @property (nonatomic, strong) WPSplitViewController *blogListSplitViewController;
 @property (nonatomic, strong) WPSplitViewController *notificationsSplitViewController;
+@property (nonatomic, strong) ReaderTabViewModel *readerTabViewModel;
 
 @property (nonatomic, strong) UIImage *notificationsTabBarImage;
 @property (nonatomic, strong) UIImage *notificationsTabBarImageUnread;
@@ -252,6 +253,14 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     }
 
     return _blogListSplitViewController;
+}
+
+- (ReaderTabViewModel *)readerTabViewModel
+{
+    if (!_readerTabViewModel) {
+        _readerTabViewModel = [self makeReaderTabViewModel];
+    }
+    return _readerTabViewModel;
 }
 
 - (UISplitViewController *)notificationsSplitViewController


### PR DESCRIPTION
Fixes #n/a

This removes the `newReaderNavigation` feature flag, all associated checks, and unused code. 

There is more cleanup that will be done in follow-up PRs. Namely:
- Remove unused files.
- Address `TODO: - READERNAV`s.

To test:

There should be no functional changes, so just smoke test the Reader and all the filters to ensure they behave as expected. 

Note: there is an [existing issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/15381) with unsaving posts from the Saved filter.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
