### PR TITLE
Add CSS for the file block

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/reader.css
@@ -32,6 +32,17 @@ table {
   overflow-x: auto;
 }
 
+.wp-block-file .wp-block-file__button {
+    background-color: var( --main-link-color);
+    color: white;
+
+    text-align: center;
+    padding: 2px 10px;
+    border-radius: 20px;
+    display: inline-block;
+    margin-left: 5px;
+}
+
 div.feedflare { display: none; }
 
 .sharedaddy, .jp-relatedposts, .mc4wp-form, .wpcnt, .OUTBRAIN, .adsbygoogle { display: none; }


### PR DESCRIPTION
Fixes #15533 

Note: I wasn't sure which CSS var colors to use so I used the main link colors. If you know of a better one please let me know.

### Screenshots
| Light Mode | Dark Mode |
|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/793774/102676736-f9e8f780-416c-11eb-8da5-364b666f8afa.png" />|![Simulator Screen Shot - iPhone 11 Pro - 2020-12-18 at 20 09 34](https://user-images.githubusercontent.com/793774/102676735-f8b7ca80-416c-11eb-8a3f-1e4ee2a3be83.png)|

### To test:
1. Launch the app
2. Tap the Reader
3. Find a post using a file block or use this test one: https://emilylaguna.wordpress.com/2020/12/19/file-block/
4. Verify the button style is rendered correctly

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
