### PR TITLE
Jetpack Section: Activity Detail Download Backup Button

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -103,17 +103,13 @@
                                                             <constraint firstAttribute="height" constant="0.5" id="BVA-WF-pjw"/>
                                                         </constraints>
                                                     </view>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qzN-1h-59z">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qzN-1h-59z">
                                                         <rect key="frame" x="0.0" y="0.5" width="343" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="NG0-1F-qwe"/>
                                                         </constraints>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                        <color key="tintColor" red="0.0" green="0.66666666669999997" blue="0.86274509799999999" alpha="1" colorSpace="calibratedRGB"/>
                                                         <inset key="titleEdgeInsets" minX="6" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                                        <state key="normal" title="Button">
-                                                            <color key="titleColor" red="0.0" green="0.66666666666666663" blue="0.86274509803921573" alpha="1" colorSpace="calibratedRGB"/>
-                                                        </state>
+                                                        <state key="normal" title="Button"/>
                                                         <connections>
                                                             <action selector="rewindButtonTappedWithSender:" destination="yav-nF-cx7" eventType="touchUpInside" id="u5C-lN-yLL"/>
                                                         </connections>
@@ -133,12 +129,12 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="fnA-qw-vPe"/>
                         <constraints>
                             <constraint firstItem="fnA-qw-vPe" firstAttribute="trailing" secondItem="2EY-TD-6V1" secondAttribute="trailing" id="36M-yw-daV"/>
                             <constraint firstItem="2EY-TD-6V1" firstAttribute="top" secondItem="fnA-qw-vPe" secondAttribute="top" id="KcE-uG-uhl"/>
                             <constraint firstItem="2EY-TD-6V1" firstAttribute="leading" secondItem="fnA-qw-vPe" secondAttribute="leading" id="uy5-pe-WY6"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="fnA-qw-vPe"/>
                     </view>
                     <connections>
                         <outlet property="bottomConstaint" destination="Fha-kb-hYl" id="vUN-uA-iaq"/>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
@@ -137,7 +137,7 @@
                                                                 <inset key="titleEdgeInsets" minX="6" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                                 <state key="normal" title="Button"/>
                                                                 <connections>
-                                                                    <action selector="rewindButtonTappedWithSender:" destination="yav-nF-cx7" eventType="touchUpInside" id="dQ9-5N-Wrh"/>
+                                                                    <action selector="backupButtonTappedWithSender:" destination="yav-nF-cx7" eventType="touchUpInside" id="kjv-NG-DTn"/>
                                                                 </connections>
                                                             </button>
                                                         </subviews>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
@@ -17,10 +17,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2EY-TD-6V1" userLabel="container view">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="331"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="361"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="mSI-6P-kcW">
-                                        <rect key="frame" x="16" y="16" width="343" height="299"/>
+                                        <rect key="frame" x="16" y="16" width="343" height="329"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="DDN-1Y-KHk" userLabel="header">
                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="38.5"/>
@@ -93,27 +93,55 @@
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ouv-sN-axZ" userLabel="rewind">
-                                                <rect key="frame" x="0.0" y="299" width="343" height="44.5"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="i00-9l-xYk">
+                                                <rect key="frame" x="0.0" y="329" width="343" height="0.0"/>
                                                 <subviews>
