### PR TITLE
All Time Widget - Tracks and deeplink

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 * [**] Reader post card and post details: added ability to mark a followed post as seen/unseen. [#15638, #15645, #15676]
 * [**] Reader site filter: show unseen post count. [#15581]
 * [*] Reader post options: fixed an issue where the options in post details did not match those on post cards. [#15778]
-* [**] iOS 14 Widgets: new All Time Widgets to display All Time Stats in your home screen.
+* [**] iOS 14 Widgets: new All Time Widgets to display All Time Stats in your home screen. [#15771, #15794]
 
 16.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [**] Reader post card and post details: added ability to mark a followed post as seen/unseen. [#15638, #15645, #15676]
 * [**] Reader site filter: show unseen post count. [#15581]
 * [*] Reader post options: fixed an issue where the options in post details did not match those on post cards. [#15778]
+* [**] iOS 14 Widgets: new All Time Widgets to display All Time Stats in your home screen.
 
 16.6
 -----

--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -71,6 +71,7 @@ extern NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey;
 extern NSString *const WPHomeWidgetTodayKind;
 extern NSString *const WPHomeWidgetAllTimeKind;
 extern NSString *const WPHomeWidgetTodayCount;
+extern NSString *const WPHomeWidgetAllTimeCount;
 
 /// Apple ID Constants
 ///

--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -70,6 +70,8 @@ extern NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey;
 /// iOS 14 Widget Constants
 extern NSString *const WPHomeWidgetTodayKind;
 extern NSString *const WPHomeWidgetAllTimeKind;
+extern NSString *const WPHomeWidgetTodayProperties;
+extern NSString *const WPHomeWidgetAllTimeProperties;
 
 /// Apple ID Constants
 ///

--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -70,8 +70,6 @@ extern NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey;
 /// iOS 14 Widget Constants
 extern NSString *const WPHomeWidgetTodayKind;
 extern NSString *const WPHomeWidgetAllTimeKind;
-extern NSString *const WPHomeWidgetTodayCount;
-extern NSString *const WPHomeWidgetAllTimeCount;
 
 /// Apple ID Constants
 ///

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -82,8 +82,6 @@ NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey       = @"WordPres
 /// iOS 14 Widget Constants
 NSString *const WPHomeWidgetTodayKind                               = @"WordPressHomeWidgetToday";
 NSString *const WPHomeWidgetAllTimeKind                             = @"WordPressHomeWidgetAllTime";
-NSString *const WPHomeWidgetTodayCount                              = @"WordPressHomeWidgetTodayCount";
-NSString *const WPHomeWidgetAllTimeCount                            = @"WordPressHomeWidgetAllTimeCount";
 
 /// Apple ID Constants
 ///

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -83,6 +83,7 @@ NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey       = @"WordPres
 NSString *const WPHomeWidgetTodayKind                               = @"WordPressHomeWidgetToday";
 NSString *const WPHomeWidgetAllTimeKind                             = @"WordPressHomeWidgetAllTime";
 NSString *const WPHomeWidgetTodayCount                              = @"WordPressHomeWidgetTodayCount";
+NSString *const WPHomeWidgetAllTimeCount                            = @"WordPressHomeWidgetAllTimeCount";
 
 /// Apple ID Constants
 ///

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -82,6 +82,8 @@ NSString *const WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey       = @"WordPres
 /// iOS 14 Widget Constants
 NSString *const WPHomeWidgetTodayKind                               = @"WordPressHomeWidgetToday";
 NSString *const WPHomeWidgetAllTimeKind                             = @"WordPressHomeWidgetAllTime";
+NSString *const WPHomeWidgetTodayProperties                         = @"WordPressHomeWidgetTodayProperties";
+NSString *const WPHomeWidgetAllTimeProperties                       = @"WordPressHomeWidgetAllTimeProperties";
 
 /// Apple ID Constants
 ///

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -424,7 +424,7 @@
 		3F526C5C2538CF2B0069706C /* WordPressStatsWidgets.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 3F526C4C2538CF2A0069706C /* WordPressStatsWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		3F526D572539FAC60069706C /* StatsWidgetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F526D562539FAC60069706C /* StatsWidgetsView.swift */; };
 		3F5689F0254209790048A9E4 /* SingleStatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5689EF254209790048A9E4 /* SingleStatView.swift */; };
-		3F568A0025420DE80048A9E4 /* FourStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5689FF25420DE80048A9E4 /* FourStatsView.swift */; };
+		3F568A0025420DE80048A9E4 /* MultiStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5689FF25420DE80048A9E4 /* MultiStatsView.swift */; };
 		3F568A1F254213B60048A9E4 /* VerticalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F568A1E254213B60048A9E4 /* VerticalCard.swift */; };
 		3F568A2F254216550048A9E4 /* FlexibleCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F568A2E254216550048A9E4 /* FlexibleCard.swift */; };
 		3F5B3EAF23A851330060FF1F /* ReaderReblogPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */; };
