### PR TITLE
Activity Log: add tracks

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -96,6 +96,9 @@ import Foundation
     case activitylogFilterbarSelectType
     case activitylogFilterbarResetType
     case activitylogFilterbarTypeButtonTapped
+    case activitylogFilterbarRangeButtonTapped
+    case activitylogFilterbarSelectRange
+    case activitylogFilterbarResetRange
 
     // Comments
     case commentViewed
@@ -269,6 +272,12 @@ import Foundation
             return "activitylog_filterbar_reset_type"
         case .activitylogFilterbarTypeButtonTapped:
             return "activitylog_filterbar_type_button_tapped"
+        case .activitylogFilterbarRangeButtonTapped:
+            return "activitylog_filterbar_range_button_tapped"
+        case .activitylogFilterbarSelectRange:
+            return "activitylog_filterbar_select_range"
+        case .activitylogFilterbarResetRange:
+            return "activitylog_filterbar_reset_range"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -95,7 +95,7 @@ import Foundation
     case jetpackWhitelistedIpsChanged
     case activitylogFilterbarSelectType
     case activitylogFilterbarResetType
-    case activitylogFilterbarRangeButtonTapped
+    case activitylogFilterbarTypeButtonTapped
 
     // Comments
     case commentViewed
@@ -267,8 +267,8 @@ import Foundation
             return "activitylog_filterbar_select_type"
         case .activitylogFilterbarResetType:
             return "activitylog_filterbar_reset_type"
-        case .activitylogFilterbarRangeButtonTapped:
-            return "activitylog_filterbar_range_button_tapped"
+        case .activitylogFilterbarTypeButtonTapped:
+            return "activitylog_filterbar_type_button_tapped"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -93,6 +93,9 @@ import Foundation
     case jetpackDisconnectRequested
     case jetpackWhitelistedIpsViewed
     case jetpackWhitelistedIpsChanged
+    case activitylogFilterbarSelectType
+    case activitylogFilterbarResetType
+    case activitylogFilterbarRangeButtonTapped
 
     // Comments
     case commentViewed
@@ -260,6 +263,12 @@ import Foundation
             return "jetpack_whitelisted_ips_viewed"
         case .jetpackWhitelistedIpsChanged:
             return "jetpack_whitelisted_ips_changed"
+        case .activitylogFilterbarSelectType:
+            return "activitylog_filterbar_select_type"
+        case .activitylogFilterbarResetType:
+            return "activitylog_filterbar_reset_type"
+        case .activitylogFilterbarRangeButtonTapped:
+            return "activitylog_filterbar_range_button_tapped"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -188,6 +188,8 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
                 return
             }
 
+            WPAnalytics.track(.activitylogFilterbarRangeButtonTapped)
+
             let activityTypeSelectorViewController = ActivityTypeSelectorViewController(
                 viewModel: self.viewModel
             )
@@ -422,7 +424,22 @@ extension ActivityListViewController: ActivityTypeSelectorDelegate {
             return
         }
 
+        trackSelectedGroups(groups)
+
         viewModel.refresh(after: viewModel.after, before: viewModel.before, group: groups)
         selectorViewController.dismiss(animated: true, completion: nil)
