### PR TITLE
Jetpack Backup: show progress

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,11 +43,11 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.26-beta'
+    # pod 'WordPressKit', '~> 4.26-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
-    # pod 'WordPressKit', :path => '../WordPressKit-iOS'
+    pod 'WordPressKit', :path => '../../WordPressKit-iOS'
 end
 
 def shared_with_all_pods

--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.26-beta'
+    pod 'WordPressKit', '~> 4.26-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'task/handle_download_id_not_given'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -45,9 +45,9 @@ end
 def wordpress_kit
     # pod 'WordPressKit', '~> 4.26-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'task/handle_download_id_not_given'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
-    pod 'WordPressKit', :path => '../../WordPressKit-iOS'
+    # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 
 def shared_with_all_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -406,7 +406,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.26.0-beta.8):
+  - WordPressKit (4.26.0-beta.9):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -504,7 +504,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.34.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `task/handle_download_id_not_given`)
+  - WordPressKit (~> 4.26-beta)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.14.0)
   - WordPressUI (~> 1.9.0)
@@ -553,6 +553,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -653,9 +654,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.45.0
-  WordPressKit:
-    :branch: task/handle_download_id_not_given
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.45.0/third-party-podspecs/Yoga.podspec.json
 
@@ -671,9 +669,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.45.0
-  WordPressKit:
-    :commit: d2fddebf76f6601c112b9698d7c07fb0ce5dd49c
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -754,7 +749,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: 7f9c41a084bfe691452bfcec8b2c9a12aed48f90
-  WordPressKit: 9794f1e1d3cf0b4ece804e6f3c0c7bab9c15bdfa
+  WordPressKit: 5ba357306ea76bdd569b0e79e3a301d5f5d8d2d1
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 99b37324ffef200ddf32694bc3de1e0c9fcfef21
   WordPressUI: 3b70cccc4c44cff09024ca3e94ae25a8768b26c1
@@ -770,6 +765,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: c8ab683ebe30c8636bd28b986cee522d08dd65d4
+PODFILE CHECKSUM: 43c648e933770b054aa6401caf9f99f53fd6b0e4
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -504,7 +504,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.34.0)
-  - WordPressKit (~> 4.26-beta)
+  - WordPressKit (from `../../WordPressKit-iOS`)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.14.0)
   - WordPressUI (~> 1.9.0)
@@ -553,7 +553,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -654,6 +653,8 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.45.0
+  WordPressKit:
+    :path: "../../WordPressKit-iOS"
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.45.0/third-party-podspecs/Yoga.podspec.json
 
@@ -765,6 +766,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 43c648e933770b054aa6401caf9f99f53fd6b0e4
+PODFILE CHECKSUM: ffa05ccd88365c5a57605d097bf16176f195379b
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -406,7 +406,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.26.0-beta.7):
+  - WordPressKit (4.26.0-beta.8):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -504,7 +504,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.34.0)
-  - WordPressKit (from `../../WordPressKit-iOS`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `task/handle_download_id_not_given`)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.14.0)
   - WordPressUI (~> 1.9.0)
@@ -654,7 +654,8 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.45.0
   WordPressKit:
-    :path: "../../WordPressKit-iOS"
+    :branch: task/handle_download_id_not_given
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.45.0/third-party-podspecs/Yoga.podspec.json
 
@@ -670,6 +671,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.45.0
+  WordPressKit:
+    :commit: d2fddebf76f6601c112b9698d7c07fb0ce5dd49c
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -750,7 +754,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: 7f9c41a084bfe691452bfcec8b2c9a12aed48f90
-  WordPressKit: a3838bf7b5a0f7d023447f3d2fcce1f3922f029a
+  WordPressKit: 9794f1e1d3cf0b4ece804e6f3c0c7bab9c15bdfa
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 99b37324ffef200ddf32694bc3de1e0c9fcfef21
   WordPressUI: 3b70cccc4c44cff09024ca3e94ae25a8768b26c1
