### PR TITLE
Get the index from the scanner's string, not the parsed string.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -468,7 +468,7 @@ class AttachmentTagProcessor: HtmlTagProcessor {
             return (parsedString, nil)
         }
 
-        let identifier = textAttachmentIdentifier + tagName + String(scanner.currentIndex.utf16Offset(in: parsedString))
+        let identifier = textAttachmentIdentifier + tagName + String(scanner.currentIndex.utf16Offset(in: scanner.string))
         let attachment = attachmentForHtml(parsedString, identifier: identifier)
 
         return (identifier, attachment)


### PR DESCRIPTION
This PR fixes an out of index issue I spotted while testing a patch for @leandroalonso.  This PR uses the correct string when retrieving an index from the scanner.

To test:
- Test in the reader with comments that contain images and videos. 
- Ensure that the images and videos continue to display correctly. 

Note there is a different, non iOS 13 specific, out of index error addressed by @leandroalonso's patch. 

@leandroalonso would you be game to review after the changes in the other PR are merged to develop?

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
