### PR TITLE
Reimplement unseenPostCount feature flag.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,6 @@
 * [*] Invite People: add link to user roles definition web page. [#15530]
 * [***] Block Editor: Cross-post suggestions are now available by typing the + character (or long-pressing the toolbar button labelled with an @-symbol) in a post on a P2 site [#15139]
 * [**] Reader: Following now only shows non-P2 sites. [#15585]
-* [**] Reader site filter: unseen post count is displayed for each site. [#15581]
 * [**] Reader site filter: selected filters now persist while in app.[#15594]
 
 16.4

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -19,6 +19,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackScan
     case activityLogFilters
     case jetpackBackupAndRestore
+    case unseenPostCount
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -61,6 +62,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return BuildConfiguration.current == .localDeveloper
         case .jetpackBackupAndRestore:
             return BuildConfiguration.current == .localDeveloper
+        case .unseenPostCount:
+            return false
         }
     }
 
@@ -123,6 +126,8 @@ extension FeatureFlag {
             return "Jetpack's Activity Log Filters"
         case .jetpackBackupAndRestore:
             return "Jetpack Backup and Restore"
+        case .unseenPostCount:
+            return "Unseen Posts Count in Reader"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -148,7 +148,10 @@ extension ReaderSiteTopic {
                     return TableDataItem(topic: topic, configure: { cell in
                         cell.textLabel?.text = topic.title
                         cell.detailTextLabel?.text = topic.siteURL
-                        addUnseenPostCount(topic, with: cell)
+
+                        if FeatureFlag.unseenPostCount.enabled {
+                            addUnseenPostCount(topic, with: cell)
+                        }
                     })
                 }
             }


### PR DESCRIPTION
Ref #15483, #15586

This reinstates the `unseenPostCount` feature flag. @develric figured out we're not ready for it yet as the apps do not yet mark posts seen, thus the counts will be inaccurate.

To test:
- Go to Reader.
- On any stream that is filterable, select Filter.
- Verify the unseen post count is no longer displayed.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
