### PR TITLE
Apply additional padding to the preferredContentSize

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] In the Comments view, overly-large twemoji are sized the same as Apple's emoji. [#15503]
 * [*] Reader 'P2s': added ability to filter by site. [#15484]
 * [**] Choose a Domain will now return more options in the search results, sort the results to have exact matches first, and let you know if no exact matches were found. [#15482]
+* [**] Fixed an issue where the Prepublishing Nudges Publish button could be cut off smaller devices [#15524]
 
 16.4
 -----

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -69,7 +69,19 @@ class PrepublishingViewController: UITableViewController {
 
         announcePublishButton()
 
-        preferredContentSize = tableView.contentSize
+        calculatePreferredContentSize()
+    }
+
+    private func calculatePreferredContentSize() {
+        // Apply additional padding to take into account the navbar / status bar height
+        let safeAreaTop = UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0
+        let navBarHeight = navigationController?.navigationBar.frame.height ?? 0
+        let offset = navBarHeight - safeAreaTop
+
+        var size = tableView.contentSize
+        size.height += offset
+
+        preferredContentSize = size
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Fixes #15511 

### Screenshots

#### Non-notch devices
|iPhone SE|iPhone 8|iPhone 8 Plus|
|:---:|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/793774/102402955-89e34180-3fb3-11eb-8915-cbc3b99c0df0.png" />|<img src="https://user-images.githubusercontent.com/793774/102402959-8b146e80-3fb3-11eb-8c27-b15d79c2a834.png" />|<img src="https://user-images.githubusercontent.com/793774/102403065-b5fec280-3fb3-11eb-91d8-544d6f7b64ae.png" />|

|iPhone 11 Pro|iPhone 11 Pro Max|iPhone 12 Mini|
|:---:|:---:|:---:|
|![Simulator Screen Shot - iPhone 11 Pro - 2020-12-16 at 15 27 23](https://user-images.githubusercontent.com/793774/102403670-9caa4600-3fb4-11eb-89c3-be15dc479733.png)|![Simulator Screen Shot - iPhone 11 Pro Max - 2020-12-16 at 15 37 18](https://user-images.githubusercontent.com/793774/102403666-9c11af80-3fb4-11eb-9db0-6d606a9b914e.png)|![Simulator Screen Shot - iPhone 12 mini - 2020-12-16 at 15 27 24](https://user-images.githubusercontent.com/793774/102403668-9c11af80-3fb4-11eb-9548-33f40826ba89.png)|

### To test:
1. Launch the app
2. Select My Site
3. Tap the pink button
4. Tap 'Blog Post'
5. Type some text in the post
6. Tap Publish
7. Verify the view is displayed and not clipped
8. Rotate to landscape
9. Verify the view is displayed and not clipped

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
