### PR TITLE
Reader post options: show message when unfollowing a site

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -301,13 +301,21 @@ struct ReaderNotificationKeys {
     // MARK: ActionDispatcher Notification helper
 
     class func dispatchToggleSeenError(post: ReaderPost) {
-        let title = post.isSeen ? ErrorMessages.unseenFailed : ErrorMessages.seenFailed
-        ActionDispatcher.dispatch(NoticeAction.post(Notice(title: title)))
+        dispatchNotice(Notice(title: post.isSeen ? NoticeMessages.unseenFailed : NoticeMessages.seenFailed))
     }
 
-    private struct ErrorMessages {
+    class func dispatchUnfollowSiteMessage(siteTitle: String) {
+        dispatchNotice(Notice(title: NoticeMessages.unfollowSuccess, message: siteTitle))
+    }
+
+    private class func dispatchNotice(_ notice: Notice) {
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
+    }
+
+    private struct NoticeMessages {
         static let seenFailed = NSLocalizedString("Unable to mark post seen", comment: "Alert displayed to the user when updating a post's seen status failed.")
         static let unseenFailed = NSLocalizedString("Unable to mark post unseen", comment: "Alert displayed to the user when updating a post's unseen status failed.")
+        static let unfollowSuccess = NSLocalizedString("Unfollowed site", comment: "Notice title when a user successfully unfollowed a site.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -65,6 +65,8 @@ final class ReaderShowMenuAction {
                                                                                  completion: {
                                                                                     if post.isFollowing {
                                                                                         vc.dispatchSubscribingNotificationNotice(with: post.blogNameForDisplay(), siteID: post.siteID)
+                                                                                    } else {
+                                                                                        ReaderHelpers.dispatchUnfollowSiteMessage(siteTitle: post.blogNameForDisplay())
                                                                                     }
 
                                                                                     if let vc = vc as? ReaderStreamViewController {
@@ -121,7 +123,7 @@ final class ReaderShowMenuAction {
         WPAnalytics.trackReader(.postCardMoreTapped)
     }
 
-    fileprivate func shouldShowBlockSiteMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {
+    private func shouldShowBlockSiteMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {
         guard let topic = readerTopic,
               isLoggedIn else {
             return false
@@ -133,7 +135,7 @@ final class ReaderShowMenuAction {
             (ReaderHelpers.topicIsFollowing(topic) && !post.isFollowing)
     }
 
-    fileprivate func shouldShowReportPostMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {
+    private func shouldShowReportPostMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {
         return shouldShowBlockSiteMenuItem(readerTopic: readerTopic, post: post)
     }
 


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15761

This shows an unfollowing message when a site is unfollowed from a post card or post details. It uses the same format as unfollowing from the Manage view.

To test:
- In the Reader, show posts you are following.
- On a post card or in post details, tap the options menu button.
- Select `Unfollow Site`.
- Verify a toast message appears.

| ![menu](https://user-images.githubusercontent.com/1816888/106830734-e4ac2780-664b-11eb-8d2b-dac8760c365f.png) | ![message](https://user-images.githubusercontent.com/1816888/106830757-ed046280-664b-11eb-99dc-0113c3a83e62.png) |
|--------|-------|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
