### PR TITLE
Fix automatic session tracking

### DIFF
--- a/WordPress/Classes/Utility/Logging/EventLoggingDelegate.swift
+++ b/WordPress/Classes/Utility/Logging/EventLoggingDelegate.swift
@@ -9,6 +9,10 @@ struct EventLoggingDelegate: AutomatticTracks.EventLoggingDelegate {
             && !UserSettings.userHasOptedOutOfCrashLogging
     }
 
+    var shouldEnableAutomaticSessionTracking: Bool {
+        return !UserSettings.userHasOptedOutOfCrashLogging
+    }
+
     func didQueueLogForUpload(_ log: LogFile) {
         NotificationCenter.default.post(name: WPLoggingStack.QueuedLogsDidChangeNotification, object: log)
         DDLogDebug("📜 Added log to queue: \(log.uuid)")


### PR DESCRIPTION
Enables automatic session tracking via Sentry in WPiOS to provide info on sessions vs crashes

To test:
- Ensure tests pass
- Do a quick smoke test on an installable build

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
