### PR TITLE
Activity Log: fix calendar device rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
@@ -89,7 +89,9 @@ class CalendarViewController: UIViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        calendarCollectionView.reloadData()
+        coordinator.animate(alongsideTransition: { _ in
+            self.calendarCollectionView.reloadData(withAnchor: self.startDate ?? Date(), completionHandler: nil)
+        }, completion: nil)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -6,7 +6,7 @@ enum CalendarCollectionViewStyle {
     case year
 }
 
-class CalendarCollectionView: JTACMonthView {
+class CalendarCollectionView: WPJTACMonthView {
 
     let calDataSource: CalendarDataSource
     let style: CalendarCollectionViewStyle
@@ -95,7 +95,7 @@ class CalendarDataSource: JTACMonthViewDataSource {
     }
 
     func configureCalendar(_ calendar: JTACMonthView) -> ConfigurationParameters {
-        /// When style is year, display the last 20 years and the next one
+        /// When style is year, display the last 20 years til this month
         if style == .year {
             var dateComponent = DateComponents()
             dateComponent.year = -20
@@ -405,5 +405,18 @@ extension Date {
         }
 
         return Calendar.current.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth)
+    }
+}
+
+class WPJTACMonthView: JTACMonthView {
+
+    // Avoids content to scroll above the maximum size
+    override func setContentOffset(_ contentOffset: CGPoint, animated: Bool) {
+        let maxY = contentSize.height - frame.size.height
+        if contentOffset.y > maxY {
+            super.setContentOffset(CGPoint(x: contentOffset.x, y: maxY), animated: animated)
+        } else {
+            super.setContentOffset(contentOffset, animated: animated)
+        }
     }
 }


### PR DESCRIPTION
Part of #15192

### To test

#### No dates selected

1. Go to Activity Log and open the calendar filter
2. Rotate the device
3. Check that it still displays the last month
4. Rotate again, check that it still displays the last month

#### Dates selected

1. Go to Activity Log and open the calendar filter
2. Select a single date or a date range
2. Rotate the device
3. Check that it scrolls to your date selection
4. Rotate again, check that it still scrolls to your date selection

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
