### PR TITLE
Jetpack Section: Scan: Adds loading and error handling

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -11,6 +11,9 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
     @IBOutlet weak var tableView: UITableView!
     let refreshControl = UIRefreshControl()
 
+    // Loading / Errors
+    private var noResultsViewController: NoResultsViewController?
+
     // MARK: - Initializers
     @objc init(blog: Blog) {
         self.blog = blog
@@ -45,15 +48,40 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
 
     // MARK: - JetpackScanView
     func render(_ scan: JetpackScan) {
+        updateNoResults(nil)
+
         refreshControl.endRefreshing()
         tableView.reloadData()
     }
 
     func showLoading() {
-
+        let model = NoResultsViewController.Model(title: NoResultsText.loading.title,
+                                                  accessoryView: NoResultsViewController.loadingAccessoryView())
+        updateNoResults(model)
     }
 
-    func showError() {
+    func showGenericError() {
+        let model =  NoResultsViewController.Model(title: NoResultsText.error.title,
+                                                   subtitle: NoResultsText.error.subtitle,
+                                                   buttonText: NoResultsText.contactSupportButtonText)
+
+        updateNoResults(model)
+    }
+
+    func showNoConnectionError() {
+        let model =  NoResultsViewController.Model(title: NoResultsText.noConnection.title,
+                                                   subtitle: NoResultsText.noConnection.subtitle,
+                                                   buttonText: NoResultsText.tryAgainButtonText)
+
+        updateNoResults(model)
+    }
+
+    func showScanStartError() {
+        let model =  NoResultsViewController.Model(title: NoResultsText.scanStartError.title,
+                                                   subtitle: NoResultsText.scanStartError.subtitle,
+                                                   buttonText: NoResultsText.contactSupportButtonText)
+
+        updateNoResults(model)
 
     }
 
@@ -136,5 +164,71 @@ extension JetpackScanViewController: UITableViewDataSource, UITableViewDelegate 
         let row = indexPath.row - Constants.tableHeaderCountOffset
 
         return threats[row]
+    }
+}
+
+// MARK: - Loading / Errors
+extension JetpackScanViewController: NoResultsViewControllerDelegate {
+    func updateNoResults(_ viewModel: NoResultsViewController.Model?) {
+        if let noResultsViewModel = viewModel {
+            showNoResults(noResultsViewModel)
+        } else {
+            noResultsViewController?.view.isHidden = true
+        }
+
+        tableView.reloadData()
+    }
+
+    private func showNoResults(_ viewModel: NoResultsViewController.Model) {
+        if noResultsViewController == nil {
+            noResultsViewController = NoResultsViewController.controller()
+            noResultsViewController?.delegate = self
+
+            guard let noResultsViewController = noResultsViewController else {
+                return
+            }
+
+            if noResultsViewController.view.superview != tableView {
+                tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+            }
+
+            addChild(noResultsViewController)
+
+            noResultsViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        noResultsViewController?.bindViewModel(viewModel)
+        noResultsViewController?.didMove(toParent: self)
+        tableView.pinSubviewToSafeArea(noResultsViewController!.view)
+        noResultsViewController?.view.isHidden = false
+    }
+
+    func actionButtonPressed() {
+        coordinator.noResultsButtonPressed()
+    }
+
+    private struct NoResultsText {
+        struct loading {
+            static let title = NSLocalizedString("Loading Scan...", comment: "Text displayed while loading the scan section for a site")
+        }
+
+        struct scanStartError {
+            static let title = NSLocalizedString("Something went wrong", comment: "Title for the error view when the scan start has failed")
+            static let subtitle = NSLocalizedString("Jetpack Scan couldn't complete a scan of your site. Please check to see if your site is down – if it's not, try again. If it is, or if Jetpack Scan is still having problems, contact our support team.", comment: "Error message shown when the scan start has failed.")
+        }
+
+        struct error {
+            static let title = NSLocalizedString("Oops", comment: "Title for the view when there's an error loading scan status")
+            static let subtitle = NSLocalizedString("There was an error loading the scan status", comment: "Text displayed when there is a failure loading the status")
+        }
+
+        struct noConnection {
+            static let title = NSLocalizedString("No connection", comment: "Title for the error view when there's no connection")
+            static let subtitle = NSLocalizedString("An active internet connection is required to view Jetpack Scan", comment: "Error message shown when trying to view the scan status and there is no internet connection.")
+        }
+
+        static let tryAgainButtonText = NSLocalizedString("Try again", comment: "Button label for trying to retrieve the scan status again")
+        static let contactSupportButtonText = NSLocalizedString("Contact support", comment: "Button label for contacting support")
+
     }
 }


### PR DESCRIPTION
Project: #15190
---

### Screenshots

#### General States
| Loading | Scan Failed To Start | Generic Error | No Internet |
|:---:|:---:|:---:|:---:|
|![loading](https://user-images.githubusercontent.com/793774/106057463-05113a80-60be-11eb-99a3-23066b01ec4f.png)|![start error](https://user-images.githubusercontent.com/793774/106057466-05a9d100-60be-11eb-8d7a-dc0a7132a93c.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-01-27 at 16 38 38](https://user-images.githubusercontent.com/793774/106057549-207c4580-60be-11eb-88a7-14e0e3a010e4.png)|![internet](https://user-images.githubusercontent.com/793774/106057459-0478a400-60be-11eb-8cd0-3787e141a4f3.png)|


### To test:
1. Launch the app, tap on the My Site, tap on a site with Jetpack Scan
2. 👁️ The loading status
3. Disable your internet
4. Pull to refresh
5. 👁️ The no internet status
6. Enable internet
7. Tap try again (it may take a minute or so for the connection to reestablish)
8. 👁️ The view loads fine

The start scan error is very hard to reproduce, the only way I've been able to reproduce it is by changing my FTP credentials and triggering a scan. 

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
