### PR TITLE
Initial replacement prologue carousel

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -407,6 +407,10 @@ extension UIColor {
             return UIColor.black.withAlphaComponent(0.05)
         }
     }
+
+    static var prologueBackground: UIColor {
+        return muriel(color: MurielColor(name: .blue, shade: .shade0))
+    }
 }
 
 extension UIColor {

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -409,7 +409,7 @@ extension UIColor {
     }
 
     static var prologueBackground: UIColor {
-        return muriel(color: MurielColor(name: .blue, shade: .shade0))
+        return UIColor(light: muriel(color: MurielColor(name: .blue, shade: .shade0)), dark: .systemBackground)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
@@ -41,9 +41,8 @@ class UnifiedProloguePageViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
+    override func loadView() {
+        view = UIView()
         view.backgroundColor = .clear
 
         configureStackView()

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
@@ -1,0 +1,78 @@
+import UIKit
+
+enum UnifiedProloguePageType: CaseIterable {
+    case intro
+    case editor
+    case notifications
+    case analytics
+    case reader
+
+    var title: String {
+        switch self {
+        case .intro:
+            return NSLocalizedString("Welcome to the world's most popular website builder.", comment: "Caption displayed in promotional screens shown during the login flow.")
+        case .editor:
+            return NSLocalizedString("With this powerful editor you can post on the go.", comment: "Caption displayed in promotional screens shown during the login flow.")
+        case .notifications:
+            return NSLocalizedString("See comments and notifications in real time.", comment: "Caption displayed in promotional screens shown during the login flow.")
+        case .analytics:
+            return NSLocalizedString("Watch your audience grow with in-depth analytics.", comment: "Caption displayed in promotional screens shown during the login flow.")
+        case .reader:
+            return NSLocalizedString("Follow your favourite sites and discover new reads.", comment: "Caption displayed in promotional screens shown during the login flow.")
+        }
+    }
+}
+
+/// Simple container for each page of the login prologue.
+///
+class UnifiedProloguePageViewController: UIViewController {
+    private let stackView = UIStackView()
+    private let titleLabel = UILabel()
+
+    private var pageType: UnifiedProloguePageType!
+
+    init(pageType: UnifiedProloguePageType) {
+        self.pageType = pageType
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .clear
+
+        configureStackView()
+        configureTitle()
+    }
+
+    private func configureStackView() {
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stackView)
+
+        view.pinSubviewToAllEdges(stackView, insets: UIEdgeInsets(top: Metrics.verticalInset,
+                                                                  left: Metrics.horizontalInset,
+                                                                  bottom: Metrics.verticalInset, right: Metrics.horizontalInset))
+    }
+
+    private func configureTitle() {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(titleLabel)
+
+        titleLabel.font = WPStyleGuide.serifFontForTextStyle(.title1)
+        titleLabel.textColor = .text
+        titleLabel.textAlignment = .center
+        titleLabel.numberOfLines = 0
+
+        titleLabel.text = pageType.title
+    }
+
+    enum Metrics {
+        static let verticalInset: CGFloat = 96
+        static let horizontalInset: CGFloat = 24
+    }
+}

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedPrologueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedPrologueViewController.swift
@@ -27,7 +27,7 @@ class UnifiedPrologueViewController: UIPageViewController {
         UnifiedProloguePageType.allCases.forEach({ type in
                                                     pages.append(UnifiedProloguePageViewController(pageType: type))
         })
-        
+
         setViewControllers([pages[0]], direction: .forward, animated: false)
         view.backgroundColor = .prologueBackground
 

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedPrologueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedPrologueViewController.swift
@@ -1,0 +1,111 @@
+import UIKit
+import WordPressAuthenticator
+
+class UnifiedPrologueViewController: UIPageViewController {
+
+    fileprivate var pages: [UIViewController] = []
+
+    fileprivate var pageControl: UIPageControl!
+
+    fileprivate struct Constants {
+        static let pagerPadding: CGFloat = 16.0
+    }
+
+    init() {
+        super.init(transitionStyle: .scroll, navigationOrientation: .horizontal)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        dataSource = self
+        delegate = self
+
+        pages.append(UIViewController())
+        pages.append(UIViewController())
+        pages.append(UIViewController())
+        pages.append(UIViewController())
+        pages.append(UIViewController())
+
+        setViewControllers([pages[0]], direction: .forward, animated: false)
+        view.backgroundColor = .prologueBackground
+
+        addPageControl()
+    }
+
+    private func addPageControl() {
+        let pageControl = UIPageControl()
+        pageControl.currentPageIndicatorTintColor = .text
+        pageControl.pageIndicatorTintColor = .textSubtle
+
+        pageControl.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(pageControl)
+
+        NSLayoutConstraint.activate([
+            pageControl.leftAnchor.constraint(equalTo: view.leftAnchor),
+            pageControl.rightAnchor.constraint(equalTo: view.rightAnchor),
+            pageControl.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -Constants.pagerPadding)
+        ])
+
+        pageControl.numberOfPages = pages.count
+        pageControl.addTarget(self, action: #selector(handlePageControlValueChanged(sender:)), for: .valueChanged)
+        self.pageControl = pageControl
+    }
+
+    @objc func handlePageControlValueChanged(sender: UIPageControl) {
+        guard let currentPage = viewControllers?.first,
+              let currentIndex = pages.firstIndex(of: currentPage) else {
+            return
+        }
+
+        let direction: UIPageViewController.NavigationDirection = sender.currentPage > currentIndex ? .forward : .reverse
+        setViewControllers([pages[sender.currentPage]], direction: direction, animated: true)
+        WordPressAuthenticator.track(.loginProloguePaged)
+    }
+}
+
+extension UnifiedPrologueViewController: UIPageViewControllerDataSource {
+
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        guard let index = pages.firstIndex(of: viewController),
+              index > 0 else {
+            return nil
+        }
+
+        return pages[index - 1]
+    }
+
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        guard let index = pages.firstIndex(of: viewController),
+              index < pages.count - 1 else {
+            return nil
+        }
+
+        return pages[index + 1]
+    }
+}
+
+extension UnifiedPrologueViewController: UIPageViewControllerDelegate {
+    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+        let toVC = previousViewControllers[0]
+        guard let index = pages.firstIndex(of: toVC) else {
+            return
+        }
+        if !completed {
+            pageControl?.currentPage = index
+        } else {
+            WordPressAuthenticator.track(.loginProloguePaged)
+        }
+    }
+
+    func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
+        let toVC = pendingViewControllers[0]
+        guard let index = pages.firstIndex(of: toVC) else {
+            return
+        }
+        pageControl?.currentPage = index
+    }
+}

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedPrologueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedPrologueViewController.swift
@@ -24,12 +24,10 @@ class UnifiedPrologueViewController: UIPageViewController {
         dataSource = self
         delegate = self
 
-        pages.append(UIViewController())
-        pages.append(UIViewController())
-        pages.append(UIViewController())
-        pages.append(UIViewController())
-        pages.append(UIViewController())
-
+        UnifiedProloguePageType.allCases.forEach({ type in
+                                                    pages.append(UnifiedProloguePageViewController(pageType: type))
+        })
+        
         setViewControllers([pages[0]], direction: .forward, animated: false)
         view.backgroundColor = .prologueBackground
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -46,6 +46,8 @@ class WordPressAuthenticationManager: NSObject {
                                                                 enableUnifiedAuth: FeatureFlag.unifiedAuth.enabled,
                                                                 enableUnifiedCarousel: FeatureFlag.unifiedPrologueCarousel.enabled)
 
+        let prologueVC: UIViewController? =  FeatureFlag.unifiedPrologueCarousel.enabled ? UnifiedPrologueViewController() : nil
+
         let style = WordPressAuthenticatorStyle(primaryNormalBackgroundColor: .primaryButtonBackground,
                                                 primaryNormalBorderColor: nil,
                                                 primaryHighlightBackgroundColor: .primaryButtonDownBackground,
@@ -72,7 +74,9 @@ class WordPressAuthenticationManager: NSObject {
                                                 navBarBadgeColor: .accent(.shade20),
                                                 navBarBackgroundColor: UIColor(light: .brand, dark: .gray(.shade100)),  // NEWBARS - This is temporary while we support old style nav bars in some of the auth flows
                                                 prologueBackgroundColor: .primary,
-                                                prologueTitleColor: .textInverted)
+                                                prologueTitleColor: .textInverted,
+                                                prologueTopContainerChildViewController: prologueVC,
+                                                statusBarStyle: .default)
 
         let unifiedStyle = WordPressAuthenticatorUnifiedStyle(borderColor: .divider,
                                                               errorColor: .error,

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -47,6 +47,7 @@ class WordPressAuthenticationManager: NSObject {
                                                                 enableUnifiedCarousel: FeatureFlag.unifiedPrologueCarousel.enabled)
 
         let prologueVC: UIViewController? =  FeatureFlag.unifiedPrologueCarousel.enabled ? UnifiedPrologueViewController() : nil
+        let statusBarStyle: UIStatusBarStyle = FeatureFlag.unifiedPrologueCarousel.enabled ? .default : .lightContent
 
         let style = WordPressAuthenticatorStyle(primaryNormalBackgroundColor: .primaryButtonBackground,
                                                 primaryNormalBorderColor: nil,
@@ -76,7 +77,7 @@ class WordPressAuthenticationManager: NSObject {
                                                 prologueBackgroundColor: .primary,
                                                 prologueTitleColor: .textInverted,
                                                 prologueTopContainerChildViewController: prologueVC,
-                                                statusBarStyle: .default)
+                                                statusBarStyle: statusBarStyle)
 
         let unifiedStyle = WordPressAuthenticatorUnifiedStyle(borderColor: .divider,
                                                               errorColor: .error,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */; };
 		17BD4A0820F76A4700975AC3 /* Routes+Banners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */; };
 		17BD4A192101D31B00975AC3 /* NavigationActionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BD4A182101D31B00975AC3 /* NavigationActionHelpers.swift */; };
