### PR TITLE
Remove mergeChanges from ContextManager

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)saveContextAndWait:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^)(void))completionBlock;
-- (void)mergeChanges:(NSManagedObjectContext *)context fromContextDidSaveNotification:(NSNotification *)notification;
 @end
 
 @interface ContextManager : NSObject <CoreDataStack>
@@ -92,14 +91,6 @@ NS_ASSUME_NONNULL_BEGIN
  @param a completion block that will be executed on the main queue
  */
 - (void)saveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^)(void))completionBlock;
-
-/**
- Merge changes for a given context with a fault-protection, on the context's queue.
-
- @param context a NSManagedObject context instance
- @return notification NSNotification from a NSManagedObjectContextDidSaveNotification.
- */
-- (void)mergeChanges:(NSManagedObjectContext *)context fromContextDidSaveNotification:(NSNotification *)notification;
 
 @end
 

--- a/WordPress/WordPressTest/TestContextManager.m
+++ b/WordPress/WordPressTest/TestContextManager.m
@@ -96,11 +96,6 @@ static TestContextManager *_instance;
     }];
 }
 
-- (void)mergeChanges:(nonnull NSManagedObjectContext *)context fromContextDidSaveNotification:(nonnull NSNotification *)notification
-{
-    [_stack mergeChanges: context fromContextDidSaveNotification:notification];
-}
-
 - (nonnull NSManagedObjectContext *const)newDerivedContext {
     return [_stack newDerivedContext];
 }


### PR DESCRIPTION
This was previous removed from outside the ContextManager in https://github.com/wordpress-mobile/WordPress-iOS/pull/15849

Continues working toward #15829.

To test:
- Ensure that tests pass – this change just removes a method that's no longer used outside `ContextManager`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
