### PR TITLE
Jetpack Section: Scan - Adds more tracks

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -119,7 +119,6 @@ import Foundation
     case jetpackScanThreatFixTapped
     case jetpackScanAllThreatsOpen
     case jetpackScanAllthreatsFixTapped
-    case jetpackScanErrorContactTapped
     case jetpackScanError
 
     // Comments
@@ -340,8 +339,6 @@ import Foundation
             return "jetpack_scan_allthreats_open"
         case .jetpackScanAllthreatsFixTapped:
             return "jetpack_scan_allthreats_fix_tapped"
-        case .jetpackScanErrorContactTapped:
-            return "jetpack_scan_error_contact_tapped"
         case .jetpackScanError:
             return "jetpack_scan_error"
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -155,6 +155,8 @@ class JetpackScanCoordinator {
 
         controller.addAction(UIAlertAction(title: Strings.fixAllAlertCancelButtonTitle, style: .cancel, handler: nil))
         controller.addAction(UIAlertAction(title: Strings.fixAllAlertConfirmButtonTitle, style: .default, handler: { [weak self] _ in
+            WPAnalytics.track(.jetpackScanAllthreatsFixTapped, properties: ["threats_fixed": threatCount])
+
             self?.fixAllThreats()
         }))
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanHistoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanHistoryViewController.swift
@@ -196,6 +196,9 @@ extension JetpackScanHistoryViewController: UITableViewDataSource, UITableViewDe
 
         let threatDetailsVC = JetpackScanThreatDetailsViewController(blog: blog, threat: threat)
         self.navigationController?.pushViewController(threatDetailsVC, animated: true)
+
+        WPAnalytics.track(.jetpackScanThreatListItemTapped, properties: ["threat_signature": threat.signature, "section": "history"])
+
     }
 
     private func configureThreatCell(cell: JetpackScanThreatCell, threat: JetpackScanThreat) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
@@ -137,7 +137,6 @@ struct JetpackScanStatusViewModel {
 
         case .contactSupport:
             coordinator.openSupport()
-            WPAnalytics.track(.jetpackScanErrorContactTapped)
         }
     }
 


### PR DESCRIPTION
Project: #15190

This adds some more scan tracks and removes the Contact Support button track since we already have one. 
### To test:

1. Launch the app
2. Tap on My Site
3. Tap on a site with Jetpack Scan enabled
4. Tap on Scan
5. Tap on History
6. Tap on a threat
7. You should see 

```
🔵 Tracked: jetpack_scan_threat_list_item_tapped <section: history, threat_signature: SIGNATURE>
```
8. Tap back
9. Tap on 'Fix All'
10. Tap on 'Fix all threats' button
11. You should see

```
🔵 Tracked: jetpack_scan_allthreats_fix_tapped <threats_fixed: NUMBER>
```

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
