### PR TITLE
Update Tracks to 0.8.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -182,7 +182,7 @@ target 'WordPress' do
 
     # Production
 
-    pod 'Automattic-Tracks-iOS', '~> 0.7.0'
+    pod 'Automattic-Tracks-iOS', '~> 0.8.0'
     # While in PR
     # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => ''
     # Local Development

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,10 +21,10 @@ PODS:
     - AppCenter/Core
   - AppCenter/Distribute (2.5.1):
     - AppCenter/Core
-  - Automattic-Tracks-iOS (0.7.1):
+  - Automattic-Tracks-iOS (0.8.1):
     - CocoaLumberjack (~> 3)
     - Reachability (~> 3)
-    - Sentry (~> 4)
+    - Sentry (~> 6)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 1)
   - boost-for-react-native (1.63.0)
@@ -384,9 +384,9 @@ PODS:
   - RNTAztecView (1.45.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.3)
-  - Sentry (4.5.0):
-    - Sentry/Core (= 4.5.0)
-  - Sentry/Core (4.5.0)
+  - Sentry (6.1.4):
+    - Sentry/Core (= 6.1.4)
+  - Sentry/Core (6.1.4)
   - Sodium (0.9.1)
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
@@ -443,7 +443,7 @@ DEPENDENCIES:
   - AMScrollingNavbar (= 5.6.0)
   - AppCenter (= 2.5.1)
   - AppCenter/Distribute (= 2.5.1)
-  - Automattic-Tracks-iOS (~> 0.7.0)
+  - Automattic-Tracks-iOS (~> 0.8.0)
   - Charts (~> 3.2.2)
   - CocoaLumberjack (~> 3.0)
   - CropViewController (= 2.5.3)
@@ -678,7 +678,7 @@ SPEC CHECKSUMS:
   AMScrollingNavbar: cf0ec5a5ee659d76ba2509f630bf14fba7e16dc3
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   AppCenter: fddcbac6e4baae3d93a196ceb0bfe0e4ce407dec
-  Automattic-Tracks-iOS: fe148d48abc7125f5cb389ba7f6595f3ffec1a46
+  Automattic-Tracks-iOS: b942ca6067f089660c75c96fd189599fd065f979
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
   CocoaLumberjack: e8955b9d337ac307103b0a34fd141c32f27e53c5
@@ -741,7 +741,7 @@ SPEC CHECKSUMS:
   RNScreens: 6833ac5c29cf2f03eed12103140530bbd75b6aea
   RNSVG: 68a534a5db06dcbdaebfd5079349191598caef7b
   RNTAztecView: 0f33f2895c7a6cb54f364ae5aa1917bcd7b24e57
-  Sentry: ab6c209f23700d1460691dbc90e19ed0a05d496b
+  Sentry: 9d055e2de30a77685e86b219acf02e59b82091fc
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
@@ -765,6 +765,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: aceaecff075beee85fa463cb7f39ab112f52e2e0
+PODFILE CHECKSUM: 51fad485974e8f9c2651378787ada36aefe69cb2
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -92,7 +92,7 @@ extension UIImageView {
                 if case .requestCancelled = (error as? AFIError) {
                     // Do not log intentionally cancelled requests as errors.
                 } else {
-                    CrashLogging.logError(error)
+                    WordPressAppDelegate.crashLogging?.logError(error)
                 }
             }
         })
@@ -122,7 +122,7 @@ extension UIImageView {
 
         let host = MediaHost(with: blog) { error in
             // We'll log the error, so we know it's there, but we won't halt execution.
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
         }
 
         let mediaRequestAuthenticator = MediaRequestAuthenticator()
@@ -132,7 +132,7 @@ extension UIImageView {
             onComplete: { [weak self] request in
                 self?.downloadSiteIcon(with: request, placeholderImage: placeholderImage)
         }) { error in
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
         }
     }
 }

