### PR TITLE
Jetpack Section: Split Restore and Backup VCs

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.24'
+    pod 'WordPressKit', '~> 4.25-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -406,7 +406,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.24.0):
+  - WordPressKit (4.25.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.33.0)
-  - WordPressKit (~> 4.24)
+  - WordPressKit (~> 4.25-beta)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.14.0)
   - WordPressUI (~> 1.9.0)
@@ -753,7 +753,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: 2699e025994e127ffe2ec507fc7481f10b1df31c
-  WordPressKit: ee58e3d313ddce1f768e87d76364d261ad86fca9
+  WordPressKit: 5ef39a5d5c279a8544cfd881fff8145d3c1e37c9
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 99b37324ffef200ddf32694bc3de1e0c9fcfef21
   WordPressUI: 3b70cccc4c44cff09024ca3e94ae25a8768b26c1
@@ -769,6 +769,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 4f3b206f825be82d564e6b74f040fd5466f994cd
+PODFILE CHECKSUM: f8b7ebc35b0c2d91f3e8054f6db9acf82ab940c2
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -322,13 +322,13 @@ extension ActivityListViewController: ActivityPresenter {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         let restoreTitle = NSLocalizedString("Restore", comment: "Title displayed for restore action.")
-        let restoreVC = JetpackRestoreViewController(site: site, activity: activity, restoreAction: .restore)
+        let restoreVC = JetpackRestoreViewController(site: site, activity: activity)
         alertController.addDefaultActionWithTitle(restoreTitle, handler: { _ in
             self.present(UINavigationController(rootViewController: restoreVC), animated: true)
         })
 
         let downloadBackupTitle = NSLocalizedString("Download Backup", comment: "Title displayed for download backup action.")
-        let downloadBackupVC = JetpackRestoreViewController(site: site, activity: activity, restoreAction: .downloadBackup)
+        let downloadBackupVC = JetpackDownloadBackupViewController(site: site, activity: activity)
         alertController.addDefaultActionWithTitle(downloadBackupTitle, handler: { _ in
             self.present(UINavigationController(rootViewController: downloadBackupVC), animated: true)
         })

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -318,7 +318,7 @@ extension ActivityListViewController: ActivityPresenter {
         self.navigationController?.pushViewController(detailVC, animated: true)
     }
 
-    func presentBackupOrRestoreFor(activity: FormattableActivity) {
+    func presentBackupOrRestoreFor(activity: Activity) {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         let restoreTitle = NSLocalizedString("Restore", comment: "Title displayed for restore action.")
@@ -366,8 +366,8 @@ extension ActivityListViewController: ActivityPresenter {
             return
         }
 
-        let warningVC = JetpackRestoreWarningViewController()
-        let navigationVC = UINavigationController(rootViewController: warningVC)
+        let restoreVC = JetpackRestoreViewController(site: site, activity: activity)
+        let navigationVC = UINavigationController(rootViewController: restoreVC)
         self.present(navigationVC, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -2,7 +2,7 @@ import WordPressFlux
 
 protocol ActivityPresenter: class {
     func presentDetailsFor(activity: FormattableActivity)
-    func presentBackupOrRestoreFor(activity: FormattableActivity)
+    func presentBackupOrRestoreFor(activity: Activity)
     func presentRestoreFor(activity: Activity)
 }
 
@@ -178,7 +178,7 @@ class ActivityListViewModel: Observable {
                         return
                     }
 
-                    presenter?.presentBackupOrRestoreFor(activity: formattableActivity)
+                    presenter?.presentBackupOrRestoreFor(activity: formattableActivity.activity)
                 }
             )
         })

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
@@ -15,8 +15,8 @@ class BaseRestoreOptionsViewController: UITableViewController {
 
     // MARK: - Private Properties
 
-    private let site: JetpackSiteRef
-    private let formattableActivity: FormattableActivity
+    private(set) var site: JetpackSiteRef
+    private(set) var formattableActivity: FormattableActivity
     private let configuration: JetpackRestoreOptionsConfiguration
     private var restoreTypes = JetpackRestoreTypes()
 
@@ -28,7 +28,7 @@ class BaseRestoreOptionsViewController: UITableViewController {
         return ActivityDateFormatting.mediumDateFormatterWithTime(for: site)
     }()
 
-    // MARK: - Initializer
+    // MARK: - Initialization
 
     init(site: JetpackSiteRef, activity: FormattableActivity) {
         fatalError("A configuration struct needs to be provided")

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
@@ -1,0 +1,229 @@
+import Foundation
+import CocoaLumberjack
+import WordPressShared
+
+struct JetpackRestoreOptionsConfiguration {
+    let title: String
+    let iconImage: UIImage
+    let messageTitle: String
+    let messageDescription: String
+    let generalSectionHeaderText: String
+    let buttonTitle: String
+}
+
+class BaseRestoreOptionsViewController: UITableViewController {
+
+    // MARK: - Private Properties
+
+    private let site: JetpackSiteRef
+    private let formattableActivity: FormattableActivity
+    private let configuration: JetpackRestoreOptionsConfiguration
+    private var restoreTypes = JetpackRestoreTypes()
+
+    private lazy var handler: ImmuTableViewHandler = {
+       return ImmuTableViewHandler(takeOver: self)
+    }()
+
+    private lazy var dateFormatter: DateFormatter = {
+        return ActivityDateFormatting.mediumDateFormatterWithTime(for: site)
+    }()
+
+    // MARK: - Initializer
+
+    init(site: JetpackSiteRef, activity: FormattableActivity) {
+        fatalError("A configuration struct needs to be provided")
+    }
+
+    init(site: JetpackSiteRef,
+         activity: FormattableActivity,
+         configuration: JetpackRestoreOptionsConfiguration) {
+        self.site = site
+        self.formattableActivity = activity
+        self.configuration = configuration
+        super.init(style: .grouped)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTitle()
+        configureNavigation()
+        configureTableView()
+        configureTableHeaderView()
+        reloadViewModel()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        tableView.layoutHeaderView()
+    }
+
+    // MARK: - Public
+
+    func actionButtonTapped() {
+        fatalError("Must override in subclass")
+    }
+
+    // MARK: - Configure
+
+    private func configureTitle() {
+        title = configuration.title
+    }
+
+    private func configureNavigation() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel,
+                                                           target: self,
+                                                           action: #selector(cancelTapped))
+    }
+
+    private func configureTableView() {
+        WPStyleGuide.configureColors(view: view, tableView: tableView)
+        ImmuTable.registerRows([SwitchRow.self], tableView: tableView)
+    }
+
+    private func configureTableHeaderView() {
+        let headerView = JetpackRestoreHeaderView.loadFromNib()
+        let publishedDate = dateFormatter.string(from: formattableActivity.activity.published)
+
+        headerView.configure(
+            iconImage: configuration.iconImage,
+            title: configuration.messageTitle,
+            description: String(format: configuration.messageDescription, publishedDate),
+            buttonTitle: configuration.buttonTitle
+        )
+
+        headerView.actionButtonHandler = { [weak self] in
+            self?.actionButtonTapped()
+        }
+
+        self.tableView.tableHeaderView = headerView
+    }
+
+    // MARK: - Model
+
+    private func reloadViewModel() {
+        handler.viewModel = tableViewModel()
+    }
+
+    private func tableViewModel() -> ImmuTable {
+        return ImmuTable(
+            sections: [
+                generalSection(),
+                contentSection(),
+                databaseSection()
+            ]
+        )
+    }
+
+    private func generalSection() -> ImmuTableSection {
+        let themesRow = SwitchRow(
+            title: Strings.themesRowTitle,
+            value: restoreTypes.themes,
+            onChange: toggleThemes(value:)
+        )
+        let pluginsRow = SwitchRow(
+            title: Strings.pluginsRowTitle,
+            value: restoreTypes.plugins,
+            onChange: togglePlugins(value:)
+        )
+        let mediaUploadsRow = SwitchRow(
+            title: Strings.mediaUploadsRowTitle,
+            value: restoreTypes.uploads,
+            onChange: toggleUploads(value:)
+        )
+        let rootRow = SwitchRow(
+            title: Strings.rootRowTitle,
+            value: restoreTypes.roots,
+            onChange: toggleRoots(value:)
+        )
+
+        return ImmuTableSection(
+            headerText: configuration.generalSectionHeaderText,
+            rows: [
+                themesRow,
+                pluginsRow,
+                mediaUploadsRow,
+                rootRow
+            ],
+            footerText: Strings.generalSectionFooterText
+        )
+    }
+
+    private func contentSection() -> ImmuTableSection {
+        let contentRow = SwitchRow(
+            title: Strings.contentRowTitle,
+            value: restoreTypes.contents,
+            onChange: toggleContents(value:)
+        )
+
+        return ImmuTableSection(
+            headerText: "",
+            rows: [contentRow],
+            footerText: Strings.contentSectionFooterText
+        )
+    }
+
+    private func databaseSection() -> ImmuTableSection {
+        let databaseRow = SwitchRow(
+            title: Strings.databaseRowTitle,
+            value: restoreTypes.sqls,
+            onChange: toggleSqls(value:)
+        )
+
+        return ImmuTableSection(
+            headerText: "",
+            rows: [databaseRow],
+            footerText: nil
+        )
+    }
+
+
+    // MARK: - Private Helpers
+
+    @objc private func cancelTapped() {
+        self.dismiss(animated: true)
+    }
+
+    private func toggleThemes(value: Bool) {
+        restoreTypes.themes = value
+    }
+
+    private func togglePlugins(value: Bool) {
+        restoreTypes.plugins = value
+    }
+
+    private func toggleUploads(value: Bool) {
+        restoreTypes.uploads = value
+    }
+
+    private func toggleRoots(value: Bool) {
+        restoreTypes.roots = value
+    }
+
+    private func toggleContents(value: Bool) {
+        restoreTypes.contents = value
+    }
+
+    private func toggleSqls(value: Bool) {
+        restoreTypes.sqls = value
+    }
+}
+
+extension BaseRestoreOptionsViewController {
+
+    private enum Strings {
+        static let themesRowTitle = NSLocalizedString("WordPress Themes", comment: "Downloadable/Restorable items: WordPress Themes")
+        static let pluginsRowTitle = NSLocalizedString("WordPress Plugins", comment: "Downloadable/Restorable items: WordPress Plugins")
+        static let mediaUploadsRowTitle = NSLocalizedString("Media Uploads", comment: "Downloadable/Restorable items: Media Uploads")
+        static let rootRowTitle = NSLocalizedString("WordPress root", comment: "Downloadable/Restorable items: WordPress root")
+        static let generalSectionFooterText = NSLocalizedString("Includes wp-config php and any non WordPress files", comment: "Downloadable/Restorable items: general section footer text")
+        static let contentRowTitle = NSLocalizedString("WP-content directory", comment: "Downloadable/Restorable items: WP-content directory")
+        static let contentSectionFooterText = NSLocalizedString("Excludes themes, plugins, and uploads", comment: "Downloadable/Restorable items: content section footer text")
+        static let databaseRowTitle = NSLocalizedString("Site database", comment: "Downloadable/Restorable items: Site Database")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
@@ -16,9 +16,9 @@ class BaseRestoreOptionsViewController: UITableViewController {
     // MARK: - Private Properties
 
     private(set) var site: JetpackSiteRef
-    private(set) var formattableActivity: FormattableActivity
+    private(set) var activity: Activity
+    private(set) var restoreTypes = JetpackRestoreTypes()
     private let configuration: JetpackRestoreOptionsConfiguration
-    private var restoreTypes = JetpackRestoreTypes()
 
     private lazy var handler: ImmuTableViewHandler = {
        return ImmuTableViewHandler(takeOver: self)
@@ -30,15 +30,15 @@ class BaseRestoreOptionsViewController: UITableViewController {
 
     // MARK: - Initialization
 
-    init(site: JetpackSiteRef, activity: FormattableActivity) {
+    init(site: JetpackSiteRef, activity: Activity) {
         fatalError("A configuration struct needs to be provided")
     }
 
     init(site: JetpackSiteRef,
-         activity: FormattableActivity,
+         activity: Activity,
          configuration: JetpackRestoreOptionsConfiguration) {
         self.site = site
-        self.formattableActivity = activity
+        self.activity = activity
         self.configuration = configuration
         super.init(style: .grouped)
     }
@@ -88,7 +88,7 @@ class BaseRestoreOptionsViewController: UITableViewController {
 
     private func configureTableHeaderView() {
         let headerView = JetpackRestoreHeaderView.loadFromNib()
-        let publishedDate = dateFormatter.string(from: formattableActivity.activity.published)
+        let publishedDate = dateFormatter.string(from: activity.published)
 
         headerView.configure(
             iconImage: configuration.iconImage,

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackDownloadBackupViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackDownloadBackupViewController.swift
@@ -6,6 +6,8 @@ import WordPressShared
 
 class JetpackDownloadBackupViewController: BaseRestoreOptionsViewController {
 
+    // MARK: - Initialization
+
     override init(site: JetpackSiteRef, activity: FormattableActivity) {
         let restoreOptionsConfiguration = JetpackRestoreOptionsConfiguration(
             title: NSLocalizedString("Download Backup", comment: "Title for the Jetpack Download Backup Site Screen"),
@@ -22,12 +24,18 @@ class JetpackDownloadBackupViewController: BaseRestoreOptionsViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - View Lifecycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
     }
 
+    // MARK: - Override
+
     override func actionButtonTapped() {
-        let statusVC = JetpackRestoreStatusViewController()
+        let statusVC = JetpackBackupStatusViewController(site: site,
+                                                         activity: formattableActivity.activity,
+                                                         restoreTypes: JetpackRestoreTypes())
         self.navigationController?.pushViewController(statusVC, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackDownloadBackupViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackDownloadBackupViewController.swift
@@ -1,0 +1,34 @@
+import Foundation
+import CocoaLumberjack
+import Gridicons
+import WordPressUI
+import WordPressShared
+
+class JetpackDownloadBackupViewController: BaseRestoreOptionsViewController {
+
+    override init(site: JetpackSiteRef, activity: FormattableActivity) {
+        let restoreOptionsConfiguration = JetpackRestoreOptionsConfiguration(
+            title: NSLocalizedString("Download Backup", comment: "Title for the Jetpack Download Backup Site Screen"),
+            iconImage: UIImage.gridicon(.history),
+            messageTitle: NSLocalizedString("Create downloadable backup", comment: "Label that describes the download backup action"),
+            messageDescription: NSLocalizedString("%1$@ is the selected point to create a downloadable backup.", comment: "Description for the download backup action. $1$@ is a placeholder for the selected date."),
+            generalSectionHeaderText: NSLocalizedString("Choose the items to download", comment: "Downloadable items: general section title"),
+            buttonTitle: NSLocalizedString("Create downloadable file", comment: "Button title for download backup action")
+        )
+        super.init(site: site, activity: activity, configuration: restoreOptionsConfiguration)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    override func actionButtonTapped() {
+        let statusVC = JetpackRestoreStatusViewController()
+        self.navigationController?.pushViewController(statusVC, animated: true)
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackDownloadBackupViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackDownloadBackupViewController.swift
@@ -8,7 +8,7 @@ class JetpackDownloadBackupViewController: BaseRestoreOptionsViewController {
 
     // MARK: - Initialization
 
-    override init(site: JetpackSiteRef, activity: FormattableActivity) {
+    override init(site: JetpackSiteRef, activity: Activity) {
         let restoreOptionsConfiguration = JetpackRestoreOptionsConfiguration(
             title: NSLocalizedString("Download Backup", comment: "Title for the Jetpack Download Backup Site Screen"),
             iconImage: UIImage.gridicon(.history),
@@ -34,7 +34,7 @@ class JetpackDownloadBackupViewController: BaseRestoreOptionsViewController {
 
     override func actionButtonTapped() {
         let statusVC = JetpackBackupStatusViewController(site: site,
-                                                         activity: formattableActivity.activity,
+                                                         activity: activity,
                                                          restoreTypes: JetpackRestoreTypes())
         self.navigationController?.pushViewController(statusVC, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreHeaderView.swift
@@ -4,10 +4,10 @@ import WordPressUI
 
 class JetpackRestoreHeaderView: UIView, NibReusable {
 
-    @IBOutlet weak var icon: UIImageView!
-    @IBOutlet weak var title: UILabel!
-    @IBOutlet weak var body: UILabel!
-    @IBOutlet weak var actionButton: FancyButton!
+    @IBOutlet private weak var icon: UIImageView!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var descriptionLabel: UILabel!
+    @IBOutlet private weak var actionButton: FancyButton!
 
     var actionButtonHandler: (() -> Void)?
 
@@ -16,43 +16,32 @@ class JetpackRestoreHeaderView: UIView, NibReusable {
         applyStyles()
     }
 
+    // MARK: - Styling
+
     private func applyStyles() {
         icon.tintColor = .success
 
-        title.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
-        title.textColor = .text
+        titleLabel.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
+        titleLabel.textColor = .text
 
-        body.font = WPStyleGuide.fontForTextStyle(.body)
-        body.textColor = .textSubtle
-        body.numberOfLines = 0
-        // Need to define preferredMaxLayoutWidth for multiline labels in a custom tableHeaderView
-        body.preferredMaxLayoutWidth = body.bounds.width
+        descriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)
+        descriptionLabel.textColor = .textSubtle
+        descriptionLabel.numberOfLines = 0
+        descriptionLabel.preferredMaxLayoutWidth = descriptionLabel.bounds.width
 
         actionButton.isPrimary = true
     }
 
-    func configure(site: JetpackSiteRef,
-                   formattableActivity: FormattableActivity,
-                   restoreAction: JetpackRestoreAction) {
+    // MARK: - Configuration
 
-        let dateFormatter = ActivityDateFormatting.mediumDateFormatterWithTime(for: site)
-        let publishedDate = dateFormatter.string(from: formattableActivity.activity.published)
-
-        switch restoreAction {
-        case .restore:
-            icon.image = UIImage.gridicon(.history)
-            title.text = NSLocalizedString("Restore site", comment: "Label that describes the restore site action")
-            let descriptionFormat = NSLocalizedString("%1$@ is the selected point for your restore.", comment: "Description for the restore action. $1$@ is a placeholder for the selected date.")
-            body.text = String(format: descriptionFormat, publishedDate)
-            actionButton.setTitle(NSLocalizedString("Restore to this point", comment: "Button title for restore site action"), for: .normal)
-        case .downloadBackup:
-            icon.image = UIImage.gridicon(.history)
-            title.text = NSLocalizedString("Create downloadable backup", comment: "Label that describes the download backup action")
-            let descriptionFormat = NSLocalizedString("%1$@ is the selected point to create a downloadable backup.", comment: "Description for the download backup action. $1$@ is a placeholder for the selected date.")
-            body.text = String(format: descriptionFormat, publishedDate)
-            actionButton.setTitle(NSLocalizedString("Create downloadable file", comment: "Button title for download backup action"), for: .normal)
-        }
+    func configure(iconImage: UIImage, title: String, description: String, buttonTitle: String) {
+        icon.image = iconImage
+        titleLabel.text = title
+        descriptionLabel.text = description
+        actionButton.setTitle(buttonTitle, for: .normal)
     }
+
+    // MARK: - IBActions
 
     @IBAction func actionButtonTapped(_ sender: UIButton) {
         actionButtonHandler?()

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreHeaderView.xib
@@ -41,7 +41,7 @@
                     </constraints>
                     <state key="normal" title="Button"/>
                     <connections>
-                        <action selector="actionButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="LFK-ND-usc"/>
+                        <action selector="actionButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="u3x-lF-FgS"/>
                     </connections>
                 </button>
             </subviews>
@@ -63,10 +63,10 @@
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="actionButton" destination="ZHA-ex-Sko" id="EFb-Qa-0RV"/>
-                <outlet property="body" destination="6ag-Xy-HZc" id="REK-aP-1lI"/>
-                <outlet property="icon" destination="n7M-ds-fce" id="byz-Qe-ZWZ"/>
-                <outlet property="title" destination="Mst-Hr-reS" id="bC4-oL-z8T"/>
+                <outlet property="actionButton" destination="ZHA-ex-Sko" id="ftK-cT-i0k"/>
+                <outlet property="descriptionLabel" destination="6ag-Xy-HZc" id="ZBU-Lb-HZp"/>
+                <outlet property="icon" destination="n7M-ds-fce" id="XL3-jc-2wb"/>
+                <outlet property="titleLabel" destination="Mst-Hr-reS" id="yvm-WQ-P3n"/>
             </connections>
             <point key="canvasLocation" x="-17" y="69"/>
         </view>

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreViewController.swift
@@ -1,33 +1,23 @@
 import Foundation
 import CocoaLumberjack
+import Gridicons
+import WordPressUI
 import WordPressShared
 
-/// Represents the ways in which a user can restore a site
-enum JetpackRestoreAction {
-    /// restore: Restore a site to a particular point in time
-    case restore
-    /// downloadBackup: Download a backup and restore manually
-    case downloadBackup
-}
+class JetpackRestoreViewController: BaseRestoreOptionsViewController {
 
-class JetpackRestoreViewController: UITableViewController {
+    // MARK: - Initializers
 
-    // MARK: - Private Properties
-
-    private let site: JetpackSiteRef
-    private let activity: FormattableActivity
-    private let restoreAction: JetpackRestoreAction
-    private lazy var handler: ImmuTableViewHandler = {
-       return ImmuTableViewHandler(takeOver: self)
-    }()
-
-    // MARK: - Initializer
-
-    init(site: JetpackSiteRef, activity: FormattableActivity, restoreAction: JetpackRestoreAction) {
-        self.site = site
-        self.activity = activity
-        self.restoreAction = restoreAction
-        super.init(style: .grouped)
+    override init(site: JetpackSiteRef, activity: FormattableActivity) {
+        let restoreOptionsConfiguration = JetpackRestoreOptionsConfiguration(
+            title: NSLocalizedString("Restore", comment: "Title for the Jetpack Restore Site Screen"),
+            iconImage: UIImage.gridicon(.history),
+            messageTitle: NSLocalizedString("Restore site", comment: "Label that describes the restore site action"),
+            messageDescription: NSLocalizedString("%1$@ is the selected point for your restore.", comment: "Description for the restore action. $1$@ is a placeholder for the selected date."),
+            generalSectionHeaderText: NSLocalizedString("Choose the items to restore", comment: "Restorable items: general section title"),
+            buttonTitle: NSLocalizedString("Restore to this point", comment: "Button title for restore site action")
+        )
+        super.init(site: site, activity: activity, configuration: restoreOptionsConfiguration)
     }
 
     required init?(coder: NSCoder) {
@@ -38,170 +28,13 @@ class JetpackRestoreViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureTitle()
-        configureNavigation()
-        configureTableView()
-        configureTableHeaderView()
-        reloadViewModel()
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        tableView.layoutHeaderView()
+    // MARK: - Override
+
+    override func actionButtonTapped() {
+        let warningVC = JetpackRestoreWarningViewController()
+        self.navigationController?.pushViewController(warningVC, animated: true)
     }
 
-    // MARK: - Configure
-
-    private func configureTitle() {
-        title = Strings.title(restoreAction)
-    }
-
-    private func configureNavigation() {
-        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel,
-                                                           target: self,
-                                                           action: #selector(cancelTapped))
-    }
-
-    private func configureTableView() {
-        WPStyleGuide.configureColors(view: view, tableView: tableView)
-        ImmuTable.registerRows([SwitchRow.self], tableView: tableView)
-    }
-
-    private func configureTableHeaderView() {
-        let headerView = JetpackRestoreHeaderView.loadFromNib()
-        headerView.configure(site: site, formattableActivity: activity, restoreAction: restoreAction)
-
-        headerView.actionButtonHandler = { [weak self] in
-            self?.actionButtonTapped()
-        }
-
-        self.tableView.tableHeaderView = headerView
-    }
-
-    // MARK: - Private Helpers
-
-    private func actionButtonTapped() {
-        switch restoreAction {
-        case .restore:
-            let warningVC = JetpackRestoreWarningViewController()
-            self.navigationController?.pushViewController(warningVC, animated: true)
-        case .downloadBackup:
-            let statusVC = JetpackRestoreStatusViewController()
-            self.navigationController?.pushViewController(statusVC, animated: true)
-        }
-    }
-
-    @objc private func cancelTapped() {
-        self.dismiss(animated: true)
-    }
-
-    // MARK: - Model
-
-    private func reloadViewModel() {
-        handler.viewModel = tableViewModel()
-    }
-
-    private func tableViewModel() -> ImmuTable {
-        return ImmuTable(
-            sections: [
-                generalSection(),
-                contentSection(),
-                databaseSection()
-            ]
-        )
-    }
-
-    private func generalSection() -> ImmuTableSection {
-        let themesRow = SwitchRow(
-            title: Strings.themesRowTitle,
-            value: true,
-            onChange: { _ in }
-        )
-        let pluginsRow = SwitchRow(
-            title: Strings.pluginsRowTitle,
-            value: true,
-            onChange: { _ in }
-        )
-        let mediaUploadsRow = SwitchRow(
-            title: Strings.mediaUploadsRowTitle,
-            value: true,
-            onChange: { _ in }
-        )
-        let rootRow = SwitchRow(
-            title: Strings.rootRowTitle,
-            value: true,
-            onChange: { _ in }
-        )
-
-        return ImmuTableSection(
-            headerText: Strings.generalSectionHeaderText(restoreAction),
-            rows: [
-                themesRow,
-                pluginsRow,
-                mediaUploadsRow,
-                rootRow
-            ],
-            footerText: Strings.generalSectionFooterText
-        )
-    }
-
-    private func contentSection() -> ImmuTableSection {
-        let contentRow = SwitchRow(
-            title: Strings.contentRowTitle,
-            value: true,
-            onChange: { _ in }
-        )
-
-        return ImmuTableSection(
-            headerText: "",
-            rows: [contentRow],
-            footerText: Strings.contentSectionFooterText
-        )
-    }
-
-    private func databaseSection() -> ImmuTableSection {
-        let databaseRow = SwitchRow(
-            title: Strings.databaseRowTitle,
-            value: true,
-            onChange: { _ in }
-        )
-
-        return ImmuTableSection(
-            headerText: "",
-            rows: [databaseRow],
-            footerText: nil
-        )
-    }
-}
-
-extension JetpackRestoreViewController {
-
-    private enum Strings {
-        static func title(_ restoreAction: JetpackRestoreAction) -> String {
-            switch restoreAction {
-            case .restore:
-                return NSLocalizedString("Restore", comment: "Title for the Jetpack Restore Site Screen")
-            case .downloadBackup:
-                return NSLocalizedString("Download Backup", comment: "Title for the Jetpack Download Backup Site Screen")
-            }
-        }
-
-        static func generalSectionHeaderText(_ restoreAction: JetpackRestoreAction) -> String {
-            switch restoreAction {
-            case .restore:
-                return NSLocalizedString("Choose the items to restore", comment: "Restorable items: general section title")
-            case .downloadBackup:
-                return NSLocalizedString("Choose the items to download", comment: "Downloadable items: general section title")
-            }
-        }
-
-        static let themesRowTitle = NSLocalizedString("WordPress Themes", comment: "Downloadable/Restorable items: WordPress Themes")
-        static let pluginsRowTitle = NSLocalizedString("WordPress Plugins", comment: "Downloadable/Restorable items: WordPress Plugins")
-        static let mediaUploadsRowTitle = NSLocalizedString("Media Uploads", comment: "Downloadable/Restorable items: Media Uploads")
-        static let rootRowTitle = NSLocalizedString("WordPress root", comment: "Downloadable/Restorable items: WordPress root")
-        static let generalSectionFooterText = NSLocalizedString("Includes wp-config php and any non WordPress files", comment: "Downloadable/Restorable items: general section footer text")
-        static let contentRowTitle = NSLocalizedString("WP-content directory", comment: "Downloadable/Restorable items: WP-content directory")
-        static let contentSectionFooterText = NSLocalizedString("Excludes themes, plugins, and uploads", comment: "Downloadable/Restorable items: content section footer text")
-        static let databaseRowTitle = NSLocalizedString("Site database", comment: "Downloadable/Restorable items: Site Database")
-    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreViewController.swift
@@ -8,7 +8,7 @@ class JetpackRestoreViewController: BaseRestoreOptionsViewController {
 
     // MARK: - Initialization
 
-    override init(site: JetpackSiteRef, activity: FormattableActivity) {
+    override init(site: JetpackSiteRef, activity: Activity) {
         let restoreOptionsConfiguration = JetpackRestoreOptionsConfiguration(
             title: NSLocalizedString("Restore", comment: "Title for the Jetpack Restore Site Screen"),
             iconImage: UIImage.gridicon(.history),
@@ -33,12 +33,10 @@ class JetpackRestoreViewController: BaseRestoreOptionsViewController {
     // MARK: - Override
 
     override func actionButtonTapped() {
-        //        let warningVC = JetpackRestoreWarningViewController()
-        //        self.navigationController?.pushViewController(warningVC, animated: true)
-        let statusVC = JetpackRestoreStatusViewController(site: site,
-                                                          activity: formattableActivity.activity,
-                                                          restoreTypes: JetpackRestoreTypes())
-        self.navigationController?.pushViewController(statusVC, animated: true)
+        let warningVC = JetpackRestoreWarningViewController(site: site,
+                                                            activity: activity,
+                                                            restoreTypes: restoreTypes)
+        self.navigationController?.pushViewController(warningVC, animated: true)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreViewController.swift
@@ -6,7 +6,7 @@ import WordPressShared
 
 class JetpackRestoreViewController: BaseRestoreOptionsViewController {
 
-    // MARK: - Initializers
+    // MARK: - Initialization
 
     override init(site: JetpackSiteRef, activity: FormattableActivity) {
         let restoreOptionsConfiguration = JetpackRestoreOptionsConfiguration(
@@ -33,8 +33,12 @@ class JetpackRestoreViewController: BaseRestoreOptionsViewController {
     // MARK: - Override
 
     override func actionButtonTapped() {
-        let warningVC = JetpackRestoreWarningViewController()
-        self.navigationController?.pushViewController(warningVC, animated: true)
+        //        let warningVC = JetpackRestoreWarningViewController()
+        //        self.navigationController?.pushViewController(warningVC, animated: true)
+        let statusVC = JetpackRestoreStatusViewController(site: site,
+                                                          activity: formattableActivity.activity,
+                                                          restoreTypes: JetpackRestoreTypes())
+        self.navigationController?.pushViewController(statusVC, animated: true)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/BaseRestoreStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/BaseRestoreStatusViewController.swift
@@ -1,0 +1,96 @@
+import Foundation
+import CocoaLumberjack
+import WordPressShared
+
+struct JetpackRestoreStatusConfiguration {
+    let title: String
+    let iconImage: UIImage
+    let messageTitle: String
+    let messageDescription: String
+    let hint: String
+    let primaryButtonTitle: String
+}
+
+class BaseRestoreStatusViewController: UIViewController {
+
+    // MARK: - Private Properties
+
+    private let site: JetpackSiteRef
+    private let activity: Activity
+    private let restoreTypes: JetpackRestoreTypes
+    private let configuration: JetpackRestoreStatusConfiguration
+
+    private lazy var dateFormatter: DateFormatter = {
+        return ActivityDateFormatting.mediumDateFormatterWithTime(for: site)
+    }()
+
+    // MARK: - Initialization
+
+    init(site: JetpackSiteRef,
+         activity: Activity,
+         restoreTypes: JetpackRestoreTypes) {
+        fatalError("A configuration struct needs to be provided")
+    }
+
+    init(site: JetpackSiteRef,
+         activity: Activity,
+         restoreTypes: JetpackRestoreTypes,
+         configuration: JetpackRestoreStatusConfiguration) {
+        self.site = site
+        self.activity = activity
+        self.restoreTypes = restoreTypes
+        self.configuration = configuration
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTitle()
+        configureNavigation()
+        configureRestoreStatusView()
+    }
+
+    // MARK: - Configure
+
+    private func configureTitle() {
+        title = configuration.title
+    }
+
+    private func configureNavigation() {
+        navigationItem.hidesBackButton = true
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
+                                                           target: self,
+                                                           action: #selector(doneTapped))
+    }
+
+    private func configureRestoreStatusView() {
+        let statusView = RestoreStatusView.loadFromNib()
+        let publishedDate = dateFormatter.string(from: activity.published)
+
+        statusView.configure(
+            iconImage: configuration.iconImage,
+            title: configuration.messageTitle,
+            description: String(format: configuration.messageDescription, publishedDate),
+            primaryButtonTitle: configuration.primaryButtonTitle,
+            hint: configuration.hint
+        )
+
+        statusView.primaryButtonHandler = { [weak self] in
+            self?.dismiss(animated: true)
+        }
+
+        statusView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(statusView)
+        view.pinSubviewToAllEdges(statusView)
+    }
+
+    @objc private func doneTapped() {
+        self.dismiss(animated: true)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
@@ -1,0 +1,32 @@
+import Foundation
+import CocoaLumberjack
+import WordPressShared
+import WordPressUI
+
+class JetpackBackupStatusViewController: BaseRestoreStatusViewController {
+
+    // MARK: - Initialization
+
+    override init(site: JetpackSiteRef, activity: Activity, restoreTypes: JetpackRestoreTypes) {
+        let restoreStatusConfiguration = JetpackRestoreStatusConfiguration(
+            title: NSLocalizedString("Backup", comment: "Title for Jetpack Backup Status screen"),
+            iconImage: .gridicon(.history),
+            messageTitle: NSLocalizedString("Currently creating a downloadable backup of you site", comment: "Title for the Jetpack Restore Status screen."),
+            messageDescription: NSLocalizedString("We're creating a downloadable backup of your site from %1$@.", comment: "Description for the restore action. %1$@ is a placeholder for the selected date."),
+            hint: NSLocalizedString("No need to wait around. We'll notify you when your backup is ready.", comment: "A hint to users about restoring their site."),
+            primaryButtonTitle: NSLocalizedString("OK, notify me!", comment: "Title for the button that will dismiss this view.")
+        )
+        super.init(site: site, activity: activity, restoreTypes: restoreTypes, configuration: restoreStatusConfiguration)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
@@ -11,9 +11,9 @@ class JetpackBackupStatusViewController: BaseRestoreStatusViewController {
         let restoreStatusConfiguration = JetpackRestoreStatusConfiguration(
             title: NSLocalizedString("Backup", comment: "Title for Jetpack Backup Status screen"),
             iconImage: .gridicon(.history),
-            messageTitle: NSLocalizedString("Currently creating a downloadable backup of you site", comment: "Title for the Jetpack Restore Status screen."),
-            messageDescription: NSLocalizedString("We're creating a downloadable backup of your site from %1$@.", comment: "Description for the restore action. %1$@ is a placeholder for the selected date."),
-            hint: NSLocalizedString("No need to wait around. We'll notify you when your backup is ready.", comment: "A hint to users about restoring their site."),
+            messageTitle: NSLocalizedString("Currently creating a downloadable backup of your site", comment: "Title for the Jetpack Backup Status message."),
+            messageDescription: NSLocalizedString("We're creating a downloadable backup of your site from %1$@.", comment: "Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date."),
+            hint: NSLocalizedString("No need to wait around. We'll notify you when your backup is ready.", comment: "A hint to users about creating a downloadable backup of their site."),
             primaryButtonTitle: NSLocalizedString("OK, notify me!", comment: "Title for the button that will dismiss this view.")
         )
         super.init(site: site, activity: activity, restoreTypes: restoreTypes, configuration: restoreStatusConfiguration)

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
@@ -11,8 +11,8 @@ class JetpackRestoreStatusViewController: BaseRestoreStatusViewController {
            let restoreStatusConfiguration = JetpackRestoreStatusConfiguration(
                title: NSLocalizedString("Restore", comment: "Title for Jetpack Restore Status screen"),
                iconImage: .gridicon(.history),
-               messageTitle: NSLocalizedString("Currently restoring site", comment: "Title for the Jetpack Restore Status screen."),
-               messageDescription: NSLocalizedString("We're restoring your site back to %1$@.", comment: "Description for the restore action. %1$@ is a placeholder for the selected date."),
+               messageTitle: NSLocalizedString("Currently restoring site", comment: "Title for the Jetpack Restore Status message."),
+               messageDescription: NSLocalizedString("We're restoring your site back to %1$@.", comment: "Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date."),
                hint: NSLocalizedString("No need to wait around. We'll notify you when your site has been fully restored.", comment: "A hint to users about restoring their site."),
                primaryButtonTitle: NSLocalizedString("OK, notify me!", comment: "Title for the button that will dismiss this view.")
            )

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
@@ -1,36 +1,32 @@
 import Foundation
 import CocoaLumberjack
 import WordPressShared
+import WordPressUI
 
-class JetpackRestoreStatusViewController: UIViewController {
+class JetpackRestoreStatusViewController: BaseRestoreStatusViewController {
+
+    // MARK: - Initialization
+
+    override init(site: JetpackSiteRef, activity: Activity, restoreTypes: JetpackRestoreTypes) {
+           let restoreStatusConfiguration = JetpackRestoreStatusConfiguration(
+               title: NSLocalizedString("Restore", comment: "Title for Jetpack Restore Status screen"),
+               iconImage: .gridicon(.history),
+               messageTitle: NSLocalizedString("Currently restoring site", comment: "Title for the Jetpack Restore Status screen."),
+               messageDescription: NSLocalizedString("We're restoring your site back to %1$@.", comment: "Description for the restore action. %1$@ is a placeholder for the selected date."),
+               hint: NSLocalizedString("No need to wait around. We'll notify you when your site has been fully restored.", comment: "A hint to users about restoring their site."),
+               primaryButtonTitle: NSLocalizedString("OK, notify me!", comment: "Title for the button that will dismiss this view.")
+           )
+           super.init(site: site, activity: activity, restoreTypes: restoreTypes, configuration: restoreStatusConfiguration)
+       }
+
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = NSLocalizedString("Restore", comment: "Title for Jetpack Restore Status screen")
-        configureNavigation()
-        configureRestoreStatusView()
-    }
-
-    private func configureNavigation() {
-        navigationItem.hidesBackButton = true
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
-                                                           target: self,
-                                                           action: #selector(doneTapped))
-    }
-
-    private func configureRestoreStatusView() {
-        let statusView = RestoreStatusView.loadFromNib()
-
-        statusView.notifyMeHandler = { [weak self] in
-            self?.dismiss(animated: true)
-        }
-
-        statusView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(statusView)
-        view.pinSubviewToAllEdges(statusView)
-    }
-
-    @objc private func doneTapped() {
-        self.dismiss(animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/RestoreStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/RestoreStatusView.swift
@@ -7,23 +7,22 @@ class RestoreStatusView: UIView, NibLoadable {
     // MARK: - Properties
 
     @IBOutlet private weak var icon: UIImageView!
-    @IBOutlet private weak var title: UILabel!
-    @IBOutlet private weak var body: UILabel!
-    @IBOutlet private weak var progressTitle: UILabel!
-    @IBOutlet private weak var progressValue: UILabel!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var descriptionLabel: UILabel!
+    @IBOutlet private weak var progressTitleLabel: UILabel!
+    @IBOutlet private weak var progressValueLabel: UILabel!
     @IBOutlet private weak var progressView: UIProgressView!
-    @IBOutlet private weak var progressDescription: UILabel!
-    @IBOutlet private weak var notifyMeButton: FancyButton!
-    @IBOutlet private weak var hint: UILabel!
+    @IBOutlet private weak var progressDescriptionLabel: UILabel!
+    @IBOutlet private weak var primaryButton: FancyButton!
+    @IBOutlet private weak var hintLabel: UILabel!
 
-    var notifyMeHandler: (() -> Void)?
+    var primaryButtonHandler: (() -> Void)?
 
     // MARK: - Initialization
 
     override func awakeFromNib() {
         super.awakeFromNib()
         applyStyles()
-        configure()
     }
 
     // MARK: - Styling
@@ -33,50 +32,44 @@ class RestoreStatusView: UIView, NibLoadable {
 
         icon.tintColor = .success
 
-        title.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
-        title.textColor = .text
+        titleLabel.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
+        titleLabel.textColor = .text
+        titleLabel.numberOfLines = 0
 
-        body.font = WPStyleGuide.fontForTextStyle(.body)
-        body.textColor = .textSubtle
-        body.numberOfLines = 0
+        descriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)
+        descriptionLabel.textColor = .textSubtle
+        descriptionLabel.numberOfLines = 0
 
-        progressTitle.font = WPStyleGuide.fontForTextStyle(.body)
-        progressTitle.textColor = .text
+        progressTitleLabel.font = WPStyleGuide.fontForTextStyle(.body)
+        progressTitleLabel.textColor = .text
 
-        progressValue.font = WPStyleGuide.fontForTextStyle(.body)
-        progressTitle.textColor = .text
+        progressValueLabel.font = WPStyleGuide.fontForTextStyle(.body)
+        progressValueLabel.textColor = .text
 
-        progressDescription.font = WPStyleGuide.fontForTextStyle(.subheadline)
-        progressDescription.textColor = .textSubtle
+        progressDescriptionLabel.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        progressDescriptionLabel.textColor = .textSubtle
 
-        hint.font = WPStyleGuide.fontForTextStyle(.subheadline)
-        hint.textColor = .textSubtle
-        hint.numberOfLines = 0
+        hintLabel.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        hintLabel.textColor = .textSubtle
+        hintLabel.numberOfLines = 0
 
-        notifyMeButton.isPrimary = true
+        primaryButton.isPrimary = true
     }
 
     // MARK: - Configuration
 
-    func configure() {
-        icon.image = .gridicon(.history)
-        title.text = Strings.title
-        body.text = String(format: Strings.bodyFormat, "placeholder date")
-        notifyMeButton.setTitle(Strings.notifyMeButtonTitle, for: .normal)
-        hint.text = Strings.hint
+    func configure(iconImage: UIImage, title: String, description: String, primaryButtonTitle: String, hint: String) {
+        icon.image = iconImage
+        titleLabel.text = title
+        descriptionLabel.text = description
+        primaryButton.setTitle(primaryButtonTitle, for: .normal)
+        hintLabel.text = hint
     }
 
     // MARK: - IBAction
 
-    @IBAction private func notifyMeButtonTapped(_ sender: Any) {
-        notifyMeHandler?()
-    }
-
-    private enum Strings {
-        static let title = NSLocalizedString("Currently restoring site", comment: "Title for the Jetpack Restore Status screen.")
-        static let bodyFormat = NSLocalizedString("We're restoring your site back to %1$@.", comment: "Description for the restore action. %1$@ is a placeholder for the selected date.")
-        static let notifyMeButtonTitle = NSLocalizedString("OK, notify me!", comment: "Title for the button that will dismiss this view.")
-        static let hint = NSLocalizedString("No need to wait around. We'll notify you when your site has been fully restored.", comment: "A hint to users about restoring their site.")
+    @IBAction private func primaryButtonTapped(_ sender: Any) {
+        primaryButtonHandler?()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/RestoreStatusView.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/RestoreStatusView.xib
@@ -72,7 +72,7 @@
                     </constraints>
                     <state key="normal" title="Button"/>
                     <connections>
-                        <action selector="notifyMeButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="lWJ-ty-BLM"/>
+                        <action selector="primaryButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="29c-HA-vme"/>
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rvV-Do-FdP">
@@ -106,15 +106,15 @@
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="body" destination="EU1-QH-BCU" id="ma9-VL-2ya"/>
-                <outlet property="hint" destination="rvV-Do-FdP" id="Rzy-HD-7nU"/>
-                <outlet property="icon" destination="Zbf-a2-qml" id="Xis-pC-52Y"/>
-                <outlet property="notifyMeButton" destination="vL1-GD-nhg" id="Tz1-gY-4iF"/>
-                <outlet property="progressDescription" destination="V9F-s0-Tu4" id="zoY-dV-K1b"/>
-                <outlet property="progressTitle" destination="BtU-j2-Om5" id="4zx-bI-jdL"/>
-                <outlet property="progressValue" destination="HwS-sP-YxX" id="Wh8-JN-zLF"/>
-                <outlet property="progressView" destination="M1m-lM-aaN" id="nOb-eo-TGy"/>
-                <outlet property="title" destination="Q7a-aL-FAq" id="0Be-fl-28q"/>
+                <outlet property="descriptionLabel" destination="EU1-QH-BCU" id="D3v-9H-Gsa"/>
+                <outlet property="hintLabel" destination="rvV-Do-FdP" id="uos-pD-3KW"/>
+                <outlet property="icon" destination="Zbf-a2-qml" id="6eT-n5-AER"/>
+                <outlet property="primaryButton" destination="vL1-GD-nhg" id="1e2-xk-eN4"/>
+                <outlet property="progressDescriptionLabel" destination="V9F-s0-Tu4" id="LAS-wy-Gbm"/>
+                <outlet property="progressTitleLabel" destination="BtU-j2-Om5" id="iQo-mC-OMS"/>
+                <outlet property="progressValueLabel" destination="HwS-sP-YxX" id="hZq-vg-wC1"/>
+                <outlet property="progressView" destination="M1m-lM-aaN" id="4mg-wq-x6m"/>
+                <outlet property="titleLabel" destination="Q7a-aL-FAq" id="TPC-5L-ZvC"/>
             </connections>
             <point key="canvasLocation" x="-16" y="110"/>
         </view>

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
@@ -4,6 +4,33 @@ import WordPressShared
 
 class JetpackRestoreWarningViewController: UIViewController {
 
+    // MARK: - Private Properties
+
+    private let site: JetpackSiteRef
+    private let activity: Activity
+    private let restoreTypes: JetpackRestoreTypes
+
+    private lazy var dateFormatter: DateFormatter = {
+        return ActivityDateFormatting.mediumDateFormatterWithTime(for: site)
+    }()
+
+    // MARK: - Initialization
+
+    init(site: JetpackSiteRef,
+         activity: Activity,
+         restoreTypes: JetpackRestoreTypes) {
+        self.site = site
+        self.activity = activity
+        self.restoreTypes = restoreTypes
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
         title = NSLocalizedString("Warning", comment: "Title for Jetpack Restore Warning screen")
@@ -14,8 +41,13 @@ class JetpackRestoreWarningViewController: UIViewController {
         let warningView = RestoreWarningView.loadFromNib()
 
         warningView.confirmHandler = { [weak self] in
-//            let statusVC = JetpackRestoreStatusViewController()
-//            self?.navigationController?.pushViewController(statusVC, animated: true)
+            guard let self = self else {
+                return
+            }
+            let statusVC = JetpackRestoreStatusViewController(site: self.site,
+                                                              activity: self.activity,
+                                                              restoreTypes: self.restoreTypes)
+            self.navigationController?.pushViewController(statusVC, animated: true)
         }
 
         warningView.cancelHandler = { [weak self] in

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
@@ -37,17 +37,15 @@ class JetpackRestoreWarningViewController: UIViewController {
         configureWarningView()
     }
 
+    // MARK: - Configure
+
     private func configureWarningView() {
         let warningView = RestoreWarningView.loadFromNib()
+        let publishedDate = dateFormatter.string(from: activity.published)
+        warningView.configure(with: publishedDate)
 
         warningView.confirmHandler = { [weak self] in
-            guard let self = self else {
-                return
-            }
-            let statusVC = JetpackRestoreStatusViewController(site: self.site,
-                                                              activity: self.activity,
-                                                              restoreTypes: self.restoreTypes)
-            self.navigationController?.pushViewController(statusVC, animated: true)
+            self?.showRestoreStatus()
         }
 
         warningView.cancelHandler = { [weak self] in
@@ -57,6 +55,15 @@ class JetpackRestoreWarningViewController: UIViewController {
         warningView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(warningView)
         view.pinSubviewToAllEdges(warningView)
+    }
+
+    // MARK: - Private Helpers
+
+    private func showRestoreStatus() {
+        let statusVC = JetpackRestoreStatusViewController(site: site,
+                                                          activity: activity,
+                                                          restoreTypes: restoreTypes)
+        self.navigationController?.pushViewController(statusVC, animated: true)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
@@ -14,8 +14,8 @@ class JetpackRestoreWarningViewController: UIViewController {
         let warningView = RestoreWarningView.loadFromNib()
 
         warningView.confirmHandler = { [weak self] in
-            let statusVC = JetpackRestoreStatusViewController()
-            self?.navigationController?.pushViewController(statusVC, animated: true)
+//            let statusVC = JetpackRestoreStatusViewController()
+//            self?.navigationController?.pushViewController(statusVC, animated: true)
         }
 
         warningView.cancelHandler = { [weak self] in

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/RestoreWarningView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/RestoreWarningView.swift
@@ -7,8 +7,8 @@ class RestoreWarningView: UIView, NibLoadable {
     // MARK: - Properties
 
     @IBOutlet private weak var icon: UIImageView!
-    @IBOutlet private weak var title: UILabel!
-    @IBOutlet private weak var body: UILabel!
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet private weak var confirmButton: FancyButton!
     @IBOutlet private weak var cancelButton: FancyButton!
 
@@ -20,7 +20,6 @@ class RestoreWarningView: UIView, NibLoadable {
     override func awakeFromNib() {
         super.awakeFromNib()
         applyStyles()
-        configure()
     }
 
     // MARK: - Styling
@@ -30,12 +29,12 @@ class RestoreWarningView: UIView, NibLoadable {
 
         icon.tintColor = .error
 
-        title.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
-        title.textColor = .text
+        titleLabel.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
+        titleLabel.textColor = .text
 
-        body.font = WPStyleGuide.fontForTextStyle(.body)
-        body.textColor = .text
-        body.numberOfLines = 0
+        descriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)
+        descriptionLabel.textColor = .text
+        descriptionLabel.numberOfLines = 0
 
         confirmButton.isPrimary = true
 
@@ -44,10 +43,10 @@ class RestoreWarningView: UIView, NibLoadable {
 
     // MARK: - Configuration
 
-    func configure() {
+    func configure(with publishedDate: String) {
         icon.image = .gridicon(.notice)
-        title.text = Strings.title
-        body.text = String(format: Strings.bodyFormat, "placeholder date")
+        titleLabel.text = Strings.title
+        descriptionLabel.text = String(format: Strings.descriptionFormat, publishedDate)
         confirmButton.setTitle(Strings.confirmButtonTitle, for: .normal)
         cancelButton.setTitle(Strings.cancelButtonTitle, for: .normal)
     }
@@ -64,7 +63,7 @@ class RestoreWarningView: UIView, NibLoadable {
 
     private enum Strings {
         static let title = NSLocalizedString("Warning", comment: "Noun. Title for Jetpack Restore warning.")
-        static let bodyFormat = NSLocalizedString("Are you sure you want to rewind your site back to %1$@? This will remove all content and options created or changed since then.", comment: "Description for the confirm restore action. %1$@ is a placeholder for the selected date.")
+        static let descriptionFormat = NSLocalizedString("Are you sure you want to restore your site back to %1$@? This will remove all content and options created or changed since then.", comment: "Description for the confirm restore action. %1$@ is a placeholder for the selected date.")
         static let confirmButtonTitle = NSLocalizedString("Confirm", comment: "Verb. Title for Jetpack Restore confirm button.")
         static let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Verb. Title for Jetpack Restore cancel button.")
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/RestoreWarningView.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/RestoreWarningView.xib
@@ -78,11 +78,11 @@
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="body" destination="EHP-Zk-FQR" id="oQv-mS-Iax"/>
                 <outlet property="cancelButton" destination="9ga-Hc-Cyk" id="wPA-30-GH5"/>
                 <outlet property="confirmButton" destination="kdA-Zi-bHr" id="AHu-Q6-GjN"/>
+                <outlet property="descriptionLabel" destination="EHP-Zk-FQR" id="1la-9s-vkS"/>
                 <outlet property="icon" destination="HDs-Xm-1E7" id="VuX-co-wO6"/>
-                <outlet property="title" destination="Xzv-RX-M1d" id="nbd-fj-fIr"/>
+                <outlet property="titleLabel" destination="Xzv-RX-M1d" id="gTa-o0-hV7"/>
             </connections>
             <point key="canvasLocation" x="-1520" y="-7"/>
         </view>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2303,6 +2303,8 @@
 		FAB4F32724EDE12A00F259BA /* FollowCommentsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */; };
 		FAB8F75025AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F74F25AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift */; };
 		FAB8F76E25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F76D25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift */; };
+		FAB8F78C25AD785400D5D54A /* BaseRestoreStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F78B25AD785400D5D54A /* BaseRestoreStatusViewController.swift */; };
+		FAB8F7AA25AD792500D5D54A /* JetpackBackupStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F7A925AD792500D5D54A /* JetpackBackupStatusViewController.swift */; };
 		FACB36F11C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */; };
 		FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */; };
 		FAE4327425874D140039EB8C /* ReaderSavedPostCellActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */; };
@@ -5044,6 +5046,8 @@
 		FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowCommentsServiceTests.swift; sourceTree = "<group>"; };
 		FAB8F74F25AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRestoreOptionsViewController.swift; sourceTree = "<group>"; };
 		FAB8F76D25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackDownloadBackupViewController.swift; sourceTree = "<group>"; };
+		FAB8F78B25AD785400D5D54A /* BaseRestoreStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRestoreStatusViewController.swift; sourceTree = "<group>"; };
+		FAB8F7A925AD792500D5D54A /* JetpackBackupStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupStatusViewController.swift; sourceTree = "<group>"; };
 		FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeWebNavigationDelegate.swift; sourceTree = "<group>"; };
 		FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartOverViewController.swift; sourceTree = "<group>"; };
 		FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostCellActions.swift; sourceTree = "<group>"; };
@@ -11000,7 +11004,9 @@
 		FA1A564825A708D30033967D /* Restore Status */ = {
 			isa = PBXGroup;
 			children = (
+				FAB8F78B25AD785400D5D54A /* BaseRestoreStatusViewController.swift */,
 				FAF13E2F25A59240003EE470 /* JetpackRestoreStatusViewController.swift */,
+				FAB8F7A925AD792500D5D54A /* JetpackBackupStatusViewController.swift */,
 				FA1A55EE25A6F0740033967D /* RestoreStatusView.swift */,
 				FA1A55FE25A6F07F0033967D /* RestoreStatusView.xib */,
 			);
@@ -13495,6 +13501,7 @@
 				D816C1F220E0894D00C4D82F /* ReplyToComment.swift in Sources */,
 				E1BB92321FDAAFFA00F2D817 /* TextWithAccessoryButtonCell.swift in Sources */,
 				C81CCD70243AFAE600A83E27 /* TenorResponse.swift in Sources */,
+				FAB8F78C25AD785400D5D54A /* BaseRestoreStatusViewController.swift in Sources */,
 				9872CB30203B8A730066A293 /* SignupEpilogueTableViewController.swift in Sources */,
 				E1B23B081BFB3B370006559B /* MyProfileViewController.swift in Sources */,
 				F532AE1C253E55D40013B42E /* CreateButtonActionSheet.swift in Sources */,
@@ -13892,6 +13899,7 @@
 				591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */,
 				3FD272E024CF8F270021F0C8 /* UIColor+Notice.swift in Sources */,
 				E1CA0A6C1FA73053004C4BBE /* PluginStore.swift in Sources */,
+				FAB8F7AA25AD792500D5D54A /* JetpackBackupStatusViewController.swift in Sources */,
 				E11DA4931E03E03F00CF07A8 /* Pinghub.swift in Sources */,
 				E1B912831BB01047003C25B9 /* PeopleRoleBadgeLabel.swift in Sources */,
 				40FC6B7F2072E3EC00B9A1CD /* ActivityDetailViewController.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -318,7 +318,7 @@
 		1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */; };
 		24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */; };
 		24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */; };
-		24CE2EB1258D687A0000C297 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 24CE2EB0258D687A0000C297 /* SwiftPackageProductDependency */; };
+		24CE2EB1258D687A0000C297 /* WordPressFlux in Frameworks */ = {isa = PBXBuildFile; productRef = 24CE2EB0258D687A0000C297 /* WordPressFlux */; };
 		2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
 		26D66DEC36ACF7442186B07D /* Pods_WordPressThisWeekWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 979B445A45E13F3289F2E99E /* Pods_WordPressThisWeekWidget.framework */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
@@ -2301,6 +2301,8 @@
 		FA5C740F1C599BA7000B528C /* TableViewHeaderDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */; };
 		FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */; };
 		FAB4F32724EDE12A00F259BA /* FollowCommentsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */; };
+		FAB8F75025AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F74F25AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift */; };
+		FAB8F76E25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F76D25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift */; };
 		FACB36F11C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */; };
 		FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */; };
 		FAE4327425874D140039EB8C /* ReaderSavedPostCellActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */; };
@@ -5040,6 +5042,8 @@
 		FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewHeaderDetailView.swift; sourceTree = "<group>"; };
 		FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserHeaderView.swift; sourceTree = "<group>"; };
 		FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowCommentsServiceTests.swift; sourceTree = "<group>"; };
+		FAB8F74F25AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRestoreOptionsViewController.swift; sourceTree = "<group>"; };
+		FAB8F76D25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackDownloadBackupViewController.swift; sourceTree = "<group>"; };
 		FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeWebNavigationDelegate.swift; sourceTree = "<group>"; };
 		FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartOverViewController.swift; sourceTree = "<group>"; };
 		FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostCellActions.swift; sourceTree = "<group>"; };
@@ -5171,7 +5175,7 @@
 				296890780FE971DC00770264 /* Security.framework in Frameworks */,
 				83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */,
 				83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */,
-				24CE2EB1258D687A0000C297 /* BuildFile in Frameworks */,
+				24CE2EB1258D687A0000C297 /* WordPressFlux in Frameworks */,
 				8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */,
 				834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */,
 				83043E55126FA31400EC9953 /* MessageUI.framework in Frameworks */,
@@ -5756,7 +5760,7 @@
 			path = GutenbergWeb;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				98D31BBF239720E4009CFF43 /* MainInterface.storyboard */,
@@ -10974,7 +10978,9 @@
 		FA1A563825A708BF0033967D /* Restore Options */ = {
 			isa = PBXGroup;
 			children = (
+				FAB8F74F25AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift */,
 				FA4F65A62594337300EAA9F5 /* JetpackRestoreViewController.swift */,
+				FAB8F76D25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift */,
 				FA4F660425946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift */,
 				FA4F661325946B8500EAA9F5 /* JetpackRestoreHeaderView.xib */,
 			);
@@ -11130,7 +11136,7 @@
 			);
 			name = WordPress;
 			packageProductDependencies = (
-				24CE2EB0258D687A0000C297 /* SwiftPackageProductDependency */,
+				24CE2EB0258D687A0000C297 /* WordPressFlux */,
 			);
 			productName = WordPress;
 			productReference = 1D6058910D05DD3D006BFB54 /* WordPress.app */;
@@ -11503,7 +11509,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -12703,11 +12709,13 @@
 				B03B9234250BC593000A40AF /* SuggestionService.swift in Sources */,
 				B555E1151C04A68D00CEC81B /* WordPress-41-42.xcmappingmodel in Sources */,
 				F56A33332538C0ED00E2AEF3 /* BlogDetailsViewController+FAB.swift in Sources */,
+				FAB8F75025AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift in Sources */,
 				F1863716253E49B8003D4BEF /* AddSiteAlertFactory.swift in Sources */,
 				F12FA5D92428FA8F0054DA21 /* AuthenticationService.swift in Sources */,
 				E16A76F11FC4758300A661E3 /* JetpackSiteRef.swift in Sources */,
 				B5B56D3219AFB68800B4E29B /* WPStyleGuide+Reply.swift in Sources */,
 				30EABE0918A5903400B73A9C /* WPBlogTableViewCell.m in Sources */,
+				FAB8F76E25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift in Sources */,
 				400A2C842217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift in Sources */,
 				7E4123BE20F4097B00DF8486 /* NotificationContentRangeFactory.swift in Sources */,
 				E6D170371EF9D8D10046D433 /* SiteInfo.swift in Sources */,
@@ -17717,7 +17725,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		24CE2EB0258D687A0000C297 /* SwiftPackageProductDependency */ = {
+		24CE2EB0258D687A0000C297 /* WordPressFlux */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = WordPressFlux;
 		};


### PR DESCRIPTION
Part of #15191 

⚠️ https://github.com/wordpress-mobile/WordPressKit-iOS/pull/325 must be merged before this PR can be merged

### Description
- Splits `JetpackRestoreViewController` and `JetpackDownloadBackupViewController`, both inherit from `BaseRestoreOptionsViewController` 
- Splits `JetpackRestoreStatusViewController` and `JetpackBackupStatusViewController`, both inherit from `BaseRestoreStatusViewController`

Restore Options | Restore Warning | Restore Status
-- | -- | --
![Screen Shot 2021-01-12 at 16 32 45](https://user-images.githubusercontent.com/6711616/104288093-b038c600-54fa-11eb-8408-c05b4df35cba.png) | ![Screen Shot 2021-01-12 at 16 45 07](https://user-images.githubusercontent.com/6711616/104288100-b4fd7a00-54fa-11eb-8ee1-6ee41137677d.png) | ![Screen Shot 2021-01-12 at 16 32 54](https://user-images.githubusercontent.com/6711616/104288113-ba5ac480-54fa-11eb-8d68-9885b70d9f3f.png)
     
Backup Options | Backup Status
-- | --
![Screen Shot 2021-01-12 at 16 33 10](https://user-images.githubusercontent.com/6711616/104288146-c6df1d00-54fa-11eb-89ed-d53d78dbd06a.png) | ![Screen Shot 2021-01-12 at 16 33 13](https://user-images.githubusercontent.com/6711616/104288149-c8104a00-54fa-11eb-8cbe-4b8a3c4b8646.png)

### To test:

#### Restore
1. My Site > Activity Log > rewindable activity cell
2. Tap on ellipsis icon
3. Tap on `Restore`
4. Tap on `Restore to this point`
     - ✅ Should display Warning screen
 5. Tap on `Confirm`
     - ✅ Should display Restore Status screen

#### Download Backups
1. My Site > Activity Log > rewindable activity cell
2. Tap on ellipsis icon
3. Tap on `Download Backup`
4. Tap on `Create downloadable file`
     - ✅ Should display Backup screen

### PR submission checklist:
- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
