### PR TITLE
Reader: fix a glitch in the following tab

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -87,6 +87,8 @@ extension ReaderTabItemsStore {
         }
         state = .loading
 
+        // Return the tab bar items right away to avoid waiting for the request to finish
+        fetchTabBarItems()
 
         // Sync the reader menu
         service.fetchReaderMenu(success: { [weak self] in

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -87,8 +87,6 @@ extension ReaderTabItemsStore {
         }
         state = .loading
 
-        // Return the tab bar items right away to avoid waiting for the request to finish
-        fetchTabBarItems()
 
         // Sync the reader menu
         service.fetchReaderMenu(success: { [weak self] in

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -424,7 +424,7 @@ class FilterTabBar: UIControl {
     ///
     private func scroll(to tab: UIButton, animated: Bool = true) {
         // Check the bar has enough content to scroll
-        guard scrollView.contentSize.width > scrollView.frame.width else {
+        guard scrollView.contentSize.width > scrollView.frame.width, bounds.width > 0 else {
             return
         }
 


### PR DESCRIPTION

Fixing an issue where the following tab is being initially laid out out off to the left of the screen

Gif of the issue:

![following_tab](https://user-images.githubusercontent.com/1335657/102299950-cb6ae280-3f08-11eb-8c42-db752fbaea60.gif)


To test:
1. Launch the app 
2. tap the Reader
3. see that the "Following" tab is not jumping from the left 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
