### PR TITLE
Fix display of time picker for post scheduling on iOS 14

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] Support contact information prompt: fixed issue that could cause the app to crash when entering email address. [#15210]
 * [*] Fixed an issue where comments viewed in the Reader would always be italicized.
 * [**] Jetpack Section - Added quick and easy access for all the Jetpack features (Stats, Activity Log, Jetpack and Settings) [#15287].
+* [*] Fixed a display issue with the time picker when scheduling posts on iOS 14. [#15392] 
 
 16.1
 -----

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -51,7 +51,7 @@ struct PublishSettingsViewModel {
         title = post.postTitle
 
         dateFormatter = SiteDateFormatters.dateFormatter(for: post.blog, dateStyle: .long, timeStyle: .none, managedObjectContext: context)
-        dateTimeFormatter = SiteDateFormatters.dateFormatter(for: post.blog, dateStyle: .long, timeStyle: .short, managedObjectContext: context)
+        dateTimeFormatter = SiteDateFormatters.dateFormatter(for: post.blog, dateStyle: .medium, timeStyle: .short, managedObjectContext: context)
 
         let blogService = BlogService(managedObjectContext: context)
         timeZone = blogService.timeZone(for: post.blog)

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
@@ -166,6 +166,11 @@ class TimePickerViewController: UIViewController, DatePickerSheet, DateCoordinat
 
     private lazy var datePicker: UIDatePicker = {
         let datePicker = UIDatePicker()
+
+        if #available(iOS 13.4, *) {
+            datePicker.preferredDatePickerStyle = .wheels
+        }
+
         datePicker.datePickerMode = .time
         datePicker.timeZone = coordinator?.timeZone
         datePicker.addTarget(self, action: #selector(timePickerChanged(_:)), for: .valueChanged)


### PR DESCRIPTION
This PR fixes the appearance of the time picker when scheduling posts on iOS 14. It was previously using the new iOS 14 style time picker, but that doesn't fit with the current setup of the view controller. This PR switches it to use the wheel style picker. It also changes the time label to use a `medium` date format, as the `long` format overflowed sometimes.

Before:

<img width="374" alt="image" src="https://user-images.githubusercontent.com/4780/100260390-3eec8600-2f41-11eb-87b5-69100c1cba68.png">

<img width="374" alt="image" src="https://user-images.githubusercontent.com/4780/100260508-63e0f900-2f41-11eb-955c-58c2764afe34.jpeg">

After:

<img width="374" alt="image" src="https://user-images.githubusercontent.com/4780/100260548-73f8d880-2f41-11eb-8e8e-3bd883093fa7.png">

To test:

- Build and run on iOS 14
- Open the editor and navigate to Post Settings > Publish Date, and try setting a time
- Also check on the pre-publishing nudges screen, where you can also set a publish date
- Also test things are still fine on iOS < 14

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
