### PR TITLE
Gutenberg - Fix Gallery block uploads when the editor is closed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,7 @@
 * [*] For DotCom and Jetpack sites, you can now subscribe to comments by tapping the "Follow conversation" button in the Comments view. [#15424]
 * [**] Reader: Added 'P2s' stream. [#15442]
 * [*] Add a new P2 default site icon to replace the generic default site icon. [#15430]
-* [*] Block Editor: Fix Gallery block uploads when the editor is closed
+* [*] Block Editor: Fix Gallery block uploads when the editor is closed. [#15457]
 
 16.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] For DotCom and Jetpack sites, you can now subscribe to comments by tapping the "Follow conversation" button in the Comments view. [#15424]
 * [**] Reader: Added 'P2s' stream. [#15442]
 * [*] Add a new P2 default site icon to replace the generic default site icon. [#15430]
+* [*] Block Editor: Fix Gallery block uploads when the editor is closed
 
 16.3
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergGalleryUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergGalleryUploadProcessor.swift
@@ -137,7 +137,7 @@ class GutenbergGalleryUploadProcessor: Processor {
             updatedBlock += jsonString
         }
         updatedBlock += " -->"
-        if let linkTo = block.attributes[GalleryBlockKeys.linkTo] as? String {
+        if let linkTo = block.attributes[GalleryBlockKeys.linkTo] as? String, linkTo != "none" {
             if linkTo == "media" {
                 self.linkToURL = self.remoteURLString
             } else if linkTo == "attachment" {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergGalleryUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergGalleryUploadProcessor.swift
@@ -138,9 +138,9 @@ class GutenbergGalleryUploadProcessor: Processor {
         }
         updatedBlock += " -->"
         if let linkTo = block.attributes[GalleryBlockKeys.linkTo] as? String, linkTo != "none" {
-            if linkTo == "media" {
+            if linkTo == "file" {
                 self.linkToURL = self.remoteURLString
-            } else if linkTo == "attachment" {
+            } else if linkTo == "post" {
                 self.linkToURL = self.mediaLink
             }
             updatedBlock += self.linkPostMediaUploadProcessor.process(block.content)

--- a/WordPress/WordPressTest/Gutenberg/GutenbergGalleryUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/Gutenberg/GutenbergGalleryUploadProcessorTests.swift
@@ -5,13 +5,13 @@ class GutenbergGalleryUploadProcessorTests: XCTestCase {
 
     let idVariations = [
         """
-<!-- wp:gallery {"ids":[-708,-415,-701],"columns":3,"linkTo":"media"} -->
+<!-- wp:gallery {"ids":[-708,-415,-701],"columns":3,"linkTo":"file"} -->
 """,
         """
-<!-- wp:gallery {"ids":["-708","-415","-701"],"columns":3,"linkTo":"media"} -->
+<!-- wp:gallery {"ids":["-708","-415","-701"],"columns":3,"linkTo":"file"} -->
 """,
         """
-<!-- wp:gallery {"ids":[-708,-415,"-701"],"columns":3,"linkTo":"media"} -->
+<!-- wp:gallery {"ids":[-708,-415,"-701"],"columns":3,"linkTo":"file"} -->
 """,
     ]
 
@@ -55,7 +55,7 @@ class GutenbergGalleryUploadProcessorTests: XCTestCase {
 """
 
     let postResultContent = """
-<!-- wp:gallery {"columns":3,"ids":[708,415,701],"linkTo":"media"} -->
+<!-- wp:gallery {"columns":3,"ids":[708,415,701],"linkTo":"file"} -->
 <figure class="wp-block-gallery columns-3 is-cropped">
     <ul class="blocks-gallery-grid">
         <li class="blocks-gallery-item">


### PR DESCRIPTION
Fixes an issue found while sanity testing the `1.43.0` Gutenberg mobile [release](https://github.com/wordpress-mobile/gutenberg-mobile/pull/2874).

Fixes https://github.com/WordPress/gutenberg/issues/27618

Due to this [Gutenberg change](https://github.com/WordPress/gutenberg/pull/25582) that updated the values for the `linkTo` attribute, the Gallery processor stopped working correctly. This PR updates the values to the new ones:

* `media` → `file` 
* `attachment` → `post`

It also takes into account the default value `none` to process the images without links.

To test:

- [ ] Gallery block - Close post with an ongoing image upload - [steps](https://github.com/wordpress-mobile/test-cases/blob/master/test-cases/gutenberg/gallery.md#tc002)

Test the different Gallery link to options: `None`, `Media File`, and `Attachment Page`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
