### PR TITLE
Reader > Discover: update UI when site is blocked

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -358,7 +358,20 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func configureNotifications() {
-        NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(willEnterForeground),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(siteBlocked(_:)),
+                                               name: .ReaderSiteBlocked,
+                                               object: nil)
+    }
+
+    @objc private func siteBlocked(_ notification: Foundation.Notification) {
+        navigationController?.popViewController(animated: true)
+        dismiss(animated: true, completion: nil)
     }
 
     /// Ask the coordinator to present the share sheet

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBlockSiteAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBlockSiteAction.swift
@@ -6,24 +6,14 @@ final class ReaderBlockSiteAction {
         self.asBlocked = asBlocked
     }
 
-    func execute(with post: ReaderPost, context: NSManagedObjectContext, completion: (() -> Void)? = nil) {
+    func execute(with post: ReaderPost, context: NSManagedObjectContext, completion: (() -> Void)? = nil, failure: ((Error?) -> Void)? = nil) {
         let service = ReaderSiteService(managedObjectContext: context)
         service.flagSite(withID: post.siteID,
                          asBlocked: asBlocked,
-                         success: nil,
-                         failure: { (error: Error?) in
-                            completion?()
-
-                            let message = error?.localizedDescription ?? ""
-                            let errorTitle = NSLocalizedString("Error Blocking Site", comment: "Title of a prompt letting the user know there was an error trying to block a site from appearing in the reader.")
-                            let cancelTitle = NSLocalizedString("OK", comment: "Text for an alert's dismissal button.")
-                            let alertController = UIAlertController(title: errorTitle,
-                                                                    message: message,
-                                                                    preferredStyle: .alert)
-                            alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
-                            alertController.presentFromRootViewController()
+                         success: {
                             WPAnalytics.trackReader(.readerBlogBlocked, properties: ["blogId": post.siteID as Any])
-        })
-
+                            completion?()
+                         },
+                         failure: failure)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -192,11 +192,32 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
                                                selector: #selector(manageControllerWasDismissed(_:)),
                                                name: .readerManageControllerWasDismissed,
                                                object: nil)
+
+        // Listens for when a site is blocked
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(siteBlocked(_:)),
+                                               name: .ReaderSiteBlocked,
+                                               object: nil)
     }
 
