### PR TITLE
Fixes a switch must be exhaustive build warning 

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -19,6 +19,8 @@ extension BlogDetailsSubsection {
             return .personalize
         case .sharing, .people, .plugins:
             return .configure
+        case .jetpackSettings:
+            return .jetpack
         @unknown default:
             fatalError()
         }


### PR DESCRIPTION
### To test:
1. Build the app
2. Make sure the `.jetpackSettings` Switch warning is no longer present
3. Run the app
4. Make sure all the actions on the Blog detail view still work correctly

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
