### PR TITLE
Remove Widgets button from Stats nav bar on iOS 14 or later

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -73,7 +73,9 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 - (void)addStatsViewControllerToView
 {
-    if (self.presentingViewController == nil) {
+    if (@available (iOS 14, *)) {
+        // do not install the widgets button on iOS 14 or later
+    } else if (self.presentingViewController == nil) {
         UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Widgets", @"Nav bar button title to set the site used for Stats widgets.") style:UIBarButtonItemStylePlain target:self action:@selector(makeSiteTodayWidgetSite:)];
         self.navigationItem.rightBarButtonItem = settingsButton;
     }

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -74,10 +74,12 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 - (void)addStatsViewControllerToView
 {
     if (@available (iOS 14, *)) {
-        // do not install the widgets button on iOS 14 or later
+        // do not install the widgets button on iOS 14 or later, if today widget feature flag is enabled
+        if (![Feature enabled:FeatureFlagTodayWidget]) {
+            [self installWidgetsButton];
+        }
     } else if (self.presentingViewController == nil) {
-        UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Widgets", @"Nav bar button title to set the site used for Stats widgets.") style:UIBarButtonItemStylePlain target:self action:@selector(makeSiteTodayWidgetSite:)];
-        self.navigationItem.rightBarButtonItem = settingsButton;
+        [self installWidgetsButton];
     }
 
     [self addChildViewController:self.siteStatsDashboardVC];
@@ -85,6 +87,11 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     [self.siteStatsDashboardVC didMoveToParentViewController:self];
 }
 
+- (void) installWidgetsButton
+{
+    UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Widgets", @"Nav bar button title to set the site used for Stats widgets.") style:UIBarButtonItemStylePlain target:self action:@selector(makeSiteTodayWidgetSite:)];
+    self.navigationItem.rightBarButtonItem = settingsButton;
+}
 
 - (void)initStats
 {


### PR DESCRIPTION
Fixes #NA

To test:

- build/run on iOS 14, go to My Site -> Stats and make sure the "Widgets" button does not appear on the navigation bar
- do the same on iOS 13 and make sure that this time the "Widgets" button does appear

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
