### PR TITLE
Add missing item to release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [***] Block Editor: Full-width and wide alignment support for Columns (https://github.com/wordpress-mobile/gutenberg-mobile/pull/2919)
 * [**] Block Editor: Image block - Add link picker to the block settings and enhance link settings with auto-hide options (https://github.com/wordpress-mobile/gutenberg-mobile/pull/2841)
 * [*] Block Editor: Fix button link setting, rel link will not be overwritten if modified by the user (https://github.com/wordpress-mobile/gutenberg-mobile/pull/2894)
+* [**] Block Editor: Added move to top/bottom when long pressing on respective block movers (https://github.com/wordpress-mobile/gutenberg-mobile/pull/2872)
 * [**] Reader: Following now only shows non-P2 sites. [#15585]
 * [**] Reader site filter: unseen post count is displayed for each site. [#15581]
 * [**] Reader site filter: selected filters now persist while in app.[#15594]


### PR DESCRIPTION
Tweaks release notes to add a missing feature that landed in WordPress/gutenberg#27554