### PR TITLE
Add @dynamic to Blog.siteSuggestions

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -55,6 +55,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 @dynamic themes;
 @dynamic media;
 @dynamic userSuggestions;
+@dynamic siteSuggestions;
 @dynamic menus;
 @dynamic menuLocations;
 @dynamic roles;


### PR DESCRIPTION
Adding @dynamic to `Blog.siteSuggestions` fixes a couple of buildtime warings such as:

```
WordPress-iOS/WordPress/Classes/Models/Blog.m:39:17: Property 'siteSuggestions' requires method 'siteSuggestions' to be defined - use @synthesize, @dynamic or provide a method implementation in this class implementation
```

Fixes #

To test:
1. Checkout `fix/suggestion_build_warnings` locally
2. Run `rake xcode`
3. Cmd+B and ensure the warning above is no longer shown in the Xcode Issue navigator

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
