### PR TITLE
Point WPAuthenticator to the branch that allows host apps to block account creation

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -198,9 +198,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.0.2'
 
-    pod 'WordPressAuthenticator', '~> 1.31.0-beta'
+    # pod 'WordPressAuthenticator', '~> 1.31.0-beta'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/no-wp-signup'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -394,7 +394,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.31.0-beta.2):
+  - WordPressAuthenticator (1.31.0-beta.3):
     - 1PasswordExtension (= 1.8.6)
     - Alamofire (= 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -504,7 +504,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.31.0-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/no-wp-signup`)
   - WordPressKit (~> 4.23.0-beta.3)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.13.0)
@@ -553,7 +553,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -655,6 +654,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.43.0-alpha2
+  WordPressAuthenticator:
+    :branch: issue/no-wp-signup
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.43.0-alpha2/third-party-podspecs/Yoga.podspec.json
 
@@ -673,6 +675,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.43.0-alpha2
+  WordPressAuthenticator:
+    :commit: b393bb8dd4eadff6237367afea07977bd9eedad7
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -752,7 +757,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a79ccdfc940373835a7d8e9fc7541e6bf61b6319
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 6144728478567e3ecb9514ac0ac434d203e7f26b
+  WordPressAuthenticator: b43cd7f1ec8eb0bd2efd5b7b93d16d72be402046
   WordPressKit: 794e212fcae36e3cda176908744608f6857f871e
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 532ad68f954d37ea901e8c7e3ca62913c43ff787
@@ -769,6 +774,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 5dac84f8c9638692da364dfd1d06a259b1dec4ec
+PODFILE CHECKSUM: 39ba6c23c0030a2cd2568af4f42280549d2c5682
 
 COCOAPODS: 1.9.3


### PR DESCRIPTION
Ref: wordpress-mobile/WordPressAuthenticator-iOS#534

This is a draft PR to help test that new functionality added to WPAuthenticator does not break the ability to register a new WordPress.com account.

<img src="https://user-images.githubusercontent.com/2722505/101126025-92dc2680-3635-11eb-9b2a-d39121501380.gif" width="350"/>

I will close this PR if/when the corresponding PR in WPAuthenticator is merged.

## Changes
* Pointed WPAuthenticator to the branch in fight

To test:
* Checkout the branch, run bundle exec pod install
* Log out if necessary
* Log in again: Tap Continue with WordPress.com, and enter an email address that does not match a WP.com account. The app should still offer creating a new WordPress.com account.


