### PR TITLE
Dismiss Create FAB tooltip if Quick Start is activated

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -117,6 +117,8 @@ extension BlogDetailsViewController {
         }
 
         QuickStartTourGuide.shared.visited(.checklist)
+
+        createButtonCoordinator?.hideCreateButtonTooltip()
     }
 
     @objc func quickStartSectionViewModel() -> BlogDetailsSection {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -2,6 +2,7 @@
 
 @class Blog;
 @class BlogDetailHeaderView;
+@class CreateButtonCoordinator;
 @protocol BlogDetailHeader;
 
 typedef NS_ENUM(NSUInteger, BlogDetailsSectionCategory) {
@@ -132,6 +133,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 
 @property (nonatomic, strong, nonnull) Blog * blog;
 @property (nonatomic, strong) id<ScenePresenter> _Nonnull meScenePresenter;
+@property (nonatomic, strong, readonly) CreateButtonCoordinator * _Nullable createButtonCoordinator;
 @property (nonatomic, strong, readwrite) UITableView * _Nonnull tableView;
 @property (nonatomic, strong, readonly) id<BlogDetailHeader> _Nonnull headerView;
 @property (nonatomic) BOOL shouldScrollToViewSite;

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -160,6 +160,11 @@ import WordPressFlux
         }
     }
 
+    func hideCreateButtonTooltip() {
+        didDismissTooltip = true
+        hideNotice()
+    }
+
     @objc func hideCreateButton() {
         hideNotice()
 


### PR DESCRIPTION
Fixes #15350 

This PR fixes an issue seen in #15350 where multiple notices + tooltips could be seen during the Quick Start process, if the FAB tooltip hadn't yet been dismissed:

![qs-1](https://user-images.githubusercontent.com/4780/106759170-570c1000-662a-11eb-9e2d-4c954b25d55b.png)

To remedy this, we're now dismissing the create button tooltip if Quick Start gets activated:

https://user-images.githubusercontent.com/4780/106761312-99cee780-662c-11eb-935c-b0541663a255.mov

**To test**

- Do a fresh install of the app and either log in or create a new user
- Do _not_ dismiss the create button tooltip
- Create a new site
- Accept the 'would you like help?' quickstart prompt that appears
- The quick start checklist will be presented
- **Select an option from the list, and ensure that the create button tooltip is dismissed automatically**
- Tap Not Now on the quickstart notice that appeared, then view the Grow Your Audience quickstart checklist
- Tap Publish This Post
- Ensure that a new tooltip is presented on the create button for this specific tour 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
