### PR TITLE
Fix login via email link flow

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -257,9 +257,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         epilogueViewController.onDismiss = { [weak self] in
             onDismiss()
 
-            if navigationController == UIApplication.shared.keyWindow?.rootViewController {
-                self?.windowManager.dismissFullscreenSignIn()
-            }
+            self?.windowManager.dismissFullscreenSignIn()
         }
 
         navigationController.pushViewController(epilogueViewController, animated: true)


### PR DESCRIPTION

Fixes #15822

To test:

**Test login via email link**

1. Build/run this branch and logout if needed.
2. tap "Continue with WordPress".
3. Enter a valid account email address and tap "Continue".
4. Tap "Get a login link by email".
5. Tap "Open Mail" and choose your email client.
6. In the email that you just received from WordPress.com, tap "Log in to the app".
7. After being redirected to the app, make sure you can dismiss the login epilogue and use the app as expected.

**Also test all the other login scenarios and make sure they work as expected**

1. Login with email and password
2. Login with Apple
3. Login with Google
4. Login with site address
5. Login with 1-3 and add a self hosted site

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
