### PR TITLE
Show loader while activating theme

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -6,6 +6,7 @@ import CocoaLumberjack
 ///
 public enum ThemeAction {
     case activate
+    case active
     case customize
     case details
     case support
@@ -36,6 +37,8 @@ public enum ThemeAction {
         switch self {
         case .activate:
             return NSLocalizedString("Activate", comment: "Theme Activate action title")
+        case .active:
+            return NSLocalizedString("Active", comment: "Label for active Theme")
         case .customize:
             return NSLocalizedString("Customize", comment: "Theme Customize action title")
         case .details:
@@ -53,7 +56,7 @@ public enum ThemeAction {
         switch self {
         case .activate:
             presenter.activateTheme(theme)
-        case .customize:
+        case .customize, .active:
             presenter.presentCustomizeForTheme(theme)
         case .details:
             presenter.presentDetailsForTheme(theme)

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -183,10 +183,12 @@ public protocol ThemePresenter: class {
         return !suspendedSearch.trim().isEmpty
     }
     
-    fileprivate lazy var activityIndicator: UIActivityIndicatorView = {
-           let indicatorView = UIActivityIndicatorView(style: .medium)
-           indicatorView.translatesAutoresizingMaskIntoConstraints = false
-           return indicatorView
+    fileprivate var activityIndicator: UIActivityIndicatorView = {
+        let indicatorView = UIActivityIndicatorView(style: .medium)
+        //TODO update color with white headers
+        indicatorView.color = .white
+        indicatorView.startAnimating()
+        return indicatorView
        }()
 
     open var filterType: ThemeType = ThemeType.mayPurchase ? .all : .free
@@ -775,10 +777,8 @@ public protocol ThemePresenter: class {
             return
         }
         
-        activateButton?.isEnabled = false
         activateButton?.customView = activityIndicator
         activityIndicator.startAnimating()
-        activityIndicator.hidesWhenStopped = true
 
         _ = themeService.activate(theme,
             for: blog,
@@ -793,8 +793,11 @@ public protocol ThemePresenter: class {
                 let successMessage = String(format: successFormat, theme?.name ?? "", theme?.author ?? "")
                 let manageTitle = NSLocalizedString("Manage site", comment: "Return to blog screen action when theme activation succeeds")
                 let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
+
                 self.activityIndicator.stopAnimating()
                 self.activateButton?.customView = nil
+                self.activateButton?.isEnabled = false
+                self.activateButton?.title = ThemeAction.active.title
 
                 let alertController = UIAlertController(title: successTitle,
                     message: successMessage,
@@ -812,6 +815,7 @@ public protocol ThemePresenter: class {
 
                 let errorTitle = NSLocalizedString("Activation Error", comment: "Title of alert when theme activation fails")
                 let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
+
                 self?.activityIndicator.stopAnimating()
                 self?.activateButton?.customView = nil
 
@@ -876,10 +880,12 @@ public protocol ThemePresenter: class {
         configuration.customTitle = theme.name
         configuration.navigationDelegate = customizerNavigationDelegate
         configuration.onClose = onClose
+
+        let title = activeButton ? ThemeAction.activate.title : ThemeAction.active.title
+        activateButton = UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(ThemeBrowserViewController.activatePresentingTheme))
+        activateButton?.isEnabled = !theme.isCurrentTheme()
+
         let webViewController = WebViewControllerFactory.controller(configuration: configuration)
-        if activeButton && !theme.isCurrentTheme() {
-           activateButton = UIBarButtonItem(title: ThemeAction.activate.title, style: .plain, target: self, action: #selector(ThemeBrowserViewController.activatePresentingTheme))
-        }
         webViewController.navigationItem.rightBarButtonItem = activateButton
         let navigation = UINavigationController(rootViewController: webViewController)
         navigation.modalPresentationStyle = modalStyle

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -185,6 +185,7 @@ public protocol ThemePresenter: class {
 
     fileprivate var activityIndicator: UIActivityIndicatorView = {
         let indicatorView = UIActivityIndicatorView(style: .medium)
+        indicatorView.frame = CGRect(x: 0.0, y: 0.0, width: 40.0, height: 20.0)
         //TODO update color with white headers
         indicatorView.color = .white
         indicatorView.startAnimating()

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -182,7 +182,7 @@ public protocol ThemePresenter: class {
     @objc func resumingSearch() -> Bool {
         return !suspendedSearch.trim().isEmpty
     }
-    
+
     fileprivate var activityIndicator: UIActivityIndicatorView = {
         let indicatorView = UIActivityIndicatorView(style: .medium)
         //TODO update color with white headers
@@ -776,7 +776,7 @@ public protocol ThemePresenter: class {
         guard let theme = theme, !theme.isCurrentTheme() else {
             return
         }
-        
+
         activateButton?.customView = activityIndicator
         activityIndicator.startAnimating()
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -784,9 +784,8 @@ public protocol ThemePresenter: class {
             for: blog,
             success: { [weak self] (theme: Theme?) in
                 WPAppAnalytics.track(.themesChangedTheme, withProperties: ["theme_id": theme?.themeId ?? ""], with: self?.blog)
-                guard let self = self else { return }
 
-                self.collectionView?.reloadData()
+                self?.collectionView?.reloadData()
 
                 let successTitle = NSLocalizedString("Theme Activated", comment: "Title of alert when theme activation succeeds")
                 let successFormat = NSLocalizedString("Thanks for choosing %@ by %@", comment: "Message of alert when theme activation succeeds")
@@ -794,10 +793,10 @@ public protocol ThemePresenter: class {
                 let manageTitle = NSLocalizedString("Manage site", comment: "Return to blog screen action when theme activation succeeds")
                 let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
 
-                self.activityIndicator.stopAnimating()
-                self.activateButton?.customView = nil
-                self.activateButton?.isEnabled = false
-                self.activateButton?.title = ThemeAction.active.title
+                self?.activityIndicator.stopAnimating()
+                self?.activateButton?.customView = nil
+                self?.activateButton?.isEnabled = false
+                self?.activateButton?.title = ThemeAction.active.title
 
                 let alertController = UIAlertController(title: successTitle,
                     message: successMessage,

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -243,6 +243,7 @@ public protocol ThemePresenter: class {
     fileprivate var themesSyncingPage = 0
     fileprivate var customThemesSyncHelper: WPContentSyncHelper!
     fileprivate let syncPadding = 5
+    fileprivate var activateButton: UIBarButtonItem?
 
     // MARK: - Private Aliases
 
@@ -858,12 +859,11 @@ public protocol ThemePresenter: class {
         configuration.navigationDelegate = customizerNavigationDelegate
         configuration.onClose = onClose
         let webViewController = WebViewControllerFactory.controller(configuration: configuration)
-        var buttons: [UIBarButtonItem]?
+        var activate: UIBarButtonItem?
         if activeButton && !theme.isCurrentTheme() {
-           let activate = UIBarButtonItem(title: ThemeAction.activate.title, style: .plain, target: self, action: #selector(ThemeBrowserViewController.activatePresentingTheme))
-            buttons = [activate]
+           activate = UIBarButtonItem(title: ThemeAction.activate.title, style: .plain, target: self, action: #selector(ThemeBrowserViewController.activatePresentingTheme))
         }
-        webViewController.navigationItem.rightBarButtonItems = buttons
+        webViewController.navigationItem.rightBarButtonItem = activate
         let navigation = UINavigationController(rootViewController: webViewController)
         navigation.modalPresentationStyle = modalStyle
 
@@ -878,6 +878,7 @@ public protocol ThemePresenter: class {
 
     @objc open func activatePresentingTheme() {
         suspendedSearch = ""
+        
         _ = navigationController?.popViewController(animated: true)
         activateTheme(presentingTheme)
         presentingTheme = nil

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -84,6 +84,7 @@ public protocol ThemePresenter: class {
 
     @objc static let reuseIdentifierForThemesHeader = "ThemeBrowserSectionHeaderViewThemes"
     @objc static let reuseIdentifierForCustomThemesHeader = "ThemeBrowserSectionHeaderViewCustomThemes"
+    static let themesLoaderFrame = CGRect(x: 0.0, y: 0.0, width: 40.0, height: 20.0)
 
     // MARK: - Properties: must be set by parent
 
@@ -185,7 +186,7 @@ public protocol ThemePresenter: class {
 
     fileprivate var activityIndicator: UIActivityIndicatorView = {
         let indicatorView = UIActivityIndicatorView(style: .medium)
-        indicatorView.frame = CGRect(x: 0.0, y: 0.0, width: 40.0, height: 20.0)
+        indicatorView.frame = themesLoaderFrame
         //TODO update color with white headers
         indicatorView.color = .white
         indicatorView.startAnimating()
@@ -218,6 +219,18 @@ public protocol ThemePresenter: class {
             return customThemesController.object(at: IndexPath(row: indexPath.row, section: 0)) as? Theme
         }
         return nil
+    }
+
+    fileprivate func updateActivateButton(isLoading: Bool) {
+        if isLoading {
+            activateButton?.customView = activityIndicator
+            activityIndicator.startAnimating()
+        } else {
+            activityIndicator.stopAnimating()
+            activateButton?.customView = nil
+            activateButton?.isEnabled = false
+            activateButton?.title = ThemeAction.active.title
+        }
     }
 
     fileprivate var presentingTheme: Theme?
@@ -778,8 +791,7 @@ public protocol ThemePresenter: class {
             return
         }
 
-        activateButton?.customView = activityIndicator
-        activityIndicator.startAnimating()
+        updateActivateButton(isLoading: true)
 
         _ = themeService.activate(theme,
             for: blog,
@@ -794,10 +806,7 @@ public protocol ThemePresenter: class {
                 let manageTitle = NSLocalizedString("Manage site", comment: "Return to blog screen action when theme activation succeeds")
                 let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
 
-                self?.activityIndicator.stopAnimating()
-                self?.activateButton?.customView = nil
-                self?.activateButton?.isEnabled = false
-                self?.activateButton?.title = ThemeAction.active.title
+                self?.updateActivateButton(isLoading: false)
 
                 let alertController = UIAlertController(title: successTitle,
                     message: successMessage,


### PR DESCRIPTION
Fixes #15329 

To test: 
1. Go to themes 
2. Got to a specific theme 
3. If its active, notice the bar item tittle is "Active" , if it's not active notice title = "Activate"
4. If it's active see Customizer, if it's not active see theme
5. Tap "Activate" and notice spinner 
6.  Notice spinner is hidden once theme is active
7. Notice title turns to disabled "Active" once the theme is activated 

* Anything else I didn't think of 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
![theme_loader](https://user-images.githubusercontent.com/1335657/108140215-7a957880-7076-11eb-96f8-5bb846198f76.gif)

