### PR TITLE
Reader > mark as seen: track events

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,5 @@
 16.6
 -----
-Reader post card and post details: added ability to mark a post as seen/unseen. [#15638, #15645]
 
 16.5
 -----

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -78,6 +78,8 @@ import Foundation
     case readerSuggestedSiteVisited
     case readerSuggestedSiteToggleFollow
     case readerDiscoverContentPresented
+    case readerPostMarkSeen
+    case readerPostMarkUnseen
 
     // What's New - Feature announcements
     case featureAnnouncementShown
@@ -247,11 +249,17 @@ import Foundation
             return "reader_suggested_site_toggle_follow"
         case .readerDiscoverContentPresented:
             return "reader_discover_content_presented"
+        case .readerPostMarkSeen:
+            return "reader_mark_as_seen"
+        case .readerPostMarkUnseen:
+            return "reader_mark_as_unseen"
+
         // What's New - Feature announcements
         case .featureAnnouncementShown:
             return "feature_announcement_shown"
         case .featureAnnouncementButtonTapped:
             return "feature_announcement_button_tapped"
+
         // Stories
         case .storyIntroShown:
             return "story_intro_shown"

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -201,7 +201,8 @@ open class ReaderPostMenu {
             return
         }
 
-        // TODO: add Tracks
+        let event: WPAnalyticsEvent = post.isSeen ? .readerPostMarkUnseen : .readerPostMarkSeen
+        WPAnalytics.track(event, properties: ["source": "post_details"])
 
         let postService = ReaderPostService(managedObjectContext: context)
         postService.toggleSeen(for: post, success: nil, failure: nil)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSeenAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSeenAction.swift
@@ -1,6 +1,10 @@
 /// Encapsulates a command to toggle a post's seen status
 final class ReaderSeenAction {
     func execute(with post: ReaderPost, context: NSManagedObjectContext, completion: (() -> Void)? = nil, failure: ((Error?) -> Void)? = nil) {
+
+        let event: WPAnalyticsEvent = post.isSeen ? .readerPostMarkUnseen : .readerPostMarkSeen
+        WPAnalytics.track(event, properties: ["source": "post_card"])
+
         let postService = ReaderPostService(managedObjectContext: context)
         postService.toggleSeen(for: post, success: completion, failure: failure)
     }


### PR DESCRIPTION
Ref #15355 

This adds tracks for when a post is marked as seen or unseen, from a reader card or post details.

TIP: I'm only seeing the events (any event, not just these) in the Xcode console when running on a real device. 🤷 

To test:
- On a Reader card, mark a post seen or unseen.
- Verify the events are tracked.

```
🔵 Tracked: reader_mark_as_unseen <source: post_card>
🔵 Tracked: reader_mark_as_seen <source: post_card>
```

- Select a post.
- In the post details, mark it seen or unseen.
- Verify the events are tracked.

```
🔵 Tracked: reader_mark_as_unseen <source: post_details>
🔵 Tracked: reader_mark_as_seen <source: post_details>
```

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
