### PR TITLE
Reader: allow horizontal scroll in tables

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
@@ -28,6 +28,10 @@ table {
   width: 100%
 }
 
+.wp-block-table {
+  overflow-x: auto;
+}
+
 div.feedflare { display: none; }
 
 .sharedaddy, .jp-relatedposts, .mc4wp-form, .wpcnt, .OUTBRAIN, .adsbygoogle { display: none; }


### PR DESCRIPTION
This PR adds a horizontal scroll to tables that are bigger than the size of the screen.

<img src="https://user-images.githubusercontent.com/7040243/101416888-8243de80-38c9-11eb-822b-92bf11d48909.gif" width="300">

### To test

1. Open Reader
2. Open a post with a table that exceeds the screen width (you can [use this one](https://atomicalonso12345.blog/2020/12/07/3066/))
3. Make sure you can scroll horizontally

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
