### PR TITLE
Enable user transition on the prepublishing nudges view

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -392,7 +392,7 @@ extension Set {
 // MARK: - DrawerPresentable
 extension PrepublishingViewController: DrawerPresentable {
     var allowsUserTransition: Bool {
-        return false
+        return true
     }
 
     var collapsedHeight: DrawerHeight {


### PR DESCRIPTION
Fixes #15707 

This PR enables the `allowsUserTransition` option on the prepublishing nudges view which allows the user to expand and scroll the view. 

### Demo

https://user-images.githubusercontent.com/793774/105904021-9e711b80-5fee-11eb-9a15-1d2646637023.mov

### To test:
1. Tap on Settings app on the device
2. Tap the Accessbility option
3. Tap on Display & Text Size
4. Tap on Larger Text
5. Enabled Larger Accessibility Sizes
6. Increase the font size
7. Open WordPress
8. Tap on My Site
9. Select a site
10. Tap the + button 
11. Tap the Blog Post option
12. Enter some content
13. Tap Publish
14. 👁️ Verify the font sizes are increased
15. 👁️ Verify you are able to swipe up and scroll the view to access the publish button
16. 👁️ Verify the Visibility / Publish Date / Tags / Categories options still work and you are able to access all the options
17.  Publish the post

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
