### PR TITLE
iOS 14 Today Widget - Refresh site list

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -399,6 +399,7 @@ static NSInteger HideSearchMinSites = 3;
 {
     self.isSyncing = NO;
     [self.tableView.refreshControl endRefreshing];
+    [self refreshStatsWidgetsSiteList];
 }
 
 - (void)removeBlogItemsFromSpotlight:(Blog *)blog {

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/BlogListViewController+StatsWidgets.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/BlogListViewController+StatsWidgets.swift
@@ -10,14 +10,14 @@ extension BlogListViewController {
         let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
         let updatedSiteList = blogService.visibleBlogsForWPComAccounts()
 
-        let newData = updatedSiteList.reduce(into: [Int: HomeWidgetTodayData]()) { result, element in
-            guard let blogID = element.dotComID else {
+        let newData = updatedSiteList.reduce(into: [Int: HomeWidgetTodayData]()) { sitesList, site in
+            guard let blogID = site.dotComID else {
                 return
             }
             let existingSite = currentData[blogID.intValue]
 
-            let siteURL = element.url ?? existingSite?.url ?? ""
-            let siteName = (element.title ?? siteURL).isEmpty ? siteURL : element.title ?? siteURL
+            let siteURL = site.url ?? existingSite?.url ?? ""
+            let siteName = (site.title ?? siteURL).isEmpty ? siteURL : site.title ?? siteURL
 
             var iconURL = existingSite?.iconURL
             var timeZone = existingSite?.timeZone ?? TimeZone.current
@@ -29,13 +29,13 @@ extension BlogListViewController {
             let date = existingSite?.date ?? Date()
             let stats = existingSite?.stats ?? TodayWidgetStats()
 
-            result[blogID.intValue] = HomeWidgetTodayData(siteID: blogID.intValue,
-                                                          siteName: siteName,
-                                                          iconURL: iconURL,
-                                                          url: siteURL,
-                                                          timeZone: timeZone,
-                                                          date: date,
-                                                          stats: stats)
+            sitesList[blogID.intValue] = HomeWidgetTodayData(siteID: blogID.intValue,
+                                                             siteName: siteName,
+                                                             iconURL: iconURL,
+                                                             url: siteURL,
+                                                             timeZone: timeZone,
+                                                             date: date,
+                                                             stats: stats)
 
 
         }

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/BlogListViewController+StatsWidgets.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/BlogListViewController+StatsWidgets.swift
@@ -1,0 +1,43 @@
+extension BlogListViewController {
+
+    @objc func refreshStatsWidgetsSiteList() {
+
+        guard let currentData = HomeWidgetTodayData.read() else {
+            return
+        }
+        let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
+        let updatedSiteList = blogService.visibleBlogsForWPComAccounts()
+
+        let newData = updatedSiteList.reduce(into: [Int: HomeWidgetTodayData]()) { result, element in
+            guard let blogID = element.dotComID else {
+                return
+            }
+            let existingSite = currentData[blogID.intValue]
+
+            let siteURL = element.url ?? existingSite?.url ?? ""
+            let siteName = (element.title ?? siteURL).isEmpty ? siteURL : element.title ?? siteURL
+
+            var iconURL = existingSite?.iconURL
+            var timeZone = existingSite?.timeZone ?? TimeZone.current
+
+            if let blog = blogService.blog(byBlogId: blogID) {
+                iconURL = blog.icon
+                timeZone = blogService.timeZone(for: blog)
+            }
+            let date = existingSite?.date ?? Date()
+            let stats = existingSite?.stats ?? TodayWidgetStats()
+
+            result[blogID.intValue] = HomeWidgetTodayData(siteID: blogID.intValue,
+                                                          siteName: siteName,
+                                                          iconURL: iconURL,
+                                                          url: siteURL,
+                                                          timeZone: timeZone,
+                                                          date: date,
+                                                          stats: stats)
+
+
+        }
+
+        HomeWidgetTodayData.write(items: newData)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/BlogListViewController+StatsWidgets.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/BlogListViewController+StatsWidgets.swift
@@ -1,3 +1,5 @@
+import WidgetKit
+
 extension BlogListViewController {
 
     @objc func refreshStatsWidgetsSiteList() {
@@ -39,5 +41,8 @@ extension BlogListViewController {
         }
 
         HomeWidgetTodayData.write(items: newData)
+        if #available(iOS 14.0, *) {
+            WidgetCenter.shared.reloadTimelines(ofKind: WPHomeWidgetTodayKind)
+        }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -318,7 +318,7 @@
 		1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */; };
 		24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */; };
 		24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */; };
-		24CE2EB1258D687A0000C297 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = 24CE2EB0258D687A0000C297 /* SwiftPackageProductDependency */; };
+		24CE2EB1258D687A0000C297 /* WordPressFlux in Frameworks */ = {isa = PBXBuildFile; productRef = 24CE2EB0258D687A0000C297 /* WordPressFlux */; };
 		2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
 		26D66DEC36ACF7442186B07D /* Pods_WordPressThisWeekWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 979B445A45E13F3289F2E99E /* Pods_WordPressThisWeekWidget.framework */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
@@ -427,6 +427,7 @@
 		3F568A0025420DE80048A9E4 /* TodayWidgetMediumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5689FF25420DE80048A9E4 /* TodayWidgetMediumView.swift */; };
 		3F568A1F254213B60048A9E4 /* VerticalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F568A1E254213B60048A9E4 /* VerticalCard.swift */; };
 		3F568A2F254216550048A9E4 /* FlexibleCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F568A2E254216550048A9E4 /* FlexibleCard.swift */; };
+		3F5A09FC25BB39FC006E52FC /* BlogListViewController+StatsWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5A09FB25BB39FC006E52FC /* BlogListViewController+StatsWidgets.swift */; };
 		3F5B3EAF23A851330060FF1F /* ReaderReblogPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */; };
 		3F5B3EB123A851480060FF1F /* ReaderReblogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B3EB023A851480060FF1F /* ReaderReblogFormatter.swift */; };
 		3F63B93C258179D100F581BE /* HomeWidgetTodayEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F63B93B258179D100F581BE /* HomeWidgetTodayEntry.swift */; };
