### PR TITLE
Jetpack Section: Initial error handling

### DIFF
--- a/WordPress/Classes/Services/JetpackBackupService.swift
+++ b/WordPress/Classes/Services/JetpackBackupService.swift
@@ -9,8 +9,11 @@ import Foundation
         return JetpackBackupServiceRemote(wordPressComRestApi: api)
     }()
 
-    func prepareBackup(for site: JetpackSiteRef, success: @escaping (JetpackBackup) -> Void, failure: @escaping (Error) -> Void) {
-        service.prepareBackup(site.siteID, success: success, failure: failure)
+    func prepareBackup(for site: JetpackSiteRef,
+                       restoreTypes: JetpackRestoreTypes? = nil,
+                       success: @escaping (JetpackBackup) -> Void,
+                       failure: @escaping (Error) -> Void) {
+        service.prepareBackup(site.siteID, types: restoreTypes, success: success, failure: failure)
     }
 
     func getBackupStatus(for site: JetpackSiteRef, downloadID: Int, success: @escaping (JetpackBackup) -> Void, failure: @escaping (Error) -> Void) {

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -363,15 +363,15 @@ extension BaseActivityListViewController: ActivityPresenter {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         let restoreTitle = NSLocalizedString("Restore", comment: "Title displayed for restore action.")
-        let restoreVC = JetpackRestoreOptionsViewController(site: site, activity: activity)
+        let restoreOptionsVC = JetpackRestoreOptionsViewController(site: site, activity: activity)
         alertController.addDefaultActionWithTitle(restoreTitle, handler: { _ in
-            self.present(UINavigationController(rootViewController: restoreVC), animated: true)
+            self.present(UINavigationController(rootViewController: restoreOptionsVC), animated: true)
         })
 
-        let downloadBackupTitle = NSLocalizedString("Download Backup", comment: "Title displayed for download backup action.")
-        let downloadBackupVC = JetpackDownloadBackupViewController(site: site, activity: activity)
-        alertController.addDefaultActionWithTitle(downloadBackupTitle, handler: { _ in
-            self.present(UINavigationController(rootViewController: downloadBackupVC), animated: true)
+        let backupTitle = NSLocalizedString("Download Backup", comment: "Title displayed for download backup action.")
+        let backupOptionsVC = JetpackBackupOptionsViewController(site: site, activity: activity)
+        alertController.addDefaultActionWithTitle(backupTitle, handler: { _ in
+            self.present(UINavigationController(rootViewController: backupOptionsVC), animated: true)
         })
 
         let cancelTitle = NSLocalizedString("Cancel", comment: "Title for cancel action. Dismisses the action sheet.")
@@ -407,8 +407,8 @@ extension BaseActivityListViewController: ActivityPresenter {
             return
         }
 
-        let restoreVC = JetpackRestoreOptionsViewController(site: site, activity: activity)
-        let navigationVC = UINavigationController(rootViewController: restoreVC)
+        let restoreOptionsVC = JetpackRestoreOptionsViewController(site: site, activity: activity)
+        let navigationVC = UINavigationController(rootViewController: restoreOptionsVC)
         self.present(navigationVC, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -368,7 +368,7 @@ extension BaseActivityListViewController: ActivityPresenter {
             self.present(UINavigationController(rootViewController: restoreOptionsVC), animated: true)
         })
 
-        let backupTitle = NSLocalizedString("Download Backup", comment: "Title displayed for download backup action.")
+        let backupTitle = NSLocalizedString("Download backup", comment: "Title displayed for download backup action.")
         let backupOptionsVC = JetpackBackupOptionsViewController(site: site, activity: activity)
         alertController.addDefaultActionWithTitle(backupTitle, handler: { _ in
             self.present(UINavigationController(rootViewController: backupOptionsVC), animated: true)

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -363,7 +363,7 @@ extension BaseActivityListViewController: ActivityPresenter {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         let restoreTitle = NSLocalizedString("Restore", comment: "Title displayed for restore action.")
-        let restoreVC = JetpackRestoreViewController(site: site, activity: activity)
+        let restoreVC = JetpackRestoreOptionsViewController(site: site, activity: activity)
         alertController.addDefaultActionWithTitle(restoreTitle, handler: { _ in
             self.present(UINavigationController(rootViewController: restoreVC), animated: true)
         })
@@ -407,7 +407,7 @@ extension BaseActivityListViewController: ActivityPresenter {
             return
         }
 
-        let restoreVC = JetpackRestoreViewController(site: site, activity: activity)
+        let restoreVC = JetpackRestoreOptionsViewController(site: site, activity: activity)
         let navigationVC = UINavigationController(rootViewController: restoreVC)
         self.present(navigationVC, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/Coordinators/JetpackBackupOptionsCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/Coordinators/JetpackBackupOptionsCoordinator.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+protocol JetpackBackupOptionsView {
+    func showError()
+    func showBackupStatus(for downloadID: Int)
+}
+
+class JetpackBackupOptionsCoordinator {
+
+    // MARK: - Properties
+
+    private let service: JetpackBackupService
+    private let site: JetpackSiteRef
+    private let restoreTypes: JetpackRestoreTypes
+    private let view: JetpackBackupOptionsView
+
+    // MARK: - Init
+
+    init(site: JetpackSiteRef,
+         restoreTypes: JetpackRestoreTypes,
+         view: JetpackBackupOptionsView,
+         service: JetpackBackupService? = nil,
+         context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
+        self.service = service ?? JetpackBackupService(managedObjectContext: context)
+        self.site = site
+        self.restoreTypes = restoreTypes
+        self.view = view
+    }
+
+    // MARK: - Public
+
+    func prepareBackup() {
+        service.prepareBackup(for: site, restoreTypes: restoreTypes, success: { [weak self] backup in
+            self?.view.showBackupStatus(for: backup.downloadID)
+        }, failure: { [weak self] error in
+            DDLogError("Error preparing downloadable backup object: \(error.localizedDescription)")
+
+            self?.view.showError()
+        })
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CocoaLumberjack
 import Gridicons
+import WordPressFlux
 import WordPressUI
 import WordPressShared
 
@@ -43,11 +44,13 @@ class JetpackBackupOptionsViewController: BaseRestoreOptionsViewController {
     }
 }
 
-
 extension JetpackBackupOptionsViewController: JetpackBackupOptionsView {
 
     func showError() {
-        // TODO: Show notification
+        let errorTitle = NSLocalizedString("Backup failed.", comment: "Title for error displayed when preparing a backup fails.")
+        let errorMessage = NSLocalizedString("We couldn't create your backup. Please try again later.", comment: "Message for error displayed when preparing a backup fails.")
+        let notice = Notice(title: errorTitle, message: errorMessage)
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
     func showBackupStatus(for downloadID: Int) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
@@ -9,7 +9,7 @@ class JetpackBackupOptionsViewController: BaseRestoreOptionsViewController {
     // MARK: - Properties
 
     private lazy var coordinator: JetpackBackupOptionsCoordinator = {
-        return JetpackBackupOptionsCoordinator(site: self.site, view: self)
+        return JetpackBackupOptionsCoordinator(site: self.site, restoreTypes: self.restoreTypes, view: self)
     }()
 
     // MARK: - Initialization
@@ -46,14 +46,13 @@ class JetpackBackupOptionsViewController: BaseRestoreOptionsViewController {
 
 extension JetpackBackupOptionsViewController: JetpackBackupOptionsView {
 
-    func showBackupStatus(for downloadID: Int) {
-        let statusVC = JetpackBackupStatusViewController(site: site,
-                                                         activity: activity,
-                                                         restoreTypes: JetpackRestoreTypes())
-        self.navigationController?.pushViewController(statusVC, animated: true)
-    }
-
     func showError() {
         // TODO: Show notification
     }
+
+    func showBackupStatus(for downloadID: Int) {
+        let statusVC = JetpackBackupStatusViewController(site: site, activity: activity, downloadID: downloadID)
+        self.navigationController?.pushViewController(statusVC, animated: true)
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
@@ -4,7 +4,13 @@ import Gridicons
 import WordPressUI
 import WordPressShared
 
-class JetpackDownloadBackupViewController: BaseRestoreOptionsViewController {
+class JetpackBackupOptionsViewController: BaseRestoreOptionsViewController {
+
+    // MARK: - Properties
+
+    private lazy var coordinator: JetpackBackupOptionsCoordinator = {
+        return JetpackBackupOptionsCoordinator(site: self.site, view: self)
+    }()
 
     // MARK: - Initialization
 
@@ -33,10 +39,21 @@ class JetpackDownloadBackupViewController: BaseRestoreOptionsViewController {
     // MARK: - Override
 
     override func actionButtonTapped() {
+        coordinator.prepareBackup()
+    }
+}
+
+
+extension JetpackBackupOptionsViewController: JetpackBackupOptionsView {
+
+    func showBackupStatus(for downloadID: Int) {
         let statusVC = JetpackBackupStatusViewController(site: site,
                                                          activity: activity,
                                                          restoreTypes: JetpackRestoreTypes())
         self.navigationController?.pushViewController(statusVC, animated: true)
     }
 
+    func showError() {
+        // TODO: Show notification
+    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreOptionsCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreOptionsCoordinator.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+protocol JetpackBackupOptionsView {
+    func showError()
+    func showBackupStatus(for downloadID: Int)
+}
+
+class JetpackBackupOptionsCoordinator {
+
+    // MARK: - Properties
+
+    private let service: JetpackBackupService
+    private let site: JetpackSiteRef
+    private let view: JetpackBackupOptionsView
+
+    // MARK: - Init
+
+    init(site: JetpackSiteRef,
+         view: JetpackBackupOptionsView,
+         service: JetpackBackupService? = nil,
+         context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
+        self.service = service ?? JetpackBackupService(managedObjectContext: context)
+        self.site = site
+        self.view = view
+    }
+
+    // MARK: - Public
+
+    func prepareBackup() {
+        service.prepareBackup(for: site, success: { [weak self] backup in
+            self?.view.showBackupStatus(for: backup.downloadID)
+        }, failure: { [weak self] error in
+            DDLogError("Error preparing downloadable backup object: \(error.localizedDescription)")
+
+            self?.view.showError()
+        })
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreOptionsViewController.swift
@@ -4,7 +4,7 @@ import Gridicons
 import WordPressUI
 import WordPressShared
 
-class JetpackRestoreViewController: BaseRestoreOptionsViewController {
+class JetpackRestoreOptionsViewController: BaseRestoreOptionsViewController {
 
     // MARK: - Initialization
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/BaseRestoreStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/BaseRestoreStatusViewController.swift
@@ -28,7 +28,6 @@ class BaseRestoreStatusViewController: UIViewController {
     private(set) var site: JetpackSiteRef
     private(set) var activity: Activity
     private(set) var configuration: JetpackRestoreStatusConfiguration
-    private let restoreTypes: JetpackRestoreTypes
 
     private lazy var dateFormatter: DateFormatter = {
         return ActivityDateFormatting.mediumDateFormatterWithTime(for: site)
@@ -36,19 +35,15 @@ class BaseRestoreStatusViewController: UIViewController {
 
     // MARK: - Initialization
 
-    init(site: JetpackSiteRef,
-         activity: Activity,
-         restoreTypes: JetpackRestoreTypes) {
+    init(site: JetpackSiteRef, activity: Activity) {
         fatalError("A configuration struct needs to be provided")
     }
 
     init(site: JetpackSiteRef,
          activity: Activity,
-         restoreTypes: JetpackRestoreTypes,
          configuration: JetpackRestoreStatusConfiguration) {
         self.site = site
         self.activity = activity
-        self.restoreTypes = restoreTypes
         self.configuration = configuration
         super.init(nibName: nil, bundle: nil)
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackBackupStatusCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackBackupStatusCoordinator.swift
@@ -12,6 +12,7 @@ class JetpackBackupStatusCoordinator {
 
     private let service: JetpackBackupService
     private let site: JetpackSiteRef
+    private let downloadID: Int
     private let view: JetpackBackupStatusView
 
     private var timer: Timer?
@@ -19,25 +20,20 @@ class JetpackBackupStatusCoordinator {
     // MARK: - Init
 
     init(site: JetpackSiteRef,
+         downloadID: Int,
          view: JetpackBackupStatusView,
          service: JetpackBackupService? = nil,
          context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
         self.service = service ?? JetpackBackupService(managedObjectContext: context)
         self.site = site
+        self.downloadID = downloadID
         self.view = view
     }
 
     // MARK: - Public
 
     func viewDidLoad() {
-        service.prepareBackup(for: site, success: { [weak self] backup in
-            self?.view.render(backup)
-            self?.startPolling(for: backup.downloadID)
-        }, failure: { [weak self] error in
-            DDLogError("Error preparing downloadable backup object: \(error.localizedDescription)")
-
-            self?.view.showError()
-        })
+        startPolling(for: downloadID)
     }
 
     func viewWillDisappear() {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackRestoreStatusCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackRestoreStatusCoordinator.swift
@@ -12,7 +12,6 @@ class JetpackRestoreStatusCoordinator {
 
     private let service: JetpackRestoreService
     private let site: JetpackSiteRef
-    private let rewindID: String?
     private let view: JetpackRestoreStatusView
 
     private var timer: Timer?
@@ -20,26 +19,18 @@ class JetpackRestoreStatusCoordinator {
     // MARK: - Init
 
     init(site: JetpackSiteRef,
-         rewindID: String?,
          view: JetpackRestoreStatusView,
          service: JetpackRestoreService? = nil,
          context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
         self.service = service ?? JetpackRestoreService(managedObjectContext: context)
         self.site = site
-        self.rewindID = rewindID
         self.view = view
     }
 
     // MARK: - Public
 
     func viewDidLoad() {
-        service.restoreSite(site, rewindID: rewindID, success: { [weak self] _ in
-            self?.startPolling()
-        }, failure: { [weak self] error in
-            DDLogError("Error restoring site: \(error.localizedDescription)")
-
-            self?.view.showError()
-        })
+        startPolling()
     }
 
     func viewWillDisappear() {
@@ -64,7 +55,7 @@ class JetpackRestoreStatusCoordinator {
     }
 
     private func refreshRestoreStatus() {
-        self.service.getRewindStatus(for: self.site, success: { [weak self] rewindStatus in
+        service.getRewindStatus(for: self.site, success: { [weak self] rewindStatus in
             guard let self = self else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
@@ -7,13 +7,17 @@ class JetpackBackupStatusViewController: BaseRestoreStatusViewController {
 
     // MARK: - Properties
 
+    private let downloadID: Int
+
     private lazy var coordinator: JetpackBackupStatusCoordinator = {
-        return JetpackBackupStatusCoordinator(site: self.site, view: self)
+        return JetpackBackupStatusCoordinator(site: self.site, downloadID: self.downloadID, view: self)
     }()
 
     // MARK: - Initialization
 
-    override init(site: JetpackSiteRef, activity: Activity, restoreTypes: JetpackRestoreTypes) {
+    init(site: JetpackSiteRef, activity: Activity, downloadID: Int) {
+        self.downloadID = downloadID
+
         let restoreStatusConfiguration = JetpackRestoreStatusConfiguration(
             title: NSLocalizedString("Backup", comment: "Title for Jetpack Backup Status screen"),
             iconImage: .gridicon(.history),
@@ -24,7 +28,8 @@ class JetpackBackupStatusViewController: BaseRestoreStatusViewController {
             placeholderProgressTitle: nil,
             progressDescription: nil
         )
-        super.init(site: site, activity: activity, restoreTypes: restoreTypes, configuration: restoreStatusConfiguration)
+
+        super.init(site: site, activity: activity, configuration: restoreStatusConfiguration)
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 import CocoaLumberjack
 import WordPressShared
 import WordPressUI
@@ -35,9 +35,13 @@ class JetpackBackupStatusViewController: BaseRestoreStatusViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        coordinator.start()
+        coordinator.viewDidLoad()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        coordinator.viewWillDisappear()
+    }
 }
 
 extension JetpackBackupStatusViewController: JetpackBackupStatusView {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
@@ -8,13 +8,13 @@ class JetpackRestoreStatusViewController: BaseRestoreStatusViewController {
     // MARK: - Properties
 
     private lazy var coordinator: JetpackRestoreStatusCoordinator = {
-        return JetpackRestoreStatusCoordinator(site: self.site, rewindID: self.activity.rewindID, view: self)
+        return JetpackRestoreStatusCoordinator(site: self.site, view: self)
     }()
 
 
     // MARK: - Initialization
 
-    override init(site: JetpackSiteRef, activity: Activity, restoreTypes: JetpackRestoreTypes) {
+    override init(site: JetpackSiteRef, activity: Activity) {
         let restoreStatusConfiguration = JetpackRestoreStatusConfiguration(
             title: NSLocalizedString("Restore", comment: "Title for Jetpack Restore Status screen"),
             iconImage: .gridicon(.history),
@@ -25,7 +25,7 @@ class JetpackRestoreStatusViewController: BaseRestoreStatusViewController {
             placeholderProgressTitle: NSLocalizedString("Initializing the restore process", comment: "Placeholder for the restore progress title."),
             progressDescription: NSLocalizedString("Currently restoring: %1$@", comment: "Description of the current entry being restored. %1$@ is a placeholder for the specific entry being restored.")
         )
-        super.init(site: site, activity: activity, restoreTypes: restoreTypes, configuration: restoreStatusConfiguration)
+        super.init(site: site, activity: activity, configuration: restoreStatusConfiguration)
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 import CocoaLumberjack
 import WordPressShared
 import WordPressUI
@@ -36,9 +36,13 @@ class JetpackRestoreStatusViewController: BaseRestoreStatusViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        coordinator.start()
+        coordinator.viewDidLoad()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        coordinator.viewWillDisappear()
+    }
 }
 
 extension JetpackRestoreStatusViewController: JetpackRestoreStatusView {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/Coordinators/JetpackRestoreWarningCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/Coordinators/JetpackRestoreWarningCoordinator.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+protocol JetpackRestoreWarningView {
+    func showError()
+    func showRestoreStatus()
+}
+
+class JetpackRestoreWarningCoordinator {
+
+    // MARK: - Properties
+
+    private let service: JetpackRestoreService
+    private let site: JetpackSiteRef
+    private let rewindID: String?
+    private let restoreTypes: JetpackRestoreTypes
+    private let view: JetpackRestoreWarningView
+
+    // MARK: - Init
+
+    init(site: JetpackSiteRef,
+         restoreTypes: JetpackRestoreTypes,
+         rewindID: String?,
+         view: JetpackRestoreWarningView,
+         service: JetpackRestoreService? = nil,
+         context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
+        self.service = service ?? JetpackRestoreService(managedObjectContext: context)
+        self.site = site
+        self.rewindID = rewindID
+        self.restoreTypes = restoreTypes
+        self.view = view
+    }
+
+    // MARK: - Public
+
+    func restoreSite() {
+        service.restoreSite(site, rewindID: rewindID, restoreTypes: restoreTypes, success: { [weak self] _ in
+            self?.view.showRestoreStatus()
+        }, failure: { [weak self] error in
+            DDLogError("Error restoring site: \(error.localizedDescription)")
+
+            self?.view.showError()
+        })
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
@@ -4,6 +4,12 @@ import WordPressShared
 
 class JetpackRestoreWarningViewController: UIViewController {
 
+    // MARK: - Properties
+
+    private lazy var coordinator: JetpackRestoreWarningCoordinator = {
+        return JetpackRestoreWarningCoordinator(site: self.site, restoreTypes: self.restoreTypes, rewindID: self.activity.rewindID, view: self)
+    }()
+
     // MARK: - Private Properties
 
     private let site: JetpackSiteRef
@@ -45,7 +51,7 @@ class JetpackRestoreWarningViewController: UIViewController {
         warningView.configure(with: publishedDate)
 
         warningView.confirmHandler = { [weak self] in
-            self?.showRestoreStatus()
+            self?.coordinator.restoreSite()
         }
 
         warningView.cancelHandler = { [weak self] in
@@ -57,13 +63,16 @@ class JetpackRestoreWarningViewController: UIViewController {
         view.pinSubviewToAllEdges(warningView)
     }
 
-    // MARK: - Private Helpers
+}
 
-    private func showRestoreStatus() {
-        let statusVC = JetpackRestoreStatusViewController(site: site,
-                                                          activity: activity,
-                                                          restoreTypes: restoreTypes)
-        self.navigationController?.pushViewController(statusVC, animated: true)
+extension JetpackRestoreWarningViewController: JetpackRestoreWarningView {
+
+    func showError() {
+        // TODO: Show notification
     }
 
+    func showRestoreStatus() {
+        let statusVC = JetpackRestoreStatusViewController(site: site, activity: activity)
+        self.navigationController?.pushViewController(statusVC, animated: true)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CocoaLumberjack
+import WordPressFlux
 import WordPressShared
 
 class JetpackRestoreWarningViewController: UIViewController {
@@ -68,7 +69,10 @@ class JetpackRestoreWarningViewController: UIViewController {
 extension JetpackRestoreWarningViewController: JetpackRestoreWarningView {
 
     func showError() {
-        // TODO: Show notification
+        let errorTitle = NSLocalizedString("Restore failed.", comment: "Title for error displayed when restoring a site fails.")
+        let errorMessage = NSLocalizedString("We couldn't restore your site. Please try again later.", comment: "Message for error displayed when restoring a site fails.")
+        let notice = Notice(title: errorTitle, message: errorMessage)
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
     func showRestoreStatus() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2313,12 +2313,13 @@
 		FAB8AB5F25AFFD0600F9F8A0 /* JetpackRestoreStatusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8AB5E25AFFD0600F9F8A0 /* JetpackRestoreStatusCoordinator.swift */; };
 		FAB8AB8B25AFFE7500F9F8A0 /* JetpackRestoreService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8AB8A25AFFE7500F9F8A0 /* JetpackRestoreService.swift */; };
 		FAB8F75025AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F74F25AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift */; };
-		FAB8F76E25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F76D25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift */; };
+		FAB8F76E25AD73C000D5D54A /* JetpackBackupOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F76D25AD73C000D5D54A /* JetpackBackupOptionsViewController.swift */; };
 		FAB8F78C25AD785400D5D54A /* BaseRestoreStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F78B25AD785400D5D54A /* BaseRestoreStatusViewController.swift */; };
 		FAB8F7AA25AD792500D5D54A /* JetpackBackupStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F7A925AD792500D5D54A /* JetpackBackupStatusViewController.swift */; };
 		FAB8FD5025AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8FD4F25AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift */; };
 		FAB8FD6E25AEB23600D5D54A /* JetpackBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8FD6D25AEB23600D5D54A /* JetpackBackupService.swift */; };
 		FACB36F11C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */; };
+		FAD9429525B5558300F011B5 /* JetpackRestoreOptionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9429425B5558300F011B5 /* JetpackRestoreOptionsCoordinator.swift */; };
 		FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */; };
 		FAE4327425874D140039EB8C /* ReaderSavedPostCellActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */; };
 		FAF13C5325A57ABD003EE470 /* JetpackRestoreWarningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */; };
@@ -5070,12 +5071,13 @@
 		FAB8AB5E25AFFD0600F9F8A0 /* JetpackRestoreStatusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreStatusCoordinator.swift; sourceTree = "<group>"; };
 		FAB8AB8A25AFFE7500F9F8A0 /* JetpackRestoreService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreService.swift; sourceTree = "<group>"; };
 		FAB8F74F25AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRestoreOptionsViewController.swift; sourceTree = "<group>"; };
-		FAB8F76D25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackDownloadBackupViewController.swift; sourceTree = "<group>"; };
+		FAB8F76D25AD73C000D5D54A /* JetpackBackupOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupOptionsViewController.swift; sourceTree = "<group>"; };
 		FAB8F78B25AD785400D5D54A /* BaseRestoreStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRestoreStatusViewController.swift; sourceTree = "<group>"; };
 		FAB8F7A925AD792500D5D54A /* JetpackBackupStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupStatusViewController.swift; sourceTree = "<group>"; };
 		FAB8FD4F25AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupStatusCoordinator.swift; sourceTree = "<group>"; };
 		FAB8FD6D25AEB23600D5D54A /* JetpackBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupService.swift; sourceTree = "<group>"; };
 		FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeWebNavigationDelegate.swift; sourceTree = "<group>"; };
+		FAD9429425B5558300F011B5 /* JetpackRestoreOptionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreOptionsCoordinator.swift; sourceTree = "<group>"; };
 		FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartOverViewController.swift; sourceTree = "<group>"; };
 		FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostCellActions.swift; sourceTree = "<group>"; };
 		FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreWarningViewController.swift; sourceTree = "<group>"; };
@@ -11018,7 +11020,7 @@
 			children = (
 				FAB8F74F25AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift */,
 				FA4F65A62594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift */,
-				FAB8F76D25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift */,
+				FAB8F76D25AD73C000D5D54A /* JetpackBackupOptionsViewController.swift */,
 				FA4F660425946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift */,
 				FA4F661325946B8500EAA9F5 /* JetpackRestoreHeaderView.xib */,
 			);
@@ -12780,7 +12782,7 @@
 				E16A76F11FC4758300A661E3 /* JetpackSiteRef.swift in Sources */,
 				B5B56D3219AFB68800B4E29B /* WPStyleGuide+Reply.swift in Sources */,
 				30EABE0918A5903400B73A9C /* WPBlogTableViewCell.m in Sources */,
-				FAB8F76E25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift in Sources */,
+				FAB8F76E25AD73C000D5D54A /* JetpackBackupOptionsViewController.swift in Sources */,
 				400A2C842217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift in Sources */,
 				7E4123BE20F4097B00DF8486 /* NotificationContentRangeFactory.swift in Sources */,
 				E6D170371EF9D8D10046D433 /* SiteInfo.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2300,7 +2300,7 @@
 		FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3536F425B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
-		FA4F65A72594337300EAA9F5 /* JetpackRestoreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F65A62594337300EAA9F5 /* JetpackRestoreViewController.swift */; };
+		FA4F65A72594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F65A62594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift */; };
 		FA4F660525946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F660425946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift */; };
 		FA4F661425946B8500EAA9F5 /* JetpackRestoreHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA4F661325946B8500EAA9F5 /* JetpackRestoreHeaderView.xib */; };
 		FA5C740F1C599BA7000B528C /* TableViewHeaderDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */; };
@@ -5057,7 +5057,7 @@
 		FA3536F425B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreCompleteViewController.swift; sourceTree = "<group>"; };
 		FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementService.swift; sourceTree = "<group>"; };
 		FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceTests.swift; sourceTree = "<group>"; };
-		FA4F65A62594337300EAA9F5 /* JetpackRestoreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreViewController.swift; sourceTree = "<group>"; };
+		FA4F65A62594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreOptionsViewController.swift; sourceTree = "<group>"; };
 		FA4F660425946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreHeaderView.swift; sourceTree = "<group>"; };
 		FA4F661325946B8500EAA9F5 /* JetpackRestoreHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = JetpackRestoreHeaderView.xib; sourceTree = "<group>"; };
 		FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewHeaderDetailView.swift; sourceTree = "<group>"; };
@@ -11017,7 +11017,7 @@
 			isa = PBXGroup;
 			children = (
 				FAB8F74F25AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift */,
-				FA4F65A62594337300EAA9F5 /* JetpackRestoreViewController.swift */,
+				FA4F65A62594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift */,
 				FAB8F76D25AD73C000D5D54A /* JetpackDownloadBackupViewController.swift */,
 				FA4F660425946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift */,
 				FA4F661325946B8500EAA9F5 /* JetpackRestoreHeaderView.xib */,
@@ -13866,7 +13866,7 @@
 				FF619DD51C75246900903B65 /* CLPlacemark+Formatting.swift in Sources */,
 				98467A3F221CD48500DF51AE /* SiteStatsDetailTableViewController.swift in Sources */,
 				E11450DF1C4E47E600A6BD0F /* MessageAnimator.swift in Sources */,
-				FA4F65A72594337300EAA9F5 /* JetpackRestoreViewController.swift in Sources */,
+				FA4F65A72594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift in Sources */,
 				7E14635720B3BEAB00B95F41 /* WPStyleGuide+Loader.swift in Sources */,
 				087EBFA81F02313E001F7ACE /* MediaThumbnailService.swift in Sources */,
 				08F8CD2A1EBD22EF0049D0C0 /* MediaExporter.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2319,7 +2319,8 @@
 		FAB8FD5025AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8FD4F25AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift */; };
 		FAB8FD6E25AEB23600D5D54A /* JetpackBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8FD6D25AEB23600D5D54A /* JetpackBackupService.swift */; };
 		FACB36F11C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */; };
-		FAD9429525B5558300F011B5 /* JetpackRestoreOptionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9429425B5558300F011B5 /* JetpackRestoreOptionsCoordinator.swift */; };
+		FAD9457E25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9457D25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift */; };
+		FAD9458E25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9458D25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift */; };
 		FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */; };
 		FAE4327425874D140039EB8C /* ReaderSavedPostCellActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */; };
 		FAF13C5325A57ABD003EE470 /* JetpackRestoreWarningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */; };
@@ -5077,7 +5078,8 @@
 		FAB8FD4F25AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupStatusCoordinator.swift; sourceTree = "<group>"; };
 		FAB8FD6D25AEB23600D5D54A /* JetpackBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupService.swift; sourceTree = "<group>"; };
 		FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeWebNavigationDelegate.swift; sourceTree = "<group>"; };
-		FAD9429425B5558300F011B5 /* JetpackRestoreOptionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreOptionsCoordinator.swift; sourceTree = "<group>"; };
+		FAD9457D25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupOptionsCoordinator.swift; sourceTree = "<group>"; };
+		FAD9458D25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreWarningCoordinator.swift; sourceTree = "<group>"; };
 		FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartOverViewController.swift; sourceTree = "<group>"; };
 		FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostCellActions.swift; sourceTree = "<group>"; };
 		FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreWarningViewController.swift; sourceTree = "<group>"; };
@@ -8422,7 +8424,6 @@
 				F1ADCAF6241FEF0C00F150D2 /* AtomicAuthenticationService.swift */,
 				822D60B81F4CCC7A0016C46D /* BlogJetpackSettingsService.swift */,
 				93C1148318EDF6E100DAC95C /* BlogService.h */,
-				8C6A22E325783D2000A79950 /* JetpackScanService.swift */,
 				8B749E7125AF522900023F03 /* JetpackCapabilitiesService.swift */,
 				93C1148418EDF6E100DAC95C /* BlogService.m */,
 				9A341E5221997A1E0036662E /* BlogService+BlogAuthors.swift */,
@@ -11018,6 +11019,7 @@
 		FA1A563825A708BF0033967D /* Restore Options */ = {
 			isa = PBXGroup;
 			children = (
+				FAD947A225B56A2C00F011B5 /* Coordinators */,
 				FAB8F74F25AD72CE00D5D54A /* BaseRestoreOptionsViewController.swift */,
 				FA4F65A62594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift */,
 				FAB8F76D25AD73C000D5D54A /* JetpackBackupOptionsViewController.swift */,
@@ -11030,6 +11032,7 @@
 		FA1A564725A708C90033967D /* Restore Warning */ = {
 			isa = PBXGroup;
 			children = (
+				FAD947A125B56A1E00F011B5 /* Coordinators */,
 				FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */,
 				FA1A543D25A6E2F60033967D /* RestoreWarningView.swift */,
 				FA1A543F25A6E3080033967D /* RestoreWarningView.xib */,
@@ -11092,6 +11095,22 @@
 			children = (
 				FAB8AB5E25AFFD0600F9F8A0 /* JetpackRestoreStatusCoordinator.swift */,
 				FAB8FD4F25AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift */,
+			);
+			path = Coordinators;
+			sourceTree = "<group>";
+		};
+		FAD947A125B56A1E00F011B5 /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				FAD9458D25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift */,
+			);
+			path = Coordinators;
+			sourceTree = "<group>";
+		};
+		FAD947A225B56A2C00F011B5 /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				FAD9457D25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -13792,6 +13811,7 @@
 				9A09F915230C3E9700F42AB7 /* StoreFetchingStatus.swift in Sources */,
 				F582060223A85495005159A9 /* SiteDateFormatters.swift in Sources */,
 				400A2C8B2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift in Sources */,
+				FAD9458E25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift in Sources */,
 				5DB3BA0518D0E7B600F3F3E9 /* WPPickerView.m in Sources */,
 				B5E94D151FE04815000E7C20 /* UIImageView+SiteIcon.swift in Sources */,
 				17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */,
@@ -13968,6 +13988,7 @@
 				1714F8D020E6DA8900226DCB /* RouteMatcher.swift in Sources */,
 				591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */,
 				3FD272E024CF8F270021F0C8 /* UIColor+Notice.swift in Sources */,
+				FAD9457E25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift in Sources */,
 				E1CA0A6C1FA73053004C4BBE /* PluginStore.swift in Sources */,
 				FAB8F7AA25AD792500D5D54A /* JetpackBackupStatusViewController.swift in Sources */,
 				E11DA4931E03E03F00CF07A8 /* Pinghub.swift in Sources */,


### PR DESCRIPTION
Part of #15191 

### Description:
- Updated flow to kick off requests to restoreSite / prepareBackup before transitioning to the restore/backup status VC
    ```
    // Restore
    (1) Restore Options
    (2) Restore Warning (send restoreSite POST req)
    (3) Restore Status  (poll rewindStatus GET req)
    (4) Restore Complete 
    
     // Backup
    (1) Backup Options (send prepareBackup POST req)
    (2) Backup Status  (poll backupStatus GET req)
    (3) Backup Complete 
    ```
- Added error handling for restoreSite / prepareBackup

### Merge instructions:
- ⚠️ Merge after https://github.com/wordpress-mobile/WordPress-iOS/pull/15657

### To test:

#### Restore
1. My Site > Activity Log > rewindable activity cell
2. Tap on ellipsis icon
3. Tap on `Restore`
4. Tap on `Restore to this point`
5. Turn wifi off, Tap on `Confirm`
     - ✅ A restore failed notice should be displayed
6. Turn wifi on, Tap on `Confirm`
     - ✅ Should transition to the Restore Status VC

#### Backup
1. My Site > Activity Log > rewindable activity cell
2. Tap on ellipsis icon
3. Turn wifi off, Tap on `Create downloadable file`
     - ✅ A download failed notice should be displayed
4. Turn wifi on, Tap on `Confirm`
     - ✅ Should transition to the Backup Status VC
  
Restore failed | Backup failed
--- | ---  
![Simulator Screen Shot - iPhone 12 Pro - 2021-01-18 at 17 39 19](https://user-images.githubusercontent.com/6711616/104891414-42861180-59b4-11eb-9de7-6f5c75e11923.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-01-18 at 17 39 48](https://user-images.githubusercontent.com/6711616/104891422-44e86b80-59b4-11eb-83ac-acac069fee94.png)

 
### PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
