### PR TITLE
Comments: provide status when fetching

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.26'
+    # pod 'WordPressKit', '~> 4.27-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/15893-comments_by_status'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.27-beta'
+    pod 'WordPressKit', '~> 4.27-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/15893-comments_by_status'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -404,12 +404,12 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.26.0):
+  - WordPressKit (4.27.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
     - UIDeviceIdentifier (~> 1.4)
-    - WordPressShared (~> 1.12)
+    - WordPressShared (~> 1.15.0-beta.1)
     - wpxmlrpc (~> 0.9)
   - WordPressMocks (0.0.9)
   - WordPressShared (1.15.0):
@@ -501,7 +501,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.35.1)
-  - WordPressKit (~> 4.26)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/15893-comments_by_status`)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.15.0)
   - WordPressUI (~> 1.9.0)
@@ -550,7 +550,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -651,6 +650,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.47.0-alpha2
+  WordPressKit:
+    :branch: feature/15893-comments_by_status
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.47.0-alpha2/third-party-podspecs/Yoga.podspec.json
 
@@ -666,6 +668,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.47.0-alpha2
+  WordPressKit:
+    :commit: f19bbbd4ad23359f4eaacd2cb2f1cb2241b4f115
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -746,7 +751,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
   WordPressAuthenticator: 7b7555d43273231e968f1f890166fc3aac72b2a3
-  WordPressKit: 63932c352c4199179f15855f68543e4541ec9da0
+  WordPressKit: 8de0bec3257984974c44c3cc914d1099c6219278
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 2d2b45d8945221b716a0e2f23932dadb750d9a74
   WordPressUI: 3b70cccc4c44cff09024ca3e94ae25a8768b26c1
@@ -762,6 +767,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 81b5fd5f19256231bfaa9f7266bbd6c983d0182c
+PODFILE CHECKSUM: 4f1c3854dbb22e720f46e03c4562ea55a779b5f2
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -501,7 +501,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
   - WordPressAuthenticator (~> 1.35.1)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/15893-comments_by_status`)
+  - WordPressKit (~> 4.27-beta)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.15.0)
   - WordPressUI (~> 1.9.0)
@@ -550,6 +550,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -650,9 +651,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.47.0-alpha2
-  WordPressKit:
-    :branch: feature/15893-comments_by_status
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.47.0-alpha2/third-party-podspecs/Yoga.podspec.json
 
@@ -668,9 +666,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.47.0-alpha2
-  WordPressKit:
-    :commit: f19bbbd4ad23359f4eaacd2cb2f1cb2241b4f115
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -767,6 +762,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 4f1c3854dbb22e720f46e03c4562ea55a779b5f2
+PODFILE CHECKSUM: 1870e9ed5f494b1c44e00d8d268938a5048db77c
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -2,6 +2,7 @@
 #import "LocalCoreDataService.h"
 
 extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
+extern NSString *commentStatusAll;
 
 @class Blog;
 @class Comment;
@@ -28,6 +29,11 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
                     success:(void (^)(BOOL hasMore))success
                     failure:(void (^)(NSError *error))failure;
 
+- (void)syncCommentsForBlog:(Blog *)blog
+                 withStatus:(NSString *)status
+                    success:(void (^)(BOOL hasMore))success
+                    failure:(void (^)(NSError *error))failure;
+
 // Determine if a recent cache is available
 + (BOOL)shouldRefreshCacheFor:(Blog *)blog;
 
@@ -36,6 +42,11 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
                         success:(void (^)(BOOL hasMore))success
                         failure:(void (^)(NSError *))failure;
 
+- (void)loadMoreCommentsForBlog:(Blog *)blog
+                     withStatus:(NSString *)status
+                        success:(void (^)(BOOL hasMore))success
+                        failure:(void (^)(NSError *))failure;
+    
 // Upload comment
 - (void)uploadComment:(Comment *)comment
               success:(void (^)(void))success

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1520,7 +1520,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
 
     if ([CommentService shouldRefreshCacheFor:self.blog]) {
-        [commentService syncCommentsForBlog:self.blog success:nil failure:nil];
+        [commentService syncCommentsForBlog:self.blog withStatus:commentStatusAll success:nil failure:nil];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -412,8 +412,9 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
         if (!blogInContext) {
             return;
         }
-        
+
         [commentService syncCommentsForBlog:blogInContext
+                                 withStatus:commentStatusAll
                                     success:^(BOOL hasMore) {
                                         if (success) {
                                             dispatch_async(dispatch_get_main_queue(), ^{
@@ -448,8 +449,9 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
         if (!blogInContext) {
             return;
         }
-        
+
         [commentService loadMoreCommentsForBlog:blogInContext
+                                     withStatus:commentStatusAll
                                         success:^(BOOL hasMore) {
                                                     if (success) {
                                                         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
Fixes: #15893 
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/350

This uses the WPKit changes to explicitly provide a Comment status when fetching. Right now it's still fetching `all`, but this will change when Comment filters are added.

The eagle-eyed reviewer (😉)  will notice it is not necessary to pass `commentStatusAll` to `syncCommentsForBlog` and `loadMoreCommentsForBlog` as I've changed it to do because the remotes add `status:all` if `status` is not provided. I did this for two reasons:
1. I'll be using this method later when I add filters.
2. It conveniently provides an easy way to test different statuses. You'll see. 😄 

To test:

There should be no visible change in the Comments displayed for WP or self-hosted sites. So for both site types:
- Go to Comments.
- Verify all Comments are listed as before, that is all Pending first followed by all Approved.

To test these changes actually work for different `status` types:
- In `CommentService`, change `commentStatusAll` to a different status. 
  - The `status` parameters for REST and XMLRPC endpoints differ for approved and unapproved.
  - To test REST, use:
    - `approved`
    - `unapproved`
  - To test XMLRPC, use:
    - `approve`
    - `hold`
  - `trash` and `spam` are the same for both.
- The Comments view does not refresh when first viewed, so pull to refresh.
  - The UI is not equipped to display all the statuses correctly, so I've added temporary log messages for the Comment content and status.
- Verify the status logged out matches the value you set for `commentStatusAll`.
```
🔴 comment content: <content>
🔴 comment status: <status>
```

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
