### PR TITLE
iOS 13: remove keyWindow deprecation warnings

### DIFF
--- a/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
@@ -7,7 +7,7 @@ import WordPressFlux
         // This method is required because the presenter ViewController must be visible, and we've got several
         // flows in which the VC that triggers the alert, might not be visible anymore.
         //
-        guard let rootViewController = UIApplication.shared.keyWindow?.rootViewController else {
+        guard let rootViewController = UIApplication.shared.mainWindow?.rootViewController else {
             print("Error loading the rootViewController")
             return
         }

--- a/WordPress/Classes/Extensions/UIApplication+mainWindow.swift
+++ b/WordPress/Classes/Extensions/UIApplication+mainWindow.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension UIApplication {
+    @objc var mainWindow: UIWindow? {
+        return UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+    }
+}

--- a/WordPress/Classes/Extensions/UIApplication+mainWindow.swift
+++ b/WordPress/Classes/Extensions/UIApplication+mainWindow.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 extension UIApplication {
     @objc var mainWindow: UIWindow? {

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -9,7 +9,7 @@ public protocol ApplicationShortcutsProvider {
 
 extension UIApplication: ApplicationShortcutsProvider {
     @objc public var is3DTouchAvailable: Bool {
-        return keyWindow?.traitCollection.forceTouchCapability == .available
+        return mainWindow?.traitCollection.forceTouchCapability == .available
     }
 }
 
@@ -141,7 +141,7 @@ open class WP3DTouchShortcutCreator: NSObject {
     }
 
     fileprivate func is3DTouchAvailable() -> Bool {
-        let window = UIApplication.shared.keyWindow
+        let window = UIApplication.shared.mainWindow
 
         return window?.traitCollection.forceTouchCapability == .available
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -318,7 +318,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         if CommandLine.arguments.contains("-no-animations") {
             UIView.setAnimationsEnabled(false)
             application.windows.first?.layer.speed = MAXFLOAT
-            application.keyWindow?.layer.speed = MAXFLOAT
+            application.mainWindow?.layer.speed = MAXFLOAT
         }
     }
 

--- a/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
+++ b/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
@@ -34,7 +34,7 @@
             }
         }];
 
-        [UIApplication sharedApplication].keyWindow.rootViewController = controller;
+        [UIApplication sharedApplication].mainWindow.rootViewController = controller;
 
         [self showExplanationAlertForReAuthenticationDueToMissingAuthToken];
         isFixingAuthTokenIssue = YES;
@@ -113,7 +113,7 @@
                                                          }];
     [alertController addAction:cancelAction];
     [alertController addAction:deleteAction];
