### PR TITLE
Stories: Update how-to Story URL

### DIFF
--- a/WordPress/Classes/ViewRelated/What's New/Views/StoriesIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/StoriesIntroViewController.swift
@@ -9,7 +9,7 @@ class StoriesIntroViewController: WhatIsNewViewController {
 
         static let example1Image = UIImage(named: "stories_intro_cover_1")
         static let example1Description = NSLocalizedString("How to create a story post", comment: "How to create story description")
-        static let example1URL = URL(string: "https://wpstories.wordpress.com/2020/12/02/story-demo-01/")
+        static let example1URL = URL(string: "https://wpstories.wordpress.com/2021/02/09/story-demo-03/")
 
         static let example2Image = UIImage(named: "stories_intro_cover_2")
         static let example2Description = NSLocalizedString("Example story title", comment: "Example story title description")


### PR DESCRIPTION
Follow-up to #15825, making a minor update to the link for the 'how to create a story' demo story. The content of the new post is the same as before for now, but the new link is meant for iOS exclusively, meaning we can update the content with iOS screenshots without affecting the demo story used for Android.

### To test:
-  Freshly install the WordPress app (or delete the storiesIntroWasAcknowledged User Default).
- Tap the FAB from your Site Details screen.
- Select the "Story post" post option.
- Ensure that tapping the demo stories opens and loads the demo stories, and that the stories shown match the preview images

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
