### PR TITLE
Reset the Prepublishing nudges view when navigating between views

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -35,9 +35,9 @@ def aztec
 end
 
 def wordpress_ui
-    pod 'WordPressUI', '~> 1.7.4'
+    #pod 'WordPressUI', '~> 1.9.0-beta.2'
     #pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :tag => ''
-    #pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :branch => ''
+    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :branch => 'issue/15531-fix-ppn-cut-off'
     #pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :commit => ''
     #pod 'WordPressUI', :path => '../WordPressUI-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -35,9 +35,9 @@ def aztec
 end
 
 def wordpress_ui
-    #pod 'WordPressUI', '~> 1.9.0-beta.2'
+    pod 'WordPressUI', '~> 1.9.0-beta.2'
     #pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :tag => ''
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :branch => 'issue/15531-fix-ppn-cut-off'
+    #pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :branch => ''
     #pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS', :commit => ''
     #pod 'WordPressUI', :path => '../WordPressUI-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -417,7 +417,7 @@ PODS:
   - WordPressShared (1.14.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
-  - WordPressUI (1.7.4)
+  - WordPressUI (1.9.0-beta.2)
   - WPMediaPicker (1.7.2)
   - wpxmlrpc (0.9.0)
   - Yoga (1.14.0)
@@ -508,7 +508,7 @@ DEPENDENCIES:
   - WordPressKit (~> 4.23)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.14.0)
-  - WordPressUI (~> 1.7.4)
+  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS`, branch `issue/15531-fix-ppn-cut-off`)
   - WPMediaPicker (~> 1.7.2)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.43.0/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.1.1)
@@ -557,7 +557,6 @@ SPEC REPOS:
     - WordPressKit
     - WordPressMocks
     - WordPressShared
-    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskCommonUISDK
@@ -655,6 +654,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.43.0
+  WordPressUI:
+    :branch: issue/15531-fix-ppn-cut-off
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.43.0/third-party-podspecs/Yoga.podspec.json
 
@@ -673,6 +675,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.43.0
+  WordPressUI:
+    :commit: 2aca2d62d61ac910e0375105a884aa0df271bead
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -756,7 +761,7 @@ SPEC CHECKSUMS:
   WordPressKit: e7603e3da7bbcf51da82c783080458b04585cf3a
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 99b37324ffef200ddf32694bc3de1e0c9fcfef21
-  WordPressUI: 4226e616dd8e7aab5a8d2172b7c378454e72182e
+  WordPressUI: 9b444ce26889a2cd00558f947ccc98dec1cb5783
   WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
   Yoga: c920bf12bf8146aa5cd118063378c2cf5682d16c
@@ -769,6 +774,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 5320591fd2357fa68b9593c9006066a66349aa0c
+PODFILE CHECKSUM: 01335ec7e7a9d30e8bf79d1b82617c238470d9cd
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -508,7 +508,7 @@ DEPENDENCIES:
   - WordPressKit (~> 4.23)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.14.0)
-  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS`, branch `issue/15531-fix-ppn-cut-off`)
+  - WordPressUI (~> 1.9.0-beta.2)
   - WPMediaPicker (~> 1.7.2)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.43.0/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.1.1)
@@ -557,6 +557,7 @@ SPEC REPOS:
     - WordPressKit
     - WordPressMocks
     - WordPressShared
+    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskCommonUISDK
@@ -654,9 +655,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.43.0
-  WordPressUI:
-    :branch: issue/15531-fix-ppn-cut-off
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.43.0/third-party-podspecs/Yoga.podspec.json
 
@@ -675,9 +673,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.43.0
-  WordPressUI:
-    :commit: 2aca2d62d61ac910e0375105a884aa0df271bead
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -774,6 +769,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: 249fa8890597086cd536bb2df5c9804d84e122b0
 
-PODFILE CHECKSUM: 01335ec7e7a9d30e8bf79d1b82617c238470d9cd
+PODFILE CHECKSUM: 0e67899058bdd2f8150c162f2510dbe7d8a0215e
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -2,7 +2,7 @@ import Foundation
 import CocoaLumberjack
 import WordPressShared
 