-                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yPg-ua-Eim">
-                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="0.5"/>
-                                                        <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="calibratedRGB"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="0.5" id="BVA-WF-pjw"/>
-                                                        </constraints>
-                                                    </view>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qzN-1h-59z">
-                                                        <rect key="frame" x="0.0" y="0.5" width="343" height="44"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="NG0-1F-qwe"/>
-                                                        </constraints>
-                                                        <inset key="titleEdgeInsets" minX="6" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                                        <state key="normal" title="Button"/>
-                                                        <connections>
-                                                            <action selector="rewindButtonTappedWithSender:" destination="yav-nF-cx7" eventType="touchUpInside" id="u5C-lN-yLL"/>
-                                                        </connections>
-                                                    </button>
+                                                    <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ouv-sN-axZ" userLabel="rewind">
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="44.5"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yPg-ua-Eim">
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="0.5"/>
+                                                                <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="0.5" id="BVA-WF-pjw"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qzN-1h-59z">
+                                                                <rect key="frame" x="0.0" y="0.5" width="343" height="44"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="44" id="NG0-1F-qwe"/>
+                                                                </constraints>
+                                                                <inset key="titleEdgeInsets" minX="6" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                                <state key="normal" title="Button"/>
+                                                                <connections>
+                                                                    <action selector="rewindButtonTappedWithSender:" destination="yav-nF-cx7" eventType="touchUpInside" id="u5C-lN-yLL"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="yyE-VA-gGp" userLabel="backup">
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="44.5"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gZy-mE-jTT">
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="0.5"/>
+                                                                <color key="backgroundColor" red="0.91372549020000005" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="0.5" id="qQX-DU-Xuz"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bA3-ay-OFJ">
+                                                                <rect key="frame" x="0.0" y="0.5" width="343" height="44"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="44" id="5CY-sV-081"/>
+                                                                </constraints>
+                                                                <inset key="titleEdgeInsets" minX="6" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                                <state key="normal" title="Button"/>
+                                                                <connections>
+                                                                    <action selector="rewindButtonTappedWithSender:" destination="yav-nF-cx7" eventType="touchUpInside" id="dQ9-5N-Wrh"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
@@ -137,7 +165,9 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="bottomConstaint" destination="Fha-kb-hYl" id="vUN-uA-iaq"/>
+                        <outlet property="backupButton" destination="bA3-ay-OFJ" id="b1y-2F-PX6"/>
+                        <outlet property="backupStackView" destination="yyE-VA-gGp" id="fnD-jB-12a"/>
+                        <outlet property="bottomConstaint" destination="Fha-kb-hYl" id="CD2-qR-3da"/>
                         <outlet property="containerView" destination="2EY-TD-6V1" id="pkP-dO-mdo"/>
                         <outlet property="contentStackView" destination="jlr-kR-xzq" id="bkc-3M-MDt"/>
                         <outlet property="dateLabel" destination="YIh-B5-5mX" id="k3s-5c-AXy"/>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -62,10 +62,16 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
     }
 
     @IBAction func rewindButtonTapped(sender: UIButton) {
-        presenter?.presentRestoreFor(activity: activity!)
+        guard let activity = activity else {
+            return
+        }
+        presenter?.presentRestoreFor(activity: activity)
     }
 
     @IBAction func backupButtonTapped(sender: UIButton) {
+        guard let activity = activity else {
+            return
+        }
         presenter?.presentBackupFor(activity: activity)
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -65,6 +65,10 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         presenter?.presentRestoreFor(activity: activity!)
     }
 
