### PR TITLE
Adds the Shadow to layout cells on starter page and home page pickers

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+16.4
+-----
+* [**] Added shadow to thumbnail cells on Site Creation and Page Creation design pickers to add better contrast [https://github.com/wordpress-mobile/WordPress-iOS/pull/15418]
+
 16.3
 -----
 * [**] Fixed a bug where @-mentions didn't work on WordPress.com sites with plugins enabled [#14844]
@@ -8,14 +12,14 @@
 * [***] Block Editor: Adding support for selecting different unit of value in Cover and Columns blocks [https://github.com/WordPress/gutenberg/pull/26161]
 * [*] Block Editor: Fix theme colors syncing with the editor [https://github.com/WordPress/gutenberg/pull/26821]
 * [*] My Site > Settings > Start Over. Correcting a translation error in the detailed instructions on the Start Over view. [#15358]
- 
+
 16.2
 -----
 * [**] Support contact email: fixed issue that prevented non-alpha characters from being entered. [#15210]
 * [*] Support contact information prompt: fixed issue that could cause the app to crash when entering email address. [#15210]
 * [*] Fixed an issue where comments viewed in the Reader would always be italicized.
 * [**] Jetpack Section - Added quick and easy access for all the Jetpack features (Stats, Activity Log, Jetpack and Settings) [#15287].
-* [*] Fixed a display issue with the time picker when scheduling posts on iOS 14. [#15392] 
+* [*] Fixed a display issue with the time picker when scheduling posts on iOS 14. [#15392]
 
 16.1
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.xib
@@ -3,14 +3,14 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CollapsableHeaderCollectionViewCell" id="gTV-IL-0wX" customClass="CollapsableHeaderCollectionViewCell" customModule="WordPress" customModuleProvider="target">
+        <collectionViewCell opaque="NO" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CollapsableHeaderCollectionViewCell" id="gTV-IL-0wX" customClass="CollapsableHeaderCollectionViewCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="160" height="230"/>
             <autoresizingMask key="autoresizingMask"/>
             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">


### PR DESCRIPTION
This takes care of an issue @iamthomasbishop pointed out. While doing some refactoring towards the end of the Modal Layout Picker Project and at the start of Home Page Picker we accidentally disabled the shadow around the layout cells. This reenables those shadows on the cells.

## To test:
1. Navigate to Site Creation "Choose a Design"
1. **Expect** to see a shadow around the thumbnail cells
1. Navigate to Starter Page Layout Picker (Create a new page)
1. **Expect** to see a shadow around the thumbnail cells

📓 The shadow is only set to appear in Light Mode (it should be hidden in dark mode)

## Screenshots:

Before | After
--- | ---
<kbd><a href="https://user-images.githubusercontent.com/3384451/100751563-7d58c980-33b5-11eb-9fd5-0a1b5501b090.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/100751563-7d58c980-33b5-11eb-9fd5-0a1b5501b090.png"/></a></kbd> | <kbd><a href="https://user-images.githubusercontent.com/3384451/100752571-c1989980-33b6-11eb-90bf-22b2e47aafbb.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/100752571-c1989980-33b6-11eb-90bf-22b2e47aafbb.png"/></a></kbd>
<kbd><a href="https://user-images.githubusercontent.com/3384451/100751608-8a75b880-33b5-11eb-84aa-ea79352e5645.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/100751608-8a75b880-33b5-11eb-84aa-ea79352e5645.png"/></a></kbd> | <kbd><a href="https://user-images.githubusercontent.com/3384451/100752504-b0e82380-33b6-11eb-9d4e-85579e90f7c5.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/100752504-b0e82380-33b6-11eb-9d4e-85579e90f7c5.png"/></a></kbd>


## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
