### PR TITLE
Jetpack: fix backup screen being dismissed

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -526,10 +526,8 @@ extension BaseActivityListViewController: JetpackRestoreStatusViewControllerDele
 
 extension BaseActivityListViewController: JetpackBackupStatusViewControllerDelegate {
 
-    func didFinishViewing(_ controller: JetpackBackupStatusViewController) {
-        controller.dismiss(animated: true, completion: { [weak self] in
-            self?.viewModel.refresh()
-        })
+    func didFinishViewing() {
+        viewModel.refresh()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
@@ -4,7 +4,7 @@ import WordPressShared
 import WordPressUI
 
 protocol JetpackBackupStatusViewControllerDelegate: class {
-    func didFinishViewing(_ controller: JetpackBackupStatusViewController)
+    func didFinishViewing()
 }
 
 class JetpackBackupStatusViewController: BaseRestoreStatusViewController {
@@ -56,13 +56,15 @@ class JetpackBackupStatusViewController: BaseRestoreStatusViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         coordinator.viewWillDisappear()
-        delegate?.didFinishViewing(self)
+        delegate?.didFinishViewing()
     }
 
     // MARK: - Override
 
     override func primaryButtonTapped() {
-        delegate?.didFinishViewing(self)
+        dismiss(animated: true, completion: { [weak self] in
+            self?.delegate?.didFinishViewing()
+        })
         WPAnalytics.track(.backupNotifiyMeButtonTapped)
     }
 }


### PR DESCRIPTION
### To test

1. Go to Activity Log or Backup
2. Trigger a backup
3. Wait for it to complete
4. The screen should not be dismissed

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
