### PR TITLE
Jetpack Section: Scan - Disable scan section for business plans

### DIFF
--- a/WordPress/Classes/Models/Blog+Capabilities.swift
+++ b/WordPress/Classes/Models/Blog+Capabilities.swift
@@ -58,7 +58,7 @@ extension Blog {
     /// Returns true if the current user is allowed to see Jetpack's Scan
     ///
     @objc public func isScanAllowed() -> Bool {
-        return isUserCapableOf("scan")
+        return !hasBusinessPlan && isUserCapableOf("scan")
     }
 
     private func isUserCapableOf(_ capability: String) -> Bool {

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -80,8 +80,6 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     BlogFeatureHomepageSettings,
     /// Does the blog support stories?
     BlogFeatureStories,
-    /// Does the blog support Jetpack Scan?
-    BlogFeatureJetpackScan
 };
 
 typedef NS_ENUM(NSInteger, SiteVisibility) {
@@ -146,9 +144,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic, strong, readwrite, nullable) NSNumber *quotaSpaceAllowed;
 @property (nonatomic, strong, readwrite, nullable) NSNumber *quotaSpaceUsed;
 @property (nullable, nonatomic, retain) NSSet<PageTemplateCategory *> *pageTemplateCategories;
-
-/// Helper flag that's set to to keep track if this blog supports Jetpack scan or not
-@property (nonatomic, assign, readwrite) BOOL supportsJetpackScan;
 
 /**
  *  @details    Maps to a BlogSettings instance, which contains a collection of the available preferences, 

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -94,7 +94,6 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 @synthesize isSyncingMedia;
 @synthesize xmlrpcApi = _xmlrpcApi;
 @synthesize wordPressOrgRestApi = _wordPressOrgRestApi;
-@synthesize supportsJetpackScan;
 
 #pragma mark - NSManagedObject subclass methods
 
@@ -535,9 +534,6 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
             return [self supportsRestApi] && [self isAdmin];
         case BlogFeatureStories:
             return [self supportsStories];
-        case BlogFeatureJetpackScan:
-            return self.supportsJetpackScan;
-
     }
 }
 


### PR DESCRIPTION
### To test:
1. Launch the app
2. Select a site under My Site that has a business plan + domain on it
3. You should not see the 'Scan' section
4. Select another site with Jetpack enabled
5. You should see the 'Scan' section

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
