### PR TITLE
Remove newMainContextChildContext from SharingButtonsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -40,7 +40,12 @@ import WordPressShared
     let labelTitle = NSLocalizedString("Label", comment: "Noun. Title for the setting to edit the sharing label text.")
     let twitterUsernameTitle = NSLocalizedString("Twitter Username", comment: "Title for the setting to edit the twitter username used when sharing to twitter.")
     let twitterServiceID = "twitter"
-    let managedObjectContext = ContextManager.sharedInstance().newMainContextChildContext()
+
+    /// Core Data Context
+    ///
+    var viewContext: NSManagedObjectContext {
+        ContextManager.sharedInstance().mainContext
+    }
 
     struct SharingCellIdentifiers {
         static let SettingsCellIdentifier = "SettingsTableViewCellIdentifier"
@@ -65,7 +70,7 @@ import WordPressShared
 
         navigationItem.title = NSLocalizedString("Manage", comment: "Verb. Title of the screen for managing sharing buttons and settings related to sharing.")
 
-        let service = SharingService(managedObjectContext: managedObjectContext)
+        let service = SharingService(managedObjectContext: viewContext)
         buttons = service.allSharingButtonsForBlog(self.blog)
         configureTableView()
         setupSections()
@@ -537,7 +542,7 @@ import WordPressShared
     /// when finished.  Fails silently if there is an error.
     ///
     private func syncSharingButtons() {
-        let service = SharingService(managedObjectContext: managedObjectContext)
+        let service = SharingService(managedObjectContext: viewContext)
         service.syncSharingButtonsForBlog(self.blog,
             success: { [weak self] in
                 self?.reloadButtons()
@@ -551,7 +556,7 @@ import WordPressShared
     /// when finished.  Fails silently if there is an error.
     ///
     private func syncSharingSettings() {
-        let service = BlogService(managedObjectContext: managedObjectContext)
+        let service = BlogService(managedObjectContext: viewContext)
         service.syncSettings(for: blog, success: { [weak self] in
                 self?.reloadSettingsSections()
             },
@@ -623,7 +628,7 @@ import WordPressShared
     /// `buttons` property and refreshes the button section and the more section.
     ///
     private func reloadButtons() {
-        let service = SharingService(managedObjectContext: managedObjectContext)
+        let service = SharingService(managedObjectContext: viewContext)
         buttons = service.allSharingButtonsForBlog(blog)
 
         refreshButtonsSection()
@@ -635,7 +640,7 @@ import WordPressShared
     /// - Parameter refresh: True if the tableview sections should be reloaded.
     ///
     private func syncButtonChangesToBlog(_ refresh: Bool) {
-        let service = SharingService(managedObjectContext: managedObjectContext)
+        let service = SharingService(managedObjectContext: viewContext)
         service.updateSharingButtonsForBlog(blog,
             sharingButtons: buttons,
             success: {[weak self] in


### PR DESCRIPTION
Like its friends #15849 and #15861, this PR continues to work towards #15829.

It replaces `newMainContextChildContext` with a reference to the global `mainContext` for now (this will be changed once we adopt `NSPersistentContainer`). There was no indication from the code _why_ it used a child context – unlike `PeopleController`, the sharing settings are persisted between runs and there are no calls to `rollback` anywhere. 

To test:
- Ensure tests path
- Pick a test site, then go to "Sharing", then choose "Manage" under the "Sharing Buttons" heading.
- Made adjustments to the available sharing buttons, then compare your adjusted settings with Calypso at WordPress.com > Settings > Sharing.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
