### PR TITLE
Reader: track when A8C and P2 are shown

### DIFF
--- a/WordPress/Classes/Models/ReaderTeamTopic.swift
+++ b/WordPress/Classes/Models/ReaderTeamTopic.swift
@@ -7,6 +7,10 @@ import Foundation
         return "organization"
     }
 
+    var shownTrackEvent: WPAnalyticsEvent {
+        return slug == ReaderTeamTopic.a8cSlug ? .readerA8CShown : .readerP2Shown
+    }
+
     static let a8cSlug = "a8c"
     static let p2Slug = "p2"
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -56,6 +56,8 @@ import Foundation
     case readerFollowingShown
     case readerSavedListShown
     case readerLikedShown
+    case readerA8CShown
+    case readerP2Shown
     case readerBlogPreviewed
     case readerDiscoverPaginated
     case readerPostCardTapped
@@ -188,6 +190,10 @@ import Foundation
             return "reader_following_shown"
         case .readerLikedShown:
             return "reader_liked_shown"
+        case .readerA8CShown:
+            return "reader_a8c_shown"
+        case .readerP2Shown:
+            return "reader_p2_shown"
         case .readerSavedListShown:
             return "reader_saved_list_shown"
         case .readerBlogPreviewed:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -157,7 +157,10 @@ import WordPressShared
         } else if isTopicTag(topic) {
             stat = .readerTagLoaded
 
+        } else if let teamTopic = topic as? ReaderTeamTopic {
+            WPAnalytics.track(teamTopic.shownTrackEvent, properties: properties)
         }
+
         if stat != nil {
             WPAnalytics.track(stat!, withProperties: properties)
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -843,7 +843,9 @@ import WordPressFlux
             return
         }
 
-        guard let topic = readerTopic, let properties = topicPropertyForStats(), isViewLoaded && view.window != nil else {
+        guard let topic = readerTopic,
+              let properties = topicPropertyForStats(),
+              isViewLoaded && view.window != nil else {
             return
         }
 


### PR DESCRIPTION
Ref: #15343 

Adds tracking for Reader A8C and P2 streams being shown.

To test:
- Navigate to Reader > A8C.
- Verify `🔵 Tracked: reader_a8c_shown <list: Automattic>` appears.
- Navigate to Reader > P2.
- Verify `🔵 Tracked: reader_p2_shown <list: P2s>` appears.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
