### PR TITLE
Migrate reader stats: use new reader tracking method

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -250,12 +250,12 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
                                               WPAppAnalyticsKeyBlogID: siteID
                                               };
                 if (like) {
-                    [WPAppAnalytics track:WPAnalyticsStatReaderArticleLiked withProperties:properties];
+                    [WPAnalytics trackReaderStat:WPAnalyticsStatReaderArticleLiked properties:properties];
                     if (railcar) {
-                        [WPAppAnalytics trackTrainTracksInteraction:WPAnalyticsStatReaderArticleLiked withProperties:railcar];
+                        [WPAnalytics trackReaderStat:WPAnalyticsStatReaderArticleLiked properties:railcar];
                     }
                 } else {
-                    [WPAppAnalytics track:WPAnalyticsStatReaderArticleUnliked withProperties:properties];
+                    [WPAnalytics trackReaderStat:WPAnalyticsStatReaderArticleUnliked properties:properties];
                 }
             }
             if (success) {

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -56,8 +56,8 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
         }
         [service followSiteWithID:siteID success:^(){
             [self fetchTopicServiceWithID:siteID success:success failure:failure];
-            
-            [WPAppAnalytics track:WPAnalyticsStatReaderSiteFollowed withBlogID:[NSNumber numberWithUnsignedInteger:siteID]];
+            NSNumber *blogID = [NSNumber numberWithUnsignedInteger:siteID];
+            [WPAnalytics trackReaderStat:WPAnalyticsStatReaderSiteFollowed properties:@{ @"blog_id": blogID }];
         } failure:failure];
 
     } failure:^(NSError *error) {
@@ -83,7 +83,8 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
         if (success) {
             success();
         }
-        [WPAppAnalytics track:WPAnalyticsStatReaderSiteUnfollowed withBlogID:[NSNumber numberWithUnsignedInteger:siteID]];
+        NSNumber *blogID = [NSNumber numberWithUnsignedInteger:siteID];
+        [WPAnalytics trackReaderStat:WPAnalyticsStatReaderSiteUnfollowed properties:@{ @"blog_id": blogID }];
         
     } failure:failure];
 }
@@ -117,7 +118,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
             if (success) {
                 success();
             }
-            [WPAppAnalytics track:WPAnalyticsStatReaderSiteFollowed withProperties:@{ @"url":sanitizedURL }];
+            [WPAnalytics trackReaderStat:WPAnalyticsStatReaderSiteFollowed properties:@{ @"url":sanitizedURL }];
 
         } failure:failure];
     } failure:^(NSError *error) {
@@ -143,7 +144,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
         if (success) {
             success();
         }
-        [WPAppAnalytics track:WPAnalyticsStatReaderSiteUnfollowed withProperties:@{@"url":siteURL}];
+        [WPAnalytics trackReaderStat:WPAnalyticsStatReaderSiteUnfollowed properties:@{@"url":siteURL}];
     } failure:failure];
 }
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -333,7 +333,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     NSDictionary *properties = @{@"tag":slug};
 
     void (^successBlock)(void) = ^{
-        [WPAnalytics track:WPAnalyticsStatReaderTagUnfollowed withProperties:properties];
+        [WPAnalytics trackReaderStat:WPAnalyticsStatReaderTagUnfollowed properties:properties];
         if (success) {
             success();
         }
@@ -362,7 +362,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     [remoteService followTopicNamed:topicName withSuccess:^(NSNumber *topicID) {
         [self fetchReaderMenuWithSuccess:^{
             NSDictionary *properties = @{@"tag":topicName};
-            [WPAnalytics track:WPAnalyticsStatReaderTagFollowed withProperties:properties];
+            [WPAnalytics trackReaderStat:WPAnalyticsStatReaderTagFollowed properties:properties];
             [self selectTopicWithID:topicID];
             if (success) {
                 success();
@@ -380,7 +380,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 {
     void (^successBlock)(void) = ^{
         NSDictionary *properties = @{@"tag":slug};
-        [WPAnalytics track:WPAnalyticsStatReaderTagFollowed withProperties:properties];
+        [WPAnalytics trackReaderStat:WPAnalyticsStatReaderTagFollowed properties:properties];
         if (success) {
             success();
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -232,7 +232,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     NSMutableDictionary *properties = [NSMutableDictionary dictionary];
     properties[WPAppAnalyticsKeyPostID] = self.post.postID;
     properties[WPAppAnalyticsKeyBlogID] = self.post.siteID;
-    [WPAppAnalytics track:WPAnalyticsStatReaderArticleCommentsOpened withProperties:properties];
+    [WPAnalytics trackReaderStat:WPAnalyticsStatReaderArticleCommentsOpened properties:properties];
 }
 
 -(void)trackCommentLikedOrUnliked:(Comment *) comment {
@@ -247,7 +247,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     NSMutableDictionary *properties = [NSMutableDictionary dictionary];
     properties[WPAppAnalyticsKeyPostID] = post.postID;
     properties[WPAppAnalyticsKeyBlogID] = post.siteID;
-    [WPAppAnalytics track: stat withProperties:properties];
+    [WPAnalytics trackReaderStat:stat properties:properties];
 }
 
 -(void)trackReplyTo:(BOOL)replyTarget {
@@ -262,7 +262,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
         properties[WPAppAnalyticsKeyFeedID] = post.feedID;
         properties[WPAppAnalyticsKeyFeedItemID] = post.feedItemID;
     }
-    [WPAppAnalytics track:WPAnalyticsStatReaderArticleCommentedOn withProperties:properties];
+    [WPAnalytics trackReaderStat:WPAnalyticsStatReaderArticleCommentedOn properties:properties];
     if (railcar) {
         [WPAppAnalytics trackTrainTracksInteraction:WPAnalyticsStatTrainTracksInteract withProperties:railcar];
     }


### PR DESCRIPTION
Part of #15431 

- Updates reader stats tracking

### To test:
1. Trigger reader stats that have been updated in this PR
2. Check that the `subscription_count` is correct and is tracked in the event properties

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
