### PR TITLE
Moves New Page quick start tour to FAB

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -275,17 +275,11 @@ struct QuickStartNewPageTour: QuickStartTour {
     let icon = UIImage.gridicon(.pages)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
+    let showWaypointNotices = false
 
     var waypoints: [WayPoint] = {
-        let pagesStepDesc = NSLocalizedString("Select %@ to continue.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let pagesStepTarget = NSLocalizedString("Site Pages", comment: "The item to select during a guided tour.")
-
-        let newStepDesc = NSLocalizedString("Select %@ to create a new page.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-
-        return [
-            (element: .pages, description: pagesStepDesc.highlighting(phrase: pagesStepTarget, icon: nil)),
-            (element: .newPage, description: newStepDesc.highlighting(phrase: "", icon: .gridicon(.plus)))
-        ]
+        let descriptionBase = NSLocalizedString("Select %@ to create a new page", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        return [(element: .newPage, description: descriptionBase.highlighting(phrase: "", icon: .gridicon(.create)))]
     }()
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of creating a new page for your site.", comment: "This value is used to set the accessibility hint text for creating a new page for the user's site.")

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -112,6 +112,8 @@ import WordPressFlux
         button.addTarget(self, action: #selector(showCreateSheet), for: .touchUpInside)
     }
 
+    private var currentTourElement: QuickStartTourElement?
+
     @objc private func showCreateSheet() {
         didDismissTooltip = true
         hideNotice()
@@ -124,9 +126,12 @@ import WordPressFlux
             actions.first?.handler()
         } else {
             let actionSheetVC = actionSheetController(with: viewController.traitCollection)
-            viewController.present(actionSheetVC, animated: true, completion: {
+            viewController.present(actionSheetVC, animated: true, completion: { [weak self] in
                 WPAnalytics.track(.createSheetShown)
-                QuickStartTourGuide.shared.visited(.newpost)
+
+                if let element = self?.currentTourElement {
+                    QuickStartTourGuide.shared.visited(element)
+                }
             })
         }
     }
@@ -209,6 +214,7 @@ import WordPressFlux
                     return
             }
 
+            self.currentTourElement = element
             self.hideNotice()
             self.didDismissTooltip = false
             self.showCreateButton(notice: self.quickStartNotice(description))

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -171,7 +171,7 @@ import WordPressFlux
         showCreateButton(notice: notice(for: blog))
     }
 
-    func showCreateButton(notice: Notice) {
+    private func showCreateButton(notice: Notice) {
         if !didDismissTooltip {
             noticeContainerView = noticeAnimator.present(notice: notice, in: viewController!.view, sourceView: button)
             shownTooltipCount += 1
@@ -199,13 +199,13 @@ import WordPressFlux
         return notice
     }
 
-    func listenForQuickStart() {
+    private func listenForQuickStart() {
         quickStartObserver = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
             guard let self = self,
                 let userInfo = notification.userInfo,
                 let element = userInfo[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement,
                 let description = userInfo[QuickStartTourGuide.notificationDescriptionKey] as? NSAttributedString,
-                element == .newpost else {
+                element == .newpost || element == .newPage else {
                     return
             }
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
@@ -17,9 +17,11 @@ struct PageAction: ActionSheetItem {
     let handler: () -> Void
 
     func makeButton() -> ActionSheetButton {
+        let highlight: Bool = QuickStartTourGuide.shared.shouldSpotlight(.newPage)
         return ActionSheetButton(title: NSLocalizedString("Site page", comment: "Create new Site Page button title"),
                                             image: .gridicon(.pages),
                                             identifier: "sitePageButton",
+                                            highlight: highlight,
                                             action: handler)
     }
 }


### PR DESCRIPTION
Fixes #15350 

Shows the New Page Quick Start on the Blog Details screen instead of the Site Pages screen:



<a href="https://user-images.githubusercontent.com/3250/101971104-fba24080-3beb-11eb-8626-6bdcdb5b490a.png"><img src="https://user-images.githubusercontent.com/3250/101971104-fba24080-3beb-11eb-8626-6bdcdb5b490a.png" width="400"></a>   <a href="https://user-images.githubusercontent.com/3250/101971112-04931200-3bec-11eb-8a8a-e1b6c0e9c6f0.png"><img src="https://user-images.githubusercontent.com/3250/101971112-04931200-3bec-11eb-8a8a-e1b6c0e9c6f0.png" width="400"></a>

To test:
- Login with an email that has no site created and accept Quick Start guidance
- Follow the guidance for Create A New Page
- On the Site Pages screen, the message overlaps the button AND on the new layout picker modal, the message persists.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
