### PR TITLE
Reader post options: show messages when seen status toggled

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -300,8 +300,12 @@ struct ReaderNotificationKeys {
 
     // MARK: ActionDispatcher Notification helper
 
-    class func dispatchToggleSeenError(post: ReaderPost) {
-        dispatchNotice(Notice(title: post.isSeen ? NoticeMessages.unseenFailed : NoticeMessages.seenFailed))
+    class func dispatchToggleSeenMessage(post: ReaderPost, success: Bool) {
+        if success {
+            dispatchNotice(Notice(title: post.isSeen ? NoticeMessages.seenSuccess: NoticeMessages.unseenSuccess))
+        } else {
+            dispatchNotice(Notice(title: post.isSeen ? NoticeMessages.unseenFail : NoticeMessages.seenFail))
+        }
     }
 
     class func dispatchUnfollowSiteMessage(siteTitle: String) {
@@ -313,8 +317,10 @@ struct ReaderNotificationKeys {
     }
 
     private struct NoticeMessages {
-        static let seenFailed = NSLocalizedString("Unable to mark post seen", comment: "Alert displayed to the user when updating a post's seen status failed.")
-        static let unseenFailed = NSLocalizedString("Unable to mark post unseen", comment: "Alert displayed to the user when updating a post's unseen status failed.")
+        static let seenFail = NSLocalizedString("Unable to mark post seen", comment: "Notice title when updating a post's seen status failed.")
+        static let unseenFail = NSLocalizedString("Unable to mark post unseen", comment: "Notice title when updating a post's unseen status failed.")
+        static let seenSuccess = NSLocalizedString("Marked post as seen", comment: "Notice title when updating a post's seen status succeeds.")
+        static let unseenSuccess = NSLocalizedString("Marked post as unseen", comment: "Notice title when updating a post's unseen status succeeds.")
         static let unfollowSuccess = NSLocalizedString("Unfollowed site", comment: "Notice title when a user successfully unfollowed a site.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -212,7 +212,7 @@ open class ReaderPostMenu {
                                             object: nil,
                                             userInfo: [ReaderNotificationKeys.post: post])
         }, failure: { _ in
-            ReaderHelpers.dispatchToggleSeenError(post: post)
+            ReaderHelpers.dispatchToggleSeenMessage(post: post, success: false)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -83,8 +83,16 @@ final class ReaderShowMenuAction {
                                                    style: .default,
                                                    handler: { (action: UIAlertAction) in
                                                     if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
-                                                        ReaderSeenAction().execute(with: post, context: context, failure: { _ in
-                                                            ReaderHelpers.dispatchToggleSeenError(post: post)
+                                                        ReaderSeenAction().execute(with: post, context: context, completion: {
+                                                            ReaderHelpers.dispatchToggleSeenMessage(post: post, success: true)
+
+                                                            // Notify Reader Stream so the post card is updated.
+                                                            NotificationCenter.default.post(name: .ReaderPostSeenToggled,
+                                                                                            object: nil,
+                                                                                            userInfo: [ReaderNotificationKeys.post: post])
+                                                        },
+                                                        failure: { _ in
+                                                            ReaderHelpers.dispatchToggleSeenMessage(post: post, success: false)
                                                         })
                                                     }
                                                    })


### PR DESCRIPTION
Ref: #15761 

Changes:
- When a post is marked seen or unseen from either post card or post details, a toast message is displayed.
- Fixes automatically marking a post as seen when post details is displayed. I broke it with https://github.com/wordpress-mobile/WordPress-iOS/pull/15778.

To test:

---
Messages:
- On a post card or in post details, tap the options menu button.
- Select `Mark as seen` / `Mark as unseen`.
- Verify a toast message appears.

| ![card_menu](https://user-images.githubusercontent.com/1816888/106952342-35745c80-66ee-11eb-9670-a936dfa64925.png) | ![unseen_message](https://user-images.githubusercontent.com/1816888/106952351-3907e380-66ee-11eb-8cac-4ab47566672c.png) |
|--------|-------|
| ![details_menu](https://user-images.githubusercontent.com/1816888/106952521-71a7bd00-66ee-11eb-9728-30eeac7ba7fd.png) | ![seen_message](https://user-images.githubusercontent.com/1816888/106952528-75d3da80-66ee-11eb-9939-dbed00539f56.png) |

---
Automatically marking a post as seen:
- Tap any post card in the Reader to display post details.
- Tap the options menu button.
- Verify the seen option is always `Mark as unseen` initially.

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
