### PR TITLE
Added analytics tracks event for suggestions

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -40,6 +40,7 @@ import Foundation
     // Gutenberg Features
     case gutenbergUnsupportedBlockWebViewShown
     case gutenbergUnsupportedBlockWebViewClosed
+    case gutenbergSuggestionSessionFinished
 
     // Notifications Permissions
     case pushNotificationsPrimerSeen
@@ -172,6 +173,8 @@ import Foundation
             return "gutenberg_unsupported_block_webview_shown"
         case .gutenbergUnsupportedBlockWebViewClosed:
             return "gutenberg_unsupported_block_webview_closed"
+        case .gutenbergSuggestionSessionFinished:
+            return "suggestion_session_finished"
         // Notifications permissions
         case .pushNotificationsPrimerSeen:
             return "notifications_primer_seen"

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -902,6 +902,26 @@ extension GutenbergViewController {
             if let previousFirstResponder = self.previousFirstResponder {
                 previousFirstResponder.becomeFirstResponder()
             }
+
+            var analyticsName: String
+            switch type {
+            case .mention:
+                analyticsName = "user"
+            case .xpost:
+                analyticsName = "xpost"
+            }
+
+            var didSelectSuggestion = false
+            if case .success(_) = result {
+                didSelectSuggestion = true
+            }
+
+            let analyticsProperties: [String: Any] = [
+                "suggestion_type": analyticsName,
+                "did_select_suggestion": didSelectSuggestion
+            ]
+
+            WPAnalytics.track(.gutenbergSuggestionSessionFinished, properties: analyticsProperties)
         }
         addChild(suggestionsController)
         view.addSubview(suggestionsController.view)


### PR DESCRIPTION
Addresses: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2602

This PR adds the `suggestion_session_finished` analytics event to track suggestions usage. The event is fired when the user has either chosen a suggestion from the available options or has exited the suggestions UI without making a selection. The following properties provide information about the interaction:
- `suggestion_type`: Indicates which type of suggestion was used, either `user` (for Mentions) or `xpost` (for Xposts)
- `did_select_suggestion`: Indicates whether the user chose a selection, either `1` (user chose a selection) or `0` (user exited the suggestions UI without making a selection)

This PR is the iOS equivalent to the WPAndroid PR here: https://github.com/wordpress-mobile/WordPress-Android/pull/13622

### To test

**What you'll need**: 
- A WordPress.com sites that is capable of xposting/@-mentioning (https://wordpress.com/p2/ can be used).
- Xcode available to run the code from this branch and view the events in Xcode's console 

While testing, you might notice that deleting the `@` or `+` character [doesn't remove said character from post](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2943), or notice that on sites that don't support Xposts, the [Xpost UI flashes on the screen momentarily](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2942) when typing `+`.

**Xpost in Gutenberg**

#### Setup
a. Checkout this branch, open it in Xcode (`rake xcode`) and run the project
b. Open Xcode's console (View → Debug Area → Activate Console)
c. Optionally add `Tracked: ` into the console filter to hide unwanted output
d. Open the block editor

##### Test
1. Type `@` (or tap the `@` toolbar button)
2. Choose an item from the list of suggestions
3. Verify the log shows the analytic event you would expect
4. Again type `@` (or tap the `@` toolbar button)
5. Choose an item from the list of suggestions
6. Verify the log shows the analytic event you would expect
7. Type `+` (or long-press the `@` toolbar button, and select Crosspost)
8. Choose an item from the list of suggestions
9. Verify the log shows the analytic event you would expect
10. Again type `+` (or long-press the `@` toolbar button, and select Crosspost)
11. Choose an item from the list of suggestions
12. Verify the log shows the analytic event you would expect

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