@@ -3033,7 +3033,7 @@
 		3F526C572538CF2B0069706C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3F526D562539FAC60069706C /* StatsWidgetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsWidgetsView.swift; sourceTree = "<group>"; };
 		3F5689EF254209790048A9E4 /* SingleStatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleStatView.swift; sourceTree = "<group>"; };
-		3F5689FF25420DE80048A9E4 /* FourStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FourStatsView.swift; sourceTree = "<group>"; };
+		3F5689FF25420DE80048A9E4 /* MultiStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiStatsView.swift; sourceTree = "<group>"; };
 		3F568A1E254213B60048A9E4 /* VerticalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalCard.swift; sourceTree = "<group>"; };
 		3F568A2E254216550048A9E4 /* FlexibleCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlexibleCard.swift; sourceTree = "<group>"; };
 		3F5B3EAE23A851330060FF1F /* ReaderReblogPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogPresenter.swift; sourceTree = "<group>"; };
@@ -6737,10 +6737,10 @@
 		3F526D2B2539F9D60069706C /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				3FAA18CB25797B85002B1911 /* UnconfiguredView.swift */,
-				3F526D562539FAC60069706C /* StatsWidgetsView.swift */,
+				3F5689FF25420DE80048A9E4 /* MultiStatsView.swift */,
 				3F5689EF254209790048A9E4 /* SingleStatView.swift */,
-				3F5689FF25420DE80048A9E4 /* FourStatsView.swift */,
+				3F526D562539FAC60069706C /* StatsWidgetsView.swift */,
+				3FAA18CB25797B85002B1911 /* UnconfiguredView.swift */,
 				3F568A1D254210950048A9E4 /* Cards */,
 				3F26569F25AF4DBF0073A832 /* Localization */,
 			);
@@ -14682,7 +14682,7 @@
 				3F2F0C16256C6B2C003351C7 /* StatsWidgetsService.swift in Sources */,
 				3F526D572539FAC60069706C /* StatsWidgetsView.swift in Sources */,
 				3F2656A125AF4DFA0073A832 /* LocalizedStringKey+extension.swift in Sources */,
-				3F568A0025420DE80048A9E4 /* FourStatsView.swift in Sources */,
+				3F568A0025420DE80048A9E4 /* MultiStatsView.swift in Sources */,
 				3F6BC05C25B24773007369D3 /* FeatureFlagOverrideStore.swift in Sources */,
 				3FD675EA25C87A25009AB3C1 /* WordPressHomeWidgetToday.swift in Sources */,
 				3F568A2F254216550048A9E4 /* FlexibleCard.swift in Sources */,

--- a/WordPress/WordPressStatsWidgets/Tracks/Tracks+TodayHomeWidget.swift
+++ b/WordPress/WordPressStatsWidgets/Tracks/Tracks+TodayHomeWidget.swift
@@ -16,7 +16,7 @@ extension Tracks {
         trackExtensionEvent(.loginLaunched)
     }
 
