### PR TITLE
Prefetch xpost suggestions in Gutenberg

### DIFF
--- a/WordPress/Classes/Services/SiteSuggestionService.swift
+++ b/WordPress/Classes/Services/SiteSuggestionService.swift
@@ -35,6 +35,17 @@ class SiteSuggestionService {
     }
 
     /**
+     If no suggestions already in Core Data, fetch them from the network and store them in Core Data.
+     @param blog The blog/site to prefetch suggestions for
+     */
+    func prefetchSuggestions(for blog: Blog) {
+        let persistedSuggestions = retrievePersistedSuggestions(for: blog)
+        if persistedSuggestions == nil || persistedSuggestions?.isEmpty == true {
+            fetchAndPersistSuggestions(for: blog, completion: { _ in})
+        }
+    }
+
+    /**
     Performs a REST API request for the given blog.
     Persists response objects to Core Data.
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -345,6 +345,8 @@ class GutenbergViewController: UIViewController, PostEditor {
         }, failure: { (error) in
             DDLogError("Error syncing JETPACK: \(String(describing: error))")
         })
+
+        SiteSuggestionService.shared.prefetchSuggestions(for: self.post.blog)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
@@ -28,6 +28,10 @@ extension PostEditor where Self: UIViewController {
             }
             self.recreatePostRevision(in: blog)
             self.mediaLibraryDataSource = MediaLibraryPickerDataSource(post: self.post)
+
+            if self.editorSession.currentEditor == .gutenberg {
+                SiteSuggestionService.shared.prefetchSuggestions(for: self.post.blog)
+            }
         }
 
         let dismissHandler: BlogSelectorDismissHandler = {


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/2602

This PR prefetches the suggestion data that populates the Xpost suggestion UI. Without this, the user experiences a network delay when first inserting an Xpost suggestion in the block editor.

#### Expected behavior 
https://user-images.githubusercontent.com/1898325/103297740-b3e72b80-49d7-11eb-8abe-8ca42dd9b382.MP4

Note: The throttle introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/15558 is a 60 second throttle. This means that the user will still experience the network delay if they wait for more than 60 seconds between opening the editor and inserting an Xpost suggestion.

### To test

**What you'll need**: Two or more WordPress.com sites that are capable of xposting (https://wordpress.com/p2/ can be used to create xpost-capable sites). It's best if you can test with a site that has lots of Xpost suggestions (10 to 20), to ensure that the network delay would be noticeable if present.

**Xpost in Gutenberg**

1. Open the block editor
2. In a Paragraph or any other rich text block, type `+` and verify that the list of Xpost suggestions is shown immediately (no network delay should be noticeable)
3. Switch to a different site from within the editor
4. Type `+` (or long press the `@` toolbar button and select Xpost) and expect the list of suggestions to be shown immediately

Note: There is an issue which @antonis first reported in https://github.com/wordpress-mobile/WordPress-iOS/pull/15139#discussion_r548485770 where sites that don't have Xposts suggestions (e.g. non-P2 sites) show the suggestions UI for an instant while the network loads. I didn't address that here because I had difficulty updating the Gutenberg capability when switching between sites while in the the editor. I created https://github.com/wordpress-mobile/gutenberg-mobile/issues/2942 to address this in a later PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