--- a/WordPress/Classes/Extensions/WKWebView+UserAgent.swift
+++ b/WordPress/Classes/Extensions/WKWebView+UserAgent.swift
@@ -13,7 +13,7 @@ extension WKWebView {
     func userAgent() -> String {
         guard let userAgent = value(forKey: WKWebView.userAgentKey) as? String,
             userAgent.count > 0 else {
-                CrashLogging.logMessage(
+                WordPressAppDelegate.crashLogging?.logMessage(
                     "This method for retrieveing the user agent seems to be no longer working.  We need to figure out an alternative.",
                     properties: [:],
                     level: .error)

--- a/WordPress/Classes/Models/UserSettings.swift
+++ b/WordPress/Classes/Models/UserSettings.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+class UserSettings {
+
+    @objc
+    @UserDefault("crashlytics_opt_out", defaultValue: false)
+    static var userHasOptedOutOfCrashLogging: Bool
+
+    @objc
+    @UserDefault("force-crash-logging", defaultValue: false)
+    static var userHasForcedCrashLoggingEnabled: Bool
+}
+
+/// A property wrapper for UserDefaults access
+@propertyWrapper
+struct UserDefault<T> {
+    let key: String
+    let defaultValue: T
+
+    init(_ key: String, defaultValue: T) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+
+    var wrappedValue: T {
+        get {
+            return UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: key)
+        }
+    }
+}

--- a/WordPress/Classes/Services/AtomicAuthenticationService.swift
+++ b/WordPress/Classes/Services/AtomicAuthenticationService.swift
@@ -48,7 +48,7 @@ class AtomicAuthenticationService {
                     }
                 }) { error in
                     // Make sure this error scenario isn't silently ignored.
-                    CrashLogging.logError(error)
+                    WordPressAppDelegate.crashLogging?.logError(error)
 
                     // Even if getting the auth cookies fail, we'll still try to load the URL
                     // so that the user sees a reasonable error situation on screen.

--- a/WordPress/Classes/Services/AuthenticationService.swift
+++ b/WordPress/Classes/Services/AuthenticationService.swift
@@ -42,7 +42,7 @@ class AuthenticationService {
                     }
                 }) { error in
                     // Make sure this error scenario isn't silently ignored.
-                    CrashLogging.logError(error)
+                    WordPressAppDelegate.crashLogging?.logError(error)
 
                     // Even if getting the auth cookies fail, we'll still try to load the URL
                     // so that the user sees a reasonable error situation on screen.
@@ -107,7 +107,7 @@ class AuthenticationService {
                     }
                 }) { error in
                     // Make sure this error scenario isn't silently ignored.
-                    CrashLogging.logError(error)
+                    WordPressAppDelegate.crashLogging?.logError(error)
 
                     // Even if getting the auth cookies fail, we'll still try to load the URL
                     // so that the user sees a reasonable error situation on screen.

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -715,7 +715,7 @@ extension MediaCoordinator {
             }
 
             self.cancelUploadAndDeleteMedia(media)
-            CrashLogging.logError(mediaError,
+            WordPressAppDelegate.crashLogging?.logError(mediaError,
                                   userInfo: ["description": "Deleting a media object that's failed to upload because of a missing local file."])
 
         }, for: nil)

--- a/WordPress/Classes/Services/SiteVerticalsService.swift
+++ b/WordPress/Classes/Services/SiteVerticalsService.swift
@@ -82,7 +82,7 @@ final class SiteCreationVerticalsService: LocalCoreDataService, SiteVerticalsSer
             switch result {
             case .success(let verticals):
                 guard let vertical = verticals.first else {
-                    CrashLogging.logMessage("The verticals service should always return at least 1 match for the precise term queried.", level: .error)
+                    WordPressAppDelegate.crashLogging?.logMessage("The verticals service should always return at least 1 match for the precise term queried.", level: .error)
                     completion(.failure(.serviceFailure))
                     return
                 }

--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -116,7 +116,7 @@ import AutomatticTracks
         }
 
         if debugKey == ApiCredentials.debuggingKey(), debugType == "force_crash" {
-            CrashLogging.crash()
+            WordPressAppDelegate.crashLogging?.crash()
         }
 
         return true

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -28,9 +28,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     }()
 
     var analytics: WPAppAnalytics?
-    private lazy var crashLoggingProvider: WPCrashLoggingProvider = {
-        return WPCrashLoggingProvider()
-    }()
 
     @objc var internetReachability: Reachability?
     @objc var connectionAvailable: Bool = true
