### PR TITLE
Reader post options: show messages when site notifications toggled

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -312,6 +312,14 @@ struct ReaderNotificationKeys {
         dispatchNotice(Notice(title: NoticeMessages.unfollowSuccess, message: siteTitle))
     }
 
+    class func dispatchToggleNotificationMessage(topic: ReaderSiteTopic, success: Bool) {
+        if success {
+            dispatchNotice(Notice(title: topic.isSubscribedForPostNotifications ? NoticeMessages.notificationOnSuccess: NoticeMessages.notificationOffSuccess))
+        } else {
+            dispatchNotice(Notice(title: topic.isSubscribedForPostNotifications ? NoticeMessages.notificationOffFail : NoticeMessages.notificationOnFail))
+        }
+    }
+
     private class func dispatchNotice(_ notice: Notice) {
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
@@ -322,6 +330,10 @@ struct ReaderNotificationKeys {
         static let seenSuccess = NSLocalizedString("Marked post as seen", comment: "Notice title when updating a post's seen status succeeds.")
         static let unseenSuccess = NSLocalizedString("Marked post as unseen", comment: "Notice title when updating a post's unseen status succeeds.")
         static let unfollowSuccess = NSLocalizedString("Unfollowed site", comment: "Notice title when a user successfully unfollowed a site.")
+        static let notificationOnFail = NSLocalizedString("Unable to turn on site notifications", comment: "Notice title when turning site notifications on fails.")
+        static let notificationOffFail = NSLocalizedString("Unable to turn off site notifications", comment: "Notice title when turning site notifications off fails.")
+        static let notificationOnSuccess = NSLocalizedString("Turned on site notifications", comment: "Notice title when turning site notifications on succeeds.")
+        static let notificationOffSuccess = NSLocalizedString("Turned off site notifications", comment: "Notice title when turning site notifications off succeeds.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -48,9 +48,19 @@ final class ReaderShowMenuAction {
                                                style: .default,
                                                handler: { (action: UIAlertAction) in
                                                 if let topic: ReaderSiteTopic = ReaderActionHelpers.existingObject(for: siteTopic.objectID, in: context) {
-                                                    ReaderSubscribingNotificationAction().execute(for: topic.siteID, context: context, subscribe: !topic.isSubscribedForPostNotifications)
+                                                    let subscribe = !topic.isSubscribedForPostNotifications
+
+                                                    ReaderSubscribingNotificationAction().execute(for: topic.siteID, context: context, subscribe: subscribe, completion: {
+
+                                                        let event: WPAnalyticsStat = subscribe ? .readerListNotificationMenuOn : .readerListNotificationMenuOff
+                                                        WPAnalytics.track(event)
+
+                                                        ReaderHelpers.dispatchToggleNotificationMessage(topic: topic, success: true)
+                                                    }, failure: { _ in
+                                                        ReaderHelpers.dispatchToggleNotificationMessage(topic: topic, success: false)
+                                                    })
                                                 }
-            })
+                                               })
         }
 
         // Following

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSubscribingNotificationAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSubscribingNotificationAction.swift
@@ -1,11 +1,11 @@
 /// Encapsulates a command to toggle subscribing to notifications for a site
 final class ReaderSubscribingNotificationAction {
-    func execute(for siteID: NSNumber?, context: NSManagedObjectContext, subscribe: Bool) {
+    func execute(for siteID: NSNumber?, context: NSManagedObjectContext, subscribe: Bool, completion: (() -> Void)? = nil, failure: ((ReaderTopicServiceError?) -> Void)? = nil) {
         guard let siteID = siteID else {
             return
         }
 
         let service = ReaderTopicService(managedObjectContext: context)
-        service.toggleSubscribingNotifications(for: siteID.intValue, subscribe: subscribe)
+        service.toggleSubscribingNotifications(for: siteID.intValue, subscribe: subscribe, completion, failure)
     }
 }


### PR DESCRIPTION
Ref: #15761 

This shows toast messages when:
- Toggling site notifications succeeds.
- Toggling site notifications fails.

To test:

---
Success:
- In the Reader, display posts you are following.
- On a post card or in post details, tap the options menu button.
- Select `Turn on site notifications` / `Turn off site notifications`.
- Verify a success toast message appears.

| ![card_menu](https://user-images.githubusercontent.com/1816888/106961100-59d63600-66fa-11eb-83c9-78733512bc45.png) | ![turned_on](https://user-images.githubusercontent.com/1816888/106961109-5d69bd00-66fa-11eb-9d32-07eab6ffefba.png) |
|--------|-------|
| ![details_menu](https://user-images.githubusercontent.com/1816888/106961137-65296180-66fa-11eb-90fe-8cd9b19f8a91.png) | ![turned_off](https://user-images.githubusercontent.com/1816888/106961151-69ee1580-66fa-11eb-8e77-2953658b762d.png) |

---
Failure:
- Disable internet connection.
- Attempt to `Turn on site notifications` / `Turn off site notifications`.
- Verify a failure toast message appears.

| ![on_fail](https://user-images.githubusercontent.com/1816888/106961595-0dd7c100-66fb-11eb-8f0d-6b90fecc2d36.jpeg) | ![off_fail](https://user-images.githubusercontent.com/1816888/106961610-129c7500-66fb-11eb-9291-746bb04137b6.jpeg) |
|--------|-------|

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
