### PR TITLE
Removes defunct code after hotfix.

### DIFF
--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -116,22 +116,6 @@ extension URL {
         }
     }
 
-    func appendingHideMasterbarParameters() -> URL? {
-        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
-            return nil
-        }
-        // FIXME: This code is commented out because of a menu navigation issue that can occur while
-        // viewing a site within the webview. See https://github.com/wordpress-mobile/WordPress-iOS/issues/9796
-        // for more details.
-        //
-        // var queryItems = components.queryItems ?? []
-        // queryItems.append(URLQueryItem(name: "preview", value: "true"))
-        // queryItems.append(URLQueryItem(name: "iframe", value: "true"))
-        // components.queryItems = queryItems
-        /////
-        return components.url
-    }
-
     var isHostedAtWPCom: Bool {
         guard let host = host else {
             return false
@@ -196,10 +180,6 @@ extension NSURL {
         return NSNumber(value: fileSize)
     }
 
-    @objc func appendingHideMasterbarParameters() -> NSURL? {
-        let url = self as URL
-        return url.appendingHideMasterbarParameters() as NSURL?
-    }
 }
 
 extension URL {

--- a/WordPress/Classes/Utility/WPWebViewController.h
+++ b/WordPress/Classes/Utility/WPWebViewController.h
@@ -34,11 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) BOOL addsWPComReferrer;
 
-/**
- *  @brief  When true adds parameters to hide the site's masterbar.
- */
-@property (nonatomic, assign) BOOL addsHideMasterbarParameters;
-
 @property (nonatomic, strong, nullable) RequestAuthenticator *authenticator;
 
 /**

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -71,7 +71,6 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
         _optionsButton = configuration.optionsButton;
         _secureInteraction = configuration.secureInteraction;
         _addsWPComReferrer = configuration.addsWPComReferrer;
-        _addsHideMasterbarParameters = configuration.addsHideMasterbarParameters;
         _customTitle = configuration.customTitle;
         _authenticator = configuration.authenticator;
     }
@@ -248,11 +247,6 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     NSMutableURLRequest *mutableRequest = [request isKindOfClass:[NSMutableURLRequest class]] ? (NSMutableURLRequest *)request : [request mutableCopy];
     if (self.addsWPComReferrer) {
         [mutableRequest setValue:WPComReferrerURL forHTTPHeaderField:@"Referer"];
-    }
-
-    if (self.addsHideMasterbarParameters &&
-        ([mutableRequest.URL.host containsString:WPComDomain] || [mutableRequest.URL.host containsString:AutomatticDomain])) {
-        mutableRequest.URL = [mutableRequest.URL appendingHideMasterbarParameters];
     }
 
     [mutableRequest setValue:[WPUserAgent wordPressUserAgent] forHTTPHeaderField:@"User-Agent"];

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -79,7 +79,6 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     @objc let navigationDelegate: WebNavigationDelegate?
     @objc var secureInteraction = false
     @objc var addsWPComReferrer = false
-    @objc var addsHideMasterbarParameters = true
     @objc var customTitle: String?
     private let opensNewInSafari: Bool
     let linkBehavior: LinkBehavior
@@ -103,7 +102,6 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         customOptionsButton = configuration.optionsButton
         secureInteraction = configuration.secureInteraction
         addsWPComReferrer = configuration.addsWPComReferrer
-        addsHideMasterbarParameters = configuration.addsHideMasterbarParameters
         customTitle = configuration.customTitle
         authenticator = configuration.authenticator
         navigationDelegate = configuration.navigationDelegate
@@ -121,7 +119,6 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         customOptionsButton = parent.customOptionsButton
         secureInteraction = parent.secureInteraction
         addsWPComReferrer = parent.addsWPComReferrer
-        addsHideMasterbarParameters = parent.addsHideMasterbarParameters
         customTitle = parent.customTitle
         authenticator = parent.authenticator
         navigationDelegate = parent.navigationDelegate
@@ -213,12 +210,6 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         var request = request
         if addsWPComReferrer {
             request.setValue(WPComReferrerURL, forHTTPHeaderField: "Referer")
-        }
-
-        if addsHideMasterbarParameters,
-            let host = request.url?.host,
-            (host.contains(WPComDomain) || host.contains(AutomatticDomain)) {
-            request.url = request.url?.appendingHideMasterbarParameters()
         }
 
         webView.load(request)

--- a/WordPress/Classes/Utility/WebViewControllerConfiguration.swift
+++ b/WordPress/Classes/Utility/WebViewControllerConfiguration.swift
@@ -6,7 +6,6 @@ class WebViewControllerConfiguration: NSObject {
     @objc var optionsButton: UIBarButtonItem?
     @objc var secureInteraction = false
     @objc var addsWPComReferrer = false
-    @objc var addsHideMasterbarParameters = true
 
     /// Opens any new pages in Safari. Otherwise, a new web view will be opened
     var opensNewInSafari = false

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1743,10 +1743,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedViewSite withBlog:self.blog];
     NSURL *targetURL = [NSURL URLWithString:self.blog.homeURL];
 
-    if (self.blog.jetpack) {
-        targetURL = [targetURL appendingHideMasterbarParameters];
-    }
-
     UIViewController *webViewController = [WebViewControllerFactory controllerWithUrl:targetURL blog:self.blog];
     LightNavigationController *navController = [[LightNavigationController alloc] initWithRootViewController:webViewController];
     if (self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad) {

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -425,10 +425,6 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
         return;
     }
 
-    if (self.comment.blog.jetpack) {
-        url = [url appendingHideMasterbarParameters];
-    }
-    
     UIViewController *webViewController = [WebViewControllerFactory controllerAuthenticatedWithDefaultAccountWithUrl:url];
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
     [self presentViewController:navController animated:YES completion:nil];

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -855,7 +855,6 @@ public protocol ThemePresenter: class {
         configuration.authenticate(blog: theme.blog)
         configuration.secureInteraction = true
         configuration.customTitle = theme.name
-        configuration.addsHideMasterbarParameters = false
         configuration.navigationDelegate = customizerNavigationDelegate
         configuration.onClose = onClose
         let webViewController = WebViewControllerFactory.controller(configuration: configuration)


### PR DESCRIPTION
Refs #9801
While investigating another issue I noticed the code commented out in #9801 and realized the app was doing some work that had no effect.  This PR removes the defunct code. 

To test:
Test as described in #9801 and ensure there are no regressions. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
