### PR TITLE
Tags and Categories description in Prepublishing bottom sheet 

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -30,11 +30,43 @@ class PrepublishingViewController: UITableViewController {
     }()
 
     private let completion: (AbstractPost) -> ()
-
+    
+    private func rowTitle(rowID: PrepublishingIdentifier) ->  NSAttributedString {
+        switch rowID {
+        case .visibility:
+            return NSAttributedString(string:NSLocalizedString("Visibility", comment: "Label for Visibility"), attributes: nil)
+        case .schedule:
+            return NSAttributedString(string: Constants.publishDateLabel, attributes: nil)
+        case .tags:
+            let font = UIFont.systemFont(ofSize: 12.0)
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: UIColor.textSubtle,
+            ]
+            
+            let firstString = NSMutableAttributedString(string: "Tags ", attributes: nil)
+            let secondString = NSAttributedString(string: "(Grow Your audience)", attributes: attributes)
+            firstString.append(secondString)
+            
+            return firstString
+        case .categories:
+            let font = UIFont.systemFont(ofSize: 12.0)
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: UIColor.textSubtle,
+            ]
+            let firstString = NSMutableAttributedString(string: "Categories ", attributes: nil)
+            let secondString = NSAttributedString(string: "(Group your posts)", attributes: attributes)
+            firstString.append(secondString)
+            
+            return firstString
+        }
+    }
+    
     private let options: [PrepublishingOption] = [
         PrepublishingOption(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility")),
         PrepublishingOption(id: .schedule, title: Constants.publishDateLabel),
-        PrepublishingOption(id: .tags, title: NSLocalizedString("Tags", comment: "Label for Tags")),
+        PrepublishingOption(id: .tags, title: "Tags"),
         PrepublishingOption(id: .categories, title: NSLocalizedString("Categories", comment: "Label for Categories"))
     ]
 
@@ -118,12 +150,16 @@ class PrepublishingViewController: UITableViewController {
 
         switch options[indexPath.row].id {
         case .tags:
+            cell.textLabel?.attributedText = rowTitle(rowID: .tags)
             configureTagCell(cell)
         case .visibility:
+            cell.textLabel?.attributedText = rowTitle(rowID: .visibility)
             configureVisibilityCell(cell)
         case .schedule:
+            cell.textLabel?.attributedText = rowTitle(rowID: .schedule)
             configureScheduleCell(cell)
         case .categories:
+            cell.textLabel?.attributedText = rowTitle(rowID: .categories)
             configureCategoriesCell(cell)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -45,7 +45,7 @@ class PrepublishingViewController: UITableViewController {
             ]
             
             let firstString = NSMutableAttributedString(string: "Tags ", attributes: nil)
-            let secondString = NSAttributedString(string: "(Grow Your audience)", attributes: attributes)
+            let secondString = NSAttributedString(string: "(Grow your audience)", attributes: attributes)
             firstString.append(secondString)
             
             return firstString

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -30,11 +30,11 @@ class PrepublishingViewController: UITableViewController {
     }()
 
     private let completion: (AbstractPost) -> ()
-    
+
     private func rowTitle(rowID: PrepublishingIdentifier) ->  NSAttributedString {
         switch rowID {
         case .visibility:
-            return NSAttributedString(string:NSLocalizedString("Visibility", comment: "Label for Visibility"), attributes: nil)
+            return NSAttributedString(string: NSLocalizedString("Visibility", comment: "Label for Visibility"), attributes: nil)
         case .schedule:
             return NSAttributedString(string: Constants.publishDateLabel, attributes: nil)
         case .tags:
@@ -43,11 +43,11 @@ class PrepublishingViewController: UITableViewController {
                 .font: font,
                 .foregroundColor: UIColor.textSubtle,
             ]
-            
+
             let firstString = NSMutableAttributedString(string: "Tags ", attributes: nil)
             let secondString = NSAttributedString(string: "(Grow your audience)", attributes: attributes)
             firstString.append(secondString)
-            
+
             return firstString
         case .categories:
             let font = UIFont.systemFont(ofSize: 12.0)
@@ -58,11 +58,11 @@ class PrepublishingViewController: UITableViewController {
             let firstString = NSMutableAttributedString(string: "Categories ", attributes: nil)
             let secondString = NSAttributedString(string: "(Group your posts)", attributes: attributes)
             firstString.append(secondString)
-            
+
             return firstString
         }
     }
-    
+
     private let options: [PrepublishingOption] = [
         PrepublishingOption(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility")),
         PrepublishingOption(id: .schedule, title: Constants.publishDateLabel),


### PR DESCRIPTION
The goal of this PR is to add a small text describing the difference between categories and tags in the prepublishing bottom sheet. 

Since the font and color attributes of the description text are different I had to create an NSAttributedString. 

The way the code is written now is not great. There are duplications in the code and settings of String and attributed string. Please help me improve this PR by:
1. Offering a better way of having the title as attributed string 
2. Possibly finding a better phrase for tags 

To test:
1. Start a new post 
2. Tap publish 
3. See the prepublishing bottom sheet 
4. See tags description and categories description 

![Simulator Screen Shot - iPhone 11 Pro - 2020-12-09 at 18 27 47](https://user-images.githubusercontent.com/1335657/101714377-51d97d00-3a4e-11eb-8a9c-c5b383e6dddd.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
