### PR TITLE
Add 60s throttle to suggestion requests

### DIFF
--- a/WordPress/Classes/Services/SuggestionService.swift
+++ b/WordPress/Classes/Services/SuggestionService.swift
@@ -41,7 +41,7 @@ class SuggestionService {
     */
     private func fetchAndPersistSuggestions(for blog: Blog, completion: @escaping ([UserSuggestion]?) -> Void) {
 
-        guard let blogId = blog.dotComID, let hostname = blog.hostname else { return }
+        guard let blogId = blog.dotComID else { return }
 
         // if there is already a request in place for this blog, just wait
         guard !blogsCurrentlyBeingRequested.contains(blogId) else { return }

--- a/WordPress/Classes/Services/SuggestionService.swift
+++ b/WordPress/Classes/Services/SuggestionService.swift
@@ -3,8 +3,8 @@ import Foundation
 /// A service to fetch and persist a list of users that can be @-mentioned in a post or comment.
 class SuggestionService {
 
-    private var blogsCurrentlyBeingRequested = [Blog]()
-    private var requests = [Blog: Date]()
+    private var blogsCurrentlyBeingRequested = [NSNumber]()
+    private var requests = [NSNumber: Date]()
 
     static let shared = SuggestionService()
 
@@ -18,7 +18,7 @@ class SuggestionService {
 
         let throttleDuration: TimeInterval = 60 // seconds
         let isBelowThrottleThreshold: Bool
-        if let requestDate = requests[blog] {
+        if let id = blog.dotComID, let requestDate = requests[id] {
             isBelowThrottleThreshold = Date().timeIntervalSince(requestDate) < throttleDuration
         } else {
             isBelowThrottleThreshold = false
@@ -41,8 +41,10 @@ class SuggestionService {
     */
     private func fetchAndPersistSuggestions(for blog: Blog, completion: @escaping ([UserSuggestion]?) -> Void) {
 
+        guard let blogId = blog.dotComID, let hostname = blog.hostname else { return }
+
         // if there is already a request in place for this blog, just wait
-        guard !blogsCurrentlyBeingRequested.contains(blog) else { return }
+        guard !blogsCurrentlyBeingRequested.contains(blogId) else { return }
 
         guard let siteID = blog.dotComID else { return }
 
@@ -50,7 +52,7 @@ class SuggestionService {
         let params = ["site_id": siteID]
 
         // add this blog to currently being requested list
-        blogsCurrentlyBeingRequested.append(blog)
+        blogsCurrentlyBeingRequested.append(blogId)
 
         defaultAccount()?.wordPressComRestApi.GET(suggestPath, parameters: params, success: { [weak self] responseObject, httpResponse in
             guard let `self` = self else { return }
@@ -73,19 +75,19 @@ class SuggestionService {
             // Save the changes
             try? blog.managedObjectContext?.save()
 
-            self.requests[blog] = Date()
+            self.requests[blogId] = Date()
 
             completion(suggestions)
 
             // remove blog from the currently being requested list
-            self.blogsCurrentlyBeingRequested.removeAll { $0 == blog }
+            self.blogsCurrentlyBeingRequested.removeAll { $0 == blogId }
         }, failure: { [weak self] error, _ in
             guard let `self` = self else { return }
 
             completion(nil)
 
             // remove blog from the currently being requested list
-            self.blogsCurrentlyBeingRequested.removeAll { $0 == blog}
+            self.blogsCurrentlyBeingRequested.removeAll { $0 == blogId}
 
             DDLogVerbose("[Rest API] ! \(error.localizedDescription)")
         })


### PR DESCRIPTION
Previously the contents of the suggestions UI (Xpost and Mention options) were cached until the app was restarted. Now a 60 second thottle limits the number of calls made to the server, by using cached results if available and if not older than the duration of the throttle.

Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/2602

### To test

**What you'll need**: A WordPress.com site that is capable of xposting to one or more other sites

_Note: https://wordpress.com/p2/ can be used to create xpost-capable sites._

**Xpost in Gutenberg**

1. Open the block editor
2. In a Paragraph or any other rich text block, type `+` and verify that the list of Xpost suggestions is shown after a slight network delay
3. Dismiss the suggestions UI, type `+` again and verify that the list of suggestions is shown instantly
4. After slightly more than 60 seconds has elapsed since Step 2, type `+` again and ensure that a slight delay is apparent before the UI loads again

**Mentions in Gutenberg**
Repeat steps 1 to 4 above, but use `@` instead so as to trigger the Mentions UI

**Smoke test Mentions outside of Gutenberg**
1. Go to a post in Reader and make sure Mentions work in comments
2. Go to a sites Comments section (My Site → Comments), select a comment, and make a reply that includes a Mention
3. Check anywhere else Mentions are used (e.g. Notification replies)

Note: There's room here to reduce code duplication and improve naming between `SuggestionService` and `SiteSuggestionService`: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2932

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
