### PR TITLE
Reader post options: refactor followed site success message

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -301,11 +301,14 @@ struct ReaderNotificationKeys {
     // MARK: ActionDispatcher Notification helper
 
     class func dispatchToggleSeenMessage(post: ReaderPost, success: Bool) {
-        if success {
-            dispatchNotice(Notice(title: post.isSeen ? NoticeMessages.seenSuccess: NoticeMessages.unseenSuccess))
-        } else {
-            dispatchNotice(Notice(title: post.isSeen ? NoticeMessages.unseenFail : NoticeMessages.seenFail))
+        var notice: Notice {
+            if success {
+                return Notice(title: post.isSeen ? NoticeMessages.seenSuccess: NoticeMessages.unseenSuccess)
+            }
+            return Notice(title: post.isSeen ? NoticeMessages.unseenFail : NoticeMessages.seenFail)
         }
+
+        dispatchNotice(notice)
     }
 
     class func dispatchToggleFollowSiteMessage(post: ReaderPost, success: Bool) {
@@ -331,11 +334,14 @@ struct ReaderNotificationKeys {
     }
 
     class func dispatchToggleNotificationMessage(topic: ReaderSiteTopic, success: Bool) {
-        if success {
-            dispatchNotice(Notice(title: topic.isSubscribedForPostNotifications ? NoticeMessages.notificationOnSuccess: NoticeMessages.notificationOffSuccess))
-        } else {
-            dispatchNotice(Notice(title: topic.isSubscribedForPostNotifications ? NoticeMessages.notificationOffFail : NoticeMessages.notificationOnFail))
+        var notice: Notice {
+            if success {
+                return Notice(title: topic.isSubscribedForPostNotifications ? NoticeMessages.notificationOnSuccess: NoticeMessages.notificationOffSuccess)
+            }
+            return Notice(title: topic.isSubscribedForPostNotifications ? NoticeMessages.notificationOffFail : NoticeMessages.notificationOnFail)
         }
+
+        dispatchNotice(notice)
     }
 
     private class func dispatchNotice(_ notice: Notice) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -309,14 +309,22 @@ struct ReaderNotificationKeys {
     }
 
     class func dispatchToggleFollowSiteMessage(post: ReaderPost, success: Bool) {
+        dispatchToggleFollowSiteMessage(siteTitle: post.blogNameForDisplay(), siteID: post.siteID, following: post.isFollowing, success: success)
+    }
+
+    class func dispatchToggleFollowSiteMessage(topic: ReaderSiteTopic, success: Bool) {
+        dispatchToggleFollowSiteMessage(siteTitle: topic.title, siteID: topic.siteID, following: topic.following, success: success)
+    }
+
+    private class func dispatchToggleFollowSiteMessage(siteTitle: String, siteID: NSNumber, following: Bool, success: Bool) {
         var notice: Notice
 
         if success {
-            notice = post.isFollowing ?
-                followedSiteNotice(post: post) :
-                Notice(title: NoticeMessages.unfollowSuccess, message: post.blogNameForDisplay())
+            notice = following ?
+                followedSiteNotice(siteTitle: siteTitle, siteID: siteID) :
+                Notice(title: NoticeMessages.unfollowSuccess, message: siteTitle)
         } else {
-            notice = Notice(title: post.isFollowing ? NoticeMessages.unfollowFail : NoticeMessages.followFail)
+            notice = Notice(title: following ? NoticeMessages.unfollowFail : NoticeMessages.followFail)
         }
 
         dispatchNotice(notice)
@@ -334,12 +342,12 @@ struct ReaderNotificationKeys {
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
-    private class func followedSiteNotice(post: ReaderPost) -> Notice {
-        let notice = Notice(title: String(format: NoticeMessages.followSuccess, post.blogNameForDisplay()),
+    private class func followedSiteNotice(siteTitle: String, siteID: NSNumber) -> Notice {
+        let notice = Notice(title: String(format: NoticeMessages.followSuccess, siteTitle),
                             message: NoticeMessages.enableNotifications,
                             actionTitle: NoticeMessages.enableButtonLabel) { _ in
             let service = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-            service.toggleSubscribingNotifications(for: post.siteID.intValue, subscribe: true, {
+            service.toggleSubscribingNotifications(for: siteID.intValue, subscribe: true, {
                 WPAnalytics.track(.readerListNotificationEnabled)
             })
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -303,7 +303,7 @@ struct ReaderNotificationKeys {
     class func dispatchToggleSeenMessage(post: ReaderPost, success: Bool) {
         var notice: Notice {
             if success {
-                return Notice(title: post.isSeen ? NoticeMessages.seenSuccess: NoticeMessages.unseenSuccess)
+                return Notice(title: post.isSeen ? NoticeMessages.seenSuccess : NoticeMessages.unseenSuccess)
             }
             return Notice(title: post.isSeen ? NoticeMessages.unseenFail : NoticeMessages.seenFail)
         }
@@ -336,7 +336,7 @@ struct ReaderNotificationKeys {
     class func dispatchToggleNotificationMessage(topic: ReaderSiteTopic, success: Bool) {
         var notice: Notice {
             if success {
-                return Notice(title: topic.isSubscribedForPostNotifications ? NoticeMessages.notificationOnSuccess: NoticeMessages.notificationOffSuccess)
+                return Notice(title: topic.isSubscribedForPostNotifications ? NoticeMessages.notificationOnSuccess : NoticeMessages.notificationOffSuccess)
             }
             return Notice(title: topic.isSubscribedForPostNotifications ? NoticeMessages.notificationOffFail : NoticeMessages.notificationOnFail)
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -309,14 +309,17 @@ struct ReaderNotificationKeys {
     }
 
     class func dispatchToggleFollowSiteMessage(post: ReaderPost, success: Bool) {
+        var notice: Notice
+
         if success {
-            if !post.isFollowing {
-                // Following is handled by dispatchSubscribingNotificationNotice.
-                dispatchNotice(Notice(title: NoticeMessages.unfollowSuccess, message: post.blogNameForDisplay()))
-            }
+            notice = post.isFollowing ?
+                followedSiteNotice(post: post) :
+                Notice(title: NoticeMessages.unfollowSuccess, message: post.blogNameForDisplay())
         } else {
-            dispatchNotice(Notice(title: post.isFollowing ? NoticeMessages.unfollowFail : NoticeMessages.followFail))
+            notice = Notice(title: post.isFollowing ? NoticeMessages.unfollowFail : NoticeMessages.followFail)
         }
+
+        dispatchNotice(notice)
     }
 
     class func dispatchToggleNotificationMessage(topic: ReaderSiteTopic, success: Bool) {
@@ -331,11 +334,25 @@ struct ReaderNotificationKeys {
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
+    private class func followedSiteNotice(post: ReaderPost) -> Notice {
+        let notice = Notice(title: String(format: NoticeMessages.followSuccess, post.blogNameForDisplay()),
+                            message: NoticeMessages.enableNotifications,
+                            actionTitle: NoticeMessages.enableButtonLabel) { _ in
+            let service = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+            service.toggleSubscribingNotifications(for: post.siteID.intValue, subscribe: true, {
+                WPAnalytics.track(.readerListNotificationEnabled)
+            })
+        }
+
+        return notice
+    }
+
     private struct NoticeMessages {
         static let seenFail = NSLocalizedString("Unable to mark post seen", comment: "Notice title when updating a post's seen status failed.")
         static let unseenFail = NSLocalizedString("Unable to mark post unseen", comment: "Notice title when updating a post's unseen status failed.")
         static let seenSuccess = NSLocalizedString("Marked post as seen", comment: "Notice title when updating a post's seen status succeeds.")
         static let unseenSuccess = NSLocalizedString("Marked post as unseen", comment: "Notice title when updating a post's unseen status succeeds.")
+        static let followSuccess = NSLocalizedString("Following %1$@", comment: "Notice title when following a site succeeds. %1$@ is a placeholder for the site name.")
         static let unfollowSuccess = NSLocalizedString("Unfollowed site", comment: "Notice title when unfollowing a site succeeds.")
         static let followFail = NSLocalizedString("Unable to follow site", comment: "Notice title when following a site fails.")
         static let unfollowFail = NSLocalizedString("Unable to unfollow site", comment: "Notice title when unfollowing a site fails.")
@@ -343,6 +360,8 @@ struct ReaderNotificationKeys {
         static let notificationOffFail = NSLocalizedString("Unable to turn off site notifications", comment: "Notice title when turning site notifications off fails.")
         static let notificationOnSuccess = NSLocalizedString("Turned on site notifications", comment: "Notice title when turning site notifications on succeeds.")
         static let notificationOffSuccess = NSLocalizedString("Turned off site notifications", comment: "Notice title when turning site notifications off succeeds.")
+        static let enableNotifications = NSLocalizedString("Enable site notifications?", comment: "Message prompting user to enable site notifications.")
+        static let enableButtonLabel = NSLocalizedString("Enable", comment: "Button title for the enable site notifications action.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -104,9 +104,9 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
     private func toggleFollowingForPost(_ post: ReaderPost) {
         ReaderFollowAction().execute(with: post,
                                      context: context,
-                                     completion: { [weak self] in
+                                     completion: {
                                         if post.isFollowing {
-                                            self?.origin?.dispatchSubscribingNotificationNotice(with: post.blogNameForDisplay(), siteID: post.siteID)
+                                            ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: true)
                                         }
                                      }, failure: { _ in
                                         ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: false)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -73,12 +73,7 @@ final class ReaderShowMenuAction {
                                                     ReaderFollowAction().execute(with: post,
                                                                                  context: context,
                                                                                  completion: {
-                                                                                    if post.isFollowing {
-                                                                                        vc.dispatchSubscribingNotificationNotice(with: post.blogNameForDisplay(), siteID: post.siteID)
-                                                                                    } else {
-                                                                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: true)
-                                                                                    }
-
+                                                                                    ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: true)
                                                                                     (vc as? ReaderStreamViewController)?.updateStreamHeaderIfNeeded()
                                                                                  }, failure: { _ in
                                                                                     ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: false)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1280,30 +1280,16 @@ import WordPressFlux
     }
 
     private func toggleFollowingForSite(_ topic: ReaderSiteTopic, completion: ((Bool) -> Void)?) {
-        let generator = UINotificationFeedbackGenerator()
-        generator.prepare()
-
-        if !topic.following {
-            generator.notificationOccurred(.success)
-        }
-
-        let toFollow = !topic.following
-        let siteID = topic.siteID
-        let siteTitle = topic.title
-
-        if !toFollow {
-            ReaderSubscribingNotificationAction().execute(for: siteID, context: managedObjectContext(), subscribe: !topic.isSubscribedForPostNotifications)
+        if topic.following {
+            ReaderSubscribingNotificationAction().execute(for: siteID, context: managedObjectContext(), subscribe: false)
         }
 
         let service = ReaderTopicService(managedObjectContext: topic.managedObjectContext!)
-        service.toggleFollowing(forSite: topic, success: { [weak self] in
-            if toFollow {
-                self?.dispatchSubscribingNotificationNotice(with: siteTitle, siteID: siteID)
-            }
-
+        service.toggleFollowing(forSite: topic, success: {
+            ReaderHelpers.dispatchToggleFollowSiteMessage(topic: topic, success: true)
             completion?(true)
         }, failure: { (error: Error?) in
-            generator.notificationOccurred(.error)
+            ReaderHelpers.dispatchToggleFollowSiteMessage(topic: topic, success: false)
             completion?(false)
         })
     }


### PR DESCRIPTION
Ref: #15761 

This changes the way successful site following notifications are dispatched. They are now sent from `ReaderHelpers` along with the other notifications, instead of from `UIViewController+Notice:dispatchSubscribingNotificationNotice`.

NOTE: `dispatchSubscribingNotificationNotice` is still used in `ReaderPostMenu`. I'll remove both later.

To test:

There should be no functional changes, so to confirm I didn't break anything:

---
- In the Reader, show posts you are not following (ex: Discover, filter by topic).
- On a post card or in post details, tap the options menu button.
- Select `Follow Site`.
- Verify a toast message appears.

This functionality has not changed, but if you tap `Enable` on the notification, you should see `Success turn notifications on` in the logs as confirmation.

| ![menu](https://user-images.githubusercontent.com/1816888/106824396-f982be00-663f-11eb-8793-b18d398881f2.png) | ![message](https://user-images.githubusercontent.com/1816888/106824427-08697080-6640-11eb-8321-169fa2bfb423.png) |
|--------|-------|

---
- In Discover, scroll down to `Sites to follow`.
- Tap the follow button.
- Verify a toast message appears.

| ![IMG_54ACFABE40FE-1](https://user-images.githubusercontent.com/1816888/107097983-5fe81780-67cb-11eb-9b3f-6bec1571c746.jpeg) | ![IMG_21066F6BC050-1](https://user-images.githubusercontent.com/1816888/107097990-64143500-67cb-11eb-999d-2eb17914b1e6.jpeg) |
|--------|-------|

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
