### PR TITLE
Update/page layout api query paramaters

### DIFF
--- a/WordPress/Classes/Services/PageLayoutService.swift
+++ b/WordPress/Classes/Services/PageLayoutService.swift
@@ -74,13 +74,8 @@ class PageLayoutService {
 
     private static let type = "mobile"
 
-    private static let isBeta: String = {
-        let isDevMode = BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
-        if isDevMode == true {
-            return "true"
-        }
-        return "false"
-    }()
+    // Return "true" or "false" for isBeta that gets passed into the endpoint.
+    private static let isBeta = String(BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest])
 
 }
 

--- a/WordPress/Classes/Services/PageLayoutService.swift
+++ b/WordPress/Classes/Services/PageLayoutService.swift
@@ -8,6 +8,8 @@ class PageLayoutService {
         static let supportedBlocks = "supported_blocks"
         static let previewWidth = "preview_width"
         static let scale = "scale"
+        static let isMobile = "is_mobile"
+        static let isBeta = "is_beta"
     }
 
     typealias CompletionHandler = (Swift.Result<Void, Error>) -> Void
@@ -30,6 +32,7 @@ class PageLayoutService {
 
     private static func fetchLayouts(_ api: WordPressComRestApi, _ dotComID: Int?, _ blogPersistentID: NSManagedObjectID, _ thumbnailSize: CGSize, _ completion: CompletionHandler?) {
         let params = parameters(thumbnailSize)
+
         PageLayoutServiceRemote.fetchLayouts(api, forBlogID: dotComID, withParameters: params) { (result) in
             switch result {
             case .success(let remoteLayouts):
@@ -52,7 +55,9 @@ class PageLayoutService {
         return [
             Parameters.supportedBlocks: supportedBlocks as AnyObject,
             Parameters.previewWidth: previewWidth(thumbnailSize) as AnyObject,
-            Parameters.scale: scale as AnyObject
+            Parameters.scale: scale as AnyObject,
+            Parameters.isMobile: isMobile as AnyObject,
+            Parameters.isBeta: isBeta as AnyObject
         ]
     }
 
@@ -66,6 +71,17 @@ class PageLayoutService {
     }
 
     private static let scale = UIScreen.main.nativeScale
+
+    private static let isMobile = true
+
+    private static let isBeta: String = {
+        let isDevMode = BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+        if isDevMode == true {
+            return "true"
+        }
+        return "false"
+    }()
+
 }
 
 extension PageLayoutService {

--- a/WordPress/Classes/Services/PageLayoutService.swift
+++ b/WordPress/Classes/Services/PageLayoutService.swift
@@ -8,7 +8,7 @@ class PageLayoutService {
         static let supportedBlocks = "supported_blocks"
         static let previewWidth = "preview_width"
         static let scale = "scale"
-        static let isMobile = "is_mobile"
+        static let type = "type"
         static let isBeta = "is_beta"
     }
 
@@ -56,7 +56,7 @@ class PageLayoutService {
             Parameters.supportedBlocks: supportedBlocks as AnyObject,
             Parameters.previewWidth: previewWidth(thumbnailSize) as AnyObject,
             Parameters.scale: scale as AnyObject,
-            Parameters.isMobile: isMobile as AnyObject,
+            Parameters.type: type as AnyObject,
             Parameters.isBeta: isBeta as AnyObject
         ]
     }
@@ -72,7 +72,7 @@ class PageLayoutService {
 
     private static let scale = UIScreen.main.nativeScale
 
-    private static let isMobile = true
+    private static let type = "mobile"
 
     private static let isBeta: String = {
         let isDevMode = BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]


### PR DESCRIPTION
This PR adds 'type=mobile and is_beta=true to the query parameters of the page layout api calls. 

This make it so that the api will be able to return type ( mobile or web ) specific page layouts as well as beta versions.

To test:
Do the tests pass. 

D55810-code implements the API side of things to make it work as expected. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.