### PR TITLE
Move `blogByBlogId` out of blog service

### DIFF
--- a/WordPress/Classes/Models/Blog+Lookup.swift
+++ b/WordPress/Classes/Models/Blog+Lookup.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// An extension dedicated to looking up and returning blog objects
+public extension Blog {
+
+    /// Lookup a Blog by ID
+    ///
+    /// - Parameters:
+    ///   - id: The ID associated with the blog.
+    ///
+    ///     On a WPMU site, this is the `blog_id` field on the [the wp_blogs table](https://codex.wordpress.org/Database_Description#Table:_wp_blogs).
+    ///   - context:  An NSManagedObjectContext containing the `Blog` object with the given `blogID`.
+    /// - Returns: The `Blog` object associated with the given `blogID`, if it exists.
+    static func lookup(withID id: Int, in context: NSManagedObjectContext) throws -> Blog? {
+        return try lookup(withID: Int64(id), in: context)
+    }
+
+    /// Lookup a Blog by ID
+    ///
+    /// - Parameters:
+    ///   - id: The ID associated with the blog.
+    ///
+    ///     On a WPMU site, this is the `blog_id` field on the [the wp_blogs table](https://codex.wordpress.org/Database_Description#Table:_wp_blogs).
+    ///   - context:  An NSManagedObjectContext containing the `Blog` object with the given `blogID`.
+    /// - Returns: The `Blog` object associated with the given `blogID`, if it exists.
+    static func lookup(withID id: Int64, in context: NSManagedObjectContext) throws -> Blog? {
+        let fetchRequest = NSFetchRequest<Self>(entityName: Blog.entityName())
+        fetchRequest.predicate = NSPredicate(format: "blogID == %ld", id)
+        return try context.fetch(fetchRequest).first
+    }
+
+    /// Lookup a Blog by ID
+    ///
+    /// - Parameters:
+    ///   - id: The NSNumber-wrapped ID associated with the blog.
+    ///
+    ///     On a WPMU site, this is the `blog_id` field on the [the wp_blogs table](https://codex.wordpress.org/Database_Description#Table:_wp_blogs).
+    ///   - context:  An NSManagedObjectContext containing the `Blog` object with the given `blogID`.
+    /// - Returns: The `Blog` object associated with the given `blogID`, if it exists.
+    @objc
+    static func lookup(withID id: NSNumber, in context: NSManagedObjectContext) -> Blog? {
+        let fetchRequest = NSFetchRequest<Self>(entityName: Blog.entityName())
+        fetchRequest.predicate = NSPredicate(format: "blogID == %@", id)
+        return try? context.fetch(fetchRequest).first
+    }
+}

--- a/WordPress/Classes/Models/WPAccount+AccountSettings.swift
+++ b/WordPress/Classes/Models/WPAccount+AccountSettings.swift
@@ -12,8 +12,7 @@ extension WPAccount {
         case .displayName(let value):
             self.displayName = value
         case .primarySite(let value):
-            let service = BlogService(managedObjectContext: managedObjectContext!)
-            defaultBlog = service.blog(byBlogId: NSNumber(value: value))
+            defaultBlog = try? Blog.lookup(withID: value, in: managedObjectContext!)
         default:
             break
         }

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -463,7 +463,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     } else {
         // Required Attributes
 
-        BlogService *blogService    = [[BlogService alloc] initWithManagedObjectContext:self.managedObjectContext];
         NSString *oauth2Token       = defaultAccount.authToken;
 
         // For the Today Extensions, if the user has set a non-primary site, use that.
@@ -472,7 +471,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         NSString *todayExtensionBlogName = [sharedDefaults objectForKey:WPStatsTodayWidgetUserDefaultsSiteNameKey];
         NSString *todayExtensionBlogUrl = [sharedDefaults objectForKey:WPStatsTodayWidgetUserDefaultsSiteUrlKey];
 
-        Blog *todayExtensionBlog = [blogService blogByBlogId:todayExtensionSiteID];
+        Blog *todayExtensionBlog = [Blog lookupWithID:todayExtensionSiteID in:self.managedObjectContext];
         NSTimeZone *timeZone = [todayExtensionBlog timeZone];
 
         if (todayExtensionSiteID == NULL) {

--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -150,10 +150,7 @@ class AccountSettingsService {
     }
 
     func primarySiteNameForSettings(_ settings: AccountSettings) -> String? {
-        let service = BlogService(managedObjectContext: context)
-        let blog = service.blog(byBlogId: NSNumber(value: settings.primarySiteID))
-
-        return blog?.settings?.name
+        return try? Blog.lookup(withID: settings.primarySiteID, in: context)?.settings?.name
     }
 
     /// Change the current user's username

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -17,11 +17,6 @@ extern NSString *const WPBlogUpdatedNotification;
 - (instancetype) init __attribute__((unavailable("must use initWithManagedObjectContext")));
 
 /**
- Returns the blog that matches with a given blogID
- */
-- (nullable Blog *)blogByBlogId:(NSNumber *)blogID;
-
-/**
  Returns the blog that matches with a given blogID and account.username
  */
 - (nullable Blog *)blogByBlogId:(NSNumber *)blogID andUsername:(NSString *)username;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -30,12 +30,6 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
     return [[BlogService alloc] initWithManagedObjectContext:context];
 }
 
-- (Blog *)blogByBlogId:(NSNumber *)blogID
-{
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"blogID == %@", blogID];
-    return [self blogWithPredicate:predicate];
-}
-
 - (Blog *)blogByBlogId:(NSNumber *)blogID andUsername:(NSString *)username
 {
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"blogID = %@ AND account.username = %@", blogID, username];

