### PR TITLE
Refresh feature announcements cache

### DIFF
--- a/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsStore.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsStore.swift
@@ -114,11 +114,23 @@ private extension CachedAnnouncementsStore {
               let maximumVersion = announcements.first?.maximumAppVersion,   // per version, but if there is, each of them must match the version
               let targetVersions = announcements.first?.appVersionTargets,   // so we might as well choose the first
               let version = versionProvider.version,
-              ((minimumVersion...maximumVersion).contains(version) || targetVersions.contains(version)) else {
+              ((minimumVersion...maximumVersion).contains(version) || targetVersions.contains(version)),
+              !cacheExpired else {
             return false
         }
         return true
     }
+
+    var cacheExpired: Bool {
+        guard let date = cache.date,
+              let elapsedTime = Calendar.current.dateComponents([.minute], from: date, to: Date()).minute else {
+            return true
+        }
+        return elapsedTime >= Self.cacheExpirationTime
+    }
+    // Time, in minutes, after which the cache expires (equivalent to 24 hours)
+    // TODO: this is not in minutes for convenience of testing. Will be converted in hours before merging
+    static let cacheExpirationTime = 1440
 
     enum Identifiers {
         // 2 is the identifier of WordPress-iOS in the backend

--- a/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsStore.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsStore.swift
@@ -118,8 +118,7 @@ private extension CachedAnnouncementsStore {
               let maximumVersion = announcements.first?.maximumAppVersion,   // per version, but if there is, each of them must match the version
               let targetVersions = announcements.first?.appVersionTargets,   // so we might as well choose the first
               let version = versionProvider.version,
-              ((minimumVersion...maximumVersion).contains(version) || targetVersions.contains(version)),
-              !cacheExpired else {
+              ((minimumVersion...maximumVersion).contains(version) || targetVersions.contains(version)) else {
             return false
         }
         return true

--- a/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsStore.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsStore.swift
@@ -127,14 +127,13 @@ private extension CachedAnnouncementsStore {
 
     var cacheExpired: Bool {
         guard let date = cache.date,
-              let elapsedTime = Calendar.current.dateComponents([.minute], from: date, to: Date()).minute else {
+              let elapsedTime = Calendar.current.dateComponents([.hour], from: date, to: Date()).hour else {
             return true
         }
         return elapsedTime >= Self.cacheExpirationTime
     }
-    // Time, in minutes, after which the cache expires (equivalent to 24 hours)
-    // TODO: this is not in minutes for convenience of testing. Will be converted in hours before merging
-    static let cacheExpirationTime = 1
+    // Time, in hours, after which the cache expires
+    static let cacheExpirationTime = 24
 
     // Asynchronously update cache without triggering state changes
     func updateCacheIfNeeded() {

--- a/WordPress/Classes/ViewRelated/What's New/Data store/Cache/AnnouncementsCache.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Data store/Cache/AnnouncementsCache.swift
@@ -3,6 +3,7 @@ import WordPressKit
 /// Generic feature announcement cache
 protocol AnnouncementsCache {
     var announcements: [Announcement]? { get set }
+    var date: Date? { get }
 }
 
 
@@ -17,6 +18,10 @@ struct UserDefaultsAnnouncementsCache: AnnouncementsCache {
             UserDefaults.standard.announcements = newValue
         }
     }
+
+    var date: Date? {
+        UserDefaults.standard.announcementsDate
+    }
 }
 
 
@@ -24,10 +29,11 @@ struct UserDefaultsAnnouncementsCache: AnnouncementsCache {
 private extension UserDefaults {
 
     static let currentAnnouncementsKey = "currentAnnouncements"
+    static let currentAnnouncementsDateKey = "currentAnnouncementsDate"
 
     var announcements: [Announcement]? {
         get {
-            guard let encodedAnnouncements = value(forKey: UserDefaults.currentAnnouncementsKey) as? Data,
+            guard let encodedAnnouncements = value(forKey: Self.currentAnnouncementsKey) as? Data,
                   let announcements = try? PropertyListDecoder().decode([Announcement].self, from: encodedAnnouncements) else {
                 return nil
             }
@@ -36,10 +42,16 @@ private extension UserDefaults {
 
         set {
             guard let announcements = newValue, let encodedAnnouncements = try? PropertyListEncoder().encode(announcements) else {
-                removeObject(forKey: UserDefaults.currentAnnouncementsKey)
+                removeObject(forKey: Self.currentAnnouncementsKey)
+                removeObject(forKey: Self.currentAnnouncementsDateKey)
                 return
             }
-            set(encodedAnnouncements, forKey: UserDefaults.currentAnnouncementsKey)
+            set(encodedAnnouncements, forKey: Self.currentAnnouncementsKey)
+            set(Date(), forKey: Self.currentAnnouncementsDateKey)
         }
+    }
+
+    var announcementsDate: Date? {
+        value(forKey: Self.currentAnnouncementsDateKey) as? Date
     }
 }

--- a/WordPress/WordPressTest/What's New/Data store/AnnouncementsDataStoreTests.swift
+++ b/WordPress/WordPressTest/What's New/Data store/AnnouncementsDataStoreTests.swift
@@ -159,7 +159,6 @@ class AnnouncementsDataStoreTests: XCTestCase {
         let cache = MockAnnouncementsCache()
         let service = MockAnnouncementsService()
         let getAnnouncementsExpectation = expectation(description: "Get announcements called")
-        getAnnouncementsExpectation.expectedFulfillmentCount = 1
         service.getAnnouncementsExpectation = getAnnouncementsExpectation
         let versionProvider = MockVersionProvider()
         let store = CachedAnnouncementsStore(cache: cache, service: service, versionProvider: versionProvider)

--- a/WordPress/WordPressTest/What's New/Data store/AnnouncementsDataStoreTests.swift
+++ b/WordPress/WordPressTest/What's New/Data store/AnnouncementsDataStoreTests.swift
@@ -8,6 +8,8 @@ struct MockAnnouncementsCache: AnnouncementsCache {
 
     var announcements: [Announcement]?
 
+    var date: Date?
+
     private let localAnnouncements = [Announcement(appVersionName: "0.0",
                                            minimumAppVersion: "1.0",
                                            maximumAppVersion: "3.0",
@@ -142,6 +144,32 @@ class AnnouncementsDataStoreTests: XCTestCase {
             }
         }
 
+        // When
+        store.getAnnouncements()
+        // Then
+        waitForExpectations(timeout: 4) { error in
+            if let error = error {
+                XCTFail("waitForExpectationsWithTimeout errored: \(error)")
+            }
+        }
+    }
+
+    func testCacheWasUpdated() {
+        // Given
+        let cache = MockAnnouncementsCache()
+        let service = MockAnnouncementsService()
+        let getAnnouncementsExpectation = expectation(description: "Get announcements called")
+        getAnnouncementsExpectation.expectedFulfillmentCount = 1
+        service.getAnnouncementsExpectation = getAnnouncementsExpectation
+        let versionProvider = MockVersionProvider()
+        let store = CachedAnnouncementsStore(cache: cache, service: service, versionProvider: versionProvider)
+        let stateChangeExpectation = expectation(description: "state change emitted")
+
+        subscription = store.onChange {
+            stateChangeExpectation.fulfill()
+            XCTAssertNotNil(store.announcements.first)
+            XCTAssertEqual(["first cached feature", "second cached feature"], store.announcements.first?.features.map { $0.title })
+        }
         // When
         store.getAnnouncements()
         // Then


### PR DESCRIPTION
Fixes #15153

To test:

- Delete the app from the device you are using
- Checkout and Install a previous version (e.g `develop`)
- Checkout this branch
- Manually change the version to 50.3
- Verify that the announcement screen (see below) appears at startup, and it's also available in "App Settings/What's New in WordPress"
- Go to Mission Control, and from the mobile announce tool, make some edits to announce 141
- Wait some time to allow the edits to propagate (I have experienced waits up to 10 minutes)
- Navigate to a different tab (e.g. "Reader"), then go back to "My Site" and then "App Settings/What's New in WordPress"
- Make sure the changes appear in the announcements.

**Important notes**
1. **When in the mobile announce tool, be sure to only edit the announce 141, to avoid changing production announcements**
2. To conveniently test this PR, you will need to tweak the property `cacheExpirationTime` in `CachedAnnouncementsStore` (unless, of course, you'd prefer to wait 24 hours to complete the test). Some options are:
    - temporarily set it to 0: this will cause the cache to always update
    - tweak the `cacheExpired` computed properties by using `.minute` instead of `.hour` and then set `cacheExpirationTime` to a low enough value (e.g. 1 minute).
  

example screenshot of announcements

<p align=center>
<img height = 500 src=https://user-images.githubusercontent.com/34376330/102263107-867b8780-3ed9-11eb-86b7-a84538abc85b.PNG>
</p>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
