### PR TITLE
[Home Page Picker] Mark Theme Selection as Completed as part of the Site Creation Flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -16,12 +16,16 @@ open class QuickStartTourGuide: NSObject {
 
     private override init() {}
 
-    func setup(for blog: Blog) {
+    func setup(for blog: Blog, withCompletedSteps steps: [QuickStartTour] = []) {
         didShowUpgradeToV2Notice(for: blog)
 
 
         let createTour = QuickStartCreateTour()
         completed(tour: createTour, for: blog)
+
+        steps.forEach { (tour) in
+            completed(tour: tour, for: blog)
+        }
     }
 
     @objc func remove(from blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -230,7 +230,7 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
         var completedTourSteps: [QuickStartTour] = []
 
         guard FeatureFlag.siteCreationHomePagePicker.enabled else { return completedTourSteps }
-        /// Only make the theme tour completed if the user didn't select skip
+        /// Only mark the theme tour as completed if the user didn't select the skip
         if siteCreator.design != nil {
             completedTourSteps.append(QuickStartThemeTour())
         }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -225,6 +225,19 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
         }
     }
 
+    /// Returns a list of completed tour items that were taken care of as part of the site creation flow.
+    private var completedTourSteps: [QuickStartTour] {
+        var completedTourSteps: [QuickStartTour] = []
+
+        guard FeatureFlag.siteCreationHomePagePicker.enabled else { return completedTourSteps }
+        /// Only make the theme tour completed if the user didn't select skip
+        if siteCreator.design != nil {
+            completedTourSteps.append(QuickStartThemeTour())
+        }
+
+        return completedTourSteps
+    }
+
     private func showQuickStartAlert(for blog: Blog) {
         guard !UserDefaults.standard.quickStartWasDismissedPermanently else {
             return
@@ -234,7 +247,7 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
             return
         }
 
-        let fancyAlert = FancyAlertViewController.makeQuickStartAlertController(blog: blog)
+        let fancyAlert = FancyAlertViewController.makeQuickStartAlertController(blog: blog, withCompletedSteps: completedTourSteps)
         fancyAlert.modalPresentationStyle = .custom
         fancyAlert.transitioningDelegate = tabBar
         tabBar.present(fancyAlert, animated: true)

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
@@ -17,16 +17,16 @@ extension FancyAlertViewController {
         static let alertKey = "alert"
     }
 
-    /// Create the fancy alert controller for the Quick Start request
+    /// Create the fancy alert controller for the Quick Start request and marks the QuickStartTourSteps as completed
     ///
     /// - Returns: FancyAlertViewController of the request
-    @objc static func makeQuickStartAlertController(blog: Blog) -> FancyAlertViewController {
+    static func makeQuickStartAlertController(blog: Blog, withCompletedSteps steps: [QuickStartTour] = []) -> FancyAlertViewController {
         WPAnalytics.track(.quickStartRequestAlertViewed)
 
         let allowButton = ButtonConfig(Strings.allowButtonText) { controller, _ in
             controller.dismiss(animated: true)
 
-            QuickStartTourGuide.shared.setup(for: blog)
+            QuickStartTourGuide.shared.setup(for: blog, withCompletedSteps: steps)
 
             WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "positive"])
         }


### PR DESCRIPTION
With the release of the home page picker https://github.com/wordpress-mobile/WordPress-iOS/pull/15303
We make users pick a theme during site creation. We thus need to mark the theme selection step as completed in the quick start tour screen.

## To test:

## Choose a theme
- Create a site
- Pick a theme
- Take the tour
- Notice "Choose a theme" is marked as completed

<kdb><a href="https://user-images.githubusercontent.com/3384451/100634714-a584f180-32fd-11eb-8b4a-854428164173.PNG"><img width="300" src="https://user-images.githubusercontent.com/3384451/100634714-a584f180-32fd-11eb-8b4a-854428164173.PNG"/></a></kdb>

## Skip site creation
- Create a site
- Select `Skip` on Choose a Design
- Take the tour
- Notice "Choose a theme" is in the checklist

<kdb><a href="https://user-images.githubusercontent.com/3384451/100634782-b6356780-32fd-11eb-90d5-bd96704f19c4.PNG"><img width="300" src="https://user-images.githubusercontent.com/3384451/100634782-b6356780-32fd-11eb-90d5-bd96704f19c4.PNG"/></a></kdb>


## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