-    [[[UIApplication sharedApplication] keyWindow].rootViewController presentViewController:alertController
+    [[[UIApplication sharedApplication] mainWindow].rootViewController presentViewController:alertController
                                                                                    animated:YES
                                                                                  completion:nil];
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -71,7 +71,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     private var footerHeight: CGFloat {
         let verticalMargins: CGFloat = 16
         let buttonHeight: CGFloat = 44
-        let safeArea = (UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0)
+        let safeArea = (UIApplication.shared.mainWindow?.safeAreaInsets.bottom ?? 0)
         return verticalMargins + buttonHeight + verticalMargins + safeArea
     }
     private var isShowingNoResults: Bool = false {

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -109,7 +109,7 @@ extension WordPressAuthenticationManager {
     ///
     @objc
     class func showSigninForWPComFixingAuthToken() {
-        guard let presenter = UIApplication.shared.keyWindow?.rootViewController else {
+        guard let presenter = UIApplication.shared.mainWindow?.rootViewController else {
             assertionFailure()
             return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -187,7 +187,7 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
         }
 
         if let url = post.featuredImageURL,
-            let desiredWidth = UIApplication.shared.keyWindow?.frame.size.width {
+            let desiredWidth = UIApplication.shared.mainWindow?.frame.size.width {
             featuredImageStackView.isHidden = false
             topPadding.constant = Constants.margin
             loadFeaturedImageIfNeeded(url, preferredSize: CGSize(width: desiredWidth, height: featuredImage.frame.height))

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -74,7 +74,7 @@ class PrepublishingViewController: UITableViewController {
 
     private func calculatePreferredContentSize() {
         // Apply additional padding to take into account the navbar / status bar height
-        let safeAreaTop = UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0
+        let safeAreaTop = UIApplication.shared.mainWindow?.safeAreaInsets.top ?? 0
         let navBarHeight = navigationController?.navigationBar.frame.height ?? 0
         let offset = navBarHeight - safeAreaTop
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
@@ -32,7 +32,7 @@ class ReaderSearchSuggestionsViewController: UIViewController {
     @objc let cellIdentifier = "CellIdentifier"
     @objc let rowAndButtonHeight = CGFloat(44.0)
     @objc var maxTableViewRows: Int {
-        let height = UIApplication.shared.keyWindow?.frame.size.height ?? 0
+        let height = UIApplication.shared.mainWindow?.frame.size.height ?? 0
         if height == 320 {
             // iPhone 4s, 5, 5s, in landscape orientation
             return 1

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -65,7 +65,7 @@ class NoticePresenter {
         self.animator = animator
 
         let windowFrame: CGRect
-        if let mainWindow = UIApplication.shared.keyWindow {
+        if let mainWindow = UIApplication.shared.mainWindow {
             windowFrame = mainWindow.offsetToAvoidStatusBar()
         } else {
             windowFrame = .zero

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -228,7 +228,7 @@ public protocol ThemePresenter: class {
      *  @brief      Load theme screenshots at maximum displayed width
      */
     @objc open var screenshotWidth: Int = {
-        let windowSize = UIApplication.shared.keyWindow!.bounds.size
+        let windowSize = UIApplication.shared.mainWindow!.bounds.size
         let vWidth = Styles.imageWidthForFrameWidth(windowSize.width)
         let hWidth = Styles.imageWidthForFrameWidth(windowSize.height)
         let maxWidth = Int(max(hWidth, vWidth))

--- a/WordPress/Classes/ViewRelated/Views/AlertView/AlertView.swift
+++ b/WordPress/Classes/ViewRelated/Views/AlertView/AlertView.swift
@@ -60,7 +60,7 @@ open class AlertView: NSObject {
     /// - Returns: The Key View.
     ///
     fileprivate func keyView() -> UIView {
-        return (UIApplication.shared.keyWindow?.subviews.first)!
+        return (UIApplication.shared.mainWindow?.subviews.first)!
     }
 
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1153,6 +1153,7 @@
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B51844525893F140085488D /* FilterBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B51844425893F140085488D /* FilterBarView.swift */; };
 		8B5FEAF125A746CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
+		8B5FEC0225A750CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
 		8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */; };
 		8B69F100255C4870006B1CEF /* ActivityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */; };
@@ -14357,6 +14358,7 @@
 				5960967F1CF7959300848496 /* PostTests.swift in Sources */,
 				3F751D462491A93D0008A2B1 /* ZendeskUtilsTests+Plans.swift in Sources */,
 				8BD36E062395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift in Sources */,
+				8B5FEC0225A750CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */,
 				E6843840221F5A2200752258 /* PostListExcessiveLoadMoreTests.swift in Sources */,
 				325D3B3D23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift in Sources */,
 				57D6C83E22945A10003DDC7E /* PostCompactCellTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1152,6 +1152,7 @@
 		8B3626F925A665E500D7CCE3 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B51844525893F140085488D /* FilterBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B51844425893F140085488D /* FilterBarView.swift */; };
+		8B5FEAF125A746CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
 		8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */; };
 		8B69F100255C4870006B1CEF /* ActivityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */; };
@@ -14451,6 +14452,7 @@
 				CC94FC68221452A4002E5825 /* EditorNoticeComponent.swift in Sources */,
 				BED4D83B1FF13B8A00A11345 /* EditorPublishEpilogueScreen.swift in Sources */,
 				CC52188C2278C622008998CE /* EditorFlow.swift in Sources */,
+				8B5FEAF125A746CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */,
 				CC52189C2279D295008998CE /* MediaPickerAlbumScreen.swift in Sources */,
 				BED4D8331FF11E3800A11345 /* LoginFlow.swift in Sources */,
 				98AA22BD25082A87005CCC13 /* PrologueScreen.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1149,6 +1149,7 @@
 		8B24C4E3249A4C3E0005E8A5 /* OfflineReaderWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B24C4E2249A4C3E0005E8A5 /* OfflineReaderWebView.swift */; };
 		8B25F8DA24B7683A009DD4C9 /* ReaderCSSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B25F8D924B7683A009DD4C9 /* ReaderCSSTests.swift */; };
 		8B260D7E2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */; };
+		8B3626F925A665E500D7CCE3 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B51844525893F140085488D /* FilterBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B51844425893F140085488D /* FilterBarView.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
@@ -3677,6 +3678,7 @@
 		8B24C4E2249A4C3E0005E8A5 /* OfflineReaderWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineReaderWebView.swift; sourceTree = "<group>"; };
 		8B25F8D924B7683A009DD4C9 /* ReaderCSSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCSSTests.swift; sourceTree = "<group>"; };
 		8B260D7D2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostVisibilitySelectorViewController.swift; sourceTree = "<group>"; };
+		8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+mainWindow.swift"; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B51844425893F140085488D /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
@@ -9429,6 +9431,7 @@
 				F12E500223C7C5330068CB5E /* WKWebView+UserAgent.swift */,
 				57276E70239BDFD200515BE2 /* NotificationCenter+ObserveMultiple.swift */,
 				3250490624F988220036B47F /* Interpolation.swift */,
+				8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -13510,6 +13513,7 @@
 				D80BC7A4207487F200614A59 /* MediaLibraryPicker.swift in Sources */,
 				E663D1901C65383E0017F109 /* SharingAccountViewController.swift in Sources */,
 				93DEB88219E5BF7100F9546D /* TodayExtensionService.m in Sources */,
+				8B3626F925A665E500D7CCE3 /* UIApplication+mainWindow.swift in Sources */,
 				3FD83CBF246C751800381999 /* CoreDataIterativeMigrator.swift in Sources */,
 				17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */,
 				400A2C832217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift in Sources */,

--- a/WordPress/WordPressTest/RichContentFormatterTests.swift
+++ b/WordPress/WordPressTest/RichContentFormatterTests.swift
@@ -12,7 +12,7 @@ class RichContentFormatterTests: XCTestCase {
             let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
             let postDict = (try? JSONSerialization.jsonObject(with: data, options: [])) as? NSDictionary,
             let content = postDict.object(forKey: "content") as? NSString,
-            let window = UIApplication.shared.keyWindow else {
+            let window = UIApplication.shared.mainWindow else {
                 XCTFail()
                 return
         }
@@ -36,7 +36,7 @@ class RichContentFormatterTests: XCTestCase {
             let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
             let postDict = (try? JSONSerialization.jsonObject(with: data, options: [])) as? NSDictionary,
             let content = postDict.object(forKey: "content") as? NSString,
-            let window = UIApplication.shared.keyWindow else {
+            let window = UIApplication.shared.mainWindow else {
                 XCTFail()
                 return
         }

--- a/WordPress/WordPressTest/System/3DTouch/WP3DTouchShortcutCreatorTests.swift
+++ b/WordPress/WordPressTest/System/3DTouch/WP3DTouchShortcutCreatorTests.swift
@@ -16,7 +16,7 @@ class WP3DTouchShortcutCreatorTests: XCTestCase {
     }
 
     fileprivate func is3DTouchAvailable() -> Bool {
-        let window = UIApplication.shared.keyWindow
+        let window = UIApplication.shared.mainWindow
 
         return window?.traitCollection.forceTouchCapability == .available
     }


### PR DESCRIPTION
Refs #15583.

This PR fixes the `keyWindow` deprecation warnings.

```
'keyWindow' was deprecated in iOS 13.0: Should not be used for applications that support multiple scenes as it returns a key window across all connected scenes
```

A little bit of context:

`keyWindow` was deprecated because it's not safe for apps that support multiple scenes. AFAIK, we don't use this (see https://developer.apple.com/documentation/uikit/app_and_environment/scenes/supporting_multiple_windows_on_ipad#3663342).

So I just went ahead and added an extension that contains a `mainWindow`, which works just like `keyWindow`.

### To test

Open the app and use parts that make use of `mainWindow` like: Reader, trigger a Notice, etc.

Please, test using an iPad too.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
