### PR TITLE
Jetpack Section: prevent backup status failed screen from being presented multiple times

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackBackupStatusCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackBackupStatusCoordinator.swift
@@ -94,7 +94,7 @@ class JetpackBackupStatusCoordinator {
 extension JetpackBackupStatusCoordinator {
 
     private enum Constants {
-        static let pollingInterval: TimeInterval = 1
+        static let pollingInterval: TimeInterval = 3
         static let maxRetryCount: Int = 3
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackBackupStatusCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackBackupStatusCoordinator.swift
@@ -15,6 +15,7 @@ class JetpackBackupStatusCoordinator {
     private let downloadID: Int
     private let view: JetpackBackupStatusView
 
+    private var isLoading: Bool = false
     private var timer: Timer?
     private var retryCount: Int = 0
 
@@ -59,10 +60,18 @@ class JetpackBackupStatusCoordinator {
     }
 
     private func refreshBackupStatus(downloadID: Int) {
+        guard isLoading == false else {
+            return
+        }
+
+        isLoading = true
+
         service.getBackupStatus(for: self.site, downloadID: downloadID, success: { [weak self] backup in
             guard let self = self else {
                 return
             }
+
+            self.isLoading = false
 
             // If a backup url exists, then we've finished creating a downloadable backup.
             if backup.url != nil {
@@ -79,16 +88,17 @@ class JetpackBackupStatusCoordinator {
                 return
             }
 
-            if self.retryCount == Constants.maxRetryCount {
-                self.stopPolling()
-                self.view.showBackupStatusUpdateFailed()
+            self.isLoading = false
+
+            guard self.retryCount >= Constants.maxRetryCount else {
+                self.retryCount += 1
                 return
             }
 
-            self.retryCount += 1
+            self.stopPolling()
+            self.view.showBackupStatusUpdateFailed()
         })
     }
-
 }
 
 extension JetpackBackupStatusCoordinator {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackBackupStatusCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackBackupStatusCoordinator.swift
@@ -60,7 +60,7 @@ class JetpackBackupStatusCoordinator {
     }
 
     private func refreshBackupStatus(downloadID: Int) {
-        guard isLoading == false else {
+        guard !isLoading else {
             return
         }
 


### PR DESCRIPTION
Part of #15191
Fixes https://github.com/wordpress-mobile/WordPress-iOS/pull/15774#pullrequestreview-582464033

### Description:
- Updated the backup polling interval to 3 seconds to fix an error where the status failed screen was being presented multiple times

_This behavior only seems to happen while testing on the simulator. It seems that this behavior is caused by the polling interval length. A polling interval of 1 second seems a bit short anyway, so I decided to increase the interval to 3 seconds to solve this issue._

### To test:

#### Should work on both a device and the simulator
1. Create a backup from My Site > Backup 
2. While a create a downloadable backup is in progress, turn off wifi
3. Wait
4. ✅ The status failed screen is presented only once

### Simulator demo:

https://user-images.githubusercontent.com/6711616/106835773-45367580-66db-11eb-8e1e-9ec104b49bb7.mov

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
