### PR TITLE
Fix typo on ignore threat message

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanThreatViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanThreatViewModel.swift
@@ -312,7 +312,7 @@ struct JetpackScanThreatViewModel {
                 }
 
                 struct messages {
-                    static let ignore = NSLocalizedString("You shouldn’t ignore a security unless you are absolutely sure it’s harmless. If you choose to ignore this threat, it will remain on your site \"%1$@\".", comment: "Message displayed in ignore threat alert. %1$@ is a placeholder for the blog name.")
+                    static let ignore = NSLocalizedString("You shouldn’t ignore a security issue unless you are absolutely sure it’s harmless. If you choose to ignore this threat, it will remain on your site \"%1$@\".", comment: "Message displayed in ignore threat alert. %1$@ is a placeholder for the blog name.")
                 }
             }
 


### PR DESCRIPTION
Fixes a typo on the ignore threat alert message

### Screenshot
<img width="300" alt="Screen Shot 2021-02-09 at 1 29 58 PM" src="https://user-images.githubusercontent.com/793774/107410173-ef970a00-6ada-11eb-85e0-20f0a7d0d524.png">



### To test:
1. Launch the app
2. Tap on the My Sites tab
3. Tap on a site with Jetpack Scan enabled
4. Tap on Scan
5. Tap on a current threat
6. Tap 'Ignore'
7. Verify the message does not contain any typos

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
