### PR TITLE
Reader: show 'Followed P2s' tab when first P2 is followed

### DIFF
--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "LocalCoreDataService.h"
+#import "ReaderTopicService.h"
 
 typedef NS_ENUM(NSUInteger, ReaderSiteServiceError) {
     ReaderSiteServiceErrorNotLoggedIn,
@@ -85,5 +86,17 @@ extern NSString * const ReaderSiteServiceErrorDomain;
              asBlocked:(BOOL)blocked
                success:(void(^)(void))success
                failure:(void(^)(NSError *error))failure;
+
+/**
+ Returns a ReaderSiteTopic for the given site URL.
+ 
+ @param siteURL The URL of the site.
+ @param success block called on a successful fetch containing the ReaderSiteTopic.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)topicWithSiteURL:(NSURL *)siteURL
+                 success:(void (^)(ReaderSiteTopic *topic))success
+                 failure:(void(^)(NSError *error))failure;
+
 
 @end

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -4,7 +4,6 @@
 #import "ContextManager.h"
 #import "ReaderPostService.h"
 #import "ReaderPost.h"
-#import "ReaderTopicService.h"
 #import "WPAccount.h"
 #import "WordPress-Swift.h"
 #import "WPAppAnalytics.h"
@@ -201,6 +200,21 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
         if (failure) {
             failure(error);
         }
+    }];
+}
+
+- (void)topicWithSiteURL:(NSURL *)siteURL success:(void (^)(ReaderSiteTopic *topic))success failure:(void(^)(NSError *error))failure
+{
+    WordPressComRestApi *api = [self apiForRequest];
+    ReaderSiteServiceRemote *service = [[ReaderSiteServiceRemote alloc] initWithWordPressComRestApi:api];
+    
+    [service findSiteIDForURL:siteURL success:^(NSUInteger siteID) {
+        ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:self.managedObjectContext];
+        NSNumber *site = [[NSNumber alloc] initWithUnsignedLong:siteID];
+        ReaderSiteTopic *topic = [topicService findSiteTopicWithSiteID:site];
+        success(topic);
+    } failure:^(NSError *error) {
+        failure(error);
     }];
 }
 

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -210,7 +210,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
     
     [service findSiteIDForURL:siteURL success:^(NSUInteger siteID) {
         ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:self.managedObjectContext];
-        NSNumber *site = [[NSNumber alloc] initWithUnsignedLong:siteID];
+        NSNumber *site = [NSNumber numberWithUnsignedLong:siteID];
         ReaderSiteTopic *topic = [topicService findSiteTopicWithSiteID:site];
         success(topic);
     } failure:^(NSError *error) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -248,9 +248,9 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
                                 message: url.host,
                                 feedbackType: .success)
             self?.post(notice)
-
             self?.syncSites()
             self?.refreshPostsForFollowedTopic()
+            self?.postFollowedNotification(siteUrl: url)
 
         }, failure: { [weak self] error in
             DDLogError("Could not follow site: \(String(describing: error))")
@@ -269,6 +269,19 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         })
     }
 
+    private func postFollowedNotification(siteUrl: URL) {
+        let service = ReaderSiteService(managedObjectContext: managedObjectContext())
+        service.topic(withSiteURL: siteUrl, success: { topic in
+            if let topic = topic {
+                NotificationCenter.default.post(name: .ReaderSiteFollowed,
+                                                object: nil,
+                                                userInfo: [ReaderNotificationKeys.topic: topic])
+            }
+        }, failure: { error in
+            DDLogError("Unable to find topic by siteURL: \(String(describing: error?.localizedDescription))")
+        })
+
+    }
 
     @objc func refreshPostsForFollowedTopic() {
         let service = ReaderPostService(managedObjectContext: managedObjectContext())

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -8,6 +8,8 @@ import WordPressFlux
 extension NSNotification.Name {
     // Sent when a site or a tag is unfollowed via Reader Manage screen.
     static let ReaderTopicUnfollowed = NSNotification.Name(rawValue: "ReaderTopicUnfollowed")
+    // Sent when a site is followed via Reader Manage screen.
+    static let ReaderSiteFollowed = NSNotification.Name(rawValue: "ReaderSiteFollowed")
     // Sent when a post's seen state has been toggled.
     static let ReaderPostSeenToggled = NSNotification.Name(rawValue: "ReaderPostSeenToggled")
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -50,6 +50,7 @@ class ReaderTabView: UIView {
         setupViewElements()
 
         NotificationCenter.default.addObserver(self, selector: #selector(topicUnfollowed(_:)), name: .ReaderTopicUnfollowed, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(siteFollowed(_:)), name: .ReaderSiteFollowed, object: nil)
     }
 
     required init?(coder: NSCoder) {
@@ -259,6 +260,18 @@ private extension ReaderTabView {
         if existingFilter.index == tabBar.selectedIndex {
             didTapResetFilterButton()
         }
+
+    }
+
+    @objc func siteFollowed(_ notification: Foundation.Notification) {
+        guard let userInfo = notification.userInfo,
+              let site = userInfo[ReaderNotificationKeys.topic] as? ReaderSiteTopic,
+              site.organizationType == .p2 else {
+            return
+        }
+
+        // Refresh the Reader menu to ensure Followed P2s is displayed.
+        viewModel.fetchReaderMenu()
     }
 
 }


### PR DESCRIPTION
Fixes #n/a
Ref: #15343 

When a user follows their first P2, the `Followed P2s` tab now appears immediately. Previously, it would require an app restart for it to show.

To test:
On an account that is not following any P2s:
- Go to Reader > Manage (the gear icon in the nav bar).
- Enter the URL of a P2 site to follow.
- Close the Manage view.
- Verify the `Followed P2s` tab appears.

Notes:
- If you unfollow all P2s, the menu item is still present. It will be removed on app restart. It got... hinky when I tried to auto-remove it. The empty state works fine, so this should be sufficient for now.
- If you unfollow a P2, the stream is not automatically refreshed. This is the behavior of the other streams, so no change here. Pull to refresh will of course refresh the stream.
- Unfollowing an external site from a reader card or post details doesn't seem to work. I checked the app store version (16.5) and it's broken there as well. I'll look at this separately as it is unrelated to this particular issue.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
