### PR TITLE
Jetpack Section: New server credentials screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
@@ -129,10 +129,16 @@ open class JetpackSettingsViewController: UITableViewController {
 
         var manageConnectionRows = [ImmuTableRow]()
         manageConnectionRows.append(
-            NavigationItemRow(title: NSLocalizedString("Manage Connection",
-                                comment: "Jetpack Settings: Manage Connection"),
+            NavigationItemRow(title: NSLocalizedString("Manage Connection", comment: "Jetpack Settings: Manage Connection"),
                               action: self.pressedManageConnection())
         )
+
+        if FeatureFlag.jetpackScan.enabled {
+            manageConnectionRows.append(
+                NavigationItemRow(title: NSLocalizedString("Server Credentials", comment: "Jetpack Settings: Server Credentials"),
+                                  action: self.pressedServerCredentials())
+            )
+        }
 
         return ImmuTable(sections: [
             ImmuTableSection(
@@ -306,6 +312,15 @@ open class JetpackSettingsViewController: UITableViewController {
             let jetpackConnectionVC = JetpackConnectionViewController(blog: blog)
             jetpackConnectionVC.delegate = self
             self.navigationController?.pushViewController(jetpackConnectionVC, animated: true)
+        }
+    }
+
+    fileprivate func pressedServerCredentials() -> ImmuTableAction {
+        return { [unowned self] row in
+            let context = ContextManager.sharedInstance().mainContext
+            let service = JetpackScanService(managedObjectContext: context)
+            let serverCredentialsVC = ServerCredentialsViewController(blog: blog, service: service)
+            self.navigationController?.pushViewController(serverCredentialsVC, animated: true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Server Credentials/ServerCredentialsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Server Credentials/ServerCredentialsViewController.swift
@@ -1,0 +1,98 @@
+import CocoaLumberjack
+import Foundation
+import WordPressShared
+
+class ServerCredentialsViewController: UITableViewController {
+
+    // MARK: - Private Properties
+
+    private var blog: Blog!
+    private var service: JetpackScanService!
+    private lazy var handler: ImmuTableViewHandler = {
+        return ImmuTableViewHandler(takeOver: self)
+    }()
+
+    // MARK: - Initialization
+
+    convenience init(blog: Blog, service: JetpackScanService) {
+        self.init(style: .grouped)
+        self.blog = blog
+        self.service = service
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = NSLocalizedString("Remote Server Credentials", comment: "Title for the Jetpack Remote Server Credentials Screen")
+        ImmuTable.registerRows([EditableTextRow.self], tableView: tableView)
+        WPStyleGuide.configureColors(view: view, tableView: tableView)
+        reloadViewModel()
+    }
+
+    // MARK: - Model
+
+    private func reloadViewModel() {
+        // FIXME: Pass credentials retrieved from getCredentials
+        self.handler.viewModel = credentialsViewModel()
+
+        /*
+        service.getCredentials(for: blog, success: { [unowned self] credentials in
+            guard let credentials = credentials?.first else {
+                return
+            }
+            self.handler.viewModel = self.credentialsViewModel(credentials)
+            DDLogInfo("Fetched Remote Server Credentials")
+        }, failure: { error in
+            DDLogError("Error while fetching Remote Server Credentials: \(error.localizedDescription)")
+        })
+        */
+    }
+
+    private func credentialsViewModel(_ credentials: JetpackScanCredentials? = nil) -> ImmuTable {
+        let credentialType = EditableTextRow(
+            title: NSLocalizedString("Credential type", comment: "Remote Server Credentials: Credential type"),
+            value: credentials?.type ?? "",
+            action: nil
+        )
+
+        let serverAddress = EditableTextRow(
+            title: NSLocalizedString("Server address", comment: "Remote Server Credentials: Server address"),
+            value: credentials?.host ?? "",
+            action: nil
+        )
+
+        var port = ""
+        if let credentialsPort = credentials?.port {
+            port = String(credentialsPort)
+        }
+        let portNumber = EditableTextRow(
+            title: NSLocalizedString("Port number", comment: "Remote Server Credentials: Port number"),
+            value: port,
+            action: nil
+        )
+
+        let serverUsername = EditableTextRow(
+            title: NSLocalizedString("Server username", comment: "Remote Server Credentials: Server username"),
+            value: credentials?.user ?? "",
+            action: nil
+        )
+
+        let installationPath = EditableTextRow(
+            title: NSLocalizedString("WordPress installation path", comment: "Remote Server Credentials: WordPress installation path"),
+            value: credentials?.path ?? "",
+            action: nil
+        )
+
+        return ImmuTable(sections: [
+            ImmuTableSection(rows: [
+                credentialType,
+                serverAddress,
+                portNumber,
+                serverUsername,
+                installationPath
+            ])
+        ])
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2281,6 +2281,7 @@
 		F9C47A90238C9D6700AAD9ED /* StatsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C47A8E238C9D6400AAD9ED /* StatsScreen.swift */; };
 		FA00863D24EB68B100C863F2 /* FollowCommentsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00863C24EB68B100C863F2 /* FollowCommentsService.swift */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
+		FA483CD6258B5FB00017ECE9 /* ServerCredentialsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA483CD5258B5FB00017ECE9 /* ServerCredentialsViewController.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
 		FA5C740F1C599BA7000B528C /* TableViewHeaderDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */; };
@@ -5013,6 +5014,7 @@
 		FA00863C24EB68B100C863F2 /* FollowCommentsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowCommentsService.swift; sourceTree = "<group>"; };
 		FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Themes.swift"; sourceTree = "<group>"; };
 		FA2D12891BCED0AD006F2A15 /* WordPress 40.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 40.xcdatamodel"; sourceTree = "<group>"; };
+		FA483CD5258B5FB00017ECE9 /* ServerCredentialsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerCredentialsViewController.swift; sourceTree = "<group>"; };
 		FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementService.swift; sourceTree = "<group>"; };
 		FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceTests.swift; sourceTree = "<group>"; };
 		FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewHeaderDetailView.swift; sourceTree = "<group>"; };
@@ -10578,6 +10580,7 @@
 			isa = PBXGroup;
 			children = (
 				2F668B5D255DD11400D0038A /* Jetpack Settings */,
+				FA483CE4258B5FB50017ECE9 /* Server Credentials */,
 				9A8ECE002254A3250043C8DA /* Login */,
 				9A8ECE032254A3260043C8DA /* Install */,
 			);
@@ -10912,6 +10915,14 @@
 				F93735F722D53C3B00A3C312 /* LoggingURLRedactorTests.swift */,
 			);
 			path = Logging;
+			sourceTree = "<group>";
+		};
+		FA483CE4258B5FB50017ECE9 /* Server Credentials */ = {
+			isa = PBXGroup;
+			children = (
+				FA483CD5258B5FB00017ECE9 /* ServerCredentialsViewController.swift */,
+			);
+			path = "Server Credentials";
 			sourceTree = "<group>";
 		};
 		FA5C74091C596E69000B528C /* Site Management */ = {
@@ -13488,6 +13499,7 @@
 				4353BFA9219E0E820009CED3 /* RevisionOperationViewController.swift in Sources */,
 				E2E7EB46185FB140004F5E72 /* WPBlogSelectorButton.m in Sources */,
 				3F09CCAA2428FF8300D00A8C /* ReaderTabView.swift in Sources */,
+				FA483CD6258B5FB00017ECE9 /* ServerCredentialsViewController.swift in Sources */,
 				9808655C203D079B00D58786 /* EpilogueUserInfoCell.swift in Sources */,
 				08216FD41CDBF96000304BA7 /* MenuItemTypeSelectionView.m in Sources */,
 				43B0BA962229927F00328C69 /* WordPressAppDelegate+openURL.swift in Sources */,


### PR DESCRIPTION
Part of #15505 

This PR adds a new Remote Server Credentials screen.

Please note that:
- This screen is not yet hooked up to any APIs
- Tapping on the cells won't do anything yet
- The UI will be updated once design specs are finalized

### To test:

1. Make sure Jetpack Scan feature flag is turned ON
2. Go to My Site > Jetpack Settings > Server Credentials
    - Should navigate to a new Remote Server Credentials screen ✅ 

Jetpack Settings | Remote Server Credentials
--- | ---
![Screen Shot 2020-12-18 at 18 35 57](https://user-images.githubusercontent.com/6711616/102598898-0d419600-4160-11eb-9aa6-d144b7a28d5b.png) | ![Screen Shot 2020-12-18 at 18 36 01](https://user-images.githubusercontent.com/6711616/102598925-17639480-4160-11eb-8532-b360d01847e1.png)




PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
