### PR TITLE
Jetpack Section: add events for backup / restore

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -106,6 +106,7 @@ import Foundation
     case backupFilterbarRangeButtonTapped
     case backupFilterbarSelectRange
     case backupFilterbarResetRange
+    case restoreOpened
 
     // Comments
     case commentViewed
@@ -301,6 +302,8 @@ import Foundation
             return "jetpack_backup_filterbar_select_range"
         case .backupFilterbarResetRange:
             return "jetpack_backup_filterbar_reset_range"
+        case .restoreOpened:
+            return "jetpack_restore_opened"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -108,6 +108,7 @@ import Foundation
     case backupFilterbarResetRange
     case restoreOpened
     case restoreConfirmed
+    case restoreError
 
     // Comments
     case commentViewed
@@ -307,6 +308,8 @@ import Foundation
             return "jetpack_restore_opened"
         case .restoreConfirmed:
             return "jetpack_restore_confirmed"
+        case .restoreError:
+            return "jetpack_restore_error"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -113,6 +113,7 @@ import Foundation
     case backupDownloadOpened
     case backupDownloadConfirmed
     case backupFileDownloadError
+    case backupNotifiyMeButtonTapped
 
     // Comments
     case commentViewed
@@ -322,6 +323,8 @@ import Foundation
             return "jetpack_backup_download_confirmed"
         case .backupFileDownloadError:
             return "jetpack_backup_file_download_error"
+        case .backupNotifiyMeButtonTapped:
+            return "jetpack_backup_notify_me_button_tapped"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -111,6 +111,7 @@ import Foundation
     case restoreError
     case restoreNotifiyMeButtonTapped
     case backupDownloadOpened
+    case backupDownloadConfirmed
 
     // Comments
     case commentViewed
@@ -316,6 +317,8 @@ import Foundation
             return "jetpack_restore_notify_me_button_tapped"
         case .backupDownloadOpened:
             return "jetpack_backup_download_opened"
+        case .backupDownloadConfirmed:
+            return "jetpack_backup_download_confirmed"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -112,6 +112,7 @@ import Foundation
     case restoreNotifiyMeButtonTapped
     case backupDownloadOpened
     case backupDownloadConfirmed
+    case backupFileDownloadError
 
     // Comments
     case commentViewed
@@ -319,6 +320,8 @@ import Foundation
             return "jetpack_backup_download_opened"
         case .backupDownloadConfirmed:
             return "jetpack_backup_download_confirmed"
+        case .backupFileDownloadError:
+            return "jetpack_backup_file_download_error"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -107,6 +107,7 @@ import Foundation
     case backupFilterbarSelectRange
     case backupFilterbarResetRange
     case restoreOpened
+    case restoreConfirmed
 
     // Comments
     case commentViewed
@@ -304,6 +305,8 @@ import Foundation
             return "jetpack_backup_filterbar_reset_range"
         case .restoreOpened:
             return "jetpack_restore_opened"
+        case .restoreConfirmed:
+            return "jetpack_restore_confirmed"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -114,6 +114,8 @@ import Foundation
     case backupDownloadConfirmed
     case backupFileDownloadError
     case backupNotifiyMeButtonTapped
+    case backupFileDownloadTapped
+    case backupDownloadShareLinkTapped
 
     // Comments
     case commentViewed
@@ -325,6 +327,10 @@ import Foundation
             return "jetpack_backup_file_download_error"
         case .backupNotifiyMeButtonTapped:
             return "jetpack_backup_notify_me_button_tapped"
+        case .backupFileDownloadTapped:
+            return "jetpack_backup_file_download_tapped"
+        case .backupDownloadShareLinkTapped:
+            return "jetpack_backup_download_share_link_tapped"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -294,13 +294,13 @@ import Foundation
         case .activitylogFilterbarResetRange:
             return "activitylog_filterbar_reset_range"
         case .backupListOpened:
-            return "backup_list_opened"
+            return "jetpack_backup_list_opened"
         case .backupFilterbarRangeButtonTapped:
-            return "backup_filterbar_range_button_tapped"
+            return "jetpack_backup_filterbar_range_button_tapped"
         case .backupFilterbarSelectRange:
-            return "backup_filterbar_select_range"
+            return "jetpack_backup_filterbar_select_range"
         case .backupFilterbarResetRange:
-            return "backup_filterbar_reset_range"
+            return "jetpack_backup_filterbar_reset_range"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -109,6 +109,7 @@ import Foundation
     case restoreOpened
     case restoreConfirmed
     case restoreError
