### PR TITLE
[Tooling] Fix bundler CI failure by updating bundler with security fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,12 @@
-source 'https://rubygems.org' do
-  gem 'rake'
-  gem 'cocoapods', '~> 1.10'
-  gem 'xcpretty-travis-formatter'
-  gem 'octokit', "~> 4.0"
-  gem 'fastlane', "~> 2.162"
-  gem 'dotenv'
-  gem 'commonmarker'
-end
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'cocoapods', '~> 1.10'
+gem 'xcpretty-travis-formatter'
+gem 'octokit', "~> 4.0"
+gem 'fastlane', "~> 2.162"
+gem 'dotenv'
+gem 'commonmarker'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,18 +307,18 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.10)!
-  commonmarker!
-  dotenv!
-  fastlane (~> 2.162)!
+  cocoapods (~> 1.10)
+  commonmarker
+  dotenv
+  fastlane (~> 2.162)
   fastlane-plugin-appcenter (~> 1.8)
   fastlane-plugin-sentry
   fastlane-plugin-test_center
   fastlane-plugin-wpmreleasetoolkit!
-  octokit (~> 4.0)!
-  rake!
+  octokit (~> 4.0)
+  rake
   rmagick (~> 3.2.0)
-  xcpretty-travis-formatter!
+  xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.1.4
+   2.2.10

--- a/fastlane/download_metadata.swift
+++ b/fastlane/download_metadata.swift
@@ -47,7 +47,7 @@ func downloadTranslation(languageCode: String, folderName: String) {
     let sema = DispatchSemaphore( value: 0)
 
     print("Downloading Language: \(languageCode)")
-	
+
     let task = session.dataTask(with: urlRequest) {
         (data, response, error) -> Void in
 
@@ -88,7 +88,7 @@ func downloadTranslation(languageCode: String, folderName: String) {
             var originalLanguage = String(key[index...])
             originalLanguage.remove(at: originalLanguage.startIndex)
             let translation = languageCode == "en-us" ? originalLanguage : firstValue
-            
+
             switch keyFirstPart {
             case glotPressSubtitleKey:
                 subtitle = translation
@@ -125,12 +125,11 @@ func downloadTranslation(languageCode: String, folderName: String) {
             print("  Error writing: \(error)")
         }
     }
-    
+
     task.resume()
     sema.wait()
 }
 
-languages.forEach( { (key: String, value: String) in
+languages.forEach { (key: String, value: String) in
     downloadTranslation(languageCode: value, folderName: key)
-})
-
+}


### PR DESCRIPTION
## Why?

CircleCI seem to recently have updated to `bundler` version `2.2.10` (we were using `2.1.4` before) on their CI images, probably due to the [important security issue that got fixed in 2.2.10](https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md#security-fixes).

That version of bundler generates a `Gemfile.lock` that is slightly different from the one we had (especially to separate gems per source, one of the changes that avoids the security exploit) and also seems to resolve the gems slightly differently, leading to running 2.2.10's `bundle install` on a `Gemfile.lock` that was generated using bundler 2.1.4 to fail to resolve the dependency for `rake` in some contexts, and thus fail on CI:

```
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Bundler could not find compatible versions for gem "rake":
  In snapshot (Gemfile.lock):
    rake (= 12.3.3)
  In Gemfile:
    fastlane (~> 2) was resolved to 2.171.0, which depends on
google-cloud-storage (>= 1.15.0, < 2.0.0) was resolved to 1.29.2, which
depends on
        digest-crc (~> 0.4) was resolved to 0.6.3, which depends on
          rake (>= 12.0.0, < 14.0.0)
    fastlane-plugin-wpmreleasetoolkit was resolved to 0.14.0, which depends on
      rake (~> 12.3)
    fastlane-plugin-wpmreleasetoolkit was resolved to 0.14.0, which depends on
      rake-compiler (~> 1.0) was resolved to 1.1.1, which depends on
        rake
```

That happened on WPAndroid, but since WPiOS's CI is now also using bundler 2.2.10, applying the fix here too.

## Root Cause

After a lot of debugging and reading the thread in bundler's PR in details, I finally ended up finding the root cause.

This is in fact due to the fact that we use a `source "…" do … end` block to provide the source for our gems in the `Gemfile`, but that block is not applied to the `Pluginfile`, where we import our release-toolkit plugin/gem. This means that the latest version of bundler now resolves this gem and its transitive dependencies only using the local gems (since there are no global remote source provided for that gem), and thus fail to find transitive dependencies like `rake` for it there.

## Solution

After a lot of trial and error, the solution was finally stop using `source` blocks in the `Gemfile`, and instead only provide the single `source 'https://rubygems.org'` declaration as a single global source applied to the whole `Gemfile`, [which now allows the plugin to also pull the transitive dependencies from that same single global source declaration](https://github.com/rubygems/rubygems/pull/3655/files#diff-48539cd5ac1a26847a9872ff68948c08648586940cba3e3fa9725f1de77e083aR24), and avoid the security risk and the CI failure.

## To Test

 - Wait for CI to go green on the first build (will rebuild the cache due to new `Gemfile.lock` checksum)
 - Ensure another build after the first one (which will use the cache) is still green (that's when the failure started to appeared before that fix)
 - Test to apply the same commits and fix on other failing PRs

## Related PRs

The same fix has currently been applied to:
 - [WPAndroid's develop](https://github.com/wordpress-mobile/WordPress-Android/pull/14082)
 - [WCAndroid's develop](https://github.com/woocommerce/woocommerce-android/pull/3585)

_I'll P2 about it once the fix is finally applied to all repos and branches._