@@ -766,6 +770,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: ffa05ccd88365c5a57605d097bf16176f195379b
+PODFILE CHECKSUM: c8ab683ebe30c8636bd28b986cee522d08dd65d4
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/Services/JetpackBackupService.swift
+++ b/WordPress/Classes/Services/JetpackBackupService.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-@objc class JetpackBackupService: LocalCoreDataService {
+class JetpackBackupService {
+
+    private let managedObjectContext: NSManagedObjectContext
 
     private lazy var service: JetpackBackupServiceRemote = {
         let api = WordPressComRestApi.defaultApi(in: managedObjectContext,
@@ -8,6 +10,10 @@ import Foundation
 
         return JetpackBackupServiceRemote(wordPressComRestApi: api)
     }()
+
+    init(managedObjectContext: NSManagedObjectContext) {
+        self.managedObjectContext = managedObjectContext
+    }
 
     func prepareBackup(for site: JetpackSiteRef,
                        rewindID: String? = nil,
@@ -19,6 +25,10 @@ import Foundation
 
     func getBackupStatus(for site: JetpackSiteRef, downloadID: Int, success: @escaping (JetpackBackup) -> Void, failure: @escaping (Error) -> Void) {
         service.getBackupStatus(site.siteID, downloadID: downloadID, success: success, failure: failure)
+    }
+
+    func getAllBackupStatus(for site: JetpackSiteRef, success: @escaping ([JetpackBackup]) -> Void, failure: @escaping (Error) -> Void) {
+        service.getAllBackupStatus(site.siteID, success: success, failure: failure)
     }
 
 }

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -21,6 +21,7 @@ enum ActivityAction: Action {
     case rewindStatusUpdateFailed(site: JetpackSiteRef, error: Error)
     case rewindStatusUpdateTimedOut(site: JetpackSiteRef)
 
+    case refreshBackupStatus(site: JetpackSiteRef)
     case backupStatusUpdated(site: JetpackSiteRef, status: JetpackBackup)
     case backupStatusUpdateFailed(site: JetpackSiteRef, error: Error)
     case backupStatusUpdateTimedOut(site: JetpackSiteRef)
@@ -229,6 +230,8 @@ class ActivityStore: QueryStore<ActivityStoreState, ActivityQuery> {
             refreshGroups(site: site, afterDate: afterDate, beforeDate: beforeDate)
         case .resetGroups(let site):
             resetGroups(site: site)
+        case .refreshBackupStatus(let site):
+            fetchBackupStatus(site: site)
         case .backupStatusUpdated(let site, let status):
             backupStatusUpdated(site: site, status: status)
         case .backupStatusUpdateFailed(let site, _):
@@ -543,7 +546,7 @@ private extension ActivityStore {
         if let progress = status.progress, progress > 0 {
             delayedRetryFetchBackupStatus(site: site)
         } else {
-            // Show nothing or show complete cell
+            // TODO: show download cell
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -496,11 +496,7 @@ extension BaseActivityListViewController: JetpackBackupStatusViewControllerDeleg
 
     func didFinishViewing(_ controller: JetpackBackupStatusViewController) {
         controller.dismiss(animated: true, completion: { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            self.viewModel.refresh()
+            self?.viewModel.refresh()
         })
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -499,7 +499,8 @@ extension BaseActivityListViewController: JetpackBackupStatusViewControllerDeleg
             guard let self = self else {
                 return
             }
-            // TODO: fetch backup status
+
+            self.viewModel.refresh()
         })
     }
 }

--- a/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
@@ -8,13 +8,15 @@ class ActivityStoreTests: XCTestCase {
     private var dispatcher: ActionDispatcher!
     private var store: ActivityStore!
     private var activityServiceMock: ActivityServiceRemoteMock!
+    private var backupServiceMock: JetpackBackupServiceMock!
 
     override func setUp() {
         super.setUp()
 
         dispatcher = ActionDispatcher()
         activityServiceMock = ActivityServiceRemoteMock()
-        store = ActivityStore.init(dispatcher: dispatcher, activityServiceRemote: activityServiceMock)
+        backupServiceMock = JetpackBackupServiceMock()
+        store = ActivityStore(dispatcher: dispatcher, activityServiceRemote: activityServiceMock, backupService: backupServiceMock)
     }
 
     override func tearDown() {
@@ -163,6 +165,19 @@ class ActivityStoreTests: XCTestCase {
         XCTAssertEqual(activityServiceMock.getActivityGroupsForSiteCalledTimes, 2)
     }
 
+    // MARK: - Backup Status
+
+    // Query for backup status call the service
+    //
+    func testBackupStatusQueryCallsService() {
+        let jetpackSiteRef = JetpackSiteRef.mock(siteID: 9, username: "foo")
+
+        _ = store.query(.backupStatus(site: jetpackSiteRef))
+        store.processQueries()
+
+        XCTAssertEqual(backupServiceMock.didCallGetAllBackupStatusWithSite, jetpackSiteRef)
+    }
+
     // MARK: - Helpers
 
     private func dispatch(_ action: ActivityAction) {
@@ -218,10 +233,26 @@ class ActivityServiceRemoteMock: ActivityServiceRemote {
             success(groupsToReturn)
         }
     }
+
+    override func getRewindStatus(_ siteID: Int, success: @escaping (RewindStatus) -> Void, failure: @escaping (Error) -> Void) {
+        
+    }
 }
 
 extension ActivityGroup {
     class func mock() -> ActivityGroup {
         try! ActivityGroup("post", dictionary: ["name": "Posts and Pages", "count": 5] as [String: AnyObject])
+    }
+}
+
+class JetpackBackupServiceMock: JetpackBackupService {
+    var didCallGetAllBackupStatusWithSite: JetpackSiteRef?
+
+    init() {
+        super.init(managedObjectContext: TestContextManager.sharedInstance().mainContext)
+    }
+
+    override func getAllBackupStatus(for site: JetpackSiteRef, success: @escaping ([JetpackBackup]) -> Void, failure: @escaping (Error) -> Void) {
+        didCallGetAllBackupStatusWithSite = site
     }
 }

--- a/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
@@ -254,5 +254,8 @@ class JetpackBackupServiceMock: JetpackBackupService {
 
     override func getAllBackupStatus(for site: JetpackSiteRef, success: @escaping ([JetpackBackup]) -> Void, failure: @escaping (Error) -> Void) {
         didCallGetAllBackupStatusWithSite = site
+
+        let jetpackBackup = JetpackBackup(backupPoint: Date(), downloadID: 100, rewindID: "", startedAt: Date(), progress: 10, downloadCount: 0, url: "", validUntil: nil)
+        success([jetpackBackup])
     }
 }

--- a/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
@@ -235,7 +235,7 @@ class ActivityServiceRemoteMock: ActivityServiceRemote {
     }
 
     override func getRewindStatus(_ siteID: Int, success: @escaping (RewindStatus) -> Void, failure: @escaping (Error) -> Void) {
-        
+
     }
 }
 


### PR DESCRIPTION
Part of #15191

This PR shows the backup progress in Activity Log and Backups screen.

<img src="https://user-images.githubusercontent.com/7040243/106761909-0c7f9900-6614-11eb-9568-ef25b6ab68ba.png" width="300">

### To test

#### Creating a backup from the app

1. Go to Activity Log or Backups screen
2. Tap the 3 dots in the first available cell
3. Tap "Download Backup"
4. Tap "Create downloadable file"
5. Tap "Ok notify me"
6. Check that the progress cell is displayed and disappear once the backup is completed

#### Creating a backup from the site

1. Go to your site and trigger a backup there
2. In the app, open Activity Log or Backups Screen
3. The progress bar should be displayed and disappear once the backup is completed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
