### PR TITLE
Jetpack Section: Scan: Push to the scan view from the Notifications

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -71,7 +71,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     func displayScanWithSiteID(_ siteID: NSNumber?) throws {
-        guard let blog = blogWithBlogID(siteID), blog.isScanAllowed() else {
+        guard Feature.enabled(.jetpackScan), let blog = blogWithBlogID(siteID), blog.isScanAllowed() else {
             throw DisplayError.missingParameter
         }
 

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -9,6 +9,7 @@ protocol ContentCoordinator {
     func displayFullscreenImage(_ image: UIImage)
     func displayPlugin(withSlug pluginSlug: String, on siteSlug: String) throws
     func displayBackupWithSiteID(_ siteID: NSNumber?) throws
+    func displayScanWithSiteID(_ siteID: NSNumber?) throws
 }
 
 
@@ -67,6 +68,15 @@ struct DefaultContentCoordinator: ContentCoordinator {
         }
 
         controller?.navigationController?.pushViewController(backupListViewController, animated: true)
+    }
+
+    func displayScanWithSiteID(_ siteID: NSNumber?) throws {
+        guard let blog = blogWithBlogID(siteID) else {
+            throw DisplayError.missingParameter
+        }
+
+        let scanViewController = JetpackScanViewController(blog: blog)
+        controller?.navigationController?.pushViewController(scanViewController, animated: true)
     }
 
     func displayFollowersWithSiteID(_ siteID: NSNumber?, expirationTime: TimeInterval) throws {

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -71,7 +71,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     func displayScanWithSiteID(_ siteID: NSNumber?) throws {
-        guard let blog = blogWithBlogID(siteID) else {
+        guard let blog = blogWithBlogID(siteID), blog.isScanAllowed() else {
             throw DisplayError.missingParameter
         }
 

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
@@ -84,4 +84,5 @@ extension FormattableRangeKind {
     public static let match      = FormattableRangeKind("match")
     public static let link       = FormattableRangeKind("link")
     public static let italic     = FormattableRangeKind("i")
+    public static let scan       = FormattableRangeKind("scan")
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
@@ -85,6 +85,9 @@ struct NotificationContentRouter {
             try coordinator.displayFollowersWithSiteID(range.siteID, expirationTime: expirationFiveMinutes)
         case .user:
             try coordinator.displayStreamWithSiteID(range.siteID)
+        case .scan:
+            try coordinator.displayScanWithSiteID(range.siteID)
+
         default:
             throw DefaultContentCoordinator.DisplayError.unsupportedType
         }

--- a/WordPress/WordPressTest/MockContentCoordinator.swift
+++ b/WordPress/WordPressTest/MockContentCoordinator.swift
@@ -33,6 +33,10 @@ class MockContentCoordinator: ContentCoordinator {
 
     }
 
+    func displayScanWithSiteID(_ siteID: NSNumber?) throws {
+
+    }
+
     var streamWasDisplayed = false
     var streamSiteID: NSNumber?
     func displayStreamWithSiteID(_ siteID: NSNumber?) throws {


### PR DESCRIPTION
Project: #15190 
---

Tapping on the threat notification will now push to the scan results view. 

### To test:
1. Launch the app
2. Tap the Notifications tab
3. Locate a "Jetpack Scan" notification
4. Tap on the "sites's scan Results" link
5. You should be pushed to the correct sites, scan results views

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
