### PR TITLE
iOS 13: Fix gray style deprecation warnings

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -26,7 +26,7 @@ class ActivityListViewController: UIViewController, TableViewContainer, ImmuTabl
     }()
 
     private lazy var spinner: UIActivityIndicatorView = {
-        let spinner = UIActivityIndicatorView(style: .gray)
+        let spinner = UIActivityIndicatorView(style: .medium)
         spinner.startAnimating()
         spinner.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 44)
         return spinner

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -164,7 +164,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     cell.textLabel.textAlignment = NSTextAlignmentCenter;
     cell.textLabel.text = [self titleForConnectionCell];
     if (self.connecting) {
-        UIActivityIndicatorView *activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+        UIActivityIndicatorView *activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
         cell.accessoryView = activityView;
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
         [activityView startAnimating];

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -106,7 +106,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     
     // Spinner
     UIActivityIndicatorView *indicator      = [[UIActivityIndicatorView alloc] initWithFrame:CommentsActivityFooterFrame];
-    indicator.activityIndicatorViewStyle    = UIActivityIndicatorViewStyleGray;
+    indicator.activityIndicatorViewStyle    = UIActivityIndicatorViewStyleMedium;
     indicator.hidesWhenStopped              = YES;
     indicator.autoresizingMask              = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     indicator.center                        = footerView.center;

--- a/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
@@ -53,7 +53,7 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
     private var customLoadingIndicator: ActivityIndicatorType?
 
     private lazy var defaultLoadingIndicator: UIActivityIndicatorView = {
-        let loadingIndicator = UIActivityIndicatorView(style: .gray)
+        let loadingIndicator = UIActivityIndicatorView(style: .medium)
         layoutViewCentered(loadingIndicator, size: nil)
         return loadingIndicator
     }()

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemSourceFooterView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemSourceFooterView.m
@@ -45,7 +45,7 @@
     if (@available(iOS 13.0, *)) {
         _activityIndicator = [[UIActivityIndicatorView alloc] init]; // defaults to Medium
     } else {
-        _activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle: UIActivityIndicatorViewStyleGray];
+        _activityIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle: UIActivityIndicatorViewStyleMedium];
     }
 
     _activityIndicator.translatesAutoresizingMaskIntoConstraints = false;

--- a/WordPress/Classes/ViewRelated/People/RoleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/RoleViewController.swift
@@ -20,7 +20,7 @@ class RoleViewController: UITableViewController {
 
     /// Activity Spinner, to be animated during Backend Interaction
     ///
-    fileprivate let activityIndicator = UIActivityIndicatorView(style: .gray)
+    fileprivate let activityIndicator = UIActivityIndicatorView(style: .medium)
 
     // MARK: - View Lifecyle Methods
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Post/Categories/WPAddPostCategoryViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/WPAddPostCategoryViewController.m
@@ -63,7 +63,7 @@
 
 - (void)addProgressIndicator
 {
-    UIActivityIndicatorView *activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    UIActivityIndicatorView *activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
     UIBarButtonItem *activityButtonItem = [[UIBarButtonItem alloc] initWithCustomView:activityView];
     [activityView startAnimating];
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -554,8 +554,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
         return _activityFooter;
     }
 
-    _activityFooter = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
-    _activityFooter.activityIndicatorViewStyle = UIActivityIndicatorViewStyleGray;
+    _activityFooter = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+    _activityFooter.activityIndicatorViewStyle = UIActivityIndicatorViewStyleMedium;
     _activityFooter.hidesWhenStopped = YES;
     _activityFooter.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     [_activityFooter stopAnimating];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -356,7 +356,7 @@ protocol ReaderSiteSearchFooterViewDelegate: class {
 
 class ReaderSiteSearchFooterView: UIView {
     private let divider = UIView()
-    private let activityIndicator = UIActivityIndicatorView(style: .gray)
+    private let activityIndicator = UIActivityIndicatorView(style: .medium)
     weak var delegate: ReaderSiteSearchFooterViewDelegate? = nil
 
     private static let expandedHeight: CGFloat = 44.0

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -44,7 +44,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     UINavigationController *statsNavVC = [[UIStoryboard storyboardWithName:@"SiteStatsDashboard" bundle:nil] instantiateInitialViewController];
     self.siteStatsDashboardVC = statsNavVC.viewControllers.firstObject;
 
-    self.loadingIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
+    self.loadingIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
     self.loadingIndicator.translatesAutoresizingMaskIntoConstraints = NO;
     [self.view addSubview:self.loadingIndicator];
     [NSLayoutConstraint activateConstraints:@[

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -73,7 +73,7 @@ class ShareModularViewController: ShareExtensionAbstractViewController {
 
     /// Activity indicator used when loading categories
     ///
-    fileprivate lazy var categoryActivityIndicator = UIActivityIndicatorView(style: .gray)
+    fileprivate lazy var categoryActivityIndicator = UIActivityIndicatorView(style: .medium)
 
     /// No results view
     ///


### PR DESCRIPTION
Refs #15583.

This PR fixes the gray style deprecation warnings.

### To test

1. Check the places where the change was made
2. There shouldn't be any visible UI difference

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
