### PR TITLE
Reader filters: retain selected filter

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,8 +7,9 @@
 * [**] Page List: Adds duplicate page functionality [#15515]
 * [*] Invite People: add link to user roles definition web page. [#15530]
 * [***] Block Editor: Cross-post suggestions are now available by typing the + character (or long-pressing the toolbar button labelled with an @-symbol) in a post on a P2 site [#15139]
-* [**] Reader site filter: unseen post count is displayed for each site. [#15581]
 * [**] Reader: Following now only shows non-P2 sites. [#15585]
+* [**] Reader site filter: unseen post count is displayed for each site. [#15581]
+* [**] Reader site filter: selected filters now persist while in app.[#15594]
 
 16.4
 -----

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -13,6 +13,7 @@ class ReaderTabView: UIView {
 
     private let viewModel: ReaderTabViewModel
 
+    private var filteredTabs: [(index: Int, topic: ReaderAbstractTopic)] = []
 
     init(viewModel: ReaderTabViewModel) {
         mainStackView = UIStackView()
@@ -199,6 +200,13 @@ extension ReaderTabView {
                   let self = self else {
                 return
             }
+
+            let selectedIndex = self.tabBar.selectedIndex
+
+            // Remove any filters for selected index, then add new filter to array.
+            self.filteredTabs.removeAll(where: { $0.index == selectedIndex })
+            self.filteredTabs.append((index: selectedIndex, topic: selectedTopic))
+
             self.resetFilterButton.isHidden = false
             self.setFilterButtonTitle(selectedTopic.title)
         }
@@ -206,6 +214,7 @@ extension ReaderTabView {
 
     /// Reset filter button
     @objc private func didTapResetFilterButton() {
+        filteredTabs.removeAll(where: { $0.index == tabBar.selectedIndex })
         setFilterButtonTitle(Appearance.defaultFilterButtonTitle)
         resetFilterButton.isHidden = true
         guard let tabItem = tabBar.currentlySelectedItem as? ReaderTabItem else {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -59,6 +59,7 @@ class ReaderTabView: UIView {
 }
 
 // MARK: - UI setup
+
 extension ReaderTabView {
 
     /// Call this method to set the title of the filter button
@@ -169,11 +170,23 @@ extension ReaderTabView {
 }
 
 // MARK: - Actions
+
 extension ReaderTabView {
+
     /// Tab bar
     @objc private func selectedTabDidChange(_ tabBar: FilterTabBar) {
-        didTapResetFilterButton()
-        addContentToContainerView()
+
+        // If the tab was previously filtered, refilter it.
+        // Otherwise reset the filter.
+        if let existingFilter = filteredTabs.first(where: { $0.index == tabBar.selectedIndex }) {
+            viewModel.setFilterContent(topic: existingFilter.topic)
+            resetFilterButton.isHidden = false
+            setFilterButtonTitle(existingFilter.topic.title)
+        } else {
+            didTapResetFilterButton()
+            addContentToContainerView()
+        }
+
         viewModel.showTab(at: tabBar.selectedIndex)
         toggleButtonsView()
     }
@@ -226,6 +239,7 @@ extension ReaderTabView {
 
 
 // MARK: - Ghost
+
 private extension ReaderTabView {
 
     /// Build the ghost tab bar
@@ -268,6 +282,7 @@ private extension ReaderTabView {
 }
 
 // MARK: - Appearance
+
 private extension ReaderTabView {
 
     enum Appearance {
@@ -294,6 +309,7 @@ private extension ReaderTabView {
 
 
 // MARK: - Accessibility
+
 extension ReaderTabView {
     private enum Accessibility {
         static let filterButtonIdentifier = "ReaderFilterButton"

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -193,11 +193,14 @@ extension ReaderTabView {
     /// Filter button
     @objc private func didTapFilterButton() {
         /// Present from the image view to align to the left hand side
-        viewModel.presentFilter(from: filterButton.imageView ?? filterButton) { [weak self] title in
-            if let title = title {
-                self?.resetFilterButton.isHidden = false
-                self?.setFilterButtonTitle(title)
+        viewModel.presentFilter(from: filterButton.imageView ?? filterButton) { [weak self] selectedTopic in
+
+            guard let selectedTopic = selectedTopic,
+                  let self = self else {
+                return
             }
+            self.resetFilterButton.isHidden = false
+            self.setFilterButtonTitle(selectedTopic.title)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -26,9 +26,10 @@ class ReaderTabViewController: UIViewController {
             guard let self = self else {
                 return
             }
-            self.viewModel.presentFilter(from: self, sourceView: fromView, completion: { [weak self] title in
+
+            self.viewModel.presentFilter(from: self, sourceView: fromView, completion: { [weak self] topic in
                 self?.dismiss(animated: true, completion: nil)
-                completion(title)
+                completion(topic)
             })
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -137,6 +137,11 @@ extension ReaderTabViewModel {
             setContent?(content)
         }
     }
+
+    func setFilterContent(topic: ReaderAbstractTopic) {
+        setContent?(ReaderContent(topic: topic))
+    }
+
 }
 
 // MARK: - Bottom Sheet

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -123,13 +123,14 @@ extension ReaderTabViewModel {
         settingsPresenter.present(on: from, animated: true, completion: nil)
     }
 
-    func presentFilter(from: UIView, completion: @escaping (String?) -> Void) {
+    func presentFilter(from: UIView, completion: @escaping (ReaderAbstractTopic?) -> Void) {
         filterTapped?(from, { [weak self] topic in
             self?.selectedFilter = topic
             if let topic = topic {
+                self?.setFilterContent(topic: topic)
                 self?.setContent?(ReaderContent(topic: topic))
             }
-            completion(topic?.title)
+            completion(topic)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -24,7 +24,6 @@ import WordPressFlux
 
     /// Completion handler for selecting a filter from the available filter list
     var filterTapped: ((UIView, @escaping (ReaderAbstractTopic?) -> Void) -> Void)?
-    var selectedFilter: ReaderAbstractTopic?
 
     /// search
     var navigateToSearch: () -> Void
@@ -125,7 +124,6 @@ extension ReaderTabViewModel {
 
     func presentFilter(from: UIView, completion: @escaping (ReaderAbstractTopic?) -> Void) {
         filterTapped?(from, { [weak self] topic in
-            self?.selectedFilter = topic
             if let topic = topic {
                 self?.setFilterContent(topic: topic)
                 self?.setContent?(ReaderContent(topic: topic))
@@ -135,7 +133,6 @@ extension ReaderTabViewModel {
     }
 
     func resetFilter(selectedItem: FilterTabBarItem) {
-        selectedFilter = nil
         if let content = (selectedItem as? ReaderTabItem)?.content {
             setContent?(content)
         }

--- a/WordPress/WordPressTest/ReaderTabViewModelTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewModelTests.swift
@@ -117,9 +117,6 @@ class ReaderTabViewModelTests: XCTestCase {
         // Given
         let context = MockContext.getContext()!
 
-        let filterTopic = ReaderAbstractTopic(context: context)
-        viewModel.selectedFilter = filterTopic
-
         let selectedTopic = ReaderAbstractTopic(context: context)
         selectedTopic.title = "selected topic"
         let item = ReaderTabItem(ReaderContent(topic: selectedTopic))


### PR DESCRIPTION
Fixes #15568 

When a Reader stream is filtered, the selected filter is now saved.
- The filter is saved for each stream that can be filtered.
- The filter is restored when changing Reader tabs.
- The filters persist while in the app.

To test:
- Go to the Reader.
- Apply filters to streams that can be filtered.
- Change Reader tabs.
  - Verify the selected filters persist for each stream.
  - Verify the stream content is still filtered.
- Clear a filter.
  - Verify the filter is cleared and remains cleared when switching Reader tabs.
  - Verify the stream content is no longer filtered.
- Muck about in other areas of the app.
- Return to the Reader.
  - Verify applied filters persist.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
