### PR TITLE
WPTableViewHandler: fix an iOS 14 crash due to operations with negative rows

### DIFF
--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -636,10 +636,12 @@ static CGFloat const DefaultCellHeight = 44.0;
 - (void)controllerDidChangeContent:(NSFetchedResultsController *)controller
 {
     [self.tableView endUpdates];
-    
-    if (self.indexPathSelectedAfterUpdates) {
+
+    // Prevent crashes in iOS 14 if the row is negative
+    // See http://git.io/JIKIB
+    if (self.indexPathSelectedAfterUpdates && self.indexPathSelectedAfterUpdates.row > 0) {
         [self.tableView selectRowAtIndexPath:self.indexPathSelectedAfterUpdates animated:NO scrollPosition:UITableViewScrollPositionNone];
-    } else if (self.indexPathSelectedBeforeUpdates) {
+    } else if (self.indexPathSelectedBeforeUpdates && self.indexPathSelectedBeforeUpdates.row > 0) {
         [self.tableView selectRowAtIndexPath:self.indexPathSelectedBeforeUpdates animated:NO scrollPosition:UITableViewScrollPositionNone];
     }
     
@@ -657,6 +659,12 @@ static CGFloat const DefaultCellHeight = 44.0;
      forChangeType:(NSFetchedResultsChangeType)type
       newIndexPath:(NSIndexPath *)newIndexPath
 {
+    // Prevent crashes in iOS 14 if the row is negative
+    // See http://git.io/JIKIB
+    if (indexPath.row < 0 || newIndexPath.row < 0) {
+        return;
+    }
+
     if (NSFetchedResultsChangeUpdate == type && newIndexPath && ![newIndexPath isEqual:indexPath]) {
         // Seriously, Apple?
         // http://developer.apple.com/library/ios/#releasenotes/iPhone/NSFetchedResultsChangeMoveReportedAsNSFetchedResultsChangeUpdate/_index.html


### PR DESCRIPTION
Fixes #15368 

After iOS 14 we've been experiencing a lot of crashes with messages similar to this one:

```
Attempted to perform update with invalid index path: <NSIndexPath: 0x2804eedc0> {length = 2, path = 2 - 18446744073709551614}
```

They're happening inside `WPTableViewHandler.m` in two different methods:

* `-[WPTableViewHandler controller:didChangeObject:atIndexPath:forChangeType:newIndexPath:]`
* `-[WPTableViewHandler controllerDidChangeContent:]`

Also, it pretty much only happens in iOS 14.

After digging a little bit I found this repo, you can use it to reproduce the exact same crash: https://github.com/jianghui1/TestReloadRowOfTableView (and it only happens in iOS 14).

This PR changes `WPTableViewHandler.m` to not call update methods in the `UITableView` if the `row` is negative.

### To test

Unfortunately, I still don't know how to reproduce the crash. So please, test the places that use `WPTableViewHandler.m`:

* Comments
* Notifications
* Pages
* Posts
* Reader

Pull to refresh to update them and etc. :)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
