### PR TITLE
Handle malformed URLs in Xpost sites

### DIFF
--- a/WordPress/Classes/Models/SiteSuggestion+CoreDataClass.swift
+++ b/WordPress/Classes/Models/SiteSuggestion+CoreDataClass.swift
@@ -27,8 +27,8 @@ public class SiteSuggestion: NSManagedObject, Decodable {
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.title = try container.decode(String.self, forKey: .title)
-        self.siteURL = try container.decode(URL.self, forKey: .siteURL)
+        self.siteURL = try? container.decode(URL.self, forKey: .siteURL)
         self.subdomain = try container.decode(String.self, forKey: .subdomain)
-        self.blavatarURL = try container.decode(URL.self, forKey: .blavatarURL)
+        self.blavatarURL = try? container.decode(URL.self, forKey: .blavatarURL)
     }
 }


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/2982

To test:

1. Find a site that can Xpost to another site that has a blavatar URL that contains an `<img>` tag
2. Make sure the Xpost UI loads correctly (the blavatar image for the site in question will not load as expected)

A proper placeholder image should be handled in a separate PR

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
