### PR TITLE
Add tracking for site creation preview device mode analytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -16,9 +16,9 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def wordpress_shared
-    pod 'WordPressShared', '~> 1.14.0'
+    #pod 'WordPressShared', '~> 1.14.0'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :tag => ''
-    #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'add/preview-device-mode-analytics'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
     #pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -414,7 +414,7 @@ PODS:
     - WordPressShared (~> 1.12)
     - wpxmlrpc (~> 0.9)
   - WordPressMocks (0.0.9)
-  - WordPressShared (1.14.0):
+  - WordPressShared (1.15.0-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
   - WordPressUI (1.9.0)
@@ -506,7 +506,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.34.0)
   - WordPressKit (~> 4.26-beta.8)
   - WordPressMocks (~> 0.0.9)
-  - WordPressShared (~> 1.14.0)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `add/preview-device-mode-analytics`)
   - WordPressUI (~> 1.9.0)
   - WPMediaPicker (~> 1.7.2)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.45.0/third-party-podspecs/Yoga.podspec.json`)
@@ -555,7 +555,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -654,6 +653,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.45.0
+  WordPressShared:
+    :branch: add/preview-device-mode-analytics
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.45.0/third-party-podspecs/Yoga.podspec.json
 
@@ -669,6 +671,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.45.0
+  WordPressShared:
+    :commit: ba14b44a55f730e4f171f6e781557e5c15878cd7
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -751,7 +756,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 7f9c41a084bfe691452bfcec8b2c9a12aed48f90
   WordPressKit: 9794f1e1d3cf0b4ece804e6f3c0c7bab9c15bdfa
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
-  WordPressShared: 99b37324ffef200ddf32694bc3de1e0c9fcfef21
+  WordPressShared: c014a047bf8a3f85c0a00aa7f5b570599b2adba7
   WordPressUI: 3b70cccc4c44cff09024ca3e94ae25a8768b26c1
   WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
@@ -765,6 +770,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: aceaecff075beee85fa463cb7f39ab112f52e2e0
+PODFILE CHECKSUM: 534ea8cfdb3e63d5cbb1ff2e80de40a57cdb836c
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -684,6 +684,15 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatEnhancedSiteCreationSiteDesignPreviewLoaded:
             eventName = @"enhanced_site_creation_site_design_preview_loaded";
             break;
+        case     WPAnalyticsStatEnhancedSiteCreationSiteDesignThumbnailModeButtonTapped:
+            eventName = @"enhanced_site_creation_site_design_thumbnail_mode_button_tapped";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationSiteDesignPreviewModeButtonTapped:
+            eventName = @"enhanced_site_creation_site_design_preview_mode_button_tapped";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationSiteDesignPreviewModeChanged:
+            eventName = @"enhanced_site_creation_site_design_preview_mode_changed";
+            break;
         case WPAnalyticsStatEnhancedSiteCreationVerticalsViewed:
             eventName = @"enhanced_site_creation_verticals_viewed";
             break;

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 class PreviewDeviceSelectionViewController: UIViewController {
-    enum PreviewDevice: CaseIterable {
-        case desktop
-        case tablet
-        case mobile
+    enum PreviewDevice: String, CaseIterable {
+        case desktop = "desktop"
+        case tablet = "tablet"
+        case mobile = "mobile"
 
         static var `default`: PreviewDevice {
             return UIDevice.current.userInterfaceIdiom == .pad ? .tablet : .mobile

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
@@ -43,7 +43,7 @@ class PreviewDeviceSelectionViewController: UIViewController {
 
     var selectedOption: PreviewDevice = PreviewDevice.default
 
-    var dismissHandler: ((PreviewDevice) -> Void)?
+    var onDeviceChange: ((PreviewDevice) -> Void)?
 
     lazy var tableView: UITableView = {
         let tableView = UITableView()
@@ -134,7 +134,10 @@ extension PreviewDeviceSelectionViewController: UITableViewDataSource {
 
 extension PreviewDeviceSelectionViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        dismissHandler?(PreviewDevice.available[indexPath.row])
+        let newlySelectedDeviceMode = PreviewDevice.available[indexPath.row]
+        if (newlySelectedDeviceMode != selectedOption) {
+            onDeviceChange?(newlySelectedDeviceMode)
+        }
         dismiss(animated: true, completion: nil)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
@@ -135,7 +135,7 @@ extension PreviewDeviceSelectionViewController: UITableViewDataSource {
 extension PreviewDeviceSelectionViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let newlySelectedDeviceMode = PreviewDevice.available[indexPath.row]
-        if (newlySelectedDeviceMode != selectedOption) {
+        if newlySelectedDeviceMode != selectedOption {
             onDeviceChange?(newlySelectedDeviceMode)
         }
         dismiss(animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -188,7 +188,7 @@ class PreviewWebKitViewController: WebKitViewController {
     @objc private func previewButtonPressed(_ sender: UIBarButtonItem) {
         let popoverContentController = PreviewDeviceSelectionViewController()
         popoverContentController.selectedOption = selectedDevice
-        popoverContentController.dismissHandler = { [weak self] option in
+        popoverContentController.onDeviceChange = { [weak self] option in
             self?.selectedDevice = option
         }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/Preview/SiteDesignPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/Preview/SiteDesignPreviewViewController.swift
@@ -59,7 +59,7 @@ class SiteDesignPreviewViewController: UIViewController, NoResultsViewHost, UIPo
         webView.scrollView.contentInset.bottom = footerView.frame.height
         webView.navigationDelegate = self
         webView.backgroundColor = .basicBackground
-        SiteCreationAnalyticsHelper.trackSiteDesignPreviewViewed(siteDesign)
+        SiteCreationAnalyticsHelper.trackSiteDesignPreviewViewed(siteDesign: siteDesign, previewMode: selectedPreviewDevice)
         observeProgressEstimations()
         configurePreviewDeviceButton()
         navigationItem.rightBarButtonItem = CollapsableHeaderViewController.closeButton(target: self, action: #selector(closeButtonTapped))
@@ -97,10 +97,13 @@ class SiteDesignPreviewViewController: UIViewController, NoResultsViewHost, UIPo
     }
 
     @objc private func previewDeviceButtonTapped() {
+        SiteCreationAnalyticsHelper.trackSiteDesignPreviewModeButtonTapped(selectedPreviewDevice)
         let popoverContentController = PreviewDeviceSelectionViewController()
         popoverContentController.selectedOption = selectedPreviewDevice
-            self?.selectedPreviewDevice = device
         popoverContentController.onDeviceChange = { [weak self] device in
+            guard let self = self else { return }
+            SiteCreationAnalyticsHelper.trackSiteDesignPreviewModeChanged(device)
+            self.selectedPreviewDevice = device
         }
 
         popoverContentController.modalPresentationStyle = .popover
@@ -141,7 +144,7 @@ class SiteDesignPreviewViewController: UIViewController, NoResultsViewHost, UIPo
 extension SiteDesignPreviewViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        SiteCreationAnalyticsHelper.trackSiteDesignPreviewLoading(siteDesign)
+        SiteCreationAnalyticsHelper.trackSiteDesignPreviewLoading(siteDesign: siteDesign, previewMode: selectedPreviewDevice)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
@@ -155,7 +158,7 @@ extension SiteDesignPreviewViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         webView.evaluateJavaScript(selectedPreviewDevice.viewportScript, completionHandler: { [weak self] (_, _) in
             guard let self = self else { return }
-            SiteCreationAnalyticsHelper.trackSiteDesignPreviewLoaded(self.siteDesign)
+            SiteCreationAnalyticsHelper.trackSiteDesignPreviewLoaded(siteDesign: self.siteDesign, previewMode: self.selectedPreviewDevice)
         })
 
         progressBar.animatableSetIsHidden(true)

--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/Preview/SiteDesignPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/Preview/SiteDesignPreviewViewController.swift
@@ -99,8 +99,8 @@ class SiteDesignPreviewViewController: UIViewController, NoResultsViewHost, UIPo
     @objc private func previewDeviceButtonTapped() {
         let popoverContentController = PreviewDeviceSelectionViewController()
         popoverContentController.selectedOption = selectedPreviewDevice
-        popoverContentController.dismissHandler = { [weak self] device in
             self?.selectedPreviewDevice = device
+        popoverContentController.onDeviceChange = { [weak self] device in
         }
 
         popoverContentController.modalPresentationStyle = .popover

--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
@@ -153,8 +153,8 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
     @objc private func previewDeviceButtonTapped() {
         let popoverContentController = PreviewDeviceSelectionViewController()
         popoverContentController.selectedOption = selectedPreviewDevice
-        popoverContentController.dismissHandler = { [weak self] device in
             self?.selectedPreviewDevice = device
+        popoverContentController.onDeviceChange = { [weak self] device in
         }
 
         popoverContentController.modalPresentationStyle = .popover

--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
@@ -76,7 +76,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
         configureCloseButton()
         configureSkipButton()
         configurePreviewDeviceButton()
-        SiteCreationAnalyticsHelper.trackSiteDesignViewed()
+        SiteCreationAnalyticsHelper.trackSiteDesignViewed(previewMode: selectedPreviewDevice)
         navigationItem.backButtonTitle = NSLocalizedString("Design", comment: "Shortened version of the main title to be used in back navigation")
     }
 
@@ -151,10 +151,13 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
     }
 
     @objc private func previewDeviceButtonTapped() {
+        SiteCreationAnalyticsHelper.trackSiteDesignThumbnailModeButtonTapped(selectedPreviewDevice)
         let popoverContentController = PreviewDeviceSelectionViewController()
         popoverContentController.selectedOption = selectedPreviewDevice
-            self?.selectedPreviewDevice = device
         popoverContentController.onDeviceChange = { [weak self] device in
+            guard let self = self else { return }
+            SiteCreationAnalyticsHelper.trackSiteDesignPreviewModeChanged(device)
+            self.selectedPreviewDevice = device
         }
 
         popoverContentController.modalPresentationStyle = .popover

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -3,7 +3,7 @@ import WordPressKit
 
 class SiteCreationAnalyticsHelper {
     typealias PreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice
-    
+
     private static let siteDesignKey = "template"
     private static let previewModeKey = "preview_mode"
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -61,8 +61,18 @@ class SiteCreationAnalyticsHelper {
     }
 
     // MARK: - Common
-    private static func commonProperties(_ siteDesign: RemoteSiteDesign?) -> [AnyHashable: Any] {
-        guard let siteDesign = siteDesign else { return [:] }
-        return  [siteDesignKey: siteDesign.slug]
+    private static func commonProperties(_ properties: Any?...) -> [AnyHashable: Any] {
+        var result: [AnyHashable: Any] = [:]
+
+        for property: Any? in properties {
+            if let siteDesign = property as? RemoteSiteDesign {
+                result.merge([siteDesignKey: siteDesign.slug]) { (_, new) in new }
+            }
+            if let previewMode = property as? PreviewDevice {
+                result.merge([previewModeKey: previewMode.rawValue]) { (_, new) in new }
+            }
+        }
+
+        return result
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -2,11 +2,18 @@ import Foundation
 import WordPressKit
 
 class SiteCreationAnalyticsHelper {
+    typealias PreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice
+    
     private static let siteDesignKey = "template"
+    private static let previewModeKey = "preview_mode"
 
     // MARK: - Site Design
-    static func trackSiteDesignViewed() {
-        WPAnalytics.track(.enhancedSiteCreationSiteDesignViewed)
+    static func trackSiteDesignViewed(previewMode: PreviewDevice) {
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignViewed, withProperties: commonProperties(previewMode))
+    }
+
+    static func trackSiteDesignThumbnailModeButtonTapped(_ previewMode: PreviewDevice) {
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignThumbnailModeButtonTapped, withProperties: commonProperties(previewMode))
     }
 
     static func trackSiteDesignSkipped() {
@@ -18,16 +25,24 @@ class SiteCreationAnalyticsHelper {
     }
 
     // MARK: - Site Design Preview
-    static func trackSiteDesignPreviewViewed(_ siteDesign: RemoteSiteDesign) {
-        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewViewed, withProperties: commonProperties(siteDesign))
+    static func trackSiteDesignPreviewViewed(siteDesign: RemoteSiteDesign, previewMode: PreviewDevice) {
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewViewed, withProperties: commonProperties(siteDesign, previewMode))
     }
 
-    static func trackSiteDesignPreviewLoading(_ siteDesign: RemoteSiteDesign) {
-        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewLoading, withProperties: commonProperties(siteDesign))
+    static func trackSiteDesignPreviewLoading(siteDesign: RemoteSiteDesign, previewMode: PreviewDevice) {
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewLoading, withProperties: commonProperties(siteDesign, previewMode))
     }
 
-    static func trackSiteDesignPreviewLoaded(_ siteDesign: RemoteSiteDesign) {
-        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewLoaded, withProperties: commonProperties(siteDesign))
+    static func trackSiteDesignPreviewLoaded(siteDesign: RemoteSiteDesign, previewMode: PreviewDevice) {
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewLoaded, withProperties: commonProperties(previewMode, siteDesign))
+    }
+
+    static func trackSiteDesignPreviewModeButtonTapped(_ previewMode: PreviewDevice) {
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewModeButtonTapped, withProperties: commonProperties(previewMode))
+    }
+
+    static func trackSiteDesignPreviewModeChanged(_ previewMode: PreviewDevice) {
+        WPAnalytics.track(.enhancedSiteCreationSiteDesignPreviewModeChanged, withProperties: commonProperties(previewMode))
     }
 
     // MARK: - Final Assembly


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/gutenberg-mobile/issues/3025

#### Related PR

`WordPress-iOS-Shared`: https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/286

### Description

This PR adds analytics tracking events for the preview / thumbnail device mode selection feature during site creation.

To test:

<details>
<summary><strong>To start the Home Page Picker screen</strong></summary>

1. Navigate to the "My Sites" screen
2. Tap the ➕ icon
3. Tap "Create WordPress.com site"
</details>

#### Note
An easy way to test for these analytics is to filter the debug logs for the string `Tracked`

### Start Home Page Picker
1. **Start** the Home Page Picker
1. **Verify** that the `🔵 Tracked: enhanced_site_creation_site_design_viewed <preview_mode: mobile>` event is emitted (the value would be `tablet` on a tablet)

### Thumbnail mode button press
1. Start the Home Page Picker
1. Press the **thumbnail mode button** next to the skip button
1. **Verify** that the `🔵 Tracked: enhanced_site_creation_site_design_thumbnail_mode_button_tapped <preview_mode: mobile>` event is emitted (where `mobile` is the current mode when the button is pressed)

### Change thumbnail mode
1. Start the Home Page Picker
1. Press the **thumbnail mode button** next to the skip button
1. Select a thumbnail mode
1. **Verify** that the `🔵 Tracked: enhanced_site_creation_site_design_preview_mode_changed <preview_mode: tablet>` event is emitted where `tablet` is the newly selected mode

### Preview
1. Start the Home Page Picker
1. Select a design
1. Press **Preview**
1. **Verify** that the following events are emitted (where `desktop` the current mode):

```
🔵 Tracked: enhanced_site_creation_site_design_preview_viewed <preview_mode: desktop, template: alves>
🔵 Tracked: enhanced_site_creation_site_design_preview_loading <preview_mode: desktop, template: alves>
🔵 Tracked: enhanced_site_creation_site_design_preview_loaded <preview_mode: desktop, template: alves>
```

### Preview mode button press
1. Start the Home Page Picker
1. Select a design
1. Press **Preview**
1. Press the **preview mode button** at the top right of the screen
1. **Verify** that the  `🔵 Tracked: enhanced_site_creation_site_design_preview_mode_button_tapped <preview_mode: desktop>` event is emitted (where `desktop` is the current mode when the button is pressed)

### Change preview mode
1. Start the Home Page Picker
1. Select a design
1. Press **Preview**
1. Press the **preview mode button** at the top right of the screen
1. Select a thumbnail mode
1. **Verify** that the `🔵 Tracked: enhanced_site_creation_site_design_preview_mode_changed <preview_mode: tablet>` event is emitted where `tablet` is the newly selected mode
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
