### PR TITLE
Replace lazy Gutenberg var with local variable

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -267,9 +267,15 @@ class GutenbergViewController: UIViewController, PostEditor {
         return GutenbergImageLoader(post: post)
     }()
 
-    private lazy var gutenberg: Gutenberg = {
-        return Gutenberg(dataSource: self, extraModules: [gutenbergImageLoader])
-    }()
+    private var _gutenberg: Gutenberg?
+    private var gutenberg: Gutenberg {
+        guard let gutenberg = _gutenberg else {
+            let gutenberg = Gutenberg(dataSource: self, extraModules: [gutenbergImageLoader])
+            _gutenberg = gutenberg
+            return gutenberg
+        }
+        return gutenberg
+    }
 
     private var requestHTMLReason: RequestHTMLReason?
     private(set) var mode: EditMode = .richText
@@ -321,7 +327,7 @@ class GutenbergViewController: UIViewController, PostEditor {
     deinit {
         tearDownKeyboardObservers()
         removeObservers(fromPost: post)
-        gutenberg.invalidate()
+        _gutenberg?.invalidate()
         attachmentDelegate.cancelAllPendingMediaRequests()
     }
 


### PR DESCRIPTION
Fixes #13758

A similar crash was fixed earlier which occurs when the class (`GutenbergViewController`) calls `deinit` before using the `gutenberg` property. This causes the lazy property to be created _during_ deinit when we want to treat it as an optional.

## Testing

#### On `develop`
- Apply [this patch](https://gist.github.com/bjtitus/f0392902dd32699a95965be861df60da).
- Open the Post Editor and verify that the crash occurs.

#### On `fix/13758-gutenberg-lazy-var`
- Apply [this patch](https://gist.github.com/bjtitus/f0392902dd32699a95965be861df60da).
- Open the Post Editor and verify no crash occurs.
- Ensure that the Gutenberg editor is running and behaves properly
- Ensure that media uploads work as expected (this should directly exercise the Gutenberg property).


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
