### PR TITLE
Discover posts sorting bottom sheet

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -80,6 +80,9 @@ import Foundation
     case readerDiscoverContentPresented
     case readerPostMarkSeen
     case readerPostMarkUnseen
+    case readerDiscoverSortingOptionButtonTapped
+    case readerDiscoverSortingOptionPopularitySelected
+    case readerDiscoverSortingOptionDateSelected
 
     // What's New - Feature announcements
     case featureAnnouncementShown
@@ -277,6 +280,12 @@ import Foundation
             return "reader_mark_as_seen"
         case .readerPostMarkUnseen:
             return "reader_mark_as_unseen"
+        case .readerDiscoverSortingOptionButtonTapped:
+            return "reader_discover_sorting_option_button_tapped"
+        case .readerDiscoverSortingOptionDateSelected:
+            return "reader_discover_sorting_option_date_selected"
+        case .readerDiscoverSortingOptionPopularitySelected:
+            return "reader_discover_sorting_option_popularity_selected"
 
         // What's New - Feature announcements
         case .featureAnnouncementShown:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -81,8 +81,7 @@ import Foundation
     case readerPostMarkSeen
     case readerPostMarkUnseen
     case readerDiscoverSortingOptionButtonTapped
-    case readerDiscoverSortingOptionPopularitySelected
-    case readerDiscoverSortingOptionDateSelected
+    case readerDiscoverSortingOptionSelected
 
     // What's New - Feature announcements
     case featureAnnouncementShown
@@ -282,10 +281,8 @@ import Foundation
             return "reader_mark_as_unseen"
         case .readerDiscoverSortingOptionButtonTapped:
             return "reader_discover_sorting_option_button_tapped"