+    case restoreNotifiyMeButtonTapped
 
     // Comments
     case commentViewed
@@ -310,6 +311,8 @@ import Foundation
             return "jetpack_restore_confirmed"
         case .restoreError:
             return "jetpack_restore_error"
+        case .restoreNotifiyMeButtonTapped:
+            return "jetpack_restore_notify_me_button_tapped"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -110,6 +110,7 @@ import Foundation
     case restoreConfirmed
     case restoreError
     case restoreNotifiyMeButtonTapped
+    case backupDownloadOpened
 
     // Comments
     case commentViewed
@@ -313,6 +314,8 @@ import Foundation
             return "jetpack_restore_error"
         case .restoreNotifiyMeButtonTapped:
             return "jetpack_restore_notify_me_button_tapped"
+        case .backupDownloadOpened:
+            return "jetpack_backup_download_opened"
 
         // Comments
         case .commentViewed:

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -101,7 +102,7 @@
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yPg-ua-Eim">
                                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="0.5"/>
-                                                                <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <color key="backgroundColor" systemColor="quaternaryLabelColor"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="0.5" id="BVA-WF-pjw"/>
                                                                 </constraints>
@@ -124,7 +125,7 @@
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gZy-mE-jTT">
                                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="0.5"/>
-                                                                <color key="backgroundColor" red="0.91372549020000005" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="calibratedRGB"/>
+                                                                <color key="backgroundColor" systemColor="quaternaryLabelColor"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="0.5" id="qQX-DU-Xuz"/>
                                                                 </constraints>
@@ -188,4 +189,9 @@
             <point key="canvasLocation" x="199" y="-36"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="quaternaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.17999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -58,7 +58,7 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         setupViews()
         setupText()
         setupAccesibility()
