### PR TITLE
Fix Xpost insertion

### DIFF
--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.swift
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.swift
@@ -102,7 +102,7 @@ extension SuggestionType {
         case (.mention, let suggestion as UserSuggestion):
             return suggestion.username
         case (.xpost, let suggestion as SiteSuggestion):
-            return suggestion.title
+            return suggestion.subdomain
         default: return nil
         }
     }


### PR DESCRIPTION
Xposts added from WordPress for iOS were not triggering an Xpost (cross-post) to be created on the site that was cross-posted to. This meant you could add an Xpost from the WPiOS app, but it wouldn't actually make a cross-post.

The reason was that the app was not inserting the destination site's subdomain (e.g. `+testsiteb`) but instead it was inserting the site's title (e.g. '+Test Site B'), which is not interpreted by the backend as a trigger to make a cross-post.

This PR fixes that by inserting the site's subdomain instead of its title.

### To test

**What you'll need**: A WordPress.com site that is capable of xposting to one or more other sites
- The ability to verify that the destination sites were successfully xpost'ed to

Note: https://wordpress.com/p2/ can be used to create xpost-capable sites. Or I can add you to my two test sites if that suits you.

- Open the block editor
- In a Paragraph or any other rich text block, type <code>+</code> and verify that the list of suggestions is shown
- Select one of the suggestions to add it to the post
- Expect the site's subdomain e.g. `+testsiteb` (not its title) to be added to the post
- Publish the post
- **Verify that the destination site received the xpost**

### PR submission checklist

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
