### PR TITLE
Activity Log: fix issue with the first month of the date picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -416,11 +416,13 @@ extension Date {
 
 class WPJTACMonthView: JTACMonthView {
 
-    // Avoids content to scroll above the maximum size
+    // Avoids content to scroll above/below the maximum/minimum size
     override func setContentOffset(_ contentOffset: CGPoint, animated: Bool) {
         let maxY = contentSize.height - frame.size.height
         if contentOffset.y > maxY {
             super.setContentOffset(CGPoint(x: contentOffset.x, y: maxY), animated: animated)
+        } else if contentOffset.y < 0 {
+            super.setContentOffset(CGPoint(x: contentOffset.x, y: 0), animated: animated)
         } else {
             super.setContentOffset(contentOffset, animated: animated)
         }


### PR DESCRIPTION
Fixes #15721

This PR fixes the scroll for the first month in the calendar.

The title of the first month is still a little bit obscured - I tried using `contentInset` without any luck. However, IMHO, the issue seems an edge case and does not impact the feature usage.

### How to test

1. Open Activity Log
2. Tap "Date Range"
3. Scroll to the very top and select a single date or date/range
4. Tap Done
5. Open the calendar again, there shouldn't be any white space present

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
