### PR TITLE
Reader: Enable `unseenPosts` feature.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,8 @@
 * [**] Site Creation: Adds the option to choose between mobile, tablet or desktop thumbnails and previews in the home page design picker when creating a WordPress.com site [https://github.com/wordpress-mobile/WordPress-iOS/pull/15688]
 * [*] Block Editor: Fix issue with uploading media after exiting the editor multiple times [https://github.com/wordpress-mobile/WordPress-iOS/pull/15656].
 * [**] Site Creation: Enables dot blog subdomains for each site design. [#15736]
+* [**] Reader post card and post details: added ability to mark a followed post as seen/unseen. [#15638, #15645, #15676]
+* [**] Reader site filter: show unseen post count. [#15581]
 
 16.6
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -63,7 +63,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .todayWidget:
             return true
         case .unseenPosts:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         }
     }
 


### PR DESCRIPTION
Fixes #15355 , Ref #15483

This enables the ability to mark a post as seen/unseen, and display the unseen post count in the Reader site filters.

To test:

---
Mark a post as seen/unseen:
- In the Reader, tap the options menu button on a card.
  - Verify `Mark as seen` / `Mark as unseen` is in the menu.
- Tap the card to show post details.
- Tap the options menu button.
  - Verify `Mark as seen` / `Mark as unseen` is in the menu.

| ![post_card](https://user-images.githubusercontent.com/1816888/105554167-07d9ed00-5cc4-11eb-9400-7ad63f28de8d.jpg) | ![post_details](https://user-images.githubusercontent.com/1816888/105554254-2fc95080-5cc4-11eb-908d-35cd05092f9c.jpg) |
|--------|-------|

---
Unseen count:
- Go to any filterable Reader stream.
- Tap `Filter`.
- Verify the count is displayed for each site that has unseen posts.

<kbd>![unseen_count](https://user-images.githubusercontent.com/1816888/105553442-9c435000-5cc2-11eb-84dc-0c48de5d1b8c.png)</kbd>

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
