### PR TITLE
Activity Log: filter bar design

### DIFF
--- a/WordPress/Classes/Extensions/UIEdgeInsets.swift
+++ b/WordPress/Classes/Extensions/UIEdgeInsets.swift
@@ -1,6 +1,14 @@
 import UIKit
 
 extension UIEdgeInsets {
+    var flippedForRightToLeft: UIEdgeInsets {
+        guard UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft else {
+            return self
+        }
+
+        return flippedForRightToLeftLayoutDirection()
+    }
+
     func flippedForRightToLeftLayoutDirection() -> UIEdgeInsets {
         return UIEdgeInsets(top: top, left: right, bottom: bottom, right: left)
     }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -170,6 +170,7 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
         filterStackView.addArrangedSubview(filterIcon)
         let scrollView = UIScrollView()
         scrollView.canCancelContentTouches = true
+        scrollView.showsHorizontalScrollIndicator = false
         filterStackView.addArrangedSubview(dateFilterChip)
         filterStackView.addArrangedSubview(activityTypeFilterChip)
         scrollView.addSubview(filterStackView)

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -14,7 +14,7 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
 
     let containerStackView = UIStackView()
 
-    let filterStackView = UIStackView()
+    let filterView = FilterBarView()
     let dateFilterChip = FilterChipButton()
     let activityTypeFilterChip = FilterChipButton()
 
@@ -35,10 +35,6 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
     fileprivate var viewModel: ActivityListViewModel
     private enum Constants {
         static let estimatedRowHeight: CGFloat = 62
-        static let filterHeightAnchor: CGFloat = 24
-        static let filterStackViewSpacing: CGFloat = 8
-        static let filterBarHorizontalPadding: CGFloat = 16
-        static let filterBarVerticalPadding: CGFloat = 8
     }
 
     // MARK: - GUI
@@ -162,48 +158,13 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
     }
 
     private func setupFilterBar() {
-        let filterIcon = UIImageView(image: UIImage.gridicon(.filter))
-        filterIcon.tintColor = .listIcon
-        filterIcon.heightAnchor.constraint(equalToConstant: Constants.filterHeightAnchor).isActive = true
-        filterStackView.alignment = .center
-        filterStackView.spacing = Constants.filterStackViewSpacing
-        filterStackView.addArrangedSubview(filterIcon)
-        let scrollView = UIScrollView()
-        scrollView.canCancelContentTouches = true
-        scrollView.showsHorizontalScrollIndicator = false
-        filterStackView.addArrangedSubview(dateFilterChip)
-        filterStackView.addArrangedSubview(activityTypeFilterChip)
-        scrollView.addSubview(filterStackView)
-        containerStackView.addArrangedSubview(scrollView)
-        filterStackView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            filterStackView.leftAnchor.constraint(equalTo: scrollView.leftAnchor, constant: Constants.filterBarHorizontalPadding),
-            filterStackView.rightAnchor.constraint(equalTo: scrollView.rightAnchor, constant: Constants.filterBarHorizontalPadding),
-            filterStackView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: Constants.filterBarVerticalPadding),
-            filterStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: Constants.filterBarVerticalPadding),
-            scrollView.heightAnchor.constraint(equalTo: filterStackView.heightAnchor, constant: 2 * Constants.filterBarVerticalPadding)
-        ])
+        containerStackView.addArrangedSubview(filterView)
 
-        // Ensure that the stackview is right aligned in RTL layouts
-        if view.userInterfaceLayoutDirection() == .rightToLeft {
-            scrollView.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
-            filterStackView.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
-        }
+        filterView.add(button: dateFilterChip)
+        filterView.add(button: activityTypeFilterChip)
 
         setupDateFilter()
-
         setupActivityTypeFilter()
-
-        let separator = UIView()
-        separator.translatesAutoresizingMaskIntoConstraints = false
-        scrollView.addSubview(separator)
-        NSLayoutConstraint.activate([
-            separator.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: 16),
-            separator.leftAnchor.constraint(equalTo: scrollView.leftAnchor),
-            separator.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
-            separator.heightAnchor.constraint(equalToConstant: 1)
-        ])
-        WPStyleGuide.applyBorderStyle(separator)
     }
 
     private func setupDateFilter() {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -184,6 +184,12 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
             scrollView.heightAnchor.constraint(equalTo: filterStackView.heightAnchor, constant: 2 * Constants.filterBarVerticalPadding)
         ])
 
