### PR TITLE
Feature/ios13 misc deprecations

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
@@ -22,7 +22,7 @@ class SelectPostViewController: UITableViewController {
         let searchController = UISearchController(searchResultsController: nil)
         searchController.searchResultsUpdater = self
         searchController.hidesNavigationBarDuringPresentation = false
-        searchController.dimsBackgroundDuringPresentation = false
+        searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchBar.sizeToFit()
         return searchController
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
@@ -34,7 +34,7 @@ class SiteIconView: UIView {
     }()
 
     let activityIndicator: UIActivityIndicatorView = {
-        let indicatorView = UIActivityIndicatorView(style: .whiteLarge)
+        let indicatorView = UIActivityIndicatorView(style: .large)
         indicatorView.translatesAutoresizingMaskIntoConstraints = false
         return indicatorView
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
@@ -157,7 +157,7 @@
     self.definesPresentationContext = YES;
 
     self.searchController = [[UISearchController alloc] initWithSearchResultsController:nil];
-    self.searchController.dimsBackgroundDuringPresentation = NO;
+    self.searchController.obscuresBackgroundDuringPresentation = NO;
     self.searchController.hidesNavigationBarDuringPresentation = !_displaysNavigationBarWhenSearching;
     self.searchController.delegate = self;
     self.searchController.searchResultsUpdater = self;

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/SiteTagsViewController.swift
@@ -36,7 +36,7 @@ final class SiteTagsViewController: UITableViewController {
     fileprivate lazy var searchController: UISearchController = {
         let returnValue = UISearchController(searchResultsController: nil)
         returnValue.hidesNavigationBarDuringPresentation = false
-        returnValue.dimsBackgroundDuringPresentation = false
+        returnValue.obscuresBackgroundDuringPresentation = false
         returnValue.searchResultsUpdater = self
         returnValue.delegate = self
 

--- a/WordPress/Classes/ViewRelated/Me/Me Main/Header/MeHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/Header/MeHeaderView.m
@@ -226,7 +226,7 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
 
 - (UIActivityIndicatorView *)newSpinner
 {
-    UIActivityIndicatorView *indicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
+    UIActivityIndicatorView *indicatorView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
     indicatorView.hidesWhenStopped = YES;
     indicatorView.translatesAutoresizingMaskIntoConstraints = NO;
     

--- a/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileHeaderView.swift
@@ -6,7 +6,7 @@ class MyProfileHeaderView: WPTableViewCell {
     @IBOutlet var gravatarButton: UIButton!
 
     var onAddUpdatePhoto: (() -> Void)?
-    let activityIndicator = UIActivityIndicatorView(style: .white)
+    let activityIndicator = UIActivityIndicatorView(style: .medium)
     var showsActivityIndicator: Bool {
         get {
             return activityIndicator.isAnimating

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -85,7 +85,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     /// Activity Indicator to be shown when refreshing a Jetpack site status.
     ///
     let activityIndicator: UIActivityIndicatorView = {
-        let indicator = UIActivityIndicatorView(style: .white)
+        let indicator = UIActivityIndicatorView(style: .medium)
         indicator.hidesWhenStopped = true
         return indicator
     }()

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
@@ -83,7 +83,7 @@ class PluginDirectoryViewController: UITableViewController {
 
         let controller = UISearchController(searchResultsController: resultsController)
         controller.obscuresBackgroundDuringPresentation = false
-        controller.dimsBackgroundDuringPresentation = false
+        controller.obscuresBackgroundDuringPresentation = false
         controller.searchResultsUpdater = self
         controller.delegate = self
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -299,7 +299,7 @@ class AbstractPostListViewController: UIViewController,
         definesPresentationContext = true
 
         searchController = UISearchController(searchResultsController: nil)
-        searchController.dimsBackgroundDuringPresentation = false
+        searchController.obscuresBackgroundDuringPresentation = false
 
         searchController.delegate = self
         searchController.searchResultsUpdater = self

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -101,7 +101,7 @@ final class AssembledSiteView: UIView {
         }()
 
         self.activityIndicator = {
-            let activityIndicator = UIActivityIndicatorView(style: .whiteLarge)
+            let activityIndicator = UIActivityIndicatorView(style: .large)
 
             activityIndicator.translatesAutoresizingMaskIntoConstraints = false
             activityIndicator.hidesWhenStopped = true

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
@@ -205,7 +205,7 @@ final class SiteAssemblyContentView: UIView {
         }()
 
         self.activityIndicator = {
-            let activityIndicator = UIActivityIndicatorView(style: .whiteLarge)
+            let activityIndicator = UIActivityIndicatorView(style: .large)
 
             activityIndicator.translatesAutoresizingMaskIntoConstraints = false
             activityIndicator.hidesWhenStopped = true

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -291,7 +291,7 @@ public protocol ThemePresenter: class {
         definesPresentationContext = true
 
         searchController = UISearchController(searchResultsController: nil)
-        searchController.dimsBackgroundDuringPresentation = false
+        searchController.obscuresBackgroundDuringPresentation = false
 
         searchController.delegate = self
         searchController.searchResultsUpdater = self

--- a/WordPress/Classes/ViewRelated/Views/LoadingStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Views/LoadingStatusView.swift
@@ -28,7 +28,7 @@ class LoadingStatusView: UIView {
     }()
 
     private lazy var activityIndicator: UIActivityIndicatorView = {
-        let indicator = UIActivityIndicatorView(style: .white)
+        let indicator = UIActivityIndicatorView(style: .medium)
         indicator.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             indicator.widthAnchor.constraint(equalToConstant: 20.0),

--- a/WordPress/Classes/ViewRelated/Views/WPUploadStatusButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPUploadStatusButton.m
@@ -25,7 +25,7 @@
     self.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     self.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     
-    UIActivityIndicatorView *indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
+    UIActivityIndicatorView *indicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
     indicator.autoresizingMask = UIViewAutoresizingNone;
     CGFloat halfButtonHeight = self.bounds.size.height / 2;
     CGFloat buttonWidth = self.bounds.size.width;


### PR DESCRIPTION
Refs #15583
This PR cleans up some deprecation warnings regarding `UIActivityIndicatorView.Style` and `dimsBackgroundDuringPresentation`.  The relevant API seems to just have been renamed without other effects. 

To test:
Build the app and check that there are no more deprecation warnings regarding `UIActivityIndicatorView.Style` and `dimsBackgroundDuringPresentation`. 
Check a few screens with spinners and search controls.  Confirm that spinners look as expected.  Confirm searching does not dim any views.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@leandroalonso could I trouble you with this one? 