### PR TITLE
Jetpack Section:  Add action to start the scan

### DIFF
--- a/WordPress/Classes/Services/JetpackScanService.swift
+++ b/WordPress/Classes/Services/JetpackScanService.swift
@@ -8,24 +8,27 @@ import Foundation
         return JetpackScanServiceRemote(wordPressComRestApi: api)
     }()
 
-    @objc func getScanAvailable(for blog: Blog, success: @escaping(Bool) -> Void, failure: @escaping(Error) -> Void) {
+    @objc func getScanAvailable(for blog: Blog, success: @escaping(Bool) -> Void, failure: @escaping(Error?) -> Void) {
         guard let siteID = blog.dotComID?.intValue else {
+            failure(nil)
             return
         }
 
         service.getScanAvailableForSite(siteID, success: success, failure: failure)
     }
 
-    func getScan(for blog: Blog, success: @escaping(JetpackScan) -> Void, failure: @escaping(Error) -> Void) {
+    func getScan(for blog: Blog, success: @escaping(JetpackScan) -> Void, failure: @escaping(Error?) -> Void) {
         guard let siteID = blog.dotComID?.intValue else {
+            failure(nil)
             return
         }
 
         service.getScanForSite(siteID, success: success, failure: failure)
     }
 
-    func startScan(for blog: Blog, success: @escaping(Bool) -> Void, failure: @escaping(Error) -> Void) {
+    func startScan(for blog: Blog, success: @escaping(Bool) -> Void, failure: @escaping(Error?) -> Void) {
         guard let siteID = blog.dotComID?.intValue else {
+            failure(nil)
             return
         }
 

--- a/WordPress/Classes/Services/JetpackScanService.swift
+++ b/WordPress/Classes/Services/JetpackScanService.swift
@@ -23,4 +23,12 @@ import Foundation
 
         service.getScanForSite(siteID, success: success, failure: failure)
     }
+
+    func startScan(for blog: Blog, success: @escaping(Bool) -> Void, failure: @escaping(Error) -> Void) {
+        guard let siteID = blog.dotComID?.intValue else {
+            return
+        }
+
+        service.startScanForSite(siteID, success: success, failure: failure)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -29,8 +29,10 @@ class JetpackScanCoordinator {
         self.view = view
     }
 
-    public func start() {
-        view.showLoading()
+    public func refreshData(showLoading: Bool = false) {
+        if showLoading {
+            view.showLoading()
+        }
 
         service.getScan(for: blog) { [weak self] scanObj in
             self?.scan = scanObj

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -37,7 +37,7 @@ class JetpackScanCoordinator {
         service.getScan(for: blog) { [weak self] scanObj in
             self?.refreshDidSucceed(with: scanObj)
         } failure: { [weak self] error in
-            DDLogError("Error fetching scan object: \(String(describing: error.localizedDescription))")
+            DDLogError("Error fetching scan object: \(String(describing: error?.localizedDescription))")
 
             self?.view.showError()
         }
@@ -72,7 +72,7 @@ class JetpackScanCoordinator {
                 self?.view.showError()
             }
         } failure: { [weak self] (error) in
-            DDLogError("Error starting scan: \(String(describing: error.localizedDescription))")
+            DDLogError("Error starting scan: \(String(describing: error?.localizedDescription))")
 
             self?.view.showError()
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -9,10 +9,10 @@ protocol JetpackScanView {
 
 class JetpackScanCoordinator {
     private let service: JetpackScanService
-    private let blog: Blog
     private let view: JetpackScanView
 
     private(set) var scan: JetpackScan?
+    let blog: Blog
 
     /// Returns the threats if we're in the idle state
     var threats: [JetpackScanThreat]? {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -60,12 +60,15 @@ class JetpackScanCoordinator {
         // Optimistically trigger the scanning state
         scan?.state = .scanning
 
+        // Refresh the view's scan state
         if let scan = scan {
             view.render(scan)
         }
 
+        // Since we've locally entered the scanning state, start polling
+        // but don't trigger a refresh immediately after calling because the
+        // server doesn't update its state immediately after starting a scan
         startPolling(triggerImmediately: false)
-
 
         service.startScan(for: blog) { [weak self] (success) in
             if success == false {
@@ -119,11 +122,10 @@ class JetpackScanCoordinator {
             self?.refreshData()
         })
 
-
+        // Immediately trigger the refresh if needed
         guard triggerImmediately else {
             return
         }
-        // Immediately trigger the refresh
         refreshData()
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -29,11 +29,13 @@ class JetpackScanCoordinator {
         self.view = view
     }
 
-    public func refreshData(showLoading: Bool = false) {
-        if showLoading {
-            view.showLoading()
-        }
+    public func viewDidLoad() {
+        view.showLoading()
 
+        refreshData()
+    }
+
+    public func refreshData() {
         service.getScan(for: blog) { [weak self] scanObj in
             self?.refreshDidSucceed(with: scanObj)
         } failure: { [weak self] error in

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -14,6 +14,11 @@ class JetpackScanCoordinator {
 
     private(set) var scan: JetpackScan?
 
+    /// Returns the threats if we're in the idle state
+    var threats: [JetpackScanThreat]? {
+        return scan?.state == .idle ? scan?.threats : nil
+    }
+
     init(blog: Blog,
          view: JetpackScanView,
          service: JetpackScanService? = nil,

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -43,6 +43,10 @@ class JetpackScanCoordinator {
         }
     }
 
+    public func viewWillDisappear() {
+        stopPolling()
+    }
+
     private func refreshDidSucceed(with scanObj: JetpackScan) {
         scan = scanObj
         view.render(scanObj)

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -43,4 +43,21 @@ class JetpackScanCoordinator {
             self?.view.showError()
         }
     }
+    public func startScan() {
+        service.startScan(for: blog) { (success) in
+
+        } failure: { [weak self] (error) in
+            DDLogError("Error starting scan: \(String(describing: error.localizedDescription))")
+
+            self?.view.showError()
+        }
+    }
+
+    public func fixThreats() {
+
+    }
+
+    public func ignoreThreat(threat: JetpackScanThreat) {
+
+    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.swift
@@ -9,6 +9,8 @@ class JetpackScanStatusCell: UITableViewCell, NibReusable {
     @IBOutlet weak var secondaryButton: FancyButton!
     @IBOutlet weak var progressView: UIProgressView!
 
+    private var model: JetpackScanStatusViewModel?
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -18,6 +20,8 @@ class JetpackScanStatusCell: UITableViewCell, NibReusable {
     }
 
     public func configure(with model: JetpackScanStatusViewModel) {
+        self.model = model
+
         iconImageView.image = UIImage(named: model.imageName)
         titleLabel.text = model.title
         descriptionLabel.text = model.description
@@ -59,9 +63,19 @@ class JetpackScanStatusCell: UITableViewCell, NibReusable {
 
     // MARK: - IBAction's
     @IBAction func primaryButtonTapped(_ sender: Any) {
+        guard let viewModel = model else {
+            return
+        }
+
+        viewModel.primaryButtonTapped(sender)
     }
 
     @IBAction func secondaryButtonTapped(_ sender: Any) {
+        guard let viewModel = model else {
+            return
+        }
+
+        viewModel.secondaryButtonTapped(sender)
     }
 
     // MARK: - Private: View Configuration

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.swift
@@ -7,12 +7,14 @@ class JetpackScanStatusCell: UITableViewCell, NibReusable {
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var primaryButton: FancyButton!
     @IBOutlet weak var secondaryButton: FancyButton!
+    @IBOutlet weak var progressView: UIProgressView!
 
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        self.primaryButton.isHidden = true
-        self.secondaryButton.isHidden = true
+        primaryButton.isHidden = true
+        secondaryButton.isHidden = true
+        configureProgressView()
     }
 
     public func configure(with model: JetpackScanStatusViewModel) {
@@ -33,5 +35,29 @@ class JetpackScanStatusCell: UITableViewCell, NibReusable {
         } else {
             secondaryButton.isHidden = true
         }
+
+        if let progress = model.progress {
+            progressView.isHidden = false
+            progressView.progress = progress
+        } else {
+            progressView.isHidden = true
+        }
+    }
+
+    // MARK: - IBAction's
+    @IBAction func primaryButtonTapped(_ sender: Any) {
+    }
+
+    @IBAction func secondaryButtonTapped(_ sender: Any) {
+    }
+
+    // MARK: - Private: View Configuration
+    private func configureProgressView() {
+        progressView.isHidden = true
+
+        progressView.layer.cornerRadius = 4
+        progressView.clipsToBounds = true
+        // TODO: Replace hex with styleguide color
+        progressView.tintColor = .init(fromHex: 0x069e08)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.swift
@@ -22,26 +22,39 @@ class JetpackScanStatusCell: UITableViewCell, NibReusable {
         titleLabel.text = model.title
         descriptionLabel.text = model.description
 
-        if let primaryTitle = model.primaryButtonTitle {
-            primaryButton.setTitle(primaryTitle, for: .normal)
-            primaryButton.isHidden = false
-        } else {
+        configurePrimaryButton(model)
+        configureSecondaryButton(model)
+        configureProgressView(model)
+    }
+
+    private func configurePrimaryButton(_ model: JetpackScanStatusViewModel) {
+        guard let primaryTitle = model.primaryButtonTitle else {
             primaryButton.isHidden = true
+            return
         }
 
-        if let secondaryTitle = model.secondaryButtonTitle {
-            secondaryButton.setTitle(secondaryTitle, for: .normal)
-            secondaryButton.isHidden = false
-        } else {
+        primaryButton.setTitle(primaryTitle, for: .normal)
+        primaryButton.isHidden = false
+    }
+
+    private func configureSecondaryButton(_ model: JetpackScanStatusViewModel) {
+        guard let secondaryTitle = model.secondaryButtonTitle else {
             secondaryButton.isHidden = true
+            return
         }
 
-        if let progress = model.progress {
-            progressView.isHidden = false
-            progressView.progress = progress
-        } else {
+        secondaryButton.setTitle(secondaryTitle, for: .normal)
+        secondaryButton.isHidden = false
+    }
+
+    private func configureProgressView(_ model: JetpackScanStatusViewModel) {
+        guard let progress = model.progress else {
             progressView.isHidden = true
+            return
         }
+
+        progressView.isHidden = false
+        progressView.setProgress(progress, animated: true)
     }
 
     // MARK: - IBAction's

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.xib
@@ -40,8 +40,14 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3IH-nw-vyL">
+                                <rect key="frame" x="10" y="98.5" width="425" height="8"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="8" id="ffh-oY-vRs"/>
+                                </constraints>
+                            </progressView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B0Y-0s-mES">
-                                <rect key="frame" x="10" y="98.5" width="425" height="52.5"/>
+                                <rect key="frame" x="10" y="116.5" width="425" height="34.5"/>
                                 <string key="text">We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time.</string>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
@@ -59,6 +65,9 @@
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
                                 </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="primaryButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="bK2-6E-P6z"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="749" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gTh-o0-42f" customClass="FancyButton" customModule="WordPressUI">
                                 <rect key="frame" x="10" y="205" width="425" height="34"/>
@@ -72,6 +81,9 @@
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
                                 </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="secondaryButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="f7N-nO-b4k"/>
+                                </connections>
                             </button>
                         </subviews>
                         <edgeInsets key="layoutMargins" top="10" left="10" bottom="10" right="10"/>
@@ -89,6 +101,7 @@
                 <outlet property="iconContainerView" destination="i3y-0r-qdg" id="a8h-6D-MT1"/>
                 <outlet property="iconImageView" destination="6Dq-eg-0YB" id="Yi8-cN-DY3"/>
                 <outlet property="primaryButton" destination="UhM-1P-HcV" id="SZs-Xy-hpD"/>
+                <outlet property="progressView" destination="3IH-nw-vyL" id="BOZ-G9-iFl"/>
                 <outlet property="secondaryButton" destination="gTh-o0-42f" id="nUe-7r-qNn"/>
                 <outlet property="titleLabel" destination="KGG-nP-4Q3" id="ci3-ID-vFr"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -24,9 +24,9 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
     // MARK: - View Methods
     override func viewDidLoad() {
         super.viewDidLoad()
-        coordinator.refreshData(showLoading: true)
 
         configureTableView()
+        coordinator.viewDidLoad()
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -9,6 +9,7 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
 
     // Table View
     @IBOutlet weak var tableView: UITableView!
+    let refreshControl = UIRefreshControl()
 
     // MARK: - Initializers
     @objc init(blog: Blog) {
@@ -30,6 +31,7 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
 
     // MARK: - JetpackScanView
     func render(_ scan: JetpackScan) {
+        refreshControl.endRefreshing()
         tableView.reloadData()
     }
 
@@ -47,6 +49,13 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
         tableView.register(JetpackScanThreatCell.defaultNib, forCellReuseIdentifier: Constants.threatCellIdentifier)
 
         tableView.tableFooterView = UIView()
+
+        tableView.refreshControl = refreshControl
+        refreshControl.addTarget(self, action: #selector(userRefresh), for: .valueChanged)
+    }
+
+    @objc func userRefresh() {
+        coordinator.refreshData()
     }
 
     // MARK: - Private: Config

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -2,9 +2,12 @@ import UIKit
 
 class JetpackScanViewController: UIViewController, JetpackScanView {
     private let blog: Blog
-    var coordinator: JetpackScanCoordinator?
 
-    // IBOutlets
+    lazy var coordinator: JetpackScanCoordinator = {
+        return JetpackScanCoordinator(blog: blog, view: self)
+    }()
+
+    // Table View
     @IBOutlet weak var tableView: UITableView!
 
     // MARK: - Initializers
@@ -20,8 +23,7 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
     // MARK: - View Methods
     override func viewDidLoad() {
         super.viewDidLoad()
-        coordinator = JetpackScanCoordinator(blog: blog, view: self)
-        coordinator?.start()
+        coordinator.refreshData(showLoading: true)
 
         configureTableView()
     }
@@ -51,14 +53,17 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
     private struct Constants {
         static let statusCellIdentifier = "StatusCell"
         static let threatCellIdentifier = "ThreatCell"
+
+        /// The number of header rows, used to get the threat rows
+        static let tableHeaderCountOffset = 1
     }
 }
 
 // MARK: - Table View
 extension JetpackScanViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        let count = coordinator?.scan?.threats?.count ?? 0
-        return count + 1
+        let count = coordinator.threats?.count ?? 0
+        return count + Constants.tableHeaderCountOffset
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -84,7 +89,7 @@ extension JetpackScanViewController: UITableViewDataSource, UITableViewDelegate 
     }
 
     private func configureStatusCell(cell: JetpackScanStatusCell) {
-        guard let scan = coordinator?.scan else {
+        guard let scan = coordinator.scan else {
             return
         }
 
@@ -100,11 +105,11 @@ extension JetpackScanViewController: UITableViewDataSource, UITableViewDelegate 
     }
 
     private func threat(for indexPath: IndexPath) -> JetpackScanThreat? {
-        guard let threats = coordinator?.scan?.threats else {
+        guard let threats = coordinator.threats else {
             return nil
         }
 
-        let row = indexPath.row - 1
+        let row = indexPath.row - Constants.tableHeaderCountOffset
 
         return threats[row]
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -98,11 +98,10 @@ extension JetpackScanViewController: UITableViewDataSource, UITableViewDelegate 
     }
 
     private func configureStatusCell(cell: JetpackScanStatusCell) {
-        guard let scan = coordinator.scan else {
+        guard let model = JetpackScanStatusViewModel(coordinator: coordinator) else {
+            // TODO: handle error
             return
         }
-
-        let model = JetpackScanStatusViewModel(scan: scan, blog: blog)
 
         tableView.beginUpdates()
         cell.configure(with: model)

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -29,6 +29,12 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
         configureTableView()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        coordinator.viewWillDisappear()
+    }
+
     // MARK: - JetpackScanView
     func render(_ scan: JetpackScan) {
         refreshControl.endRefreshing()

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
@@ -4,8 +4,9 @@ struct JetpackScanStatusViewModel {
     let imageName: String
     let title: String
     let description: String
-    let primaryButtonTitle: String?
-    let secondaryButtonTitle: String?
+    private(set) var primaryButtonTitle: String?
+    private(set) var secondaryButtonTitle: String?
+    private(set) var progress: Float? = nil
 
     init(scan: JetpackScan, blog: Blog) {
         let state = Self.viewState(for: scan)
@@ -28,7 +29,6 @@ struct JetpackScanStatusViewModel {
             title = Strings.noThreatsTitle
             description = descriptionTitle
             secondaryButtonTitle = Strings.scanNowTitle
-            primaryButtonTitle = nil
 
         case .hasThreats, .hasFixableThreats:
             let threatCount = scan.threats?.count ?? 0
@@ -47,7 +47,6 @@ struct JetpackScanStatusViewModel {
 
             if state == .hasThreats {
                 secondaryButtonTitle = Strings.scanNowTitle
-                primaryButtonTitle = nil
             } else {
                 primaryButtonTitle = Strings.fixAllTitle
                 secondaryButtonTitle = Strings.scanAgainTitle
@@ -57,15 +56,13 @@ struct JetpackScanStatusViewModel {
             imageName = "jetpack-scan-state-progress"
             title = Strings.preparingTitle
             description = Strings.scanningDescription
-            primaryButtonTitle = nil
-            secondaryButtonTitle = nil
+            progress = 0
 
         case .scanning:
             imageName = "jetpack-scan-state-progress"
             title = Strings.scanningTitle
             description = Strings.scanningDescription
-            primaryButtonTitle = nil
-            secondaryButtonTitle = nil
+            progress = Float(scan.current?.progress ?? 0) / 100.0
 
         case .error:
             imageName = "jetpack-scan-state-error"

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
@@ -8,7 +8,16 @@ struct JetpackScanStatusViewModel {
     private(set) var secondaryButtonTitle: String?
     private(set) var progress: Float? = nil
 
-    init(scan: JetpackScan, blog: Blog) {
+    private let coordinator: JetpackScanCoordinator
+
+    init?(coordinator: JetpackScanCoordinator) {
+        self.coordinator = coordinator
+
+        guard let scan = coordinator.scan else {
+            return nil
+        }
+
+        let blog = coordinator.blog
         let state = Self.viewState(for: scan)
 
         switch state {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
@@ -86,21 +86,16 @@ struct JetpackScanStatusViewModel {
     private static func viewState(for scan: JetpackScan) -> StatusViewState {
         let viewState: StatusViewState
 
-//        // If the most recent or current scan has failed, display an error state
-//        TODO: Disabled for now until I implement the error state
-//        if scan.current?.didFail ?? false || scan.mostRecent?.didFail ?? false {
-//            return .error
-//        }
-
         switch scan.state {
         case .idle:
             if let threats = scan.threats, threats.count > 0 {
                 let fixableThreats = threats.filter { $0.fixable != nil }.count > 0
                 viewState = fixableThreats ? .hasFixableThreats : .hasThreats
             } else {
-                if scan.mostRecent?.didFail == true {
-
+                if scan.mostRecent?.didFail ?? false {
+                    return .error
                 }
+
                 viewState = .noThreats
             }
 


### PR DESCRIPTION
Project: #15190

This PR adds:
- Adds logic to start / stop auto refreshing the state every 5 seconds when a scan is in progress. 
- Adds pull to refresh on the scan view
- Changes the coordinator to a lazy var
- Adds a relationship between the `JetpackScanStatusViewModel` and the `JetpackScanCoordinator`
- Placeholders for the fix / contact support actions
- Ability to start a scan

### Screenshots

https://user-images.githubusercontent.com/793774/104596611-357ac280-5642-11eb-9920-15d6f817be36.mov

### To test:
1. Launch the app
2. Tap on My Sites
3. Tap on a Jetpack site with Scan enabled
4. Tap on Scan
5. Tap on the 'Start Scan' button
6. 👁️ The state immediately changes to "preparing"
7. After 5 seconds the progress should update
8. Pull down to manually trigger a refresh
9. Wait for the scan to finish
10. The state should return to idle (okay 🟢  or threats detected 🔴 )
11. Open the site on wordpress.com 
12. Initiate a scan
13. In WPiOS pull to refresh
14. 👁️ You should see the state change, and the view start polling every 5 seconds again
15. After the scan finishes tap back
16. Go back to the wordpress.com and trigger another scan
17. In WPiOS tap on the site
18. 👁️ You should see the scanning state, and it refreshing every 5 seconds

### PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
