### PR TITLE
Display loader when site title is updating

### DIFF
--- a/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
@@ -7,6 +7,7 @@ protocol Spotlightable: UIView {
 class SpotlightableButton: UIButton, Spotlightable {
 
     var spotlight: QuickStartSpotlightView?
+    var originalTtile: String?
 
     var shouldShowSpotlight: Bool {
         get {
@@ -24,12 +25,14 @@ class SpotlightableButton: UIButton, Spotlightable {
     }
 
     func startLoading() {
+        originalTtile = titleLabel?.text
         setTitle("", for: .normal)
         activityIndicator.startAnimating()
     }
 
     func stopLoading() {
         activityIndicator.stopAnimating()
+        setTitle(originalTtile, for: .normal)
     }
 
     private lazy var activityIndicator: UIActivityIndicatorView = {

--- a/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
@@ -23,6 +23,28 @@ class SpotlightableButton: UIButton, Spotlightable {
         }
     }
 
+    func startLoading() {
+        setTitle("", for: .normal)
+        activityIndicator.startAnimating()
+    }
+    
+    func stopLoading() {
+        activityIndicator.stopAnimating()
+    }
+
+    private lazy var activityIndicator: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView(style: .large)
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(activityIndicator)
+        
+        NSLayoutConstraint.activate([
+            activityIndicator.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            activityIndicator.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+        ])
+        
+        return activityIndicator
+    }()
+
     private func setupSpotlight() {
         spotlight?.removeFromSuperview()
 

--- a/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
@@ -32,7 +32,7 @@ class SpotlightableButton: UIButton, Spotlightable {
 
     func stopLoading() {
         activityIndicator.stopAnimating()
-        setTitle(originalTtile, for: .normal)
+        setTitle(originalTitle, for: .normal)
     }
 
     private lazy var activityIndicator: UIActivityIndicatorView = {

--- a/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
@@ -25,7 +25,7 @@ class SpotlightableButton: UIButton, Spotlightable {
     }
 
     func startLoading() {
-        originalTtile = titleLabel?.text
+        originalTitle = titleLabel?.text
         setTitle("", for: .normal)
         activityIndicator.startAnimating()
     }

--- a/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
@@ -27,7 +27,7 @@ class SpotlightableButton: UIButton, Spotlightable {
         setTitle("", for: .normal)
         activityIndicator.startAnimating()
     }
-    
+
     func stopLoading() {
         activityIndicator.stopAnimating()
     }
@@ -36,12 +36,12 @@ class SpotlightableButton: UIButton, Spotlightable {
         let activityIndicator = UIActivityIndicatorView(style: .large)
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         addSubview(activityIndicator)
-        
+
         NSLayoutConstraint.activate([
             activityIndicator.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             activityIndicator.centerXAnchor.constraint(equalTo: self.centerXAnchor)
         ])
-        
+
         return activityIndicator
     }()
 

--- a/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
@@ -7,7 +7,7 @@ protocol Spotlightable: UIView {
 class SpotlightableButton: UIButton, Spotlightable {
 
     var spotlight: QuickStartSpotlightView?
-    var originalTtile: String?
+    var originalTitle: String?
 
     var shouldShowSpotlight: Bool {
         get {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
@@ -67,6 +67,7 @@ extension BlogDetailsViewController {
         // Save the old value in case we need to roll back
         let existingBlogTitle = blog.settings?.name ?? SiteTitleStrings.defaultSiteTitle
         blog.settings?.name = title
+        headerView.updateLoadingTitle(isLoading: true)
 
         let service = BlogService(managedObjectContext: context)
         service.updateSettings(for: blog, success: { [weak self] in
@@ -77,6 +78,7 @@ extension BlogDetailsViewController {
                                 feedbackType: .success)
             ActionDispatcher.global.dispatch(NoticeAction.post(notice))
 
+            self?.headerView.updateLoadingTitle(isLoading: false)
             self?.headerView.refreshSiteTitle()
         }, failure: { [weak self] error in
             self?.blog.settings?.name = existingBlogTitle

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
@@ -67,7 +67,7 @@ extension BlogDetailsViewController {
         // Save the old value in case we need to roll back
         let existingBlogTitle = blog.settings?.name ?? SiteTitleStrings.defaultSiteTitle
         blog.settings?.name = title
-        headerView.updateLoadingTitle(isLoading: true)
+        headerView.setTitleLoading(true)
 
         let service = BlogService(managedObjectContext: context)
         service.updateSettings(for: blog, success: { [weak self] in
@@ -78,11 +78,11 @@ extension BlogDetailsViewController {
                                 feedbackType: .success)
             ActionDispatcher.global.dispatch(NoticeAction.post(notice))
 
-            self?.headerView.updateLoadingTitle(isLoading: false)
+            self?.headerView.setTitleLoading(false)
             self?.headerView.refreshSiteTitle()
         }, failure: { [weak self] error in
             self?.blog.settings?.name = existingBlogTitle
-
+            self?.headerView.setTitleLoading(false)
             let notice = Notice(title: SiteTitleStrings.settingsSaveErrorTitle,
                                 message: SiteTitleStrings.settingsSaveErrorMessage,
                                 feedbackType: .error)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeader.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeader.swift
@@ -35,5 +35,5 @@ protocol BlogDetailHeader: NSObjectProtocol {
     func toggleSpotlightOnSiteIcon()
 
     @objc
-    func updateLoadingTitle(isLoading: Bool)
+    func setTitleLoading(_ isLoading: Bool)
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeader.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeader.swift
@@ -33,4 +33,7 @@ protocol BlogDetailHeader: NSObjectProtocol {
 
     @objc
     func toggleSpotlightOnSiteIcon()
+    
+    @objc
+    func updateLoadingTitle(isLoading: Bool)
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeader.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeader.swift
@@ -33,7 +33,7 @@ protocol BlogDetailHeader: NSObjectProtocol {
 
     @objc
     func toggleSpotlightOnSiteIcon()
-    
+
     @objc
     func updateLoadingTitle(isLoading: Bool)
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -91,6 +91,10 @@ class BlogDetailHeaderView: UIView, BlogDetailHeader {
     @objc func toggleSpotlightOnSiteIcon() {
         siteIconView.spotlightIsShown = QuickStartTourGuide.shared.isCurrentElement(.siteIcon)
     }
+    
+    @objc func updateLoadingTitle(isLoading: Bool) {
+        isLoading ? titleButton.startLoading() : titleButton.stopLoading()
+    }
 
     private enum Constants {
         static let spacingBelowIcon: CGFloat = 16

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -92,7 +92,7 @@ class BlogDetailHeaderView: UIView, BlogDetailHeader {
         siteIconView.spotlightIsShown = QuickStartTourGuide.shared.isCurrentElement(.siteIcon)
     }
 
-    @objc func updateLoadingTitle(isLoading: Bool) {
+    @objc func setTitleLoading(_ isLoading: Bool) {
         isLoading ? titleButton.startLoading() : titleButton.stopLoading()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -32,7 +32,7 @@ class BlogDetailHeaderView: UIView, BlogDetailHeader {
         label.adjustsFontForContentSizeCategory = true
         return label
     }()
-    
+
     private let siteIconView: SiteIconView = {
         let view = SiteIconView(frame: .zero)
         return view

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -32,7 +32,7 @@ class BlogDetailHeaderView: UIView, BlogDetailHeader {
         label.adjustsFontForContentSizeCategory = true
         return label
     }()
-
+    
     private let siteIconView: SiteIconView = {
         let view = SiteIconView(frame: .zero)
         return view
@@ -91,7 +91,7 @@ class BlogDetailHeaderView: UIView, BlogDetailHeader {
     @objc func toggleSpotlightOnSiteIcon() {
         siteIconView.spotlightIsShown = QuickStartTourGuide.shared.isCurrentElement(.siteIcon)
     }
-    
+
     @objc func updateLoadingTitle(isLoading: Bool) {
         isLoading ? titleButton.startLoading() : titleButton.stopLoading()
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -70,7 +70,7 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
 
         toggleSpotlightOnSiteIcon()
     }
-    
+
     func updateLoadingTitle(isLoading: Bool) {
         isLoading ? titleButton.startLoading() : titleButton.stopLoading()
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -70,6 +70,10 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
 
         toggleSpotlightOnSiteIcon()
     }
+    
+    func updateLoadingTitle(isLoading: Bool) {
+        isLoading ? titleButton.startLoading() : titleButton.stopLoading()
+    }
 
     func refreshSiteTitle() {
         let blogName = blog?.settings?.name

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -71,7 +71,7 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
         toggleSpotlightOnSiteIcon()
     }
 
-    func updateLoadingTitle(isLoading: Bool) {
+    func setTitleLoading(_ isLoading: Bool) {
         isLoading ? titleButton.startLoading() : titleButton.stopLoading()
     }
 


### PR DESCRIPTION
Fixes #15717 

To test:
on the My Site page:

1. Tap the title of your site under the icon
2. A Site Title modal will open where you can edit.
3. Make some change and Save
4. See loader 
5. See loader removed when stopped loading 
6. See title updated 


https://user-images.githubusercontent.com/1335657/107131474-6b027c80-688b-11eb-98bb-d21833a9bc69.mov



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