+    }
+
+    private func trackSelectedGroups(_ selectedGroups: [ActivityGroup]) {
+        if !viewModel.selectedGroups.isEmpty && selectedGroups.isEmpty {
+            WPAnalytics.track(.activitylogFilterbarResetType)
+        } else {
+            let totalActivitiesSelected = selectedGroups.map { $0.count }.reduce(0, +)
+            var selectTypeProperties: [AnyHashable: Any] = [:]
+            selectedGroups.forEach { selectTypeProperties["filter_group_\($0.key)"] = true }
+            selectTypeProperties["num_groups_selected"] = selectedGroups.count
+            selectTypeProperties["num_total_activities_selected"] = totalActivitiesSelected
+            WPAnalytics.track(.activitylogFilterbarSelectType, properties: selectTypeProperties)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -188,7 +188,7 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
                 return
             }
 
-            WPAnalytics.track(.activitylogFilterbarRangeButtonTapped)
+            WPAnalytics.track(.activitylogFilterbarTypeButtonTapped)
 
             let activityTypeSelectorViewController = ActivityTypeSelectorViewController(
                 viewModel: self.viewModel

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -176,6 +176,7 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
         }
 
         dateFilterChip.resetTapped = { [weak self] in
+            WPAnalytics.track(.activitylogFilterbarResetRange)
             self?.viewModel.removeDateFilter()
             self?.dateFilterChip.disableResetButton()
         }
@@ -409,8 +410,33 @@ extension ActivityListViewController: CalendarViewControllerDelegate {
             return
         }
 
+        trackSelectedRange(startDate: startDate, endDate: endDate)
+
         viewModel.refresh(after: startDate, before: endDate, group: viewModel.selectedGroups)
         calendar.dismiss(animated: true, completion: nil)
+    }
+
+    private func trackSelectedRange(startDate: Date?, endDate: Date?) {
+        guard let startDate = startDate else {
+            if viewModel.after != nil || viewModel.before != nil {
+                WPAnalytics.track(.activitylogFilterbarResetRange)
+            }
+
+            return
+        }
+
+        var duration: Int // Number of selected days
+        var distance: Int // Distance from the startDate to today (in days)
+
+        if let endDate = endDate {
+            duration = Int((endDate.timeIntervalSinceReferenceDate - startDate.timeIntervalSinceReferenceDate) / Double(24 * 60 * 60)) + 1
+        } else {
+            duration = 1
+        }
+
+        distance = Int((Date().timeIntervalSinceReferenceDate - startDate.timeIntervalSinceReferenceDate) / Double(24 * 60 * 60))
+
+        WPAnalytics.track(.activitylogFilterbarSelectRange, properties: ["duration": duration, "distance": distance])
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -171,6 +171,7 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
         dateFilterChip.resetButton.accessibilityLabel = NSLocalizedString("Reset Date Range filter", comment: "Accessibility label for the reset date range button")
 
         dateFilterChip.tapped = { [weak self] in
+            WPAnalytics.track(.activitylogFilterbarRangeButtonTapped)
             self?.showCalendar()
         }
 
@@ -199,6 +200,7 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
         }
 
         activityTypeFilterChip.resetTapped = { [weak self] in
+            WPAnalytics.track(.activitylogFilterbarResetType)
             self?.viewModel.removeGroupFilter()
             self?.activityTypeFilterChip.disableResetButton()
         }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTypeSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTypeSelectorViewController.swift
@@ -59,7 +59,9 @@ class ActivityTypeSelectorViewController: UITableViewController {
     }
 
     @objc private func done() {
-        delegate?.didSelect(selectorViewController: self, groups: viewModel.groups.filter { selectedGroupsKeys.contains($0.key) })
+        let selectedGroups = viewModel.groups.filter { selectedGroupsKeys.contains($0.key) }
+
+        delegate?.didSelect(selectorViewController: self, groups: selectedGroups)
     }
 
     @objc private func cancel() {
@@ -98,6 +100,7 @@ class ActivityTypeSelectorViewController: UITableViewController {
             selectedGroupsKeys.append(selectedGroupKey)
         }
     }
+
 
     private enum Constants {
         static let groupCellIdentifier = "GroupCellIdentifier"


### PR DESCRIPTION
Part of #15192

Adds analytics tracking to Activity Log filters.

### To test

#### Selecting a date range

1. Open Activity Log
2. Tap "Date Range"
3. Check that `activitylog_filterbar_range_button_tapped` is fired
4. Select a date range and tap Done
5. Make sure `activitylog_filterbar_select_range` is fired with `distance` and `duration` values
6. Reset date range and tap Done
7. Make sure `activitylog_filterbar_reset_range` is fired

#### Selecting a single date

1. Open Activity Log
2. Tap "Date Range"
3. Select a date range and tap Done
4. Open Date Range again
5. Clear your selection
6. Tap Done
7. Make sure `activitylog_filterbar_reset_range` is fired

#### Selecting activity type

1. Open Activity Log
2. Tap "Activity Type"
3. Make sure `activitylog_filterbar_type_button_tapped` is fired
4. Select one or more activity types and tap done
5. Make sure `activitylog_filterbar_select_type` is fired with props about the selected groups, number of groups and total number of activities
6. Tap reset
7. Make sure `activitylog_filterbar_reset_type` is fired

### Clearing activity types

1. Open Activity Log
2. Tap "Activity Type"
3. Select one or more activities type and tap done
4. Tap "Activity Type" again
5. Clear your selection and tap done
6. Make sure `activitylog_filterbar_reset_type` is fired

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
