### PR TITLE
Remove newMainContextChildContext in ReaderStreamViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -181,11 +181,6 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     }
 
     private func addObservers() {
-        // Observe the managedObjectContext for changes (likes, saves) and reload the tableView
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(reload(_:)),
-                                               name: .NSManagedObjectContextDidSave,
-                                               object: managedObjectContext())
 
         // Listens for when the reader manage view controller is dismissed
         NotificationCenter.default.addObserver(self,


### PR DESCRIPTION
Works towards #15829

**To test:**
- Launch the app, use the reader stream
- Navigate from the reader stream to My Site to test dealloc behaviour
- Block a site from within the feed, and note that it disappears. (I'm not sure how you would unblock a site from the feed given that it disappears, but given that it works exactly the same I have no reason to believe it wouldn't work if it's possible)


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
