### PR TITLE
Enhance rotation for collapsable header screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -539,7 +539,7 @@ extension CollapsableHeaderViewController: UIScrollViewDelegate {
     }
 
     private func updateTitleViewVisibility(_ animated: Bool = true) {
-        let shouldHide = (headerHeightConstraint.constant > midHeaderHeight) && !shouldUseCompactLayout
+        let shouldHide = shouldUseCompactLayout ? false : (headerHeightConstraint.isActive || (headerHeightConstraint.constant > midHeaderHeight))
         titleView.animatableSetIsHidden(shouldHide, animated: animated)
     }
 
@@ -549,7 +549,7 @@ extension CollapsableHeaderViewController: UIScrollViewDelegate {
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard stashedOffset == nil else {
+        guard stashedOffset == nil || stashedOffset == CGPoint.zero else {
             restoreContentOffsetIfNeeded(scrollView)
             return
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -238,6 +238,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         }
 
         if let previousTraitCollection = previousTraitCollection, traitCollection.verticalSizeClass != previousTraitCollection.verticalSizeClass {
+            isUserInitiatedScroll = false
             layoutHeaderInsets()
 
             // This helps reset the header changes after a rotation.

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -444,6 +444,9 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     /// order to preserve the header's collpased state we cache the offset and attempt to reapply it if needed.
     private var stashedOffset: CGPoint? = nil
 
+    /// Tracks if the current scroll behavior was intiated by a user drag event
+    private var isUserInitiatedScroll = false
+
     /// A public interface to notify the container that the content size of the scroll view is about to change. This is useful in adjusting the bottom insets to allow the
     /// view to still be scrollable with the content size is less than the total space of the expanded screen.
     public func contentSizeWillChange() {
@@ -539,13 +542,14 @@ extension CollapsableHeaderViewController: UIScrollViewDelegate {
     }
 
     private func updateTitleViewVisibility(_ animated: Bool = true) {
-        let shouldHide = shouldUseCompactLayout ? false : (headerHeightConstraint.isActive || (headerHeightConstraint.constant > midHeaderHeight))
+        let shouldHide = shouldUseCompactLayout ? false : (headerHeightConstraint.constant > midHeaderHeight)
         titleView.animatableSetIsHidden(shouldHide, animated: animated)
     }
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         /// Clear the stashed offset because the user has initiated a change
         stashedOffset = nil
+        isUserInitiatedScroll = true
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -562,12 +566,13 @@ extension CollapsableHeaderViewController: UIScrollViewDelegate {
         }
         disableInitialLayoutHelpers()
         resizeHeaderIfNeeded(scrollView)
-        updateTitleViewVisibility()
+        updateTitleViewVisibility(isUserInitiatedScroll)
         updateSeperatorStyle()
     }
 
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         snapToHeight(scrollView)
+        isUserInitiatedScroll = false
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {

--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
@@ -15,6 +15,9 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
     var selectedIndexPath: IndexPath? = nil
     var siteDesigns: [RemoteSiteDesign] = [] {
         didSet {
+            if oldValue.count == 0 {
+                scrollableView.setContentOffset(.zero, animated: false)
+            }
             contentSizeWillChange()
             collectionView.reloadData()
         }


### PR DESCRIPTION
## Description
Resolves an issue where the scroll position and header doesn't properly resize when rotated after initial load.

## To test:
1. Open either: 
    - Site Creation: Choose your design
    - Site Creation: Choose your domain
    - Page Creation: Starter Page Template Picker
2. _Without scrolling first_ - Rotate the device
3. **Expect** the header to resize to the proper collapsed position. 

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
