### PR TITLE
People views: misc fixes

### DIFF
--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -443,14 +443,6 @@
             <point key="canvasLocation" x="1282" y="1519"/>
         </scene>
     </scenes>
-    <designables>
-        <designable name="5Qj-Ek-EUq">
-            <size key="intrinsicContentSize" width="39.5" height="16"/>
-        </designable>
-        <designable name="MH9-O4-5bD">
-            <size key="intrinsicContentSize" width="71" height="16"/>
-        </designable>
-    </designables>
     <inferredMetricsTieBreakers>
         <segue reference="e6P-Kc-Mxa"/>
     </inferredMetricsTieBreakers>

--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -233,12 +233,10 @@
                                         <constraint firstItem="Mh2-fk-1eW" firstAttribute="leading" secondItem="yMs-a3-NfF" secondAttribute="trailing" constant="8" id="HG9-YQ-Uv0"/>
                                         <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="yMs-a3-NfF" secondAttribute="bottom" priority="750" constant="4" id="NwY-Hh-w1T"/>
                                         <constraint firstItem="Mh2-fk-1eW" firstAttribute="centerY" secondItem="v2L-Gv-S2P" secondAttribute="centerY" id="QRn-W5-5We"/>
-                                        <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="Mh2-fk-1eW" secondAttribute="bottom" constant="4" id="RJO-Q4-rcK"/>
                                         <constraint firstItem="yMs-a3-NfF" firstAttribute="leading" secondItem="v2L-Gv-S2P" secondAttribute="leadingMargin" id="VPt-Vf-Ir3"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="Mh2-fk-1eW" secondAttribute="trailing" id="ZV4-gb-pqe"/>
                                         <constraint firstItem="yMs-a3-NfF" firstAttribute="centerY" secondItem="v2L-Gv-S2P" secondAttribute="centerY" id="pZ8-9v-EOW"/>
                                         <constraint firstItem="yMs-a3-NfF" firstAttribute="top" relation="greaterThanOrEqual" secondItem="v2L-Gv-S2P" secondAttribute="topMargin" priority="750" constant="4" id="qTc-fI-WmB"/>
-                                        <constraint firstItem="Mh2-fk-1eW" firstAttribute="top" relation="greaterThanOrEqual" secondItem="v2L-Gv-S2P" secondAttribute="topMargin" constant="4" id="we0-kz-Epc"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <connections>

--- a/WordPress/Classes/ViewRelated/People/PeopleRoleBadgeLabel.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleRoleBadgeLabel.swift
@@ -1,10 +1,7 @@
 import UIKit
 import WordPressShared.WPStyleGuide
 
-@IBDesignable
 class PeopleRoleBadgeLabel: BadgeLabel {
-    // MARK: Initialization
-
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
@@ -15,7 +12,7 @@ class PeopleRoleBadgeLabel: BadgeLabel {
         setupView()
     }
 
-    fileprivate func setupView() {
+    private func setupView() {
         adjustsFontForContentSizeCategory = true
         adjustsFontSizeToFitWidth = true
         horizontalPadding = WPStyleGuide.People.RoleBadge.padding

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -437,17 +437,20 @@ private extension PersonViewController {
         cell.textLabel?.text       = NSLocalizedString("First Name", comment: "User's First Name")
         cell.detailTextLabel?.text = person.firstName
         cell.isHidden              = isFullnamePrivate
+        cell.isUserInteractionEnabled = false
     }
 
     func configureLastNameCell(_ cell: UITableViewCell) {
         cell.textLabel?.text       = NSLocalizedString("Last Name", comment: "User's Last Name")
         cell.detailTextLabel?.text = person.lastName
         cell.isHidden              = isFullnamePrivate
+        cell.isUserInteractionEnabled = false
     }
 
     func configureDisplayNameCell(_ cell: UITableViewCell) {
         cell.textLabel?.text       = NSLocalizedString("Display Name", comment: "User's Display Name")
         cell.detailTextLabel?.text = person.displayName
+        cell.isUserInteractionEnabled = false
     }
 
     func configureRoleCell(_ cell: UITableViewCell) {


### PR DESCRIPTION
Ref #15356 

This fixes a few misc issues with `People.storyboard`.
1. The storyboard was taking _forever_ to load.
2. Person details view: `Full Name Label` and `User Name Label` had constraint errors.
3. Person details view: tapping First Name, Last Name, and Display Name rows flashed grey.

To test:

---
Storyboard loading:
- Open `People.storyboard`. 
- Verify Xcode is still responsive, and does not lock up for several minutes.
  - The fix was to remove `@IBDesignable` from `PeopleRoleBadgeLabel`. The side effect is the badge labels no longer show in the `People Scene`, but I think we can live with that.
- I couldn't repro this consistently, but occasionally I would see this build error when I had the storyboard open. It should no longer appear now.
```
file:///Users/stephenie/Dev/fix_storyboard_loading/WordPress/Classes/ViewRelated/People/People.storyboard: error: IB Designables: Failed to render and update auto layout status for PeopleViewController (5ll-RY-leg): dlopen(WordPressAuthenticator.framework, 1): no suitable image found.  Did find:
	WordPressAuthenticator.framework: unknown file type, first eight bytes: 0x21 0x3C 0x61 0x72 0x63 0x68 0x3E 0x0A
```

---
Person view:
- In `People.storyboard` > `Person View Controller Scene`, verify `Full Name Label` and `User Name Label` no longer have these constraint errors:

<img width="352" alt="person_contraints" src="https://user-images.githubusercontent.com/1816888/104072947-bd3b7980-51c9-11eb-9432-77bc03535eff.png">

- Run the app.
- Go to People, and select a user.
- Verify the full name and username are positioned correctly, i.e. centered vertically in the cell.

<img width="438" alt="user_info" src="https://user-images.githubusercontent.com/1816888/104073137-24592e00-51ca-11eb-9a06-78ff5b58fa00.png">

- Tap the First Name, Last Name, and Display Name rows.
- Verify they don't flash grey.

<img width="441" alt="rows" src="https://user-images.githubusercontent.com/1816888/104073715-a4cc5e80-51cb-11eb-9493-da2c0d3b01e4.png">

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
