### PR TITLE
Reader: update 'Following' site filter to display cached sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -144,7 +144,7 @@ extension ReaderSiteTopic {
         })
     }
 
-    /// Fetch sites from the Core Data
+    /// Fetch sites from Core Data
     ///
     private static func fetchStoredFollowedSites(completion: @escaping (Result<[ReaderSiteTopic], Error>) -> Void) {
         do {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -146,9 +146,10 @@ import WordPressFlux
             }
             syncHelper?.delegate = self
 
-            if let newTopic = readerTopic {
+            if let newTopic = readerTopic,
+               let context = newTopic.managedObjectContext {
                 newTopic.inUse = true
-                ContextManager.sharedInstance().save(newTopic.managedObjectContext!)
+                ContextManager.sharedInstance().save(context)
             }
 
             if readerTopic != nil && readerTopic != oldValue {


### PR DESCRIPTION
Ref: #15343

This updates the 'Following' site filter to display cached sites before re-fetching.
- When initially shown, the list will be what's in Core Data.
- After the sites are re-fetched, the list is updated with any changes.

To test:
- Go to Reader > Following.
- Select the site filter.
  - The list now populates immediately.
- Follow and/or unfollow a site.
  - Return to the filter.
  - After a few seconds (when the re-fetching is complete), the list will update with any changes.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
