### PR TITLE
Dynamically identify Discover and P2 Reader tabs

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -270,15 +270,14 @@ private extension ReaderTabView {
     @objc func siteFollowed(_ notification: Foundation.Notification) {
         guard let userInfo = notification.userInfo,
               let site = userInfo[ReaderNotificationKeys.topic] as? ReaderSiteTopic,
-              site.organizationType == .p2 else {
+              site.organizationType == .p2,
+              p2Index == nil else {
             return
         }
 
-        // If a P2 has been followed but the P2 tab isn't in the Reader tab bar,
+        // If a P2 is followed but the P2 tab is not in the Reader tab bar,
         // refresh the Reader menu to display it.
-        if p2Index == nil {
-            viewModel.fetchReaderMenu()
-        }
+        viewModel.fetchReaderMenu()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -274,8 +274,11 @@ private extension ReaderTabView {
             return
         }
 
-        // Refresh the Reader menu to ensure Followed P2s is displayed.
-        viewModel.fetchReaderMenu()
+        // If a P2 has been followed but the P2 tab isn't in the Reader tab bar,
+        // refresh the Reader menu to display it.
+        if p2Index == nil {
+            viewModel.fetchReaderMenu()
+        }
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -18,7 +18,9 @@ class ReaderTabView: UIView {
     private var previouslySelectedIndex: Int = 0
 
     private var discoverIndex: Int? {
-        return tabBar.items.firstIndex(where: { $0.title == NSLocalizedString("Discover", comment: "Discover tab name") })
+        return tabBar.items.firstIndex(where: { ($0 as? ReaderTabItem)?.content.topicType == .discover })
+    }
+
     }
 
     init(viewModel: ReaderTabViewModel) {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -21,6 +21,8 @@ class ReaderTabView: UIView {
         return tabBar.items.firstIndex(where: { ($0 as? ReaderTabItem)?.content.topicType == .discover })
     }
 
+    private var p2Index: Int? {
+        return tabBar.items.firstIndex(where: { (($0 as? ReaderTabItem)?.content.topic as? ReaderTeamTopic)?.organizationID == SiteOrganizationType.p2.rawValue })
     }
 
     init(viewModel: ReaderTabViewModel) {


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/15668, https://github.com/wordpress-mobile/WordPress-iOS/pull/15737

This adds properties to dynamically find the tab index for 'Discover' and 'Followed P2s'.

To test:

---
Discover:
There should be no functional change. Please follow the testing steps on https://github.com/wordpress-mobile/WordPress-iOS/pull/15668 to verify.

---
Followed P2s:
The Reader tab bar is now only refreshed when a P2 is followed and the P2 tab is not already displayed. Previously (https://github.com/wordpress-mobile/WordPress-iOS/pull/15737), it was refreshed every time a P2 was followed regardless.

On an account that is not following any P2s:
- Go to Reader > Manage (the gear icon in the nav bar).
- Enter the URL of a P2 site to follow.
- Close the Manage view.
  - Verify the `Followed P2s` tab appears.
- Follow another P2 site.
  - Verify the menu is not reloaded. 
  - Tip: you may want to add a breakpoint in `ReaderTabView:siteFollowed` where it [calls](https://github.com/wordpress-mobile/WordPress-iOS/blob/29c3f9bd4b6dc0847a0056fb5bd12ffbc523596f/WordPress/Classes/ViewRelated/Reader/Tab%20Navigation/ReaderTabView.swift#L280) `viewModel.fetchReaderMenu()` to make sure it is not called.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
