### PR TITLE
Unsave post from saved tab

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -15,7 +15,8 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
     private weak var saveForLaterAction: ReaderSaveForLaterAction?
 
     /// Saved posts that have been removed but not yet discarded
-    private var removedPosts = ReaderSaveForLaterRemovedPosts()
+    var removedPosts = ReaderSaveForLaterRemovedPosts()
+    weak var savedPostsDelegate: ReaderSavedPostCellActionsDelegate?
 
     init(context: NSManagedObjectContext, origin: UIViewController, topic: ReaderAbstractTopic? = nil, visibleConfirmation: Bool = true) {
         self.context = context
@@ -51,6 +52,7 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
             if let post = provider as? ReaderPost {
                 removedPosts.add(post)
             }
+            savedPostsDelegate?.willRemove(cell)
         } else {
             guard let post = provider as? ReaderPost else {
                 return

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
@@ -32,11 +32,15 @@ final class ReaderSaveForLaterAction {
         let readerPostService = ReaderPostService(managedObjectContext: context)
 
         readerPostService.toggleSavedForLater(for: post, success: {
-            self.presentSuccessNotice(for: post, context: context, origin: origin, completion: completion)
+            if origin == .otherStream {
+                self.presentSuccessNotice(for: post, context: context, origin: origin, completion: completion)
+            }
             completion?()
-            }, failure: { error in
+        }, failure: { error in
+            if origin == .otherStream {
                 self.presentErrorNotice(error, activating: !post.isSavedForLater)
-                completion?()
+            }
+            completion?()
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -1,0 +1,15 @@
+protocol ReaderSavedPostCellActionsDelegate: class {
+    func willRemove(_ cell: ReaderPostCardCell)
+}
+
+
+/// Specialises ReaderPostCellActions to provide specific overrides for the ReaderSavedPostsViewController
+final class ReaderSavedPostCellActions: ReaderPostCellActions {
+
+    override func readerCell(_ cell: ReaderPostCardCell, saveActionForProvider provider: ReaderPostContentProvider) {
+        if let post = provider as? ReaderPost {
+            removedPosts.add(post)
+        }
+        savedPostsDelegate?.willRemove(cell)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -169,11 +169,6 @@ import WordPressFlux
     var isContentFiltered: Bool = false
 
     var contentType: ReaderContentType = .topic {
-        willSet {
-            if contentType == .saved && newValue != .saved {
-                postCellActions?.clearRemovedPosts()
-            }
-        }
         didSet {
             if contentType == .saved {
                 updateContent(synchronize: false)
@@ -357,6 +352,11 @@ import WordPressFlux
         super.viewWillDisappear(animated)
 
         dismissNoNetworkAlert()
+
+        // When navigating away from the Saved tab, make sure removed posts are no longer marked as "saved for later".
+        if contentType == .saved {
+            postCellActions?.clearRemovedPosts()
+        }
 
         // We want to listen for any changes (following, liked) in a post detail so we can refresh the child context.
         let mainContext = ContextManager.sharedInstance().mainContext

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1208,6 +1208,7 @@ import WordPressFlux
             postCellActions = ReaderPostCellActions(context: managedObjectContext(), origin: self, topic: readerTopic)
         }
         postCellActions?.isLoggedIn = isLoggedIn
+        postCellActions?.savedPostsDelegate = self
 
         // Restrict the topics header to only display on the Discover, and tag detail views
         var displayTopics = false
@@ -1846,6 +1847,15 @@ extension ReaderStreamViewController: ReaderContentViewController {
             ReaderTracker.shared.start(.filteredList)
         } else {
             ReaderTracker.shared.stop(.filteredList)
+        }
+    }
+}
+
+// MARK: - Saved Posts Delegate
+extension ReaderStreamViewController: ReaderSavedPostCellActionsDelegate {
+    func willRemove(_ cell: ReaderPostCardCell) {
+        if let cellIndex = tableView.indexPath(for: cell) {
+            tableView.reloadRows(at: [cellIndex], with: .fade)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -169,6 +169,11 @@ import WordPressFlux
     var isContentFiltered: Bool = false
 
     var contentType: ReaderContentType = .topic {
+        willSet {
+            if contentType == .saved {
+                postCellActions?.clearRemovedPosts()
+            }
+        }
         didSet {
             if contentType == .saved {
                 updateContent(synchronize: false)
@@ -352,11 +357,6 @@ import WordPressFlux
         super.viewWillDisappear(animated)
 
         dismissNoNetworkAlert()
-
-        // When navigating away from the Saved tab, make sure removed posts are no longer marked as "saved for later".
-        if contentType == .saved {
-            postCellActions?.clearRemovedPosts()
-        }
 
         // We want to listen for any changes (following, liked) in a post detail so we can refresh the child context.
         let mainContext = ContextManager.sharedInstance().mainContext

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2285,6 +2285,7 @@
 		FAB4F32724EDE12A00F259BA /* FollowCommentsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */; };
 		FACB36F11C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */; };
 		FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */; };
+		FAE4327425874D140039EB8C /* ReaderSavedPostCellActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */; };
 		FAFF153D1C98962E007D1C90 /* SiteSettingsViewController+SiteManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFF153C1C98962E007D1C90 /* SiteSettingsViewController+SiteManagement.swift */; };
 		FD21397F13128C5300099582 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FD21397E13128C5300099582 /* libiconv.dylib */; };
 		FD3D6D2C1349F5D30061136A /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD3D6D2B1349F5D30061136A /* ImageIO.framework */; };
@@ -5011,6 +5012,7 @@
 		FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowCommentsServiceTests.swift; sourceTree = "<group>"; };
 		FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeWebNavigationDelegate.swift; sourceTree = "<group>"; };
 		FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartOverViewController.swift; sourceTree = "<group>"; };
+		FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostCellActions.swift; sourceTree = "<group>"; };
 		FAFF153C1C98962E007D1C90 /* SiteSettingsViewController+SiteManagement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SiteSettingsViewController+SiteManagement.swift"; sourceTree = "<group>"; };
 		FD0D42C11499F31700F5E115 /* WordPress 4.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 4.xcdatamodel"; sourceTree = "<group>"; };
 		FD21397E13128C5300099582 /* libiconv.dylib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
@@ -10052,6 +10054,7 @@
 				8B7F51C724EED488008CF5B5 /* Analytics */,
 				5D1D04731B7A50B100CDE646 /* Reader.storyboard */,
 				321955BE24BE234C00E3F316 /* ReaderInterestsCoordinator.swift */,
+				FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */,
 				8BADF16324801B4B005AD038 /* Detail */,
 				32E1BFD824A66801007A08F0 /* Select Interests */,
 				F5A738C1244DF92300EDE065 /* Manage */,
@@ -13174,6 +13177,7 @@
 				D816C1F020E0893A00C4D82F /* LikeComment.swift in Sources */,
 				59E1D46E1CEF77B500126697 /* Page.swift in Sources */,
 				321955BF24BE234C00E3F316 /* ReaderInterestsCoordinator.swift in Sources */,
+				FAE4327425874D140039EB8C /* ReaderSavedPostCellActions.swift in Sources */,
 				7E4123C220F4097B00DF8486 /* FormattableContentFormatter.swift in Sources */,
 				7E21C765202BBF4400837CF5 /* SearchAdsAttribution.swift in Sources */,
 				5DF8D26119E82B1000A2CD95 /* ReaderCommentsViewController.m in Sources */,


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/15381

This PR addresses fixes the following:

- When a user taps the save icon button for a post in the `Saved` tab, the post cell wasn't being updated to a `ReaderSavedPostUndoCell`
    - `ReaderSavedPostCellActionsDelegate` was deleted in #15414, but looks like we need it for this usecase 👀  
- When a user taps the save icon button for a post in the `Saved` tab, the post wasn't being unsaved

### To test:

1. Go to the Reader tab
2. Save a post from the `Following` tab
3. Go to the `Saved` tab and unsave the post
    - The post cell should be updated to a `ReaderSavedPostUndoCell` ✅ 
4. Go to the `Following` tab and pull down to refresh
    - The post should be no longer be marked as "saved" ✅ 
5. Go to the `Saved` tab
    - The post should no longer appear in the `Saved` tab ✅ 

![unsave](https://user-images.githubusercontent.com/6711616/102202135-58fb0200-3f0a-11eb-8ecf-0f154df0db4b.gif)


### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
