### PR TITLE
Register Domain Flow: Fix issue where submit footer view had zero width

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [**] Activity Log: adds support for Date Range and Activity Type filters. [https://github.com/wordpress-mobile/WordPress-iOS/issues/15192]
 * [*] Quick Start: Removed the Browse theme step and added guidance for reviewing pages and editing your Homepage. [#15680]
 * [**] iOS 14 Widgets: new Today Widgets to display your Today Stats in your home screen.
+* [*] Fixes an issue where the submit button was invisible during the domain registration flow.
 
 16.5
 -----

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+HeaderFooter.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+HeaderFooter.swift
@@ -9,9 +9,7 @@ extension RegisterDomainDetailsViewController {
     func configureTableFooterView(width: CGFloat = 0) {
         let width = width > 0 ? width : view.frame.size.width
 
-        var safeAreaInset: CGFloat = 0
-
-        safeAreaInset = tableView.safeAreaInsets.bottom
+        let safeAreaInset: CGFloat = tableView.safeAreaInsets.bottom
 
         //Creating a UIView with a custom frame because table tableFooterView doesn't support autolayout
         let footer = UIView(frame: CGRect(x: 0,
@@ -20,12 +18,13 @@ extension RegisterDomainDetailsViewController {
                                           height: Constants.buttonContainerHeight + safeAreaInset))
         footerView.frame = footer.frame
         footer.addSubview(footerView)
-        footer.addConstraints([
+
+        NSLayoutConstraint.activate([
             footer.topAnchor.constraint(equalTo: footerView.topAnchor),
-            footer.rightAnchor.constraint(equalTo: footerView.rightAnchor),
             footer.bottomAnchor.constraint(equalTo: footerView.bottomAnchor),
-            footer.leftAnchor.constraint(equalTo: footerView.leftAnchor),
-            ])
+            footer.leadingAnchor.constraint(equalTo: footerView.leadingAnchor),
+            footer.trailingAnchor.constraint(equalTo: footerView.trailingAnchor),
+        ])
         tableView.tableFooterView = footer
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -22,6 +22,7 @@ class RegisterDomainDetailsViewController: UITableViewController {
 
     private(set) lazy var footerView: RegisterDomainDetailsFooterView = {
         let buttonView = RegisterDomainDetailsFooterView.loadFromNib()
+        buttonView.translatesAutoresizingMaskIntoConstraints = false
 
         buttonView.submitButton.isEnabled = false
         buttonView.submitButton.addTarget(
@@ -64,10 +65,6 @@ class RegisterDomainDetailsViewController: UITableViewController {
         viewModel.prefill()
 
         setupEditingEndingTapGestureRecognizer()
-    }
-
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        configureTableFooterView(width: size.width)
     }
 
     private func configureTableView() {


### PR DESCRIPTION
This PR fixes an issue where the submit button in the RegisterDomainViewController footerView had a zero width, making it invisible. This prevented the user from continuing the registration flow.

**To test**

- Build and run
- Access a site where you have a paid plan that includes a domain name, but the name hasn't been claimed
- You should see the 'register domain' row at the top of My Site:

<img width="255" alt="CleanShot 2021-01-31 at 19 49 36@2x" src="https://user-images.githubusercontent.com/4780/106396038-7d009d00-63fd-11eb-8ab5-61e249ddce0b.png">

- Tap this button, and choose a domain from the list
- Scroll to the bottom of the registration details screen, and ensure that you can see the footer. Check that it remains the correct size if you rotate the device or resize the app.

<img width="325" src="https://user-images.githubusercontent.com/4780/106396063-99043e80-63fd-11eb-853a-cafe29002ae7.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