+		17C2FF0925D4852400CDB712 /* UnifiedProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2FF0825D4852400CDB712 /* UnifiedProloguePages.swift */; };
 		17C64BD2248E26A200AF09D7 /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C64BD1248E26A200AF09D7 /* AppAppearance.swift */; };
 		17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */; };
 		17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */; };
@@ -2779,6 +2780,7 @@
 		17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewController.swift; sourceTree = "<group>"; };
 		17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Banners.swift"; sourceTree = "<group>"; };
 		17BD4A182101D31B00975AC3 /* NavigationActionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationActionHelpers.swift; sourceTree = "<group>"; };
+		17C2FF0825D4852400CDB712 /* UnifiedProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedProloguePages.swift; sourceTree = "<group>"; };
 		17C64BD1248E26A200AF09D7 /* AppAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAppearance.swift; sourceTree = "<group>"; };
 		17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchService.swift; sourceTree = "<group>"; };
 		17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchViewController.swift; sourceTree = "<group>"; };
@@ -5783,6 +5785,7 @@
 			isa = PBXGroup;
 			children = (
 				176E194625C465F70058F1C5 /* UnifiedPrologueViewController.swift */,
+				17C2FF0825D4852400CDB712 /* UnifiedProloguePages.swift */,
 			);
 			name = Prologue;
 			sourceTree = "<group>";
