### PR TITLE
Tracks: Adds app scheme to global properties.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -153,6 +153,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     }];
 
     NSMutableDictionary *userProperties = [NSMutableDictionary new];
+    userProperties[@"app_scheme"] = WPComScheme;
     userProperties[@"platform"] = @"iOS";
     userProperties[@"dotcom_user"] = @(dotcom_user);
     userProperties[@"jetpack_user"] = @(jetpackBlogsPresent);


### PR DESCRIPTION
Closes #15719

This PR adds a new global property to tracks events to identify the build type of the app in use.

To test:
Launch the app. 
Check the user properties dictionary that the new field is present. 
Check tracks for new events from your account and confirm the field is present. 

@yaelirub would you be so kind? 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
