### PR TITLE
Reader: fix post options menu tracks

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -306,7 +306,8 @@ class ReaderDetailCoordinator {
                                                                      context: context,
                                                                      readerTopic: readerTopic,
                                                                      anchor: anchorView,
-                                                                     vc: viewController)
+                                                                     vc: viewController,
+                                                                     source: ReaderPostMenuSource.details)
     }
 
     private func showTopic(_ topic: String) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -308,6 +308,8 @@ class ReaderDetailCoordinator {
                                                                      anchor: anchorView,
                                                                      vc: viewController,
                                                                      source: ReaderPostMenuSource.details)
+
+        WPAnalytics.trackReader(.readerArticleDetailMoreTapped)
     }
 
     private func showTopic(_ topic: String) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -19,6 +19,20 @@ struct ReaderNotificationKeys {
     static let topic = "topic"
 }
 
+// Used for event tracking properties
+enum ReaderPostMenuSource {
+    case card
+    case details
+
+    var description: String {
+        switch self {
+        case .card:
+            return "post_card"
+        case .details:
+            return "post_details"
+        }
+    }
+}
 
 /// A collection of helper methods used by the Reader.
 ///

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuAction.swift
@@ -5,7 +5,12 @@ final class ReaderMenuAction {
         isLoggedIn = logged
     }
 
-    func execute(post: ReaderPost, context: NSManagedObjectContext, readerTopic: ReaderAbstractTopic? = nil, anchor: UIView, vc: UIViewController) {
+    func execute(post: ReaderPost,
+                 context: NSManagedObjectContext,
+                 readerTopic: ReaderAbstractTopic? = nil,
+                 anchor: UIView,
+                 vc: UIViewController,
+                 source: ReaderPostMenuSource) {
         let service: ReaderTopicService = ReaderTopicService(managedObjectContext: context)
         let siteTopic: ReaderSiteTopic? = post.isFollowing ? service.findSiteTopic(withSiteID: post.siteID) : nil
 
@@ -14,6 +19,7 @@ final class ReaderMenuAction {
                                                            siteTopic: siteTopic,
                                                            readerTopic: readerTopic,
                                                            anchor: anchor,
-                                                           vc: vc)
+                                                           vc: vc,
+                                                           source: source)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -81,6 +81,7 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         }
 
         ReaderMenuAction(logged: isLoggedIn).execute(post: post, context: context, readerTopic: topic, anchor: sender, vc: origin, source: ReaderPostMenuSource.card)
+        WPAnalytics.trackReader(.postCardMoreTapped)
     }
 
     func readerCell(_ cell: ReaderPostCardCell, attributionActionForProvider provider: ReaderPostContentProvider) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -80,7 +80,7 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
             return
         }
 
-        ReaderMenuAction(logged: isLoggedIn).execute(post: post, context: context, readerTopic: topic, anchor: sender, vc: origin)
+        ReaderMenuAction(logged: isLoggedIn).execute(post: post, context: context, readerTopic: topic, anchor: sender, vc: origin, source: ReaderPostMenuSource.card)
     }
 
     func readerCell(_ cell: ReaderPostCardCell, attributionActionForProvider provider: ReaderPostContentProvider) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSeenAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSeenAction.swift
@@ -1,10 +1,6 @@
 /// Encapsulates a command to toggle a post's seen status
 final class ReaderSeenAction {
     func execute(with post: ReaderPost, context: NSManagedObjectContext, completion: (() -> Void)? = nil, failure: ((Error?) -> Void)? = nil) {
-
-        let event: WPAnalyticsEvent = post.isSeen ? .readerPostMarkUnseen : .readerPostMarkSeen
-        WPAnalytics.track(event, properties: ["source": "post_card"])
-
         let postService = ReaderPostService(managedObjectContext: context)
         postService.toggleSeen(for: post, success: completion, failure: failure)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -11,7 +11,8 @@ final class ReaderShowMenuAction {
                  siteTopic: ReaderSiteTopic? = nil,
                  readerTopic: ReaderAbstractTopic? = nil,
                  anchor: UIView,
-                 vc: UIViewController) {
+                 vc: UIViewController,
+                 source: ReaderPostMenuSource) {
 
         // Create the action sheet
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
@@ -88,6 +89,10 @@ final class ReaderShowMenuAction {
                 alertController.addActionWithTitle(post.isSeen ? ReaderPostMenuButtonTitles.markUnseen : ReaderPostMenuButtonTitles.markSeen,
                                                    style: .default,
                                                    handler: { (action: UIAlertAction) in
+
+                                                    let event: WPAnalyticsEvent = post.isSeen ? .readerPostMarkUnseen : .readerPostMarkSeen
+                                                    WPAnalytics.track(event, properties: ["source": source.description])
+
                                                     if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
                                                         ReaderSeenAction().execute(with: post, context: context, completion: {
                                                             ReaderHelpers.dispatchToggleSeenMessage(post: post, success: true)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -132,12 +132,9 @@ final class ReaderShowMenuAction {
                 presentationController.sourceView = anchor
                 presentationController.sourceRect = anchor.bounds
             }
-
         } else {
             vc.present(alertController, animated: true)
         }
-
-        WPAnalytics.trackReader(.postCardMoreTapped)
     }
 
     private func shouldShowBlockSiteMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {


### PR DESCRIPTION
Ref: #15761 

This fixes some tracks that got lost when I merged the Reader post options menus on https://github.com/wordpress-mobile/WordPress-iOS/pull/15778.

To test:

Post card > tap more button:
`🔵 Tracked: post_card_more_tapped <subscription_count: xxx>`

Post card > toggle seen:
`🔵 Tracked: reader_mark_as_unseen <source: post_card>`
`🔵 Tracked: reader_mark_as_seen <source: post_card>`

Post details > tap more button: 
`🔵 Tracked: reader_article_detail_more_tapped <subscription_count: xxx>`

Post details > toggle seen:
`🔵 Tracked: reader_mark_as_unseen <source: post_details>`
`🔵 Tracked: reader_mark_as_seen <source: post_details>`



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
