### PR TITLE
[Home Page Picker] Switches close and preview icon placement in Home Page Picker Preview

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/Preview/SiteDesignPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/Preview/SiteDesignPreviewViewController.swift
@@ -62,7 +62,7 @@ class SiteDesignPreviewViewController: UIViewController, NoResultsViewHost, UIPo
         SiteCreationAnalyticsHelper.trackSiteDesignPreviewViewed(siteDesign: siteDesign, previewMode: selectedPreviewDevice)
         observeProgressEstimations()
         configurePreviewDeviceButton()
-        navigationItem.rightBarButtonItem = CollapsableHeaderViewController.closeButton(target: self, action: #selector(closeButtonTapped))
+        navigationItem.leftBarButtonItem = CollapsableHeaderViewController.closeButton(target: self, action: #selector(closeButtonTapped))
     }
 
     deinit {
@@ -93,7 +93,7 @@ class SiteDesignPreviewViewController: UIViewController, NoResultsViewHost, UIPo
 
     private func configurePreviewDeviceButton() {
         let button = UIBarButtonItem(image: UIImage(named: "icon-devices"), style: .plain, target: self, action: #selector(previewDeviceButtonTapped))
-        navigationItem.leftBarButtonItem = button
+        navigationItem.rightBarButtonItem = button
     }
 
     @objc private func previewDeviceButtonTapped() {
@@ -175,7 +175,7 @@ extension SiteDesignPreviewViewController {
         }
 
         popoverPresentationController.permittedArrowDirections = .up
-        popoverPresentationController.barButtonItem = navigationItem.leftBarButtonItem
+        popoverPresentationController.barButtonItem = navigationItem.rightBarButtonItem
     }
 
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {


### PR DESCRIPTION
Fixes #15841

## Description
witches close and preview icon placement in Home Page Picker preview screen

## To test:

1. Start the site creation flow (e.g. Choose site > Add button)
2. Select the Create WordPress.com site option
3. Select a layout
4. Press the Preview button
5. Verify that the preview icon is displayed at the top right of the screen and the close button at the top left

## Screenshots

|Before|After|
|---|---|
<image width="360" src="https://user-images.githubusercontent.com/712873/107392978-3c251a00-6ac8-11eb-8367-69d814d2af5e.png"/>|<image width="360" src="https://user-images.githubusercontent.com/304044/107535588-893ce500-6bc9-11eb-87cd-c54136130c7e.png">|


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
