### PR TITLE
Enable dot Blog domains for all URL searches

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,8 @@
 16.7
 -----
 * [**] Site Creation: Adds the option to choose between mobile, tablet or desktop thumbnails and previews in the home page design picker when creating a WordPress.com site [https://github.com/wordpress-mobile/WordPress-iOS/pull/15688]
- 
+* [**] Site Creation: Enables dot blog subdomains for each site design. [#15736]
+
 16.6
 -----
 * [**] Activity Log: adds support for Date Range and Activity Type filters. [https://github.com/wordpress-mobile/WordPress-iOS/issues/15192]

--- a/WordPress/Classes/Services/SiteAddressService.swift
+++ b/WordPress/Classes/Services/SiteAddressService.swift
@@ -107,7 +107,7 @@ final class DomainsServiceAdapter: LocalCoreDataService, SiteAddressService {
     func addresses(for query: String, completion: @escaping SiteAddressServiceCompletion) {
         domainsService.getDomainSuggestions(base: query,
                                             quantity: domainRequestQuantity,
-                                            domainSuggestionType: .onlyWordPressDotCom,
+                                            domainSuggestionType: .wordPressDotComAndDotBlogSubdomains,
                                             success: { domainSuggestions in
                                                 completion(Result.success(self.sortSuggestions(for: query, suggestions: domainSuggestions)))
                                             },

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -184,9 +184,15 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
     private func fetchAddresses(_ searchTerm: String) {
         isShowingError = false
         data = []
-        // If the segment ID isn't set (which could happen in the case of the user skipping the site design selection) we'll fall through and search for dotcom only domains.
-        guard let segmentID = siteCreator.segment?.identifier ?? siteCreator.design?.segmentID else {
-            fetchDotComAddresses(searchTerm)
+
+        if FeatureFlag.siteCreationHomePagePicker.enabled {
+            fetchDotComAndDotBlogAddresses(searchTerm)
+            return
+        }
+        // If siteCreationHomePagePicker is disabled we'll continue down this path.
+        // If the segment ID isn't set we'll fall through and search for dotcom and blog domains
+        guard let segmentID = siteCreator.segment?.identifier else {
+            fetchDotComAndDotBlogAddresses(searchTerm)
             return
         }
 
@@ -199,9 +205,7 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
     }
 
     // Fetches Addresss suggestions for dotCom sites without requiring a segment.
-    private func fetchDotComAddresses(_ searchTerm: String) {
-        guard FeatureFlag.siteCreationHomePagePicker.enabled else { return }
-
+    private func fetchDotComAndDotBlogAddresses(_ searchTerm: String) {
         updateIcon(isLoading: true)
         service.addresses(for: searchTerm) { [weak self] results in
             DispatchQueue.main.async {


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-iOS/issues/15553

## To test:
1. Go to My Site > Switch Site > "+" > Create WordPress.com site
2. Tap "SKIP" or select any design. 
3. Type a keyword to search for a site address
4. **Expect** to see `.wordpress.com` and `.blog` subdomains populated.

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
