### PR TITLE
Allow collapsed title to shrink the font to fit the space

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -33,6 +33,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         title.font = WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.largeTitle, fontWeight: .semibold).withSize(17)
         title.isHidden = true
         title.adjustsFontSizeToFitWidth = true
+        title.minimumScaleFactor = 2/3
         return title
     }()
     @IBOutlet weak var largeTitleTopSpacingConstraint: NSLayoutConstraint!

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -32,6 +32,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         title.adjustsFontForContentSizeCategory = true
         title.font = WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.largeTitle, fontWeight: .semibold).withSize(17)
         title.isHidden = true
+        title.adjustsFontSizeToFitWidth = true
         return title
     }()
     @IBOutlet weak var largeTitleTopSpacingConstraint: NSLayoutConstraint!


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-Android/pull/13563#issuecomment-742232259

cc @iamthomasbishop @kyleaparker This is the PR to align iOS to the shrinking behavior we discussed for Android on the Choose a Design screen.

## To test:
1. Switch your [device language](https://support.apple.com/en-us/HT204031) to a language that such has a longer translated string for Choose a design
    - `Russian` and `Albanian` are the longest by per character count
1. Open the app and Create a new site
    - My Sites > ➕ > Create WordPress.com Site
1. Scroll so that the header collpases to the small title
1. **Expect** to have the title fix in the space and not show an elipsee 

Before | After
--- | ---
<kbd><a href="https://user-images.githubusercontent.com/3384451/101820300-640df680-3af4-11eb-9aec-09080c145fc8.jpeg"><img width="300" src="https://user-images.githubusercontent.com/3384451/101820300-640df680-3af4-11eb-9aec-09080c145fc8.jpeg"/></a></kbd> | <kbd><a href="https://user-images.githubusercontent.com/3384451/101820325-6e2ff500-3af4-11eb-8afa-847e88b10f26.jpeg"><img width="300" src="https://user-images.githubusercontent.com/3384451/101820325-6e2ff500-3af4-11eb-8afa-847e88b10f26.jpeg"/></a></kbd>

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
