### PR TITLE
iOS 13: remove editActionsForRowAtIndexPath deprecation warnings

### DIFF
--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -360,9 +360,9 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
         return false
     }
 
-    open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        if target.responds(to: #selector(UITableViewDelegate.tableView(_:editActionsForRowAt:))) {
-            return target.tableView?(tableView, editActionsForRowAt: indexPath)
+    public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        if target.responds(to: #selector(UITableViewDelegate.tableView(_:trailingSwipeActionsConfigurationForRowAt:))) {
+            return target.tableView?(tableView, trailingSwipeActionsConfigurationForRowAt: indexPath)
         }
 
         return nil

--- a/WordPress/Classes/Utility/WPTableViewHandler.h
+++ b/WordPress/Classes/Utility/WPTableViewHandler.h
@@ -49,7 +49,6 @@
 
 #pragma mark - Editing actions
 
-- (nullable NSArray<UITableViewRowAction *> *)tableView:(nonnull UITableView *)tableView editActionsForRowAtIndexPath:(nonnull NSIndexPath *)indexPath;
 - (nullable UISwipeActionsConfiguration *)tableView:(nonnull UITableView *)tableView leadingSwipeActionsConfigurationForRowAtIndexPath:(nonnull NSIndexPath *)indexPath;
 - (nullable UISwipeActionsConfiguration *)tableView:(nonnull UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(nonnull NSIndexPath *)indexPath;
 

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -334,15 +334,6 @@ static CGFloat const DefaultCellHeight = 44.0;
     return UITableViewCellEditingStyleNone;
 }
 
-- (NSArray *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    if ([self.delegate respondsToSelector:@selector(tableView:editActionsForRowAtIndexPath:)]) {
-        return [self.delegate tableView:tableView editActionsForRowAtIndexPath:indexPath];
-    }
-    
-    return nil;
-}
-
 - (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView leadingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     if ([self.delegate respondsToSelector:@selector(tableView:leadingSwipeActionsConfigurationForRowAtIndexPath:)]) {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -268,19 +268,18 @@ extension ActivityListViewController: UITableViewDelegate {
         return row.activity.isRewindable
     }
 
-    func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let row = handler.viewModel.rowAtIndexPath(indexPath) as? ActivityListRow, row.activity.isRewindable else {
             return nil
         }
 
-        let rewindAction = UITableViewRowAction(style: .normal,
-                                                title: NSLocalizedString("Rewind", comment: "Title displayed when user swipes on a rewind cell"),
-                                                handler: { [weak self] _, indexPath in
-                                                    self?.presentRewindFor(activity: row.activity)
-        })
+        let rewindAction = UIContextualAction(style: .normal,
+                                              title: NSLocalizedString("Rewind", comment: "Title displayed when user swipes on a rewind cell")) { [weak self] (_, _, _) in
+            self?.presentRewindFor(activity: row.activity)
+        }
         rewindAction.backgroundColor = .primary(.shade40)
 
-        return [rewindAction]
+        return UISwipeActionsConfiguration(actions: [rewindAction])
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -648,47 +648,50 @@ static NSInteger HideSearchMinSites = 3;
     }
 }
 
-- (NSArray *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath
+- (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     Blog *blog = [self.dataSource blogAtIndexPath:indexPath];
     NSMutableArray *actions = [NSMutableArray array];
     __typeof(self) __weak weakSelf = self;
 
     if ([blog supports:BlogFeatureRemovable]) {
-        UITableViewRowAction *removeAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal
-                                                                                title:NSLocalizedString(@"Remove", @"Removes a self hosted site from the app")
-                                                                              handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
-                                                                                  [ReachabilityUtils onAvailableInternetConnectionDo:^{
-                                                                                      [weakSelf showRemoveSiteAlertForIndexPath:indexPath];
-                                                                                  }];
-                                                                              }];
+        UIContextualAction *removeAction = [UIContextualAction
+                                            contextualActionWithStyle:UIContextualActionStyleNormal title:NSLocalizedString(@"Remove", @"Removes a self hosted site from the app")
+                                            handler:^(UIContextualAction * _Nonnull action, __kindof UIView * _Nonnull sourceView, void (^ _Nonnull completionHandler)(BOOL)) {
+            [ReachabilityUtils onAvailableInternetConnectionDo:^{
+                [weakSelf showRemoveSiteAlertForIndexPath:indexPath];
+            }];
+        }];
+
         removeAction.backgroundColor = [UIColor murielError];
         [actions addObject:removeAction];
     } else {
         if (blog.visible) {
-            UITableViewRowAction *hideAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal
-                                                                                  title:NSLocalizedString(@"Hide", @"Hides a site from the site picker list")
-                                                                                handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
-                                                                                    [ReachabilityUtils onAvailableInternetConnectionDo:^{
-                                                                                        [weakSelf hideBlogAtIndexPath:indexPath];
-                                                                                    }];
-                                                                                }];
+            UIContextualAction *hideAction = [UIContextualAction
+                                                contextualActionWithStyle:UIContextualActionStyleNormal title:NSLocalizedString(@"Hide", @"Hides a site from the site picker list")
+                                                handler:^(UIContextualAction * _Nonnull action, __kindof UIView * _Nonnull sourceView, void (^ _Nonnull completionHandler)(BOOL)) {
+                [ReachabilityUtils onAvailableInternetConnectionDo:^{
+                    [weakSelf hideBlogAtIndexPath:indexPath];
+                }];
+            }];
+
             hideAction.backgroundColor = [UIColor murielNeutral30];
             [actions addObject:hideAction];
         } else {
-            UITableViewRowAction *unhideAction = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal
-                                                                                    title:NSLocalizedString(@"Unhide", @"Unhides a site from the site picker list")
-                                                                                  handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
-                                                                                      [ReachabilityUtils onAvailableInternetConnectionDo:^{
-                                                                                          [weakSelf unhideBlogAtIndexPath:indexPath];
-                                                                                      }];
-                                                                                  }];
+            UIContextualAction *unhideAction = [UIContextualAction
+                                                contextualActionWithStyle:UIContextualActionStyleNormal title:NSLocalizedString(@"Unhide", @"Unhides a site from the site picker list")
+                                                handler:^(UIContextualAction * _Nonnull action, __kindof UIView * _Nonnull sourceView, void (^ _Nonnull completionHandler)(BOOL)) {
+                [ReachabilityUtils onAvailableInternetConnectionDo:^{
+                    [weakSelf unhideBlogAtIndexPath:indexPath];
+                }];
+            }];
+
             unhideAction.backgroundColor = [UIColor murielSuccess];
             [actions addObject:unhideAction];
         }
     }
 
