### PR TITLE
Log Out: fix a crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -183,7 +183,8 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             return
         }
 
-        likeButton.isEnabled = (ReaderHelpers.isLoggedIn() || post.likeCount.intValue > 0) && !post.isExternal
+        let postLikeCount = post.likeCount?.intValue ?? 0
+        likeButton.isEnabled = (ReaderHelpers.isLoggedIn() || postLikeCount > 0) && !post.isExternal
         // as by design spec, only display like counts
         let likeCount = post.likeCount()?.intValue ?? 0
         let title = likeLabel(count: likeCount)


### PR DESCRIPTION
Fixes #15509

### To test

1. Log in into your A8C account in the simulator
2. Enable notifications*
3. Log out
4. You shouldn't see any crash

* I'm really not sure why this step is needed, but I couldn't reproduce the crash in `develop` without enabling notifications.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
