### PR TITLE
Fix white ghost cells in post list refresh

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -254,6 +254,10 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         super.selectedFilterDidChange(filterBar)
     }
 
+    override func refresh(_ sender: AnyObject) {
+        updateGhostableTableViewOptions()
+        super.refresh(sender)
+    }
 
     /// Update the `GhostOptions` to correctly show compact or default cells
     private func updateGhostableTableViewOptions() {


### PR DESCRIPTION

Fixes #15393

To test:

- run the app with an account that has at least one empty tab in "Blog Posts"
- Pulldown to refresh and make sure that the ghost table cells look right in both light and dark mode

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
