### PR TITLE
Remove obtainPermanentIDForObject

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -55,8 +55,9 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     post.postFormat = blog.settings.defaultPostFormat;
     post.postType = Post.typeDefaultIdentifier;
 
-    [[ContextManager sharedInstance] obtainPermanentIDForObject:post];
-    
+    [blog.managedObjectContext obtainPermanentIDsForObjects:@[post] error:nil];
+    NSAssert(![post.objectID isTemporaryID], @"The new post for this blog must have a permanent ObjectID");
+
     return post;
 }
 
@@ -73,7 +74,8 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     page.date_created_gmt = [NSDate date];
     page.remoteStatus = AbstractPostRemoteStatusSync;
 
-    [[ContextManager sharedInstance] obtainPermanentIDForObject:page];
+    [blog.managedObjectContext obtainPermanentIDsForObjects:@[page] error:nil];
+    NSAssert(![page.objectID isTemporaryID], @"The new page for this blog must have a permanent ObjectID");
 
     return page;
 }

--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)saveContextAndWait:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^)(void))completionBlock;
-- (BOOL)obtainPermanentIDForObject:(NSManagedObject *)managedObject;
 - (void)mergeChanges:(NSManagedObjectContext *)context fromContextDidSaveNotification:(NSNotification *)notification;
 @end
 
@@ -93,14 +92,6 @@ NS_ASSUME_NONNULL_BEGIN
  @param a completion block that will be executed on the main queue
  */
 - (void)saveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^)(void))completionBlock;
-
-/**
- Get a permanent NSManagedObjectID for the specified NSManagedObject
- 
- @param managedObject A managedObject with a temporary NSManagedObjectID
- @return YES if the permanentID was successfully obtained, or NO if it failed.
- */
-- (BOOL)obtainPermanentIDForObject:(NSManagedObject *)managedObject;
 
 /**
  Merge changes for a given context with a fault-protection, on the context's queue.

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -159,26 +159,6 @@ static ContextManager *_override;
     }
 }
 
-- (BOOL)obtainPermanentIDForObject:(NSManagedObject *)managedObject
-{
-    // Failsafe
-    if (!managedObject) {
-        return NO;
-    }
-
-    if (managedObject && ![managedObject.objectID isTemporaryID]) {
-        // Object already has a permanent ID so just return success.
-        return YES;
-    }
-
-    NSError *error;
-    if (![managedObject.managedObjectContext obtainPermanentIDsForObjects:@[managedObject] error:&error]) {
-        DDLogError(@"Error obtaining permanent object ID for %@, %@", managedObject, error);
-        return NO;
-    }
-    return YES;
-}
-
 - (void)mergeChanges:(NSManagedObjectContext *)context fromContextDidSaveNotification:(NSNotification *)notification
 {
     [context performBlock:^{

--- a/WordPress/WordPressTest/TestContextManager.m
+++ b/WordPress/WordPressTest/TestContextManager.m
@@ -113,10 +113,6 @@ static TestContextManager *_instance;
     return [_stack newMainContextChildContext];
 }
 
-- (BOOL)obtainPermanentIDForObject:(nonnull NSManagedObject *)managedObject {
-    return [_stack obtainPermanentIDForObject:managedObject];
-}
-
 - (NSURL *)storeURL
 {
     NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,


### PR DESCRIPTION
A little bit of cleanup on the way to #15821.

This PR removes the `obtainPermanentIDForObject` method from the `ContextManager` for a few reasons:
1. It's only called from a single place.
2. When it's called, the return value is currently ignored.
3. The Core Data Stack shouldn't be responsible for this – if anything, this should be an extension of `NSManagedObjectContext` (though because of the single use, I'm not sure it's worth converting).

For safety, I've added an `NSAssert` to the the `PostService`, but I could see a strong argument for making it crash in production as well – if a post isn't set up correctly, IMHO it's better to crash than potentially lose user data.

To test:
- Ensure tests pass
- Ensure making an empty post/page works correctly in a `debug` build.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
