### PR TITLE
Reader: A8C and P2: update type to "organization"

### DIFF
--- a/WordPress/Classes/Models/ReaderTeamTopic.swift
+++ b/WordPress/Classes/Models/ReaderTeamTopic.swift
@@ -4,7 +4,7 @@ import Foundation
     @NSManaged open var slug: String
 
     override open class var TopicType: String {
-        return "team"
+        return "organization"
     }
 
     @objc open var icon: UIImage? {

--- a/WordPress/Classes/Models/ReaderTeamTopic.swift
+++ b/WordPress/Classes/Models/ReaderTeamTopic.swift
@@ -7,17 +7,5 @@ import Foundation
         return "organization"
     }
 
-    @objc open var icon: UIImage? {
-        guard bundledTeamIcons.contains(slug) else {
-            return nil
-        }
-
-        return UIImage(named: slug)
-    }
-
-    fileprivate let bundledTeamIcons: [String] = [
-        ReaderTeamTopic.a8cTeamSlug
-    ]
-
     static let a8cTeamSlug = "a8c"
 }

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -770,10 +770,13 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 {
     if ([remoteTopic.path rangeOfString:@"/tags/"].location != NSNotFound) {
         return [self tagTopicForRemoteTopic:remoteTopic];
+    }
 
-    } else if ([remoteTopic.path rangeOfString:@"/list/"].location != NSNotFound) {
+    if ([remoteTopic.path rangeOfString:@"/list/"].location != NSNotFound) {
         return [self listTopicForRemoteTopic:remoteTopic];
-    } else if ([remoteTopic.type isEqualToString:@"team"]) {
+    }
+
+    if ([remoteTopic.type isEqualToString:@"organization"]) {
         return [self teamTopicForRemoteTopic:remoteTopic];
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -262,7 +262,7 @@ import WordPressShared
             return .tag
         }
         if topic is ReaderTeamTopic {
-            return .team
+            return .organization
         }
         return .noTopic
     }
@@ -347,6 +347,6 @@ enum ReaderTopicType {
     case search
     case site
     case tag
-    case team
+    case organization
     case noTopic
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -116,7 +116,7 @@ extension ReaderTabItemsStore {
     }
 
     private enum ReaderTopicsConstants {
-        static let predicateFormat = "type == 'default' OR type == 'team' OR (type == 'list' AND following == %@ AND showInMenu == YES)"
+        static let predicateFormat = "type == 'default' OR type == 'organization' OR (type == 'list' AND following == %@ AND showInMenu == YES)"
         static let entityName = "ReaderAbstractTopic"
         static let sortByKey = "type"
         static let fetchRequestError = "There was a problem fetching topics for the menu. "


### PR DESCRIPTION
Ref: #15343 

With v1.3 of the endpoint `read/menu`, the `type` for A8C and P2 are `organization`. Previously, A8C was `team`. This updates the app to match the new type.

There should be no visible change, so smoke testing the `Automattic` and `P2s` Reader streams should do it. 

To test:

---
No P2s:
- Log in with an account that is not subscribed to any P2s or A8C P2s.
- Verify the Reader does not have an `Automattic` or `P2s` menu item.

---
P2s:
- Log in with an account that is following/a user on a new P2.
- Verify the Reader does have a `P2s` menu item.

---
Automattic:
- Log in with an account that is following A8C P2s.
- Verify the Reader does have an `Automattic` menu item.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
