### PR TITLE
Quick start tour update: Mark the theme selection step as completed

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -21,9 +21,12 @@ open class QuickStartTourGuide: NSObject {
 
 
         let createTour = QuickStartCreateTour()
-        let themeTour = QuickStartThemeTour()
         completed(tour: createTour, for: blog)
-        completed(tour: themeTour, for: blog)
+
+        if FeatureFlag.siteCreationHomePagePicker.enabled {
+            let themeTour = QuickStartThemeTour()
+            completed(tour: themeTour, for: blog)
+        }
     }
 
     @objc func remove(from blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -21,7 +21,9 @@ open class QuickStartTourGuide: NSObject {
 
 
         let createTour = QuickStartCreateTour()
+        let themeTour = QuickStartThemeTour()
         completed(tour: createTour, for: blog)
+        completed(tour: themeTour, for: blog)
     }
 
     @objc func remove(from blog: Blog) {


### PR DESCRIPTION
With the release of the home page picker https://github.com/wordpress-mobile/WordPress-iOS/pull/15303
We make users pick a theme during site creation. We thus need to mark the theme selection step as completed in the quick start tour screen.

To test:
- Create a site
- Pick a theme
- Take the tour
- Notice "Choose a theme" is marked as completed

<img src="https://user-images.githubusercontent.com/230230/100604279-9b1b2580-3306-11eb-83b6-46683fec8fba.png" width="30%"/>

## TODO
- [ ] Don't mark it as completed if user chose "Skip"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
