### PR TITLE
Accessibility: treat title as a heading + add escape gesture in Reader Detail

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -163,6 +163,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         })
     }
 
+    override func accessibilityPerformEscape() -> Bool {
+        navigationController?.popViewController(animated: true)
+        return true
+    }
+
     func render(_ post: ReaderPost) {
         configureDiscoverAttribution(post)
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
@@ -252,7 +252,7 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
         isAccessibilityElement = false
 
         titleLabel.accessibilityLabel = title
-        titleLabel.accessibilityTraits = .staticText
+        titleLabel.accessibilityTraits = .header
     }
 
 }


### PR DESCRIPTION
Fixes #12904

This PR addresses two issues mentioned in https://github.com/wordpress-mobile/WordPress-iOS/issues/12904#issuecomment-734787963

1. Article titles should be displayed as headings in the Reader Detail view
2. It should be possible to return to the article overview in the Reader tab with the escape gesture

Note that the [original issue regarding inconsistencies in VoiceOver navigation](https://github.com/wordpress-mobile/WordPress-iOS/issues/12904#issue-519432103), which was reported over a year ago, has already been resolved.

### To test:

1. Build and run this branch on a device
2. Enable VoiceOver
3. Navigate to Reader tab > Pick a post > Reader Detail 
    - The title should be recognized as a **heading** in VoiceOver ✅ 
4. Trigger the [escape gesture with a two-finger Z-shaped gesture](https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/SupportingAccessibility.html)
    - Triggering the escape gesture **should bring a user back to the Reader tab** ✅ 

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
