### PR TITLE
Reader: add site filter to Automattic and P2s

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+16.5
+-----
+* [*] Reader 'P2s': added ability to filter by site. [#15484]
+
 16.4
 -----
 * [internal] Removed unused Reader files. Should be no functional changes. [#15414]

--- a/WordPress/Classes/Models/ReaderSiteTopic.swift
+++ b/WordPress/Classes/Models/ReaderSiteTopic.swift
@@ -30,9 +30,12 @@ import Foundation
         }
     }
 
+    var organizationType: SiteOrganizationType? {
+        SiteOrganizationType(rawValue: organizationID.intValue)
+    }
+
     var isP2Type: Bool {
-        let orgType = SiteOrganizationType(rawValue: organizationID.intValue)
-        return orgType == .p2 || orgType == .automattic
+        return organizationType == .p2 || organizationType == .automattic
     }
 
     @objc open var blogNameToDisplay: String {

--- a/WordPress/Classes/Models/ReaderTeamTopic.swift
+++ b/WordPress/Classes/Models/ReaderTeamTopic.swift
@@ -11,6 +11,10 @@ import Foundation
         return slug == ReaderTeamTopic.a8cSlug ? .readerA8CShown : .readerP2Shown
     }
 
+    var organizationType: SiteOrganizationType {
+        return slug == ReaderTeamTopic.a8cSlug ? .automattic : .p2
+    }
+
     static let a8cSlug = "a8c"
     static let p2Slug = "p2"
 }

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
@@ -94,7 +94,7 @@ class FilterSheetView: UIView {
         set {
             if let filter = newValue {
                 dataSource = FilterTableViewDataSource(data: filter.items, reuseIdentifier: filter.reuseIdentifier)
-                if filter.state.isReady == false {
+                if !filter.state.isReady {
                     /// Loading state
                     emptyView.isHidden = true
                     tableView.isHidden = true

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItem.swift
@@ -2,6 +2,7 @@ struct ReaderTabItem: FilterTabBarItem {
 
     let shouldHideButtonsView: Bool
     let shouldHideSettingsButton: Bool
+    let shouldHideTagFilter: Bool
 
     let content: ReaderContent
 
@@ -12,9 +13,10 @@ struct ReaderTabItem: FilterTabBarItem {
     /// initialize with topic
     init(_ content: ReaderContent) {
         self.content = content
-
-        self.shouldHideButtonsView = content.topicType != .following && content.type != .selfHostedFollowing
-        self.shouldHideSettingsButton = content.type == .selfHostedFollowing
+        let filterableTopicTypes = [ReaderTopicType.following, .organization]
+        shouldHideButtonsView = !filterableTopicTypes.contains(content.topicType) && content.type != .selfHostedFollowing
+        shouldHideSettingsButton = content.type == .selfHostedFollowing
+        shouldHideTagFilter = content.topicType == .organization
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -171,6 +171,7 @@ extension ReaderTabView {
 extension ReaderTabView {
     /// Tab bar
     @objc private func selectedTabDidChange(_ tabBar: FilterTabBar) {
+        didTapResetFilterButton()
         addContentToContainerView()
         viewModel.showTab(at: tabBar.selectedIndex)
         toggleButtonsView()

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -144,10 +144,15 @@ extension ReaderTabViewModel {
 // MARK: - Bottom Sheet
 extension ReaderTabViewModel {
     private func makeFilterSheetViewController(completion: @escaping (ReaderAbstractTopic) -> Void) -> FilterSheetViewController {
-        return FilterSheetViewController(filters:
-            [ReaderSiteTopic.filterProvider(),
-             ReaderTagTopic.filterProvider()],
-            changedFilter: completion)
+        let selectedTab = tabItems[selectedIndex]
+        let siteType = (selectedTab.content.topic as? ReaderTeamTopic)?.organizationType
+        var filters = [ReaderSiteTopic.filterProvider(for: siteType)]
+
+        if !selectedTab.shouldHideTagFilter {
+            filters.append(ReaderTagTopic.filterProvider())
+        }
+
+        return FilterSheetViewController(filters: filters, changedFilter: completion)
     }
 }
 


### PR DESCRIPTION
Ref: #15343 

For Automattic and P2 reader streams, the 'Filter' tab bar option is now available to filter by site.

To test:

---
- Go to Reader > Following.
- Select `Filter`.
- Verify nothing has changed. That is, all followed sites and P2s appear in the `Sites` list, and filtering by `Topics` is available.

<kbd>![following](https://user-images.githubusercontent.com/1816888/102130554-397eaf00-3e0e-11eb-9dbc-ad75c1280038.png)</kbd>

---
- Go to Reader > P2s.
- Select `Filter`.
- Verify the `Sites` list only contains non-A8C P2s. 
- Verify filtering by `Topic` is not available.

<kbd>![p2](https://user-images.githubusercontent.com/1816888/102130834-967a6500-3e0e-11eb-9475-7977436ee511.png)</kbd>

---
- Go to Reader > Automattic.
- Select `Filter`.
- Verify the `Sites` list only contains A8C P2s. 
- Verify filtering by `Topic` is not available.

<kbd>![a8c](https://user-images.githubusercontent.com/1816888/102130879-a2febd80-3e0e-11eb-9a05-ca931641468b.png)</kbd>

 ---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
