### PR TITLE
Modify Quick Start Steps to support quick start steps

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 16.6
 -----
+* [*] Quick Start: Removed the Browse theme step and added guidance for reviewing pages and editing your Homepage. [#15680]
 
 16.5
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -62,6 +62,7 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementStats = 18,
     QuickStartTourElementPlans = 19,
     QuickStartTourElementSiteTitle = 20,
+    QuickStartTourElementEditHomepage = 21,
 };
 
 typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -265,7 +265,7 @@ open class QuickStartTourGuide: NSObject {
         QuickStartCreateTour(),
         QuickStartSiteTitleTour(),
         QuickStartSiteIconTour(),
-        QuickStartThemeTour(),
+        QuickStartReviewPagesTour(),
         QuickStartViewTour()
     ]
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -265,6 +265,7 @@ open class QuickStartTourGuide: NSObject {
         QuickStartCreateTour(),
         QuickStartSiteTitleTour(),
         QuickStartSiteIconTour(),
+        QuickStartEditHomepageTour(),
         QuickStartReviewPagesTour(),
         QuickStartViewTour()
     ]

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -250,11 +250,35 @@ struct QuickStartReviewPagesTour: QuickStartTour {
     let icon = UIImage.gridicon(.pages)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
-    let showWaypointNotices = false
 
     var waypoints: [WayPoint] = {
         let descriptionBase = NSLocalizedString("Select %@ to see your page list.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        return [(element: .pages, description: descriptionBase.highlighting(phrase: "", icon: .gridicon(.pages)))]
+        let descriptionTarget = NSLocalizedString("Site Pages", comment: "The item to select during a guided tour.")
+        return [(element: .pages, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: .gridicon(.pages)))]
+    }()
+
+    let accessibilityHintText = NSLocalizedString("Guides you through the process of creating a new page for your site.", comment: "This value is used to set the accessibility hint text for creating a new page for the user's site.")
+}
+
+struct QuickStartEditHomepageTour: QuickStartTour {
+    let key = "quick-start-edit-homepage-tour"
+    let analyticsKey = "edit-homepage"
+    let title = NSLocalizedString("Edit your homepage", comment: "Title of a Quick Start Tour")
+    let titleMarkedCompleted = NSLocalizedString("Completed: Edit your homepage", comment: "The Quick Start Tour title after the user finished the step.")
+    let description = NSLocalizedString("Change, add, or remove content from your site's homepage.", comment: "Description of a Quick Start Tour")
+    let icon = UIImage.gridicon(.house)
+    let suggestionNoText = Strings.notNow
+    let suggestionYesText = Strings.yesShowMe
+
+    var waypoints: [WayPoint] = {
+        let descriptionBase = NSLocalizedString("Select %@ to see your page list.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let descriptionTarget = NSLocalizedString("Site Pages", comment: "The item to select during a guided tour.")
+        let descriptionHomepage = NSLocalizedString("Select %@ to edit your Homepage.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let homepageTarget = NSLocalizedString("Homepage", comment: "The item to select during a guided tour.")
+        return [
+            (element: .pages, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: .gridicon(.pages))),
+            (element: .editHomepage, description: descriptionHomepage.highlighting(phrase: homepageTarget, icon: .gridicon(.house)))
+        ]
     }()
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of creating a new page for your site.", comment: "This value is used to set the accessibility hint text for creating a new page for the user's site.")

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -262,7 +262,7 @@ struct QuickStartReviewPagesTour: QuickStartTour {
 
 struct QuickStartEditHomepageTour: QuickStartTour {
     let key = "quick-start-edit-homepage-tour"
-    let analyticsKey = "edit-homepage"
+    let analyticsKey = "edit_homepage"
     let title = NSLocalizedString("Edit your homepage", comment: "Title of a Quick Start Tour")
     let titleMarkedCompleted = NSLocalizedString("Completed: Edit your homepage", comment: "The Quick Start Tour title after the user finished the step.")
     let description = NSLocalizedString("Change, add, or remove content from your site's homepage.", comment: "Description of a Quick Start Tour")

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -124,31 +124,6 @@ struct QuickStartThemeTour: QuickStartTour {
     let accessibilityHintText = NSLocalizedString("Guides you through the process of choosing a theme for your site.", comment: "This value is used to set the accessibility hint text for choosing a theme for the user's site.")
 }
 
-struct QuickStartCustomizeTour: QuickStartTour {
-    let key = "quick-start-customize-tour"
-    let analyticsKey = "customize_site"
-    let title = NSLocalizedString("Customize your site", comment: "Title of a Quick Start Tour")
-    let titleMarkedCompleted = NSLocalizedString("Completed: Customize your site", comment: "The Quick Start Tour title after the user finished the step.")
-    let description = NSLocalizedString("Change colors, fonts, and images for a perfectly personalized site.", comment: "Description of a Quick Start Tour")
-    let icon = UIImage.gridicon(.customize)
-    let suggestionNoText = Strings.notNow
-    let suggestionYesText = Strings.yesShowMe
-
-    var waypoints: [WayPoint] = {
-        let step1DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let step1DescriptionTarget = NSLocalizedString("Themes", comment: "The menu item to select during a guided tour.")
-        let step1: WayPoint = (element: .themes, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.themes)))
-
-        let step2DescriptionBase = NSLocalizedString("Select %@ to start personalising your site", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let step2DescriptionTarget = NSLocalizedString("Customize", comment: "The menu item to select during a guided tour.")
-        let step2: WayPoint = (element: .customize, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.themes)))
-
-        return [step1, step2]
-    }()
-
-    let accessibilityHintText = NSLocalizedString("Guides you through the process of customizing your site.", comment: "This value is used to set the accessibility hint text for customizing a user's site.")
-}
-
 struct QuickStartShareTour: QuickStartTour {
     let key = "quick-start-share-tour"
     let analyticsKey = "share_site"

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -266,20 +266,20 @@ struct QuickStartSiteIconTour: QuickStartTour {
     let accessibilityHintText = NSLocalizedString("Guides you through the process of uploading an icon for your site.", comment: "This value is used to set the accessibility hint text for uploading a site icon.")
 }
 
-struct QuickStartNewPageTour: QuickStartTour {
-    let key = "quick-start-new-page-tour"
-    let analyticsKey = "new_page"
-    let title = NSLocalizedString("Create a new page", comment: "Title of a Quick Start Tour")
-    let titleMarkedCompleted = NSLocalizedString("Completed: Create a new page", comment: "The Quick Start Tour title after the user finished the step.")
-    let description = NSLocalizedString("Add a page for key content — an “About” page is a great start.", comment: "Description of a Quick Start Tour")
+struct QuickStartReviewPagesTour: QuickStartTour {
+    let key = "quick-start-review-pages-tour"
+    let analyticsKey = "review_pages"
+    let title = NSLocalizedString("Review site pages", comment: "Title of a Quick Start Tour")
+    let titleMarkedCompleted = NSLocalizedString("Completed: Review site pages", comment: "The Quick Start Tour title after the user finished the step.")
+    let description = NSLocalizedString("Change, add, or remove your site's pages.", comment: "Description of a Quick Start Tour")
     let icon = UIImage.gridicon(.pages)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
     let showWaypointNotices = false
 
     var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Select %@ to create a new page", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        return [(element: .newPage, description: descriptionBase.highlighting(phrase: "", icon: .gridicon(.create)))]
+        let descriptionBase = NSLocalizedString("Select %@ to see your page list.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        return [(element: .pages, description: descriptionBase.highlighting(phrase: "", icon: .gridicon(.pages)))]
     }()
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of creating a new page for your site.", comment: "This value is used to set the accessibility hint text for creating a new page for the user's site.")

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -151,6 +151,11 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         }
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        QuickStartTourGuide.shared.endCurrentTour()
+    }
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.horizontalSizeClass == .compact {
@@ -404,6 +409,10 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         tableView.deselectRow(at: indexPath, animated: true)
 
         let page = pageAtIndexPath(indexPath)
+        if page.isSiteHomepage {
+            QuickStartTourGuide.shared.visited(.editHomepage)
+            tableView.reloadRows(at: [indexPath], with: .automatic)
+        }
 
         guard page.status != .trash else {
             return
@@ -423,6 +432,10 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
 
         configureCell(cell, at: indexPath)
+
+        if page.isSiteHomepage && QuickStartTourGuide.shared.isCurrentElement(.editHomepage) {
+            cell.accessoryView = QuickStartSpotlightView()
+        }
 
         return cell
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -73,6 +73,10 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         controller.blog = blog
         controller.restorationClass = self
 
+        if QuickStartTourGuide.shared.isCurrentElement(.pages) {
+            controller.filterSettings.setFilterWithPostStatus(BasePost.Status.publish)
+        }
+
         return controller
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -226,19 +226,6 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
         }
     }
 
-    /// Returns a list of completed tour items that were taken care of as part of the site creation flow.
-    private var completedTourSteps: [QuickStartTour] {
-        var completedTourSteps: [QuickStartTour] = []
-
-        guard FeatureFlag.siteCreationHomePagePicker.enabled else { return completedTourSteps }
-        /// Only mark the theme tour as completed if the user didn't select the skip
-        if siteCreator.design != nil {
-            completedTourSteps.append(QuickStartThemeTour())
-        }
-
-        return completedTourSteps
-    }
-
     private func showQuickStartAlert(for blog: Blog) {
         guard !UserDefaults.standard.quickStartWasDismissedPermanently else {
             return
@@ -248,7 +235,7 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
             return
         }
 
-        let fancyAlert = FancyAlertViewController.makeQuickStartAlertController(blog: blog, withCompletedSteps: completedTourSteps)
+        let fancyAlert = FancyAlertViewController.makeQuickStartAlertController(blog: blog)
         fancyAlert.modalPresentationStyle = .custom
         fancyAlert.transitioningDelegate = tabBar
         tabBar.present(fancyAlert, animated: true)


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-iOS/issues/15675

## To test:

### Setup steps
1. Create a site. 
2. Select "Yes, Help Me"

### Removed steps
3. (After the setup if needed) Open the Customize Quick Start Tour
4. **Expect:** to **NOT** see "Browse themes", "Customize your site", or "Create a new page" in the list or in "Complete"

### Edit your homepage
3. (After the setup if needed) Open the Customize Quick Start Tour
4. Select "Edit your homepage"
5. **Expect:** 
    - Quick Start to dismiss.
    - The table to scroll to "Site Pages" and present a notice. 
    - Show a tap indicator on "Site Pages" row
6. Tap the highlighted row.
7. **Expect:** 
    - Page List to be displayed
    - A Notice for selecting the homepage should be displayed 
       - backing out should dismiss the notice
    - Show a tap indicator on the Homepage cell
        - 📓 I didn't add logic to scroll to the Homepage as it's highly likely to be on the screen
8. Tap the highlighted row.
9. **Expect:** To see the Gutenberg Editor
10. Backout to the Site Detail screen
11. **Expect:** 
    - To be prompted to start the next step. 
    - To have the "Edit your homepage" marked as complete

<details>
<summary>Sample run</summary>
<kbd><a href="https://user-images.githubusercontent.com/3384451/105253113-cc68e280-5b4c-11eb-851a-79e1172eb338.gif"><img width="300" src="https://user-images.githubusercontent.com/3384451/105253113-cc68e280-5b4c-11eb-851a-79e1172eb338.gif"/></a></kbd>
</details>

### Restart Edit your homepage
3. (After the setup if needed) Open the Customize Quick Start Tour
4. Complete the Homepage Tour
5. Open the Customize Quick Start Tour
4. Select "Edit your homepage" in the "Completed" section
5. Expect to be able to rerun through the Edit your homepage tour

### Review site pages
3. (After the setup if needed) Open the Customize Quick Start Tour
4. Select "Review site pages"
5. **Expect:** 
    - Quick Start to dismiss.
    - The table to scroll to "Site Pages" and present a notice. 
    - Show a tap indicator on "Site Pages" row
6. Tap the highlighted row.
7. **Expect:** 
8. Backout to the Site Detail screen
9. **Expect:** 
    - To be prompted to start the next step. 
    - To have the "Review site pages" marked as complete

<details>
<summary>Sample run</summary>
<kbd><a href="https://user-images.githubusercontent.com/3384451/105253194-ffab7180-5b4c-11eb-9c85-26dcb4754acb.gif"><img width="300" src="https://user-images.githubusercontent.com/3384451/105253194-ffab7180-5b4c-11eb-9c85-26dcb4754acb.gif"/></a></kbd>
</details>

### Restart Review site pages
3. (After the setup if needed) Open the Customize Quick Start Tour
4. Complete the Homepage Tour
5. Open the Customize Quick Start Tour
4. Select "Review site pages" in the "Completed" section
5. Expect to be able to rerun through the Review site pages tour
 
### Full Tour
1. Select Create Your Site 
2. Expect to be able to walk through the full tour

<details>
<summary>Sample run</summary>
<kbd><a href="https://user-images.githubusercontent.com/3384451/105253241-1a7de600-5b4d-11eb-9571-6acf9c5b47a9.gif"><img width="300" src="https://user-images.githubusercontent.com/3384451/105253241-1a7de600-5b4d-11eb-9571-6acf9c5b47a9.gif"/></a></kbd>
</details>

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
