### PR TITLE
People > Invite: make Message field scrollable

### DIFF
--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -431,6 +431,7 @@ private extension InvitePersonViewController {
         messageTextView.font = WPStyleGuide.tableviewTextFont()
         messageTextView.textColor = .text
         messageTextView.backgroundColor = .listForeground
+        messageTextView.delegate = self
     }
 
     func setupPlaceholderLabel() {
@@ -493,3 +494,16 @@ private extension InvitePersonViewController {
         placeholderLabel?.isHidden = !messageTextView.text.isEmpty
     }
 }
+
+// MARK: - UITextViewDelegate
+
+extension InvitePersonViewController: UITextViewDelegate {
+    func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
+        // This calls the segue in People.storyboard
+        // that shows the SettingsMultiTextViewController.
+        performSegue(withIdentifier: "message", sender: nil)
+        return false
+    }
+    
+}
+

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -504,6 +504,5 @@ extension InvitePersonViewController: UITextViewDelegate {
         performSegue(withIdentifier: "message", sender: nil)
         return false
     }
-    
-}
 
+}

--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -335,27 +335,19 @@
                             </tableViewSection>
                             <tableViewSection id="KTt-dH-XgO">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" rowHeight="88" id="sdj-uY-1LY">
-                                        <rect key="frame" x="0.0" y="178" width="375" height="88"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" rowHeight="100" id="sdj-uY-1LY">
+                                        <rect key="frame" x="0.0" y="178" width="375" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="sdj-uY-1LY" id="Y8v-KJ-xnc">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="88"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="100"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nh9-39-Mdw">
-                                                    <rect key="frame" x="16" y="11" width="343" height="66"/>
+                                                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="nh9-39-Mdw">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="100"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="72" id="ARy-hL-nFx"/>
-                                                    </constraints>
                                                     <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</string>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                                    <variation key="default">
-                                                        <mask key="constraints">
-                                                            <exclude reference="ARy-hL-nFx"/>
-                                                        </mask>
-                                                    </variation>
                                                 </textView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom message..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jyo-4B-Bt9" userLabel="Placeholder Label">
                                                     <rect key="frame" x="16" y="11" width="139" height="19.5"/>
@@ -367,12 +359,12 @@
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailingMargin" secondItem="nh9-39-Mdw" secondAttribute="trailing" id="06N-1n-lgP"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="nh9-39-Mdw" secondAttribute="bottom" id="Avz-ZP-kHa"/>
-                                                <constraint firstItem="nh9-39-Mdw" firstAttribute="top" secondItem="Y8v-KJ-xnc" secondAttribute="topMargin" id="HlP-n4-smH"/>
+                                                <constraint firstItem="nh9-39-Mdw" firstAttribute="leading" secondItem="Y8v-KJ-xnc" secondAttribute="leading" constant="16" id="0cN-hB-5DE"/>
+                                                <constraint firstAttribute="trailing" secondItem="nh9-39-Mdw" secondAttribute="trailing" constant="16" id="3YE-iy-glN"/>
                                                 <constraint firstItem="Jyo-4B-Bt9" firstAttribute="top" secondItem="Y8v-KJ-xnc" secondAttribute="topMargin" id="KCB-49-L7U"/>
-                                                <constraint firstItem="nh9-39-Mdw" firstAttribute="leading" secondItem="Y8v-KJ-xnc" secondAttribute="leadingMargin" id="Sq4-Av-m3J"/>
                                                 <constraint firstItem="Jyo-4B-Bt9" firstAttribute="leading" secondItem="Y8v-KJ-xnc" secondAttribute="leadingMargin" id="Tt0-eO-4t1"/>
+                                                <constraint firstItem="nh9-39-Mdw" firstAttribute="top" secondItem="Y8v-KJ-xnc" secondAttribute="top" id="eJ6-Gv-uEP"/>
+                                                <constraint firstAttribute="bottom" secondItem="nh9-39-Mdw" secondAttribute="bottom" id="qeC-n5-gJx"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
@@ -397,7 +389,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fuT-BL-XQM" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1994" y="1519"/>
+            <point key="canvasLocation" x="1992.8" y="1518.8905547226389"/>
         </scene>
         <!--Username TextViewController-->
         <scene sceneID="tMT-sn-IIW">


### PR DESCRIPTION
Fixes #10795
Ref #15356

This enables scrolling on the Invite message field. 

Because this required enabling user interaction, it disrupted tapping the cell to show the text entry view. So when the field is tapped, it programmatically calls the same segue.

Also, since there is a lot of space on this view, I increased the Message field height a bit to show more lines (from 88 to 100).

To test:
- Go to People > + on the nav bar.
- Tap the Message field.
- Enter either a long message or one with returns (i.e. to get multiple lines).
- Return to the Invite view.
- Verify the Message field is scrollable.
- Verify tapping it relaunches the text entry view.

![invite_message](https://user-images.githubusercontent.com/1816888/104057658-c586bb00-51af-11eb-9980-3229c480e1d7.gif)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
