### PR TITLE
Jetpack Section: Scan: Updates fix / ignore flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -10,9 +10,7 @@ protocol JetpackScanView {
 
     func presentAlert(_ alert: UIAlertController)
 
-    func showFixThreatSuccess(for threat: JetpackScanThreat)
     func showIgnoreThreatSuccess(for threat: JetpackScanThreat)
-    func showFixThreatError(for threat: JetpackScanThreat)
     func showIgnoreThreatError(for threat: JetpackScanThreat)
 }
 
@@ -149,11 +147,9 @@ class JetpackScanCoordinator {
         view.presentAlert(controller)
     }
 
-    public func fixAllThreats() {
-        let fixableThreats = threats?.filter { $0.fixable != nil } ?? []
-
+    private func fixThreats(threats: [JetpackScanThreat]) {
         // If there are no fixable threats just reload the state since it may be out of date
-        guard fixableThreats.count > 0 else {
+        guard threats.count > 0 else {
             refreshData()
             return
         }
@@ -161,7 +157,7 @@ class JetpackScanCoordinator {
         // Optimistically trigger the fixing state
         // and map all the fixable threats to in progress threats
         scan?.state = .fixingThreats
-        scan?.threatFixStatus = fixableThreats.compactMap {
+        scan?.threatFixStatus = threats.compactMap {
             var threatCopy = $0
             threatCopy.status = .fixing
             return JetpackThreatFixStatus(with: threatCopy)
@@ -172,7 +168,7 @@ class JetpackScanCoordinator {
 
         startPolling(triggerImmediately: false)
 
-        service.fixThreats(fixableThreats, blog: blog) { [weak self] (response) in
+        service.fixThreats(threats, blog: blog) { [weak self] (response) in
             if response.success == false {
                 DDLogError("Error starting scan: Scan response returned false")
                 self?.stopPolling()
@@ -187,14 +183,13 @@ class JetpackScanCoordinator {
         }
     }
 
-    public func fixThreat(threat: JetpackScanThreat) {
-        service.fixThreat(threat, blog: blog, success: { [weak self] _ in
-            self?.view.showFixThreatSuccess(for: threat)
-        }, failure: { [weak self] error in
-            DDLogError("Error fixing threat: \(error.localizedDescription)")
+    public func fixAllThreats() {
+        let fixableThreats = threats?.filter { $0.fixable != nil } ?? []
+        fixThreats(threats: fixableThreats)
+    }
 
-            self?.view.showFixThreatError(for: threat)
-        })
+    public func fixThreat(threat: JetpackScanThreat) {
+        fixThreats(threats: [threat])
     }
 
     public func ignoreThreat(threat: JetpackScanThreat) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
@@ -38,6 +38,7 @@ class JetpackScanThreatDetailsViewController: UIViewController {
     @IBOutlet private weak var buttonsStackView: UIStackView!
     @IBOutlet private weak var fixThreatButton: FancyButton!
     @IBOutlet private weak var ignoreThreatButton: FancyButton!
+    @IBOutlet weak var ignoreActivityIndicatorView: UIActivityIndicatorView!
 
     // MARK: - Properties
 
@@ -102,6 +103,10 @@ class JetpackScanThreatDetailsViewController: UIViewController {
             guard let self = self else {
                 return
             }
+
+            self.ignoreThreatButton.isHidden = true
+            self.ignoreActivityIndicatorView.startAnimating()
+
             self.delegate?.willIgnoreThreat(self.threat, controller: self)
         }))
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -20,6 +20,7 @@
                 <outlet property="generalInfoStackView" destination="qsb-nP-xMd" id="0Bj-0p-hiz"/>
                 <outlet property="generalInfoTitleLabel" destination="NW5-tp-l3e" id="kbo-Nz-Ahz"/>
                 <outlet property="icon" destination="DG0-pO-N3I" id="hkl-TO-NeO"/>
+                <outlet property="ignoreActivityIndicatorView" destination="TJx-Vn-QMb" id="vKx-Vx-KzB"/>
                 <outlet property="ignoreThreatButton" destination="UtF-fM-vn6" id="1mF-Ng-Xuq"/>
                 <outlet property="problemDescriptionLabel" destination="5lm-cp-cZQ" id="NET-pY-Cv5"/>
                 <outlet property="problemStackView" destination="1LA-OE-cJv" id="Ch9-bH-eFe"/>
@@ -42,10 +43,10 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xhr-6F-hsq">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="621"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="681"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="2wc-xZ-ViF">
-                                    <rect key="frame" x="16" y="24" width="382" height="573"/>
+                                    <rect key="frame" x="16" y="24" width="382" height="633"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qsb-nP-xMd">
                                             <rect key="frame" x="0.0" y="0.0" width="382" height="89"/>
@@ -165,7 +166,7 @@
                                             </subviews>
                                         </stackView>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="VuK-rQ-GXS">
-                                            <rect key="frame" x="0.0" y="469" width="382" height="104"/>
+                                            <rect key="frame" x="0.0" y="469" width="382" height="164"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lSM-Kx-kG9" customClass="FancyButton" customModule="WordPressUI">
                                                     <rect key="frame" x="0.0" y="0.0" width="382" height="44"/>
@@ -187,6 +188,12 @@
                                                         <action selector="ignoreThreatButtonTapped:" destination="-1" eventType="touchUpInside" id="hAL-WY-v7K"/>
                                                     </connections>
                                                 </button>
+                                                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="TJx-Vn-QMb">
+                                                    <rect key="frame" x="0.0" y="120" width="382" height="44"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="44" id="Xpd-PH-uoL"/>
+                                                    </constraints>
+                                                </activityIndicatorView>
                                             </subviews>
                                         </stackView>
                                     </subviews>

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -97,29 +97,19 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
         present(alert, animated: true, completion: nil)
     }
 
-    func showFixThreatSuccess(for threat: JetpackScanThreat) {
-        self.navigationController?.popToViewController(self, animated: true)
-
-        let model = JetpackScanThreatViewModel(threat: threat)
-        let notice = Notice(title: model.fixSuccessTitle)
-        ActionDispatcher.dispatch(NoticeAction.post(notice))
-    }
-
     func showIgnoreThreatSuccess(for threat: JetpackScanThreat) {
-        self.navigationController?.popToViewController(self, animated: true)
+        navigationController?.popViewController(animated: true)
+        coordinator.refreshData()
 
         let model = JetpackScanThreatViewModel(threat: threat)
         let notice = Notice(title: model.ignoreSuccessTitle)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
-    func showFixThreatError(for threat: JetpackScanThreat) {
-        let model = JetpackScanThreatViewModel(threat: threat)
-        let notice = Notice(title: model.fixErrorTitle)
-        ActionDispatcher.dispatch(NoticeAction.post(notice))
-    }
-
     func showIgnoreThreatError(for threat: JetpackScanThreat) {
+        navigationController?.popViewController(animated: true)
+        coordinator.refreshData()
+
         let model = JetpackScanThreatViewModel(threat: threat)
         let notice = Notice(title: model.ignoreErrorTitle)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
@@ -159,13 +149,14 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
 extension JetpackScanViewController: JetpackScanThreatDetailsViewControllerDelegate {
 
     func willFixThreat(_ threat: JetpackScanThreat, controller: JetpackScanThreatDetailsViewController) {
+        navigationController?.popViewController(animated: true)
+
         coordinator.fixThreat(threat: threat)
     }
 
     func willIgnoreThreat(_ threat: JetpackScanThreat, controller: JetpackScanThreatDetailsViewController) {
         coordinator.ignoreThreat(threat: threat)
     }
-
 }
 
 // MARK: - Table View


### PR DESCRIPTION
Project: #15190
---

This updates the fix / ignore flow to use the new flow introduced in: https://github.com/wordpress-mobile/WordPress-iOS/pull/15755

### Demos
https://user-images.githubusercontent.com/793774/106806752-54171c80-6636-11eb-88f2-534223723e97.mov

https://user-images.githubusercontent.com/793774/106806571-203bf700-6636-11eb-912f-2c5256274e62.mov

### To test:
1. Launch the app
2. Tap My Site
3. Tap a site with Jetpack Scan enabled
4. Tap on a threat to view its details
5. Tap the Fix button
6. You should be brought back to the main view and the state should display as fixing
7. After a few seconds it should be updated to the idle state
8. Tap another threat to view its details
9. Tap the Ignore button
10. You should see an async spinner
11. Once it's ignored you are brought back to the main view and a message informing you it was fixed will be displayed

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
