### PR TITLE
Activity Log filters: improve accessibility

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -168,6 +168,8 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
     }
 
     private func setupDateFilter() {
+        dateFilterChip.resetButton.accessibilityLabel = NSLocalizedString("Reset Date Range filter", comment: "Accessibility label for the reset date range button")
+
         dateFilterChip.tapped = { [weak self] in
             self?.showCalendar()
         }
@@ -179,6 +181,8 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
     }
 
     private func setupActivityTypeFilter() {
+        activityTypeFilterChip.resetButton.accessibilityLabel = NSLocalizedString("Reset Activity Type filter", comment: "Accessibility label for the reset activity type button")
+
         activityTypeFilterChip.tapped = { [weak self] in
             guard let self = self else {
                 return

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
@@ -64,6 +64,7 @@ class FilterChipButton: UIView {
     func disableResetButton() {
         resetButton.isHidden = true
         mainButton.contentEdgeInsets = Constants.buttonContentInset
+        UIAccessibility.post(notification: .layoutChanged, argument: mainButton)
     }
 
     @objc private func mainButtonTapped() {

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -220,6 +220,8 @@ class DateCell: JTACDayCell {
     let leftPlaceholder = UIView()
     let rightPlaceholder = UIView()
 
+    let dateFormatter = DateFormatter()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -287,6 +289,10 @@ extension DateCell {
                    hideInOutDates: Bool = false) {
 
         dateLabel.text = state.text
+
+        dateFormatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
+        dateLabel.accessibilityLabel = dateFormatter.string(from: state.date)
+        dateLabel.accessibilityTraits = .button
 
         var textColor: UIColor
 


### PR DESCRIPTION
Part of #15192

Improves accessibility to Activity Log filter bar.

### To test

Please, test using a real device with voice over enabled.

#### Filter bar

1. Go to Activity Log
2. Check that both the Date Range button and Activity Type button are accessible

#### Date Range

Z gesture:

1. Tap the Date Range button
2. Use the Z gesture (with two fingers), the screen should be dismisses

Selecting date:

1. Tap the Date Range button
2. Check that every date cell is read by Voice Over (the complete date)
3. Select a date range
4. Go to the header and make sure voice over read it's contents
5. Tap Done

Reset button:

1. Check that the voice over reads the reset button

#### Activity Type

Z gesture:

1. Tap the Activity Type button
2. Use the Z gesture (with two fingers), the screen should be dismisses

Selecting activities:

1. Tap the Activity Type button
2. Select one or more activity types
5. Tap Done

Reset button:

1. Check that the voice over reads the reset button

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
