### PR TITLE
Open stats in the app when tapping on Today Widget

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -11,6 +11,11 @@ import AutomatticTracks
             return true
         }
 
+        if UniversalLinkRouter.shared.canHandle(url: url) {
+            UniversalLinkRouter.shared.handle(url: url, shouldTrack: true)
+            return true
+        }
+
         guard url.scheme == WPComScheme else {
             return false
         }

--- a/WordPress/WordPressStatsWidgets/Views/TodayWidgetView.swift
+++ b/WordPress/WordPressStatsWidgets/Views/TodayWidgetView.swift
@@ -44,9 +44,9 @@ struct TodayWidgetView: View {
 
 
 private extension HomeWidgetTodayData {
-    static let statsUrl = "\(WPComScheme)://" + "viewstats?siteId="
+    static let statsUrl = "https://wordpress.com/stats/day/"
 
     var statsURL: URL? {
-        URL(string: Self.statsUrl + "\(siteID)")
+        URL(string: Self.statsUrl + "\(siteID)?source=widget")
     }
 }

--- a/WordPress/WordPressStatsWidgets/Views/TodayWidgetView.swift
+++ b/WordPress/WordPressStatsWidgets/Views/TodayWidgetView.swift
@@ -22,6 +22,7 @@ struct TodayWidgetView: View {
                 TodayWidgetSmallView(content: content,
                                      widgetTitle: LocalizableStrings.widgetTitle,
                                      viewsTitle: LocalizableStrings.viewsTitle)
+                    .widgetURL(content.statsURL)
                     .padding()
 
             case .systemMedium:
@@ -31,11 +32,21 @@ struct TodayWidgetView: View {
                                       visitorsTitle: LocalizableStrings.visitorsTitle,
                                       likesTitle: LocalizableStrings.likesTitle,
                                       commentsTitle: LocalizableStrings.commentsTitle)
+                    .widgetURL(content.statsURL)
                     .padding()
 
             default:
                 Text("View is unavailable")
             }
         }
+    }
+}
+
+
+private extension HomeWidgetTodayData {
+    static let statsUrl = "\(WPComScheme)://" + "viewstats?siteId="
+
+    var statsURL: URL? {
+        URL(string: Self.statsUrl + "\(siteID)")
     }
 }


### PR DESCRIPTION
Fixes an issue that causes tapping on the widget to just open the app, without showing the current stats
Fixes #NA

To test:

- build/run and install the widget
- configure the widget with any site
- tap on the widget and make sure it opens a modal in the app displaying the stats of that same site

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
