### PR TITLE
Updates the WordPressKit pod version.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.22-beta.2'
+    pod 'WordPressKit', '~> 4.22-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''

--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.21.0'
+    pod 'WordPressKit', '~> 4.22-beta.2'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.29.0)
-  - WordPressKit (~> 4.22-beta.2)
+  - WordPressKit (~> 4.22-beta)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.13.0)
   - WordPressUI (~> 1.7.4-beta.1)
@@ -769,6 +769,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 274813fdb9bd1d3e3674f63ad45732f1c0cf84eb
+PODFILE CHECKSUM: 1d840cd2312e1c085e31c91e3656083657ad120f
 
 COCOAPODS: 1.9.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -406,7 +406,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7.0)
-  - WordPressKit (4.21.0):
+  - WordPressKit (4.22.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.29.0)
-  - WordPressKit (~> 4.21.0)
+  - WordPressKit (~> 4.22-beta.2)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.13.0)
   - WordPressUI (~> 1.7.4-beta.1)
@@ -753,7 +753,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: c8bd7279b38e1c56dd620b8f05535e350117c99e
-  WordPressKit: d3b78d26af69a402974fd1489511f63518956a49
+  WordPressKit: b3287fe7f56a36ede0cf423bfd81e79ac80964c2
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 532ad68f954d37ea901e8c7e3ca62913c43ff787
   WordPressUI: 8e33da6093701c1c9b6ed5a3ee2de80d73849d8a
@@ -769,6 +769,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 1ee77316da67fd96e6b7d8cb15e5dbfeb686f66c
+PODFILE CHECKSUM: 274813fdb9bd1d3e3674f63ad45732f1c0cf84eb
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
Closes #15332

This change is already tested as part of https://github.com/wordpress-mobile/WordPressKit-iOS/pull/305

To test:
Make sure everything builds. 

Thanks again for the nudge @ScoutHarris !

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
