### PR TITLE
Add readerSortingOption to FeatureFlag enum

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -19,6 +19,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackBackupAndRestore
     case todayWidget
     case unseenPosts
+    case readerSortingOption
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -61,6 +62,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .unseenPosts:
             return true
+        case .readerSortingOption:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 
@@ -123,6 +126,8 @@ extension FeatureFlag {
             return "iOS 14 Today Widget"
         case .unseenPosts:
             return "Unseen Posts in Reader"
+        case .readerSortingOption:
+            return "Sorting Option in Reader Discover screen"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -109,6 +109,9 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     // MARK: - Sorting
 
     private func setupSortingButton() {
+        guard FeatureFlag.readerSortingOption.enabled else {
+            return
+        }
         updateSortingOption(.popularity, reloadCards: false)
         tableView.tableHeaderView = sortingButton
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
@@ -106,7 +106,7 @@ class ReaderTopicsTableCardCell: UITableViewCell {
     }
 
     private enum Constants {
-        static let containerInsets = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
+        static let containerInsets = UIEdgeInsets(top: FeatureFlag.readerSortingOption.enabled ? 0 : 8, left: 0, bottom: 0, right: 0)
     }
 }
 


### PR DESCRIPTION
Ref [#14765](https://github.com/wordpress-mobile/WordPress-iOS/issues/14765)

Added `readerSortingOption` to `FeatureFlag` enum to be able to enable/disable sorting option for users on Discover screen in Reader tab.

### To test:

- Disable the `readerSortingOption` feature, open the Reader tab (Discover) and check if the control is not showing.
- Enable the `readerSortingOption` feature, open the Reader tab (Discover) and check if the control is showing and user can choose sorting option.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
