### PR TITLE
Allow updatable statusbars on each tab bar view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -10,13 +10,12 @@ extension WPTabBarController {
     }
 
     override open var childForStatusBarStyle: UIViewController? {
-        guard
-            let topViewController = readerNavigationController?.topViewController,
-            ((topViewController as? DefinesVariableStatusBarStyle) != nil)
-        else {
-            return nil
+        var selectedController = selectedViewController
+        if let navController = selectedController as? UINavigationController {
+            selectedController = navController.topViewController
         }
-        return topViewController
+
+        return selectedController
     }
 }
 


### PR DESCRIPTION
Fixes #15506

### To test:
1. Launch the app in Light Mode
2. Tap on the notifications tab
3. Tap on an item that links to the Reader Detail view
4. Note the statusbar is not invisible
5. Tap on other tabs (My Site, Reader) and make sure the status bar is the same style

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
