### PR TITLE
Jetpack Section: Fix iPad issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -2,7 +2,7 @@ import WordPressFlux
 
 protocol ActivityPresenter: class {
     func presentDetailsFor(activity: FormattableActivity)
-    func presentBackupOrRestoreFor(activity: Activity)
+    func presentBackupOrRestoreFor(activity: Activity, from sender: UIButton)
     func presentRestoreFor(activity: Activity)
     func presentBackupFor(activity: Activity)
 }
@@ -189,7 +189,7 @@ class ActivityListViewModel: Observable {
                         return
                     }
 
-                    presenter?.presentBackupOrRestoreFor(activity: formattableActivity.activity)
+                    presenter?.presentBackupOrRestoreFor(activity: formattableActivity.activity, from: button)
                 }
             )
         })

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -367,7 +367,7 @@ extension BaseActivityListViewController: ActivityPresenter {
         self.navigationController?.pushViewController(detailVC, animated: true)
     }
 
-    func presentBackupOrRestoreFor(activity: Activity) {
+    func presentBackupOrRestoreFor(activity: Activity, from sender: UIButton) {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         let restoreTitle = NSLocalizedString("Restore", comment: "Title displayed for restore action.")
@@ -389,6 +389,12 @@ extension BaseActivityListViewController: ActivityPresenter {
         let cancelTitle = NSLocalizedString("Cancel", comment: "Title for cancel action. Dismisses the action sheet.")
         alertController.addCancelActionWithTitle(cancelTitle)
 
+        if let presentationController = alertController.popoverPresentationController {
+            presentationController.permittedArrowDirections = .any
+            presentationController.sourceView = sender
+            presentationController.sourceRect = sender.bounds
+        }
+
         self.present(alertController, animated: true, completion: nil)
     }
 
@@ -408,6 +414,7 @@ extension BaseActivityListViewController: ActivityPresenter {
             let alertController = UIAlertController(title: title,
                                                     message: message,
                                                     preferredStyle: .alert)
+
             alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Verb. A button title."))
             alertController.addDestructiveActionWithTitle(NSLocalizedString("Confirm Rewind",
                                                                             comment: "Confirm Rewind button title"),

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/BaseRestoreCompleteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/BaseRestoreCompleteViewController.swift
@@ -65,7 +65,7 @@ class BaseRestoreCompleteViewController: UIViewController {
         fatalError("Must override in subclass")
     }
 
-    func secondaryButtonTapped() {
+    func secondaryButtonTapped(from sender: UIButton) {
         fatalError("Must override in subclass")
     }
 
@@ -99,8 +99,8 @@ class BaseRestoreCompleteViewController: UIViewController {
             self?.primaryButtonTapped()
         }
 
-        completeView.secondaryButtonHandler = { [weak self] in
-            self?.secondaryButtonTapped()
+        completeView.secondaryButtonHandler = { [weak self] sender in
+            self?.secondaryButtonTapped(from: sender)
         }
 
         view.addSubview(completeView)

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackBackupCompleteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackBackupCompleteViewController.swift
@@ -44,8 +44,8 @@ class JetpackBackupCompleteViewController: BaseRestoreCompleteViewController {
         WPAnalytics.track(.backupFileDownloadTapped)
     }
 
-    override func secondaryButtonTapped() {
-        shareLink()
+    override func secondaryButtonTapped(from sender: UIButton) {
+        shareLink(from: sender)
         WPAnalytics.track(.backupDownloadShareLinkTapped)
     }
 
@@ -65,7 +65,7 @@ class JetpackBackupCompleteViewController: BaseRestoreCompleteViewController {
         UIApplication.shared.open(downloadURL)
     }
 
-    private func shareLink() {
+    private func shareLink(from sender: UIButton) {
         guard let url = backup.url,
               let downloadURL = URL(string: url),
               let activities = WPActivityDefaults.defaultActivities() as? [UIActivity] else {
@@ -78,7 +78,9 @@ class JetpackBackupCompleteViewController: BaseRestoreCompleteViewController {
         }
 
         let activityVC = UIActivityViewController(activityItems: [downloadURL], applicationActivities: activities)
-        activityVC.popoverPresentationController?.sourceView = self.view
+        activityVC.popoverPresentationController?.sourceView = sender
+        activityVC.modalPresentationStyle = .popover
+
 
         self.present(activityVC, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackRestoreCompleteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/JetpackRestoreCompleteViewController.swift
@@ -38,7 +38,7 @@ class JetpackRestoreCompleteViewController: BaseRestoreCompleteViewController {
         self.dismiss(animated: true)
     }
 
-    override func secondaryButtonTapped() {
+    override func secondaryButtonTapped(from sender: UIButton) {
         visitSite()
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/Views/RestoreCompleteView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Complete/Views/RestoreCompleteView.swift
@@ -13,7 +13,7 @@ class RestoreCompleteView: UIView, NibLoadable {
     @IBOutlet private weak var hintLabel: UILabel!
 
     var primaryButtonHandler: (() -> Void)?
-    var secondaryButtonHandler: (() -> Void)?
+    var secondaryButtonHandler: ((_ sender: UIButton) -> Void)?
 
     // MARK: - Initialization
 
@@ -92,7 +92,7 @@ class RestoreCompleteView: UIView, NibLoadable {
         primaryButtonHandler?()
     }
 
-    @IBAction private func secondaryButtonTapped(_ sender: Any) {
-        secondaryButtonHandler?()
+    @IBAction private func secondaryButtonTapped(_ sender: UIButton) {
+        secondaryButtonHandler?(sender as UIButton)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.xib
@@ -56,7 +56,7 @@
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UhM-1P-HcV" customClass="FancyButton" customModule="WordPressUI">
                                 <rect key="frame" x="10" y="161" width="425" height="34"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="34" id="Ha4-Re-jtu"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="Ha4-Re-jtu"/>
                                 </constraints>
                                 <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="20" bottom="8" trailing="20"/>
                                 <state key="normal" title="Fix All">
@@ -72,7 +72,7 @@
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="749" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gTh-o0-42f" customClass="FancyButton" customModule="WordPressUI">
                                 <rect key="frame" x="10" y="205" width="425" height="34"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="34" id="tnl-xQ-FTS"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="34" id="tnl-xQ-FTS"/>
                                 </constraints>
                                 <directionalEdgeInsets key="directionalLayoutMargins" top="8" leading="20" bottom="8" trailing="20"/>
                                 <state key="normal" title="Scan Again">

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatCell.swift
@@ -20,6 +20,9 @@ class JetpackScanThreatCell: UITableViewCell, NibReusable {
         iconImageView.isHidden = model.isFixing
         iconBackgroundImageView.isHidden = model.isFixing
 
+        selectionStyle = model.isFixing ? .none : .default
+        accessoryType = model.isFixing ? .none : .disclosureIndicator
+
         if model.isFixing {
             activityIndicator.startAnimating()
         } else {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -260,7 +260,7 @@ extension JetpackScanViewController: UITableViewDataSource, UITableViewDelegate 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        guard let threat = threat(for: indexPath) else {
+        guard let threat = threat(for: indexPath), threat.status != .fixing else {
             return
         }
 


### PR DESCRIPTION
Project: https://github.com/wordpress-mobile/WordPress-iOS/issues/15193

### To test:
#### Backup menu crash
1. Launch the app
2. Tap on My Site
3. Tap on Backup or Activity Log
4. Tap on the ... menu
5. The alert should be presented and the app should not crash

#### Share Menu Issue
1. Launch the app
2. Tap on My Site
3. Tap on Backup or Activity Log
4. Tap on Download backup
5. Create a downloadable backup, and wait
6. On the final view tap on Share Link
7. The share dialog should be displayed and not clipped

#### Scan status clipping
1. Launch the app
2. Tap on My Site
3. Tap on Scan
4. The scan status buttons should not be clipped

#### Don't allow selection on threats being fixed
1. Launch the app
2. Tap on My Site
3. Tap on Scan
4. Fix a threat
5. You should not be able to select the threat that is being fixed

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
