### PR TITLE
Reader: fix main thread warning

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -105,10 +105,10 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         refreshCount += 1
 
         cardsService.fetch(isFirstPage: true, refreshCount: refreshCount, success: { [weak self] cardsCount, hasMore in
-            self?.trackApiResponse()
+            self?.trackContentPresented()
             success(cardsCount, hasMore)
         }, failure: { [weak self] error in
-            self?.trackApiResponse()
+            self?.trackContentPresented()
             failure(error)
         })
     }
@@ -144,12 +144,14 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     /// Track when the API returned the cards and the user is still on the screen
     /// This is used to create a funnel to check if users are leaving the screen
     /// before the API response
-    private func trackApiResponse() {
-        guard isVisible else {
-            return
-        }
+    private func trackContentPresented() {
+        DispatchQueue.main.async {
+            guard self.isVisible else {
+                return
+            }
 
-        WPAnalytics.trackReader(.readerDiscoverContentPresented)
+            WPAnalytics.track(.readerDiscoverContentPresented)
+        }
     }
 
     // MARK: - TableViewHandler


### PR DESCRIPTION
### To test:

1. Open Reader
2. Delete all your followed tags
3. Check that this warning doesn't appear: `Main Thread Checker: UI API called on a background thread: -[UIViewController isViewLoaded]`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
