### PR TITLE
Remove external access to the Core Data Stack’s persistentStoreCoordinator and managedObjectModel

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -5,7 +5,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol CoreDataStack
 @property (nonatomic, readonly, strong) NSManagedObjectContext *mainContext;
-@property (nonatomic, readonly, strong) NSManagedObjectModel *managedObjectModel;
 - (NSManagedObjectContext *const)newDerivedContext;
 - (NSManagedObjectContext *const)newMainContextChildContext;
 - (void)saveContextAndWait:(NSManagedObjectContext *)context;
@@ -25,11 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 ///----------------------------------------------
 @property (nonatomic, readonly, strong) NSManagedObjectContext *mainContext;
-
-///-------------------------------------------------------------
-///@name Access to the managed object model
-///-------------------------------------------------------------
-@property (nonatomic, readonly, strong) NSManagedObjectModel *managedObjectModel;
 
 ///--------------------------------------
 ///@name ContextManager

--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -5,7 +5,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol CoreDataStack
 @property (nonatomic, readonly, strong) NSManagedObjectContext *mainContext;
-@property (nonatomic, readonly, strong) NSPersistentStoreCoordinator *persistentStoreCoordinator;
 @property (nonatomic, readonly, strong) NSManagedObjectModel *managedObjectModel;
 - (NSManagedObjectContext *const)newDerivedContext;
 - (NSManagedObjectContext *const)newMainContextChildContext;
@@ -28,9 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) NSManagedObjectContext *mainContext;
 
 ///-------------------------------------------------------------
-///@name Access to the persistent store and managed object model
+///@name Access to the managed object model
 ///-------------------------------------------------------------
-@property (nonatomic, readonly, strong) NSPersistentStoreCoordinator *persistentStoreCoordinator;
 @property (nonatomic, readonly, strong) NSManagedObjectModel *managedObjectModel;
 
 ///--------------------------------------

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -362,7 +362,7 @@
         return nil;
     }
     [mainContext performBlockAndWait:^{
-        NSManagedObjectID *assetID = [[[ContextManager sharedInstance] persistentStoreCoordinator] managedObjectIDForURIRepresentation:assetURL];
+        NSManagedObjectID *assetID = [[mainContext persistentStoreCoordinator] managedObjectIDForURIRepresentation:assetURL];
         media = (Media *)[mainContext objectWithID:assetID];
     }];
 

--- a/WordPress/WordPressTest/ContextManagerMock.m
+++ b/WordPress/WordPressTest/ContextManagerMock.m
@@ -1,5 +1,12 @@
 #import "ContextManagerMock.h"
 
+// This deserves a little bit of explanation – this was previously part of the public interface for `ContextManager`, which shouldn't make this API
+// public to the hosting app. Rather than rework the `CoreDataMigrationTests` right away (which will be done later as part of adopting Woo's
+// updated and well-tested migrator), we can use this hack for now to preserve the behaviour for those tests and come back to them later.
+@interface ContextManager(DeprecatedAccessors)
+    - (NSPersistentStoreCoordinator *) persistentStoreCoordinator;
+    - (NSManagedObjectModel *) managedObjectModel;
+@end
 
 @implementation ContextManagerMock
 

--- a/WordPress/WordPressTest/MockContext.swift
+++ b/WordPress/WordPressTest/MockContext.swift
@@ -26,10 +26,4 @@ class MockContext: NSManagedObjectContext {
         successExpectation?.fulfill()
         return returnedObjects!
     }
-
-    class func getContext() -> MockContext? {
-            let managedObjectContext = MockContext(concurrencyType: .privateQueueConcurrencyType)
-            managedObjectContext.persistentStoreCoordinator = ContextManager.sharedInstance().persistentStoreCoordinator
-            return managedObjectContext
-    }
 }

