### PR TITLE
Reader: align options menus on post card and post details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [**] Site Creation: Enables dot blog subdomains for each site design. [#15736]
 * [**] Reader post card and post details: added ability to mark a followed post as seen/unseen. [#15638, #15645, #15676]
 * [**] Reader site filter: show unseen post count. [#15581]
+* [*] Reader post options: fixed an issue where the options in post details did not match those on post cards. [#15778]
 
 16.6
 -----

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -13,6 +13,9 @@ class ReaderDetailCoordinator {
         }
     }
 
+    /// Used to determine if block and report are shown in the options menu.
+    var readerTopic: ReaderAbstractTopic?
+
     /// A post URL to be loaded and be displayed
     var postURL: URL?
 
@@ -301,7 +304,7 @@ class ReaderDetailCoordinator {
 
         ReaderMenuAction(logged: ReaderHelpers.isLoggedIn()).execute(post: post,
                                                                      context: context,
-                                                                     readerTopic: nil,
+                                                                     readerTopic: readerTopic,
                                                                      anchor: anchorView,
                                                                      vc: viewController)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -294,19 +294,16 @@ class ReaderDetailCoordinator {
     ///
     private func showMenu(_ anchorView: UIView) {
         guard let post = post,
-            let context = post.managedObjectContext else {
+            let context = post.managedObjectContext,
+            let viewController = viewController else {
             return
         }
 
-        guard post.isFollowing else {
-            ReaderPostMenu.showMenuForPost(post, fromView: anchorView, inViewController: viewController)
-            return
-        }
-
-        let service: ReaderTopicService = ReaderTopicService(managedObjectContext: context)
-        let siteTopic: ReaderSiteTopic? = service.findSiteTopic(withSiteID: post.siteID)
-
-        ReaderPostMenu.showMenuForPost(post, topic: siteTopic, fromView: anchorView, inViewController: viewController)
+        ReaderMenuAction(logged: ReaderHelpers.isLoggedIn()).execute(post: post,
+                                                                     context: context,
+                                                                     readerTopic: nil,
+                                                                     anchor: anchorView,
+                                                                     vc: viewController)
     }
 
     private func showTopic(_ topic: String) {
@@ -314,7 +311,7 @@ class ReaderDetailCoordinator {
         viewController?.navigationController?.pushViewController(controller, animated: true)
     }
 
-    /// Show a list with posts contianing this tag
+    /// Show a list with posts containing this tag
     ///
     private func showTag() {
         guard let post = post else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
@@ -4,19 +4,16 @@ final class ReaderMenuAction {
     init(logged: Bool) {
         isLoggedIn = logged
     }
-    func execute(post: ReaderPost, context: NSManagedObjectContext, readerTopic: ReaderAbstractTopic?, anchor: UIView, vc: UIViewController) {
-        guard post.isFollowing else {
-            showMenuForPost(post, context: context, readerTopic: readerTopic, fromView: anchor, vc: vc)
-            return
-        }
 
+    func execute(post: ReaderPost, context: NSManagedObjectContext, readerTopic: ReaderAbstractTopic? = nil, anchor: UIView, vc: UIViewController) {
         let service: ReaderTopicService = ReaderTopicService(managedObjectContext: context)
-        let siteTopic: ReaderSiteTopic? = service.findSiteTopic(withSiteID: post.siteID)
+        let siteTopic: ReaderSiteTopic? = post.isFollowing ? service.findSiteTopic(withSiteID: post.siteID) : nil
 
-        showMenuForPost(post, context: context, topic: siteTopic, readerTopic: readerTopic, fromView: anchor, vc: vc)
-    }
-
-    fileprivate func showMenuForPost(_ post: ReaderPost, context: NSManagedObjectContext, topic: ReaderSiteTopic? = nil, readerTopic: ReaderAbstractTopic?, fromView anchorView: UIView, vc: UIViewController) {
-        ReaderShowMenuAction(loggedIn: isLoggedIn).execute(with: post, context: context, topic: topic, readerTopic: readerTopic, anchor: anchorView, vc: vc)
+        ReaderShowMenuAction(loggedIn: isLoggedIn).execute(with: post,
+                                                           context: context,
+                                                           siteTopic: siteTopic,
+                                                           readerTopic: readerTopic,
+                                                           anchor: anchor,
+                                                           vc: vc)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -6,7 +6,13 @@ final class ReaderShowMenuAction {
         isLoggedIn = loggedIn
     }
 
-    func execute(with post: ReaderPost, context: NSManagedObjectContext, topic: ReaderSiteTopic? = nil, readerTopic: ReaderAbstractTopic?, anchor: UIView, vc: UIViewController) {
+    func execute(with post: ReaderPost,
+                 context: NSManagedObjectContext,
+                 siteTopic: ReaderSiteTopic? = nil,
+                 readerTopic: ReaderAbstractTopic? = nil,
+                 anchor: UIView,
+                 vc: UIViewController) {
+
         // Create the action sheet
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alertController.addCancelActionWithTitle(ReaderPostMenuButtonTitles.cancel, handler: nil)
@@ -35,13 +41,13 @@ final class ReaderShowMenuAction {
         }
 
         // Notification
-        if let topic = topic, isLoggedIn, post.isFollowing {
-            let isSubscribedForPostNotifications = topic.isSubscribedForPostNotifications
+        if let siteTopic = siteTopic, isLoggedIn, post.isFollowing {
+            let isSubscribedForPostNotifications = siteTopic.isSubscribedForPostNotifications
             let buttonTitle = isSubscribedForPostNotifications ? ReaderPostMenuButtonTitles.unsubscribe : ReaderPostMenuButtonTitles.subscribe
             alertController.addActionWithTitle(buttonTitle,
                                                style: .default,
                                                handler: { (action: UIAlertAction) in
-                                                if let topic: ReaderSiteTopic = ReaderActionHelpers.existingObject(for: topic.objectID, in: context) {
+                                                if let topic: ReaderSiteTopic = ReaderActionHelpers.existingObject(for: siteTopic.objectID, in: context) {
                                                     ReaderSubscribingNotificationAction().execute(for: topic.siteID, context: context, value: !topic.isSubscribedForPostNotifications)
                                                 }
             })
@@ -113,17 +119,19 @@ final class ReaderShowMenuAction {
     }
 
     fileprivate func shouldShowBlockSiteMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {
-        guard let topic = readerTopic else {
+        guard let topic = readerTopic,
+              isLoggedIn else {
             return false
         }
-        if isLoggedIn {
-            return ReaderHelpers.isTopicTag(topic) || ReaderHelpers.topicIsDiscover(topic)
-                || ReaderHelpers.topicIsFreshlyPressed(topic) || (ReaderHelpers.topicIsFollowing(topic) && !post.isFollowing)
-        }
-        return false
+
+        return ReaderHelpers.isTopicTag(topic) ||
+            ReaderHelpers.topicIsDiscover(topic) ||
+            ReaderHelpers.topicIsFreshlyPressed(topic) ||
+            (ReaderHelpers.topicIsFollowing(topic) && !post.isFollowing)
     }
 
     fileprivate func shouldShowReportPostMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {
         return shouldShowBlockSiteMenuItem(readerTopic: readerTopic, post: post)
     }
+
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1590,6 +1590,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         }
 
         let controller = ReaderDetailViewController.controllerWithPost(post)
+        controller.coordinator?.readerTopic = readerTopic
 
         if post.isSavedForLater || contentType == .saved {
             trackSavedPostNavigation()


### PR DESCRIPTION
Ref #15761

This change does two things:
- The options menu in post details now uses the same as post card. 
- Post details options now has Block and Report when applicable.

Notes: 
- Block and Report where the only differences I found with the two menus. i.e. all the post card and post details options should now match. 
- I have not yet aligned the success/failure messages, so those still differ.
- Following from post details no longer shows a toast message since post card never did. I'll fix this when I align the messaging.
- Just a tip. If you happen to block a site and want to unblock it, https://wordpress.com/me/site-blocks is the place to be.

To test:

Menu change: 
- There should be no visible or functional change. All the menu options should perform the same action as before.

Block / Report:
- Discover > post details now has Block and Report options.
- Discover > You might like > topic > post details now has Report option.
- Following > filter by topic > post details now has Report option.

| Discover post | Discover topic post | Following topic post |
|--------|-------|------|
| ![discover](https://user-images.githubusercontent.com/1816888/106797644-202dfe00-661a-11eb-963a-1a0116d4be93.png) | ![discover_topic](https://user-images.githubusercontent.com/1816888/106797699-32a83780-661a-11eb-8c7e-ddd0710ee907.png) | ![followed_topic](https://user-images.githubusercontent.com/1816888/106797735-3f2c9000-661a-11eb-9d44-85bce8ed1f5e.png) |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
