### PR TITLE
iOS 14 Widgets: Customizer - removes hidden sites from and orders the sites alphabetically.

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -1029,7 +1029,7 @@ private extension InsightStoreState {
 
         let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
 
-        return blogService.blogsForAllAccounts().reduce(into: [Int: HomeWidgetTodayData]()) { result, element in
+        return blogService.visibleBlogsForWPComAccounts().reduce(into: [Int: HomeWidgetTodayData]()) { result, element in
             if let blogID = element.dotComID,
                let url = element.url,
                let blog = blogService.blog(byBlogId: blogID) {

--- a/WordPress/WordPressIntents/SitesDataProvider.swift
+++ b/WordPress/WordPressIntents/SitesDataProvider.swift
@@ -39,7 +39,20 @@ class SitesDataProvider {
                 display: data.siteName,
                 subtitle: siteDomain,
                 image: nil)
-        }.sorted(by: { $0.displayString.lowercased() < $1.displayString.lowercased() })
+        }.sorted(by: { (firstSite, secondSite) -> Bool in
+            let firstTitle = firstSite.displayString.lowercased()
+            let secondTitle = secondSite.displayString.lowercased()
+
+            guard firstTitle != secondTitle else {
+                let firstSubtitle = firstSite.subtitleString?.lowercased() ?? ""
+                let secondSubtitle = secondSite.subtitleString?.lowercased() ?? ""
+
+                return firstSubtitle <= secondSubtitle
+            }
+
+            return firstTitle < secondTitle
+
+        })
     }
 
     // MARK: - Default Site

--- a/WordPress/WordPressIntents/SitesDataProvider.swift
+++ b/WordPress/WordPressIntents/SitesDataProvider.swift
@@ -39,7 +39,7 @@ class SitesDataProvider {
                 display: data.siteName,
                 subtitle: siteDomain,
                 image: nil)
-        }
+        }.sorted(by: { $0.displayString.lowercased() < $1.displayString.lowercased() })
     }
 
     // MARK: - Default Site


### PR DESCRIPTION
Changes to the widget customizer to remove all hidden sites and to order the selectable sites alphabetically.

## To test:

It could be best to remove your existing WP installation so that this is run from scratch.

1. Launch the app to ensure the list of sites is stored in the cache
2. Launch the Intents extension, and select WordPress to run it.
3. Once WPiOS is up, go back to the Springboard.
4. Add the Widget if it's not already added.
5. Long tap on the widget, and tap "Edit Widget"
6. Open the site picker.

- Make sure none of your hidden sites are listed.
- Make sure sites are listed alphabetically.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