-    public func trackWidgetUpdated() {
+    public func trackWidgetUpdated(widgetKind: String, widgetCountKey: String) {
 
         DispatchQueue.global().async {
             WidgetCenter.shared.getCurrentConfigurations { result in
@@ -24,7 +24,8 @@ extension Tracks {
                 switch result {
 
                 case .success(let widgetInfo):
-                    self.trackUpdatedWidgetInfo(widgetInfo: widgetInfo)
+                    let widgetKindInfo = widgetInfo.filter { $0.kind == widgetKind }
+                    self.trackUpdatedWidgetInfo(widgetInfo: widgetKindInfo, widgetCountKey: widgetCountKey)
 
                 case .failure(let error):
                     DDLogError("Home Widget Today error: unable to read widget information. \(error.localizedDescription)")
@@ -33,17 +34,17 @@ extension Tracks {
         }
     }
 
-    private func trackUpdatedWidgetInfo(widgetInfo: [WidgetInfo]) {
+    private func trackUpdatedWidgetInfo(widgetInfo: [WidgetInfo], widgetCountKey: String) {
         /// - TODO: TODAYWIDGET - This might need to change depending on wether or not we use one extension for multiple widgets
 
-        let previousCount = UserDefaults(suiteName: WPAppGroupName)?.object(forKey: WPHomeWidgetTodayCount) as? Int ?? 0
+        let previousCount = UserDefaults(suiteName: WPAppGroupName)?.object(forKey: widgetCountKey) as? Int ?? 0
         let newCount = widgetInfo.count
 
         guard previousCount != newCount else {
             return
         }
 
-        UserDefaults(suiteName: WPAppGroupName)?.set(newCount, forKey: WPHomeWidgetTodayCount)
+        UserDefaults(suiteName: WPAppGroupName)?.set(newCount, forKey: widgetCountKey)
 
         let properties = ["total_widgets": newCount,
                           "small_widgets": widgetInfo.filter { $0.family == .systemSmall }.count,

--- a/WordPress/WordPressStatsWidgets/Tracks/Tracks+TodayHomeWidget.swift
+++ b/WordPress/WordPressStatsWidgets/Tracks/Tracks+TodayHomeWidget.swift
@@ -51,7 +51,7 @@ extension Tracks {
                           "medium_widgets": widgetInfo.filter { $0.family == .systemMedium }.count,
                           "large_widgets": widgetInfo.filter { $0.family == .systemLarge }.count]
 
-        trackExtensionEvent(.widgetUpdated, properties: properties as [String: AnyObject]?)
+        trackExtensionEvent(ExtensionEvents.widgetUpdated(for: widgetCountKey), properties: properties as [String: AnyObject]?)
     }
 
     // MARK: - Private Helpers
@@ -68,7 +68,22 @@ extension Tracks {
         case statsLaunched  = "wpios_today_home_extension_stats_launched"
         // User taps widget to login to the app
         case loginLaunched  = "wpios_today_home_extension_login_launched"
-        // User installs an instance of the widget
-        case widgetUpdated = "wpios_today_home_extension_widget_updated"
+        // User installs an instance of the today widget
+        case todayWidgetUpdated = "wpios_today_home_extension_widget_updated"
+        // User installs an instance of the all time widget
+        case allTimeWidgetUpdated = "wpios_alltime_home_extension_widget_updated"
+
+        case noEvent
+
+        static func widgetUpdated(for key: String) -> ExtensionEvents {
+            switch key {
+            case WPHomeWidgetTodayCount:
+                return .todayWidgetUpdated
+            case WPHomeWidgetAllTimeCount:
+                return .allTimeWidgetUpdated
+            default:
+                return .noEvent
+            }
+        }
     }
 }

--- a/WordPress/WordPressStatsWidgets/Views/Cards/FlexibleCard.swift
+++ b/WordPress/WordPressStatsWidgets/Views/Cards/FlexibleCard.swift
@@ -5,6 +5,14 @@ struct FlexibleCard: View {
     let axis: Axis
     let title: LocalizedStringKey
     let value: Value
+    let lineLimit: Int
+
+    init(axis: Axis, title: LocalizedStringKey, value: Value, lineLimit: Int = 1) {
+        self.axis = axis
+        self.title = title
+        self.value = value
+        self.lineLimit = lineLimit
+    }
 
     enum Value {
         case number(Int)
@@ -22,7 +30,7 @@ struct FlexibleCard: View {
                            font: Appearance.textFont,
                            fontWeight: Appearance.textFontWeight,
                            foregroundColor: Appearance.textColor,
-                           lineLimit: Appearance.textLineLimit)
+                           lineLimit: lineLimit)
 
         case .description(let description):
 
@@ -30,7 +38,7 @@ struct FlexibleCard: View {
                 .font(Appearance.textFont)
                 .fontWeight(Appearance.textFontWeight)
                 .foregroundColor(Appearance.textColor)
-                .lineLimit(Appearance.textLineLimit)
+                .lineLimit(lineLimit)
         }
     }
 
@@ -66,7 +74,6 @@ extension FlexibleCard {
         static let textFont = Font.footnote
         static let textFontWeight = Font.Weight.semibold
         static let textColor = Color(.label)
-        static let textLineLimit = 2
 
         static let titleFont = Font.caption
         static let titleColor = Color(.secondaryLabel)

--- a/WordPress/WordPressStatsWidgets/Views/MultiStatsView.swift
+++ b/WordPress/WordPressStatsWidgets/Views/MultiStatsView.swift
@@ -1,6 +1,6 @@
  import SwiftUI
 
- struct FourStatsView: View {
+ struct MultiStatsView: View {
     let content: HomeWidgetData
     let widgetTitle: LocalizedStringKey
     let upperLeftTitle: LocalizedStringKey

--- a/WordPress/WordPressStatsWidgets/Views/SingleStatView.swift
+++ b/WordPress/WordPressStatsWidgets/Views/SingleStatView.swift
@@ -12,7 +12,7 @@ struct SingleStatView: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading) {
-                FlexibleCard(axis: .vertical, title: widgetTitle, value: .description(content.siteName))
+                FlexibleCard(axis: .vertical, title: widgetTitle, value: .description(content.siteName), lineLimit: 2)
 
                 Spacer()
                 VerticalCard(title: title, value: views, largeText: true)

--- a/WordPress/WordPressStatsWidgets/Views/StatsWidgetsView.swift
+++ b/WordPress/WordPressStatsWidgets/Views/StatsWidgetsView.swift
@@ -23,15 +23,17 @@ struct StatsWidgetsView: View {
                     SingleStatView(content: content,
                                          widgetTitle: LocalizableStrings.todayWidgetTitle,
                                          title: LocalizableStrings.viewsTitle)
+                        .widgetURL(content.statsURL)
                         .padding()
 
                 case .systemMedium:
-                    FourStatsView(content: content,
+                    MultiStatsView(content: content,
                                           widgetTitle: LocalizableStrings.todayWidgetTitle,
                                           upperLeftTitle: LocalizableStrings.viewsTitle,
                                           upperRightTitle: LocalizableStrings.visitorsTitle,
                                           lowerLeftTitle: LocalizableStrings.likesTitle,
                                           lowerRightTitle: LocalizableStrings.commentsTitle)
+                        .widgetURL(content.statsURL)
                         .padding()
 
                 default:
@@ -44,15 +46,17 @@ struct StatsWidgetsView: View {
                     SingleStatView(content: content,
                                          widgetTitle: LocalizableStrings.allTimeWidgetTitle,
                                          title: LocalizableStrings.viewsTitle)
+                        .widgetURL(content.statsURL)
                         .padding()
 
                 case .systemMedium:
-                    FourStatsView(content: content,
+                    MultiStatsView(content: content,
                                           widgetTitle: LocalizableStrings.allTimeWidgetTitle,
                                           upperLeftTitle: LocalizableStrings.viewsTitle,
                                           upperRightTitle: LocalizableStrings.visitorsTitle,
                                           lowerLeftTitle: LocalizableStrings.postsTitle,
                                           lowerRightTitle: LocalizableStrings.bestViewsTitle)
+                        .widgetURL(content.statsURL)
                         .padding()
 
                 default:
@@ -60,5 +64,23 @@ struct StatsWidgetsView: View {
                 }
             }
         }
+    }
+}
+
+
+private extension HomeWidgetTodayData {
+    static let statsUrl = "https://wordpress.com/stats/day/"
+
+    var statsURL: URL? {
+        URL(string: Self.statsUrl + "\(siteID)?source=widget")
+    }
+}
+
+
+private extension HomeWidgetAllTimeData {
+    static let statsUrl = "https://wordpress.com/stats/insights/"
+
+    var statsURL: URL? {
+        URL(string: Self.statsUrl + "\(siteID)?source=widget")
     }
 }

--- a/WordPress/WordPressStatsWidgets/Views/StatsWidgetsView.swift
+++ b/WordPress/WordPressStatsWidgets/Views/StatsWidgetsView.swift
@@ -13,9 +13,10 @@ struct StatsWidgetsView: View {
 
         case .loggedOut:
             UnconfiguredView()
-
+                .widgetURL(nil)
+                // This seems to prevent a bug where the URL for subsequent widget
+                // types is being triggered if one isn't specified here.
         case .siteSelected(let content):
-            /// - TODO: Handle at least one more case (all time widget)
             if let content = content as? HomeWidgetTodayData {
                 switch family {
 

--- a/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetAllTime.swift
+++ b/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetAllTime.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 
 struct WordPressHomeWidgetAllTime: Widget {
-    /// - TODO: ALLTIMEWIDGET - Add tracks here
+    private let tracks = Tracks(appGroupName: WPAppGroupName)
 
     private let placeholderContent = HomeWidgetAllTimeData(siteID: 0,
                                                         siteName: "My WordPress Site",
@@ -22,7 +22,9 @@ struct WordPressHomeWidgetAllTime: Widget {
             provider: SiteListProvider<HomeWidgetAllTimeData>(service: StatsWidgetsService(), placeholderContent: placeholderContent)
         ) { (entry: StatsWidgetEntry) -> StatsWidgetsView in
 
-            /// - TODO: ALLTIMEWIDGET - Add tracks call here
+            defer {
+                tracks.trackWidgetUpdated(widgetKind: WPHomeWidgetAllTimeKind, widgetCountKey: WPHomeWidgetAllTimeCount)
+            }
 
             return StatsWidgetsView(timelineEntry: entry)
         }

--- a/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetAllTime.swift
+++ b/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetAllTime.swift
@@ -23,7 +23,7 @@ struct WordPressHomeWidgetAllTime: Widget {
         ) { (entry: StatsWidgetEntry) -> StatsWidgetsView in
 
             defer {
-                tracks.trackWidgetUpdated(widgetKind: WPHomeWidgetAllTimeKind)
+                tracks.trackWidgetUpdated(widgetKind: WPHomeWidgetAllTimeKind, widgetCountKey: WPHomeWidgetAllTimeProperties)
             }
 
             return StatsWidgetsView(timelineEntry: entry)

--- a/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetAllTime.swift
+++ b/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetAllTime.swift
@@ -23,7 +23,7 @@ struct WordPressHomeWidgetAllTime: Widget {
         ) { (entry: StatsWidgetEntry) -> StatsWidgetsView in
 
             defer {
-                tracks.trackWidgetUpdated(widgetKind: WPHomeWidgetAllTimeKind, widgetCountKey: WPHomeWidgetAllTimeCount)
+                tracks.trackWidgetUpdated(widgetKind: WPHomeWidgetAllTimeKind)
             }
 
             return StatsWidgetsView(timelineEntry: entry)

--- a/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetToday.swift
+++ b/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetToday.swift
@@ -23,7 +23,7 @@ struct WordPressHomeWidgetToday: Widget {
         ) { (entry: StatsWidgetEntry) -> StatsWidgetsView in
 
             defer {
-                tracks.trackWidgetUpdated(widgetKind: WPHomeWidgetTodayKind)
+                tracks.trackWidgetUpdated(widgetKind: WPHomeWidgetTodayKind, widgetCountKey: WPHomeWidgetTodayProperties)
             }
 
             return StatsWidgetsView(timelineEntry: entry)

--- a/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetToday.swift
+++ b/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetToday.swift
@@ -23,7 +23,7 @@ struct WordPressHomeWidgetToday: Widget {
         ) { (entry: StatsWidgetEntry) -> StatsWidgetsView in
 
             defer {
-                tracks.trackWidgetUpdated(widgetKind: WPHomeWidgetTodayKind, widgetCountKey: WPHomeWidgetTodayCount)
+                tracks.trackWidgetUpdated(widgetKind: WPHomeWidgetTodayKind)
             }
 
             return StatsWidgetsView(timelineEntry: entry)

--- a/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetToday.swift
+++ b/WordPress/WordPressStatsWidgets/Widgets/WordPressHomeWidgetToday.swift
@@ -23,7 +23,7 @@ struct WordPressHomeWidgetToday: Widget {
         ) { (entry: StatsWidgetEntry) -> StatsWidgetsView in
 
             defer {
-                tracks.trackWidgetUpdated()
+                tracks.trackWidgetUpdated(widgetKind: WPHomeWidgetTodayKind, widgetCountKey: WPHomeWidgetTodayCount)
             }
 
             return StatsWidgetsView(timelineEntry: entry)


### PR DESCRIPTION
This PR adds tracks to the all time widget, as well as deep linking the tap to the 'Insights' page of the selected site.
It also updates the release notes

Fixes #NA

To test:

- build/run on iOS 14
- install one or more All Time widgets, and select sites of your preference on them
- make sure that tapping on a widget opens the 'Insights' page for the same site in the app
- In mission control, select the tracks live view tool (Metrics -> Tracks -> Live view), and input wpios_alltime_home_extension_widget_updated as event name
- Wait for at least five minutes (sometimes it takes 8/9 minutes) and see the incoming tracks in the log
- Expand the tracks and verify that the info medium_widgets, small_widgets and total_widgets are consistent with that you installed

Known issues: 
- two widgets of the same size and the same site, seem to be counted as one.
- some events may appear more than once in the live view

PR submission checklist:

- [ ] I have considered adding unit tests where possible.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
