### PR TITLE
Update the background color of the search header on choose a domain

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+16.4
+-----
+* [*] Adjusted the search box background color in dark mode on Choose a domain screen to be full width. [https://github.com/wordpress-mobile/WordPress-iOS/pull/15419]
+
 16.3
 -----
 * [**] Fixed a bug where @-mentions didn't work on WordPress.com sites with plugins enabled [#14844]

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -124,6 +124,7 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
         searchHeader.addConstraints([top, bottom, leading, trailing])
         searchHeader.addTopBorder(withColor: .divider)
         searchHeader.addBottomBorder(withColor: .divider)
+        searchHeader.backgroundColor = searchTextField.backgroundColor
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
This fixes an issue I discovered while doing some testing. The Search box header background color cuts off at the safe areas instead of going to the edges. 

## To test:
1. Switch phone to Dark Mode
1. Navigate to Site Creation 
1. Complete the flow up to Choose a Domain
1. **Expect** the background color to be full width on the header

Before | After
--- | ---
<kbd><a href="https://user-images.githubusercontent.com/3384451/100756265-10e0c900-33bb-11eb-95c4-1a1902f49132.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/100756265-10e0c900-33bb-11eb-95c4-1a1902f49132.png"/></a></kbd> | <kbd><a href="https://user-images.githubusercontent.com/3384451/100756314-1ccc8b00-33bb-11eb-947a-afa49a9929ae.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/100756314-1ccc8b00-33bb-11eb-947a-afa49a9929ae.png"/></a></kbd>

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
