### PR TITLE
Jetpack: adds Backup screen

### DIFF
--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -245,10 +245,13 @@ private extension ActivityStore {
                 }
 
                 let loadingMore = offset > 0
-                actionDispatcher.dispatch(ActivityAction.receiveActivities(
-                                            site: site,
-                                            activities: self.onlyRestorableItems ? activities.filter { $0.isRewindable } : activities,
-                                            hasMore: hasMore, loadingMore: loadingMore))
+                actionDispatcher.dispatch(
+                    ActivityAction.receiveActivities(
+                        site: site,
+                        activities: self.onlyRestorableItems ? activities.filter { $0.isRewindable } : activities,
+                        hasMore: hasMore,
+                        loadingMore: loadingMore)
+                )
         },
             failure: { [actionDispatcher] error in
                 actionDispatcher.dispatch(ActivityAction.receiveActivitiesFailed(site: site, error: error))

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -72,7 +72,8 @@ class ActivityStore: QueryStore<ActivityStoreState, ActivityQuery> {
 
     private let activityServiceRemote: ActivityServiceRemote?
 
-    var onlyRewindableItems = false
+    /// When set to true, this store will only return items that are restorable
+    var onlyRestorableItems = false
 
     override func queriesChanged() {
         super.queriesChanged()
@@ -246,7 +247,7 @@ private extension ActivityStore {
                 let loadingMore = offset > 0
                 actionDispatcher.dispatch(ActivityAction.receiveActivities(
                                             site: site,
-                                            activities: self.onlyRewindableItems ? activities.filter { $0.isRewindable } : activities,
+                                            activities: self.onlyRestorableItems ? activities.filter { $0.isRewindable } : activities,
                                             hasMore: hasMore, loadingMore: loadingMore))
         },
             failure: { [actionDispatcher] error in

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -32,7 +32,7 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
         return spinner
     }()
 
-    fileprivate var viewModel: ActivityListViewModel
+    var viewModel: ActivityListViewModel
     private enum Constants {
         static let estimatedRowHeight: CGFloat = 62
     }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -53,12 +53,9 @@ class ActivityListViewModel: Observable {
     }
 
     init(site: JetpackSiteRef,
-         store: ActivityStore = StoreContainer.shared.activity,
-         onlyRewindableItems: Bool = false) {
+         store: ActivityStore = StoreContainer.shared.activity) {
         self.site = site
         self.store = store
-
-        store.onlyRewindableItems = onlyRewindableItems
 
         activitiesReceipt = store.query(.activities(site: site))
         rewindStatusReceipt = store.query(.restoreStatus(site: site))

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class BackupListViewController: ActivityListViewController {
     override init(site: JetpackSiteRef, store: ActivityStore, isFreeWPCom: Bool = false) {
-        store.onlyRewindableItems = true
+        store.onlyRestorableItems = true
 
         super.init(site: site, store: store, isFreeWPCom: isFreeWPCom)
 

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
@@ -7,6 +7,8 @@ class BackupListViewController: ActivityListViewController {
         super.init(site: site, store: store, isFreeWPCom: isFreeWPCom)
 
         title = NSLocalizedString("Backup", comment: "Title for the Jetpack's backup list")
+
+        activityTypeFilterChip.isHidden = true
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+class BackupListViewController: ActivityListViewController {
+    override init(site: JetpackSiteRef, store: ActivityStore, isFreeWPCom: Bool = false) {
+        super.init(site: site, store: store, isFreeWPCom: isFreeWPCom)
+
+        self.viewModel = ActivityListViewModel(site: site, store: store, onlyRewindableItems: true)
+
+        self.changeReceipt = viewModel.onChange { [weak self] in
+            self?.refreshModel()
+        }
+
+        title = NSLocalizedString("Backup", comment: "Title for the Jetpack's backup list")
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
@@ -2,13 +2,9 @@ import Foundation
 
 class BackupListViewController: ActivityListViewController {
     override init(site: JetpackSiteRef, store: ActivityStore, isFreeWPCom: Bool = false) {
+        store.onlyRewindableItems = true
+
         super.init(site: site, store: store, isFreeWPCom: isFreeWPCom)
-
-        self.viewModel = ActivityListViewModel(site: site, store: store, onlyRewindableItems: true)
-
-        self.changeReceipt = viewModel.onChange { [weak self] in
-            self?.refreshModel()
-        }
 
         title = NSLocalizedString("Backup", comment: "Title for the Jetpack's backup list")
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -839,7 +839,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Backup", @"Noun. Links to a blog's Jetpack Backups screen.")
                                                         image:[UIImage gridiconOfType:GridiconTypeCloudUpload]
                                                      callback:^{
-                                                         [weakSelf showActivity];
+                                                         [weakSelf showBackup];
                                                      }]];
     }
 
@@ -1699,6 +1699,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
+}
+
+- (void)showBackup
+{
+    BackupListViewController *controller = [[BackupListViewController alloc] initWithBlog:self.blog];
+    [self showDetailViewController:controller sender:self];
 }
 
 - (void)showThemes

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -834,6 +834,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                      }]];
     }
 
+
+    if ([Feature enabled:FeatureFlagJetpackBackupAndRestore]) {
+        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Backup", @"Noun. Links to a blog's Jetpack Backups screen.")
+                                                        image:[UIImage gridiconOfType:GridiconTypeCloudUpload]
+                                                     callback:^{
+                                                         [weakSelf showActivity];
+                                                     }]];
+    }
+
     if ([self.blog supports:BlogFeatureJetpackScan]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Scan", @"Noun. Links to a blog's Jetpack Scan screen.")
                                                         image:[UIImage gridiconOfType:GridiconTypeHistory]

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1149,6 +1149,7 @@
 		8B24C4E3249A4C3E0005E8A5 /* OfflineReaderWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B24C4E2249A4C3E0005E8A5 /* OfflineReaderWebView.swift */; };
 		8B25F8DA24B7683A009DD4C9 /* ReaderCSSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B25F8D924B7683A009DD4C9 /* ReaderCSSTests.swift */; };
 		8B260D7E2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */; };
