### PR TITLE
Reader filters: clear filter when topic is unfollowed

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -59,7 +59,9 @@ extension ReaderTagsTableViewModel {
             let topic = tableViewHandler.resultsController.object(at: adjustIndexPath) as? ReaderTagTopic else {
                 return
         }
+
         unfollow(topic)
+        NotificationCenter.default.post(name: .ReaderTopicUnfollowed, object: nil, userInfo: [topicUserInfoKey: topic])
     }
 
     /// Presents a new view controller for subscribing to a new tag.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -210,6 +210,8 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
             return
         }
 
+        NotificationCenter.default.post(name: .ReaderTopicUnfollowed, object: nil, userInfo: [topicUserInfoKey: site])
+
         let service = ReaderTopicService(managedObjectContext: managedObjectContext())
         service.toggleFollowing(forSite: site, success: { [weak self] in
             let siteURL = URL(string: site.siteURL)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -1,5 +1,12 @@
 import UIKit
 
+// NSNotification sent when a site or a tag is unfollowed via Reader Manage screen.
+extension NSNotification.Name {
+    static let ReaderTopicUnfollowed = NSNotification.Name(rawValue: "ReaderTopicUnfollowed")
+}
+let topicUserInfoKey = "topic"
+
+
 class ReaderTabView: UIView {
 
     private let mainStackView: UIStackView


### PR DESCRIPTION
Ref: #15568

When a site or tag is unfollowed via the Reader Manage view:
- Any corresponding saved filter is removed.
- If the current stream is filtered by the site/tag, the stream is reloaded.

To test:
- Go the Reader.
- Filter a stream by a site/tag.
- Go to the Manage view (gear icon on the nav bar).
- Unfollow the same site/tag.
- Verify the filter bar is reset.
- Verify the stream is no longer filtered.

![no_more_cats](https://user-images.githubusercontent.com/1816888/103954922-6dde4600-5102-11eb-9bb1-7568613e5045.gif)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
