### PR TITLE
Remove "Create a new Page" and "Customize your site" from Quick Start

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -256,7 +256,6 @@ open class QuickStartTourGuide: NSObject {
         QuickStartCreateTour(),
         QuickStartViewTour(),
         QuickStartThemeTour(),
-        QuickStartCustomizeTour(),
         QuickStartShareTour(),
         QuickStartPublishTour(),
         QuickStartFollowTour()
@@ -267,8 +266,6 @@ open class QuickStartTourGuide: NSObject {
         QuickStartSiteTitleTour(),
         QuickStartSiteIconTour(),
         QuickStartThemeTour(),
-        QuickStartCustomizeTour(),
-        QuickStartNewPageTour(),
         QuickStartViewTour()
     ]
 


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-iOS/issues/15584

### To test:
- Navigate to the Create WordPress.com site
    - My Sites > ➕ > Create WordPress.com site
- Complete the site creation flow
- Choose "Yes, Help Me" on the "Want a little help..." dialog
- **Expect** To no longer see the options for "Create a new Page" or "Customize your site"

## Screenshots
Before | After
--- | ---
<kbd><a href="https://user-images.githubusercontent.com/3384451/103805806-1bc5f380-5022-11eb-9ba5-c8501087eeee.PNG"><img width="300" src="https://user-images.githubusercontent.com/3384451/103805806-1bc5f380-5022-11eb-9ba5-c8501087eeee.PNG"/></a></kbd> |  <kbd><a href="https://user-images.githubusercontent.com/3384451/104383897-97321400-54fe-11eb-9e4e-47034e2945eb.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/104383897-97321400-54fe-11eb-9e4e-47034e2945eb.png"/></a></kbd>

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