@@ -3009,6 +3010,7 @@
 		3F5689FF25420DE80048A9E4 /* TodayWidgetMediumView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayWidgetMediumView.swift; sourceTree = "<group>"; };
 		3F568A1E254213B60048A9E4 /* VerticalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalCard.swift; sourceTree = "<group>"; };
 		3F568A2E254216550048A9E4 /* FlexibleCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexibleCard.swift; sourceTree = "<group>"; };
+		3F5A09FB25BB39FC006E52FC /* BlogListViewController+StatsWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogListViewController+StatsWidgets.swift"; sourceTree = "<group>"; };
 		3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogPresenter.swift; sourceTree = "<group>"; };
 		3F5B3EB023A851480060FF1F /* ReaderReblogFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogFormatter.swift; sourceTree = "<group>"; };
 		3F63B93B258179D100F581BE /* HomeWidgetTodayEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWidgetTodayEntry.swift; sourceTree = "<group>"; };
@@ -5366,7 +5368,7 @@
 				296890780FE971DC00770264 /* Security.framework in Frameworks */,
 				83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */,
 				83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */,
-				24CE2EB1258D687A0000C297 /* BuildFile in Frameworks */,
+				24CE2EB1258D687A0000C297 /* WordPressFlux in Frameworks */,
 				8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */,
 				834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */,
 				83043E55126FA31400EC9953 /* MessageUI.framework in Frameworks */,
@@ -5971,7 +5973,7 @@
 			path = GutenbergWeb;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				98D31BBF239720E4009CFF43 /* MainInterface.storyboard */,
@@ -6740,6 +6742,7 @@
 			children = (
 				3F6DA04025646F96002AB88F /* HomeWidgetData.swift */,
 				3FA53E9B256571D800F4D9A2 /* HomeWidgetCache.swift */,
+				3F5A09FB25BB39FC006E52FC /* BlogListViewController+StatsWidgets.swift */,
 			);
 			path = "iOS 14 Widgets";
 			sourceTree = "<group>";
@@ -11545,7 +11548,7 @@
 			);
 			name = WordPress;
 			packageProductDependencies = (
-				24CE2EB0258D687A0000C297 /* SwiftPackageProductDependency */,
+				24CE2EB0258D687A0000C297 /* WordPressFlux */,
 			);
 			productName = WordPress;
 			productReference = 1D6058910D05DD3D006BFB54 /* WordPress.app */;
@@ -11964,7 +11967,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -13560,6 +13563,7 @@
 				FAB8AB5F25AFFD0600F9F8A0 /* JetpackRestoreStatusCoordinator.swift in Sources */,
 				F913BB0E24B3C58B00C19032 /* EventLoggingDelegate.swift in Sources */,
 				4089C51022371B120031CE78 /* TodayStatsRecordValue+CoreDataClass.swift in Sources */,
+				3F5A09FC25BB39FC006E52FC /* BlogListViewController+StatsWidgets.swift in Sources */,
 				988F073523D0CE8800AC67A6 /* WidgetUrlCell.swift in Sources */,
 				74729CAE205722E300D1394D /* AbstractPost+Searchable.swift in Sources */,
 				2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */,
@@ -18850,7 +18854,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		24CE2EB0258D687A0000C297 /* SwiftPackageProductDependency */ = {
+		24CE2EB0258D687A0000C297 /* WordPressFlux */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = WordPressFlux;
 		};


### PR DESCRIPTION
This PR refreshes the site list when `syncBlogs` in `BlogListViewController` is called.

Note that this requires `BlogListViewController` to appear on screen. Another approach could be to call `BlogService.syncBlogsForAccount` every time some information about a site is updated (e.g. creation, title change etc), but considering that this operations would not occur so frequently, and they would not cover 100% of the cases anyway (e.g. add a site from another platform), I chose to avoid additional write calls to CoreData for now. If this proves to be a problem we can always add these behaviors.

Fixes #NA

To test:

- Install Today Widget and visualize existing stats in it
- Add a site in the app, then navigate back to the site list
- Go back to the widget, long press then edit widget, make sure the site appears in the available sites list
- Go back to the app and delete a site, this should redirect you to the sites list
- Go back to the widget, long press then edit widget and make sure the site you just deleted is not available in the list anymore. Note: if you delete a site that was selected in the widget, the widget should fall back to the default site after deletion

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
