### PR TITLE
Update Comment dropping the iOS 12 specifics.

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -263,9 +263,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     /*
      * To allow more flexibility in the navigation bar's header items, we keep the navigation bar available.
      * However, that space is also essential to a uniform design of the header. This function updates the design of the
-     * navigation bar. On iOS 13+, we're able to set the design to the `navigationItem`, which is ViewController specific.
-     * On iOS 12 and below, we need to set those values to the `navigationBar`. We cache the original values in
-     * `originalNavBarAppearance` and then revert the changes when the view is dismissed by calling `restoreNavigationBar`
+     * navigation bar. We set the design to the `navigationItem`, which is ViewController specific.
      */
     private func formatNavigationController() {
         let newAppearance = UINavigationBarAppearance()


### PR DESCRIPTION
This cleans up the iOS 12 references in the comments that related to the code that was removed in:
https://github.com/wordpress-mobile/WordPress-iOS/pull/15583/commits/91d24ee04965976beb6c76450dddaa7371a2de21

## To test:
No official code change here so nothing to test

