### PR TITLE
Add device modes for View Site previews

### DIFF
--- a/WordPress/Classes/Utility/WebViewControllerFactory.swift
+++ b/WordPress/Classes/Utility/WebViewControllerFactory.swift
@@ -21,10 +21,10 @@ class WebViewControllerFactory: NSObject {
         return controller(configuration: configuration)
     }
 
-    @objc static func controller(url: URL, blog: Blog) -> UIViewController {
+    @objc static func controller(url: URL, blog: Blog, withDeviceModes: Bool = false) -> UIViewController {
         let configuration = WebViewControllerConfiguration(url: url)
         configuration.authenticate(blog: blog)
-        return controller(configuration: configuration)
+        return withDeviceModes ? PreviewWebKitViewController(configuration: configuration) : controller(configuration: configuration)
     }
 
     @objc static func controller(url: URL, account: WPAccount) -> UIViewController {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1717,7 +1717,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedViewSite withBlog:self.blog];
     NSURL *targetURL = [NSURL URLWithString:self.blog.homeURL];
 
-    UIViewController *webViewController = [WebViewControllerFactory controllerWithUrl:targetURL blog:self.blog];
+    UIViewController *webViewController = [WebViewControllerFactory controllerWithUrl:targetURL blog:self.blog withDeviceModes:true];
     LightNavigationController *navController = [[LightNavigationController alloc] initWithRootViewController:webViewController];
     if (self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
         navController.modalPresentationStyle = UIModalPresentationFullScreen;

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -4,7 +4,7 @@ import WebKit
 /// An augmentation of WebKitViewController to provide Previewing for different devices
 class PreviewWebKitViewController: WebKitViewController {
 
-    let post: AbstractPost
+    let post: AbstractPost?
 
     private let canPublish: Bool
 
@@ -75,6 +75,8 @@ class PreviewWebKitViewController: WebKitViewController {
     }
 
     func trackOpenEvent() {
+        guard let post = post else { return }
+
         let eventProperties: [String: Any] = [
             "post_type": post.analyticsPostType ?? "unsupported",
             "blog_type": post.blog.analyticsType.rawValue
@@ -162,7 +164,7 @@ class PreviewWebKitViewController: WebKitViewController {
 
         alertController.addCancelActionWithTitle(cancelTitle)
         alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
-            PostCoordinator.shared.publish(self.post)
+            PostCoordinator.shared.publish(self.post!)
 
             if let editorVC = (self.presentingViewController?.presentingViewController as? EditPostViewController) {
                 editorVC.closeEditor(true, showPostEpilogue: false, from: self)

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -122,7 +122,9 @@ class PreviewWebKitViewController: WebKitViewController {
                 space,
                 shareButton,
                 space,
-                safariButton
+                safariButton,
+                space,
+                previewButton
             ]
         case .hostOnly:
             if canPublish {

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -172,7 +172,8 @@ class PreviewWebKitViewController: WebKitViewController {
 
         alertController.addCancelActionWithTitle(cancelTitle)
         alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
-            PostCoordinator.shared.publish(self.post!)
+            guard let post = self.post else { return }
+            PostCoordinator.shared.publish(post)
 
             if let editorVC = (self.presentingViewController?.presentingViewController as? EditPostViewController) {
                 editorVC.closeEditor(true, showPostEpilogue: false, from: self)

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -70,6 +70,12 @@ class PreviewWebKitViewController: WebKitViewController {
         super.init(configuration: configuration)
     }
 
+    @objc override init(configuration: WebViewControllerConfiguration) {
+        post = nil
+        canPublish = false
+        super.init(configuration: configuration)
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/PreviewWebKitViewControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/PreviewWebKitViewControllerTests.swift
@@ -74,4 +74,16 @@ class PreviewWebKitViewControllerTests: XCTestCase {
         XCTAssertTrue(items.contains(vc.forwardButton), "Preview toolbar for page should contain forward button.")
         XCTAssertTrue(items.contains(vc.previewButton), "Preview toolbar for page should contain preview button.")
     }
+
+    func testToolbarItemsWithDefaultConfiguration() {
+        let config = WebViewControllerConfiguration(url: URL(string: "https://example.com"))
+        let vc = PreviewWebKitViewController(configuration: config)
+        let items = vc.toolbarItems(linkBehavior: vc.linkBehavior)
+
+        XCTAssertFalse(items.contains(vc.publishButton), "Preview toolbar for page should not contain publish button.")
+        XCTAssertTrue(items.contains(vc.safariButton), "Preview toolbar for page should contain Safari button.")
+        XCTAssertTrue(items.contains(vc.backButton), "Preview toolbar for page should contain back button.")
+        XCTAssertTrue(items.contains(vc.forwardButton), "Preview toolbar for page should contain forward button.")
+        XCTAssertTrue(items.contains(vc.previewButton), "Preview toolbar for page should contain preview button.")
+    }
 }


### PR DESCRIPTION
### Description

This PR adds device modes to the View Site preview screen.

I utilized the existing `PreviewWebKitViewController`, which subclasses `WebKitViewController`. I also added an optional boolean (default false) to the factory method of the parent class. Since the site preview isn't associated with a particular `post`, it was necessary to make that optional in the subclass.

I''ve added a button for the device modes here: https://github.com/wordpress-mobile/WordPress-iOS/pull/15758/files#diff-8515b18aa430fd6d7e25e540843b387c5b0ef97acdaedf383c39e7b653c235d9R125-R127, but I'm not sure whether I've tested all cases for when `linkBehavior == .all`. @bjtitus :wave: :smile: , do you know whether there are cases where this subclass is being used where the setting is left unimplemented? . Fwiw, when I tried making `post` private, I noticed a build failure from a required visibility in `SearchManager`, so I tried a viewing a few posts from the post list search screen, and everything I tried seems to work as expected.

Ideally, we could enable the device modes everywhere we use these webviews for previews, for consistency, so please feel free to let me know if I've missed a case. On a related note, I'd considered moving the device modes to the parent class, but I think it makes sense to defer to a later PR, as I'd want to have a more comprehensive understanding of the impact before introducing it there (there may be some cases / paths where the feature does not make sense, for example). Wdyt?

To test:

* On the My Site screen, scoll to the bottom and under "External" tap "View Site"
* When the preview opens, expect a device modes button to appear in the lower right corner
* Tap the device modes button (the currently selected device should reflect the default for the device you are on (i.e. mobile or tablet)
* Tap a different device mode (e.g. desktop)
* Expect the preview to reload with the selected device mode's viewport size

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
