### PR TITLE
Notifications: route backup notification to Backups screen

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -8,6 +8,7 @@ protocol ContentCoordinator {
     func displayWebViewWithURL(_ url: URL)
     func displayFullscreenImage(_ image: UIImage)
     func displayPlugin(withSlug pluginSlug: String, on siteSlug: String) throws
+    func displayBackupWithSiteID(_ siteID: NSNumber?) throws
 }
 
 
@@ -57,6 +58,15 @@ struct DefaultContentCoordinator: ContentCoordinator {
         let statsViewController = StatsViewController()
         statsViewController.blog = blog
         controller?.navigationController?.pushViewController(statsViewController, animated: true)
+    }
+
+    func displayBackupWithSiteID(_ siteID: NSNumber?) throws {
+        guard let blog = blogWithBlogID(siteID),
+              let backupListViewController = BackupListViewController(blog: blog) else {
+            throw DisplayError.missingParameter
+        }
+
+        controller?.navigationController?.pushViewController(backupListViewController, animated: true)
     }
 
     func displayFollowersWithSiteID(_ siteID: NSNumber?, expirationTime: TimeInterval) throws {

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
@@ -26,6 +26,17 @@ class BackupListViewController: BaseActivityListViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    @objc convenience init?(blog: Blog) {
+        precondition(blog.dotComID != nil)
+        guard let siteRef = JetpackSiteRef(blog: blog) else {
+            return nil
+        }
+
+
+        let isFreeWPCom = blog.isHostedAtWPcom && !blog.hasPaidPlan
+        self.init(site: siteRef, store: StoreContainer.shared.activity, isFreeWPCom: isFreeWPCom)
+    }
+
     // MARK: - View lifecycle
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
@@ -73,7 +73,14 @@ struct NotificationContentRouter {
         case .comment:
             try coordinator.displayCommentsWithPostId(range.postID, siteID: range.siteID)
         case .stats:
-            try coordinator.displayStatsWithSiteID(range.siteID)
+            /// Backup notifications are configured as "stat" notifications
+            /// For now this is just a workaround to fix the routing
+            if url.absoluteString.matches(regex: "\\/backup\\/").count > 0 &&
+                FeatureFlag.jetpackBackupAndRestore.enabled {
+                try coordinator.displayBackupWithSiteID(range.siteID)
+            } else {
+                try coordinator.displayStatsWithSiteID(range.siteID)
+            }
         case .follow:
             try coordinator.displayFollowersWithSiteID(range.siteID, expirationTime: expirationFiveMinutes)
         case .user:

--- a/WordPress/WordPressTest/MockContentCoordinator.swift
+++ b/WordPress/WordPressTest/MockContentCoordinator.swift
@@ -30,7 +30,7 @@ class MockContentCoordinator: ContentCoordinator {
     }
 
     func displayBackupWithSiteID(_ siteID: NSNumber?) throws {
-        
+
     }
 
     var streamWasDisplayed = false

--- a/WordPress/WordPressTest/MockContentCoordinator.swift
+++ b/WordPress/WordPressTest/MockContentCoordinator.swift
@@ -29,6 +29,10 @@ class MockContentCoordinator: ContentCoordinator {
 
     }
 
+    func displayBackupWithSiteID(_ siteID: NSNumber?) throws {
+        
+    }
+
     var streamWasDisplayed = false
     var streamSiteID: NSNumber?
     func displayStreamWithSiteID(_ siteID: NSNumber?) throws {


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/15191

### Additional information

In order to properly fix that we need to change the notification type returned by the API.

### To test

1. Open the app
2. Go to notifications
3. Open a "Your backup is ready for download" notification (if you don't have any, trigger a backup through Backup option under Jetpack section)
4. Tap on the "site's Backups" link
5. The backups screen should appear

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
