### PR TITLE
Fix Jetpack header and add Whitelisted IPs tracking

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -89,6 +89,8 @@ import Foundation
     case jetpackManageConnectionViewed
     case jetpackDisconnectTapped
     case jetpackDisconnectRequested
+    case jetpackWhitelistedIpsViewed
+    case jetpackWhitelistedIpsChanged
 
     /// A String that represents the event
     var value: String {
@@ -236,6 +238,10 @@ import Foundation
             return "jetpack_disconnect_tapped"
         case .jetpackDisconnectRequested:
             return "jetpack_disconnect_requested"
+        case .jetpackWhitelistedIpsViewed:
+            return "jetpack_whitelisted_ips_viewed"
+        case .jetpackWhitelistedIpsChanged:
+            return "jetpack_whitelisted_ips_changed"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1339,9 +1339,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     BlogDetailsSection *section = [self.tableSections objectAtIndex:sectionNum];
     if (section.showQuickStartMenu) {
         return [self quickStartHeaderWithTitle:section.title];
-    } else {
-        return nil;
+    } else if (sectionNum == 0 && [self.blog supports:BlogFeatureJetpackSettings]) {
+        // Jetpack header shouldn't have any padding
+        BlogDetailsSectionHeaderView *headerView = (BlogDetailsSectionHeaderView *)[tableView dequeueReusableHeaderFooterViewWithIdentifier:BlogDetailsSectionHeaderViewIdentifier];
+        headerView.ellipsisButton.hidden = YES;
+        headerView.title = @"";
+        return headerView;
     }
+
+    return nil;
 }
 
 - (UIView *)quickStartHeaderWithTitle:(NSString *)title

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
@@ -255,12 +255,14 @@ open class JetpackSettingsViewController: UITableViewController {
                                                                // viewWillAppear will trigger a refresh, maybe before
                                                                // the new IPs are saved, so lets refresh again here
                                                                self?.refreshSettings()
+                                                            WPAnalytics.track(.jetpackWhitelistedIpsChanged)
                                                            },
                                                            failure: { [weak self] (_) in
                                                                self?.refreshSettingsAfterSavingError()
                                                            })
             }
             self.navigationController?.pushViewController(settingsViewController, animated: true)
+            WPAnalytics.track(.jetpackWhitelistedIpsViewed)
         }
     }
 


### PR DESCRIPTION
Fixes #15396

### To test

#### Jetpack header

1. Open a Jetpack site
2. Check that the Jetpack header doesn't have an additional top padding

#### Whitelisted IPs events

1. Open Jetpack Settings
2. Tap "Whitelisted IP addresses" and make sure `jetpack_whitelisted_ips_viewed` is fired
3. Add a new IP (or remove) and make sure `jetpack_whitelisted_ips_changed` is fired

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
