### PR TITLE
Quick Start: Cancel Edit homepage when homepage is removed

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -102,6 +102,13 @@ extension BlogDetailsViewController {
         showQuickStart(with: .grow)
     }
 
+    @objc func cancelCompletedToursIfNeeded() {
+        if blog.homepagePageID == nil {
+            // Ends the tour Edit Homepage if the site doesn't have a homepage set or uses the blog.
+            QuickStartTourGuide.shared.complete(tour: QuickStartEditHomepageTour(), for: blog, postNotification: false)
+        }
+    }
+
     private func showQuickStart(with type: QuickStartType) {
         let checklist = QuickStartChecklistViewController(blog: blog, type: type)
         let navigationViewController = UINavigationController(rootViewController: checklist)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -414,6 +414,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
+    [self cancelCompletedToursIfNeeded];
     if ([self.tabBarController isKindOfClass:[WPTabBarController class]]) {
         [self.createButtonCoordinator showCreateButtonFor:self.blog];
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
@@ -163,15 +163,6 @@ final class PageListTableViewHandler: WPTableViewHandler {
             return []
         }
 
-        cancelTourIfNeeded()
         return status == .published ? pages.setHomePageFirst().hierarchySort() : pages
     }
-
-    private func cancelTourIfNeeded() {
-        if QuickStartTourGuide.shared.isCurrentElement(.editHomepage) && blog.homepagePageID == nil {
-            // Ends the tour Edit Homepage if the site doesn't have a homepage set or uses the blog.
-            QuickStartTourGuide.shared.visited(.editHomepage)
-        }
-    }
-
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
@@ -71,7 +71,6 @@ final class PageListTableViewHandler: WPTableViewHandler {
         }
     }
 
-
     // MARK: - Public methods
 
     func page(at indexPath: IndexPath) -> Page {
@@ -164,6 +163,15 @@ final class PageListTableViewHandler: WPTableViewHandler {
             return []
         }
 
+        cancelTourIfNeeded()
         return status == .published ? pages.setHomePageFirst().hierarchySort() : pages
     }
+
+    private func cancelTourIfNeeded() {
+        if QuickStartTourGuide.shared.isCurrentElement(.editHomepage) && blog.homepagePageID == nil {
+            // Ends the tour Edit Homepage if the site doesn't have a homepage set or uses the blog.
+            QuickStartTourGuide.shared.visited(.editHomepage)
+        }
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -727,6 +727,22 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         }
     }
 
+    override func deletePost(_ apost: AbstractPost) {
+        completeQuickStartStepIfNeeded(apost)
+        super.deletePost(apost)
+    }
+
+    private func completeQuickStartStepIfNeeded(_ page: AbstractPost) {
+        guard let page = page as? Page else { return }
+        guard page.isSiteHomepage else { return }
+
+        if QuickStartTourGuide.shared.isCurrentElement(.editHomepage) {
+            QuickStartTourGuide.shared.visited(.editHomepage)
+        } else {
+            QuickStartTourGuide.shared.complete(tour: QuickStartEditHomepageTour(), for: blog, postNotification: false)
+        }
+    }
+
     private func addEditAction(to controller: UIAlertController, for page: AbstractPost) {
         if page.status == .trash {
             return

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -412,6 +412,9 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         if page.isSiteHomepage {
             QuickStartTourGuide.shared.visited(.editHomepage)
             tableView.reloadRows(at: [indexPath], with: .automatic)
+        } else {
+            QuickStartTourGuide.shared.endCurrentTour()
+            tableView.reloadData()
         }
 
         guard page.status != .trash else {
@@ -435,6 +438,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         if page.isSiteHomepage && QuickStartTourGuide.shared.isCurrentElement(.editHomepage) {
             cell.accessoryView = QuickStartSpotlightView()
+        } else {
+            cell.accessoryView = nil
         }
 
         return cell


### PR DESCRIPTION
Fixes this report from the 16.6 testing

> I got stuck on “Select Homepage” step on the Pages screen, since I had no homepage. I wasn’t able to dismiss the prompt, and it obstructed some of the actions on that page. If you don’t have a Homepage and create one using “Home” layout it will not be recognized by Quick Start logic.

## To test:
### Remove Homepage
1. Create a site. 
2. Select "Yes, Help Me" in the quick start prompt
3. Remove your homepage. You can do this by:
    - Going to Pages and deleting your homepage (I'll create an issue for this because Web blocks you from deleting your HomePage)
-or-
    - Going to Site Settings > Homepage Settings and select Classic Blog
4. Return to Quick Start 
5. **Expect** Edit Your homepage to be marked as completed

### Abandon flow
1. Create a site. 
2. Select "Yes, Help Me" in the quick start prompt
3. Start the "Edit your homepage" tour
4. Select Pages
5. Select a different page 
6. **Expect** The notice to dismiss 

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