+		8B36256625A60CCA00D7CCE3 /* BackupListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B36256525A60CCA00D7CCE3 /* BackupListViewController.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B51844525893F140085488D /* FilterBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B51844425893F140085488D /* FilterBarView.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
@@ -3680,6 +3681,7 @@
 		8B24C4E2249A4C3E0005E8A5 /* OfflineReaderWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineReaderWebView.swift; sourceTree = "<group>"; };
 		8B25F8D924B7683A009DD4C9 /* ReaderCSSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCSSTests.swift; sourceTree = "<group>"; };
 		8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostVisibilitySelectorViewController.swift; sourceTree = "<group>"; };
+		8B36256525A60CCA00D7CCE3 /* BackupListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupListViewController.swift; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B51844425893F140085488D /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
@@ -7815,6 +7817,7 @@
 		82FC61181FA8ADAC00A1757E /* Activity */ = {
 			isa = PBXGroup;
 			children = (
+				8B36256425A60CAB00D7CCE3 /* Backup */,
 				8B93412D257029E30097D0AC /* Filter */,
 				7E4123C620F4178E00DF8486 /* FormattableContent */,
 				82FC612B1FA8B7FC00A1757E /* ActivityListRow.swift */,
@@ -8147,6 +8150,14 @@
 			children = (
 			);
 			name = "Recovered References";
+			sourceTree = "<group>";
+		};
+		8B36256425A60CAB00D7CCE3 /* Backup */ = {
+			isa = PBXGroup;
+			children = (
+				8B36256525A60CCA00D7CCE3 /* BackupListViewController.swift */,
+			);
+			path = Backup;
 			sourceTree = "<group>";
 		};
 		8B69F0E2255C2BC0006B1CEF /* Activity */ = {
@@ -12975,6 +12986,7 @@
 				74AF4D741FE417D200E3EBFE /* MediaUploadOperation.swift in Sources */,
 				981C986E21B9D71400A7C0C8 /* PostingActivityCollectionViewCell.swift in Sources */,
 				436D55D9210F85DD00CEAA33 /* NibLoadable.swift in Sources */,
+				8B36256625A60CCA00D7CCE3 /* BackupListViewController.swift in Sources */,
 				32A218D8251109DB00D1AE6C /* ReaderReportPostAction.swift in Sources */,
 				D8D7DF5A20AD18A400B40A2D /* ImgUploadProcessor.swift in Sources */,
 				436D56222117312700CEAA33 /* RegisterDomainDetailsViewModel.swift in Sources */,

--- a/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
+++ b/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
@@ -16,7 +16,7 @@ class ActivityListViewModelTests: XCTestCase {
 
         XCTAssertEqual(activityStoreMock.dispatchedAction, "loadMoreActivities")
         XCTAssertEqual(activityStoreMock.quantity, 20)
-        XCTAssertEqual(activityStoreMock.offset, 0)
+        XCTAssertEqual(activityStoreMock.offset, 20)
     }
 
     // Check if `loadMore` dispatchs the correct offset
@@ -28,10 +28,11 @@ class ActivityListViewModelTests: XCTestCase {
         activityStoreMock.state.activities[jetpackSiteRef] = [Activity.mock(), Activity.mock(), Activity.mock()]
 
         activityListViewModel.loadMore()
+        activityListViewModel.loadMore()
 
         XCTAssertEqual(activityStoreMock.dispatchedAction, "loadMoreActivities")
         XCTAssertEqual(activityStoreMock.quantity, 20)
-        XCTAssertEqual(activityStoreMock.offset, 3)
+        XCTAssertEqual(activityStoreMock.offset, 40)
     }
 
     // Check if `loadMore` dispatchs the correct after/before date and groups

--- a/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
+++ b/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
@@ -118,8 +118,8 @@ class ActivityStoreMock: ActivityStore {
 }
 
 extension Activity {
-    static func mock() -> Activity {
-        let dictionary = ["activity_id": "1", "summary": "", "content": ["text": ""], "published": "2020-11-09T13:16:43.701+00:00"] as [String: AnyObject]
+    static func mock(isRewindable: Bool = false) -> Activity {
+        let dictionary = ["activity_id": "1", "summary": "", "is_rewindable": isRewindable, "rewind_id": "1", "content": ["text": ""], "published": "2020-11-09T13:16:43.701+00:00"] as [String: AnyObject]
         return try! Activity(dictionary: dictionary)
     }
 }

--- a/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
@@ -86,6 +86,20 @@ class ActivityStoreTests: XCTestCase {
         XCTAssertFalse(store.state.hasMore)
     }
 
+    // Check if loadMoreActivities keep the activies and add the new retrieved ones
+    //
+    func testReturnOnlyRewindableActivities() {
+        let jetpackSiteRef = JetpackSiteRef.mock(siteID: 9, username: "foo")
+        store.state.activities[jetpackSiteRef] = [Activity.mock()]
+        activityServiceMock.activitiesToReturn = [Activity.mock(isRewindable: true), Activity.mock()]
+        activityServiceMock.hasMore = true
+
+        store.onlyRewindableItems = true
+        dispatch(.loadMoreActivities(site: jetpackSiteRef, quantity: 10, offset: 20, afterDate: nil, beforeDate: nil, group: []))
+
+        XCTAssertEqual(store.state.activities[jetpackSiteRef]?.filter { $0.isRewindable }.count, 1)
+    }
+
     // refreshGroups call the service with the correct params
     //
     func testRefreshGroups() {

--- a/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
@@ -94,7 +94,7 @@ class ActivityStoreTests: XCTestCase {
         activityServiceMock.activitiesToReturn = [Activity.mock(isRewindable: true), Activity.mock()]
         activityServiceMock.hasMore = true
 
-        store.onlyRewindableItems = true
+        store.onlyRestorableItems = true
         dispatch(.loadMoreActivities(site: jetpackSiteRef, quantity: 10, offset: 20, afterDate: nil, beforeDate: nil, group: []))
 
         XCTAssertEqual(store.state.activities[jetpackSiteRef]?.filter { $0.isRewindable }.count, 1)


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/15193

This PR adds the Backup screen under the Jetpack section.

<img src="https://user-images.githubusercontent.com/7040243/103813355-bd5b3e00-503e-11eb-8d8f-192cf60b678e.gif" width="300">

@momo-ozawa I'm using the same feature flag as backup/rewind. Let me know if you think this is a problem. :) 

### To test

1. Open any site detail
2. Tap Backup
3. You should see a list containing ONLY items that can be downloaded or rewinded
4. Scroll down and compare your list to the one in wordpress.com

Filtering by date:

1. Open any site detail
2. Tap Backup
3. Select a single date or a date range
4. You should see only items that can be downloaded or rewinded in the range or day you selected

This PR only covers showing the Backup screen. This will be covered in future PRs:

* Checking if the site has the Backup feature
* Changing the error messages
* Refactoring `ActivityListViewController` and `BackupListViewController` to make the inheritance more obvious
* Updating the events

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
