### PR TITLE
Fix 15542: Next Quick Start Tour after Site Page

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Route+Page.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route+Page.swift
@@ -13,7 +13,7 @@ struct NewPageForSiteRoute: Route {
 struct NewPageNavigationAction: NavigationAction {
     func perform(_ values: [String: String], source: UIViewController? = nil) {
         if let blog = blog(from: values) {
-            WPTabBarController.sharedInstance()?.showPageEditor(forBlog: blog)
+            WPTabBarController.sharedInstance()?.showPageEditor(blog: blog)
         } else {
             WPTabBarController.sharedInstance()?.showPageEditor()
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
@@ -8,12 +8,20 @@ extension BlogDetailsViewController {
         let newPage = { [weak self] in
             let controller = self?.tabBarController as? WPTabBarController
             let blog = controller?.currentOrLastBlog()
-            controller?.showPageEditor(forBlog: blog)
+            controller?.showPageEditor(blog: blog, completion: {
+                if QuickStartTourGuide.shared.isCurrentElement(.newPage) {
+                    QuickStartTourGuide.shared.visited(.newPage)
+                }
+                self?.startAlertTimer()
+            })
         }
 
         let newPost = { [weak self] in
             let controller = self?.tabBarController as? WPTabBarController
             controller?.showPostTab(completion: {
+                if QuickStartTourGuide.shared.isCurrentElement(.newpost) {
+                    QuickStartTourGuide.shared.visited(.newpost)
+                }
                 self?.startAlertTimer()
             })
         }

--- a/WordPress/Classes/ViewRelated/Pages/EditPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/EditPageViewController.swift
@@ -8,20 +8,23 @@ class EditPageViewController: UIViewController {
     fileprivate var hasShownEditor = false
     fileprivate var appliedTemplate: String?
 
-    convenience init(page: Page) {
-        self.init(page: page, blog: page.blog, postTitle: nil, content: nil, appliedTemplate: nil)
+    private let completion: (() -> Void)?
+
+    convenience init(page: Page, completion: (() -> Void)? = nil) {
+        self.init(page: page, blog: page.blog, postTitle: nil, content: nil, appliedTemplate: nil, completion: completion)
     }
 
-    convenience init(blog: Blog, postTitle: String?, content: String?, appliedTemplate: String?) {
-        self.init(page: nil, blog: blog, postTitle: postTitle, content: content, appliedTemplate: appliedTemplate)
+    convenience init(blog: Blog, postTitle: String?, content: String?, appliedTemplate: String?, completion: (() -> Void)? = nil) {
+        self.init(page: nil, blog: blog, postTitle: postTitle, content: content, appliedTemplate: appliedTemplate, completion: completion)
     }
 
-    fileprivate init(page: Page?, blog: Blog, postTitle: String?, content: String?, appliedTemplate: String?) {
+    fileprivate init(page: Page?, blog: Blog, postTitle: String?, content: String?, appliedTemplate: String?, completion: (() -> Void)?) {
         self.page = page
         self.blog = blog
         self.postTitle = postTitle
         self.content = content
         self.appliedTemplate = appliedTemplate
+        self.completion = completion
 
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .overFullScreen
@@ -79,6 +82,7 @@ class EditPageViewController: UIViewController {
             self?.dismiss(animated: true) {
                 // Dismiss self
                 self?.dismiss(animated: false)
+                self?.completion?()
             }
         }
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -112,8 +112,6 @@ import WordPressFlux
         button.addTarget(self, action: #selector(showCreateSheet), for: .touchUpInside)
     }
 
-    private var currentTourElement: QuickStartTourElement?
-
     @objc private func showCreateSheet() {
         didDismissTooltip = true
         hideNotice()
@@ -128,10 +126,6 @@ import WordPressFlux
             let actionSheetVC = actionSheetController(with: viewController.traitCollection)
             viewController.present(actionSheetVC, animated: true, completion: { [weak self] in
                 WPAnalytics.track(.createSheetShown)
-
-                if let element = self?.currentTourElement {
-                    QuickStartTourGuide.shared.visited(element)
-                }
             })
         }
     }
@@ -214,7 +208,6 @@ import WordPressFlux
                     return
             }
 
-            self.currentTourElement = element
             self.hideNotice()
             self.didDismissTooltip = false
             self.showCreateButton(notice: self.quickStartNotice(description))

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -1,27 +1,23 @@
 extension WPTabBarController {
 
-    @objc func showPageEditor(forBlog: Blog? = nil) {
-        showPageEditor(blog: forBlog)
-    }
-
     @objc func showStoryEditor(forBlog: Blog? = nil) {
         showStoryEditor(blog: forBlog)
     }
 
     /// Show the page tab
     /// - Parameter blog: Blog to a add a page to. Uses the current or last blog if not provided
-    func showPageEditor(blog inBlog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button") {
+    func showPageEditor(blog inBlog: Blog? = nil, title: String? = nil, content: String? = nil, source: String = "create_button", completion: (() -> Void)? = nil) {
 
         // If we are already showing a view controller, dismiss and show the editor afterward
         guard presentedViewController == nil else {
             dismiss(animated: true) { [weak self] in
-                self?.showPageEditor(blog: inBlog, title: title, content: content, source: source)
+                self?.showPageEditor(blog: inBlog, title: title, content: content, source: source, completion: completion)
             }
             return
         }
         guard let blog = inBlog ?? self.currentOrLastBlog() else { return }
         guard content == nil else {
-            showEditor(blog: blog, title: title, content: content, templateKey: nil)
+            showEditor(blog: blog, title: title, content: content, templateKey: nil, completion: completion)
             return
         }
 
@@ -29,12 +25,12 @@ extension WPTabBarController {
         WPAnalytics.track(WPAnalyticsEvent.editorCreatedPage, properties: [WPAppAnalyticsKeyTapSource: source, WPAppAnalyticsKeyBlogID: blogID, WPAppAnalyticsKeyPostType: "page"])
 
         PageCoordinator.showLayoutPickerIfNeeded(from: self, forBlog: blog) { [weak self] (selectedLayout) in
-            self?.showEditor(blog: blog, title: selectedLayout?.title, content: selectedLayout?.content, templateKey: selectedLayout?.slug)
+            self?.showEditor(blog: blog, title: selectedLayout?.title, content: selectedLayout?.content, templateKey: selectedLayout?.slug, completion: completion)
         }
     }
 
-    private func showEditor(blog: Blog, title: String?, content: String?, templateKey: String?) {
-        let editorViewController = EditPageViewController(blog: blog, postTitle: title, content: content, appliedTemplate: templateKey)
+    private func showEditor(blog: Blog, title: String?, content: String?, templateKey: String?, completion: (() -> Void)?) {
+        let editorViewController = EditPageViewController(blog: blog, postTitle: title, content: content, appliedTemplate: templateKey, completion: completion)
         present(editorViewController, animated: false)
     }
 


### PR DESCRIPTION
Moves tour completion + next tour trigger to happen _after_ the user has exited the blog post or site page view.

Fixes #15542

To test:
- Create a new site and opt-in to the Quick Start tour.
- Select the "Create a new page" tour item.
- The new page tour item should not be completed until after the user dismisses the Page editor.
- The new page tour item should not be completed until after the user dismisses the Page editor.
- Ensure that the next tour item is suggested upon returning to the Blog Details screen. ("Set your site title" if you haven't completed anything else)
- Try the "Publish a post" tour item
- Ensure that the item is not completed until the user has dismissed the Blog Editor.


https://user-images.githubusercontent.com/3250/103695235-721b2f80-4f59-11eb-9389-61c99abbe27c.mp4

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
