### PR TITLE
Jetpack Section: add tracking for Jetpack Scan events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -107,6 +107,21 @@ import Foundation
     case backupFilterbarSelectRange
     case backupFilterbarResetRange
 
+    // Jetpack Scan
+    case jetpackScanAccessed
+    case jetpackScanHistoryAccessed
+    case jetpackScanHistoryFilter
+    case jetpackScanThreatListItemTapped
+    case jetpackScanRunTapped
+    case jetpackScanIgnoreThreatDialogOpen
+    case jetpackScanThreatIgnoreTapped
+    case jetpackScanFixThreatDialogOpen
+    case jetpackScanThreatFixTapped
+    case jetpackScanAllThreatsOpen
+    case jetpackScanAllthreatsFixTapped
+    case jetpackScanErrorContactTapped
+    case jetpackScanError
+
     // Comments
     case commentViewed
     case commentApproved
@@ -302,6 +317,34 @@ import Foundation
         case .backupFilterbarResetRange:
             return "backup_filterbar_reset_range"
 
+        // Jetpack Scan
+        case .jetpackScanAccessed:
+            return "jetpack_scan_accessed"
+        case .jetpackScanHistoryAccessed:
+            return "jetpack_scan_history_accessed"
+        case .jetpackScanHistoryFilter:
+            return "jetpack_scan_history_filter"
+        case .jetpackScanThreatListItemTapped:
+            return "jetpack_scan_threat_list_item_tapped"
+        case .jetpackScanRunTapped:
+            return "jetpack_scan_run_tapped"
+        case .jetpackScanIgnoreThreatDialogOpen:
+            return "jetpack_scan_ignorethreat_dialogopen"
+        case .jetpackScanThreatIgnoreTapped:
+            return "jetpack_scan_threat_ignore_tapped"
+        case .jetpackScanFixThreatDialogOpen:
+            return "jetpack_scan_fixthreat_dialogopen"
+        case .jetpackScanThreatFixTapped:
+            return "jetpack_scan_threat_fix_tapped"
+        case .jetpackScanAllThreatsOpen:
+            return "jetpack_scan_allthreats_open"
+        case .jetpackScanAllthreatsFixTapped:
+            return "jetpack_scan_allthreats_fix_tapped"
+        case .jetpackScanErrorContactTapped:
+            return "jetpack_scan_error_contact_tapped"
+        case .jetpackScanError:
+            return "jetpack_scan_error"
+
         // Comments
         case .commentViewed:
             return "comment_viewed"
@@ -323,7 +366,6 @@ import Foundation
             return "comment_edited"
         case .commentRepliedTo:
             return "comment_replied_to"
-
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -115,11 +115,18 @@ class JetpackScanCoordinator {
         service.startScan(for: blog) { [weak self] (success) in
             if success == false {
                 DDLogError("Error starting scan: Scan response returned false")
+
+                WPAnalytics.track(.jetpackScanError, properties: ["action": "scan",
+                                                                  "cause": "scan response returned false"])
+
                 self?.stopPolling()
                 self?.view.showScanStartError()
             }
         } failure: { [weak self] (error) in
             DDLogError("Error starting scan: \(String(describing: error?.localizedDescription))")
+
+            WPAnalytics.track(.jetpackScanError, properties: ["action": "scan",
+                                                              "cause": error?.localizedDescription ?? "remote"])
 
             self?.refreshDidFail(with: error)
         }
@@ -202,6 +209,9 @@ class JetpackScanCoordinator {
             self?.view.showIgnoreThreatSuccess(for: threat)
         }, failure: { [weak self] error in
             DDLogError("Error ignoring threat: \(error.localizedDescription)")
+
+            WPAnalytics.track(.jetpackScanError, properties: ["action": "ignore",
+                                                              "cause": error.localizedDescription])
 
             self?.view.showIgnoreThreatError(for: threat)
         })

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanHistoryCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanHistoryCoordinator.swift
@@ -194,6 +194,17 @@ class JetpackScanHistoryCoordinator {
                     return "filter_toolbar_ignored"
             }
         }
