### PR TITLE
Invite People: misc updates

### DIFF
--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -74,7 +74,7 @@ class InvitePersonViewController: UITableViewController {
 
     /// Last Section Footer Text
     ///
-    fileprivate let lastSectionFooterText = NSLocalizedString("Add a custom message (optional).", comment: "Invite Footer Text")
+    private let lastSectionFooterText = NSLocalizedString("Optional: Enter a custom message to be sent with your invitation.", comment: "Invite Footer Text")
 
 
     // MARK: - Outlets

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -392,7 +392,7 @@ private extension InvitePersonViewController {
     }
 
     func setupPlaceholderLabel() {
-        placeholderLabel.text = NSLocalizedString("Custom message...", comment: "Placeholder for Invite People message field.")
+        placeholderLabel.text = NSLocalizedString("Custom message…", comment: "Placeholder for Invite People message field.")
         placeholderLabel.font = WPStyleGuide.tableviewTextFont()
         placeholderLabel.textColor = UIColor.textPlaceholder
     }

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -384,7 +384,7 @@ private extension InvitePersonViewController {
     }
 
     func setupNavigationBar() {
-        title = NSLocalizedString("Add a Person", comment: "Invite People Title")
+        title = NSLocalizedString("Invite People", comment: "Invite People Title")
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel,
                                                            target: self,

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -97,9 +97,17 @@ class InvitePersonViewController: UITableViewController {
         }
     }
 
+    /// Message Placeholder Label
+    ///
+    @IBOutlet private var placeholderLabel: UILabel! {
+        didSet {
+            setupPlaceholderLabel()
+        }
+    }
+
     /// Message Cell
     ///
-    @IBOutlet fileprivate var messageTextView: UITextView! {
+    @IBOutlet private var messageTextView: UITextView! {
         didSet {
             setupMessageTextView()
             refreshMessageTextView()
@@ -383,6 +391,12 @@ private extension InvitePersonViewController {
         messageTextView.backgroundColor = .listForeground
     }
 
+    func setupPlaceholderLabel() {
+        placeholderLabel.text = NSLocalizedString("Custom message...", comment: "Placeholder for Invite People message field.")
+        placeholderLabel.font = WPStyleGuide.tableviewTextFont()
+        placeholderLabel.textColor = UIColor.textPlaceholder
+    }
+
     func setupNavigationBar() {
         title = NSLocalizedString("Invite People", comment: "Invite People Title")
 
@@ -430,5 +444,10 @@ private extension InvitePersonViewController {
 
     func refreshMessageTextView() {
         messageTextView.text = message
+        refreshPlaceholderLabel()
+    }
+
+    func refreshPlaceholderLabel() {
+        placeholderLabel?.isHidden = !messageTextView.text.isEmpty
     }
 }

--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="5ll-RY-leg">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="5ll-RY-leg">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -34,7 +34,7 @@
                                 <rect key="frame" x="0.0" y="55.5" width="375" height="86"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Wdc-br-fiq" id="enq-cQ-RBD">
-                                    <rect key="frame" x="0.0" y="0.0" width="347.5" height="86"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="348" height="86"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="8zx-wm-uHU" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -45,13 +45,13 @@
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Jorge Bernal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Vt-sK-TAK">
-                                            <rect key="frame" x="87" y="20" width="252.5" height="17"/>
+                                            <rect key="frame" x="87" y="20" width="253" height="17"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
                                             <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@koke" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1F5-Qy-cZx">
-                                            <rect key="frame" x="87" y="35.5" width="252.5" height="13.5"/>
+                                            <rect key="frame" x="87" y="35.5" width="253" height="13.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                             <color key="textColor" red="0.0" green="0.66666666669999997" blue="0.86274509799999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -288,7 +288,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="igf-wZ-skT">
-                                                    <rect key="frame" x="317.5" y="13" width="41.5" height="19.5"/>
+                                                    <rect key="frame" x="317" y="13" width="42" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -319,7 +319,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="w3p-Ei-KVz">
-                                                    <rect key="frame" x="317.5" y="13" width="41.5" height="19.5"/>
+                                                    <rect key="frame" x="317" y="13" width="42" height="19.5"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                     <color key="textColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -335,7 +335,7 @@
                             </tableViewSection>
                             <tableViewSection id="KTt-dH-XgO">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="88" id="sdj-uY-1LY">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" rowHeight="88" id="sdj-uY-1LY">
                                         <rect key="frame" x="0.0" y="178" width="375" height="88"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="sdj-uY-1LY" id="Y8v-KJ-xnc">
@@ -348,7 +348,7 @@
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="72" id="ARy-hL-nFx"/>
                                                     </constraints>
-                                                    <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                                    <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</string>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                     <variation key="default">
@@ -357,12 +357,22 @@
                                                         </mask>
                                                     </variation>
                                                 </textView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom message..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jyo-4B-Bt9" userLabel="Placeholder Label">
+                                                    <rect key="frame" x="16" y="11" width="146" height="20.5"/>
+                                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                    <size key="shadowOffset" width="-1" height="-1"/>
+                                                </label>
                                             </subviews>
                                             <constraints>
                                                 <constraint firstAttribute="trailingMargin" secondItem="nh9-39-Mdw" secondAttribute="trailing" id="06N-1n-lgP"/>
                                                 <constraint firstAttribute="bottomMargin" secondItem="nh9-39-Mdw" secondAttribute="bottom" id="Avz-ZP-kHa"/>
                                                 <constraint firstItem="nh9-39-Mdw" firstAttribute="top" secondItem="Y8v-KJ-xnc" secondAttribute="topMargin" id="HlP-n4-smH"/>
+                                                <constraint firstItem="Jyo-4B-Bt9" firstAttribute="top" secondItem="Y8v-KJ-xnc" secondAttribute="topMargin" id="KCB-49-L7U"/>
                                                 <constraint firstItem="nh9-39-Mdw" firstAttribute="leading" secondItem="Y8v-KJ-xnc" secondAttribute="leadingMargin" id="Sq4-Av-m3J"/>
+                                                <constraint firstItem="Jyo-4B-Bt9" firstAttribute="leading" secondItem="Y8v-KJ-xnc" secondAttribute="leadingMargin" id="Tt0-eO-4t1"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
@@ -380,6 +390,7 @@
                     <navigationItem key="navigationItem" title="Add a Person" id="MO7-QW-hIa"/>
                     <connections>
                         <outlet property="messageTextView" destination="nh9-39-Mdw" id="EvO-0d-MLp"/>
+                        <outlet property="placeholderLabel" destination="Jyo-4B-Bt9" id="xG0-wq-EAn"/>
                         <outlet property="roleCell" destination="JUH-Ao-gEv" id="xIB-S2-RYP"/>
                         <outlet property="usernameCell" destination="i2R-sD-lxa" id="wgx-nw-l50"/>
                     </connections>
@@ -442,10 +453,18 @@
             <point key="canvasLocation" x="1282" y="1519"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="gravatar" width="85" height="85"/>
-    </resources>
+    <designables>
+        <designable name="5Qj-Ek-EUq">
+            <size key="intrinsicContentSize" width="39.5" height="16"/>
+        </designable>
+        <designable name="MH9-O4-5bD">
+            <size key="intrinsicContentSize" width="71" height="16"/>
+        </designable>
+    </designables>
     <inferredMetricsTieBreakers>
         <segue reference="e6P-Kc-Mxa"/>
     </inferredMetricsTieBreakers>
+    <resources>
+        <image name="gravatar" width="85" height="85"/>
+    </resources>
 </document>


### PR DESCRIPTION
Ref: #15356 

Misc enhancements to invitation view:
- View title: changed to `Invite People`.
- Message: updated helper text (the text under the field).
- Message: added placeholder text.
- Message: fixed issue where a grey box would appear inside the field when it was tapped.

To test:
- Go to Site > People. Tap + in the nav bar.
- Verify the view title is `Invite People`.
- Verify `Custom message...` appears in the message field.
- Verify `Optional: Enter a custom message to be sent with your invitation.` appears under the message field.
- Tap the message field.
- Verify the gray box does not appears. (see example below)
- Enter a message and return to the invite view.
- Verify the placeholder text does not appear.

---
Updated view:

| ![updated_view](https://user-images.githubusercontent.com/1816888/102287260-50e59700-3ef7-11eb-9689-d4d5c55e82f9.png) | ![dark](https://user-images.githubusercontent.com/1816888/102287272-5642e180-3ef7-11eb-970b-2f0f8d9f9399.png) |
|--------|-------|

---
Message field selection bug:

![grey_box](https://user-images.githubusercontent.com/1816888/102287327-74a8dd00-3ef7-11eb-8537-beeda5a8c7d4.gif)

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
