### PR TITLE
Jetpack Section: track "detail" source

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -65,14 +65,14 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         guard let activity = activity else {
             return
         }
-        presenter?.presentRestoreFor(activity: activity)
+        presenter?.presentRestoreFor(activity: activity, from: "\(presentedFrom())/detail")
     }
 
     @IBAction func backupButtonTapped(sender: UIButton) {
         guard let activity = activity else {
             return
         }
-        presenter?.presentBackupFor(activity: activity)
+        presenter?.presentBackupFor(activity: activity, from: "\(presentedFrom())/detail")
     }
 
     private func setupLabelStyles() {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -3,8 +3,8 @@ import WordPressFlux
 protocol ActivityPresenter: class {
     func presentDetailsFor(activity: FormattableActivity)
     func presentBackupOrRestoreFor(activity: Activity, from sender: UIButton)
-    func presentRestoreFor(activity: Activity)
-    func presentBackupFor(activity: Activity)
+    func presentRestoreFor(activity: Activity, from: String?)
+    func presentBackupFor(activity: Activity, from: String?)
 }
 
 class ActivityListViewModel: Observable {

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -416,7 +416,7 @@ extension BaseActivityListViewController: ActivityPresenter {
         self.present(alertController, animated: true, completion: nil)
     }
 
-    func presentRestoreFor(activity: Activity) {
+    func presentRestoreFor(activity: Activity, from: String? = nil) {
         guard activity.isRewindable, let rewindID = activity.rewindID else {
             return
         }
@@ -446,15 +446,15 @@ extension BaseActivityListViewController: ActivityPresenter {
 
         let restoreOptionsVC = JetpackRestoreOptionsViewController(site: site, activity: activity)
         restoreOptionsVC.restoreStatusDelegate = self
-        restoreOptionsVC.presentedFrom = configuration.identifier
+        restoreOptionsVC.presentedFrom = from ?? configuration.identifier
         let navigationVC = UINavigationController(rootViewController: restoreOptionsVC)
         self.present(navigationVC, animated: true)
     }
 
-    func presentBackupFor(activity: Activity) {
+    func presentBackupFor(activity: Activity, from: String? = nil) {
         let backupOptionsVC = JetpackBackupOptionsViewController(site: site, activity: activity)
         backupOptionsVC.backupStatusDelegate = self
-        backupOptionsVC.presentedFrom = configuration.identifier
+        backupOptionsVC.presentedFrom = from ?? configuration.identifier
         let navigationVC = UINavigationController(rootViewController: backupOptionsVC)
         self.present(navigationVC, animated: true)
     }


### PR DESCRIPTION
When the user access Restore/Backup from the detail, track the correct `source`.

### To test

Activity Log:

1. Open Activity Log
2. Tap a cell (that has the 3 dots button)
3. Tap Rewind and Backup
4. Make sure the event is fired with `source:activity_log/detail`

Backups:

1. Open Backups screen
2. Tap a cell (that has the 3 dots button)
3. Tap Rewind and Backup
4. Make sure the event is fired with `source:backup/detail`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
