### PR TITLE
Update release-toolkit to add new actions to trigger CircleCI jobs via API calls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
       - store_artifacts:
           path: Artifacts
           destination: Artifacts
-  Beta Build:
+  beta-build:
     executor:
       name: ios/default
       <<: *xcode_version
@@ -349,7 +349,7 @@ workflows:
   Beta Build:
     when: or [ << pipeline.parameters.beta_build >>, << pipeline.parameters.release_build >> ]
     jobs: 
-      - Beta Build
+      - beta-build
   Translation Review Build:
     when: << pipeline.parameters.translation_review_build >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
       - store_artifacts:
           path: Artifacts
           destination: Artifacts
-  beta-build:
+  Beta Build:
     executor:
       name: ios/default
       <<: *xcode_version
@@ -347,9 +347,9 @@ workflows:
             tags:
               only: /^\d.\d?(.\d)?(.\d)?(.\d{1,4})$/
   Beta Build:
-    when: or [ << pipeline.parameters.beta_build >>, << pipeline.parameters.release_build >> ]
+    when: << pipeline.parameters.beta_build >>
     jobs: 
-      - beta-build
+      - Beta Build
   Translation Review Build:
     when: << pipeline.parameters.translation_review_build >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,12 @@ parameters:
   translation_review_lang_id:
     type: string
     default: all-lang
+  beta_build:
+    type: boolean
+    default: false 
+  release_build:
+    type: boolean 
+    default: false
 
 xcode_version: &xcode_version
   xcode-version: "12.1.0"
@@ -168,6 +174,31 @@ jobs:
       - store_artifacts:
           path: Artifacts
           destination: Artifacts
+  Beta Build:
+    executor:
+      name: ios/default
+      <<: *xcode_version
+    steps:
+      - when:
+          condition: << pipeline.parameters.beta_build >>
+          steps:
+            - run:
+                name: Beta Build Test
+                command: |
+                  echo "export SLACK_SUCCESS_MESSAGE=':tada: A new Beta build has been triggered via API!'" >> $BASH_ENV 
+      - when:
+          condition: << pipeline.parameters.release_build >>
+          steps:
+            - run:
+                name: Release Build Test
+                command: |
+                  echo "export SLACK_SUCCESS_MESSAGE=':tada: A new Release build has been triggered via API!'" >> $BASH_ENV
+      - slack/status:
+          include_job_number_field: false
+          include_project_field: false
+          include_visit_job_action: true
+          webhook: '${SLACK_BUILD_WEBHOOK}'
+          success_message: '${SLACK_SUCCESS_MESSAGE}'
   Release Build:
     executor:
       name: ios/default
@@ -315,6 +346,10 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d.\d?(.\d)?(.\d)?(.\d{1,4})$/
+  Beta Build:
+    when: << pipeline.parameters.beta_build >> || << pipeline.parameters.release_build >>
+    jobs: 
+      - Beta Build
   Translation Review Build:
     when: << pipeline.parameters.translation_review_build >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,7 +347,8 @@ workflows:
             tags:
               only: /^\d.\d?(.\d)?(.\d)?(.\d{1,4})$/
   Beta Build:
-    when: << pipeline.parameters.beta_build >>
+    when: 
+      or: [ << pipeline.parameters.beta_build >>, << pipeline.parameters.release_build >> ]
     jobs: 
       - Beta Build
   Translation Review Build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,7 +347,7 @@ workflows:
             tags:
               only: /^\d.\d?(.\d)?(.\d)?(.\d{1,4})$/
   Beta Build:
-    when: << pipeline.parameters.beta_build >> || << pipeline.parameters.release_build >>
+    when: or [ << pipeline.parameters.beta_build >>, << pipeline.parameters.release_build >> ]
     jobs: 
       - Beta Build
   Translation Review Build:

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
-source 'https://rubygems.org' do
-  gem 'rake'
-  gem 'cocoapods', '~> 1.10'
-  gem 'xcpretty-travis-formatter'
-  gem 'octokit', "~> 4.0"
-  gem 'fastlane', "~> 2.162"
-  gem 'dotenv'
-  gem 'commonmarker'
-end
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'cocoapods', '~> 1.10'
+gem 'xcpretty-travis-formatter'
+gem 'octokit', "~> 4.0"
+gem 'fastlane', "~> 2.162"
+gem 'dotenv'
+gem 'commonmarker'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: a932bd25320f2b82be0774b66e550c6862cd8765
-  tag: 0.12.0
+  revision: 24db1b638b964ded7ea8a908a765ed8c60728722
+  ref: 24db1b638b964ded7ea8a908a765ed8c60728722
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.12.0)
+    fastlane-plugin-wpmreleasetoolkit (0.13.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -230,7 +230,7 @@ GEM
     octokit (4.19.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.11.1)
+    oj (3.11.2)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 24db1b638b964ded7ea8a908a765ed8c60728722
-  ref: 24db1b638b964ded7ea8a908a765ed8c60728722
+  revision: 4d8c76bfce3b47ad5f9795580bb192ae8fbab6c5
+  ref: 4d8c76bfce3b47ad5f9795580bb192ae8fbab6c5
   specs:
     fastlane-plugin-wpmreleasetoolkit (0.13.0)
       activesupport (~> 5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,18 +307,18 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.10)!
-  commonmarker!
-  dotenv!
-  fastlane (~> 2.162)!
+  cocoapods (~> 1.10)
+  commonmarker
+  dotenv
+  fastlane (~> 2.162)
   fastlane-plugin-appcenter (~> 1.8)
   fastlane-plugin-sentry
   fastlane-plugin-test_center
   fastlane-plugin-wpmreleasetoolkit!
-  octokit (~> 4.0)!
-  rake!
+  octokit (~> 4.0)
+  rake
   rmagick (~> 3.2.0)
-  xcpretty-travis-formatter!
+  xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.1.4
+   2.2.10

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -581,6 +581,15 @@ import "./ScreenshotFastfile"
     )
   end
 
