### PR TITLE
Use the full version string on the “About” screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutViewController.swift
@@ -203,6 +203,20 @@ open class AboutViewController: UITableViewController {
         return String(format: localizedTitleText, year)
     }()
 
+    fileprivate lazy var versionString: String = {
+
+        guard let bundleVersion = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String else {
+            return Bundle.main.shortVersionString()
+        }
+
+        /// The version number doesn't really matter for debug builds
+        #if DEBUG
+        return Bundle.main.shortVersionString()
+        #else
+        return Bundle.main.shortVersionString() + "(\(bundleVersion))"
+        #endif
+    }()
+
     fileprivate var rows: [[Row]] {
         let appsBlogHostname = URL(string: WPAutomatticAppsBlogURL)?.host ?? String()
 
@@ -211,7 +225,7 @@ open class AboutViewController: UITableViewController {
         return [
             [
                 Row(title: NSLocalizedString("Version", comment: "Displays the version of the App"),
-                    details: Bundle.main.shortVersionString(),
+                    details: versionString,
                     handler: nil),
 
                 Row(title: NSLocalizedString("Terms of Service", comment: "Opens the Terms of Service Web"),


### PR DESCRIPTION
Per request from @startuptester, adds the full build version to the Me > App Settings > About WordPress for iOS screen.

To test:
- Run an installable build, note that it has a different version number
- Run a local debug build, note that its version is `16.7 (DEV)`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