-    return actions;
+    return [UISwipeActionsConfiguration configurationWithActions:actions];
 }
 
 - (void)showRemoveSiteAlertForIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
@@ -122,17 +122,18 @@ extension QuickStartChecklistManager: UITableViewDelegate {
         return .delete
     }
 
-    func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let section = Sections(rawValue: indexPath.section), section == .todo else {
             return nil
         }
 
         let buttonTitle = NSLocalizedString("Skip", comment: "Button title that appears when you swipe to left the row. It indicates the possibility to skip a specific tour.")
-        let skip = UITableViewRowAction(style: .destructive, title: buttonTitle) { [weak self] (_, indexPath) in
+        let skip = UIContextualAction(style: .destructive, title: buttonTitle) { [weak self] (_, _, _) in
             self?.tableView(tableView, completeTourAt: indexPath)
         }
         skip.backgroundColor = .error
-        return [skip]
+        
+        return UISwipeActionsConfiguration(actions: [skip])
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
@@ -132,7 +132,7 @@ extension QuickStartChecklistManager: UITableViewDelegate {
             self?.tableView(tableView, completeTourAt: indexPath)
         }
         skip.backgroundColor = .error
-        
+
         return UISwipeActionsConfiguration(actions: [skip])
     }
 }


### PR DESCRIPTION
Refs #15583.

This PR migrates the implementation of `editActionsForRowAtIndexPath` to `trailingSwipeActionsConfigurationForRowAtIndexPath` to remove deprecation warnings.

### To test

#### My Sites list

1. Open the app
2. Go to the blog list
3. Swipe right
4. Hide/unhide blogs

_I wasn't able to test the "Remove" option (for self-hosted sites)_

#### Activity Log

1. Open the app
2. Go to Activity List
3. Find an item that is rewindable
4. Swipe right
5. Tap "Rewind"

#### Quick Start

1. Go to App Settings -> Debug -> Enable Quick Start for Site and select a site
2. Go to the site detail of the selected site
3. Tap "Customize your site"
4. Swipe right and tap "Skip"

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