+        // Ensure that the stackview is right aligned in RTL layouts
+        if view.userInterfaceLayoutDirection() == .rightToLeft {
+            scrollView.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
+            filterStackView.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
+        }
+
         setupDateFilter()
 
         setupActivityTypeFilter()

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -35,6 +35,10 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
     fileprivate var viewModel: ActivityListViewModel
     private enum Constants {
         static let estimatedRowHeight: CGFloat = 62
+        static let filterHeightAnchor: CGFloat = 24
+        static let filterStackViewSpacing: CGFloat = 8
+        static let filterBarHorizontalPadding: CGFloat = 16
+        static let filterBarVerticalPadding: CGFloat = 8
     }
 
     // MARK: - GUI
@@ -158,22 +162,41 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
     }
 
     private func setupFilterBar() {
+        let filterIcon = UIImageView(image: UIImage.gridicon(.filter))
+        filterIcon.tintColor = .listIcon
+        filterIcon.heightAnchor.constraint(equalToConstant: Constants.filterHeightAnchor).isActive = true
+        filterStackView.alignment = .center
+        filterStackView.spacing = Constants.filterStackViewSpacing
+        filterStackView.addArrangedSubview(filterIcon)
         let scrollView = UIScrollView()
+        scrollView.canCancelContentTouches = true
         filterStackView.addArrangedSubview(dateFilterChip)
         filterStackView.addArrangedSubview(activityTypeFilterChip)
         scrollView.addSubview(filterStackView)
         containerStackView.addArrangedSubview(scrollView)
         filterStackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            filterStackView.leftAnchor.constraint(equalTo: scrollView.leftAnchor),
-            filterStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-            filterStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
-            scrollView.heightAnchor.constraint(equalTo: filterStackView.heightAnchor)
+            filterStackView.leftAnchor.constraint(equalTo: scrollView.leftAnchor, constant: Constants.filterBarHorizontalPadding),
+            filterStackView.rightAnchor.constraint(equalTo: scrollView.rightAnchor, constant: Constants.filterBarHorizontalPadding),
+            filterStackView.topAnchor.constraint(equalTo: scrollView.topAnchor, constant: Constants.filterBarVerticalPadding),
+            filterStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: Constants.filterBarVerticalPadding),
+            scrollView.heightAnchor.constraint(equalTo: filterStackView.heightAnchor, constant: 2 * Constants.filterBarVerticalPadding)
         ])
 
         setupDateFilter()
 
         setupActivityTypeFilter()
