### PR TITLE
Disable block editor informative popup

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [**] Posts List: Adds duplicate post functionality [#15460]
 * [***] Block Editor: New Block: File [https://github.com/wordpress-mobile/gutenberg-mobile/pull/2835]
 * [*] Reader: Removes gray tint from site icons that contain transparency (located in Reader > Settings > Followed sites).
+* [*] Block Editor: Remove popup informing user that they will be using the block editor by default
 
 16.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,7 @@
 * [**] Posts List: Adds duplicate post functionality [#15460]
 * [***] Block Editor: New Block: File [https://github.com/wordpress-mobile/gutenberg-mobile/pull/2835]
 * [*] Reader: Removes gray tint from site icons that contain transparency (located in Reader > Settings > Followed sites).
-* [*] Block Editor: Remove popup informing user that they will be using the block editor by default
+* [*] Block Editor: Remove popup informing user that they will be using the block editor by default [#15492]
 
 16.3
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -337,7 +337,6 @@ class GutenbergViewController: UIViewController, PostEditor {
         refreshInterface()
 
         gutenberg.delegate = self
-        showInformativeDialogIfNecessary()
         fetchEditorTheme()
         presentNewPageNoticeIfNeeded()
 


### PR DESCRIPTION
We'll soon be removing the ability to switch to Aztec, so in preparation for that, this PR disables the popup that informs users that the app has switched them back over to Gutenberg. Note that the aim is to preserve the underlying behavior, just the popup is no longer presented.

I took the easiest route and just removed the single-line that allowed these popups to appear. We will remove the code that does the actual switching  in a future PR (issue is https://github.com/wordpress-mobile/gutenberg-mobile/issues/2901).

To test:

1. On a fresh install, open the editor on a site that has the Block Editor enabled
2. Ensure that the "Block editor enabled" popup is **not** shown
3. Go to site settings and disable the Block Editor
4. Kill the app
5. Reopen the app and open the editor
6. Expect no "Block editor enabled" popup despite the Block Editor being shown (the logic that switches editors was purposefully left intact)
7. Go to site settings and disable the Block Editor
8. Kill the app
9. Reopen the app and open the editor
6. Expect the Aztec editor to be shown


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
