### PR TITLE
Activity Log: change it to UIViewController and change ImmuTable to accepts VCs with tableView

### DIFF
--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -234,7 +234,7 @@ public enum ImmuTableCell {
 ///         reference to the handler from your view controller.
 ///
 open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDelegate {
-    typealias UIViewControllerWithTableView = ImmuTableView & UITableViewDataSource & UITableViewDelegate & UIViewController
+    typealias UIViewControllerWithTableView = TableViewContainer & UITableViewDataSource & UITableViewDelegate & UIViewController
 
     @objc unowned let target: UIViewControllerWithTableView
     private weak var passthroughScrollViewDelegate: UIScrollViewDelegate?
@@ -453,8 +453,8 @@ extension UITableView: CellRegistrar {
 
 // MARK: - UITableViewController conformance
 
-@objc public protocol ImmuTableView: class {
+@objc public protocol TableViewContainer: class {
     var tableView: UITableView! { get set }
 }
 
-extension UITableViewController: ImmuTableView {}
+extension UITableViewController: TableViewContainer {}

--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -234,13 +234,15 @@ public enum ImmuTableCell {
 ///         reference to the handler from your view controller.
 ///
 open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDelegate {
-    @objc unowned let target: UITableViewController
+    typealias UIViewControllerWithTableView = ImmuTableView & UITableViewDataSource & UITableViewDelegate & UIViewController
+
+    @objc unowned let target: UIViewControllerWithTableView
     private weak var passthroughScrollViewDelegate: UIScrollViewDelegate?
 
     /// Initializes the handler with a target table view controller.
     /// - postcondition: After initialization, it becomse the data source and
     ///   delegate for the the target's table view.
-    @objc public init(takeOver target: UITableViewController, with passthroughScrollViewDelegate: UIScrollViewDelegate? = nil) {
+    @objc init(takeOver target: UIViewControllerWithTableView, with passthroughScrollViewDelegate: UIScrollViewDelegate? = nil) {
         self.target = target
         self.passthroughScrollViewDelegate = passthroughScrollViewDelegate
 
@@ -293,14 +295,14 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
     open func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         if target.responds(to: #selector(UITableViewDelegate.tableView(_:willSelectRowAt:))) {
-            return target.tableView(tableView, willSelectRowAt: indexPath)
+            return target.tableView?(tableView, willSelectRowAt: indexPath)
         } else {
             return indexPath
         }
     }
     open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if target.responds(to: #selector(UITableViewDelegate.tableView(_:didSelectRowAt:))) {
-            target.tableView(tableView, didSelectRowAt: indexPath)
+            target.tableView?(tableView, didSelectRowAt: indexPath)
         } else {
             let row = viewModel.rowAtIndexPath(indexPath)
             row.action?(row)
@@ -320,7 +322,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
     open func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         if target.responds(to: #selector(UITableViewDelegate.tableView(_:heightForFooterInSection:))) {
-            return target.tableView(tableView, heightForFooterInSection: section)
+            return target.tableView?(tableView, heightForFooterInSection: section) ?? UITableView.automaticDimension
         }
 
         return UITableView.automaticDimension
@@ -328,7 +330,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
     open func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         if target.responds(to: #selector(UITableViewDelegate.tableView(_:heightForHeaderInSection:))) {
-            return target.tableView(tableView, heightForHeaderInSection: section)
+            return target.tableView?(tableView, heightForHeaderInSection: section) ?? UITableView.automaticDimension
         }
 
         return UITableView.automaticDimension
@@ -336,7 +338,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
     open func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         if target.responds(to: #selector(UITableViewDelegate.tableView(_:viewForFooterInSection:))) {
-            return target.tableView(tableView, viewForFooterInSection: section)
+            return target.tableView?(tableView, viewForFooterInSection: section)
         }
 
         return nil
@@ -344,7 +346,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
     open func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         if target.responds(to: #selector(UITableViewDelegate.tableView(_:viewForHeaderInSection:))) {
-            return target.tableView(tableView, viewForHeaderInSection: section)
+            return target.tableView?(tableView, viewForHeaderInSection: section)
         }
 
         return nil
@@ -352,7 +354,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
     open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         if target.responds(to: #selector(UITableViewDataSource.tableView(_:canEditRowAt:))) {
-            return target.tableView(tableView, canEditRowAt: indexPath)
+            return target.tableView?(tableView, canEditRowAt: indexPath) ?? false
         }
 
         return false
@@ -360,7 +362,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
     open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
         if target.responds(to: #selector(UITableViewDelegate.tableView(_:editActionsForRowAt:))) {
-            return target.tableView(tableView, editActionsForRowAt: indexPath)
+            return target.tableView?(tableView, editActionsForRowAt: indexPath)
         }
 
         return nil
@@ -448,3 +450,11 @@ extension UITableView: CellRegistrar {
         }
     }
 }
+
+// MARK: - UITableViewController conformance
+
+@objc public protocol ImmuTableView: class {
+    var tableView: UITableView! { get set }
+}
+
+extension UITableViewController: ImmuTableView {}

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -4,14 +4,16 @@ import SVProgressHUD
 import WordPressShared
 import WordPressFlux
 
-class ActivityListViewController: UITableViewController, ImmuTablePresenter {
-
+class ActivityListViewController: UIViewController, ImmuTableView, ImmuTablePresenter {
     let site: JetpackSiteRef
     let store: ActivityStore
     let isFreeWPCom: Bool
 
     var changeReceipt: Receipt?
     var isUserTriggeredRefresh: Bool = false
+
+    var tableView: UITableView = UITableView()
+    let refreshControl = UIRefreshControl()
 
     fileprivate lazy var handler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self, with: self)
@@ -41,14 +43,18 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
         self.isFreeWPCom = isFreeWPCom
         self.viewModel = ActivityListViewModel(site: site, store: store)
 
-        super.init(style: .plain)
+        super.init(nibName: nil, bundle: nil)
 
         self.changeReceipt = viewModel.onChange { [weak self] in
             self?.refreshModel()
         }
 
-        refreshControl = UIRefreshControl()
-        refreshControl?.addTarget(self, action: #selector(userRefresh), for: .valueChanged)
+        view.addSubview(tableView)
+
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToSafeArea(tableView)
+
+        refreshControl.addTarget(self, action: #selector(userRefresh), for: .valueChanged)
 
         title = NSLocalizedString("Activity", comment: "Title for the activity list")
     }
@@ -105,10 +111,6 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
     }
 
     private func updateRefreshControl() {
-        guard let refreshControl = refreshControl else {
-            return
-        }
-
         switch (viewModel.refreshing, refreshControl.isRefreshing) {
         case (true, false):
             if isUserTriggeredRefresh {
@@ -127,11 +129,21 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
 
 }
 
+extension ActivityListViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        handler.tableView(tableView, numberOfRowsInSection: section)
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        handler.tableView(tableView, cellForRowAt: indexPath)
+    }
+}
+
 // MARK: - UITableViewDelegate
 
-extension ActivityListViewController {
+extension ActivityListViewController: UITableViewDelegate {
 
-    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         let isLastSection = handler.viewModel.sections.count == section + 1
 
         guard isFreeWPCom, isLastSection, let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: ActivityListSectionHeaderView.identifier) as? ActivityListSectionHeaderView else {
@@ -144,7 +156,7 @@ extension ActivityListViewController {
         return cell
     }
 
-    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         let isLastSection = handler.viewModel.sections.count == section + 1
 
         guard isFreeWPCom, isLastSection else {
@@ -154,7 +166,7 @@ extension ActivityListViewController {
         return UITableView.automaticDimension
     }
 
-    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: ActivityListSectionHeaderView.identifier) as? ActivityListSectionHeaderView else {
             return nil
         }
@@ -164,11 +176,11 @@ extension ActivityListViewController {
         return cell
     }
 
-    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return ActivityListSectionHeaderView.height
     }
 
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         guard let row = handler.viewModel.rowAtIndexPath(indexPath) as? ActivityListRow else {
             return false
         }
@@ -176,7 +188,7 @@ extension ActivityListViewController {
         return row.activity.isRewindable
     }
 
-    override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
         guard let row = handler.viewModel.rowAtIndexPath(indexPath) as? ActivityListRow, row.activity.isRewindable else {
             return nil
         }
@@ -191,7 +203,7 @@ extension ActivityListViewController {
         return [rewindAction]
     }
 
-    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
         let contentHeight = scrollView.contentSize.height
         let shouldLoadMore = offsetY > contentHeight - (2 * scrollView.frame.size.height) && viewModel.hasMore

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -4,7 +4,7 @@ import SVProgressHUD
 import WordPressShared
 import WordPressFlux
 
-class ActivityListViewController: UIViewController, ImmuTableView, ImmuTablePresenter {
+class ActivityListViewController: UIViewController, TableViewContainer, ImmuTablePresenter {
     let site: JetpackSiteRef
     let store: ActivityStore
     let isFreeWPCom: Bool


### PR DESCRIPTION
This PR does two changes:

1. Changes `ImmuTableViewHandler` to accepts `UIViewController`s that has a tableView and conforms to `UITableViewDelegate` and `UITableViewDataSource`
2. Changes `ActivityListViewController` to `UIViewController`

The reason for this change is that for the new Activity Log I need to add custom views, like this filter at the top:

<img src="https://user-images.githubusercontent.com/7040243/100141639-81469200-2e71-11eb-9c5f-39c37860bb72.png" width="300">

`UITableViewController` makes this simple change extremely hard and painfully (even when using `tableViewHeader`).

This change keeps the functionality for all the existent `ImmuTableViewHandler` consumers (with zero code changes in them) while allows it to be used with plain `UIViewController`.

Another solution would be to get rid of `ImmuTable` stuff from the ActivityListViewController, but based on my analysis this would be a little bit more complex. Analyzing the trade-off, it seems that this is the best option (for now)

### To test

1. Tap in any blog on your list
2. Go to Activity Log
3. Scroll down, make sure pagination works

#### Testing other parts that uses `ImmuTableViewHandler`

1. Tap your profile picture
2. Go to Help & Support and make sure the table view appears correctly
3. Close it, open another site that uses Jetpack
4. Tap Jetpack Settings
5. Make sure the table view appears correctly (tap some options)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
