### PR TITLE
Pages List: Add notice after page parent is set

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -758,8 +758,15 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let parentPageNavigationController = ParentPageSettingsViewController.navigationController(with: pages, selectedPage: selectedPage) {
             self._tableViewHandler.isSearching = false
             self._tableViewHandler.refreshTableView(at: index)
+            self.handleSetParentSuccess()
         }
         present(parentPageNavigationController, animated: true)
+    }
+
+    private func handleSetParentSuccess() {
+        let setParentSuccefullyNotice =  NSLocalizedString("Page Parent updated.", comment: "Message informing the user that their pages parent has been set successfully")
+        let notice = Notice(title: setParentSuccefullyNotice, feedbackType: .success)
+        ActionDispatcher.global.dispatch(NoticeAction.post(notice))
     }
 
     fileprivate func pageForObjectID(_ objectID: NSManagedObjectID) -> Page? {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -755,10 +755,12 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let selectedPage = pageAtIndexPath(index)
         let newIndex = _tableViewHandler.index(for: selectedPage)
         let pages = _tableViewHandler.removePage(from: newIndex)
-        let parentPageNavigationController = ParentPageSettingsViewController.navigationController(with: pages, selectedPage: selectedPage, onClose: {
-            self._tableViewHandler.isSearching = false
-            self._tableViewHandler.refreshTableView(at: index)
-        }, onSuccess: { self.handleSetParentSuccess() } )
+        let parentPageNavigationController = ParentPageSettingsViewController.navigationController(with: pages, selectedPage: selectedPage, onClose: { [weak self] in
+            self?._tableViewHandler.isSearching = false
+            self?._tableViewHandler.refreshTableView(at: index)
+        }, onSuccess: { [weak self] in
+            self?.handleSetParentSuccess()
+        } )
         present(parentPageNavigationController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -755,11 +755,10 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let selectedPage = pageAtIndexPath(index)
         let newIndex = _tableViewHandler.index(for: selectedPage)
         let pages = _tableViewHandler.removePage(from: newIndex)
-        let parentPageNavigationController = ParentPageSettingsViewController.navigationController(with: pages, selectedPage: selectedPage) {
+        let parentPageNavigationController = ParentPageSettingsViewController.navigationController(with: pages, selectedPage: selectedPage, onClose: {
             self._tableViewHandler.isSearching = false
             self._tableViewHandler.refreshTableView(at: index)
-            self.handleSetParentSuccess()
-        }
+        }, onSuccess: { self.handleSetParentSuccess() } )
         present(parentPageNavigationController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -763,7 +763,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     private func handleSetParentSuccess() {
-        let setParentSuccefullyNotice =  NSLocalizedString("Page Parent updated.", comment: "Message informing the user that their pages parent has been set successfully")
+        let setParentSuccefullyNotice =  NSLocalizedString("Parent page successfully updated.", comment: "Message informing the user that their pages parent has been set successfully")
         let notice = Notice(title: setParentSuccefullyNotice, feedbackType: .success)
         ActionDispatcher.global.dispatch(NoticeAction.post(notice))
     }

--- a/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
@@ -43,6 +43,7 @@ extension Row: Equatable {
 
 class ParentPageSettingsViewController: UIViewController {
     var onClose: (() -> Void)?
+    var onSuccess: (() -> Void)?
 
     @IBOutlet private var cancelButton: UIBarButtonItem!
     @IBOutlet private var doneButton: UIBarButtonItem!
@@ -245,6 +246,7 @@ class ParentPageSettingsViewController: UIViewController {
                 self?.selectedPage.parentID = parentId
             } else {
                 self?.dismiss()
+                self?.onSuccess?()
             }
         }
     }
@@ -304,7 +306,7 @@ extension ParentPageSettingsViewController: UITableViewDelegate {
 /// ParentPageSettingsViewController class constructor
 //
 extension ParentPageSettingsViewController {
-    class func navigationController(with pages: [Page], selectedPage: Page, onClose: (() -> Void)? = nil) -> UINavigationController {
+    class func navigationController(with pages: [Page], selectedPage: Page, onClose: (() -> Void)? = nil, onSuccess: (() -> Void)? = nil) -> UINavigationController {
         let storyBoard = UIStoryboard(name: "Pages", bundle: Bundle.main)
         guard let controller = storyBoard.instantiateViewController(withIdentifier: "ParentPageSettings") as? UINavigationController else {
             fatalError("A navigation view controller is required for Parent Page Settings")
@@ -314,6 +316,7 @@ extension ParentPageSettingsViewController {
         }
         parentPageSettingsViewController.set(pages: pages, for: selectedPage)
         parentPageSettingsViewController.onClose = onClose
+        parentPageSettingsViewController.onSuccess = onSuccess
         return controller
     }
 }


### PR DESCRIPTION
This PR add a notice that shows up after a user changes the post parent.

## To test:
1. Go to pages.
2. From the 3 dot menu select "Set parent"
3. Choose a parent. 
4. Notice the pill notice at the bottom.

<img width="438" alt="Screen Shot 2021-01-18 at 9 38 15 AM" src="https://user-images.githubusercontent.com/115071/104948137-ad622900-5971-11eb-8c02-f6e3c56aca13.png">


5. From the 3 dot menu select "Set parent"
6. Choose "Cancel"
7. Notice that the pill doesn't show up at the bottom.


PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