+    @IBAction func backupButtonTapped(sender: UIButton) {
+        presenter?.presentBackupFor(activity: activity)
+    }
+
     private func setupLabelStyles() {
         nameLabel.textColor = .text
         nameLabel.font = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize,

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -40,12 +40,14 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
 
     @IBOutlet private var headerStackView: UIStackView!
     @IBOutlet private var rewindStackView: UIStackView!
+    @IBOutlet private var backupStackView: UIStackView!
     @IBOutlet private var contentStackView: UIStackView!
     @IBOutlet private var containerView: UIView!
 
     @IBOutlet private var bottomConstaint: NSLayoutConstraint!
 
     @IBOutlet private var rewindButton: UIButton!
+    @IBOutlet private var backupButton: UIButton!
 
     private var activity: Activity?
 
@@ -76,6 +78,9 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
 
         rewindButton.setTitleColor(.primary, for: .normal)
         rewindButton.setTitleColor(.primaryDark, for: .highlighted)
+
+        backupButton.setTitleColor(.primary, for: .normal)
+        backupButton.setTitleColor(.primaryDark, for: .highlighted)
     }
 
     private func setupViews() {
@@ -91,8 +96,12 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         textView.textContainer.lineFragmentPadding = 0
 
         if activity.isRewindable {
-            rewindStackView.isHidden = false
             bottomConstaint.constant = 0
+            rewindStackView.isHidden = false
+
+            if FeatureFlag.jetpackBackupAndRestore.enabled {
+                backupStackView.isHidden = false
+            }
         }
 
         if let avatar = activity.actor?.avatarURL, let avatarURL = URL(string: avatar) {
@@ -108,6 +117,9 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
 
         rewindButton.naturalContentHorizontalAlignment = .leading
         rewindButton.setImage(.gridicon(.history, size: Constants.gridiconSize), for: .normal)
+
+        backupButton.naturalContentHorizontalAlignment = .leading
+        backupButton.setImage(.gridicon(.cloudDownload, size: Constants.gridiconSize), for: .normal)
     }
 
     private func setupText() {
@@ -122,8 +134,15 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         textView.attributedText = formattableActivity?.formattedContent(using: ActivityContentStyles())
         summaryLabel.text = activity.summary
 
-        rewindButton.setTitle(NSLocalizedString("Rewind", comment: "Title for button allowing user to rewind their Jetpack site"),
-                                                for: .normal)
+        if FeatureFlag.jetpackBackupAndRestore.enabled {
+            rewindButton.setTitle(NSLocalizedString("Restore", comment: "Title for button allowing user to restore their Jetpack site"),
+                                                    for: .normal)
+            backupButton.setTitle(NSLocalizedString("Download backup", comment: "Title for button allowing user to backup their Jetpack site"),
+                                                    for: .normal)
+        } else {
+            rewindButton.setTitle(NSLocalizedString("Rewind", comment: "Title for button allowing user to rewind their Jetpack site"),
+                                                    for: .normal)
+        }
 
         let dateFormatter = ActivityDateFormatting.longDateFormatterWithoutTime(for: site)
         dateLabel.text = dateFormatter.string(from: activity.published)

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -4,6 +4,7 @@ protocol ActivityPresenter: class {
     func presentDetailsFor(activity: FormattableActivity)
     func presentBackupOrRestoreFor(activity: Activity)
     func presentRestoreFor(activity: Activity)
+    func presentBackupFor(activity: Activity)
 }
 
 class ActivityListViewModel: Observable {

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -416,6 +416,12 @@ extension BaseActivityListViewController: ActivityPresenter {
         let navigationVC = UINavigationController(rootViewController: restoreOptionsVC)
         self.present(navigationVC, animated: true)
     }
+
+    func presentBackupFor(activity: Activity) {
+        let backupOptionsVC = JetpackBackupOptionsViewController(site: site, activity: activity)
+        let navigationVC = UINavigationController(rootViewController: backupOptionsVC)
+        self.present(navigationVC, animated: true)
+    }
 }
 
 // MARK: - Restores handling

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackBackupCompleteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackBackupCompleteViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import CocoaLumberjack
+import WordPressFlux
 import WordPressShared
 import WordPressUI
 
@@ -51,6 +52,11 @@ class JetpackBackupCompleteViewController: BaseRestoreCompleteViewController {
     private func downloadFile() {
         guard let url = backup.url,
               let downloadURL = URL(string: url) else {
+
+            let title = NSLocalizedString("Unable to download file", comment: "Message displayed when opening the link to the downloadable backup fails.")
+            let notice = Notice(title: title)
+            ActionDispatcher.dispatch(NoticeAction.post(notice))
+
             return
         }
 
@@ -61,6 +67,11 @@ class JetpackBackupCompleteViewController: BaseRestoreCompleteViewController {
         guard let url = backup.url,
               let downloadURL = URL(string: url),
               let activities = WPActivityDefaults.defaultActivities() as? [UIActivity] else {
+
+            let title = NSLocalizedString("Unable to share link", comment: "Message displayed when sharing a link to the downloadable backup fails.")
+            let notice = Notice(title: title)
+            ActionDispatcher.dispatch(NoticeAction.post(notice))
+
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackBackupCompleteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackBackupCompleteViewController.swift
@@ -49,7 +49,12 @@ class JetpackBackupCompleteViewController: BaseRestoreCompleteViewController {
     // MARK: - Private
 
     private func downloadFile() {
-        // TODO
+        guard let url = backup.url,
+              let downloadURL = URL(string: url) else {
+            return
+        }
+
+        UIApplication.shared.open(downloadURL)
     }
 
     private func shareLink() {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackRestoreCompleteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackRestoreCompleteViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import CocoaLumberjack
+import WordPressFlux
 import WordPressShared
 import WordPressUI
 
@@ -45,6 +46,11 @@ class JetpackRestoreCompleteViewController: BaseRestoreCompleteViewController {
 
     private func visitSite() {
         guard let homeURL = URL(string: site.homeURL) else {
+
+            let title = NSLocalizedString("Unable to visit site", comment: "Message displayed when visiting a site fails.")
+            let notice = Notice(title: title)
+            ActionDispatcher.dispatch(NoticeAction.post(notice))
+
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/Views/RestoreCompleteView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/Views/RestoreCompleteView.swift
@@ -32,7 +32,7 @@ class RestoreCompleteView: UIView, NibLoadable {
         titleLabel.numberOfLines = 0
 
         descriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)
-        descriptionLabel.textColor = .text
+        descriptionLabel.textColor = .textSubtle
         descriptionLabel.numberOfLines = 0
 
         primaryButton.isPrimary = true

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
@@ -51,7 +51,7 @@ extension JetpackBackupOptionsViewController: JetpackBackupOptionsView {
     }
 
     func showBackupRequestFailed() {
-        let errorTitle = NSLocalizedString("Backup failed.", comment: "Title for error displayed when preparing a backup fails.")
+        let errorTitle = NSLocalizedString("Backup failed", comment: "Title for error displayed when preparing a backup fails.")
         let errorMessage = NSLocalizedString("We couldn't create your backup. Please try again later.", comment: "Message for error displayed when preparing a backup fails.")
         let notice = Notice(title: errorTitle, message: errorMessage)
         ActionDispatcher.dispatch(NoticeAction.post(notice))

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
@@ -78,7 +78,7 @@ extension JetpackRestoreWarningViewController: JetpackRestoreWarningView {
     }
 
     func showRestoreRequestFailed() {
-        let errorTitle = NSLocalizedString("Restore failed.", comment: "Title for error displayed when restoring a site fails.")
+        let errorTitle = NSLocalizedString("Restore failed", comment: "Title for error displayed when restoring a site fails.")
         let errorMessage = NSLocalizedString("We couldn't restore your site. Please try again later.", comment: "Message for error displayed when restoring a site fails.")
         let notice = Notice(title: errorTitle, message: errorMessage)
         ActionDispatcher.dispatch(NoticeAction.post(notice))


### PR DESCRIPTION
Part of #15191

### Description:
- Added `Download backup` button to Activity Detail VC for rewindable activities
- Added button action for `Download file` button in Restore Complete VC

### Merge instructions:
- ⚠️ Merge after https://github.com/wordpress-mobile/WordPress-iOS/pull/15673

### To test:
1. My Site > Activity Log
2. Tap on a rewindable cell to view Activity Detail
    - ✅ `Restore` and `Download backup` buttons
3. Tap on `Download backup` button
    - ✅ Should navigate to Backup Options VC 
4. Tap on `Create downloadable file` and wait until your backup completes
5. Tap on `Download file`
    - ✅ Should open Safari with download prompt

Feature Flag OFF | Feature Flag ON | Download file -> Safari
--- | --- | ---
![IMG_1136](https://user-images.githubusercontent.com/6711616/105318364-c5060f80-5c06-11eb-9fb5-a9a3a9fcd7d7.PNG) | ![IMG_1137](https://user-images.githubusercontent.com/6711616/105318362-c46d7900-5c06-11eb-9726-25474e24dc49.PNG) | ![IMG_1140](https://user-images.githubusercontent.com/6711616/105333632-4a92bb00-5c19-11eb-9782-6eca50215893.PNG)


### PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