-        WPAnalytics.track(.activityLogDetailViewed)
+        WPAnalytics.track(.activityLogDetailViewed, withProperties: ["source": presentedFrom()])
     }
 
     @IBAction func rewindButtonTapped(sender: UIButton) {
@@ -218,6 +218,16 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
             setupLabelStyles()
             setupAccesibility()
+        }
+    }
+
+    private func presentedFrom() -> String {
+        if presenter is JetpackActivityLogViewController {
+            return "activity_log"
+        } else if presenter is BackupListViewController {
+            return "backup"
+        } else {
+            return "unknown"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
@@ -5,6 +5,7 @@ class BackupListViewController: BaseActivityListViewController {
         store.onlyRestorableItems = true
 
         let activityListConfiguration = ActivityListConfiguration(
+            identifier: "backup",
             title: NSLocalizedString("Backup", comment: "Title for the Jetpack's backup list"),
             loadingTitle: NSLocalizedString("Loading Backups...", comment: "Text displayed while loading the activity feed for a site"),
             noActivitiesTitle: NSLocalizedString("Your first backup will be ready soon", comment: "Title for the view when there aren't any Backups to display"),

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -5,6 +5,9 @@ import WordPressShared
 import WordPressFlux
 
 struct ActivityListConfiguration {
+    /// An identifier of the View Controller
+    let identifier: String
+
     /// The title of the View Controller
     let title: String
 
@@ -370,6 +373,7 @@ extension BaseActivityListViewController: ActivityPresenter {
         let restoreTitle = NSLocalizedString("Restore", comment: "Title displayed for restore action.")
         let restoreOptionsVC = JetpackRestoreOptionsViewController(site: site, activity: activity)
         restoreOptionsVC.restoreStatusDelegate = self
+        restoreOptionsVC.presentedFrom = configuration.identifier
         alertController.addDefaultActionWithTitle(restoreTitle, handler: { _ in
             self.present(UINavigationController(rootViewController: restoreOptionsVC), animated: true)
         })
@@ -377,6 +381,7 @@ extension BaseActivityListViewController: ActivityPresenter {
         let backupTitle = NSLocalizedString("Download backup", comment: "Title displayed for download backup action.")
         let backupOptionsVC = JetpackBackupOptionsViewController(site: site, activity: activity)
         backupOptionsVC.backupStatusDelegate = self
+        restoreOptionsVC.presentedFrom = configuration.identifier
         alertController.addDefaultActionWithTitle(backupTitle, handler: { _ in
             self.present(UINavigationController(rootViewController: backupOptionsVC), animated: true)
         })

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -381,7 +381,7 @@ extension BaseActivityListViewController: ActivityPresenter {
         let backupTitle = NSLocalizedString("Download backup", comment: "Title displayed for download backup action.")
         let backupOptionsVC = JetpackBackupOptionsViewController(site: site, activity: activity)
         backupOptionsVC.backupStatusDelegate = self
-        restoreOptionsVC.presentedFrom = configuration.identifier
+        backupOptionsVC.presentedFrom = configuration.identifier
         alertController.addDefaultActionWithTitle(backupTitle, handler: { _ in
             self.present(UINavigationController(rootViewController: backupOptionsVC), animated: true)
         })
@@ -421,6 +421,7 @@ extension BaseActivityListViewController: ActivityPresenter {
 
         let restoreOptionsVC = JetpackRestoreOptionsViewController(site: site, activity: activity)
         restoreOptionsVC.restoreStatusDelegate = self
+        restoreOptionsVC.presentedFrom = configuration.identifier
         let navigationVC = UINavigationController(rootViewController: restoreOptionsVC)
         self.present(navigationVC, animated: true)
     }
@@ -428,6 +429,7 @@ extension BaseActivityListViewController: ActivityPresenter {
     func presentBackupFor(activity: Activity) {
         let backupOptionsVC = JetpackBackupOptionsViewController(site: site, activity: activity)
         backupOptionsVC.backupStatusDelegate = self
+        backupOptionsVC.presentedFrom = configuration.identifier
         let navigationVC = UINavigationController(rootViewController: backupOptionsVC)
         self.present(navigationVC, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 class JetpackActivityLogViewController: BaseActivityListViewController {
     override init(site: JetpackSiteRef, store: ActivityStore, isFreeWPCom: Bool = false) {
         let activityListConfiguration = ActivityListConfiguration(
+            identifier: "activity_log",
             title: NSLocalizedString("Activity", comment: "Title for the activity list"),
             loadingTitle: NSLocalizedString("Loading Activities...", comment: "Text displayed while loading the activity feed for a site"),
             noActivitiesTitle: NSLocalizedString("No activity yet", comment: "Title for the view when there aren't any Activities to display in the Activity Log"),

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackBackupCompleteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackBackupCompleteViewController.swift
@@ -41,10 +41,12 @@ class JetpackBackupCompleteViewController: BaseRestoreCompleteViewController {
 
     override func primaryButtonTapped() {
         downloadFile()
+        WPAnalytics.track(.backupFileDownloadTapped)
     }
 
     override func secondaryButtonTapped() {
         shareLink()
+        WPAnalytics.track(.backupDownloadShareLinkTapped)
     }
 
     // MARK: - Private

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
@@ -32,6 +32,9 @@ class BaseRestoreOptionsViewController: UITableViewController {
         return JetpackRestoreHeaderView.loadFromNib()
     }()
 
+    /// A String identifier from the screen that presented this VC
+    var presentedFrom: String = "unknown"
+
     // MARK: - Initialization
 
     init(site: JetpackSiteRef, activity: Activity) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
@@ -49,6 +49,15 @@ class JetpackBackupOptionsViewController: BaseRestoreOptionsViewController {
     // MARK: - Override
 
     override func actionButtonTapped() {
+        WPAnalytics.track(.backupDownloadConfirmed, properties: ["restore_types": [
+            "themes": restoreTypes.themes,
+            "plugins": restoreTypes.plugins,
+            "uploads": restoreTypes.uploads,
+            "sqls": restoreTypes.sqls,
+            "roots": restoreTypes.roots,
+            "contents": restoreTypes.contents
+        ]])
+
         coordinator.prepareBackup()
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
@@ -40,8 +40,10 @@ class JetpackBackupOptionsViewController: BaseRestoreOptionsViewController {
 
     // MARK: - View Lifecycle
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        WPAnalytics.track(.backupDownloadOpened, properties: ["source": presentedFrom])
     }
 
     // MARK: - Override

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackBackupOptionsViewController.swift
@@ -66,12 +66,14 @@ extension JetpackBackupOptionsViewController: JetpackBackupOptionsView {
 
     func showNoInternetConnection() {
         ReachabilityUtils.showAlertNoInternetConnection()
+        WPAnalytics.track(.backupFileDownloadError, properties: ["cause": "offline"])
     }
 
     func showBackupAlreadyRunning() {
         let title = NSLocalizedString("There's a backup currently being prepared, please wait before starting the next one", comment: "Text displayed when user tries to create a downloadable backup when there is already one being prepared")
         let notice = Notice(title: title)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
+        WPAnalytics.track(.backupFileDownloadError, properties: ["cause": "other"])
     }
 
     func showBackupRequestFailed() {
@@ -79,6 +81,7 @@ extension JetpackBackupOptionsViewController: JetpackBackupOptionsView {
         let errorMessage = NSLocalizedString("We couldn't create your backup. Please try again later.", comment: "Message for error displayed when preparing a backup fails.")
         let notice = Notice(title: errorTitle, message: errorMessage)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
+        WPAnalytics.track(.backupFileDownloadError, properties: ["cause": "remote"])
     }
 
     func showBackupStarted(for downloadID: Int) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreOptionsViewController.swift
@@ -30,8 +30,10 @@ class JetpackRestoreOptionsViewController: BaseRestoreOptionsViewController {
 
     // MARK: - View Lifecycle
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        WPAnalytics.track(.restoreOpened, properties: ["source": presentedFrom])
     }
 
     // MARK: - Override

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
@@ -62,6 +62,7 @@ class JetpackBackupStatusViewController: BaseRestoreStatusViewController {
 
     override func primaryButtonTapped() {
         delegate?.didFinishViewing(self)
+        WPAnalytics.track(.backupNotifiyMeButtonTapped)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
@@ -56,6 +56,7 @@ class JetpackRestoreStatusViewController: BaseRestoreStatusViewController {
 
     override func primaryButtonTapped() {
         delegate?.didFinishViewing(self)
+        WPAnalytics.track(.restoreNotifiyMeButtonTapped)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
@@ -59,7 +59,20 @@ class JetpackRestoreWarningViewController: UIViewController {
         warningView.configure(with: publishedDate)
 
         warningView.confirmHandler = { [weak self] in
-            self?.coordinator.restoreSite()
+            guard let self = self else {
+                return
+            }
+
+            WPAnalytics.track(.restoreConfirmed, properties: ["restore_types": [
+                "themes": self.restoreTypes.themes,
+                "plugins": self.restoreTypes.plugins,
+                "uploads": self.restoreTypes.uploads,
+                "sqls": self.restoreTypes.sqls,
+                "roots": self.restoreTypes.roots,
+                "contents": self.restoreTypes.contents
+            ]])
+
+            self.coordinator.restoreSite()
         }
 
         warningView.cancelHandler = { [weak self] in

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/JetpackRestoreWarningViewController.swift
@@ -90,12 +90,14 @@ extension JetpackRestoreWarningViewController: JetpackRestoreWarningView {
 
     func showNoInternetConnection() {
         ReachabilityUtils.showAlertNoInternetConnection()
+        WPAnalytics.track(.restoreError, properties: ["cause": "offline"])
     }
 
     func showRestoreAlreadyRunning() {
         let title = NSLocalizedString("There's a restore currently in progress, please wait before starting the next one", comment: "Text displayed when user tries to start a restore when there is already one running")
         let notice = Notice(title: title)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
+        WPAnalytics.track(.restoreError, properties: ["cause": "other"])
     }
 
     func showRestoreRequestFailed() {
@@ -103,6 +105,7 @@ extension JetpackRestoreWarningViewController: JetpackRestoreWarningView {
         let errorMessage = NSLocalizedString("We couldn't restore your site. Please try again later.", comment: "Message for error displayed when restoring a site fails.")
         let notice = Notice(title: errorTitle, message: errorMessage)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
+        WPAnalytics.track(.restoreError, properties: ["cause": "remote"])
     }
 
     func showRestoreStarted() {

--- a/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
+++ b/WordPress/WordPressTest/Activity/ActivityListViewModelTests.swift
@@ -6,6 +6,7 @@ import WordPressFlux
 class ActivityListViewModelTests: XCTestCase {
 
     let activityListConfiguration = ActivityListConfiguration(
+        identifier: "identifier",
         title: "Title",
         loadingTitle: "Loading Activities...",
         noActivitiesTitle: "No activity yet",


### PR DESCRIPTION
Part of #15191

### To test

- [ ] Tap "Restore" from Activity Log and Backups screen and make sure the events are fired with the correct `source` property
- [ ] Restore your site to any point and make sure the restore confirmed event is fired with the selected types
- [ ] When restoring, tap the "notify me" button and make sure the correlated event is fired
- [ ] Restore your site and turn off Wi-fi, make sure an event is fired with the `cause` property
- [ ] Tap "Download Backup" from Activity Log and Backups screen and make sure the events are fired with the correct `source` property
- [ ] Confirm a backup and make sure an event is fired with the selected types
- [ ] Turn off wi-fi while a backup is being generated make sure an event is fired with the `cause` property
- [ ] Tap the "notify me" button wile the backup is being generated and make sure the event is fired
- [ ] When the backup is done, tap the download button and make sure an event is fired
- [ ] Tap the share button and make sure the event is fired

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
