### PR TITLE
Fix iOS 13 requestImageData warnings

### DIFF
--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -442,7 +442,7 @@ extension ImageLoader {
         imageView.image = placeholder
         imageView.startLoadingAnimation()
 
-        PHImageManager.default().requestImageData(for: asset,
+        PHImageManager.default().requestImageDataAndOrientation(for: asset,
                                                   options: assetRequestOptions,
                                                   resultHandler: { [weak self] (data, str, orientation, info) -> Void in
             guard info?[PHImageErrorKey] == nil else {

--- a/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
@@ -111,7 +111,7 @@ class MediaAssetExporter: MediaExporter {
         }
 
         // Request the image.
-        imageManager.requestImageData(for: asset,
+        imageManager.requestImageDataAndOrientation(for: asset,
                              options: options,
                              resultHandler: { (data, uti, orientation, info) in
                                 progress.completedUnitCount = MediaExportProgressUnits.halfDone


### PR DESCRIPTION
Project: https://github.com/wordpress-mobile/WordPress-iOS/pull/15583
---

Replaces `requestImageData` with `requestImageDataAndOrientation`

### To test:
1. Verify the `requestImageData` warnings are gone and the build is 🟢 
1. Launch the app
2. Tap on My Site
3. Tap on a Site if one isn't selected
4. Tap on the Media icon
5. Tap the + button
6. Tap 'Choose from My Device'
7. Select an image
8. Verify the correct image is uploaded

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
