### PR TITLE
Fix crash on Notifications tab when device is offline

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] Prevent deleting published homepages which would have the effect of breaking a site. [#15797]
 * [**] Prevent converting published homepage to a draft in the page list and settings which would have the effect of breaking a site. [#15797]
+* [*] Fix app crash when device is offline and user visits Notification or Reader screens [#15897] 
 
 16.7
 -----

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -52,6 +52,14 @@ CGFloat const STVSeparatorHeight = 1.f;
 }
 
 
+- (void)didMoveToSuperview {
+    [super didMoveToSuperview];
+
+    if (!_suggestions && _siteID != nil) {
+        [self fetchSuggestionsFor:_siteID];
+    }
+}
+
 #pragma mark Private methods
 
 - (void)updateHeaderStyles
@@ -312,16 +320,6 @@ CGFloat const STVSeparatorHeight = 1.f;
     cell.subtitleLabel.text = [self subtitleFor:suggestion];
     [self loadImageFor:suggestion in:cell at:indexPath];
     return cell;
-}
-
-#pragma mark - Suggestion list management
-
-- (NSArray *)suggestions
-{
-    if (!_suggestions && _siteID != nil) {
-        [self fetchSuggestionsFor:_siteID];
-    }
-    return _suggestions;
 }
 
 @end


### PR DESCRIPTION
The app crashed when the device was offline and the suggestions code (which handles Mentions and Cross-posts) returned a `nil` result. This result was interpreted by the `SuggestionsTableView` code as "suggestions haven't been fetched yet". The code, which has logic for fetching suggestions tied to the suggestions data source (a property), then entered an infinite loop of reloading the suggestions list.

The fix here is to undo an architectural decision made long ago to tie the fetching of suggestions to the suggestions data source. I've used `didMoveToSuperview` on the suggestions view as the trigger to fetch suggestions. This method, somewhat similar to `UIViewController`'s `viewDidLoad`, is called once each time the suggestions UI is shown.

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/15873

### To test

```
- [ ] Reproduce the crash on 16.7 beta
- [ ] Verify the crash is fixed on this branch
- [ ] Regression testing
```

#### Reproduce the crash on 16.7 beta

To ensure the fix addresses the bug, first download the 16.7 beta from TestFlight (any 16.7 build is fine). Log in to the app and before doing anything else, turn off the device wifi and data connections. Then tap the Notifications tab and expect the app to crash.

#### Verify the crash is fixed on this branch

Download the build from [this comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/15897#issuecomment-780202413) below and repeat the same steps as above, expect no crash to occur.

#### Regression testing

Mentions suggestions should work just as they did before this bug fix was applied. Check mentions in Reader, the Block editor, Notifications replies, comments (My Site > Comments), etc.

Cross-post suggestions – which are available by typing the `+` character (or long-pressing the toolbar button labelled with an @-symbol) in a post on a site that has the O2 plugin installed (e.g. [P2 sites](https://wordpress.com/p2/) – should continue to work as before. These are only available within the Gutenberg editor (not in other places such as comments, replies, etc).

Expect a slight network delay the first time suggestions are displayed for a particular site. However, if they are displayed before one minute has passed, they should be shown immediately.

Suggestions (mentions and cross-posts) should be available when the device is offline, _if_ they were used previously while the device was online.

### PR submission checklist

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
