### PR TITLE
checking the bounds width > 0 before setting the reader tabs

### DIFF
--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -424,7 +424,7 @@ class FilterTabBar: UIControl {
     ///
     private func scroll(to tab: UIButton, animated: Bool = true) {
         // Check the bar has enough content to scroll
-        guard scrollView.contentSize.width > scrollView.frame.width else {
+        guard scrollView.contentSize.width > scrollView.frame.width, bounds.width > 0 else {
             return
         }
 


### PR DESCRIPTION
Like this https://github.com/wordpress-mobile/WordPress-iOS/pull/15513 but targeting the right branch