@@ -13727,6 +13730,7 @@
 				FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */,
 				B57B99D519A2C20200506504 /* NoteTableHeaderView.swift in Sources */,
 				1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */,
+				17C2FF0925D4852400CDB712 /* UnifiedProloguePages.swift in Sources */,
 				400A2C882217A985000A8A59 /* CountryStatsRecordValue+CoreDataClass.swift in Sources */,
 				08D345561CD7FBA900358E8C /* MenuHeaderViewController.m in Sources */,
 				B5120B381D47CC6C0059361A /* NotificationDetailsViewController.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		1767494E1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */; };
 		176BB87F20D0068500751DCE /* FancyAlertViewController+SavedPosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176BB87E20D0068500751DCE /* FancyAlertViewController+SavedPosts.swift */; };
 		176DEEE91D4615FE00331F30 /* WPSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */; };
+		176E194725C465F70058F1C5 /* UnifiedPrologueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176E194625C465F70058F1C5 /* UnifiedPrologueViewController.swift */; };
 		177074851FB209F100951A4A /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177074841FB209F100951A4A /* CircularProgressView.swift */; };
 		177076211EA206C000705A4A /* PlayIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177076201EA206C000705A4A /* PlayIconView.swift */; };
 		177E7DAD1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */; };
