### PR TITLE
Reader: Reset content when switching from Discover to filtered stream

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -42,7 +42,7 @@ extension ReaderStreamViewController {
             return Bundle.main.loadNibNamed("ReaderListStreamHeader", owner: nil, options: nil)?.first as? ReaderListStreamHeader
         }
 
-        if ReaderHelpers.isTopicSite(topic) {
+        if ReaderHelpers.isTopicSite(topic) && !isContentFiltered {
             return Bundle.main.loadNibNamed("ReaderSiteStreamHeader", owner: nil, options: nil)?.first as? ReaderSiteStreamHeader
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -125,8 +125,6 @@ import WordPressFlux
         }
     }
 
-    private var hideHeader = false
-
     private var isShowingResultStatusView: Bool {
         return resultsStatusView.view?.superview != nil
     }
@@ -520,17 +518,12 @@ import WordPressFlux
             return
         }
 
-        guard !hideHeader else {
-            tableView.tableHeaderView = nil
-            hideHeader = false
-            return
-        }
-
         if let tableHeaderView = tableView.tableHeaderView {
             header.isHidden = tableHeaderView.isHidden
         }
 
         tableView.tableHeaderView = header
+
         // This feels somewhat hacky, but it is the only way I found to insert a stack view into the header without breaking the autolayout constraints.
         let centerConstraint = header.centerXAnchor.constraint(equalTo: tableView.centerXAnchor)
         let topConstraint = header.topAnchor.constraint(equalTo: tableView.topAnchor)
@@ -1832,12 +1825,13 @@ extension ReaderStreamViewController: UIViewControllerTransitioningDelegate {
 extension ReaderStreamViewController: ReaderContentViewController {
     func setContent(_ content: ReaderContent) {
         isContentFiltered = content.topicType == .tag || content.topicType == .site
-        hideHeader = content.topicType == .site
         readerTopic = content.topicType == .discover ? nil : content.topic
         contentType = content.type
+
         guard !shouldDisplayNoTopicController else {
             return
         }
+
         siteID = content.topicType == .discover ? ReaderHelpers.discoverSiteID : nil
         trackFilterTime()
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -21,6 +21,11 @@ class ReaderTabView: UIView {
     private let viewModel: ReaderTabViewModel
 
     private var filteredTabs: [(index: Int, topic: ReaderAbstractTopic)] = []
+    private var previouslySelectedIndex: Int = 0
+
+    private var discoverIndex: Int? {
+        return tabBar.items.firstIndex(where: { $0.title == NSLocalizedString("Discover", comment: "Discover tab name") })
+    }
 
     init(viewModel: ReaderTabViewModel) {
         mainStackView = UIStackView()
@@ -57,15 +62,6 @@ class ReaderTabView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func selectDiscover() {
-        guard let discoverIndex = tabBar.items
-            .firstIndex(where: { $0.title == NSLocalizedString("Discover", comment: "Discover tab name") }) else {
-            return
-        }
-
-        tabBar.setSelectedIndex(discoverIndex)
-        selectedTabDidChange(tabBar)
-    }
 }
 
 // MARK: - UI setup
@@ -109,6 +105,8 @@ extension ReaderTabView {
         guard let tabItem = tabBar.currentlySelectedItem as? ReaderTabItem else {
             return
         }
+
+        previouslySelectedIndex = tabBar.selectedIndex
         buttonsStackView.isHidden = tabItem.shouldHideButtonsView
         horizontalDivider.isHidden = tabItem.shouldHideButtonsView
     }
@@ -189,13 +187,22 @@ private extension ReaderTabView {
         // If the tab was previously filtered, refilter it.
         // Otherwise reset the filter.
         if let existingFilter = filteredTabs.first(where: { $0.index == tabBar.selectedIndex }) {
+
+            if previouslySelectedIndex == discoverIndex {
+                // Reset the container view to show a feed's content.
+                addContentToContainerView()
+            }
+
             viewModel.setFilterContent(topic: existingFilter.topic)
+
             resetFilterButton.isHidden = false
             setFilterButtonTitle(existingFilter.topic.title)
         } else {
             didTapResetFilterButton()
             addContentToContainerView()
         }
+
+        previouslySelectedIndex = tabBar.selectedIndex
 
         viewModel.showTab(at: tabBar.selectedIndex)
         toggleButtonsView()

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -126,7 +126,6 @@ extension ReaderTabViewModel {
         filterTapped?(from, { [weak self] topic in
             if let topic = topic {
                 self?.setFilterContent(topic: topic)
-                self?.setContent?(ReaderContent(topic: topic))
             }
             completion(topic)
         })


### PR DESCRIPTION
Fixes #15649

When switching from the Discover tab to a filtered stream, the stream content is now correctly restored.

To test:

---
- Go to a Reader tab that can be filtered, and select a filter.
- Switch to the Discover tab, and back to the filtered tab.
- Verify:
  - The content matches the filter.
  - The stream header does not appear.

| ![filtered](https://user-images.githubusercontent.com/1816888/105083011-96930380-5a51-11eb-8235-a1791aedd9a0.png) | ![discover](https://user-images.githubusercontent.com/1816888/105083041-a01c6b80-5a51-11eb-8761-c09b871d313d.png) |
|--------|-------|

---
- Tap a site's card header.
- Verify the stream header does appear.

| ![card_header](https://user-images.githubusercontent.com/1816888/105083114-b75b5900-5a51-11eb-9fe4-3c4c0cf742ec.png) | ![site_header](https://user-images.githubusercontent.com/1816888/105083146-c0e4c100-5a51-11eb-9bec-10781163e1a0.png) |
|--------|-------|

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