+
+        let separator = UIView()
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(separator)
+        NSLayoutConstraint.activate([
+            separator.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: 16),
+            separator.leftAnchor.constraint(equalTo: scrollView.leftAnchor),
+            separator.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+            separator.heightAnchor.constraint(equalToConstant: 1)
+        ])
+        WPStyleGuide.applyBorderStyle(separator)
     }
 
     private func setupDateFilter() {

--- a/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
@@ -138,7 +138,7 @@ class CalendarViewController: UIViewController {
 
     private func startEndDateHeader() -> UIView {
         let header = UIStackView(frame: .zero)
-        header.distribution = .fillProportionally
+        header.distribution = .fill
 
         let startDate = UILabel()
         startDateLabel = startDate
@@ -151,12 +151,14 @@ class CalendarViewController: UIViewController {
             startDate.textAlignment = .left
         }
         header.addArrangedSubview(startDate)
+        startDate.widthAnchor.constraint(equalTo: header.widthAnchor, multiplier: 0.47).isActive = true
 
         let separator = UILabel()
         separatorDateLabel = separator
         separator.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
         separator.textAlignment = .center
         header.addArrangedSubview(separator)
+        separator.widthAnchor.constraint(equalTo: header.widthAnchor, multiplier: 0.06).isActive = true
 
         let endDate = UILabel()
         endDateLabel = endDate
@@ -169,6 +171,7 @@ class CalendarViewController: UIViewController {
             endDate.textAlignment = .right
         }
         header.addArrangedSubview(endDate)
+        endDate.widthAnchor.constraint(equalTo: header.widthAnchor, multiplier: 0.47).isActive = true
 
         resetLabels()
 

--- a/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
@@ -11,6 +11,7 @@ class CalendarViewController: UIViewController {
     private var startDateLabel: UILabel!
     private var separatorDateLabel: UILabel!
     private var endDateLabel: UILabel!
+    private let gradient = GradientView()
 
     private var startDate: Date?
     private var endDate: Date?
@@ -70,6 +71,8 @@ class CalendarViewController: UIViewController {
 
         setupNavButtons()
 
+        setUpGradient()
+
         calendarCollectionView.calDataSource.didSelect = { [weak self] startDate, endDate in
             self?.updateDates(startDate: startDate, endDate: endDate)
         }
@@ -87,6 +90,12 @@ class CalendarViewController: UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
 
         calendarCollectionView.reloadData()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        setUpGradientColors()
     }
 
     private func setupNavButtons() {
@@ -196,6 +205,26 @@ class CalendarViewController: UIViewController {
             label?.textColor = .textSubtle
             label?.font = WPStyleGuide.fontForTextStyle(.title3)
         }
+    }
+
+    private func setUpGradient() {
+        gradient.isUserInteractionEnabled = false
+        gradient.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(gradient)
+
+        NSLayoutConstraint.activate([
+            gradient.heightAnchor.constraint(equalToConstant: 50),
+            gradient.topAnchor.constraint(equalTo: calendarCollectionView.topAnchor),
+            gradient.leadingAnchor.constraint(equalTo: calendarCollectionView.leadingAnchor),
+            gradient.trailingAnchor.constraint(equalTo: calendarCollectionView.trailingAnchor)
+        ])
+
+        setUpGradientColors()
+    }
+
+    private func setUpGradientColors() {
+        gradient.fromColor = .basicBackground
+        gradient.toColor = UIColor.basicBackground.withAlphaComponent(0)
     }
 
     @objc private func done() {

--- a/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
@@ -25,6 +25,7 @@ class CalendarViewController: UIViewController {
 
     private enum Constants {
         static let headerPadding: CGFloat = 16
+        static let endDateLabel = NSLocalizedString("End Date", comment: "Placeholder for the end date in calendar range selection")
     }
 
     /// Creates a full screen year calendar controller
@@ -110,15 +111,17 @@ class CalendarViewController: UIViewController {
 
         startDateLabel.text = formatter.string(from: startDate)
         startDateLabel.textColor = .text
-        startDateLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
+        startDateLabel.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
 
         if let endDate = endDate {
             endDateLabel.text = formatter.string(from: endDate)
             endDateLabel.textColor = .text
-            endDateLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
+            endDateLabel.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
             separatorDateLabel.textColor = .text
-            separatorDateLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
+            separatorDateLabel.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
         } else {
+            endDateLabel.text = Constants.endDateLabel
+            endDateLabel.font = WPStyleGuide.fontForTextStyle(.title3)
             endDateLabel.textColor = .textSubtle
             separatorDateLabel.textColor = .textSubtle
         }
@@ -130,7 +133,7 @@ class CalendarViewController: UIViewController {
 
         let startDate = UILabel()
         startDateLabel = startDate
-        startDate.font = .preferredFont(forTextStyle: .body)
+        startDate.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
         if view.effectiveUserInterfaceLayoutDirection == .leftToRight {
             // swiftlint:disable:next inverse_text_alignment
             startDate.textAlignment = .right
@@ -142,13 +145,13 @@ class CalendarViewController: UIViewController {
 
         let separator = UILabel()
         separatorDateLabel = separator
-        separator.font = .preferredFont(forTextStyle: .body)
+        separator.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
         separator.textAlignment = .center
         header.addArrangedSubview(separator)
 
         let endDate = UILabel()
         endDateLabel = endDate
-        endDate.font = .preferredFont(forTextStyle: .body)
+        endDate.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
         if view.effectiveUserInterfaceLayoutDirection == .leftToRight {
             // swiftlint:disable:next natural_text_alignment
             endDate.textAlignment = .left
@@ -179,11 +182,11 @@ class CalendarViewController: UIViewController {
 
         separatorDateLabel.text = "-"
 
-        endDateLabel.text = NSLocalizedString("End Date", comment: "Placeholder for the end date in calendar range selection")
+        endDateLabel.text = Constants.endDateLabel
 
         [startDateLabel, separatorDateLabel, endDateLabel].forEach { label in
             label?.textColor = .textSubtle
-            label?.font = .preferredFont(forTextStyle: .body)
+            label?.font = WPStyleGuide.fontForTextStyle(.title3)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
@@ -171,10 +171,18 @@ class CalendarViewController: UIViewController {
             calendarCollectionView.superview?.layoutIfNeeded()
         }
 
-        calendarCollectionView.scrollToDate(startDate ?? Date(),
-                                            animateScroll: true,
-                                            preferredScrollPosition: .centeredVertically,
-                                            extraAddedOffset: -(self.calendarCollectionView.frame.height / 2))
+        if let startDate = startDate {
+            calendarCollectionView.scrollToDate(startDate,
+                                                animateScroll: true,
+                                                preferredScrollPosition: .centeredVertically,
+                                                extraAddedOffset: -(self.calendarCollectionView.frame.height / 2))
+        } else {
+            calendarCollectionView.setContentOffset(CGPoint(
+                                                        x: 0,
+                                                        y: calendarCollectionView.contentSize.height - calendarCollectionView.frame.size.height
+            ), animated: false)
+        }
+
     }
 
     private func resetLabels() {

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterBarView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterBarView.swift
@@ -28,22 +28,31 @@ class FilterBarView: UIScrollView {
             heightAnchor.constraint(equalTo: filterStackView.heightAnchor, constant: 2 * Constants.filterBarVerticalPadding)
         ])
 
-        let separator = UIView()
-        separator.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(separator)
-        NSLayoutConstraint.activate([
-            separator.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 16),
-            separator.leftAnchor.constraint(equalTo: leftAnchor),
-            separator.widthAnchor.constraint(equalTo: widthAnchor),
-            separator.heightAnchor.constraint(equalToConstant: 1)
-        ])
-        WPStyleGuide.applyBorderStyle(separator)
-
         // Ensure that the stackview is right aligned in RTL layouts
         if userInterfaceLayoutDirection() == .rightToLeft {
             transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
             filterStackView.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
         }
+    }
+
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+
+        guard let superview = superview else {
+            return
+        }
+
+        let separator = UIView()
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        superview.addSubview(separator)
+        NSLayoutConstraint.activate([
+            separator.bottomAnchor.constraint(equalTo: bottomAnchor),
+            separator.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
+            separator.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
+            separator.heightAnchor.constraint(equalToConstant: 1)
+        ])
+        WPStyleGuide.applyBorderStyle(separator)
+        separator.layer.zPosition = 10
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterBarView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterBarView.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+class FilterBarView: UIScrollView {
+    let filterStackView = UIStackView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        filterStackView.alignment = .center
+        filterStackView.spacing = Constants.filterStackViewSpacing
+        filterStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        let filterIcon = UIImageView(image: UIImage.gridicon(.filter))
+        filterIcon.tintColor = .listIcon
+        filterIcon.heightAnchor.constraint(equalToConstant: Constants.filterHeightAnchor).isActive = true
+
+        filterStackView.addArrangedSubview(filterIcon)
+
+        canCancelContentTouches = true
+        showsHorizontalScrollIndicator = false
+        addSubview(filterStackView)
+
+        NSLayoutConstraint.activate([
+            filterStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.filterBarHorizontalPadding),
+            filterStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -1 * Constants.filterBarHorizontalPadding),
+            filterStackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.filterBarVerticalPadding),
+            filterStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constants.filterBarVerticalPadding),
+            heightAnchor.constraint(equalTo: filterStackView.heightAnchor, constant: 2 * Constants.filterBarVerticalPadding)
+        ])
+
+        let separator = UIView()
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(separator)
+        NSLayoutConstraint.activate([
+            separator.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 16),
+            separator.leftAnchor.constraint(equalTo: leftAnchor),
+            separator.widthAnchor.constraint(equalTo: widthAnchor),
+            separator.heightAnchor.constraint(equalToConstant: 1)
+        ])
+        WPStyleGuide.applyBorderStyle(separator)
+
+        // Ensure that the stackview is right aligned in RTL layouts
+        if userInterfaceLayoutDirection() == .rightToLeft {
+            transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
+            filterStackView.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    func add(button chip: FilterChipButton) {
+        filterStackView.addArrangedSubview(chip)
+    }
+
+    private enum Constants {
+        static let filterHeightAnchor: CGFloat = 24
+        static let filterStackViewSpacing: CGFloat = 8
+        static let filterBarHorizontalPadding: CGFloat = 16
+        static let filterBarVerticalPadding: CGFloat = 8
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterBarView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterBarView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class FilterBarView: UIScrollView {
     let filterStackView = UIStackView()
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
@@ -10,8 +10,8 @@ class FilterChipButton: UIView {
         }
     }
 
-    let mainButton = UIButton(type: .system)
-    let resetButton = UIButton(type: .system)
+    let mainButton = UIButton(type: .custom)
+    let resetButton = UIButton(type: .custom)
 
     /// Callback called when the button is tapped
     var tapped: (() -> Void)?
@@ -27,7 +27,9 @@ class FilterChipButton: UIView {
 
         stackView.addArrangedSubview(mainButton)
 
-        resetButton.setTitle("X", for: .normal)
+        resetButton.setImage(UIImage.gridicon(.crossCircle).imageWithTintColor(.text), for: .normal)
+        resetButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Constants.minResetButtonWidth).isActive = true
+        resetButton.imageEdgeInsets = Constants.resetImageInsets
         resetButton.isHidden = true
         stackView.addArrangedSubview(resetButton)
 
@@ -37,6 +39,15 @@ class FilterChipButton: UIView {
         addSubview(stackView)
         pinSubviewToAllEdges(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        layer.borderColor = UIColor.textQuaternary.cgColor
+        layer.borderWidth = Constants.borderWidth
+        layer.cornerRadius = Constants.cornerRadius
+
+        mainButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.callout)
+        mainButton.setTitleColor(.text, for: .normal)
+        mainButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.minButtonHeight).isActive = true
+        mainButton.contentEdgeInsets = Constants.buttonContentInset
     }
 
     required init?(coder: NSCoder) {
@@ -46,11 +57,13 @@ class FilterChipButton: UIView {
     /// Enables the reset button
     func enableResetButton() {
         resetButton.isHidden = false
+        mainButton.contentEdgeInsets = Constants.buttonContentInsetWithResetEnabled
     }
 
     /// Disables the reset button
     func disableResetButton() {
         resetButton.isHidden = true
+        mainButton.contentEdgeInsets = Constants.buttonContentInset
     }
 
     @objc private func mainButtonTapped() {
@@ -59,5 +72,15 @@ class FilterChipButton: UIView {
 
     @objc private func resetButtonTapped() {
         resetTapped?()
+    }
+
+    private enum Constants {
+        static let minResetButtonWidth: CGFloat = 32
+        static let resetImageInsets = UIEdgeInsets(top: 8, left: 6, bottom: 8, right: 10)
+        static let borderWidth: CGFloat = 1
+        static let cornerRadius: CGFloat = 16
+        static let minButtonHeight: CGFloat = 32
+        static let buttonContentInset = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
+        static let buttonContentInsetWithResetEnabled = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
@@ -82,12 +82,12 @@ class FilterChipButton: UIView {
 
     private enum Constants {
         static let minResetButtonWidth: CGFloat = 32
-        static let resetImageInsets = UIEdgeInsets(top: 8, left: 6, bottom: 8, right: 10)
+        static let resetImageInsets = UIEdgeInsets(top: 8, left: 6, bottom: 8, right: 10).flippedForRightToLeft
         static let borderWidth: CGFloat = 1
         static let cornerRadius: CGFloat = 16
         static let minButtonHeight: CGFloat = 32
-        static let buttonContentInset = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
-        static let buttonContentInsetWithResetEnabled = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
+        static let buttonContentInset = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12).flippedForRightToLeft
+        static let buttonContentInsetWithResetEnabled = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0).flippedForRightToLeft
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
@@ -10,8 +10,8 @@ class FilterChipButton: UIView {
         }
     }
 
-    let mainButton = UIButton(type: .custom)
-    let resetButton = UIButton(type: .custom)
+    let mainButton = UIButton(type: .system)
+    let resetButton = UIButton(type: .system)
 
     /// Callback called when the button is tapped
     var tapped: (() -> Void)?
@@ -76,7 +76,8 @@ class FilterChipButton: UIView {
 
     private func applyColors() {
         layer.borderColor = UIColor.textQuaternary.cgColor
-        resetButton.setImage(UIImage.gridicon(.crossCircle).imageWithTintColor(.text), for: .normal)
+        resetButton.setImage(UIImage.gridicon(.crossCircle), for: .normal)
+        resetButton.tintColor = .text
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
@@ -77,7 +77,7 @@ class FilterChipButton: UIView {
     private func applyColors() {
         layer.borderColor = UIColor.textQuaternary.cgColor
         resetButton.setImage(UIImage.gridicon(.crossCircle), for: .normal)
-        resetButton.tintColor = .text
+        resetButton.tintColor = .textSubtle
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
@@ -27,7 +27,6 @@ class FilterChipButton: UIView {
 
         stackView.addArrangedSubview(mainButton)
 
-        resetButton.setImage(UIImage.gridicon(.crossCircle).imageWithTintColor(.text), for: .normal)
         resetButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Constants.minResetButtonWidth).isActive = true
         resetButton.imageEdgeInsets = Constants.resetImageInsets
         resetButton.isHidden = true
@@ -40,7 +39,6 @@ class FilterChipButton: UIView {
         pinSubviewToAllEdges(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
-        layer.borderColor = UIColor.textQuaternary.cgColor
         layer.borderWidth = Constants.borderWidth
         layer.cornerRadius = Constants.cornerRadius
 
@@ -48,6 +46,8 @@ class FilterChipButton: UIView {
         mainButton.setTitleColor(.text, for: .normal)
         mainButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.minButtonHeight).isActive = true
         mainButton.contentEdgeInsets = Constants.buttonContentInset
+
+        applyColors()
     }
 
     required init?(coder: NSCoder) {
@@ -74,6 +74,11 @@ class FilterChipButton: UIView {
         resetTapped?()
     }
 
+    private func applyColors() {
+        layer.borderColor = UIColor.textQuaternary.cgColor
+        resetButton.setImage(UIImage.gridicon(.crossCircle).imageWithTintColor(.text), for: .normal)
+    }
+
     private enum Constants {
         static let minResetButtonWidth: CGFloat = 32
         static let resetImageInsets = UIEdgeInsets(top: 8, left: 6, bottom: 8, right: 10)
@@ -82,5 +87,13 @@ class FilterChipButton: UIView {
         static let minButtonHeight: CGFloat = 32
         static let buttonContentInset = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
         static let buttonContentInsetWithResetEnabled = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 0)
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if #available(iOS 13, *), traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            applyColors()
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -100,8 +100,7 @@ class CalendarDataSource: JTACMonthViewDataSource {
             var dateComponent = DateComponents()
             dateComponent.year = -20
             let startDate = Calendar.current.date(byAdding: dateComponent, to: Date())
-            dateComponent.year = 1
-            let endDate = Calendar.current.date(byAdding: dateComponent, to: Date())
+            let endDate = Date().endOfMonth
 
             if let startDate = startDate, let endDate = endDate {
                 return ConfigurationParameters(startDate: startDate, endDate: endDate, calendar: self.calendar)
@@ -137,6 +136,11 @@ extension CalendarDataSource: JTACMonthViewDelegate {
 
     func calendar(_ calendar: JTACMonthView, didSelectDate date: Date, cell: JTACDayCell?, cellState: CellState, indexPath: IndexPath) {
         if style == .year {
+            // If the date is in the future, bail out
+            if date > Date() {
+                return
+            }
+
             if let firstDate = firstDate {
                 if let endDate = endDate {
                     // When tapping a selected firstDate or endDate reset the rest
@@ -321,7 +325,9 @@ extension DateCell {
             leftPlaceholder.backgroundColor = .clear
             rightPlaceholder.backgroundColor = .clear
             dateLabel.backgroundColor = .clear
-            if state.dateBelongsTo == .thisMonth {
+            if state.date > Date() {
+                textColor = .textSubtle
+            } else if state.dateBelongsTo == .thisMonth {
               textColor = .text
             } else {
               textColor = .textSubtle
@@ -385,5 +391,19 @@ class CalendarYearHeaderView: JTACMonthReusableView {
         static let stackViewSpacing: CGFloat = 16
         static let spacingAfterWeekdays: CGFloat = 8
         static let titleColor = UIColor(light: .gray(.shade70), dark: .textSubtle)
+    }
+}
+
+extension Date {
+    var startOfMonth: Date? {
+        return Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: Calendar.current.startOfDay(for: self)))
+    }
+
+    var endOfMonth: Date? {
+        guard let startOfMonth = startOfMonth else {
+            return nil
+        }
+
+        return Calendar.current.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -257,14 +257,14 @@ class DateCell: JTACDayCell {
         NSLayoutConstraint.activate([
             leftPlaceholder.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.6),
             leftPlaceholder.heightAnchor.constraint(equalTo: dateLabel.heightAnchor),
-            leftPlaceholder.rightAnchor.constraint(equalTo: centerXAnchor),
+            leftPlaceholder.trailingAnchor.constraint(equalTo: centerXAnchor),
             leftPlaceholder.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
 
         NSLayoutConstraint.activate([
             rightPlaceholder.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 0.5),
             rightPlaceholder.heightAnchor.constraint(equalTo: dateLabel.heightAnchor),
-            rightPlaceholder.leftAnchor.constraint(equalTo: centerXAnchor, constant: 0),
+            rightPlaceholder.leadingAnchor.constraint(equalTo: centerXAnchor, constant: 0),
             rightPlaceholder.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1149,6 +1149,7 @@
 		8B25F8DA24B7683A009DD4C9 /* ReaderCSSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B25F8D924B7683A009DD4C9 /* ReaderCSSTests.swift */; };
 		8B260D7E2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
+		8B51844525893F140085488D /* FilterBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B51844425893F140085488D /* FilterBarView.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
 		8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */; };
 		8B69F100255C4870006B1CEF /* ActivityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */; };
@@ -3686,6 +3687,7 @@
 		8B25F8D924B7683A009DD4C9 /* ReaderCSSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCSSTests.swift; sourceTree = "<group>"; };
 		8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostVisibilitySelectorViewController.swift; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
+		8B51844425893F140085488D /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
 		8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListViewModelTests.swift; sourceTree = "<group>"; };
 		8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStoreTests.swift; sourceTree = "<group>"; };
@@ -8181,6 +8183,7 @@
 			isa = PBXGroup;
 			children = (
 				8B93412E257029F50097D0AC /* FilterChipButton.swift */,
+				8B51844425893F140085488D /* FilterBarView.swift */,
 			);
 			path = Filter;
 			sourceTree = "<group>";
@@ -13000,6 +13003,7 @@
 				46D6114F2555DAED00B0B7BB /* SiteCreationAnalyticsHelper.swift in Sources */,
 				B54866CA1A0D7042004AC79D /* NSAttributedString+Helpers.swift in Sources */,
 				C81CCD81243BF7A600A83E27 /* TenorService.swift in Sources */,
+				8B51844525893F140085488D /* FilterBarView.swift in Sources */,
 				E105205B1F2B1CF400A948F6 /* BlogToBlogMigration_61_62.swift in Sources */,
 				E16FB7E31F8B61040004DD9F /* WebKitViewController.swift in Sources */,
 				3F8CBE0B24EEB0EA00F71234 /* AnnouncementsDataSource.swift in Sources */,


### PR DESCRIPTION
Part of #15192

Adds filter bar design + few enhancements on the calendar.

<img src="https://user-images.githubusercontent.com/7040243/101831830-443afa80-3b15-11eb-9cc7-cd8e35bf427a.gif" width="300">

### To test

1. Open Activity Log
2. Play with date range and activity type filters :)

Please, test by:

1. Running it on iPad and iPhone
2. Light and dark mode

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
