### PR TITLE
Reader post options: show messages when (un)following site fails

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -398,7 +398,7 @@ class ReaderDetailCoordinator {
                                      completion: { [weak self] in
                                          self?.view?.updateHeader()
                                      },
-                                     failure: { [weak self] in
+                                     failure: { [weak self] _ in
                                          self?.view?.updateHeader()
                                      })
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowAction.swift
@@ -3,38 +3,14 @@ final class ReaderFollowAction {
     func execute(with post: ReaderPost,
                  context: NSManagedObjectContext,
                  completion: (() -> Void)? = nil,
-                 failure: (() -> Void)? = nil) {
-        let siteID = post.siteID
-        var errorMessage: String
-        var errorTitle: String
+                 failure: ((Error?) -> Void)? = nil) {
+
         if post.isFollowing {
-            errorTitle = NSLocalizedString("Problem Unfollowing Site", comment: "Title of a prompt")
-            errorMessage = NSLocalizedString("There was a problem unfollowing the site. If the problem persists you can contact us via the Me > Help & Support screen.", comment: "Short notice that there was a problem unfollowing a site and instructions on how to notify us of the problem.")
-        } else {
-            errorTitle = NSLocalizedString("Problem Following Site", comment: "Title of a prompt")
-            errorMessage = NSLocalizedString("There was a problem following the site.  If the problem persists you can contact us via the Me > Help & Support screen.", comment: "Short notice that there was a problem following a site and instructions on how to notify us of the problem.")
+            ReaderSubscribingNotificationAction().execute(for: post.siteID, context: context, subscribe: false)
+            WPAnalytics.track(.readerListNotificationMenuOff)
         }
 
         let postService = ReaderPostService(managedObjectContext: context)
-        let toFollow = !post.isFollowing
-
-        if !toFollow {
-            ReaderSubscribingNotificationAction().execute(for: siteID, context: context, subscribe: false)
-
-        }
-
-        postService.toggleFollowing(for: post,
-                                    success: {
-                                        completion?()
-            },
-                                    failure: { _ in
-                                        failure?()
-                                        let cancelTitle = NSLocalizedString("OK", comment: "Text of an OK button to dismiss a prompt.")
-                                        let alertController = UIAlertController(title: errorTitle,
-                                                                                message: errorMessage,
-                                                                                preferredStyle: .alert)
-                                        alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
-                                        alertController.presentFromRootViewController()
-        })
+        postService.toggleFollowing(for: post, success: completion, failure: failure)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -308,8 +308,15 @@ struct ReaderNotificationKeys {
         }
     }
 
-    class func dispatchUnfollowSiteMessage(siteTitle: String) {
-        dispatchNotice(Notice(title: NoticeMessages.unfollowSuccess, message: siteTitle))
+    class func dispatchToggleFollowSiteMessage(post: ReaderPost, success: Bool) {
+        if success {
+            if !post.isFollowing {
+                // Following is handled by dispatchSubscribingNotificationNotice.
+                dispatchNotice(Notice(title: NoticeMessages.unfollowSuccess, message: post.blogNameForDisplay()))
+            }
+        } else {
+            dispatchNotice(Notice(title: post.isFollowing ? NoticeMessages.unfollowFail : NoticeMessages.followFail))
+        }
     }
 
     class func dispatchToggleNotificationMessage(topic: ReaderSiteTopic, success: Bool) {
@@ -329,7 +336,9 @@ struct ReaderNotificationKeys {
         static let unseenFail = NSLocalizedString("Unable to mark post unseen", comment: "Notice title when updating a post's unseen status failed.")
         static let seenSuccess = NSLocalizedString("Marked post as seen", comment: "Notice title when updating a post's seen status succeeds.")
         static let unseenSuccess = NSLocalizedString("Marked post as unseen", comment: "Notice title when updating a post's unseen status succeeds.")
-        static let unfollowSuccess = NSLocalizedString("Unfollowed site", comment: "Notice title when a user successfully unfollowed a site.")
+        static let unfollowSuccess = NSLocalizedString("Unfollowed site", comment: "Notice title when unfollowing a site succeeds.")
+        static let followFail = NSLocalizedString("Unable to follow site", comment: "Notice title when following a site fails.")
+        static let unfollowFail = NSLocalizedString("Unable to unfollow site", comment: "Notice title when unfollowing a site fails.")
         static let notificationOnFail = NSLocalizedString("Unable to turn on site notifications", comment: "Notice title when turning site notifications on fails.")
         static let notificationOffFail = NSLocalizedString("Unable to turn off site notifications", comment: "Notice title when turning site notifications off fails.")
         static let notificationOnSuccess = NSLocalizedString("Turned on site notifications", comment: "Notice title when turning site notifications on succeeds.")

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -101,18 +101,16 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         return imageRequestAuthToken
     }
 
-    fileprivate func toggleFollowingForPost(_ post: ReaderPost) {
-        let siteTitle = post.blogNameForDisplay()
-        let siteID = post.siteID
-        let toFollow = !post.isFollowing
-
-        ReaderFollowAction().execute(with: post, context: context,
+    private func toggleFollowingForPost(_ post: ReaderPost) {
+        ReaderFollowAction().execute(with: post,
+                                     context: context,
                                      completion: { [weak self] in
-                                        if toFollow {
-                                            self?.origin?.dispatchSubscribingNotificationNotice(with: siteTitle, siteID: siteID)
+                                        if post.isFollowing {
+                                            self?.origin?.dispatchSubscribingNotificationNotice(with: post.blogNameForDisplay(), siteID: post.siteID)
                                         }
-                                     },
-                                     failure: nil)
+                                     }, failure: { _ in
+                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: false)
+                                     })
     }
 
     func toggleSavedForLater(for post: ReaderPost) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -76,12 +76,13 @@ final class ReaderShowMenuAction {
                                                                                     if post.isFollowing {
                                                                                         vc.dispatchSubscribingNotificationNotice(with: post.blogNameForDisplay(), siteID: post.siteID)
                                                                                     } else {
-                                                                                        ReaderHelpers.dispatchUnfollowSiteMessage(siteTitle: post.blogNameForDisplay())
+                                                                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: true)
                                                                                     }
 
                                                                                     (vc as? ReaderStreamViewController)?.updateStreamHeaderIfNeeded()
-                                                                                 },
-                                                                                 failure: nil)
+                                                                                 }, failure: { _ in
+                                                                                    ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: false)
+                                                                                 })
                                                 }
                                                })
         }


### PR DESCRIPTION
Ref: #15761

This shows notifications when site following and unfollowing fail. It also changes how unfollowed notifications are dispatched.

A successful site following notification is already being displayed by `dispatchSubscribingNotificationNotice`. I'll move this into `ReaderHelpers` in a follow-up PR.

To test:

---
Unfollowing:

- In the Reader, display posts you are following.
- On a post card or in post details, tap the options menu button.
- Select `Unfollow Site`.
- Verify a success toast message appears.

| ![menu](https://user-images.githubusercontent.com/1816888/106974735-72524a80-6712-11eb-923c-0707f3006872.jpeg) | ![message](https://user-images.githubusercontent.com/1816888/106974750-767e6800-6712-11eb-9589-8b58dd751168.jpeg) |
|--------|-------|

---
Failures:
- Disable internet connection.
- Attempt to `Follow Site` / `Unfollow Site`.
- Verify a failure toast message appears.

| ![follow_fail](https://user-images.githubusercontent.com/1816888/106975017-f99fbe00-6712-11eb-9670-d050a89f2434.jpeg) | ![unfollow_fail](https://user-images.githubusercontent.com/1816888/106975024-fd334500-6712-11eb-9691-793534626e6d.jpeg) |
|--------|-------|

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
