### PR TITLE
Reader: Updates the text for the follow conversation label.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -143,8 +143,8 @@ const CGFloat PostHeaderViewFollowConversationButtonHeight = 32.0;
 
     [WPStyleGuide applyReaderFollowConversationButtonStyle:button];
 
-    NSString *normalText = NSLocalizedString(@"Follow conversation", @"Verb. Button title. Follow the comments on a post.");
-    NSString *selectedText = NSLocalizedString(@"Following conversation", @"Verb. Button title. The user is following the comments on a post.");
+    NSString *normalText = NSLocalizedString(@"Follow conversation by email", @"Verb. Button title. Follow the comments on a post.");
+    NSString *selectedText = NSLocalizedString(@"Following conversation by email", @"Verb. Button title. The user is following the comments on a post.");
 
     [button setTitle:normalText forState:UIControlStateNormal];
     [button setTitle:selectedText forState:UIControlStateSelected];
@@ -152,7 +152,7 @@ const CGFloat PostHeaderViewFollowConversationButtonHeight = 32.0;
 
     // Default accessibility label and hint.
     button.accessibilityLabel = button.isSelected ? selectedText : normalText;
-    button.accessibilityHint = NSLocalizedString(@"Follows the comments on a post.", @"VoiceOver accessibility hint, informing the user the button can be used to follow the comments a post.");
+    button.accessibilityHint = NSLocalizedString(@"Follows the comments on a post by email.", @"VoiceOver accessibility hint, informing the user the button can be used to follow the comments a post.");
     
     NSLayoutConstraint *height = [button.heightAnchor constraintEqualToConstant:PostHeaderViewFollowConversationButtonHeight];
     [NSLayoutConstraint activateConstraints:@[height]];


### PR DESCRIPTION
Refs pbArwn-1zZ-p2

This PR updates the text of the follow conversation button to read "Follow conversation by email" or "Following conversation by email"

To test:
Launch the app and confirm the text change.

![Simulator Screen Shot - iPhone 11 Pro - 2021-01-22 at 11 18 24](https://user-images.githubusercontent.com/1435271/105523418-f54fbb80-5ca3-11eb-8834-e54b65dbdf9b.png)
![Simulator Screen Shot - iPhone 11 Pro - 2021-01-22 at 11 18 27](https://user-images.githubusercontent.com/1435271/105523420-f5e85200-5ca3-11eb-9cce-58feadd1cf96.png)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
