### PR TITLE
Jetpack Section: Scan dark mode support

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
@@ -209,7 +209,7 @@ extension JetpackScanThreatDetailsViewController {
         technicalDetailsFileContainerView.backgroundColor = viewModel.fileNameBackgroundColor
 
         technicalDetailsFileLabel.font = viewModel.fileNameFont
-        technicalDetailsFileLabel.textColor = .text
+        technicalDetailsFileLabel.textColor = viewModel.fileNameColor
         technicalDetailsFileLabel.numberOfLines = 0
 
         technicalDetailsDescriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanThreatViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanThreatViewModel.swift
@@ -21,6 +21,7 @@ struct JetpackScanThreatViewModel {
     let technicalDetailsDescription: String
     let fileName: String?
     let fileNameBackgroundColor: UIColor
+    let fileNameColor: UIColor
     let fileNameFont: UIFont
 
     // Threat Detail Action
@@ -92,6 +93,7 @@ struct JetpackScanThreatViewModel {
         fileName = threat.fileName
         fileNameBackgroundColor = Constants.colors.normal.background
         fileNameFont = Constants.monospacedFont
+        fileNameColor = Constants.colors.normal.text
 
         // Threat Details Action
         fixActionTitle = Self.fixActionTitle(for: threat)
@@ -366,20 +368,20 @@ struct JetpackScanThreatViewModel {
     }
 
     private struct Constants {
-        static let monospacedFont = UIFont.monospacedSystemFont(ofSize: 13, weight: .semibold)
+        static let monospacedFont = UIFont.monospacedSystemFont(ofSize: 13, weight: .regular)
 
         struct colors {
             struct normal {
-                static let text = UIColor(red: 0.17, green: 0.20, blue: 0.22, alpha: 1.00)
-                static let background = UIColor(red: 0.96, green: 0.97, blue: 0.97, alpha: 1.00)
-                static let numberText = UIColor(red: 0.39, green: 0.41, blue: 0.44, alpha: 1.00)
-                static let numberBackground = UIColor(red: 0.76, green: 0.77, blue: 0.78, alpha: 1.00)
+                static let text = UIColor.muriel(color: .gray, .shade100)
+                static let background = UIColor.muriel(color: .gray, .shade5)
+                static let numberText = UIColor.muriel(color: .gray, .shade100)
+                static let numberBackground = UIColor.muriel(color: .gray, .shade20)
             }
 
             struct highlighted {
                 static let text = UIColor.white
-                static let background = UIColor(red: 0.84, green: 0.21, blue: 0.22, alpha: 1.00)
-                static let numberBackground = UIColor(red: 0.95, green: 0.85, blue: 0.85, alpha: 1.00)
+                static let background = UIColor.muriel(color: .error, .shade50)
+                static let numberBackground = UIColor.muriel(color: .error, .shade5)
             }
         }
     }


### PR DESCRIPTION
Project #15193 

Fixes some dark mode issues. 

### Screenshots

| Light | Dark |
|:---:|:---:|
|![Simulator Screen Shot - iPhone 11 Pro - 2021-02-05 at 09 33 55](https://user-images.githubusercontent.com/793774/107047910-57291e80-6796-11eb-9e4f-6a13336c673a.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-02-05 at 09 33 53](https://user-images.githubusercontent.com/793774/107048188-a5d6b880-6796-11eb-9ac0-2896b0c45514.png)|

### To test:
1. Launch the app
2. Select My Site
3. Tap on a site with Jetpack Scan enabled
4. Tap on Scan
5. Tap on a threat to view the details
6. Check the code context in light and dark modes

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