+
+        var eventProperty: String {
+            switch self {
+            case .all:
+                return ""
+            case .fixed:
+                return "fixed"
+            case .ignored:
+                return "ignored"
+            }
+        }
     }
 
     private enum ErrorButtonAction {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanHistoryCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanHistoryCoordinator.swift
@@ -55,6 +55,9 @@ class JetpackScanHistoryCoordinator {
             self?.refreshDidSucceed(with: scanObj)
         } failure: { [weak self] error in
             DDLogError("Error fetching scan object: \(String(describing: error.localizedDescription))")
+
+            WPAnalytics.track(.jetpackScanError, properties: ["action": "fetch_scan_history",
+                                                              "cause": error.localizedDescription])
             self?.refreshDidFail(with: error)
         }
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanHistoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanHistoryViewController.swift
@@ -37,6 +37,12 @@ class JetpackScanHistoryViewController: UIViewController {
         coordinator.viewDidLoad()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        WPAnalytics.track(.jetpackScanHistoryAccessed)
+    }
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         coordinator.animate(alongsideTransition: { _ in
@@ -53,6 +59,8 @@ class JetpackScanHistoryViewController: UIViewController {
         }
 
         coordinator.changeFilter(filter)
+
+        WPAnalytics.track(.jetpackScanHistoryFilter, properties: ["filter": filter.eventProperty])
     }
 
     // MARK: - Private: Config

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
@@ -83,9 +83,12 @@ class JetpackScanThreatDetailsViewController: UIViewController {
                 return
             }
             self.delegate?.willFixThreat(self.threat, controller: self)
+            self.trackEvent(.jetpackScanThreatFixTapped)
         }))
 
         present(alert, animated: true)
+
+        trackEvent(.jetpackScanFixThreatDialogOpen)
     }
 
     @IBAction private func ignoreThreatButtonTapped(_ sender: Any) {
@@ -103,9 +106,18 @@ class JetpackScanThreatDetailsViewController: UIViewController {
                 return
             }
             self.delegate?.willIgnoreThreat(self.threat, controller: self)
+            self.trackEvent(.jetpackScanThreatIgnoreTapped)
         }))
 
         present(alert, animated: true)
+
+        trackEvent(.jetpackScanIgnoreThreatDialogOpen)
+    }
+
+    // MARK: - Private
+
+    private func trackEvent(_ event: WPAnalyticsEvent) {
+        WPAnalytics.track(event, properties: ["threat_signature": threat.signature])
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -40,6 +40,12 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
                                                             action: #selector(showHistory))
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        WPAnalytics.track(.jetpackScanAccessed)
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
@@ -230,6 +236,8 @@ extension JetpackScanViewController: UITableViewDataSource, UITableViewDelegate 
         let threatDetailsVC = JetpackScanThreatDetailsViewController(blog: blog, threat: threat)
         threatDetailsVC.delegate = self
         self.navigationController?.pushViewController(threatDetailsVC, animated: true)
+
+        WPAnalytics.track(.jetpackScanThreatListItemTapped, properties: ["threat_signature": threat.signature, "section": "scanner"])
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
@@ -129,12 +129,15 @@ struct JetpackScanStatusViewModel {
         switch action {
         case .fixAll:
             coordinator.presentFixAllAlert()
+            WPAnalytics.track(.jetpackScanAllThreatsOpen)
 
         case .triggerScan:
             coordinator.startScan()
+            WPAnalytics.track(.jetpackScanRunTapped)
 
         case .contactSupport:
             coordinator.openSupport()
+            WPAnalytics.track(.jetpackScanErrorContactTapped)
         }
     }
 


### PR DESCRIPTION
Part of #15190

### Description:
- Added tracking for Jetpack Scan events 👀 

### To test:

Verify that the following actions fire the correct event with the correct properties.

Please refer to the event tracking spreadsheet for more details about the event name / event properties.

Action | Event
--- | ---
Open the scan screen | `jetpack_scan_accessed`
Tap the history button | `jetpack_scan_history_accessed`
Switch tabs on the scan history screen | `jetpack_scan_history_filter`
Go back to scan screen and tap on scan now | `jetpack_scan_run_tapped`
Tap on a threat | `jetpack_scan_threat_list_item_tapped`
Tap on ignore threat | `jetpack_scan_ignorethreat_dialogopen`
Confirm ignore on alert dialog | `jetpack_scan_threat_ignore_tapped`
Tap on a threat then tap on fix threat | `jetpack_scan_fixthreat_dialogopen`
Confirm fix on alert dialog | `jetpack_scan_threat_fix_tapped`
Tap on fix all in scan screen | `jetpack_scan_allthreats_open`
Tap on contact support in scan screen (scan error) | `jetpack_scan_error_contact_tapped`

#### Errors
Error | Event
--- | ---
Scan error (turn wifi off mid process) | `jetpack_scan_error`
Ignore error (turn wifi off mid process) |  `jetpack_scan_error`
Fetch scan history error (turn wifi off mid process) | `jetpack_scan_error`



### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
