### PR TITLE
Migrate reader events: use new reader tracking method

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService+Subscriptions.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+Subscriptions.swift
@@ -54,12 +54,12 @@ extension ReaderTopicService {
         case .notifications(let siteId):
             if subscribe {
                 service.subscribeSiteNotifications(with: siteId, {
-                    WPAnalytics.track(.followedBlogNotificationsReaderMenuOn, properties: ["blogId": siteId])
+                    WPAnalytics.trackReader(.followedBlogNotificationsReaderMenuOn, properties: ["blogId": siteId])
                     successBlock()
                 }, failure)
             } else {
                 service.unsubscribeSiteNotifications(with: siteId, {
-                    WPAnalytics.track(.followedBlogNotificationsReaderMenuOff, properties: ["blog_id": siteId])
+                    WPAnalytics.trackReader(.followedBlogNotificationsReaderMenuOff, properties: ["blog_id": siteId])
                     successBlock()
                 }, failure)
             }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -353,7 +353,7 @@ extension WPAnalytics {
     /// - Parameter event: a `String` that represents the Reader event name
     /// - Parameter properties: a `Hash` that represents the properties
     ///
-    static func trackReader(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any]) {
+    static func trackReader(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any] = [:]) {
         var props = properties
         props[WPAppAnalyticsKeySubscriptionCount] = subscriptionCount
         WPAnalytics.track(event, properties: props)
@@ -365,7 +365,7 @@ extension WPAnalytics {
     /// - Parameter event: a `String` that represents the Reader event name
     /// - Parameter properties: a `Hash` that represents the properties
     ///
-    static func trackReader(_ stat: WPAnalyticsStat, properties: [AnyHashable: Any]) {
+    static func trackReader(_ stat: WPAnalyticsStat, properties: [AnyHashable: Any] = [:]) {
         var props = properties
         props[WPAppAnalyticsKeySubscriptionCount] = subscriptionCount
         WPAnalytics.track(stat, withProperties: props)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -114,7 +114,7 @@ class ReaderDetailCoordinator {
 
         sharingController.shareReaderPost(post, fromView: anchorView, inViewController: view)
 
-        WPAnalytics.track(.readerSharedItem)
+        WPAnalytics.trackReader(.readerSharedItem)
     }
 
     /// Set a postID, siteID and isFeed
@@ -175,7 +175,7 @@ class ReaderDetailCoordinator {
             return
         }
 
-        WPAnalytics.track(.readerArticleVisited)
+        WPAnalytics.trackReader(.readerArticleVisited)
         presentWebViewController(postURL)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBlockSiteAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBlockSiteAction.swift
@@ -22,7 +22,7 @@ final class ReaderBlockSiteAction {
                                                                     preferredStyle: .alert)
                             alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
                             alertController.presentFromRootViewController()
-                            WPAnalytics.track(.readerBlogBlocked, properties: ["blogId": post.siteID as Any])
+                            WPAnalytics.trackReader(.readerBlogBlocked, properties: ["blogId": post.siteID as Any])
         })
 
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -117,7 +117,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         footerView.showSpinner(true)
 
         page += 1
-        WPAnalytics.track(.readerDiscoverPaginated, properties: ["page": page])
+        WPAnalytics.trackReader(.readerDiscoverPaginated, properties: ["page": page])
 
         cardsService.fetch(isFirstPage: false, success: { _, hasMore in
             success?(hasMore)
@@ -149,7 +149,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
             return
         }
 
-        WPAnalytics.track(.readerDiscoverContentPresented)
+        WPAnalytics.trackReader(.readerDiscoverContentPresented)
     }
 
     // MARK: - TableViewHandler
@@ -253,14 +253,14 @@ private extension ReaderCardsStreamViewController {
 extension ReaderCardsStreamViewController: ReaderTopicsTableCardCellDelegate {
     func didSelect(topic: ReaderAbstractTopic) {
         if topic as? ReaderTagTopic != nil {
-            WPAnalytics.track(.readerDiscoverTopicTapped)
+            WPAnalytics.trackReader(.readerDiscoverTopicTapped)
 
             let topicStreamViewController = ReaderStreamViewController.controllerWithTopic(topic)
             navigationController?.pushViewController(topicStreamViewController, animated: true)
         } else if let siteTopic = topic as? ReaderSiteTopic {
             var properties = [String: Any]()
             properties[WPAppAnalyticsKeyBlogID] = siteTopic.siteID
-            WPAnalytics.track(.readerSuggestedSiteVisited, properties: properties)
+            WPAnalytics.trackReader(.readerSuggestedSiteVisited, properties: properties)
 
             let topicStreamViewController = ReaderStreamViewController.controllerWithSiteID(siteTopic.siteID, isFeed: false)
             navigationController?.pushViewController(topicStreamViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -139,17 +139,17 @@ import WordPressShared
             stat = .readerFreshlyPressedLoaded
 
         } else if topicIsFollowing(topic) {
-            WPAnalytics.track(.readerFollowingShown, properties: properties)
+            WPAnalytics.trackReader(.readerFollowingShown, properties: properties)
 
         } else if topicIsLiked(topic) {
-            WPAnalytics.track(.readerLikedShown, properties: properties)
+            WPAnalytics.trackReader(.readerLikedShown, properties: properties)
 
         } else if isTopicSite(topic) {
-            WPAnalytics.track(.readerBlogPreviewed, properties: properties)
+            WPAnalytics.trackReader(.readerBlogPreviewed, properties: properties)
 
         } else if isTopicDefault(topic) && topicIsDiscover(topic) {
             // Tracks Discover only if it was one of the default menu items.
-            WPAnalytics.track(.readerDiscoverShown, properties: properties)
+            WPAnalytics.trackReaderEvent(.readerDiscoverShown, properties: properties)
 
         } else if isTopicList(topic) {
             stat = .readerListLoaded
@@ -158,7 +158,7 @@ import WordPressShared
             stat = .readerTagLoaded
 
         } else if let teamTopic = topic as? ReaderTeamTopic {
-            WPAnalytics.track(teamTopic.shownTrackEvent, properties: properties)
+            WPAnalytics.trackReader(teamTopic.shownTrackEvent, properties: properties)
         }
 
         if stat != nil {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -90,7 +90,7 @@ open class ReaderPostMenu {
             viewController.present(alertController, animated: true)
         }
 
-        WPAnalytics.track(.readerArticleDetailMoreTapped)
+        WPAnalytics.trackReader(.readerArticleDetailMoreTapped)
     }
 
     fileprivate class func existingObject<T>(for objectID: NSManagedObjectID?, context: NSManagedObjectContext?) -> T? {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReportPostAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReportPostAction.swift
@@ -22,7 +22,7 @@ final class ReaderReportPostAction {
 
         // Track the report action
         let properties = ReaderHelpers.statsPropertiesForPost(post, andValue: nil, forKey: nil)
-        WPAnalytics.track(.readerPostReported, properties: properties)
+        WPAnalytics.trackReader(.readerPostReported, properties: properties)
     }
 
     /// Safely generate the report URL

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -66,7 +66,7 @@ extension ReaderSaveForLaterAction {
     func trackViewAllSavedPostsAction(origin: ReaderSaveForLaterOrigin) {
         let properties = [ readerSaveForLaterSourceKey: origin.viewAllPostsValue ]
 
-        WPAnalytics.track(.readerSavedListShown, properties: properties)
+        WPAnalytics.trackReader(.readerSavedListShown, properties: properties)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShareAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShareAction.swift
@@ -6,7 +6,7 @@ final class ReaderShareAction {
             let sharingController = PostSharingController()
 
             sharingController.shareReaderPost(post, fromView: anchor, inViewController: vc)
-            WPAnalytics.track(.itemSharedReader, properties: ["blogId": post.siteID as Any])
+            WPAnalytics.trackReader(.itemSharedReader, properties: ["blogId": post.siteID as Any])
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -94,7 +94,7 @@ final class ReaderShowMenuAction {
             vc.present(alertController, animated: true)
         }
 
-        WPAnalytics.track(.postCardMoreTapped)
+        WPAnalytics.trackReader(.postCardMoreTapped)
     }
 
     fileprivate func shouldShowBlockSiteMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSitesCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSitesCardCell.swift
@@ -64,6 +64,6 @@ extension ReaderSitesCardCell: ReaderRecommendedSitesCardCellDelegate {
         properties[WPAppAnalyticsKeyFollowAction] = !topic.following
         properties[WPAppAnalyticsKeyBlogID] = topic.siteID
 
-        WPAnalytics.track(.readerSuggestedSiteToggleFollow, properties: properties)
+        WPAnalytics.trackReader(.readerSuggestedSiteToggleFollow, properties: properties)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -168,6 +168,6 @@ extension ReaderStreamViewController {
 // MARK: - Tracks
 extension ReaderStreamViewController {
     func trackSavedListAccessed() {
-        WPAnalytics.track(.readerSavedListShown, properties: ["source": ReaderSaveForLaterOrigin.readerMenu.viewAllPostsValue])
+        WPAnalytics.trackReader(.readerSavedListShown, properties: ["source": ReaderSaveForLaterOrigin.readerMenu.viewAllPostsValue])
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -829,7 +829,7 @@ import WordPressFlux
             return
         }
         syncHelper?.syncContentWithUserInteraction(true)
-        WPAnalytics.track(.readerPullToRefresh, properties: topicPropertyForStats() ?? [:])
+        WPAnalytics.trackReader(.readerPullToRefresh, properties: topicPropertyForStats() ?? [:])
     }
 
 
@@ -1580,7 +1580,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         if post.isSavedForLater || contentType == .saved {
             trackSavedPostNavigation()
         } else {
-            WPAnalytics.track(.readerPostCardTapped, properties: topicPropertyForStats() ?? [:])
+            WPAnalytics.trackReader(.readerPostCardTapped, properties: topicPropertyForStats() ?? [:])
         }
 
         navigationController?.pushFullscreenViewController(controller, animated: true)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderVisitSiteAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderVisitSiteAction.swift
@@ -16,6 +16,6 @@ final class ReaderVisitSiteAction {
         let controller = WebViewControllerFactory.controller(configuration: configuration)
         let navController = UINavigationController(rootViewController: controller)
         origin.present(navController, animated: true)
-        WPAnalytics.track(.readerArticleVisited)
+        WPAnalytics.trackReader(.readerArticleVisited)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -71,7 +71,7 @@ class ReaderSelectInterestsViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        WPAnalytics.track(.selectInterestsShown)
+        WPAnalytics.trackReader(.selectInterestsShown)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -186,7 +186,7 @@ class ReaderSelectInterestsViewController: UIViewController {
             WPAnalytics.track(.readerTagFollowed, withProperties: ["tag": $0.slug])
         }
 
-        WPAnalytics.track(.selectInterestsPicked, properties: ["quantity": selectedInterests.count])
+        WPAnalytics.trackReader(.selectInterestsPicked, properties: ["quantity": selectedInterests.count])
     }
 
     // MARK: - Private: UI Helpers

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -200,7 +200,7 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
         layout.isExpanded = !layout.isExpanded
         layout.invalidateLayout()
 
-        WPAnalytics.track(.readerChipsMoreToggled)
+        WPAnalytics.trackReader(.readerChipsMoreToggled)
 
         delegate?.coordinator(self, didChangeState: layout.isExpanded ? .expanded: .collapsed)
     }


### PR DESCRIPTION
Part of #15431 

- Updates reader event tracking

### To test:
1. Trigger reader events that have been updated in this PR
2. Check that the `subscription_count` is correct and is tracked in the event properties

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
