### PR TITLE
iOS 13: Fix scroll indicator deprecation warnings

### DIFF
--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -911,7 +911,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
     frame = [self.view.window convertRect:frame toView:self.view];
 
     UIEdgeInsets inset = self.scrollView.contentInset;
-    UIEdgeInsets scrollInset = self.scrollView.scrollIndicatorInsets;
+    UIEdgeInsets scrollInset = self.scrollView.verticalScrollIndicatorInsets;
 
     if (frame.origin.y > self.view.frame.size.height) {
         inset.bottom = 0.0;
@@ -930,7 +930,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
     self.observesKeyboardChanges = NO;
 
     UIEdgeInsets inset = self.scrollView.contentInset;
-    UIEdgeInsets scrollInset = self.scrollView.scrollIndicatorInsets;
+    UIEdgeInsets scrollInset = self.scrollView.verticalScrollIndicatorInsets;
     inset.bottom = 0;
     scrollInset.bottom = 0;
     self.scrollView.contentInset = inset;

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -184,7 +184,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         tableView.tableHeaderView = searchController.searchBar
 
-        tableView.scrollIndicatorInsets.top = searchController.searchBar.bounds.height
+        tableView.verticalScrollIndicatorInsets.top = searchController.searchBar.bounds.height
     }
 
     override func configureAuthorFilter() {
@@ -895,7 +895,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func didPresentSearchController(_ searchController: UISearchController) {
-        tableView.scrollIndicatorInsets.top = searchController.searchBar.bounds.height + searchController.searchBar.frame.origin.y - view.safeAreaInsets.top
+        tableView.verticalScrollIndicatorInsets.top = searchController.searchBar.bounds.height + searchController.searchBar.frame.origin.y - view.safeAreaInsets.top
     }
 
     func didDismissSearchController(_ searchController: UISearchController) {

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
@@ -70,7 +70,7 @@ class PluginDirectoryViewController: UITableViewController {
 
         containerView.addSubview(searchController.searchBar)
         tableView.tableHeaderView = containerView
-        tableView.scrollIndicatorInsets.top = searchController.searchBar.bounds.height
+        tableView.verticalScrollIndicatorInsets.top = searchController.searchBar.bounds.height
         // for some... particlar reason, which I haven't been able to fully track down, if the searchBar is added directly
         // as the tableHeaderView, the UITableView sort of freaks out and adds like 400pts of random padding
         // below the content of the tableView. Wrapping it in this container fixes it ¯\_(ツ)_/¯
@@ -153,7 +153,7 @@ extension PluginDirectoryViewController: UISearchControllerDelegate {
             searchController.searchBar.becomeFirstResponder()
         }
         updateTableHeaderSize()
-        tableView.scrollIndicatorInsets.top = searchWrapperView.bounds.height
+        tableView.verticalScrollIndicatorInsets.top = searchWrapperView.bounds.height
         tableView.contentInset.top = 0
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -328,7 +328,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         searchWrapperView.addSubview(searchController.searchBar)
 
-        tableView.scrollIndicatorInsets.top = searchController.searchBar.bounds.height
+        tableView.verticalScrollIndicatorInsets.top = searchController.searchBar.bounds.height
 
         updateTableHeaderSize()
     }
@@ -755,7 +755,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         updateTableHeaderSize()
         _tableViewHandler.isSearching = true
 
-        tableView.scrollIndicatorInsets.top = searchWrapperView.bounds.height
+        tableView.verticalScrollIndicatorInsets.top = searchWrapperView.bounds.height
         tableView.contentInset.top = 0
     }
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -377,8 +377,8 @@ public protocol ThemePresenter: class {
         let keyboardHeight = collectionView.frame.maxY - keyboardFrame.origin.y
 
         collectionView.contentInset.bottom = keyboardHeight
-        collectionView.scrollIndicatorInsets.top = searchBarHeight
-        collectionView.scrollIndicatorInsets.bottom = keyboardHeight
+        collectionView.verticalScrollIndicatorInsets.top = searchBarHeight
+        collectionView.verticalScrollIndicatorInsets.bottom = keyboardHeight
     }
 
     @objc open func keyboardWillHide(_ notification: Foundation.Notification) {
@@ -386,8 +386,8 @@ public protocol ThemePresenter: class {
 
         collectionView.contentInset.top = view.safeAreaInsets.top
         collectionView.contentInset.bottom = tabBarHeight
-        collectionView.scrollIndicatorInsets.top = searchBarHeight
-        collectionView.scrollIndicatorInsets.bottom = tabBarHeight
+        collectionView.verticalScrollIndicatorInsets.top = searchBarHeight
+        collectionView.verticalScrollIndicatorInsets.bottom = tabBarHeight
     }
 
     fileprivate func localKeyboardFrameFromNotification(_ notification: Foundation.Notification) -> CGRect {
@@ -685,7 +685,7 @@ public protocol ThemePresenter: class {
         if sections[1] == .themes || sections[1] == .customThemes {
             setInfoSectionHidden(false)
         }
-        collectionView.scrollIndicatorInsets.top = view.safeAreaInsets.top
+        collectionView.verticalScrollIndicatorInsets.top = view.safeAreaInsets.top
     }
 
     fileprivate func setInfoSectionHidden(_ hidden: Bool) {

--- a/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
@@ -1198,7 +1198,7 @@ private extension ShareExtensionEditorViewController {
     func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
         let referenceView: UIScrollView = richTextView
         let bottomInset = (view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom) + Constants.insetBottomPadding)
-        let scrollInsets = UIEdgeInsets(top: referenceView.scrollIndicatorInsets.top, left: 0, bottom: bottomInset, right: 0)
+        let scrollInsets = UIEdgeInsets(top: referenceView.verticalScrollIndicatorInsets.top, left: 0, bottom: bottomInset, right: 0)
         let contentInsets  = UIEdgeInsets(top: referenceView.contentInset.top, left: 0, bottom: bottomInset, right: 0)
 
         richTextView.scrollIndicatorInsets = scrollInsets


### PR DESCRIPTION
Refs #15583. This PR fixes the scroll indicator deprecation warnings present in `feature/ios13-min-build-version`.

To test:

- Check the code. It seemed that all of the usages of scrollIndicators were using vertical insets, so I've converted them all to vertical.
- Open up each of the affected screens in the app and ensure that scroll insets still work correctly – most of them seem to be used when the keyboard appears / disappears. NOTE: There is a pre-existing issue with the inset at the top of the theme browser, which I've left as-is for this PR.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