--- a/WordPress/WordPressTest/ReaderReblogActionTests.swift
+++ b/WordPress/WordPressTest/ReaderReblogActionTests.swift
@@ -42,19 +42,22 @@ class MockPostService: PostService {
 
 
 class ReblogTestCase: XCTestCase {
-    var context: NSManagedObjectContext?
+    var contextManager: TestContextManager!
+    var context: NSManagedObjectContext!
     var readerPost: ReaderPost?
     var blogService: MockBlogService?
     var postService: MockPostService?
 
     override func setUp() {
-        context = MockContext.getContext()
+        contextManager = TestContextManager()
+        context = contextManager.getMockContext()
         readerPost = ReaderPost(context: self.context!)
         blogService = MockBlogService(managedObjectContext: self.context!)
         postService = MockPostService(managedObjectContext: self.context!)
     }
 
     override func tearDown() {
+        contextManager = nil
         context = nil
         readerPost = nil
         blogService = nil

--- a/WordPress/WordPressTest/ReaderTabItemsStoreTests.swift
+++ b/WordPress/WordPressTest/ReaderTabItemsStoreTests.swift
@@ -27,22 +27,25 @@ class MockTopicService: ReaderTopicService {
 
 class ReaderTabItemsStoreTests: XCTestCase {
 
+    var contextManager: TestContextManager!
+    var context: MockContext!
     private var subscription: Receipt?
     private var store: ReaderTabItemsStore!
-    private var context: MockContext!
     private var service: MockTopicService!
 
     private let mockError = NSError(domain: "mockContextDomain", code: -1, userInfo: nil)
 
     override func setUp() {
-        context = MockContext.getContext()
+        contextManager = TestContextManager()
+        context = contextManager.getMockContext()
         service = MockTopicService(managedObjectContext: context)
         store = ReaderTabItemsStore(context: context, service: service)
     }
 
     override func tearDown() {
-        service = nil
+        contextManager = nil
         context = nil
+        service = nil
         subscription = nil
         store = nil
     }

--- a/WordPress/WordPressTest/ReaderTabViewModelTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewModelTests.swift
@@ -47,6 +47,9 @@ class ReaderTabViewModelTests: XCTestCase {
     var viewModel: ReaderTabViewModel!
     var settingsPresenter: MockSettingsPresenter!
 
+    var contextManager: TestContextManager!
+    var context: MockContext!
+
     override func setUp() {
         store = MockItemsStore()
         settingsPresenter = MockSettingsPresenter()
@@ -54,6 +57,9 @@ class ReaderTabViewModelTests: XCTestCase {
                                        searchNavigationFactory: { },
                                        tabItemsStore: store,
                                        settingsPresenter: settingsPresenter)
+
+        contextManager = TestContextManager()
+        context = contextManager.getMockContext()
     }
 
     override func tearDown() {
@@ -61,6 +67,9 @@ class ReaderTabViewModelTests: XCTestCase {
         store = nil
         settingsPresenter = nil
         makeContentControllerExpectation = nil
+
+        contextManager = nil
+        context = nil
     }
 
     func testRefreshTabBar() {
@@ -115,8 +124,6 @@ class ReaderTabViewModelTests: XCTestCase {
 
     func testResetFilter() {
         // Given
-        let context = MockContext.getContext()!
-
         let selectedTopic = ReaderAbstractTopic(context: context)
         selectedTopic.title = "selected topic"
         let item = ReaderTabItem(ReaderContent(topic: selectedTopic))
@@ -140,7 +147,6 @@ class ReaderTabViewModelTests: XCTestCase {
         // Given
         makeContentControllerExpectation = expectation(description: "Content controller was constructed")
 
-        let context = MockContext.getContext()!
         let topic = ReaderAbstractTopic(context: context)
         topic.title = "content topic"
         let content = ReaderContent(topic: topic)

--- a/WordPress/WordPressTest/ReaderTabViewTests.swift
+++ b/WordPress/WordPressTest/ReaderTabViewTests.swift
@@ -4,10 +4,24 @@ import XCTest
 
 class ReaderTabViewTests: XCTestCase {
 
+    var contextManager: TestContextManager!
+    var context: MockContext!
+
+    override func setUp() {
+        super.setUp()
+        contextManager = TestContextManager()
+        context = contextManager.getMockContext()
+    }
+
+    override func tearDown() {
+        contextManager = nil
+        context = nil
+        super.tearDown()
+    }
+
     func testRefreshTabBarWithHiddenButtons() {
         // Given
         let store = MockItemsStore()
-        let context = MockContext.getContext()!
         let topic = ReaderAbstractTopic(context: context)
 
         let viewModel = ReaderTabViewModel(readerContentFactory: readerContentControllerFactory(_:),
@@ -31,7 +45,6 @@ class ReaderTabViewTests: XCTestCase {
     func testRefreshTabBarWithNoHiddenButtons() {
         // Given
         let store = MockItemsStore()
-        let context = MockContext.getContext()!
         let topic = ReaderAbstractTopic(context: context)
         topic.path = "myPath/read/following"
 
@@ -56,7 +69,6 @@ class ReaderTabViewTests: XCTestCase {
     func testSelectIndex() {
         // Given
         let store = MockItemsStore()
-        let context = MockContext.getContext()!
         let topic = ReaderAbstractTopic(context: context)
         topic.path = "myPath/read/following"
 

--- a/WordPress/WordPressTest/TestContextManager.h
+++ b/WordPress/WordPressTest/TestContextManager.h
@@ -2,6 +2,7 @@
 #import "ContextManagerMock.h"
 #import <XCTest/XCTest.h>
 
+@class MockContext;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -35,6 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)sharedInstance;
 + (void)overrideSharedInstance:(id <CoreDataStack> _Nullable)contextManager;
+
+- (MockContext *)getMockContext;
 
 @end
 

--- a/WordPress/WordPressTest/TestContextManager.m
+++ b/WordPress/WordPressTest/TestContextManager.m
@@ -153,6 +153,12 @@ static TestContextManager *_instance;
     return dict;
 }
 
+- (MockContext *) getMockContext {
+    MockContext *managedObjectContext = [[MockContext alloc] initWithConcurrencyType: NSMainQueueConcurrencyType];
+    managedObjectContext.persistentStoreCoordinator = self.persistentStoreCoordinator;
+    return managedObjectContext;
+}
+
 + (instancetype)sharedInstance
 {
     if (_instance) {


### PR DESCRIPTION
Continues to work toward #15829 by removing external access to the Core Data Stack's `persistentStoreCoordinator` (PSC) and `managedObjectModel` (MOM).

The PSC and MOM should be an implementation detail of the Core Data Stack. Right now, the PSC is used indirectly for state restoration or similar using `managedObjectID forURIRepresentation:`.

In the future, this could probably be an extension on `NSManagedObject` that could simplify external usage with something like:

```swift
static func from(URIRepresentation url: URL, in context: NSManagedObjectContext) -> Self? {
    guard
        let persistentStoreCoordinator = context.persistentStoreCoordinator,
        let objectID = persistentStoreCoordinator.managedObjectID(forURIRepresentation: url)
    else {
        return nil
    }

    return context.object(with: objectID) as? Self
}
```

For now, removing the PSC from the `CoreDataStack` protocol helps prepare it for replacement.

The MOM is not used from anywhere in the app, which IMHO helps to validate its removal as a property.

The MOM and PSC are both used by the test target on some very old migration tests. While I don't want to remove those tests (in fact, I'd love to expand them further), reworking them entirely is IMHO outside the scope of this PR given that part of this project will be to finish the work started by @Gio2018 to adopt the WooCommerce iterative migrator. To resolve this cyclical dependency, for now I've just swizzled the methods into the test class for use until they can be replaced.

Additionally, some tests previously relied on the persistent store coordinator for `ContextManager.sharedInstance` – this can be resolved by relying on a full mock stack while under test, so this PR adjusts the affected tests to work that way instead (and removes the static initializer for `MockContext`, moving it to the `TestContextManager` instead to avoid re-introducing this usage in future tests).

@Gio2018 The `MockContext` mostly has your name on it, so would you be willing to take a look at this one? 😃 

**To test:**
- Ensure tests pass – there was only one use of this method that was trivially replaced in app code, but there's a (relatively straightforward) swizzling of stack internals in the `ContextManagerMock.m` file now.

**PR submission checklist:**
- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