-        case .readerDiscoverSortingOptionDateSelected:
-            return "reader_discover_sorting_option_date_selected"
-        case .readerDiscoverSortingOptionPopularitySelected:
-            return "reader_discover_sorting_option_popularity_selected"
+        case .readerDiscoverSortingOptionSelected:
+            return "reader_discover_sorting_option_selected"
 
         // What's New - Feature announcements
         case .featureAnnouncementShown:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -15,6 +15,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     private lazy var sortingButton: ReaderSortingOptionButton = {
         let view = ReaderSortingOptionButton()
         view.addTarget(self, action: #selector(didTapSortingButton), for: .touchUpInside)
+        view.accessibilityHint = NSLocalizedString("Tap to change sorting option", comment: "Accessibility hint for sorting option button.")
         return view
     }()
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -140,7 +140,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         let availableSortingOptions: [ReaderSortingOption] = [.popularity, .date]
         let viewController = ReaderSortingOptionViewController(options: availableSortingOptions, preselectedOption: sortingButton.sortingOption) { [weak self] option in
             if let trackingEvent = option.trackingEvent {
-                WPAnalytics.track(trackingEvent)
+                WPAnalytics.track(trackingEvent, properties: ["sortingOption": option.rawValue])
             }
             self?.updateSortingOption(option)
             if self?.presentedViewController != nil {
@@ -366,13 +366,9 @@ extension ReaderCardsStreamViewController {
 
 extension ReaderSortingOption {
     var trackingEvent: WPAnalyticsEvent? {
-        switch self {
-        case .date:
-            return .readerDiscoverSortingOptionDateSelected
-        case .popularity:
-            return .readerDiscoverSortingOptionPopularitySelected
-        case .noSorting:
+        if self == .noSorting {
             return nil
         }
+        return .readerDiscoverSortingOptionSelected
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -116,6 +116,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
             return
         }
 
+        sortingButton.setLabelBottomCompensation(8.0)
         updateSortingOption(ReaderCardsStreamViewController.sortingOption ?? .popularity, reloadCards: false)
         tableView.tableHeaderView = sortingButton
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -346,6 +346,8 @@ extension ReaderCardsStreamViewController: ReaderSitesCardCellDelegate {
     }
 }
 
+// MARK: - UIViewControllerTransitioningDelegate
+
 extension ReaderCardsStreamViewController {
     public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return BottomSheetAnimationController(transitionType: .presenting)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -10,6 +10,8 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     /// Refresh counter used to for random posts on pull to refresh
     private var refreshCount = 0
 
+    private static var sortingOption: ReaderSortingOption?
+
     private lazy var sortingButton: ReaderSortingOptionButton = {
         let view = ReaderSortingOptionButton()
         view.addTarget(self, action: #selector(didTapSortingButton), for: .touchUpInside)
@@ -112,7 +114,8 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         guard FeatureFlag.readerSortingOption.enabled else {
             return
         }
-        updateSortingOption(.popularity, reloadCards: false)
+
+        updateSortingOption(ReaderCardsStreamViewController.sortingOption ?? .popularity, reloadCards: false)
         tableView.tableHeaderView = sortingButton
         NSLayoutConstraint.activate([
             sortingButton.widthAnchor.constraint(equalTo: tableView.widthAnchor),
@@ -123,6 +126,7 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
         let optionChanged = sortingButton.sortingOption != sortingOption
 
         sortingButton.sortingOption = sortingOption
+        ReaderCardsStreamViewController.sortingOption = sortingOption
 
         if optionChanged, reloadCards {
             showGhost()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -128,8 +128,12 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     }
 
     @objc func didTapSortingButton() {
+        WPAnalytics.track(.readerDiscoverSortingOptionButtonTapped)
         let availableSortingOptions: [ReaderSortingOption] = [.popularity, .date]
         let viewController = ReaderSortingOptionViewController(options: availableSortingOptions, preselectedOption: sortingButton.sortingOption) { [weak self] option in
+            if let trackingEvent = option.trackingEvent {
+                WPAnalytics.track(trackingEvent)
+            }
             self?.updateSortingOption(option)
             if self?.presentedViewController != nil {
                 self?.dismiss(animated: true, completion: nil)
@@ -349,5 +353,18 @@ extension ReaderCardsStreamViewController {
 
     public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         return (presentedViewController?.presentationController as? BottomSheetPresentationController)?.interactionController
+    }
+}
+
+extension ReaderSortingOption {
+    var trackingEvent: WPAnalyticsEvent? {
+        switch self {
+        case .date:
+            return .readerDiscoverSortingOptionDateSelected
+        case .popularity:
+            return .readerDiscoverSortingOptionPopularitySelected
+        case .noSorting:
+            return nil
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
@@ -106,7 +106,7 @@ class ReaderTopicsTableCardCell: UITableViewCell {
     }
 
     private enum Constants {
-        static let containerInsets = UIEdgeInsets(top: FeatureFlag.readerSortingOption.enabled ? 0 : 8, left: 0, bottom: 0, right: 0)
+        static let containerInsets = UIEdgeInsets(top: 8, left: 0, bottom: 0, right: 0)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
@@ -142,7 +142,7 @@ class ReaderSortingOptionButton: UIControl {
         label.text = sortingOption.localizedDescription
         iconView.image = sortingOption.image
     }
-    
+
     public func setLabelBottomCompensation(_ compensation: CGFloat) {
         labelBottomConstraint.constant = Constants.bottom + compensation
     }

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
@@ -66,6 +66,10 @@ class ReaderSortingOptionButton: UIControl {
         return view
     }()
 
+    private lazy var labelBottomConstraint: NSLayoutConstraint = {
+        return label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constants.bottom)
+    }()
+
     private lazy var chevronView: UIImageView = {
         let view = UIImageView()
         view.image = .gridicon(.chevronDown)
@@ -119,13 +123,12 @@ class ReaderSortingOptionButton: UIControl {
         NSLayoutConstraint.activate([
             iconView.heightAnchor.constraint(equalToConstant: Constants.iconsHeight),
             iconView.widthAnchor.constraint(equalToConstant: Constants.iconsWidth),
-            iconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            iconView.centerYAnchor.constraint(equalTo: label.centerYAnchor),
             iconView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: Constants.iconLeading),
-            label.centerYAnchor.constraint(equalTo: centerYAnchor),
             label.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: Constants.labelLeading),
             label.topAnchor.constraint(equalTo: topAnchor, constant: Constants.top),
-            label.bottomAnchor.constraint(equalTo: bottomAnchor, constant: Constants.bottom),
-            chevronView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            labelBottomConstraint,
+            chevronView.centerYAnchor.constraint(equalTo: label.centerYAnchor),
             chevronView.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: Constants.chevronLeading),
             chevronView.trailingAnchor.constraint(lessThanOrEqualTo: safeAreaLayoutGuide.trailingAnchor, constant: Constants.chevronTrailing),
             chevronView.heightAnchor.constraint(equalToConstant: Constants.iconsHeight),
@@ -138,5 +141,9 @@ class ReaderSortingOptionButton: UIControl {
     private func bindSortingOption() {
         label.text = sortingOption.localizedDescription
         iconView.image = sortingOption.image
+    }
+    
+    public func setLabelBottomCompensation(_ compensation: CGFloat) {
+        labelBottomConstraint.constant = Constants.bottom + compensation
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
@@ -110,7 +110,7 @@ class ReaderSortingOptionButton: UIControl {
 
         // TODO: check if accessibility is set correctly
         accessibilityIdentifier = "Reader sorting option button"
-        accessibilityLabel = NSLocalizedString("Reader sorting option button", comment: "Accessibility label for sorting option button")
+        accessibilityLabel = NSLocalizedString("Choose reader sorting option", comment: "Accessibility label for sorting option button")
 
         addSubview(iconView)
         addSubview(label)

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
@@ -110,7 +110,7 @@ class ReaderSortingOptionButton: UIControl {
 
         // TODO: check if accessibility is set correctly
         accessibilityIdentifier = "Reader sorting option button"
-        accessibilityLabel = NSLocalizedString("Sorting option button", comment: "Accessibility label for sorting option button")
+        accessibilityLabel = NSLocalizedString("Reader sorting option button", comment: "Accessibility label for sorting option button")
 
         addSubview(iconView)
         addSubview(label)

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
@@ -3,7 +3,7 @@ import UIKit
 extension ReaderSortingOption {
 
     var localizedDescription: String? {
-        // TODO: check if strings are localized
+        // TODO: check if strings are localized properly
         switch self {
         case .date:
             return NSLocalizedString("Recent", comment: "Description of the date sorting option in the Discover tab")
@@ -42,8 +42,9 @@ class ReaderSortingOptionButton: UIControl {
         static let chevronTrailing: CGFloat = -16.0
         // TODO: check if we can use iOS system colors here
         static let iconsTintColor: UIColor = UIColor(light: UIColor(hexString: "4D4D4D"), dark: UIColor(hexString: "BFBFBF"))
+        static let labelColor: UIColor = UIColor(light: .black, dark: .white)
         static let isHighlightedAlpha: CGFloat = 0.5
-        static let isNotHighlightedAlpha: CGFloat = 1
+        static let isNotHighlightedAlpha: CGFloat = 1.0
     }
 
     var sourceView: UIView {
@@ -59,7 +60,7 @@ class ReaderSortingOptionButton: UIControl {
 
     private lazy var label: UILabel = {
         let view = UILabel()
-        view.textColor = UIColor(light: .black, dark: .white)
+        view.textColor = Constants.labelColor
         view.font = WPFontManager.systemSemiBoldFont(ofSize: Constants.fontSize)
         view.translatesAutoresizingMaskIntoConstraints = false
         return view

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
@@ -71,6 +71,7 @@ class ReaderSortingActionSheetOptionControl: ClosureControl {
         label.text = option.title
         accessibilityIdentifier = option.identifier
         accessibilityLabel = option.identifier
+        accessibilityHint = option.sortingOption.accessibilityHint
     }
 
     override init(frame: CGRect, minimalTappableHeight: CGFloat?, closure: @escaping () -> Void) {
@@ -274,5 +275,18 @@ class ClosureControl: UIControl {
             return tappableArea.contains(point)
         }
         return super.point(inside: point, with: event)
+    }
+}
+
+extension ReaderSortingOption {
+    var accessibilityHint: String? {
+        switch self {
+        case .date:
+            return NSLocalizedString("Tap to sort by date", comment: "Accessibility hint for sorting option button.")
+        case .popularity:
+            return NSLocalizedString("Tap to sort by popularity", comment: "Accessibility hint for sorting option button.")
+        case .noSorting:
+            return nil
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
@@ -1,0 +1,277 @@
+import UIKit
+
+struct ReaderSortingActionSheetOption {
+    let title: String
+    let image: UIImage
+    let checked: Bool
+    let identifier: String
+    let sortingOption: ReaderSortingOption
+
+    init(title: String, image: UIImage, checked: Bool, identifier: String, sortingOption: ReaderSortingOption) {
+        self.title = title
+        self.image = image
+        self.checked = checked
+        self.identifier = identifier
+        self.sortingOption = sortingOption
+    }
+}
+
+class ReaderSortingActionSheetOptionControl: ClosureControl {
+    enum Constants {
+        static let iconsHeight: CGFloat = 24.0
+        static let iconsWidth: CGFloat = 24.0
+        static let iconLeading: CGFloat = 16.0
+        static let labelLeading: CGFloat = 6.0
+        static let minimalTappableHeight: CGFloat = 44.0
+        // TODO: check if we should color from assets or from hex
+        static let checkTintColor: UIColor = UIColor(light: UIColor(named: "Blue50") ?? UIColor(hexString: "2271B1"), dark: UIColor(named: "Blue30") ?? UIColor(hexString: "5198D9"))
+        // TODO: check if we can use iOS system colors here
+        static let iconTintColor: UIColor = UIColor(light: UIColor(hexString: "4D4D4D"), dark: UIColor(hexString: "BFBFBF"))
+        static let labelColor: UIColor = UIColor(light: .black, dark: .white)
+    }
+
+    private lazy var checkView: UIImageView = {
+        let view = UIImageView()
+        view.image = .gridicon(.checkmark)
+        view.tintColor = Constants.checkTintColor
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private lazy var imageView: UIImageView = {
+        let view = UIImageView()
+        view.tintColor = Constants.iconTintColor
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private lazy var label: UILabel = {
+        let view = UILabel()
+        view.textColor = Constants.labelColor
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private(set) var option: ReaderSortingOption = .noSorting
+
+    override var isSelected: Bool {
+        didSet {
+            checkView.isHidden = !isSelected
+        }
+    }
+
+    // MARK: - setup
+
+    convenience init(option: ReaderSortingActionSheetOption, closure: @escaping () -> Void) {
+        self.init(frame: CGRect.zero, minimalTappableHeight: Constants.minimalTappableHeight, closure: closure)
+
+        self.option = option.sortingOption
+        isSelected = option.checked
+        imageView.image = option.image
+        label.text = option.title
+        accessibilityIdentifier = option.identifier
+        accessibilityLabel = option.identifier
+    }
+
+    override init(frame: CGRect, minimalTappableHeight: CGFloat?, closure: @escaping () -> Void) {
+        super.init(frame: frame, minimalTappableHeight: minimalTappableHeight, closure: closure)
+
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+
+        setup()
+    }
+
+    private func setup() {
+        translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(checkView)
+        addSubview(imageView)
+        addSubview(label)
+
+        NSLayoutConstraint.activate([
+            checkView.heightAnchor.constraint(equalToConstant: Constants.iconsHeight),
+            checkView.widthAnchor.constraint(equalToConstant: Constants.iconsWidth),
+            imageView.heightAnchor.constraint(equalToConstant: Constants.iconsHeight),
+            imageView.widthAnchor.constraint(equalToConstant: Constants.iconsWidth),
+            checkView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            imageView.leadingAnchor.constraint(equalTo: checkView.trailingAnchor, constant: Constants.iconLeading),
+            label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: Constants.labelLeading),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+            checkView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            checkView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            checkView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+            imageView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            imageView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+            label.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+        ])
+    }
+}
+
+class ReaderSortingOptionViewController: UIViewController {
+    enum Constants {
+        static let gripHeight: CGFloat = 5.0
+        static let cornerRadius: CGFloat = 8.0
+        static let minimumWidth: CGFloat = 300.0
+        static let top: CGFloat = 32.0
+        static let bottom: CGFloat = 32.0
+        static let leading: CGFloat = 16.0
+        static let trailing: CGFloat = 16.0
+
+        enum Stack {
+            static let spacing: CGFloat = 24.0
+        }
+    }
+
+    private let options: [ReaderSortingOption]
+    private let preselectedOption: ReaderSortingOption
+    private let optionChanged: ((ReaderSortingOption) -> Void)?
+
+    private lazy var gripButton: UIButton = {
+        let button = GripButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var headerLabel: UILabel = {
+        let label = UILabel()
+        label.font = WPStyleGuide.fontForTextStyle(.headline)
+        label.text = NSLocalizedString("Sort by", comment: "Sorting bottom sheet header title")
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var optionViews: [ReaderSortingActionSheetOptionControl] = {
+        return options.compactMap({ (option) -> ReaderSortingActionSheetOptionControl? in
+            guard let image = option.image, let title = option.localizedDescription else {
+                return nil
+            }
+            return ReaderSortingActionSheetOptionControl(option: ReaderSortingActionSheetOption(title: title, image: image, checked: option == self.preselectedOption, identifier: title, sortingOption: option)) {
+                self.optionSelected(option)
+            }
+        })
+    }()
+
+    // MARK: - init
+
+    init(options: [ReaderSortingOption], preselectedOption: ReaderSortingOption, optionChanged: ((ReaderSortingOption) -> Void)?) {
+        self.options = options
+        self.preselectedOption = preselectedOption
+        self.optionChanged = optionChanged
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - view lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.clipsToBounds = true
+        view.layer.cornerRadius = Constants.cornerRadius
+        view.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
+        view.backgroundColor = .basicBackground
+
+        setupContent()
+        refreshForTraits()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        refreshForTraits()
+    }
+
+    private func refreshForTraits() {
+        if presentingViewController?.traitCollection.horizontalSizeClass == .regular && presentingViewController?.traitCollection.verticalSizeClass != .compact {
+            gripButton.isHidden = true
+        } else {
+            gripButton.isHidden = false
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        return preferredContentSize = CGSize(width: Constants.minimumWidth, height: view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height)
+    }
+
+    // MARK: - setup
+
+    private func setupContent() {
+        let stackView = UIStackView(arrangedSubviews: optionViews)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = Constants.Stack.spacing
+        stackView.axis = .vertical
+
+        view.addSubview(gripButton)
+        view.addSubview(headerLabel)
+        view.addSubview(stackView)
+
+        let bottomAnchor = stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -Constants.bottom)
+        bottomAnchor.priority = .defaultHigh
+
+        NSLayoutConstraint.activate([
+            gripButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constants.gripHeight),
+            gripButton.heightAnchor.constraint(equalToConstant: Constants.gripHeight),
+            gripButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            headerLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constants.top),
+            headerLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Constants.leading),
+            headerLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Constants.trailing),
+            stackView.topAnchor.constraint(equalTo: headerLabel.bottomAnchor, constant: Constants.top),
+            stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Constants.leading),
+            stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -Constants.trailing),
+            bottomAnchor
+        ])
+    }
+
+    // MARK: - actions
+
+    @objc func buttonPressed() {
+        dismiss(animated: true, completion: nil)
+    }
+
+    private func optionSelected(_ option: ReaderSortingOption) {
+        for optionView in optionViews {
+            optionView.isSelected = option == optionView.option
+        }
+        optionChanged?(option)
+    }
+}
+
+class ClosureControl: UIControl {
+    private let minimalTappableHeight: CGFloat?
+    private let closure: () -> Void
+
+    init(frame: CGRect, minimalTappableHeight: CGFloat?, closure: @escaping () -> Void) {
+        self.minimalTappableHeight = minimalTappableHeight
+        self.closure = closure
+        super.init(frame: frame)
+        self.addTarget(self, action: #selector(tapped), for: .touchUpInside)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc func tapped() {
+        closure()
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        if let minimalTappableHeight = minimalTappableHeight {
+            let offset = max(0.0, (minimalTappableHeight - bounds.height)/2.0)
+            let tappableArea = bounds.insetBy(dx: 0, dy: -offset)
+            return tappableArea.contains(point)
+        }
+        return super.point(inside: point, with: event)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
@@ -153,6 +153,7 @@ class ReaderSortingOptionViewController: UIViewController {
             guard let image = option.image, let title = option.localizedDescription else {
                 return nil
             }
+            // TODO: what should be the accessibility label/identifer for the bottom sheet options?
             return ReaderSortingActionSheetOptionControl(option: ReaderSortingActionSheetOption(title: title, image: image, checked: option == self.preselectedOption, identifier: title, sortingOption: option)) {
                 self.optionSelected(option)
             }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1956,6 +1956,7 @@
 		D8CB56202181A8CE00554EAE /* SiteSegmentsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CB561F2181A8CE00554EAE /* SiteSegmentsService.swift */; };
 		D8D7DF5A20AD18A400B40A2D /* ImgUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F126FDFE20A33BDB0010EB6E /* ImgUploadProcessor.swift */; };
 		D8EB1FD121900810002AE1C4 /* BlogListViewController+SiteCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8EB1FD021900810002AE1C4 /* BlogListViewController+SiteCreation.swift */; };
+		DA19147B25C879D20021B4B9 /* ReaderSortingOptionSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA19147A25C879D20021B4B9 /* ReaderSortingOptionSheetViewController.swift */; };
 		DA417E1425C4877000C45B9E /* ReaderSortingOptionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA417E1325C4877000C45B9E /* ReaderSortingOptionButton.swift */; };
 		E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */; };
 		E10290741F30615A00DAC588 /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10290731F30615A00DAC588 /* Role.swift */; };
@@ -4715,6 +4716,7 @@
 		D8C31CC52188490000A33B35 /* SiteSegmentsCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SiteSegmentsCell.xib; sourceTree = "<group>"; };
 		D8CB561F2181A8CE00554EAE /* SiteSegmentsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteSegmentsService.swift; sourceTree = "<group>"; };
 		D8EB1FD021900810002AE1C4 /* BlogListViewController+SiteCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogListViewController+SiteCreation.swift"; sourceTree = "<group>"; };
+		DA19147A25C879D20021B4B9 /* ReaderSortingOptionSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSortingOptionSheetViewController.swift; sourceTree = "<group>"; };
 		DA417E1325C4877000C45B9E /* ReaderSortingOptionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSortingOptionButton.swift; sourceTree = "<group>"; };
 		DA67DF58196D8F6A005B5BC8 /* WordPress 20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 20.xcdatamodel"; sourceTree = "<group>"; };
 		E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-11-12.xcmappingmodel"; sourceTree = "<group>"; };
@@ -10703,6 +10705,7 @@
 			isa = PBXGroup;
 			children = (
 				DA417E1325C4877000C45B9E /* ReaderSortingOptionButton.swift */,
+				DA19147A25C879D20021B4B9 /* ReaderSortingOptionSheetViewController.swift */,
 			);
 			path = Sorting;
 			sourceTree = "<group>";
@@ -13335,6 +13338,7 @@
 				1759F1801FE1460C0003EC81 /* NoticeView.swift in Sources */,
 				40C403F42215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift in Sources */,
 				7E4A773920F80417001C706D /* ActivityPluginRange.swift in Sources */,
+				DA19147B25C879D20021B4B9 /* ReaderSortingOptionSheetViewController.swift in Sources */,
 				7462BFD02028C49800B552D8 /* ShareNoticeViewModel.swift in Sources */,
 				17A4A36920EE51870071C2CA /* Routes+Reader.swift in Sources */,
 				0807CB721CE670A800CDBDAC /* WPContentSearchHelper.swift in Sources */,


### PR DESCRIPTION
Ref [#14765](https://github.com/wordpress-mobile/WordPress-iOS/issues/14765)

To test:

Open Reader tab, switch to Discover screen, tap sorting option button on top of the posts, switch sorting option and see if the posts reload properly depending on the sorting option.

https://user-images.githubusercontent.com/6242034/107681320-303f8080-6c9f-11eb-99fe-48bd644fb9bd.mov

Things left to check/do:
- [ ] if used strings are localized
- [ ] use proper icons
- [ ] set accessibility correctly
- [ ] check if the styling is correct
- [ ] tracking support

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
