### PR TITLE
iOS 14 Today Widget - Feature flag and release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] Activity Log: adds support for Date Range and Activity Type filters. [https://github.com/wordpress-mobile/WordPress-iOS/issues/15192]
 * [*] Quick Start: Removed the Browse theme step and added guidance for reviewing pages and editing your Homepage. [#15680]
+* [**] iOS 14 Widgets: new Today Widgets to display your Today Stats in your home screen.
 
 16.5
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -61,7 +61,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .jetpackBackupAndRestore:
             return BuildConfiguration.current == .localDeveloper
         case .todayWidget:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .unseenPosts:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }


### PR DESCRIPTION

Fixes #NA

To test:
- the feature flag is now enabled for any configuration, if you really want to test it, build and run the app with a configuration different from debug and make sure you can install the today widget
- take a look at the release notes change and make sure it reads correctly
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