--- a/WordPress/Classes/Services/DomainsService.swift
+++ b/WordPress/Classes/Services/DomainsService.swift
@@ -96,9 +96,7 @@ struct DomainsService {
     }
 
     fileprivate func blogForSiteID(_ siteID: Int) -> Blog? {
-        let service = BlogService(managedObjectContext: context)
-
-        guard let blog = service.blog(byBlogId: NSNumber(value: siteID)) else {
+        guard let blog = try? Blog.lookup(withID: siteID, in: context) else {
             let error = "Tried to obtain a Blog for a non-existing site (ID: \(siteID))"
             assertionFailure(error)
             DDLogError(error)

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -238,9 +238,9 @@ struct PlanStorage {
     static func activatePlan(_ planID: Int, forSite siteID: Int) {
         let manager = ContextManager.sharedInstance()
         let context = manager.newDerivedContext()
-        let service = BlogService(managedObjectContext: context)
+
         context.performAndWait {
-            guard let blog = service.blog(byBlogId: NSNumber(value: siteID)) else {
+            guard let blog = try? Blog.lookup(withID: siteID, in: context) else {
                 let error = "Tried to activate a plan for a non-existing site (ID: \(siteID))"
                 assertionFailure(error)
                 DDLogError(error)
@@ -256,9 +256,9 @@ struct PlanStorage {
     static func updateHasDomainCredit(_ planID: Int, forSite siteID: Int, hasDomainCredit: Bool) {
         let manager = ContextManager.sharedInstance()
         let context = manager.newDerivedContext()
-        let service = BlogService(managedObjectContext: context)
+
         context.performAndWait {
-            guard let blog = service.blog(byBlogId: NSNumber(value: siteID)) else {
+            guard let blog = try? Blog.lookup(withID: siteID, in: context) else {
                 let error = "Tried to update a plan for a non-existing site (ID: \(siteID))"
                 assertionFailure(error)
                 DDLogError(error)

--- a/WordPress/Classes/Services/SiteSuggestionService.swift
+++ b/WordPress/Classes/Services/SiteSuggestionService.swift
@@ -140,15 +140,4 @@ class SiteSuggestionService {
         guard let suggestions = blog.siteSuggestions else { return nil }
         return Array(suggestions)
     }
-
-    /**
-     Retrieve the persisted blog/site for a given site ID
-
-     @param siteID the dotComID to retrieve
-     @return Blog the blog/site
-     */
-    func persistedBlog(for siteID: NSNumber) -> Blog? {
-        let context = ContextManager.shared.mainContext
-        return BlogService(managedObjectContext: context).blog(byBlogId: siteID)
-    }
 }

--- a/WordPress/Classes/Services/SuggestionService.swift
+++ b/WordPress/Classes/Services/SuggestionService.swift
@@ -119,15 +119,4 @@ class SuggestionService {
         guard let suggestions = blog.userSuggestions else { return nil }
         return Array(suggestions)
     }
-
-    /**
-     Retrieve the persisted blog/site for a given site ID
-
-     @param siteID the dotComID to retrieve
-     @return Blog the blog/site
-     */
-    func persistedBlog(for siteID: NSNumber) -> Blog? {
-        let context = ContextManager.shared.mainContext
-        return BlogService(managedObjectContext: context).blog(byBlogId: siteID)
-    }
 }

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -185,7 +185,7 @@ class StatsInsightsStore: QueryStore<InsightStoreState, InsightQuery> {
     func persistToCoreData() {
         guard
             let siteID = SiteStatsInformation.sharedInstance.siteID,
-            let blog = BlogService.withMainContext().blog(byBlogId: siteID) else {
+            let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else {
                 return
         }
 
@@ -326,7 +326,7 @@ private extension StatsInsightsStore {
     func loadFromCache() {
         guard
             let siteID = SiteStatsInformation.sharedInstance.siteID,
-            let blog = BlogService.withMainContext().blog(byBlogId: siteID) else {
+            let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else {
                 return
         }
 
@@ -982,5 +982,107 @@ private extension InsightStoreState {
                 return false
         }
         return true
+    }
+}
+
+// MARK: - iOS 14 Widgets Data
+private extension InsightStoreState {
+
+    private func storeHomeWidgetData<T: HomeWidgetData>(widgetType: T.Type, stats: Codable) {
+        guard #available(iOS 14.0, *),
+              let siteID = SiteStatsInformation.sharedInstance.siteID else {
+            return
+        }
+
+        var homeWidgetCache = T.read() ?? initializeHomeWidgetData(type: widgetType)
+        guard let oldData = homeWidgetCache[siteID.intValue] else {
+            DDLogError("StatsWidgets: Failed to find a matching site")
+            return
+        }
+
+        guard let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else {
+            DDLogError("StatsWidgets: the site does not exist anymore")
+            // if for any reason that site does not exist anymore, remove it from the cache.
+            homeWidgetCache.removeValue(forKey: siteID.intValue)
+            T.write(items: homeWidgetCache)
+            return
+        }
+        var widgetKind = ""
+        if widgetType == HomeWidgetTodayData.self, let stats = stats as? TodayWidgetStats {
+
+            widgetKind = WPHomeWidgetTodayKind
+
+            homeWidgetCache[siteID.intValue] = HomeWidgetTodayData(siteID: siteID.intValue,
+                                                                   siteName: blog.title ?? oldData.siteName,
+                                                                   url: blog.url ?? oldData.url,
+                                                                   timeZone: blog.timeZone,
+                                                                   date: Date(),
+                                                                   stats: stats) as? T
+
+
+        } else if widgetType == HomeWidgetAllTimeData.self, let stats = stats as? AllTimeWidgetStats {
+            widgetKind = WPHomeWidgetAllTimeKind
+
+            homeWidgetCache[siteID.intValue] = HomeWidgetAllTimeData(siteID: siteID.intValue,
+                                                                     siteName: blog.title ?? oldData.siteName,
+                                                                     url: blog.url ?? oldData.url,
+                                                                     timeZone: blog.timeZone,
+                                                                     date: Date(),
+                                                                     stats: stats) as? T
+        }
+
+        T.write(items: homeWidgetCache)
+        WidgetCenter.shared.reloadTimelines(ofKind: widgetKind)
+
+
+    }
+
+    private func initializeHomeWidgetData<T: HomeWidgetData>(type: T.Type) -> [Int: T] {
+        let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
+
+        return blogService.visibleBlogsForWPComAccounts().reduce(into: [Int: T]()) { result, element in
+            if let blogID = element.dotComID,
+               let url = element.url,
+               let blog = Blog.lookup(withID: blogID, in: ContextManager.shared.mainContext) {
+                // set the title to the site title, if it's not nil and not empty; otherwise use the site url
+                let title = (element.title ?? url).isEmpty ? url : element.title ?? url
+                let timeZone = blog.timeZone
+                if type == HomeWidgetTodayData.self {
+                    result[blogID.intValue] = HomeWidgetTodayData(siteID: blogID.intValue,
+                                                                  siteName: title,
+                                                                  url: url,
+                                                                  timeZone: timeZone,
+                                                                  date: Date(),
+                                                                  stats: TodayWidgetStats()) as? T
+                } else if type == HomeWidgetAllTimeData.self {
+                    result[blogID.intValue] = HomeWidgetAllTimeData(siteID: blogID.intValue,
+                                                                    siteName: title,
+                                                                    url: url,
+                                                                    timeZone: timeZone,
+                                                                    date: Date(),
+                                                                    stats: AllTimeWidgetStats()) as? T
+                }
+            }
+        }
+    }
+}
+
+// refresh iOS 14 widgets at login/logout
+private extension StatsInsightsStore {
+    func observeAccountChangesForWidgets() {
+        guard #available(iOS 14.0, *) else {
+            return
+        }
+
+
+        NotificationCenter.default.addObserver(forName: .WPAccountDefaultWordPressComAccountChanged,
+                                               object: nil,
+                                               queue: nil) { notification in
+            HomeWidgetTodayData.delete()
+            WidgetCenter.shared.reloadTimelines(ofKind: WPHomeWidgetTodayKind)
+            HomeWidgetAllTimeData.delete()
+            WidgetCenter.shared.reloadTimelines(ofKind: WPHomeWidgetAllTimeKind)
+
+        }
     }
 }

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -249,7 +249,7 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
     func persistToCoreData() {
         guard
             let siteID = SiteStatsInformation.sharedInstance.siteID,
-            let blog = BlogService.withMainContext().blog(byBlogId: siteID) else {
+            let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else {
                 return
         }
 
@@ -531,7 +531,7 @@ private extension StatsPeriodStore {
     func loadFromCache(date: Date, period: StatsPeriodUnit) {
         guard
             let siteID = SiteStatsInformation.sharedInstance.siteID,
-            let blog = BlogService.withMainContext().blog(byBlogId: siteID) else {
+            let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else {
                 return
         }
 

--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -75,9 +75,8 @@ class StatsWidgetsStore {
             DDLogError("StatsWidgets: Failed to find a matching site")
             return
         }
-        let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
 
-        guard let blog = blogService.blog(byBlogId: siteID) else {
+        guard let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else {
             DDLogError("StatsWidgets: the site does not exist anymore")
             // if for any reason that site does not exist anymore, remove it from the cache.
             homeWidgetCache.removeValue(forKey: siteID.intValue)
@@ -158,7 +157,7 @@ private extension StatsWidgetsStore {
 
             var timeZone = existingSite?.timeZone ?? TimeZone.current
 
-            if let blog = blogService.blog(byBlogId: blogID) {
+            if let blog = Blog.lookup(withID: blogID, in: ContextManager.shared.mainContext) {
                 timeZone = blog.timeZone
             }
 
@@ -206,7 +205,7 @@ private extension StatsWidgetsStore {
         return blogService.visibleBlogsForWPComAccounts().reduce(into: [Int: T]()) { result, element in
             if let blogID = element.dotComID,
                let url = element.url,
-               let blog = blogService.blog(byBlogId: blogID) {
+               let blog = Blog.lookup(withID: blogID, in: ContextManager.shared.mainContext) {
                 // set the title to the site title, if it's not nil and not empty; otherwise use the site url
                 let title = (element.title ?? url).isEmpty ? url : element.title ?? url
                 let timeZone = blog.timeZone

--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -77,11 +77,10 @@ import AutomatticTracks
     }
 
     private func handleViewStats(url: URL) -> Bool {
-        let blogService = BlogService(managedObjectContext: ContextManager.sharedInstance().mainContext)
 
         guard let params = url.queryItems,
             let siteId = params.intValue(of: "siteId"),
-            let blog = blogService.blog(byBlogId: NSNumber(value: siteId)) else {
+            let blog = try? Blog.lookup(withID: siteId, in: ContextManager.shared.mainContext) else {
             return false
         }
 

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -116,8 +116,8 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
 
 + (NSString *)siteTypeForBlogWithID:(NSNumber *)blogID
 {
-    BlogService *service = [[BlogService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
-    Blog *blog = [service blogByBlogId:blogID];
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    Blog *blog = [Blog lookupWithID:blogID in:context];
     return [blog isWPForTeams] ? WPAppAnalyticsValueSiteTypeP2 : WPAppAnalyticsValueSiteTypeBlog;
 }
 

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -141,8 +141,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
             return nil
         }
 
-        let service = BlogService(managedObjectContext: mainContext)
-        return service.blog(byBlogId: blogID)
+        return Blog.lookup(withID: blogID, in: mainContext)
     }
 
 }

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -52,7 +52,10 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     func displayStatsWithSiteID(_ siteID: NSNumber?) throws {
-        guard let blog = blogWithBlogID(siteID), blog.supports(.stats) else {
+        guard let siteID = siteID,
+              let blog = Blog.lookup(withID: siteID, in: mainContext),
+              blog.supports(.stats)
+        else {
             throw DisplayError.missingParameter
         }
 
@@ -62,8 +65,10 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     func displayBackupWithSiteID(_ siteID: NSNumber?) throws {
-        guard let blog = blogWithBlogID(siteID),
-              let backupListViewController = BackupListViewController(blog: blog) else {
+        guard let siteID = siteID,
+              let blog = Blog.lookup(withID: siteID, in: mainContext),
+              let backupListViewController = BackupListViewController(blog: blog)
+        else {
             throw DisplayError.missingParameter
         }
 
@@ -71,7 +76,11 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     func displayScanWithSiteID(_ siteID: NSNumber?) throws {
-        guard Feature.enabled(.jetpackScan), let blog = blogWithBlogID(siteID), blog.isScanAllowed() else {
+        guard Feature.enabled(.jetpackScan),
+              let siteID = siteID,
+              let blog = Blog.lookup(withID: siteID, in: mainContext),
+              blog.isScanAllowed()
+        else {
             throw DisplayError.missingParameter
         }
 
@@ -80,7 +89,9 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     func displayFollowersWithSiteID(_ siteID: NSNumber?, expirationTime: TimeInterval) throws {
-        guard let blog = blogWithBlogID(siteID) else {
+        guard let siteID = siteID,
+              let blog = Blog.lookup(withID: siteID, in: mainContext)
+        else {
             throw DisplayError.missingParameter
         }
 
@@ -135,13 +146,4 @@ struct DefaultContentCoordinator: ContentCoordinator {
         }
         return jetpack
     }
-
-    private func blogWithBlogID(_ blogID: NSNumber?) -> Blog? {
-        guard let blogID = blogID else {
-            return nil
-        }
-
-        return Blog.lookup(withID: blogID, in: mainContext)
-    }
-
 }

--- a/WordPress/Classes/Utility/NSManagedObject+Lookup.swift
+++ b/WordPress/Classes/Utility/NSManagedObject+Lookup.swift
@@ -1,0 +1,14 @@
+import CoreData
+
+extension NSManagedObject {
+
+    /// Lookup an object by its NSManagedObjectID
+    ///
+    /// - Parameters:
+    ///   - objectID: The `NSManagedObject` subclass' objectID as defined by Core Data.
+    ///   - context:  An NSManagedObjectContext that contains the associated object.
+    /// - Returns: The `NSManagedObject` subclass associated with the given `objectID`, if it exists.
+    static func lookup(withObjectID objectID: NSManagedObjectID, in context: NSManagedObjectContext) -> Self? {
+        return context.object(with: objectID) as? Self
+    }
+}

--- a/WordPress/Classes/Utility/NSManagedObject+Lookup.swift
+++ b/WordPress/Classes/Utility/NSManagedObject+Lookup.swift
@@ -9,6 +9,6 @@ extension NSManagedObject {
     ///   - context:  An NSManagedObjectContext that contains the associated object.
     /// - Returns: The `NSManagedObject` subclass associated with the given `objectID`, if it exists.
     static func lookup(withObjectID objectID: NSManagedObjectID, in context: NSManagedObjectContext) -> Self? {
-        return context.object(with: objectID) as? Self
+        return try? context.existingObject(with: objectID) as? Self
     }
 }

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -253,8 +253,8 @@ fileprivate extension SearchManager {
                    onSuccess: @escaping (_ post: AbstractPost) -> Void,
                    onFailure: @escaping () -> Void) {
         let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-        guard let blog = blogService.blog(byBlogId: blogID) else {
+
+        guard let blog = Blog.lookup(withID: blogID, in: context) else {
                 onFailure()
                 return
         }
@@ -291,8 +291,8 @@ fileprivate extension SearchManager {
                    onSuccess: @escaping (_ blog: Blog) -> Void,
                    onFailure: @escaping () -> Void) {
         let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-        guard let blog = blogService.blog(byBlogId: blogID) else {
+
+        guard let blog = Blog.lookup(withID: blogID, in: context) else {
             onFailure()
             return
         }

--- a/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
+++ b/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
@@ -23,7 +23,7 @@ extension NavigationAction {
 
         // Some stats URLs use a site ID instead
         if let siteIDValue = Int(domain) {
-            return service.blog(byBlogId: NSNumber(value: siteIDValue))
+            return try? Blog.lookup(withID: siteIDValue, in: context)
         }
 
         return nil

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDateFormatting.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDateFormatting.swift
@@ -23,9 +23,8 @@ struct ActivityDateFormatting {
     }
 
     static func timeZone(for site: JetpackSiteRef, managedObjectContext: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) -> TimeZone {
-        let blogService = BlogService(managedObjectContext: managedObjectContext)
 
-        guard let blog = blogService.blog(byBlogId: site.siteID as NSNumber) else {
+        guard let blog = try? Blog.lookup(withID: site.siteID, in: managedObjectContext) else {
             DDLogInfo("[ActivityDateFormatting] Couldn't find a blog with specified siteID. Falling back to UTC.")
             return TimeZone(secondsFromGMT: 0)!
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
@@ -271,8 +271,7 @@
     
     // Retrieve
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-    BlogService *service = [[BlogService alloc] initWithManagedObjectContext:context];
-    Blog *selectedBlog = [service blogByBlogId:self.selectedObjectDotcomID];
+    Blog *selectedBlog = [Blog lookupWithID:self.selectedObjectDotcomID in:context];
     
     // Cache
     _selectedObjectID = selectedBlog.objectID;

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @objc public extension CommentViewController {
     func shouldShowSuggestions(for siteID: NSNumber?) -> Bool {
-        guard let siteID = siteID, let blog = SuggestionService.shared.persistedBlog(for: siteID) else { return false }
+        guard let siteID = siteID, let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else { return false }
         return SuggestionService.shared.shouldShowSuggestions(for: blog)
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/FullScreenCommentReplyViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/FullScreenCommentReplyViewController.swift
@@ -357,7 +357,7 @@ private extension FullScreenCommentReplyViewController {
 
     /// Determine if suggestions are enabled and visible for this site
     var shouldShowSuggestions: Bool {
-        guard let siteID = self.siteID, let blog = SuggestionService.shared.persistedBlog(for: siteID) else { return false }
+        guard let siteID = self.siteID, let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else { return false }
         return SuggestionService.shared.shouldShowSuggestions(for: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -544,7 +544,7 @@ private extension NotificationDetailsViewController {
 
     var shouldAttachSuggestionsView: Bool {
         guard let siteID = note.metaSiteID,
-              let blog = SuggestionService.shared.persistedBlog(for: siteID) else {
+              let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else {
             return false
         }
         return shouldAttachReplyView && SuggestionService.shared.shouldShowSuggestions(for: blog)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @objc public extension ReaderCommentsViewController {
     func shouldShowSuggestions(for siteID: NSNumber?) -> Bool {
-        guard let siteID = siteID, let blog = SuggestionService.shared.persistedBlog(for: siteID) else { return false }
+        guard let siteID = siteID, let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else { return false }
         return SuggestionService.shared.shouldShowSuggestions(for: blog)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -283,12 +283,7 @@ struct ReaderPostMenuButtonTitles {
     }
 
     @objc open class func isUserAdminOnSiteWithID(_ siteID: NSNumber) -> Bool {
-        let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-        if let blog = blogService.blog(byBlogId: siteID) {
-            return blog.isAdmin
-        }
-        return false
+        Blog.lookup(withID: siteID, in: ContextManager.sharedInstance().mainContext)?.isAdmin ?? false
     }
 
     // convenience method that returns the topic type

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
@@ -15,10 +15,8 @@ import Foundation
 
     func updateTimeZone() {
         let context = ContextManager.shared.mainContext
-        let blogService = BlogService.init(managedObjectContext: context)
 
-        guard let siteID = siteID,
-        let blog = blogService.blog(byBlogId: siteID) else {
+        guard let siteID = siteID, let blog = Blog.lookup(withID: siteID, in: context) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -412,8 +412,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
     }
 
     func showShareForPost(postID: NSNumber, fromView: UIView) {
-        guard let blogId = SiteStatsInformation.sharedInstance.siteID,
-        let blog = blogService.blog(byBlogId: blogId) else {
+        guard let blogId = SiteStatsInformation.sharedInstance.siteID, let blog = Blog.lookup(withID: blogId, in: mainContext) else {
             DDLogInfo("Failed to get blog with id \(String(describing: SiteStatsInformation.sharedInstance.siteID))")
             return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -246,8 +246,7 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
 
     func displayMediaWithID(_ mediaID: NSNumber) {
 
-        guard let siteID = SiteStatsInformation.sharedInstance.siteID,
-            let blog = blogService.blog(byBlogId: siteID) else {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID, let blog = Blog.lookup(withID: siteID, in: mainContext) else {
                 DDLogInfo("Unable to get blog when trying to show media from Stats.")
                 return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -295,7 +295,7 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
     func displayMediaWithID(_ mediaID: NSNumber) {
 
         guard let siteID = SiteStatsInformation.sharedInstance.siteID,
-            let blog = blogService.blog(byBlogId: siteID) else {
+              let blog = Blog.lookup(withID: siteID, in: mainContext) else {
                 DDLogInfo("Unable to get blog when trying to show media from Stats details.")
                 return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/BlogListViewController+StatsWidgets.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/iOS 14 Widgets/BlogListViewController+StatsWidgets.swift
@@ -39,7 +39,7 @@ extension BlogListViewController {
 
             var timeZone = existingSite?.timeZone ?? TimeZone.current
 
-            if let blog = blogService.blog(byBlogId: blogID) {
+            if let blog = Blog.lookup(withID: blogID, in: ContextManager.shared.mainContext) {
                 timeZone = blog.timeZone
             }
 

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.swift
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.swift
@@ -12,12 +12,12 @@ extension SuggestionType {
 @objc public extension SuggestionsTableView {
 
     func userSuggestions(for siteID: NSNumber, completion: @escaping ([UserSuggestion]?) -> Void) {
-        guard let blog = SuggestionService.shared.persistedBlog(for: siteID) else { return }
+        guard let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else { return }
         SuggestionService.shared.suggestions(for: blog, completion: completion)
     }
 
     func siteSuggestions(for siteID: NSNumber, completion: @escaping ([SiteSuggestion]?) -> Void) {
-        guard let blog = SuggestionService.shared.persistedBlog(for: siteID) else { return }
+        guard let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else { return }
         SiteSuggestionService.shared.suggestions(for: blog, completion: completion)
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -317,11 +317,12 @@
 		1E672D95257663CE00421F13 /* GutenbergAudioUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E672D94257663CE00421F13 /* GutenbergAudioUploadProcessor.swift */; };
 		1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */; };
 		241E60B325CA0D2900912CEB /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241E60B225CA0D2900912CEB /* UserSettings.swift */; };
-		24A2948325D602710000A51E /* BlogTimeZoneTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 24A2948225D602710000A51E /* BlogTimeZoneTests.m */; };
 		2420BEF125D8DAB300966129 /* Blog+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2420BEF025D8DAB300966129 /* Blog+Lookup.swift */; };
+		24A2948325D602710000A51E /* BlogTimeZoneTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 24A2948225D602710000A51E /* BlogTimeZoneTests.m */; };
 		24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */; };
 		24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */; };
 		24CE2EB1258D687A0000C297 /* WordPressFlux in Frameworks */ = {isa = PBXBuildFile; productRef = 24CE2EB0258D687A0000C297 /* WordPressFlux */; };
+		24F3789825E6E62100A27BB7 /* NSManagedObject+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */; };
 		2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
 		26D66DEC36ACF7442186B07D /* Pods_WordPressThisWeekWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 979B445A45E13F3289F2E99E /* Pods_WordPressThisWeekWidget.framework */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
@@ -2917,12 +2918,13 @@
 		1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergRollout.swift; sourceTree = "<group>"; };
 		2262D835FA89938EBF63EADF /* Pods-WordPressShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		241E60B225CA0D2900912CEB /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
-		24A2948225D602710000A51E /* BlogTimeZoneTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BlogTimeZoneTests.m; sourceTree = "<group>"; };
 		2420BEF025D8DAB300966129 /* Blog+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Lookup.swift"; sourceTree = "<group>"; };
+		24A2948225D602710000A51E /* BlogTimeZoneTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BlogTimeZoneTests.m; sourceTree = "<group>"; };
 		24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagStore.swift; sourceTree = "<group>"; };
 		24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagTests.swift; sourceTree = "<group>"; };
 		24D40491253F6CEE002843AC /* WordPressStatsWidgetsRelease-Internal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WordPressStatsWidgetsRelease-Internal.entitlements"; sourceTree = "<group>"; };
 		24D40492253F6D01002843AC /* WordPressStatsWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WordPressStatsWidgets.entitlements; sourceTree = "<group>"; };
+		24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Lookup.swift"; sourceTree = "<group>"; };
 		27AE66536E0C5378203F9312 /* Pods-WordPressUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressUITests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressUITests/Pods-WordPressUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		28A0AAE50D9B0CCF005BE974 /* WordPress_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPress_Prefix.pch; sourceTree = "<group>"; };
 		2906F80F110CDA8900169D56 /* EditCommentViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditCommentViewController.h; sourceTree = "<group>"; };
@@ -10120,6 +10122,7 @@
 				C545E0A11811B9880020844C /* ContextManager.m */,
 				E1E5EE36231E47A80018E9E3 /* ContextManager+ErrorHandling.swift */,
 				B5ECA6C91DBAA0020062D7E0 /* CoreDataHelper.swift */,
+				24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */,
 			);
 			name = CoreData;
 			sourceTree = "<group>";
@@ -14527,6 +14530,7 @@
 				40EC1F0F2249CA8400F6785E /* OtherAndTotalViewsCount+CoreDataClass.swift in Sources */,
 				98579BC7203DD86F004086E4 /* EpilogueSectionHeaderFooter.swift in Sources */,
 				2F605FA8251430C200F99544 /* PostCategoriesViewController.swift in Sources */,
+				24F3789825E6E62100A27BB7 /* NSManagedObject+Lookup.swift in Sources */,
 				17D4153C22C2308D006378EF /* StatsPeriodHelper.swift in Sources */,
 				7E3E7A5920E44D2F0075D159 /* FooterContentStyles.swift in Sources */,
 				C81CCD7E243BF7A600A83E27 /* TenorMedia.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -318,6 +318,7 @@
 		1E9D544D23C4C56300F6A9E0 /* GutenbergRollout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E9D544C23C4C56300F6A9E0 /* GutenbergRollout.swift */; };
 		241E60B325CA0D2900912CEB /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241E60B225CA0D2900912CEB /* UserSettings.swift */; };
 		24A2948325D602710000A51E /* BlogTimeZoneTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 24A2948225D602710000A51E /* BlogTimeZoneTests.m */; };
+		2420BEF125D8DAB300966129 /* Blog+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2420BEF025D8DAB300966129 /* Blog+Lookup.swift */; };
 		24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */; };
 		24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */; };
 		24CE2EB1258D687A0000C297 /* WordPressFlux in Frameworks */ = {isa = PBXBuildFile; productRef = 24CE2EB0258D687A0000C297 /* WordPressFlux */; };
@@ -2917,6 +2918,7 @@
 		2262D835FA89938EBF63EADF /* Pods-WordPressShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		241E60B225CA0D2900912CEB /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
 		24A2948225D602710000A51E /* BlogTimeZoneTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BlogTimeZoneTests.m; sourceTree = "<group>"; };
+		2420BEF025D8DAB300966129 /* Blog+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Lookup.swift"; sourceTree = "<group>"; };
 		24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagStore.swift; sourceTree = "<group>"; };
 		24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagTests.swift; sourceTree = "<group>"; };
 		24D40491253F6CEE002843AC /* WordPressStatsWidgetsRelease-Internal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WordPressStatsWidgetsRelease-Internal.entitlements"; sourceTree = "<group>"; };
@@ -9610,6 +9612,7 @@
 				FF00889A204DF3ED007CCE66 /* Blog+Quota.swift */,
 				43290D03215C28D800F6B398 /* Blog+QuickStart.swift */,
 				401AC82622DD2387006D78D4 /* Blog+Plans.swift */,
+				2420BEF025D8DAB300966129 /* Blog+Lookup.swift */,
 			);
 			name = Blog;
 			sourceTree = "<group>";
@@ -14384,6 +14387,7 @@
 				F1112AA3255C2D4100F1F746 /* BlogDetailHeader.swift in Sources */,
 				E60C2ED71DE5075100488630 /* ReaderCommentCell.swift in Sources */,
 				4625B556253789C000C04AAD /* CollapsableHeaderViewController.swift in Sources */,
+				2420BEF125D8DAB300966129 /* Blog+Lookup.swift in Sources */,
 				5DBCD9D518F35D7500B32229 /* ReaderTopicService.m in Sources */,
 				2F09D134245223D300956257 /* HeaderDetailsContentStyles.swift in Sources */,
 				403F57BC20E5CA6A004E889A /* RewindStatusRow.swift in Sources */,

--- a/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
@@ -88,8 +88,8 @@ import WordPressFlux
             }
 
             let context = ContextManager.sharedInstance().mainContext
-            let blogService = BlogService(managedObjectContext: context)
-            guard let blog = blogService.blog(byBlogId: NSNumber(value: postUploadOp.siteID)) else {
+
+            guard let blog = try? Blog.lookup(withID: postUploadOp.siteID, in: context) else {
                 return
             }
 

--- a/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
@@ -46,14 +46,13 @@ class ShareNoticeNavigationCoordinator {
                                   onSuccess: @escaping (_ post: Post?) -> Void,
                                   onFailure: @escaping () -> Void) {
         let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
         let postService = PostService(managedObjectContext: context)
 
         guard let postIDString = userInfo[ShareNoticeUserInfoKey.postID] as? String,
             let postID = NumberFormatter().number(from: postIDString),
             let siteIDString = userInfo[ShareNoticeUserInfoKey.blogID] as? String,
             let siteID = NumberFormatter().number(from: siteIDString),
-            let blog = blogService.blog(byBlogId: siteID) else {
+            let blog = Blog.lookup(withID: siteID, in: context) else {
                 onFailure()
                 return
         }
@@ -78,9 +77,7 @@ class ShareNoticeNavigationCoordinator {
                 return
         }
 
-        let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-        let blog = blogService.blog(byBlogId: siteID)
-        onSuccess(blog)
+        let context = ContextManager.shared.mainContext
+        onSuccess(Blog.lookup(withID: siteID, in: context))
     }
 }

--- a/WordPress/WordPressTest/BlogTests.swift
+++ b/WordPress/WordPressTest/BlogTests.swift
@@ -31,4 +31,35 @@ final class BlogTests: XCTestCase {
 
         XCTAssertFalse(blog.isAtomic())
     }
+
+    func testThatLookupByBlogIDWorks() throws {
+        let blog = BlogBuilder(context).build()
+        XCTAssertNotNil(blog.dotComID)
+        XCTAssertNotNil(Blog.lookup(withID: blog.dotComID!, in: context))
+    }
+
+    func testThatLookupByBlogIDFailsForInvalidBlogID() throws {
+        XCTAssertNil(Blog.lookup(withID: NSNumber(integerLiteral: 1), in: context))
+    }
+
+    func testThatLookupByBlogIDWorksForIntegerBlogID() throws {
+        let blog = BlogBuilder(context).build()
+        XCTAssertNotNil(blog.dotComID)
+        XCTAssertNotNil(try Blog.lookup(withID: blog.dotComID!.intValue, in: context))
+    }
+
+    func testThatLookupByBlogIDFailsForInvalidIntegerBlogID() throws {
+        XCTAssertNil(try Blog.lookup(withID: 1, in: context))
+    }
+
+    func testThatLookupBlogIDWorksForInt64BlogID() throws {
+        let blog = BlogBuilder(context).build()
+        XCTAssertNotNil(blog.dotComID)
+        XCTAssertNotNil(try Blog.lookup(withID: blog.dotComID!.int64Value, in: context))
+    }
+
+    func testThatLookupByBlogIDFailsForInvalidInt64BlogID() throws {
+        XCTAssertNil(try Blog.lookup(withID: Int64(1), in: context))
+    }
+
 }


### PR DESCRIPTION
Moves blog look-ups out of the `BlogService` object.

## Why?

The current approach to looking up a single `Blog` object either has insufficient context for proper threading, or requires state leaking into the service. It also encourages the creation of many intermediate `BlogService` objects that are strictly used for looking up `Blog` objects. This complicates a refactor to avoid global access to the Core Data Stack, because we'd need to thread the stack to these instances. If we instead 

Consider the following pseudo-code examples:

```swift
// An example why we can't just use a single context in a service
class BlogService
{
  init(context: NSManagedObjectContext) {
    self.context = context
  }

  func syncBlogs() {
    let blogs = self.allBlogs()
    let remote = BlogRemote(blog.wpcomAPIRemote)
    remote.fetchAllBlogs { blogs in
      // If we want to perform writes here on a context other than the main one, we need a 
      // temporary context. For that we need the stack.
    }
  }
}
```

```swift
// This is better, but now the BlogService doesn't know how to reliably determine where it 
// should perform operations

class BlogService
{
  init(stack: CoreDataStack) {
    self.coreDataStack = stack
  }

  func updateBlogName(forSiteID siteID: Int, name: String) {
    let context = coreDataStack.newDerivedContext()

    context.performAndWait { context in
      // How do we tell Core Data which context to use for this lookup?
      // We could say "always fetch on the view context", but that precludes lookups in a background context
      let blog = self.blog(withID: siteID)
      blog.name = name
      self.coreDataStack.saveContext(context)
    }
  }
}
```

```swift
// Instead, let's pass the `context` in which we're performing the lookup into the service:
class BlogService
{
  init(stack: CoreDataStack) {
    self.coreDataStack = stack
  }

  func updateBlogName(forSiteID siteID: Int, name: String) {
    let context = coreDataStack.newDerivedContext()

    context.performAndWait { context in
      // How do we tell Core Data which context to use for this lookup?
      // We could say "always fetch on the view context", but that precludes lookups in a background context
      let blog = self.blog(withID: siteID, in: context)
      blog.name = name
      self.coreDataStack.saveContext(context)
    }
  }
  
  func blog(withID siteID: Int, in context: NSManagedObjectContext) -> Blog? {
    let fetchRequest = NSFetchRequest<Self>(entityName: Blog.entityName())
    fetchRequest.predicate = NSPredicate(format: "blogID == %@", siteID)
    return try? context.fetch(fetchRequest).first
  }
}
```

Let's pause here. We've fixed the background problem, but our API is very strange now. Consider trying to use it externally:

```swift
let service = BlogService(stack: self.coreDataStack)
let blog = service.blog(withID: 4, in: self.coreDataStack.viewContext) /// why do I need to provide a context _and_ a stack?!
```

Taking a step back, let's look at the problem this API is trying to solve – we want to be able to fetch `Blog` objects without needing to write the `NSFetchRequest` by hand each time. We see this in other services:

```swift
class PostService 
{
  // [...snip...]

  func downloadPosts(forSite siteID: Int) {
     let api = BlogService(context: self.coreDataStack.viewContext).blog(withID: siteID).wpcomAPIRemote
     let remote = PostRemote(api)
     // [...snip...]
  }
}
```

and even in helpers

```swift
class StatsInsightsHelper 
{
   func getStatsCountForBlog(withID siteID: Int) -> [Stat] {
     return BlogService(content: ContextManager.shared.mainContext).blog(withID: siteID).stats 
   }
}
```


We can improve all of these examples by moving the fetch logic into a static method on the `Blog` object:


```swift
extension Blog {
     static func lookup(withID id: Int, in context: NSManagedObjectContext) -> Blog? {
       let fetchRequest = NSFetchRequest<Self>(entityName: Blog.entityName())
       fetchRequest.predicate = NSPredicate(format: "blogID == %d", id)
       return try? context.fetch(fetchRequest).first
     }
  }
}
```

And here is how those examples would look with the new lookup API:

```swift
class BlogService
{
  init(stack: CoreDataStack) {
    self.coreDataStack = stack
  }

  func updateBlogName(forSiteID siteID: Int, name: String) {
    let context = coreDataStack.newDerivedContext()

    context.performAndWait { context in
      // How do we tell Core Data which context to use for this lookup?
      // We could say "always fetch on the view context", but that precludes lookups in a background context
      let blog = Blog.lookup(withID: siteID, in: context)
      blog.name = name
      self.coreDataStack.saveContext(context)
    }
  }
}

```

```swift
/// no need to provide a stack or have an intermediate object
let blog = Blog.lookup(withID: 4, in: self.coreDataStack.viewContext) 
```

```swift
class PostService 
{
  // [...snip...]

  func downloadPosts(forSite siteID: Int) {
    let api = Blog.lookup(siteID, in: self.coreDataStack.viewContext).wpcomAPIRemote
    let remote = PostRemote(api)
    // [...snip...]
  }
}
```

```swift
class StatsInsightsHelper 
{
   func getStatsCountForBlog(withID siteID: Int) -> [Stat] {
      return Blog.lookup(siteID, in: ContextManager.shared.mainContext).stats
   }
}

// One benefit here is that this method becomes far easier to clean up – it now feels an awfully
// lot like something that could go in a `StatsInsightsService`.
//
// So let's refactor it into one

class StatsInsightsService
{
  init(stack: CoreDataStack) {
    self.coreDataStack = stack
  }

  func getStatsCountForBlog(withID siteID: Int) -> [Stat] {
    // Service methods should only ever be called from the main thread since they're accessed from the UI layer
    assert(Thread.isMainThread) 
    return Blog.lookup(withID: siteID, in: self.coreDataStack).stats
  }
}
```

Requesting review from @aerych and @frosty, as y'all have been around this code a lot for a long time. If both of you would be willing to 👍 it, I'll take that as a sign that it's a good refactoring 😅. Happy to answer questions and/or discuss more – there's a lot of explanation I left out to try to keep this from becoming a novel.

**To test:**
Ensure test pass. To review this PR, if you go commit-by-commit, it should be very clear that the change is mechanical, with no new functionality (except tests)

**PR submission checklist:**
- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
