### PR TITLE
Reader seen toggle: Call the correct endpoint based on isWPCom or not.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.26-beta'
+    # pod 'WordPressKit', '~> 4.26-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/15355-update_seen_endpoints'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.26-beta'
+    pod 'WordPressKit', '~> 4.26-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/15355-update_seen_endpoints'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -406,7 +406,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.26.0-beta.2):
+  - WordPressKit (4.26.0-beta.3):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.34.0)
-  - WordPressKit (~> 4.26-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/15355-update_seen_endpoints`)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.14.0)
   - WordPressUI (~> 1.9.0)
@@ -554,7 +554,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -655,6 +654,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.45.0
+  WordPressKit:
+    :branch: feature/15355-update_seen_endpoints
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.45.0/third-party-podspecs/Yoga.podspec.json
 
@@ -673,6 +675,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.45.0
+  WordPressKit:
+    :commit: aba0ca49a1c1381117af8c12b1be8b89f1b248e6
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -753,7 +758,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: 7f9c41a084bfe691452bfcec8b2c9a12aed48f90
-  WordPressKit: de1e4152e07a130c82ee9f36a4aa71dd607b7804
+  WordPressKit: 15004700604b398fbb81edd05e3f2c601763c96a
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 99b37324ffef200ddf32694bc3de1e0c9fcfef21
   WordPressUI: 3b70cccc4c44cff09024ca3e94ae25a8768b26c1
@@ -769,6 +774,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 43c648e933770b054aa6401caf9f99f53fd6b0e4
+PODFILE CHECKSUM: 1bf3f919d0892866b804deebce82fdd76ba370f5
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -505,7 +505,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.34.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/15355-update_seen_endpoints`)
+  - WordPressKit (~> 4.26-beta)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.14.0)
   - WordPressUI (~> 1.9.0)
@@ -554,6 +554,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -654,9 +655,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.45.0
-  WordPressKit:
-    :branch: feature/15355-update_seen_endpoints
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.45.0/third-party-podspecs/Yoga.podspec.json
 
@@ -675,9 +673,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.45.0
-  WordPressKit:
-    :commit: aba0ca49a1c1381117af8c12b1be8b89f1b248e6
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -774,6 +769,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 1bf3f919d0892866b804deebce82fdd76ba370f5
+PODFILE CHECKSUM: 43c648e933770b054aa6401caf9f99f53fd6b0e4
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -64,16 +64,13 @@ open class ReaderPostMenu {
 
         // Seen
         if FeatureFlag.unseenPosts.enabled {
-            // Only show option for posts that are followed
-            if post.feedItemID != nil {
-                alertController.addActionWithTitle(post.isSeen ? ReaderPostMenuButtonTitles.markUnseen : ReaderPostMenuButtonTitles.markSeen,
-                                                   style: .default,
-                                                   handler: { (action: UIAlertAction) in
-                                                    if let post: ReaderPost = self.existingObject(for: post.objectID, context: post.managedObjectContext) {
-                                                        self.toggleSeenForPost(post)
-                                                    }
-                                                   })
-            }
+            alertController.addActionWithTitle(post.isSeen ? ReaderPostMenuButtonTitles.markUnseen : ReaderPostMenuButtonTitles.markSeen,
+                                               style: .default,
+                                               handler: { (action: UIAlertAction) in
+                                                if let post: ReaderPost = self.existingObject(for: post.objectID, context: post.managedObjectContext) {
+                                                    self.toggleSeenForPost(post)
+                                                }
+                                               })
         }
 
         // Visit site

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -69,18 +69,15 @@ final class ReaderShowMenuAction {
 
         // Seen
         if FeatureFlag.unseenPosts.enabled {
-            // Only show option for posts that are followed
-            if post.feedItemID != nil {
-                alertController.addActionWithTitle(post.isSeen ? ReaderPostMenuButtonTitles.markUnseen : ReaderPostMenuButtonTitles.markSeen,
-                                                   style: .default,
-                                                   handler: { (action: UIAlertAction) in
-                                                    if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
-                                                        ReaderSeenAction().execute(with: post, context: context, failure: { _ in
-                                                            ReaderHelpers.dispatchToggleSeenError(post: post)
-                                                        })
-                                                    }
-                                                   })
-            }
+            alertController.addActionWithTitle(post.isSeen ? ReaderPostMenuButtonTitles.markUnseen : ReaderPostMenuButtonTitles.markSeen,
+                                               style: .default,
+                                               handler: { (action: UIAlertAction) in
+                                                if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
+                                                    ReaderSeenAction().execute(with: post, context: context, failure: { _ in
+                                                        ReaderHelpers.dispatchToggleSeenError(post: post)
+                                                    })
+                                                }
+                                               })
         }
 
         // Visit


### PR DESCRIPTION
Ref #15355 
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/336

This uses the updated endpoints in WPKit to mark a post seen/unseen.
- Posts on WP sites use `seen-posts/seen/blog/new` and `seen-posts/seen/blog/delete`, utilizing the `postID`.
- Posts on non-WP sites use `seen-posts/seen/new` and `seen-posts/seen/delete`, utilizing the `feedItemID`.

It also removed the check for `feedItemID` when showing the options menus to see if the seen toggle should be displayed, making the toggle available to all posts.

To test:

---
- On any Reader card, tap the menu button.
  - Verify `Mark as seen` / `Mark as unseen` is included.
  - Select it.
  - Verify the option is now the opposite.
- Tap a Reader card to show the post details.
  - Tap the menu button.
  - Verify `Mark as seen` / `Mark as unseen` is included.
  - Select it.
  - Verify the option is now the opposite.

| Post Card | Post Details |
|--------|-------|
| ![post_card](https://user-images.githubusercontent.com/1816888/105922795-8e5e3980-5ff8-11eb-90a0-9acc4ba7d95d.png) | ![post_details](https://user-images.githubusercontent.com/1816888/105922809-93bb8400-5ff8-11eb-8a91-26b1b661600f.png) |

---
- Filter any stream by a followed site.
  - Verify the seen option is shown in both menus.
- Toggle seen.
- Re-display the site filter.
- Verify the unseen count for that site is updated. Note this may take a few seconds while the site list is updated in the background.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
