### PR TITLE
Invite People: add roles link

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] In the Comments view, overly-large twemoji are sized the same as Apple's emoji. [#15503]
 * [*] Reader 'P2s': added ability to filter by site. [#15484]
 * [**] Choose a Domain will now return more options in the search results, sort the results to have exact matches first, and let you know if no exact matches were found. [#15482]
+* [*] Invite People: add link to user roles definition web page. [#15530]
 
 16.4
 -----

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -66,6 +66,8 @@ class InvitePersonViewController: UITableViewController {
         return roles
     }
 
+    private let rolesDefinitionUrl = "https://wordpress.com/support/user-roles/"
+
     // MARK: - Outlets
 
     /// Username Cell
@@ -128,6 +130,7 @@ class InvitePersonViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        addTapGesture(toView: view, inSection: section)
         WPStyleGuide.configureTableViewSectionFooter(view)
     }
 
@@ -303,6 +306,27 @@ extension InvitePersonViewController {
 
         // Note: This viewController might not be visible anymore
         alertController.presentFromRootViewController()
+    }
+
+    private func addTapGesture(toView footerView: UIView, inSection section: Int) {
+        guard let footer = footerView as? UITableViewHeaderFooterView,
+           Section(rawValue: section) == .role else {
+            return
+        }
+
+        footer.textLabel?.isUserInteractionEnabled = true
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleRoleFooterTap(_:)))
+        footer.addGestureRecognizer(tap)
+    }
+
+    @objc private func handleRoleFooterTap(_ sender: UITapGestureRecognizer) {
+        guard let url = URL(string: rolesDefinitionUrl) else {
+            return
+        }
+
+        let webViewController = WebViewControllerFactory.controller(url: url)
+        let navController = UINavigationController(rootViewController: webViewController)
+        present(navController, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -66,17 +66,6 @@ class InvitePersonViewController: UITableViewController {
         return roles
     }
 
-    /// Last Section Index
-    ///
-    fileprivate var lastSectionIndex: Int {
-        return tableView.numberOfSections - 1
-    }
-
-    /// Last Section Footer Text
-    ///
-    private let lastSectionFooterText = NSLocalizedString("Optional: Enter a custom message to be sent with your invitation.", comment: "Invite Footer Text")
-
-
     // MARK: - Outlets
 
     /// Username Cell
@@ -135,10 +124,7 @@ class InvitePersonViewController: UITableViewController {
     // MARK: - UITableView Methods
 
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
-        guard section == lastSectionIndex else {
-            return nil
-        }
-        return lastSectionFooterText
+        return Section.footerText(for: section)
     }
 
     override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
@@ -228,10 +214,33 @@ class InvitePersonViewController: UITableViewController {
 
     // MARK: - Private Enums
 
-    fileprivate enum SegueIdentifier: String {
+    private enum SegueIdentifier: String {
         case Username   = "username"
         case Role       = "role"
         case Message    = "message"
+    }
+
+    // The case order matches the custom sections order in People.storyboard.
+    private enum Section: Int {
+        case username
+        case role
+        case message
+
+        static func footerText(for index: Int) -> String? {
+            let section = Section(rawValue: index)
+            return section?.footerText
+        }
+
+        var footerText: String? {
+            switch self {
+            case .role:
+                return NSLocalizedString("Learn more about roles", comment: "Footer text for Invite People role field.")
+            case .message:
+                return NSLocalizedString("Optional: Enter a custom message to be sent with your invitation.", comment: "Footer text for Invite People message field.")
+            default:
+                return nil
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Ref: #15356 

This adds a URL under the Roles row to display the roles definition page.

To test:
- Go to Site > People.
- Tap '+' in the nav bar.
- Verify `Learn more about roles` appears under `Role`.
- Tap it.
- Verify a web view opens with the `Invite People to Your Site` page.

| ![invite](https://user-images.githubusercontent.com/1816888/102418763-9d92a600-3fbb-11eb-9e7e-f5b02ae5fbb4.png) | ![webpage](https://user-images.githubusercontent.com/1816888/102418775-a5524a80-3fbb-11eb-83ac-087448949b8d.png) |
|--------|-------|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
