### PR TITLE
Reader Following site filter: don't show P2 or A8C sites.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] Invite People: add link to user roles definition web page. [#15530]
 * [***] Block Editor: Cross-post suggestions are now available by typing the + character (or long-pressing the toolbar button labelled with an @-symbol) in a post on a P2 site [#15139]
 * [**] Reader site filter: unseen post count is displayed for each site. [#15581]
+* [**] Reader: Following now only shows non-P2 sites. [#15585]
 
 16.4
 -----

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -145,7 +145,14 @@ extension ReaderTabViewModel {
 extension ReaderTabViewModel {
     private func makeFilterSheetViewController(completion: @escaping (ReaderAbstractTopic) -> Void) -> FilterSheetViewController {
         let selectedTab = tabItems[selectedIndex]
-        let siteType = (selectedTab.content.topic as? ReaderTeamTopic)?.organizationType
+
+        let siteType: SiteOrganizationType = {
+            if let teamTopic = selectedTab.content.topic as? ReaderTeamTopic {
+                return teamTopic.organizationType
+            }
+            return .none
+        }()
+
         var filters = [ReaderSiteTopic.filterProvider(for: siteType)]
 
         if !selectedTab.shouldHideTagFilter {


### PR DESCRIPTION
Fixes #15578 

This removes P2 and A8C sites from the `Following` site filter to match the web Reader.

The Following stream itself was already filtering them out, so no changes were needed there.

To test:
- Go to Reader > Following.
- Select `Filter`.
- Verify only non-P2/A8C sites are displayed (i.e. the list matches `Followed Sites` in the web Reader).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