-class PostTagPickerViewController: UIViewController, DrawerPresentable {
+class PostTagPickerViewController: UIViewController {
     private let originalTags: [String]
     @objc var onValueChanged: ((String) -> Void)?
     @objc let blog: Blog
@@ -467,5 +467,15 @@ extension WPStyleGuide {
         WPStyleGuide.configureTableViewCell(cell)
         cell.textLabel?.textColor = .text
         cell.backgroundColor = .listForeground
+    }
+}
+
+extension PostTagPickerViewController: DrawerPresentable {
+    var collapsedHeight: DrawerHeight {
+        return .contentHeight(300)
+    }
+
+    var scrollableView: UIScrollView? {
+        return tableView
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
@@ -35,19 +35,21 @@ class PrepublishingNavigationController: LightNavigationController {
     override func pushViewController(_ viewController: UIViewController, animated: Bool) {
         super.pushViewController(viewController, animated: animated)
 
-        if let bottomSheet = self.parent as? BottomSheetViewController, let presentedVC = bottomSheet.presentedVC {
-            presentedVC.transition(to: .collapsed)
-        }
+        transition()
     }
 
     override func popViewController(animated: Bool) -> UIViewController? {
         let viewController = super.popViewController(animated: animated)
 
+        transition()
+
+        return viewController
+    }
+
+    private func transition() {
         if let bottomSheet = self.parent as? BottomSheetViewController, let presentedVC = bottomSheet.presentedVC {
             presentedVC.transition(to: .collapsed)
         }
-
-        return viewController
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
@@ -24,12 +24,30 @@ class PrepublishingNavigationController: LightNavigationController {
                 return Constants.iPadPreferredContentSize
             }
 
-            guard  let visibleViewController = viewControllers.last else {
+            guard let visibleViewController = viewControllers.last else {
                 return .zero
             }
 
             return visibleViewController.preferredContentSize
         }
+    }
+
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        super.pushViewController(viewController, animated: animated)
+
+        if let bottomSheet = self.parent as? BottomSheetViewController, let presentedVC = bottomSheet.presentedVC {
+            presentedVC.transition(to: .collapsed)
+        }
+    }
+
+    override func popViewController(animated: Bool) -> UIViewController? {
+        let viewController = super.popViewController(animated: animated)
+
+        if let bottomSheet = self.parent as? BottomSheetViewController, let presentedVC = bottomSheet.presentedVC {
+            presentedVC.transition(to: .collapsed)
+        }
+
+        return viewController
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingNavigationController.swift
@@ -60,7 +60,11 @@ class PrepublishingNavigationController: LightNavigationController {
 
 extension PrepublishingNavigationController: DrawerPresentable {
     var allowsUserTransition: Bool {
-        return false
+        guard let visibleDrawer = visibleViewController as? DrawerPresentable else {
+            return true
+        }
+
+        return visibleDrawer.allowsUserTransition
     }
 
     var expandedHeight: DrawerHeight {
@@ -68,13 +72,15 @@ extension PrepublishingNavigationController: DrawerPresentable {
     }
 
     var collapsedHeight: DrawerHeight {
-        return .intrinsicHeight
+        guard let visibleDrawer = visibleViewController as? DrawerPresentable else {
+            return .contentHeight(300)
+        }
+
+        return visibleDrawer.collapsedHeight
     }
 
     var scrollableView: UIScrollView? {
-        let scroll = topViewController?.view as? UIScrollView
-
-        return scroll
+        return topViewController?.view as? UIScrollView
     }
 
     func handleDismiss() {

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -199,7 +199,7 @@ class PrepublishingViewController: UITableViewController {
         }
 
         navigationController?.pushViewController(categoriesViewController, animated: true)
-       }
+    }
 
     // MARK: - Visibility
 
@@ -385,5 +385,17 @@ extension PrepublishingViewController: PostCategoriesViewControllerDelegate {
 extension Set {
     var array: [Element] {
         return Array(self)
+    }
+}
+
+
+// MARK: - DrawerPresentable
+extension PrepublishingViewController: DrawerPresentable {
+    var allowsUserTransition: Bool {
+        return false
+    }
+
+    var collapsedHeight: DrawerHeight {
+        return .intrinsicHeight
     }
 }


### PR DESCRIPTION
Fixes #15531 

### To Test:

Follow the steps on Related PR: https://github.com/wordpress-mobile/WordPressUI-iOS/pull/81

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