-    @objc func manageControllerWasDismissed(_ notification: Foundation.Notification) {
+    @objc private func manageControllerWasDismissed(_ notification: Foundation.Notification) {
         shouldForceRefresh = true
         self.displaySelectInterestsIfNeeded()
+    }
+
+    /// Update the post card when a site is blocked from post details.
+    ///
+    @objc private func siteBlocked(_ notification: Foundation.Notification) {
+        guard let userInfo = notification.userInfo,
+              let post = userInfo[ReaderNotificationKeys.post] as? ReaderPost,
+              let posts = content.content as? [ReaderCard], // let posts = cards
+              let contentPost = posts.first(where: { $0.post?.postID == post.postID }),
+              let indexPath = content.indexPath(forObject: contentPost) else {
+            return
+        }
+
+        super.syncIfAppropriate(forceSync: true)
+        tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.fade)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -12,6 +12,8 @@ extension NSNotification.Name {
     static let ReaderSiteFollowed = NSNotification.Name(rawValue: "ReaderSiteFollowed")
     // Sent when a post's seen state has been toggled.
     static let ReaderPostSeenToggled = NSNotification.Name(rawValue: "ReaderPostSeenToggled")
+    // Sent when a site is blocked.
+    static let ReaderSiteBlocked = NSNotification.Name(rawValue: "ReaderSiteBlocked")
 }
 
 struct ReaderNotificationKeys {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -18,7 +18,6 @@ struct ReaderPostMenuButtonTitles {
 
 
 open class ReaderPostMenu {
-    public static let BlockSiteNotification = "ReaderPostMenuBlockSiteNotification"
 
     open class func showMenuForPost(_ post: ReaderPost, topic: ReaderSiteTopic? = nil, fromView anchorView: UIView, inViewController viewController: UIViewController?) {
 
@@ -142,9 +141,7 @@ open class ReaderPostMenu {
 
 
     fileprivate class func blockSiteForPost(_ post: ReaderPost) {
-        // TODO: Dispatch notification to block the site for the specified post.
-        // The list and the detail will need to handle this separately
-        NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: BlockSiteNotification), object: nil, userInfo: ["post": post])
+        NotificationCenter.default.post(name: .ReaderSiteBlocked, object: nil, userInfo: ["post": post])
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -24,9 +24,20 @@ final class ReaderShowMenuAction {
                                                style: .destructive,
                                                handler: { (action: UIAlertAction) in
                                                 if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
-                                                    ReaderBlockSiteAction(asBlocked: true).execute(with: post, context: context, completion: {})
+                                                    ReaderBlockSiteAction(asBlocked: true).execute(with: post, context: context, completion: {
+
+                                                        // TODO: show success message
+
+                                                        // Notify Reader Cards Stream so the post card is updated.
+                                                        NotificationCenter.default.post(name: .ReaderSiteBlocked,
+                                                                                        object: nil,
+                                                                                        userInfo: [ReaderNotificationKeys.post: post])
+                                                    },
+                                                    failure: { _ in
+                                                        // TODO: show error message
+                                                    })
                                                 }
-            })
+                                               })
         }
 
         // Report button

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -610,7 +610,7 @@ import WordPressFlux
             listentingForBlockedSiteNotification = true
             NotificationCenter.default.addObserver(self,
                 selector: #selector(ReaderStreamViewController.handleBlockSiteNotification(_:)),
-                name: NSNotification.Name(rawValue: ReaderPostMenu.BlockSiteNotification),
+                name: .ReaderSiteBlocked,
                 object: nil)
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -749,23 +749,20 @@ import WordPressFlux
 
     // MARK: - Blocking
 
-    private func blockSiteForPost(_ post: ReaderPost) {
-        guard let indexPath = content.indexPath(forObject: post) else {
+    /// Update the post card when a site is blocked from post details.
+    ///
+    @objc private func handleBlockSiteNotification(_ notification: Foundation.Notification) {
+        guard let userInfo = notification.userInfo,
+              let aPost = userInfo[ReaderNotificationKeys.post] as? ReaderPost,
+              let post = (try? managedObjectContext().existingObject(with: aPost.objectID)) as? ReaderPost,
+              let indexPath = content.indexPath(forObject: post) else {
             return
         }
 
-        let objectID = post.objectID
-        recentlyBlockedSitePostObjectIDs.add(objectID)
+        recentlyBlockedSitePostObjectIDs.remove(post.objectID)
         updateAndPerformFetchRequest()
-
         tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.fade)
-
-        ReaderBlockSiteAction(asBlocked: true).execute(with: post, context: managedObjectContext()) { [weak self] in
-            self?.recentlyBlockedSitePostObjectIDs.remove(objectID)
-            self?.tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.fade)
-        }
     }
-
 
     private func unblockSiteForPost(_ post: ReaderPost) {
         guard let indexPath = content.indexPath(forObject: post) else {
@@ -780,26 +777,6 @@ import WordPressFlux
         ReaderBlockSiteAction(asBlocked: false).execute(with: post, context: managedObjectContext()) { [weak self] in
             self?.recentlyBlockedSitePostObjectIDs.add(objectID)
             self?.tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.fade)
-        }
-    }
-
-
-    /// A user can block a site from the detail screen.  When this happens, we need
-    /// to update the list UI to properly reflect the change. Listen for the
-    /// notification and call blockSiteForPost as needed.
-    ///
-    @objc private func handleBlockSiteNotification(_ notification: Foundation.Notification) {
-        guard let userInfo = notification.userInfo, let aPost = userInfo["post"] as? ReaderPost else {
-            return
-        }
-
-        guard let post = (try? managedObjectContext().existingObject(with: aPost.objectID)) as? ReaderPost else {
-            DDLogError("Error fetching existing post from context.")
-            return
-        }
-
-        if let _ = content.indexPath(forObject: post) {
-            blockSiteForPost(post)
         }
     }
 


### PR DESCRIPTION
Ref: #15761 

This updates relevant UI when a site is blocked from Discover > post card and post details.
- Post card: the Discover stream is updated to automatically remove blocked posts.
- Post details:
  - The Discover stream is updated to automatically remove blocked posts.
  - The post details is automatically dismissed.

Notes:

These changes relate to a conversation on https://github.com/wordpress-mobile/WordPress-iOS/pull/15778. 

> menu still says "Block This Site". Tapping the option a second time yields an error.

I realized the Discover stream was not refreshed to remove blocked site posts, and probably should have been to mimic the behavior when blocking via tag filter. This has been fixed, so you no longer have the opportunity to re-block a site.

> should we automatically dismiss the detail?

Once I realized the stream should automatically remove posts, this made more sense. As noted above, this now happens.

To test:

---
- Go to Reader > Discover.
  - On a post card, `Block This Site`.
  - Verify the stream is refreshed, and the post card is removed.

https://user-images.githubusercontent.com/1816888/107437659-91732280-6aec-11eb-9766-13387077461f.mp4

---
- Tap a Discover post card.
  -  In post details, `Block This Site`.
  - Verify the post details is dismissed.
  - Verify the stream is refreshed, and the post card is removed.

https://user-images.githubusercontent.com/1816888/107437855-da2adb80-6aec-11eb-8b6c-fc336bbfb9c4.mp4

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
