### PR TITLE
Contact Info - Adding Feature Flag + Jetpack API for version check

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@ Unreleased
 -----
 
 * [*] Added preview device mode selector in the page layout previews [#16141]
+* [**] Block Editor: Added Contact Info block to sites on WPcom or with Jetpack version >= 8.5.
 
 17.0
 -----
@@ -18,11 +19,6 @@ Unreleased
 * [***] We updated the app's design, with fresh new headers throughout and a new site switcher in My Site. [#15750] 
 
 16.9
-16.7
------
-* [**] Block Editor: Added Contact Info block to sites on WPcom or with Jetpack version >= 8.5.
-
-16.5
 -----
 * [*] Adds helper UI to Choose a Domain screen to provide a hint of what a domain is. [#15962]
 * [**] Site Creation: Adds filterable categories to the site design picker when creating a WordPress.com site, and includes single-page site designs [#15933]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,11 @@ Unreleased
 * [***] We updated the app's design, with fresh new headers throughout and a new site switcher in My Site. [#15750] 
 
 16.9
+16.7
+-----
+* [**] Block Editor: Added Contact Info block to sites on WPcom or with Jetpack version >= 8.5.
+
+16.5
 -----
 * [*] Adds helper UI to Choose a Domain screen to provide a hint of what a domain is. [#15962]
 * [**] Site Creation: Adds filterable categories to the site design picker when creating a WordPress.com site, and includes single-page site designs [#15933]

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -80,6 +80,8 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     BlogFeatureHomepageSettings,
     /// Does the blog support stories?
     BlogFeatureStories,
+    /// Does the blog support Jetpack contact info block?
+    BlogFeatureContactInfo,
 };
 
 typedef NS_ENUM(NSInteger, SiteVisibility) {

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -643,7 +643,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 - (BOOL)supportsContactInfo
 {
-    return [self hasRequiredJetpackVersion:@"9.1"] || self.isHostedAtWPcom;
+    return [self hasRequiredJetpackVersion:@"8.5"] || self.isHostedAtWPcom;
 }
 
 - (BOOL)accountIsDefaultAccount

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -565,6 +565,8 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
             return [self supportsRestApi] && [self isAdmin];
         case BlogFeatureStories:
             return [self supportsStories];
+        case BlogFeatureContactInfo:
+            return [self supportsContactInfo];
     }
 }
 
@@ -637,6 +639,11 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 {
     BOOL hasRequiredJetpack = [self hasRequiredJetpackVersion:@"9.1"];
     return hasRequiredJetpack || self.isHostedAtWPcom;
+}
+
+- (BOOL)supportsContactInfo
+{
+    return [self hasRequiredJetpackVersion:@"9.1"] || self.isHostedAtWPcom;
 }
 
 - (BOOL)accountIsDefaultAccount

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -11,6 +11,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case newNavBarAppearance
     case unifiedPrologueCarousel
     case stories
+    case contactInfo
     case siteCreationHomePagePicker
     case jetpackScan
     case activityLogFilters
@@ -45,6 +46,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .stories:
             return true
+        case .contactInfo:
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .siteCreationHomePagePicker:
             return true
         case .jetpackScan:
@@ -105,6 +108,8 @@ extension FeatureFlag {
             return "Unified Prologue Carousel"
         case .stories:
             return "Stories"
+        case .contactInfo:
+            return "Contact Info"
         case .siteCreationHomePagePicker:
             return "Site Creation: Home Page Picker"
         case .jetpackScan:

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift
@@ -31,7 +31,9 @@ struct GutenbergNetworkRequest {
     }
 
     private func dotComPath(with dotComID: NSNumber) -> String {
-        return path.replacingOccurrences(of: "/wp/v2/", with: "/wp/v2/sites/\(dotComID)/")
+        return path
+            .replacingOccurrences(of: "/wp/v2/", with: "/wp/v2/sites/\(dotComID)/")
+            .replacingOccurrences(of: "/wpcom/v2/", with: "/wpcom/v2/sites/\(dotComID)/")
     }
 
     // MARK: - Self-Hosed

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift
@@ -33,7 +33,6 @@ struct GutenbergNetworkRequest {
     private func dotComPath(with dotComID: NSNumber) -> String {
         return path
             .replacingOccurrences(of: "/wp/v2/", with: "/wp/v2/sites/\(dotComID)/")
-            .replacingOccurrences(of: "/wpcom/v2/", with: "/wpcom/v2/sites/\(dotComID)/")
     }
 
     // MARK: - Self-Hosed

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift
@@ -31,8 +31,7 @@ struct GutenbergNetworkRequest {
     }
 
     private func dotComPath(with dotComID: NSNumber) -> String {
-        return path
-            .replacingOccurrences(of: "/wp/v2/", with: "/wp/v2/sites/\(dotComID)/")
+        return path.replacingOccurrences(of: "/wp/v2/", with: "/wp/v2/sites/\(dotComID)/")
     }
 
     // MARK: - Self-Hosed

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1064,6 +1064,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
         return [
             .mentions: FeatureFlag.gutenbergMentions.enabled && SuggestionService.shared.shouldShowSuggestions(for: post.blog),
             .xposts: FeatureFlag.gutenbergXposts.enabled && SiteSuggestionService.shared.shouldShowSuggestions(for: post.blog),
+            .contactInfoBlock: post.blog.supports(.contactInfo) && FeatureFlag.contactInfo.enabled,
             .unsupportedBlockEditor: isUnsupportedBlockEditorEnabled,
             .canEnableUnsupportedBlockEditor: post.blog.jetpack?.isConnected ?? false,
             .audioBlock: !isFreeWPCom, // Disable audio block until it's usable on free sites via "Insert from URL" capability


### PR DESCRIPTION
## Description
Added capabilities in order to determine whether contact info should be shown or not.

See further descriptions in linked PRs:
* `gutenberg-mobile`: [#3001](https://github.com/wordpress-mobile/gutenberg-mobile/pull/3001)
* `gutenberg`: [#28168](https://github.com/WordPress/gutenberg/pull/28168)
* `WPAndroid`: [#13758](https://github.com/wordpress-mobile/WordPress-Android/pull/13758)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
