### PR TITLE
Replace newMainContextChildContext in PeopleViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -78,9 +78,16 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
 
     /// Core Data Context
     ///
-    private var viewContext: NSManagedObjectContext {
-        ContextManager.sharedInstance().mainContext
-    }
+    /// This particular section of the app is interesting because it's completely ephemeral – none of the data the user sees is persisted at any point. For this reason, we create a special context that
+    /// only lives as long as the `PeopleViewController` does. In the future, this could be adjusted to use its own entire Core Data Stack with NSInMemoryStoreType or some other
+    /// mechanism to deal with this (or could be adapted to persist its data but disable interactivity until on a User / Follower until we've validated that our local data is still correct).
+    /// Either way, for now this approach is preserved for this unique case while not requiring the Core Data Stack to be aware of it.
+    /// - @jkmassel, Feb 11 2021
+    private lazy var viewContext: NSManagedObjectContext = {
+        let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        context.parent = ContextManager.sharedInstance().mainContext
+        return context
+    }()
 
     /// Core Data FRC
     ///


### PR DESCRIPTION
In the style of #15849, this PR continues to work towards #15829.

There's no logic in this file (or in the `PeopleService`) that requires a child context, so swapping this for the `mainContext` should work with no further adjustments – and does in my testing.

To test:
- Launch the app, then navigate to "My Site" > "People" (only available for sites you're an admin on – I'd recommend apps.wordpress.com)
- Try inviting someone to the site
- Try removing someone from the site
- Try changing someone's role on a site
- Any other tests you can think to run 😅

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
