### PR TITLE
Hide Xpost UI on unsupported sites

### DIFF
--- a/WordPress/Classes/Services/SiteSuggestionService.swift
+++ b/WordPress/Classes/Services/SiteSuggestionService.swift
@@ -5,7 +5,7 @@ class SiteSuggestionService {
 
     private var blogsCurrentlyBeingRequested = [NSNumber]()
     private var requests = [NSNumber: Date]()
-    var disabledBlogs = [NSNumber]()
+    private var disabledBlogs = [NSNumber]()
 
     static let shared = SiteSuggestionService()
 

--- a/WordPress/Classes/Services/SiteSuggestionService.swift
+++ b/WordPress/Classes/Services/SiteSuggestionService.swift
@@ -5,6 +5,7 @@ class SiteSuggestionService {
 
     private var blogsCurrentlyBeingRequested = [NSNumber]()
     private var requests = [NSNumber: Date]()
+    var disabledBlogs = [NSNumber]()
 
     static let shared = SiteSuggestionService()
 
@@ -38,10 +39,12 @@ class SiteSuggestionService {
      If no suggestions already in Core Data, fetch them from the network and store them in Core Data.
      @param blog The blog/site to prefetch suggestions for
      */
-    func prefetchSuggestions(for blog: Blog) {
+    func prefetchSuggestions(for blog: Blog, completion: @escaping () -> Void) {
         let persistedSuggestions = retrievePersistedSuggestions(for: blog)
         if persistedSuggestions == nil || persistedSuggestions?.isEmpty == true {
-            fetchAndPersistSuggestions(for: blog, completion: { _ in})
+            fetchAndPersistSuggestions(for: blog, completion: { _ in
+                completion()
+            })
         }
     }
 
@@ -86,13 +89,17 @@ class SiteSuggestionService {
 
             self.requests[blogId] = Date()
 
+            self.disabledBlogs.removeAll { $0 == blogId }
             completion(suggestions)
 
             // remove blog from the currently being requested list
             self.blogsCurrentlyBeingRequested.removeAll { $0 == blogId }
-        }, failure: { [weak self] error, _ in
+        }, failure: { [weak self] error, response in
             guard let `self` = self else { return }
 
+            if response?.statusCode == 400 {    // blog/site does not have Xposts available
+                self.disabledBlogs.append(blogId)
+            }
             completion([])
 
             // remove blog from the currently being requested list
@@ -109,6 +116,11 @@ class SiteSuggestionService {
     @return BOOL Whether the caller should show suggestions
     */
     func shouldShowSuggestions(for blog: Blog) -> Bool {
+
+        // Any blog/site that has previously returned an error indicating Xposts are not available is marked as disabled.
+        guard let blogId = blog.dotComID, disabledBlogs.contains(blogId) == false else {
+            return false
+        }
 
         // The device must be online or there must be already persisted suggestions
         guard ReachabilityUtils.isInternetReachable() || retrievePersistedSuggestions(for: blog)?.isEmpty == false else {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -345,8 +345,6 @@ class GutenbergViewController: UIViewController, PostEditor {
         }, failure: { (error) in
             DDLogError("Error syncing JETPACK: \(String(describing: error))")
         })
-
-        SiteSuggestionService.shared.prefetchSuggestions(for: self.post.blog)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -435,6 +433,10 @@ class GutenbergViewController: UIViewController, PostEditor {
 
         setTitle(post.postTitle ?? "")
         setHTML(content)
+
+        SiteSuggestionService.shared.prefetchSuggestions(for: self.post.blog) { [weak self] in
+            self?.gutenberg.updateCapabilities()
+        }
     }
 
     private func refreshInterface() {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
@@ -28,10 +28,6 @@ extension PostEditor where Self: UIViewController {
             }
             self.recreatePostRevision(in: blog)
             self.mediaLibraryDataSource = MediaLibraryPickerDataSource(post: self.post)
-
-            if self.editorSession.currentEditor == .gutenberg {
-                SiteSuggestionService.shared.prefetchSuggestions(for: self.post.blog)
-            }
         }
 
         let dismissHandler: BlogSelectorDismissHandler = {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/2942

Previously, sites that don't support Xposts (e.g. Simple WordPress.com sites) showed the suggestions UI for a few seconds while the network loaded when the user typed a `+` character. This PR fixes this by disabling the suggestions UI as soon as the Xpost prefetch request returns a result from the network that indicates that Xposts are not available.

If after the app determines that a site has Xposts disabled, the site then becomes Xpost-enabled remotely, the app will be able to pick up this change only once the app is restarted (that is, when the `SiteSuggestionService` singleton is cleared from memory).

### To test

**What you'll need**: One WP.com site that is capable of xposting (https://wordpress.com/p2/ can be used to create xpost-capable sites) and one WP.com site that is **not** capable of xposting.

**Xpost in Gutenberg**

1. Open the block editor on the site capable of Xposting
2. In a Paragraph or any other rich text block, type `+` and verify that the list of Xpost suggestions is shown
3. Switch to the site that is not xpost capable
4. Type `+` and ensure that no suggestion UI is shown
5. Verify that long-pressing the `@` toolbar button does not show Xpost options (expect the long-press gesture to be disabled)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
