### PR TITLE
iOS 13 Warnings: Fixes a number of decoding, archiving, secure coding, etc warnings

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -437,12 +437,21 @@ private extension NoResultsViewController {
     }
 
     func copyTitleLabel() -> UILabel? {
-        guard let titleLabel = titleLabel else {
+        // Copy the `titleLabel` to get the style for Title View Only label
+
+        // Note: unarchivedObjectOfClass:fromData:error: sets secure coding to true
+        // We setup our own unarchiver to work around that
+        guard
+            let titleLabel = titleLabel,
+            let data = try? NSKeyedArchiver.archivedData(withRootObject: titleLabel, requiringSecureCoding: false),
+            let unarchiver = try? NSKeyedUnarchiver(forReadingFrom: data)
+        else {
             return nil
         }
-        // Copy the `titleLabel` to get the style for Title View Only label
-        let data = NSKeyedArchiver.archivedData(withRootObject: titleLabel)
-        return NSKeyedUnarchiver.unarchiveObject(with: data) as? UILabel ?? nil
+
+        unarchiver.requiresSecureCoding = false
+
+        return try? unarchiver.decodeTopLevelObject(of: UILabel.self, forKey: "root")
     }
 
     func configureTitleViewConstraints() {

--- a/WordPress/Shared/SharePost.swift
+++ b/WordPress/Shared/SharePost.swift
@@ -68,11 +68,10 @@ import MobileCoreServices
     }
 
     @objc var data: Data {
-        let data = NSMutableData()
-        let encoder = NSKeyedArchiver(forWritingWith: data)
+        let encoder = NSKeyedArchiver(requiringSecureCoding: false)
         encode(with: encoder)
         encoder.finishEncoding()
-        return data as Data
+        return encoder.encodedData
     }
 }
 

--- a/WordPress/Shared/SharePost.swift
+++ b/WordPress/Shared/SharePost.swift
@@ -38,8 +38,12 @@ import MobileCoreServices
     }
 
     @objc convenience init?(data: Data) {
-        let decoder = NSKeyedUnarchiver(forReadingWith: data)
-        self.init(coder: decoder)
+        do {
+            let decoder = try NSKeyedUnarchiver(forReadingFrom: data)
+            self.init(coder: decoder)
+        } catch {
+            return nil
+        }
     }
 
     func encode(with aCoder: NSCoder) {

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationContent/RichNotificationViewModel.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationContent/RichNotificationViewModel.swift
@@ -61,12 +61,16 @@ private extension CodingUserInfoKey {
     }
 
     convenience init?(data: Data) {
-        let decoder = NSKeyedUnarchiver(forReadingWith: data)
-        decoder.requiresSecureCoding = true
+        do {
+            let decoder = try NSKeyedUnarchiver(forReadingFrom: data)
+            decoder.requiresSecureCoding = true
 
-        self.init(coder: decoder)
+            self.init(coder: decoder)
 
-        decoder.finishDecoding()
+            decoder.finishDecoding()
+        } catch {
+            return nil
+        }
     }
 
     var data: Data {

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationContent/RichNotificationViewModel.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationContent/RichNotificationViewModel.swift
@@ -74,14 +74,11 @@ private extension CodingUserInfoKey {
     }
 
     var data: Data {
-        let data = NSMutableData()
-
-        let encoder = NSKeyedArchiver(forWritingWith: data)
-        encoder.requiresSecureCoding = true
+        let encoder = NSKeyedArchiver(requiringSecureCoding: true)
         encode(with: encoder)
         encoder.finishEncoding()
 
-        return data as Data
+        return encoder.encodedData
     }
 
     // MARK: NSSecureCoding


### PR DESCRIPTION
Project: #15583
---

Fixes all the archiver iOS warnings 

I'll go through each commit with some testing steps and other notes.

### To test:

#### General Test:
1. Build the app
2. Verify there are no warnings related to the unarchiver, writing, secure coding

#### Test 1: b4a98ebe8cec443c14642f6bcee74e28d649c872 and a314d45e5a9afaf57fd4505cb4c18060a04d8fff:
1. So these I have not been able to figure out how to fire, but I did test the changes in a separate test project and they worked fine. 

#### Test 2: 84fdc9194bc45f7d744cef643f2d82b93ea9f65d:
**Note:** This was a huge pain to figure out, I eventually used Hopper to reverse engineer the code to see what they changed. I then replicated the code minus `secureCoding` 
1. This is another one that is very hard to trigger
2. What I did was change line 57 of `NoResultsViewController` to:
```
private var displayTitleViewOnly: Bool = false {
        didSet {
            displayTitleViewOnly = true
        }
    }
```
3. Put a breakpoint on line 458
3. Run the app
4. Tap on the Reader tab
5. Tap on Discover
6. The breakpoint should be triggered
7. Type `po try? unarchiver.decodeTopLevelObject(of: UILabel.self, forKey: "root")` into the debugger
8. The value should not be nil
9. Yes I know, sorry it's a lot of steps :( 

#### Test 3: c24e751240a81008f729271f27e814061c2c4c24:
1. Launch the app
2. Tap on the Reader
3. Tap on the ellipsis menu
4. Tap on Share
5. When the Share menu is presented share the post to WordPress
6. Verify the content is correct

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
