### PR TITLE
[Home Page Picker] Adjust Home Page Picker Image Ratio

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
@@ -4,7 +4,10 @@ import WordPressKit
 class SiteDesignContentCollectionViewController: CollapsableHeaderViewController {
     let completion: SiteDesignStep.SiteDesignSelection
     let itemSpacing: CGFloat = 20
-    let cellSize = CGSize(width: 160, height: 230)
+    static let aspectRatio: CGFloat = 0.75
+    static let cellWidth: CGFloat = 160
+    static let cellHeight: CGFloat = cellWidth / aspectRatio
+    let cellSize = CGSize(width: cellWidth, height: cellHeight)
     let restAPI = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress())
     let collectionView: UICollectionView
     let collectionViewLayout: UICollectionViewFlowLayout


### PR DESCRIPTION
Resolves a cropping issue discovered in the call for testing for the home page picker. 

## To test:
1. Create a site.
1. On Choose a Design screen; expect the screenshot titles to not be cut off.

Before | After
--- | ---
<kdb><a href="https://user-images.githubusercontent.com/3384451/100657120-c9573000-331b-11eb-8b54-e8ad8e7a7bd8.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/100657120-c9573000-331b-11eb-8b54-e8ad8e7a7bd8.png"/></a></kdb> | <kdb><a href="https://user-images.githubusercontent.com/3384451/100657296-091e1780-331c-11eb-984f-71fd076be30a.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/100657296-091e1780-331c-11eb-984f-71fd076be30a.png"/></a></kdb>

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