@@ -2756,6 +2757,7 @@
 		1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSearchHeaderView.swift; sourceTree = "<group>"; };
 		176BB87E20D0068500751DCE /* FancyAlertViewController+SavedPosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FancyAlertViewController+SavedPosts.swift"; sourceTree = "<group>"; };
 		176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPSplitViewController.swift; sourceTree = "<group>"; };
+		176E194625C465F70058F1C5 /* UnifiedPrologueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedPrologueViewController.swift; sourceTree = "<group>"; };
 		177074841FB209F100951A4A /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
 		177076201EA206C000705A4A /* PlayIconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayIconView.swift; sourceTree = "<group>"; };
 		177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+SplitViewFullscreen.swift"; sourceTree = "<group>"; };
@@ -5775,6 +5777,14 @@
 				F50B0E7A246212B8006601DD /* NoticeAnimator.swift */,
 			);
 			path = Notices;
+			sourceTree = "<group>";
+		};
+		176E194525C465E00058F1C5 /* Prologue */ = {
+			isa = PBXGroup;
+			children = (
+				176E194625C465F70058F1C5 /* UnifiedPrologueViewController.swift */,
+			);
+			name = Prologue;
 			sourceTree = "<group>";
 		};
 		1797373920EBDA1100377B4E /* Universal Links */ = {
@@ -11095,6 +11105,7 @@
 		E6417B961CA07B060084050A /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				176E194525C465E00058F1C5 /* Prologue */,
 				98A437AD20069097004A8A57 /* DomainSuggestionsTableViewController.swift */,
 				E6C1E8431EF1D21F00D139D9 /* Epilogue */,
 				98C43E841FE98041006FEF54 /* Social Signup */,
@@ -14332,6 +14343,7 @@
 				FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */,
 				D8A3A5B5206A4C7800992576 /* StockPhotosPicker.swift in Sources */,
 				F1112AA3255C2D4100F1F746 /* BlogDetailHeader.swift in Sources */,
+				176E194725C465F70058F1C5 /* UnifiedPrologueViewController.swift in Sources */,
 				E60C2ED71DE5075100488630 /* ReaderCommentCell.swift in Sources */,
 				4625B556253789C000C04AAD /* CollapsableHeaderViewController.swift in Sources */,
 				5DBCD9D518F35D7500B32229 /* ReaderTopicService.m in Sources */,


### PR DESCRIPTION
Refs #15056. This PR implements a basic replacement login prologue carousel in WPiOS, which overrides the usual one that is bundled with WordPressAuthenticator. This first version simply adds the paging carousel, and pages with titles. Full design treatment and each new page will be coming later.

<img src="https://user-images.githubusercontent.com/4780/107693166-acd55d80-6ca5-11eb-9fb9-5de479383387.png" width="350px"/>

**To test**

- Set the `unifiedPrologueCarousel` feature flag to `true`.
- Build and run.
- If you're not already signed out, sign out so you can see the login prologue.
- Swipe through each page and ensure you see a title.
- Build and run again with the feature flag disabled and check that you see the original carousel.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
