### PR TITLE
Add a subscription_count property to the reader_* events/stats

### DIFF
--- a/WordPress/Classes/Services/FollowCommentsService.swift
+++ b/WordPress/Classes/Services/FollowCommentsService.swift
@@ -67,7 +67,7 @@ class FollowCommentsService: NSObject {
             var properties = [String: Any]()
             properties[WPAppAnalyticsKeyFollowAction] = followAction.rawValue
             properties[WPAppAnalyticsKeyBlogID] = self.siteID
-            WPAnalytics.trackReader(.readerToggleFollowConversation, properties: properties, service: self.readerTopicService)
+            WPAnalytics.trackReader(.readerToggleFollowConversation, properties: properties)
 
             success()
         }

--- a/WordPress/Classes/Services/FollowCommentsService.swift
+++ b/WordPress/Classes/Services/FollowCommentsService.swift
@@ -6,11 +6,16 @@ class FollowCommentsService: NSObject {
     let post: ReaderPost
     let remote: ReaderPostServiceRemote
 
+    private let coreDataStack: CoreDataStack
+    private let readerTopicService: ReaderTopicService
+
     fileprivate let postID: Int
     fileprivate let siteID: Int
 
     @objc required init?(post: ReaderPost,
-                         remote: ReaderPostServiceRemote = ReaderPostServiceRemote.withDefaultApi()) {
+                         remote: ReaderPostServiceRemote = ReaderPostServiceRemote.withDefaultApi(),
+                         coreDataStack: CoreDataStack = ContextManager.shared,
+                         readerTopicService: ReaderTopicService? = nil) {
         guard let postID = post.postID as? Int, let siteID = post.siteID as? Int else {
             return nil
         }
@@ -19,6 +24,8 @@ class FollowCommentsService: NSObject {
         self.postID = postID
         self.siteID = siteID
         self.remote = remote
+        self.coreDataStack = coreDataStack
+        self.readerTopicService = ReaderTopicService(managedObjectContext: coreDataStack.mainContext)
     }
 
     @objc class func createService(with post: ReaderPost) -> FollowCommentsService? {
@@ -60,7 +67,7 @@ class FollowCommentsService: NSObject {
             var properties = [String: Any]()
             properties[WPAppAnalyticsKeyFollowAction] = followAction.rawValue
             properties[WPAppAnalyticsKeyBlogID] = self.siteID
-            WPAnalytics.track(.readerToggleFollowConversation, properties: properties)
+            WPAnalytics.trackReader(.readerToggleFollowConversation, properties: properties, service: self.readerTopicService)
 
             success()
         }

--- a/WordPress/Classes/Services/FollowCommentsService.swift
+++ b/WordPress/Classes/Services/FollowCommentsService.swift
@@ -6,16 +6,11 @@ class FollowCommentsService: NSObject {
     let post: ReaderPost
     let remote: ReaderPostServiceRemote
 
-    private let coreDataStack: CoreDataStack
-    private let readerTopicService: ReaderTopicService
-
     fileprivate let postID: Int
     fileprivate let siteID: Int
 
     @objc required init?(post: ReaderPost,
-                         remote: ReaderPostServiceRemote = ReaderPostServiceRemote.withDefaultApi(),
-                         coreDataStack: CoreDataStack = ContextManager.shared,
-                         readerTopicService: ReaderTopicService? = nil) {
+                         remote: ReaderPostServiceRemote = ReaderPostServiceRemote.withDefaultApi()) {
         guard let postID = post.postID as? Int, let siteID = post.siteID as? Int else {
             return nil
         }
@@ -24,8 +19,6 @@ class FollowCommentsService: NSObject {
         self.postID = postID
         self.siteID = siteID
         self.remote = remote
-        self.coreDataStack = coreDataStack
-        self.readerTopicService = ReaderTopicService(managedObjectContext: coreDataStack.mainContext)
     }
 
     @objc class func createService(with post: ReaderPost) -> FollowCommentsService? {

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -358,6 +358,12 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 
     // Define success block
     void (^successBlock)(void) = ^void() {
+        
+        // Update subscription count
+        NSInteger oldSubscriptionCount = [WPAnalytics subscriptionCount];
+        NSInteger newSubscriptionCount = follow ? oldSubscriptionCount + 1 : oldSubscriptionCount - 1;
+        [WPAnalytics setSubscriptionCount:newSubscriptionCount];
+        
         if (shouldRefreshFollowedPosts) {
             [self refreshPostsForFollowedTopic];
         }

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -500,12 +500,13 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
     // Define success block
     void (^successBlock)(void) = ^void() {
-        [self refreshPostsForFollowedTopic];
         
         // Update subscription count
         NSInteger oldSubscriptionCount = [WPAnalytics subscriptionCount];
         NSInteger newSubscriptionCount = newFollowValue ? oldSubscriptionCount + 1 : oldSubscriptionCount - 1;
         [WPAnalytics setSubscriptionCount:newSubscriptionCount];
+        
+        [self refreshPostsForFollowedTopic];
         
         if (success) {
             success();

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -51,6 +51,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 {
     ReaderTopicServiceRemote *service = [[ReaderTopicServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
     [service fetchFollowedSitesWithSuccess:^(NSArray *sites) {
+        [WPAnalytics setSubscriptionCount: sites.count];
         [self mergeFollowedSites:sites withSuccess:success];
     } failure:^(NSError *error) {
         if (failure) {
@@ -500,6 +501,12 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     // Define success block
     void (^successBlock)(void) = ^void() {
         [self refreshPostsForFollowedTopic];
+        
+        // Update subscription count
+        NSInteger oldSubscriptionCount = [WPAnalytics subscriptionCount];
+        NSInteger newSubscriptionCount = newFollowValue ? oldSubscriptionCount + 1 : oldSubscriptionCount - 1;
+        [WPAnalytics setSubscriptionCount:newSubscriptionCount];
+        
         if (success) {
             success();
         }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -303,6 +303,8 @@ import Foundation
 
 extension WPAnalytics {
 
+    private static let WPAppAnalyticsKeySubscriptionCount: String = "subscription_count"
+
     /// Track a event
     ///
     /// This will call each registered tracker and fire the given event.

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -349,6 +349,18 @@ extension WPAnalytics {
         WPAnalytics.track(event, properties: props)
     }
 
+    /// Track a Reader stat
+    ///
+    /// This will call each registered tracker and fire the given event
+    /// - Parameter event: a `String` that represents the Reader event name
+    /// - Parameter properties: a `Hash` that represents the properties
+    ///
+    static func trackReader(_ stat: WPAnalyticsStat, properties: [AnyHashable: Any], service: ReaderTopicService) {
+        var props = properties
+        props[WPAppAnalyticsKeySubscriptionCount] = service.allSiteTopics()?.count ?? 0
+        WPAnalytics.track(stat, withProperties: props)
+    }
+
     /// Track a event in Obj-C
     ///
     /// This will call each registered tracker and fire the given event
@@ -382,6 +394,18 @@ extension WPAnalytics {
         var props = properties
         props[WPAppAnalyticsKeySubscriptionCount] = service.allSiteTopics()?.count ?? 0
         WPAnalytics.track(event, properties: props)
+    }
+
+    /// Track a Reader stat in Obj-C
+    ///
+    /// This will call each registered tracker and fire the given stat
+    /// - Parameter stat: a `String` that represents the Reader stat name
+    /// - Parameter properties: a `Hash` that represents the properties
+    ///
+    @objc static func trackReaderStat(_ stat: WPAnalyticsStat, properties: [AnyHashable: Any], service: ReaderTopicService) {
+        var props = properties
+        props[WPAppAnalyticsKeySubscriptionCount] = service.allSiteTopics()?.count ?? 0
+        WPAnalytics.track(stat, withProperties: props)
     }
 
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -303,6 +303,8 @@ import Foundation
 
 extension WPAnalytics {
 
+    @objc static var subscriptionCount: Int = 0
+
     private static let WPAppAnalyticsKeySubscriptionCount: String = "subscription_count"
 
     /// Track a event
@@ -345,9 +347,9 @@ extension WPAnalytics {
     /// - Parameter event: a `String` that represents the Reader event name
     /// - Parameter properties: a `Hash` that represents the properties
     ///
-    static func trackReader(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any], service: ReaderTopicService) {
+    static func trackReader(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any]) {
         var props = properties
-        props[WPAppAnalyticsKeySubscriptionCount] = service.allSiteTopics()?.count ?? 0
+        props[WPAppAnalyticsKeySubscriptionCount] = subscriptionCount
         WPAnalytics.track(event, properties: props)
     }
 
@@ -357,9 +359,9 @@ extension WPAnalytics {
     /// - Parameter event: a `String` that represents the Reader event name
     /// - Parameter properties: a `Hash` that represents the properties
     ///
-    static func trackReader(_ stat: WPAnalyticsStat, properties: [AnyHashable: Any], service: ReaderTopicService) {
+    static func trackReader(_ stat: WPAnalyticsStat, properties: [AnyHashable: Any]) {
         var props = properties
-        props[WPAppAnalyticsKeySubscriptionCount] = service.allSiteTopics()?.count ?? 0
+        props[WPAppAnalyticsKeySubscriptionCount] = subscriptionCount
         WPAnalytics.track(stat, withProperties: props)
     }
 
@@ -392,9 +394,9 @@ extension WPAnalytics {
     /// - Parameter event: a `String` that represents the Reader event name
     /// - Parameter properties: a `Hash` that represents the properties
     ///
-    @objc static func trackReaderEvent(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any], service: ReaderTopicService) {
+    @objc static func trackReaderEvent(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any]) {
         var props = properties
-        props[WPAppAnalyticsKeySubscriptionCount] = service.allSiteTopics()?.count ?? 0
+        props[WPAppAnalyticsKeySubscriptionCount] = subscriptionCount
         WPAnalytics.track(event, properties: props)
     }
 
@@ -404,9 +406,9 @@ extension WPAnalytics {
     /// - Parameter stat: a `String` that represents the Reader stat name
     /// - Parameter properties: a `Hash` that represents the properties
     ///
-    @objc static func trackReaderStat(_ stat: WPAnalyticsStat, properties: [AnyHashable: Any], service: ReaderTopicService) {
+    @objc static func trackReaderStat(_ stat: WPAnalyticsStat, properties: [AnyHashable: Any]) {
         var props = properties
-        props[WPAppAnalyticsKeySubscriptionCount] = service.allSiteTopics()?.count ?? 0
+        props[WPAppAnalyticsKeySubscriptionCount] = subscriptionCount
         WPAnalytics.track(stat, withProperties: props)
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -325,7 +325,6 @@ extension WPAnalytics {
         WPAnalytics.trackString(event.value, withProperties: mergedProperties)
     }
 
-
     /// This will call each registered tracker and fire the given event.
     /// - Parameters:
     ///   - event: a `String` that represents the event name
@@ -335,6 +334,18 @@ extension WPAnalytics {
         var props = properties
         props[WPAppAnalyticsKeyBlogID] = blog.dotComID
         props[WPAppAnalyticsKeySiteType] = blog.isWPForTeams() ? WPAppAnalyticsValueSiteTypeP2 : WPAppAnalyticsValueSiteTypeBlog
+        WPAnalytics.track(event, properties: props)
+    }
+
+    /// Track a Reader event
+    ///
+    /// This will call each registered tracker and fire the given event
+    /// - Parameter event: a `String` that represents the Reader event name
+    /// - Parameter properties: a `Hash` that represents the properties
+    ///
+    static func trackReader(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any], service: ReaderTopicService) {
+        var props = properties
+        props[WPAppAnalyticsKeySubscriptionCount] = service.allSiteTopics()?.count ?? 0
         WPAnalytics.track(event, properties: props)
     }
 
@@ -359,6 +370,18 @@ extension WPAnalytics {
 
 
         WPAnalytics.trackString(event.value, withProperties: mergedProperties)
+    }
+
+    /// Track a Reader event in Obj-C
+    ///
+    /// This will call each registered tracker and fire the given event
+    /// - Parameter event: a `String` that represents the Reader event name
+    /// - Parameter properties: a `Hash` that represents the properties
+    ///
+    @objc static func trackReaderEvent(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any], service: ReaderTopicService) {
+        var props = properties
+        props[WPAppAnalyticsKeySubscriptionCount] = service.allSiteTopics()?.count ?? 0
+        WPAnalytics.track(event, properties: props)
     }
 
 }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -13,6 +13,7 @@ extern NSString * const WPAppAnalyticsKeyFeedID;
 extern NSString * const WPAppAnalyticsKeyFeedItemID;
 extern NSString * const WPAppAnalyticsKeyIsJetpack;
 extern NSString * const WPAppAnalyticsKeySessionCount;
+extern NSString * const WPAppAnalyticsKeySubscriptionCount;
 extern NSString * const WPAppAnalyticsKeyEditorSource;
 extern NSString * const WPAppAnalyticsKeyCommentID;
 extern NSString * const WPAppAnalyticsKeyLegacyQuickAction;

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -13,7 +13,6 @@ extern NSString * const WPAppAnalyticsKeyFeedID;
 extern NSString * const WPAppAnalyticsKeyFeedItemID;
 extern NSString * const WPAppAnalyticsKeyIsJetpack;
 extern NSString * const WPAppAnalyticsKeySessionCount;
-extern NSString * const WPAppAnalyticsKeySubscriptionCount;
 extern NSString * const WPAppAnalyticsKeyEditorSource;
 extern NSString * const WPAppAnalyticsKeyCommentID;
 extern NSString * const WPAppAnalyticsKeyLegacyQuickAction;

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -19,6 +19,7 @@ NSString * const WPAppAnalyticsKeyFeedID                            = @"feed_id"
 NSString * const WPAppAnalyticsKeyFeedItemID                        = @"feed_item_id";
 NSString * const WPAppAnalyticsKeyIsJetpack                         = @"is_jetpack";
 NSString * const WPAppAnalyticsKeySessionCount                      = @"session_count";
+NSString * const WPAppAnalyticsKeySubscriptionCount                 = @"subscription_count";
 NSString * const WPAppAnalyticsKeyEditorSource                      = @"editor_source";
 NSString * const WPAppAnalyticsKeyCommentID                         = @"comment_id";
 NSString * const WPAppAnalyticsKeyLegacyQuickAction                 = @"is_quick_action";


### PR DESCRIPTION
Partially fixes #15431 

- Adds a `subscription_count` property to reader events/stats
- Updates the `readerToggleFollowConversation` to use the new reader event tracking method

Please note that we'll need to migrate all the other existing reader events in a follow-up PR.

### To test:

1. Try following/unfollowing sites from various places
    - Reader card cell > Options > Follow/unfollow a site
    - Manage > Followed sites > Enter url of a site to follow
    - Manage > Followed sites > Unfollow site
    - Reader post detail > Follow/unfollow a site
2. Navigate to Reader tab > Reader card cell > Comments
3. Toggle the `Follow Conversation` button
4. Check that the `subscription_count` is correct and is tracked in the event properties


### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
