### PR TITLE
Update Auth version and add new delegate methods.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -198,7 +198,7 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.2'
 
-    pod 'WordPressAuthenticator', '~> 1.30.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.31.0-beta'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -394,7 +394,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.30.0-beta.2):
+  - WordPressAuthenticator (1.31.0-beta.2):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -504,7 +504,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.30.0-beta)
+  - WordPressAuthenticator (~> 1.31.0-beta)
   - WordPressKit (~> 4.22-beta)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.13.0)
@@ -752,7 +752,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 711c32e897f78dfa2b7b3b81f2ec64b5ba0b0ce7
+  WordPressAuthenticator: 6144728478567e3ecb9514ac0ac434d203e7f26b
   WordPressKit: b3287fe7f56a36ede0cf423bfd81e79ac80964c2
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 532ad68f954d37ea901e8c7e3ca62913c43ff787
@@ -769,6 +769,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 2fd7b5e045c068b43de83b7f418278e998277687
+PODFILE CHECKSUM: 79048254e3ceb0282df0302ca3d3c2e614ed70df
 
 COCOAPODS: 1.9.3

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -329,6 +329,22 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         }
     }
 
+    /// Indicates if the given Auth error should be handled by the host app.
+    ///
+    func shouldHandleError(_ error: Error) -> Bool {
+        // Here for protocol compliance.
+        return false
+    }
+
+    /// Handles the given error.
+    /// Called if `shouldHandleError` is true.
+    ///
+    func handleError(_ error: Error, onCompletion: @escaping (UIViewController) -> Void) {
+        // Here for protocol compliance.
+        let vc = UIViewController()
+        onCompletion(vc)
+    }
+
     /// Tracks a given Analytics Event.
     ///
     func track(event: WPAnalyticsStat) {


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/525

This updates Auth to `1.31.0-beta` and adds two new delegate methods added in the above PR.

To test:
- Update pods.
- Verify WP builds.
- Verify you can login with a self-hosted site.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
