### PR TITLE
Reader filters: show tab title as view title

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
@@ -2,13 +2,10 @@ import WordPressFlux
 
 class FilterSheetView: UIView {
 
-    enum Constants {
-        enum Header {
-            static let spacing: CGFloat = 16
-            static let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
-            static let title = NSLocalizedString("Following", comment: "Title for Reader Filter Sheet")
-            static let font = WPStyleGuide.fontForTextStyle(.headline)
-        }
+    private struct HeaderConstants {
+        static let spacing: CGFloat = 16
+        static let insets: UIEdgeInsets = UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
+        static let font = WPStyleGuide.fontForTextStyle(.headline)
     }
 
     // MARK: View Setup
@@ -49,11 +46,11 @@ class FilterSheetView: UIView {
     private lazy var headerLabelView: UIView = {
         let labelView = UIView()
         let label = UILabel()
-        label.font = Constants.Header.font
-        label.text = Constants.Header.title
+        label.font = HeaderConstants.font
+        label.text = viewTitle
         label.translatesAutoresizingMaskIntoConstraints = false
         labelView.addSubview(label)
-        labelView.pinSubviewToAllEdges(label, insets: Constants.Header.insets)
+        labelView.pinSubviewToAllEdges(label, insets: HeaderConstants.insets)
         return labelView
     }()
 
@@ -66,7 +63,7 @@ class FilterSheetView: UIView {
             emptyView
         ])
 
-        stack.setCustomSpacing(Constants.Header.spacing, after: headerLabelView)
+        stack.setCustomSpacing(HeaderConstants.spacing, after: headerLabelView)
         stack.axis = .vertical
         stack.translatesAutoresizingMaskIntoConstraints = false
         return stack
@@ -118,14 +115,20 @@ class FilterSheetView: UIView {
         }
     }
 
+    private let viewTitle: String
     private let filters: [FilterProvider]
 
     // MARK: Methods
 
-    init(filters: [FilterProvider], presentationController: UIViewController, changedFilter: @escaping (ReaderAbstractTopic) -> Void) {
+    init(viewTitle: String,
+         filters: [FilterProvider],
+         presentationController: UIViewController,
+         changedFilter: @escaping (ReaderAbstractTopic) -> Void) {
+        self.viewTitle = viewTitle
+        self.filters = filters
         self.presentationController = presentationController
         self.changedFilter = changedFilter
-        self.filters = filters
+
         super.init(frame: .zero)
 
         filterTabBar.items = filters

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
@@ -1,10 +1,13 @@
 class FilterSheetViewController: UIViewController {
 
+    private let viewTitle: String
     private let filters: [FilterProvider]
     private let changedFilter: (ReaderAbstractTopic) -> Void
 
-    //TODO: Make changedFilter generic
-    init(filters: [FilterProvider], changedFilter: @escaping (ReaderAbstractTopic) -> Void) {
+    init(viewTitle: String,
+         filters: [FilterProvider],
+         changedFilter: @escaping (ReaderAbstractTopic) -> Void) {
+        self.viewTitle = viewTitle
         self.filters = filters
         self.changedFilter = changedFilter
         super.init(nibName: nil, bundle: nil)
@@ -15,7 +18,10 @@ class FilterSheetViewController: UIViewController {
     }
 
     override func loadView() {
-        view = FilterSheetView(filters: filters, presentationController: self, changedFilter: changedFilter)
+        view = FilterSheetView(viewTitle: viewTitle,
+                               filters: filters,
+                               presentationController: self,
+                               changedFilter: changedFilter)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -152,7 +152,9 @@ extension ReaderTabViewModel {
             filters.append(ReaderTagTopic.filterProvider())
         }
 
-        return FilterSheetViewController(filters: filters, changedFilter: completion)
+        return FilterSheetViewController(viewTitle: selectedTab.title,
+                                         filters: filters,
+                                         changedFilter: completion)
     }
 }
 


### PR DESCRIPTION
Ref: #15343 , https://github.com/wordpress-mobile/WordPress-iOS/pull/15484#issuecomment-744859379

When the filter view is displayed, the view title now matches the selected Reader tab. 

To test:
- Go to Reader > Following, Automattic, and P2s.
- Select `Filter`.
- Verify the filter sheet title matches the selected Reader tab.

| <img width="432" alt="Screen Shot 2020-12-14 at 6 30 12 PM" src="https://user-images.githubusercontent.com/1816888/102156312-89736b00-3e3a-11eb-8c9f-619f4a6d46a7.png"> | <img width="435" alt="Screen Shot 2020-12-14 at 6 30 22 PM" src="https://user-images.githubusercontent.com/1816888/102156321-909a7900-3e3a-11eb-8ad9-0183de617b1e.png"> | <img width="434" alt="Screen Shot 2020-12-14 at 6 30 34 PM" src="https://user-images.githubusercontent.com/1816888/102156346-998b4a80-3e3a-11eb-8706-6ddd4b3c904c.png"> |
|--------|-------|-------|


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
