### PR TITLE
Comments: fix beyond current run storage crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -31,15 +31,7 @@ class ReaderCommentCell: UITableViewCell {
     @IBOutlet var actionBar: UIStackView!
     @IBOutlet var leadingContentConstraint: NSLayoutConstraint?
 
-    private let textView: WPRichContentView = {
-        let newTextView = WPRichContentView(frame: .zero, textContainer: nil)
-        newTextView.isScrollEnabled = false
-        newTextView.isEditable = false
-        newTextView.translatesAutoresizingMaskIntoConstraints = false
-        newTextView.backgroundColor = .clear
-
-        return newTextView
-    }()
+    private var textView: WPRichContentView!
 
     @objc weak var delegate: ReaderCommentCellDelegate? {
         didSet {
@@ -81,6 +73,7 @@ class ReaderCommentCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        textView = newRichContentView()
         setupContentView()
         applyStyles()
     }
@@ -143,11 +136,15 @@ class ReaderCommentCell: UITableViewCell {
 
     // MARK: - Configuration
 
-
     @objc func configureCell(comment: Comment, attributedString: NSAttributedString) {
+        if comment.commentID == self.comment?.commentID {
+            return
+        }
+
         self.comment = comment
         self.attributedString = attributedString
 
+        resetTextView()
         configureAvatar()
         configureAuthorButton()
         configureTime()
@@ -155,6 +152,17 @@ class ReaderCommentCell: UITableViewCell {
         configureActionBar()
     }
 
+    // Always reset textView instead of reusing it to prevent http://git.io/Jtl2U
+    func resetTextView() {
+        if textView.attributedText != nil {
+            let newTextView = newRichContentView()
+            newTextView.delegate = delegate
+            textView.removeFromSuperview()
+            textView = newTextView
+            textView.textContainerInset = Constants.textViewInsets
+            parentStackView.insertArrangedSubview(textView, at: 1)
+        }
+    }
 
     @objc func configureAvatar() {
         guard let comment = comment else {
@@ -258,6 +266,16 @@ class ReaderCommentCell: UITableViewCell {
         }
 
         return .publicSite
+    }
+
+    private func newRichContentView() -> WPRichContentView {
+        let newTextView = WPRichContentView(frame: .zero, textContainer: nil)
+        newTextView.isScrollEnabled = false
+        newTextView.isEditable = false
+        newTextView.translatesAutoresizingMaskIntoConstraints = false
+        newTextView.backgroundColor = .clear
+
+        return newTextView
     }
 
     // MARK: - Actions

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -137,10 +137,6 @@ class ReaderCommentCell: UITableViewCell {
     // MARK: - Configuration
 
     @objc func configureCell(comment: Comment, attributedString: NSAttributedString) {
-        if comment.commentID == self.comment?.commentID {
-            return
-        }
-
         self.comment = comment
         self.attributedString = attributedString
 


### PR DESCRIPTION
Fixes #11145

### To test

1. Open p7DVsv-amK-p2 in the Reader
2. Tap the comment icon
3. Scroll down to the bottom of the comment list
4. Check that no crashes occur
5. Interact with comments/links/images and check that their behavior is the same as before

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
