### PR TITLE
Remove what's new feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -9,7 +9,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case homepageSettings
     case gutenbergMentions
     case gutenbergXposts
-    case whatIsNew
     case newNavBarAppearance
     case unifiedPrologueCarousel
     case stories
@@ -40,8 +39,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .gutenbergMentions:
             return true
         case .gutenbergXposts:
-            return true
-        case .whatIsNew:
             return true
         case .newNavBarAppearance:
             return BuildConfiguration.current == .localDeveloper
@@ -103,8 +100,6 @@ extension FeatureFlag {
             return "Mentions in Gutenberg"
         case .gutenbergXposts:
             return "Xposts in Gutenberg"
-        case .whatIsNew:
-            return "What's New / Feature Announcement"
         case .newNavBarAppearance:
             return "New Navigation Bar Appearance"
         case .unifiedPrologueCarousel:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -425,9 +425,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self scrollToElement:QuickStartTourElementViewSite];
         self.shouldScrollToViewSite = NO;
     }
-    if([Feature enabled:FeatureFlagWhatIsNew]) {
-        [WPTabBarController.sharedInstance presentWhatIsNewOn:self];
-    }
+    [WPTabBarController.sharedInstance presentWhatIsNewOn:self];
 }
 
 - (CreateButtonCoordinator *)createButtonCoordinator

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -481,8 +481,7 @@ private extension AppSettingsViewController {
             rows.append(debugRow)
         }
 
-        if FeatureFlag.whatIsNew.enabled,
-            let presenter = WPTabBarController.sharedInstance()?.whatIsNewScenePresenter as? WhatIsNewScenePresenter,
+        if let presenter = WPTabBarController.sharedInstance()?.whatIsNewScenePresenter as? WhatIsNewScenePresenter,
             presenter.versionHasAnnouncements {
             let whatIsNewRow = NavigationItemRow(title: NSLocalizedString("What's New in WordPress",
                                                                           comment: "Opens the What's New / Feature Announcement modal"),

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -188,9 +188,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         showNotificationPrimerAlertIfNeeded()
         showSecondNotificationsAlertIfNeeded()
 
-        if FeatureFlag.whatIsNew.enabled {
-            WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
-        }
+        WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -50,9 +50,7 @@ class ReaderTabViewController: UIViewController {
 
         ReaderTracker.shared.start(.main)
 
-        if FeatureFlag.whatIsNew.enabled {
-            WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
-        }
+        WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
Fixes #NA

To test:
- go to the mobile announce tool in mission control and create a test announcement, or reuse an existing one (if you create a test announcement, please make sure to use a future version, and to delete it once the test is completed)
- manually update the release in the project
- re-run and make sure the feature announcement shows up at launch, and in App Settings /What's new in WordPress
- discard the changes and make sure you don't see any announcement (assuming you are testing on a release that does not have announcement)
- Don't forget to remove the test announcement from the mobile announce tool, if you had created one.

**Note**
I did some tests with new announcements and was not able to pull them from the backend (maybe it takes a while to be written?). You can use the announce 141 which seems to be working (needs to be enabled)
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