@@ -67,6 +64,18 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         return UploadsManager(uploaders: uploaders)
     }()
 
+    private let loggingStack = WPLoggingStack()
+
+    /// Access the crash logging type
+    class var crashLogging: CrashLogging? {
+        shared?.loggingStack.crashLogging
+    }
+
+    /// Access the event logging type
+    class var eventLogging: EventLogging? {
+        shared?.loggingStack.eventLogging
+    }
+
     @objc class var shared: WordPressAppDelegate? {
         return UIApplication.shared.delegate as? WordPressAppDelegate
     }
@@ -82,9 +91,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         // Start CrashLogging as soon as possible (in case a crash happens during startup)
-        let dataSource = EventLoggingDataProvider.fromDDFileLogger(WPLogger.shared().fileLogger)
-        let eventLogging = EventLogging(dataSource: dataSource, delegate: crashLoggingProvider.loggingUploadDelegate)
-        CrashLogging.start(withDataProvider: crashLoggingProvider, eventLogging: eventLogging)
+        try? loggingStack.start()
 
         // Configure WPCom API overrides
         configureWordPressComApi()

--- a/WordPress/Classes/Utility/Logging/EventLoggingDelegate.swift
+++ b/WordPress/Classes/Utility/Logging/EventLoggingDelegate.swift
@@ -6,7 +6,7 @@ struct EventLoggingDelegate: AutomatticTracks.EventLoggingDelegate {
     var shouldUploadLogFiles: Bool {
         return
             !ProcessInfo.processInfo.isLowPowerModeEnabled
-            && !WPCrashLoggingProvider.userHasOptedOut
+            && !UserSettings.userHasOptedOutOfCrashLogging
     }
 
     func didQueueLogForUpload(_ log: LogFile) {

--- a/WordPress/Classes/Utility/Logging/EventLoggingDelegate.swift
+++ b/WordPress/Classes/Utility/Logging/EventLoggingDelegate.swift
@@ -10,29 +10,29 @@ struct EventLoggingDelegate: AutomatticTracks.EventLoggingDelegate {
     }
 
     func didQueueLogForUpload(_ log: LogFile) {
-        NotificationCenter.default.post(name: WPCrashLoggingProvider.QueuedLogsDidChangeNotification, object: log)
+        NotificationCenter.default.post(name: WPLoggingStack.QueuedLogsDidChangeNotification, object: log)
         DDLogDebug("📜 Added log to queue: \(log.uuid)")
 
-        if let eventLogging = CrashLogging.eventLogging {
+        if let eventLogging = WordPressAppDelegate.eventLogging {
             DDLogDebug("📜\t There are \(eventLogging.queuedLogFiles.count) logs in the queue.")
         }
     }
 
     func didStartUploadingLog(_ log: LogFile) {
-        NotificationCenter.default.post(name: WPCrashLoggingProvider.QueuedLogsDidChangeNotification, object: log)
+        NotificationCenter.default.post(name: WPLoggingStack.QueuedLogsDidChangeNotification, object: log)
         DDLogDebug("📜 Started uploading encrypted log: \(log.uuid)")
     }
 
     func didFinishUploadingLog(_ log: LogFile) {
-        NotificationCenter.default.post(name: WPCrashLoggingProvider.QueuedLogsDidChangeNotification, object: log)
+        NotificationCenter.default.post(name: WPLoggingStack.QueuedLogsDidChangeNotification, object: log)
         DDLogDebug("📜 Finished uploading encrypted log: \(log.uuid)")
-        if let eventLogging = CrashLogging.eventLogging {
+        if let eventLogging = WordPressAppDelegate.eventLogging {
             DDLogDebug("📜\t There are \(eventLogging.queuedLogFiles.count) logs remaining in the queue.")
         }
     }
 
     func uploadFailed(withError error: Error, forLog log: LogFile) {
-        NotificationCenter.default.post(name: WPCrashLoggingProvider.QueuedLogsDidChangeNotification, object: log)
+        NotificationCenter.default.post(name: WPLoggingStack.QueuedLogsDidChangeNotification, object: log)
         DDLogError("📜 Error uploading encrypted log: \(log.uuid)")
         DDLogError("📜\t\(error.localizedDescription)")
 

--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -1,31 +1,49 @@
 import UIKit
 import AutomatticTracks
 
-fileprivate let UserOptedOutKey = "crashlytics_opt_out"
-
-class WPCrashLoggingProvider: CrashLoggingDataProvider {
+/// A wrapper around the logging stack – provides shared initialization and configuration for Tracks Crash and Event Logging
+struct WPLoggingStack {
 
     static let QueuedLogsDidChangeNotification = NSNotification.Name("WPCrashLoggingQueueDidChange")
 
+    let crashLogging: CrashLogging
+    let eventLogging: EventLogging
+
+    private let eventLoggingDataProvider = EventLoggingDataProvider.fromDDFileLogger(WPLogger.shared().fileLogger)
+    private let eventLoggingDelegate = EventLoggingDelegate()
+
     init() {
+
+        let eventLogging = EventLogging(dataSource: eventLoggingDataProvider, delegate: eventLoggingDelegate)
+
+        self.eventLogging = eventLogging
+        self.crashLogging = CrashLogging(dataProvider: WPCrashLoggingDataProvider(), eventLogging: eventLogging)
+
         /// Upload any remaining files any time the app becomes active
         let willEnterForeground = UIApplication.willEnterForegroundNotification
-        NotificationCenter.default.addObserver(forName: willEnterForeground, object: nil, queue: nil) { note in
-            CrashLogging.eventLogging?.uploadNextLogFileIfNeeded()
-            DDLogDebug("📜 Resumed encrypted log upload queue due to app entering foreground")
-        }
+        NotificationCenter.default.addObserver(forName: willEnterForeground, object: nil, queue: nil, using: self.willEnterForeground)
     }
 
-    var sentryDSN: String = ApiCredentials.sentryDSN()
+    func start() throws {
+        _ = try crashLogging.start()
+    }
 
-    var buildType: String = BuildConfiguration.current.rawValue
+    private func willEnterForeground(note: Foundation.Notification) {
+        self.eventLogging.uploadNextLogFileIfNeeded()
+        DDLogDebug("📜 Resumed encrypted log upload queue due to app entering foreground")
+    }
+}
+
+struct WPCrashLoggingDataProvider: CrashLoggingDataProvider {
+    let sentryDSN: String = ApiCredentials.sentryDSN()
 
     var userHasOptedOut: Bool {
         WPCrashLoggingProvider.userHasOptedOut
     }
 
-    var currentUser: TracksUser? {
+    var buildType: String = BuildConfiguration.current.rawValue
 
+    var currentUser: TracksUser? {
         let context = ContextManager.sharedInstance().mainContext
         let service = AccountService(managedObjectContext: context)
         guard let account = service.defaultWordPressComAccount() else {
@@ -33,20 +51,5 @@ class WPCrashLoggingProvider: CrashLoggingDataProvider {
         }
 
         return TracksUser(userID: account.userID.stringValue, email: account.email, username: account.username)
-    }
-
-    var loggingUploadDelegate = EventLoggingDelegate()
-}
-
-// MARK: - Static Property
-extension WPCrashLoggingProvider {
-
-    static var userHasOptedOut: Bool {
-        get {
-            return UserDefaults.standard.bool(forKey: UserOptedOutKey)
-        }
-        set {
-            UserDefaults.standard.set(newValue, forKey: UserOptedOutKey)
-        }
     }
 }

--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -38,7 +38,7 @@ struct WPCrashLoggingDataProvider: CrashLoggingDataProvider {
     let sentryDSN: String = ApiCredentials.sentryDSN()
 
     var userHasOptedOut: Bool {
-        WPCrashLoggingProvider.userHasOptedOut
+        return UserSettings.userHasOptedOutOfCrashLogging
     }
 
     var buildType: String = BuildConfiguration.current.rawValue

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -107,7 +107,7 @@ import AutomatticTracks
     func loadImage(with url: URL, from post: AbstractPost, preferredSize size: CGSize = .zero, placeholder: UIImage?, success: ImageLoaderSuccessBlock?, error: ImageLoaderFailureBlock?) {
 
         let host = MediaHost(with: post, failure: { error in
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
         })
 
         loadImage(with: url, from: host, preferredSize: size, placeholder: placeholder, success: success, error: error)
@@ -117,7 +117,7 @@ import AutomatticTracks
     func loadImage(with url: URL, from readerPost: ReaderPost, preferredSize size: CGSize = .zero, placeholder: UIImage?, success: ImageLoaderSuccessBlock?, error: ImageLoaderFailureBlock?) {
 
         let host = MediaHost(with: readerPost, failure: { error in
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
         })
 
         loadImage(with: url, from: host, preferredSize: size, placeholder: placeholder, success: success, error: error)
@@ -154,7 +154,7 @@ import AutomatticTracks
                 self.downloadGif(from: request)
         },
             onFailure: { error in
-                CrashLogging.logError(error)
+                WordPressAppDelegate.crashLogging?.logError(error)
                 self.callErrorHandler(with: error)
         })
     }
@@ -180,7 +180,7 @@ import AutomatticTracks
         mediaRequestAuthenticator.authenticatedRequest(for: finalURL, from: host, onComplete: { request in
             self.downloadImage(from: request)
         }) { error in
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
             self.callErrorHandler(with: error)
         }
     }
@@ -359,7 +359,7 @@ extension ImageLoader {
         if url.isGif {
             let host = MediaHost(with: media.blog) { error in
                 // We'll log the error, so we know it's there, but we won't halt execution.
-                CrashLogging.logError(error)
+                WordPressAppDelegate.crashLogging?.logError(error)
             }
 
             loadGif(with: url, from: host, preferredSize: size)

--- a/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
+++ b/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
@@ -155,7 +155,7 @@ class RequestAuthenticator: NSObject {
             done()
         }) { error in
             // Make sure this error scenario isn't silently ignored.
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
 
             // Even if getting the auth cookies fail, we'll still try to load the URL
             // so that the user sees a reasonable error situation on screen.
@@ -176,7 +176,7 @@ class RequestAuthenticator: NSObject {
         // a context at all...
         guard let account = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext).defaultWordPressComAccount() else {
 
-            CrashLogging.logMessage("It shouldn't be possible to reach this point without an account.", properties: nil, level: .error)
+            WordPressAppDelegate.crashLogging?.logMessage("It shouldn't be possible to reach this point without an account.", properties: nil, level: .error)
             return
         }
         let authenticationService = AtomicAuthenticationService(account: account)
@@ -185,7 +185,7 @@ class RequestAuthenticator: NSObject {
             done()
         }) { error in
             // Make sure this error scenario isn't silently ignored.
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
 
             // Even if getting the auth cookies fail, we'll still try to load the URL
             // so that the user sees a reasonable error situation on screen.
@@ -215,7 +215,7 @@ class RequestAuthenticator: NSObject {
             done()
         }) { error in
             // Make sure this error scenario isn't silently ignored.
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
 
             // Even if getting the auth cookies fail, we'll still try to load the URL
             // so that the user sees a reasonable error situation on screen.
@@ -261,7 +261,7 @@ class RequestAuthenticator: NSObject {
             done()
         }) { error in
             // Make sure this error scenario isn't silently ignored.
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
 
             // Even if getting the auth cookies fail, we'll still try to load the URL
             // so that the user sees a reasonable error situation on screen.
@@ -282,7 +282,7 @@ class RequestAuthenticator: NSObject {
             done()
         }) { error in
             // Make sure this error scenario isn't silently ignored.
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
 
             // Even if getting the auth cookies fail, we'll still try to load the URL
             // so that the user sees a reasonable error situation on screen.

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -627,7 +627,7 @@ private extension ZendeskUtils {
             let delegate = EventLoggingDelegate()
 
             /// Some users may be opted out – let's inform support that this is the case (otherwise the UUID just wouldn't work)
-            if WPCrashLoggingProvider.userHasOptedOut {
+            if UserSettings.userHasOptedOutOfCrashLogging {
                 return "No log file uploaded: User opted out"
             }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1108,7 +1108,7 @@ extension AztecPostViewController {
         guard let action = self.postEditorStateContext.secondaryPublishButtonAction else {
             // If the user tapped on the secondary publish action button, it means we should have a secondary publish action.
             let error = NSError(domain: errorDomain, code: ErrorCode.expectedSecondaryAction.rawValue, userInfo: nil)
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
@@ -19,7 +19,7 @@ final class AuthenticatedImageDownload: AsyncOperation {
         let mediaRequestAuthenticator = MediaRequestAuthenticator()
         let host = MediaHost(with: blog) { error in
             // We'll log the error, so we know it's there, but we won't halt execution.
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
         }
 
         mediaRequestAuthenticator.authenticatedRequest(

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -80,7 +80,7 @@ extension GutenbergViewController {
         guard let action = self.postEditorStateContext.secondaryPublishButtonAction else {
             // If the user tapped on the secondary publish action button, it means we should have a secondary publish action.
             let error = NSError(domain: errorDomain, code: ErrorCode.expectedSecondaryAction.rawValue, userInfo: nil)
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
@@ -160,7 +160,7 @@ class PrivacySettingsViewController: UITableViewController {
 
     func crashReportingChanged(_ enabled: Bool) {
       WPCrashLoggingProvider.userHasOptedOut = !enabled
-      CrashLogging.setNeedsDataRefresh()
+        WordPressAppDelegate.crashLogging?.setNeedsDataRefresh()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
@@ -93,7 +93,7 @@ class PrivacySettingsViewController: UITableViewController {
 
         let reportCrashes = SwitchRow(
             title: NSLocalizedString("Crash reports", comment: "Label for switch to turn on/off sending crashes info"),
-            value: !WPCrashLoggingProvider.userHasOptedOut,
+            value: !UserSettings.userHasOptedOutOfCrashLogging,
             icon: .gridicon(.bug),
             onChange: crashReportingChanged
         )
@@ -159,10 +159,9 @@ class PrivacySettingsViewController: UITableViewController {
     }
 
     func crashReportingChanged(_ enabled: Bool) {
-      WPCrashLoggingProvider.userHasOptedOut = !enabled
+        UserSettings.userHasOptedOutOfCrashLogging = !enabled
         WordPressAppDelegate.crashLogging?.setNeedsDataRefresh()
     }
-
 }
 
 private class InfoCell: WPTableViewCellDefault {

--- a/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
@@ -77,7 +77,7 @@ class PostActionSheet {
                         self?.interactivePostViewDelegate?.share(post, fromView: view)
                     }
                 case .more:
-                    CrashLogging.logMessage("Cannot handle unexpected button for post action sheet: \(button). This is a configuration error.", level: .error)
+                    WordPressAppDelegate.crashLogging?.logMessage("Cannot handle unexpected button for post action sheet: \(button). This is a configuration error.", level: .error)
                 }
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -204,7 +204,7 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
 
         let host = MediaHost(with: post) { error in
             // We'll log the error, so we know it's there, but we won't halt execution.
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
         }
 
         if currentLoadedFeaturedImage != url.absoluteString {

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -104,7 +104,7 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
 
             let host = MediaHost(with: post, failure: { error in
                 // We'll log the error, so we know it's there, but we won't halt execution.
-                CrashLogging.logError(error)
+                WordPressAppDelegate.crashLogging?.logError(error)
             })
 
             imageLoader.loadImage(with: url, from: host, preferredSize: CGSize(width: featuredImageView.frame.width, height: featuredImageView.frame.height))

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -252,12 +252,12 @@ class ReaderCommentCell: UITableViewCell {
         if let blog = comment?.blog {
             return MediaHost(with: blog, failure: { error in
                 // We'll log the error, so we know it's there, but we won't halt execution.
-                CrashLogging.logError(error)
+                WordPressAppDelegate.crashLogging?.logError(error)
             })
         } else if let post = comment?.post as? ReaderPost, post.isPrivate() {
             return MediaHost(with: post, failure: { error in
                 // We'll log the error, so we know it's there, but we won't halt execution.
-                CrashLogging.logError(error)
+                WordPressAppDelegate.crashLogging?.logError(error)
             })
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -120,14 +120,14 @@ private extension ReaderCrossPostCell {
         }
 
         let host = MediaHost(with: contentProvider) { error in
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
         }
 
         let mediaAuthenticator = MediaRequestAuthenticator()
         mediaAuthenticator.authenticatedRequest(for: url, from: host, onComplete: { [weak self] request in
             self?.blavatarImageView.af_setImage(withURLRequest: request, placeholderImage: placeholder)
         }) { [weak self] error in
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
             self?.blavatarImageView.image = placeholder
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -335,7 +335,7 @@ private extension ReaderPostCardCell {
         let mediaRequestAuthenticator = MediaRequestAuthenticator()
         let host = MediaHost(with: contentProvider, failure: { error in
             // We'll log the error, so we know it's there, but we won't halt execution.
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
         })
 
         mediaRequestAuthenticator.authenticatedRequest(
@@ -346,7 +346,7 @@ private extension ReaderPostCardCell {
                 self.avatarImageView.isHidden = false
             },
             onFailure: { error in
-                CrashLogging.logError(error)
+                WordPressAppDelegate.crashLogging?.logError(error)
                 self.avatarImageView.isHidden = true
             })
     }
@@ -451,7 +451,7 @@ private extension ReaderPostCardCell {
         let size = CGSize(width: featuredImageDesiredWidth, height: featuredImageHeight)
         let host = MediaHost(with: contentProvider, failure: { error in
             // We'll log the error, so we know it's there, but we won't halt execution.
-            CrashLogging.logError(error)
+            WordPressAppDelegate.crashLogging?.logError(error)
         })
         imageLoader.loadImage(with: featuredImageURL, from: host, preferredSize: size)
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		1E5D00142493E8C90004B708 /* GutenGhostView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1E5D00132493E8C90004B708 /* GutenGhostView.xib */; };
 		1E672D95257663CE00421F13 /* GutenbergAudioUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E672D94257663CE00421F13 /* GutenbergAudioUploadProcessor.swift */; };
 		1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */; };
+		241E60B325CA0D2900912CEB /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241E60B225CA0D2900912CEB /* UserSettings.swift */; };
 		24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */; };
 		24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */; };
 		24CE2EB1258D687A0000C297 /* WordPressFlux in Frameworks */ = {isa = PBXBuildFile; productRef = 24CE2EB0258D687A0000C297 /* WordPressFlux */; };
@@ -2900,6 +2901,7 @@
 		1E672D94257663CE00421F13 /* GutenbergAudioUploadProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergAudioUploadProcessor.swift; sourceTree = "<group>"; };
 		1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergRollout.swift; sourceTree = "<group>"; };
 		2262D835FA89938EBF63EADF /* Pods-WordPressShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		241E60B225CA0D2900912CEB /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
 		24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagStore.swift; sourceTree = "<group>"; };
 		24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagTests.swift; sourceTree = "<group>"; };
 		24D40491253F6CEE002843AC /* WordPressStatsWidgetsRelease-Internal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WordPressStatsWidgetsRelease-Internal.entitlements"; sourceTree = "<group>"; };
@@ -6277,6 +6279,7 @@
 				E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */,
 				43AF2F962107D3800069C012 /* QuickStartTourState.swift */,
 				17EFD3732578201100AB753C /* ValueTransformers.swift */,
+				241E60B225CA0D2900912CEB /* UserSettings.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -14553,6 +14556,7 @@
 				73FF7032221F469100541798 /* Charts+Support.swift in Sources */,
 				F16601C423E9E783007950AE /* SharingAuthorizationWebViewController.swift in Sources */,
 				171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */,
+				241E60B325CA0D2900912CEB /* UserSettings.swift in Sources */,
 				0815CF461E96F22600069916 /* MediaImportService.swift in Sources */,
 				B56F25881FBDE502005C33E4 /* NSAttributedStringKey+Conversion.swift in Sources */,
 				FFABD80821370496003C65B6 /* SelectPostViewController.swift in Sources */,


### PR DESCRIPTION
Upgrades Sentry and cleans up associated code.

To test:
- Download the installable build from this PR onto a test device
- Go to Me > App Settings > Debug, and tap "Send Log Message", then "Send Test Crash". Relaunch the app.
- Go to https://sentry.io/organizations/a8c/discover/results/ and enter `user.email:$your_email`, and note that the events show up (might take up to 5 minutes)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
