### PR TITLE
Stats: Update Today widget when refreshing Day data for the current day.

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -130,6 +130,7 @@ struct PeriodStoreState {
     var summary: StatsSummaryTimeIntervalData? {
         didSet {
             storeThisWeekWidgetData()
+            storeTodayHomeWidgetData()
         }
     }
 
@@ -1345,6 +1346,22 @@ extension StatsPeriodStore {
 // MARK: - Widget Data
 
 private extension PeriodStoreState {
+
+    // Store data for the iOS 14 Today widget. We don't need to check if the site
+    // matches here, as `storeHomeWidgetData` does that for us.
+    func storeTodayHomeWidgetData() {
+        guard summary?.period == .day,
+              summary?.periodEndDate == StatsDataHelper.currentDateForSite().normalizedDate(),
+              let todayData = summary?.summaryData.last else {
+            return
+        }
+
+        let todayWidgetStats = TodayWidgetStats(views: todayData.viewsCount,
+                                                visitors: todayData.visitorsCount,
+                                                likes: todayData.likesCount,
+                                                comments: todayData.commentsCount)
+        StoreContainer.shared.statsWidgets.storeHomeWidgetData(widgetType: HomeWidgetTodayData.self, stats: todayWidgetStats)
+    }
 
     func storeThisWeekWidgetData() {
         // Only store data if:


### PR DESCRIPTION
Fixes #15826. This PR ensures that the data for a Today widget is refreshed if the matching Day view is loaded in Stats within the app.

**To test**

- Build and run
- Add a Today widget and ensure it shows some data
- Navigate to Stats > Days for the matching site in the app
- Go back to the home screen
- Trigger more views for the site (visit it from another device, get somebody else to visit it)
- Go back to the app and refresh the Day view – ensure that a higher visit count is shown
- Go back to the home screen and check that the widget shows the updated count

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
