### PR TITLE
Change the background colors for badge notifications in dark mode.

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -391,7 +391,7 @@ extension NotificationDetailsViewController {
         tableView.keyboardDismissMode       = .interactive
         tableView.backgroundColor           = .neutral(.shade5)
         tableView.accessibilityIdentifier   = NSLocalizedString("Notification Details Table", comment: "Notifications Details Accessibility Identifier")
-        tableView.backgroundColor           = .listBackground
+        tableView.backgroundColor           = note.isBadge ? .ungroupedListBackground : .listBackground
     }
 
     func setupTableViewCells() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -383,13 +383,12 @@ extension NotificationDetailsViewController {
     }
 
     func setupMainView() {
-        view.backgroundColor = .listBackground
+        view.backgroundColor = note.isBadge ? .ungroupedListBackground : .listBackground
     }
 
     func setupTableView() {
         tableView.separatorStyle            = .none
         tableView.keyboardDismissMode       = .interactive
-        tableView.backgroundColor           = .neutral(.shade5)
         tableView.accessibilityIdentifier   = NSLocalizedString("Notification Details Table", comment: "Notifications Details Accessibility Identifier")
         tableView.backgroundColor           = note.isBadge ? .ungroupedListBackground : .listBackground
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTableViewCell.swift
@@ -11,7 +11,11 @@ class NoteBlockTableViewCell: WPTableViewCell {
     ///
     /// - Note: After setting this property you should explicitly call `refreshSeparators` from within `UITableView.willDisplayCell`.
     ///
-    @objc var isBadge = false
+    @objc var isBadge = false {
+        didSet {
+            separatorsView.backgroundColor = WPStyleGuide.Notifications.blockBackgroundColorForRichText(isBadge)
+        }
+    }
 
     /// Indicates if the receiver is the last row in the group.
     ///


### PR DESCRIPTION
Fixes #15323

I confirmed with @mbshakti that the light mode should display a white background still. 

### Screenshots

| Light Mode | Dark Mode |
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/793774/102275485-74a6de00-3ef3-11eb-8218-8b54ada7fe47.png" />|<img src="https://user-images.githubusercontent.com/793774/102275502-7b355580-3ef3-11eb-98dc-c5bfa7d2e4df.png" />|

### To test:
1. Launch the app
2. Tap on the Notifications Tab
3. Locate a "badge" notification such as Jetpack Scan Threat, Anniversary Badge, Number of likes on a blog

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
