### PR TITLE
Fix a scenario where quick start prompts when marking a step as complete

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -103,7 +103,7 @@ extension BlogDetailsViewController {
     }
 
     @objc func cancelCompletedToursIfNeeded() {
-        if blog.homepagePageID == nil {
+        if shouldShowQuickStartChecklist() && blog.homepagePageID == nil {
             // Ends the tour Edit Homepage if the site doesn't have a homepage set or uses the blog.
             QuickStartTourGuide.shared.complete(tour: QuickStartEditHomepageTour(), for: blog, postNotification: false)
         }


### PR DESCRIPTION
### Description
Fixes an issue introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/15724 where the quick start menu will pop-up while trying to update completed steps. 

The change here will only attempt to update the quick start steps if the menu option to display quick start is being displayed. This will prevent the unintentional activation of the quick start menu.

### To test:
Using a site that is set with the HomePage to a Classic Blog:
1. Navigate to My Site Page
2. **Expect** the Homepage to not present. 

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
