### PR TITLE
Reverts: Allow updatable statusbars on each tab bar view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -10,12 +10,13 @@ extension WPTabBarController {
     }
 
     override open var childForStatusBarStyle: UIViewController? {
-        var selectedController = selectedViewController
-        if let navController = selectedController as? UINavigationController {
-            selectedController = navController.topViewController
+        guard
+            let topViewController = readerNavigationController?.topViewController,
+            ((topViewController as? DefinesVariableStatusBarStyle) != nil)
+        else {
+            return nil
         }
-
-        return selectedController
+        return topViewController
     }
 }
 


### PR DESCRIPTION
I've reverted this change that fixed #15506

### To test:
In order to test in the simulator you need to change line 47 in `FeatureFlag.swift` to `false` to disable the white nav bar appearance.
```
        case .newNavBarAppearance:
            return false
```

1. Launch app
2. Tap on the My Site tab
3. Verify the status bar icons are white
4. Tap on Reader, and verify the status bar icons are white
5. Tap on Notifications, and verify the status bar icons are white
6. Verify the original issue exists (Invisible status bar icons) by navigating to the Reader Detail in the Notifications tab

### PR submission checklist:
- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