+  lane :test_release_build do | options |
+    circleci_trigger_job(
+      circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"], 
+      repository:PROJECT_NAME, 
+      branch:"feature/trigger-ci-via-api",
+      job_params: {"release_build" => true}
+    )
+  end
+
 ########################################################################
 # Configure Lanes
 ########################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -69,7 +69,7 @@ ENV["PUBLIC_CONFIG_FILE"]=File.join(PROJECT_ROOT_FOLDER, "config", "Version.Publ
 ENV["INTERNAL_CONFIG_FILE"]=File.join(PROJECT_ROOT_FOLDER, "config", "Version.internal.xcconfig")
 ENV["DOWNLOAD_METADATA"]="./fastlane/download_metadata.swift"
 ENV["PROJECT_ROOT_FOLDER"]=PROJECT_ROOT_FOLDER
-PROJECT_NAME="WordPress-iOS"
+REPOSITORY_NAME="WordPress-iOS"
 
 ########################################################################
 # Screenshots
@@ -575,8 +575,8 @@ import "./ScreenshotFastfile"
   lane :test_beta_build do | options |
     circleci_trigger_job(
       circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"], 
-      repository:PROJECT_NAME, 
-      branch:"feature/trigger-ci-via-api",
+      repository: REPOSITORY_NAME, 
+      branch: "feature/trigger-ci-via-api",
       job_params: {"beta_build" => true}
     )
   end
@@ -584,8 +584,8 @@ import "./ScreenshotFastfile"
   lane :test_release_build do | options |
     circleci_trigger_job(
       circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"], 
-      repository:PROJECT_NAME, 
-      branch:"feature/trigger-ci-via-api",
+      repository: REPOSITORY_NAME, 
+      branch: "feature/trigger-ci-via-api",
       job_params: {"release_build" => true}
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -69,6 +69,7 @@ ENV["PUBLIC_CONFIG_FILE"]=File.join(PROJECT_ROOT_FOLDER, "config", "Version.Publ
 ENV["INTERNAL_CONFIG_FILE"]=File.join(PROJECT_ROOT_FOLDER, "config", "Version.internal.xcconfig")
 ENV["DOWNLOAD_METADATA"]="./fastlane/download_metadata.swift"
 ENV["PROJECT_ROOT_FOLDER"]=PROJECT_ROOT_FOLDER
+PROJECT_NAME="WordPress-iOS"
 
 ########################################################################
 # Screenshots
@@ -568,6 +569,15 @@ import "./ScreenshotFastfile"
     add_all_devices_to_provisioning_profiles(
       team_id: get_required_env("EXT_EXPORT_TEAM_ID"),
       app_identifier: ALL_BUNDLE_IDENTIFIERS
+    )
+  end
+
+  lane :test_beta_build do | options |
+    circleci_trigger_job(
+      circle_ci_token: ENV["CIRCLE_CI_AUTH_TOKEN"], 
+      repository:PROJECT_NAME, 
+      branch:"feature/trigger-ci-via-api",
+      job_params: {"beta_build" => true}
     )
   end
 

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,8 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '24db1b638b964ded7ea8a908a765ed8c60728722'
-#gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../wordpress-mobile/release-toolkit'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '4d8c76bfce3b47ad5f9795580bb192ae8fbab6c5'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,9 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.12.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', ref: '24db1b638b964ded7ea8a908a765ed8c60728722'
+#gem 'fastlane-plugin-wpmreleasetoolkit', path: '../../../wordpress-mobile/release-toolkit'
+
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'
 gem 'fastlane-plugin-test_center'

--- a/fastlane/env/user.env-example
+++ b/fastlane/env/user.env-example
@@ -4,3 +4,5 @@ DELIVER_USER=<Your Apple ID for fastlane>
 GHHELPER_ACCESS=<GitHub access token>
 APPCENTER_API_TOKEN=<AppCenter Api Token>
 SENTRY_AUTH_TOKEN=<Sentry Auth Token>
+
+CIRCLE_CI_AUTH_TOKEN=<CircleCI Auth Token>


### PR DESCRIPTION
This PR update `release-toolkit` to a new version which adds a `circleci_trigger_job` action. 
It also sets up a test workflow in CircleCI which will be used as a base for the next steps in a follow-up PR. 

Since testing changes to the release tooling is always complex, I'm splitting this feature in multiple PRs which should make testing easier. Because of this, this PR targets a feature branch.

**To test**
The test workflow is set up to post a message on Slack.

1. `bundle install`
2. Run `bundle exec fastlane test_release_build` and verify that the `A new Release build has been triggered via API!` message has been posted on the build channel on Slack.
3. Run `bundle exec fastlane test_beta_build` and verify that the `A new Beta build has been triggered via API!` message has been posted on the build channel on Slack.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
