### PR TITLE
Reader: add a source property when following a topic

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1471,6 +1471,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
         case WPAnalyticsStatReaderTagFollowed:
             eventName = @"reader_reader_tag_followed";
+            eventProperties = @{ @"source" : @"unknown" };
             break;
         case WPAnalyticsStatReaderTagLoaded:
             eventName = @"reader_tag_loaded";

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -183,7 +183,7 @@ class ReaderSelectInterestsViewController: UIViewController {
 
     private func trackEvents(with selectedInterests: [RemoteReaderInterest]) {
         selectedInterests.forEach {
-            WPAnalytics.track(.readerTagFollowed, withProperties: ["tag": $0.slug])
+            WPAnalytics.track(.readerTagFollowed, withProperties: ["tag": $0.slug, "source": "discover"])
         }
 
         WPAnalytics.trackReader(.selectInterestsPicked, properties: ["quantity": selectedInterests.count])


### PR DESCRIPTION
Fixes #15636

### To test

#### Following from Discover

1. Remove all the followed topics you might have
2. Go to Reader -> Discover
3. Select a few topics and tap "Done"
4. Check that `reader_reader_tag_followed` is fired with a `source: discover` property

#### Following from somewhere else

1. Tap the cog icon (Reader navigation bar, on the right side)
2. Add a topic
3. Check that  `reader_reader_tag_followed` is fired with a `source: unknown` property

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
