### PR TITLE
Add the Kanvas editor for creating a story

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ end
 def kanvas
   #pod 'Kanvas', :git => 'https://github.com/Automattic/Kanvas-iOS.git', :tag => ''
   #pod 'Kanvas', :git => 'https://github.com/Automattic/Kanvas-iOS.git', :commit => ''
-  pod 'Kanvas', :git => 'git@github.com:tumblr/kanvas-ios.git', :branch => 'stories/archiving'
+  pod 'Kanvas', :git => 'git@github.com:tumblr/kanvas-ios.git', :branch => 'main'
   #pod 'Kanvas', :path => '../Kanvas-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -50,6 +50,13 @@ def wordpress_kit
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 
+def kanvas
+  #pod 'Kanvas', :git => 'https://github.com/Automattic/Kanvas-iOS.git', :tag => ''
+  #pod 'Kanvas', :git => 'https://github.com/Automattic/Kanvas-iOS.git', :commit => ''
+  pod 'Kanvas', :git => 'git@github.com:tumblr/kanvas-ios.git', :branch => 'stories/archiving'
+  #pod 'Kanvas', :path => '../Kanvas-iOS'
+end
+
 def shared_with_all_pods
     wordpress_shared
     pod 'CocoaLumberjack', '~> 3.0'
@@ -178,6 +185,7 @@ target 'WordPress' do
     ##
     wordpress_kit
     wordpress_shared
+    kanvas
 
     # Production
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -456,7 +456,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.1.0)
   - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.47.0-alpha2`)
   - JTAppleCalendar (~> 8.0.2)
-  - "Kanvas (from `git@github.com:tumblr/kanvas-ios.git`, branch `stories/archiving`)"
+  - "Kanvas (from `git@github.com:tumblr/kanvas-ios.git`, branch `main`)"
   - MediaEditor (~> 1.2.1)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
@@ -584,7 +584,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.47.0-alpha2
   Kanvas:
-    :branch: stories/archiving
+    :branch: main
     :git: "git@github.com:tumblr/kanvas-ios.git"
   RCTRequired:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.47.0-alpha2/third-party-podspecs/RCTRequired.podspec.json
@@ -668,7 +668,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.47.0-alpha2
   Kanvas:
-    :commit: fdcbd627eef7ce729d4394e6a422a523453d292c
+    :commit: 08e47a4f5892e939fc7c5466e909575bd9b189e4
     :git: "git@github.com:tumblr/kanvas-ios.git"
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
@@ -771,6 +771,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 5861e22f9baa835b3ae42841d9eb53e723d69df6
+PODFILE CHECKSUM: cb9234c7ca23f6a633df8e67672774110b5f890a
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -79,6 +79,7 @@ PODS:
     - React-RCTImage (= 0.61.5)
     - RNTAztecView
   - JTAppleCalendar (8.0.3)
+  - Kanvas (1.1.1)
   - lottie-ios (3.1.9)
   - MediaEditor (1.2.1):
     - CropViewController (~> 2.5.3)
@@ -455,6 +456,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.1.0)
   - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.47.0-alpha2`)
   - JTAppleCalendar (~> 8.0.2)
+  - "Kanvas (from `git@github.com:tumblr/kanvas-ios.git`, branch `stories/archiving`)"
   - MediaEditor (~> 1.2.1)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
@@ -581,6 +583,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.47.0-alpha2
+  Kanvas:
+    :branch: stories/archiving
+    :git: "git@github.com:tumblr/kanvas-ios.git"
   RCTRequired:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.47.0-alpha2/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
@@ -662,6 +667,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.47.0-alpha2
+  Kanvas:
+    :commit: fdcbd627eef7ce729d4394e6a422a523453d292c
+    :git: "git@github.com:tumblr/kanvas-ios.git"
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
@@ -695,6 +703,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   Gutenberg: f283b145b3669f82ce13e6d8a6f0130172b19301
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
+  Kanvas: 565caff19d90e883194e6e646f6ea994e14fcde5
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
   MediaEditor: 20cdeb46bdecd040b8bc94467ac85a52b53b193a
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
@@ -762,6 +771,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 81b5fd5f19256231bfaa9f7266bbd6c983d0182c
+PODFILE CHECKSUM: 5861e22f9baa835b3ae42841d9eb53e723d69df6
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -122,6 +122,10 @@ extension AbstractPost {
         return content?.contains("<!-- wp:") ?? false
     }
 
+    @objc func containsStoriesBlocks() -> Bool {
+        return content?.contains("<!-- wp:jetpack/story") ?? false
+    }
+
     var analyticsPostType: String? {
         switch self {
         case is Post:

--- a/WordPress/Classes/Services/Stories/CameraHandler.swift
+++ b/WordPress/Classes/Services/Stories/CameraHandler.swift
@@ -3,9 +3,9 @@ import Kanvas
 /// Handles basic `CameraControllerDelegate` methods and calls `createdMedia` on export.
 class CameraHandler: CameraControllerDelegate {
 
-    let createdMedia: ([Result<KanvasMedia?, Error>]) -> Void
+    let createdMedia: (CameraController.MediaOutput) -> Void
 
-    init(created: @escaping ([Result<KanvasMedia?, Error>]) -> Void) {
+    init(created: @escaping (CameraController.MediaOutput) -> Void) {
         createdMedia = created
     }
 
@@ -17,7 +17,7 @@ class CameraHandler: CameraControllerDelegate {
         return UIView()
     }
 
-    func didCreateMedia(_ cameraController: CameraController, media: [Result<KanvasMedia?, Error>], exportAction: KanvasExportAction) {
+    func didCreateMedia(_ cameraController: CameraController, media: CameraController.MediaOutput, exportAction: KanvasExportAction) {
         createdMedia(media)
     }
 

--- a/WordPress/Classes/Services/Stories/CameraHandler.swift
+++ b/WordPress/Classes/Services/Stories/CameraHandler.swift
@@ -1,5 +1,6 @@
 import Kanvas
 
+/// Handles basic `CameraControllerDelegate` methods and calls `createdMedia` on export.
 class CameraHandler: CameraControllerDelegate {
 
     let createdMedia: ([Result<KanvasMedia?, Error>]) -> Void

--- a/WordPress/Classes/Services/Stories/CameraHandler.swift
+++ b/WordPress/Classes/Services/Stories/CameraHandler.swift
@@ -1,0 +1,86 @@
+import Kanvas
+
+class CameraHandler: CameraControllerDelegate {
+
+    let createdMedia: ([Result<KanvasMedia?, Error>]) -> Void
+
+    init(created: @escaping ([Result<KanvasMedia?, Error>]) -> Void) {
+        createdMedia = created
+    }
+
+    func getQuickPostButton() -> UIView {
+        return UIView()
+    }
+
+    func getBlogSwitcher() -> UIView {
+        return UIView()
+    }
+
+    func didCreateMedia(_ cameraController: CameraController, media: [Result<KanvasMedia?, Error>], exportAction: KanvasExportAction) {
+        createdMedia(media)
+    }
+
+    func dismissButtonPressed(_ cameraController: CameraController) {
+        if let editor = cameraController as? StoryEditor {
+            editor.cancelEditing()
+        } else {
+            cameraController.dismiss(animated: true, completion: nil)
+        }
+    }
+
+    func tagButtonPressed() {
+
+    }
+
+    func editorDismissed(_ cameraController: CameraController) {
+        if let editor = cameraController as? StoryEditor {
+            editor.cancelEditing()
+        }
+    }
+
+    func didDismissWelcomeTooltip() {
+
+    }
+
+    func cameraShouldShowWelcomeTooltip() -> Bool {
+        return false
+    }
+
+    func didDismissColorSelectorTooltip() {
+
+    }
+
+    func editorShouldShowColorSelectorTooltip() -> Bool {
+        return true
+    }
+
+    func didEndStrokeSelectorAnimation() {
+
+    }
+
+    func editorShouldShowStrokeSelectorAnimation() -> Bool {
+        return true
+    }
+
+    func provideMediaPickerThumbnail(targetSize: CGSize, completion: @escaping (UIImage?) -> Void) {
+        PHPhotoLibrary.requestAuthorization { status in
+            completion(nil)
+        }
+    }
+
+    func didBeginDragInteraction() {
+
+    }
+
+    func didEndDragInteraction() {
+
+    }
+
+    func openAppSettings(completion: ((Bool) -> ())?) {
+        if let targetURL = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(targetURL)
+        } else {
+            assertionFailure("Couldn't unwrap Settings URL")
+        }
+    }
+}

--- a/WordPress/Classes/Services/Stories/StoriesEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoriesEditor.swift
@@ -1,0 +1,164 @@
+import Foundation
+import Kanvas
+
+class StoryEditor: CameraController {
+
+    var post: AbstractPost = AbstractPost()
+
+    var onClose: ((Bool, Bool) -> Void)? = nil
+
+    lazy var editorSession: PostEditorAnalyticsSession = {
+        PostEditorAnalyticsSession(editor: .stories, post: post)
+    }()
+
+    let navigationBarManager: PostEditorNavigationBarManager? = nil
+
+    fileprivate(set) lazy var debouncer: Debouncer = {
+        return Debouncer(delay: PostEditorDebouncerConstants.autoSavingDelay, callback: debouncerCallback)
+    }()
+
+    private(set) lazy var postEditorStateContext: PostEditorStateContext = {
+        return PostEditorStateContext(post: post, delegate: self)
+    }()
+
+    var verificationPromptHelper: VerificationPromptHelper? = nil
+
+    var analyticsEditorSource: String {
+        return "wp_stories_creator"
+    }
+
+    private let publishOnCompletion: Bool
+    private var cameraHandler: CameraHandler?
+
+    private static let useMetal = true
+
+    static var cameraSettings: CameraSettings {
+        let settings = CameraSettings()
+        settings.features.ghostFrame = true
+        settings.features.metalPreview = useMetal
+        settings.features.metalFilters = useMetal
+        settings.features.openGLPreview = !useMetal
+        settings.features.openGLCapture = !useMetal
+        settings.features.cameraFilters = false
+        settings.features.experimentalCameraFilters = true
+        settings.features.editor = true
+        settings.features.editorGIFMaker = false
+        settings.features.editorFilters = false
+        settings.features.editorText = true
+        settings.features.editorMedia = true
+        settings.features.editorDrawing = false
+        settings.features.editorMedia = false
+        settings.features.mediaPicking = true
+        settings.features.editorPostOptions = false
+        settings.features.newCameraModes = true
+        settings.features.gifs = false
+        settings.features.multipleExports = true
+        settings.crossIconInEditor = true
+        settings.enabledModes = [.normal]
+        settings.defaultMode = .normal
+        settings.features.scaleMediaToFill = true
+        settings.animateEditorControls = false
+        settings.exportStopMotionPhotoAsVideo = false
+        settings.fontSelectorUsesFont = true
+
+        return settings
+    }
+
+    static func editor(blog: Blog, context: NSManagedObjectContext) -> StoryEditor {
+        let post = PostService(managedObjectContext: context).createDraftPost(for: blog)
+        return editor(post: post, publishOnCompletion: true)
+    }
+
+    static func editor(post: AbstractPost, publishOnCompletion: Bool = false) -> StoryEditor {
+        let controller = StoryEditor(post: post,
+                                     onClose: nil,
+                                     settings: cameraSettings,
+                                     stickerProvider: nil,
+                                     analyticsProvider: nil,
+                                     quickBlogSelectorCoordinator: nil,
+                                     tagCollection: nil,
+                                     publishOnCompletion: publishOnCompletion)
+        controller.modalPresentationStyle = .fullScreen
+        controller.modalTransitionStyle = .crossDissolve
+        return controller
+    }
+
+
+    init(post: AbstractPost,
+                     onClose: ((Bool, Bool) -> Void)?,
+                     settings: CameraSettings,
+                     stickerProvider: StickerProvider?,
+                     analyticsProvider: KanvasAnalyticsProvider?,
+                     quickBlogSelectorCoordinator: KanvasQuickBlogSelectorCoordinating?,
+                     tagCollection: UIView?,
+                     publishOnCompletion: Bool) {
+        self.post = post
+        self.onClose = onClose
+        self.publishOnCompletion = publishOnCompletion
+
+        let saveDirectory = try! FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+
+        super.init(settings: settings,
+                 mediaPicker: nil,
+                 stickerProvider: nil,
+                 analyticsProvider: nil,
+                 quickBlogSelectorCoordinator: nil,
+                 tagCollection: nil,
+                 saveDirectory: saveDirectory)
+
+        cameraHandler = CameraHandler(created: { [weak self] _ in
+            if publishOnCompletion {
+                self?.publishPost(action: .publish, dismissWhenDone: true, analyticsStat:
+                                    .editorPublishedPost)
+            } else {
+                self?.dismiss(animated: true, completion: nil)
+            }
+        })
+        self.delegate = cameraHandler
+    }
+}
+
+extension StoryEditor: PublishingEditor {
+    var prepublishingSourceView: UIView? {
+        return nil
+    }
+
+    var alertBarButtonItem: UIBarButtonItem? {
+        return nil
+    }
+
+    var isUploadingMedia: Bool {
+        return false
+    }
+
+    var postTitle: String {
+        get {
+            return post.postTitle ?? ""
+        }
+        set {
+            post.postTitle = newValue
+        }
+    }
+
+    func getHTML() -> String {
+        return post.content ?? ""
+    }
+
+    func cancelUploadOfAllMedia(for post: AbstractPost) {
+
+    }
+
+    var wordCount: UInt {
+        return post.content?.wordCount() ?? 0
+    }
+}
+
+extension StoryEditor: PostEditorStateContextDelegate {
+    func context(_ context: PostEditorStateContext, didChangeAction: PostEditorAction) {
+
+    }
+
+    func context(_ context: PostEditorStateContext, didChangeActionAllowed: Bool) {
+
+    }
+}

--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -96,7 +96,13 @@ class StoryEditor: CameraController {
         self.onClose = onClose
         self.publishOnCompletion = publishOnCompletion
 
-        let saveDirectory = try! FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+        let saveDirectory: URL?
+        do {
+            saveDirectory = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+        } catch let error {
+            assertionFailure("Should be able to create a save directory in documents \(error)")
+            saveDirectory = nil
+        }
 
         super.init(settings: settings,
                  mediaPicker: nil,
@@ -146,6 +152,10 @@ extension StoryEditor: PublishingEditor {
 
     func cancelUploadOfAllMedia(for post: AbstractPost) {
 
+    }
+
+    func publishingDismissed() {
+        hideLoading()
     }
 
     var wordCount: UInt {

--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Kanvas
 
+/// An story editor which displays the Kanvas camera + editing screens.
 class StoryEditor: CameraController {
 
     var post: AbstractPost = AbstractPost()
@@ -82,7 +83,6 @@ class StoryEditor: CameraController {
         controller.modalTransitionStyle = .crossDissolve
         return controller
     }
-
 
     init(post: AbstractPost,
                      onClose: ((Bool, Bool) -> Void)?,

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -21,6 +21,7 @@ import Foundation
     // Settings and Prepublishing Nudges
     case editorPostPublishTap
     case editorPostScheduledChanged
+    case editorPostTitleChanged
     case editorPostVisibilityChanged
     case editorPostTagsChanged
     case editorPostPublishNowTapped
@@ -173,6 +174,8 @@ import Foundation
             return "editor_post_publish_tapped"
         case .editorPostScheduledChanged:
             return "editor_post_scheduled_changed"
+        case .editorPostTitleChanged:
+            return "editor_post_title_changed"
         case .editorPostVisibilityChanged:
             return "editor_post_visibility_changed"
         case .editorPostTagsChanged:

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -32,6 +32,8 @@ NSString * const WPAppAnalyticsKeyReplyingTo                        = @"replying
 NSString * const WPAppAnalyticsKeySiteType                          = @"site_type";
 
 NSString * const WPAppAnalyticsKeyHasGutenbergBlocks                = @"has_gutenberg_blocks";
+NSString * const WPAppAnalyticsKeyHasStoriesBlocks                  = @"has_wp_stories_blocks";
+
 static NSString * const WPAppAnalyticsKeyLastVisibleScreen          = @"last_visible_screen";
 static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_app";
 
@@ -300,6 +302,7 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
         mutableProperties[WPAppAnalyticsKeyPostID] = postOrPage.postID;
     }
     mutableProperties[WPAppAnalyticsKeyHasGutenbergBlocks] = @([postOrPage containsGutenbergBlocks]);
+    mutableProperties[WPAppAnalyticsKeyHasStoriesBlocks] = @([postOrPage containsStoriesBlocks]);
 
     [WPAppAnalytics track:stat withProperties:mutableProperties withBlog:postOrPage.blog];
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -1,7 +1,54 @@
 import Foundation
 import WordPressFlux
 
-extension PostEditor where Self: UIViewController {
+protocol PublishingEditor where Self: UIViewController {
+    //TODO: Add publishing things
+    var post: AbstractPost { get set }
+
+    var isUploadingMedia: Bool { get }
+
+    /// Post editor state context
+    var postEditorStateContext: PostEditorStateContext { get }
+
+    /// Editor Session information for analytics reporting
+    var editorSession: PostEditorAnalyticsSession { get set }
+
+    /// Verification prompt helper
+    var verificationPromptHelper: VerificationPromptHelper? { get }
+
+    /// Describes the editor type to be used in analytics reporting
+    var analyticsEditorSource: String { get }
+
+    /// Title of the post
+    var postTitle: String { get set }
+
+    var prepublishingSourceView: UIView? { get }
+
+    var alertBarButtonItem: UIBarButtonItem? { get }
+
+    /// Closure to be executed when the editor gets closed.
+    var onClose: ((_ changesSaved: Bool, _ shouldShowPostPost: Bool) -> Void)? { get set }
+
+    /// Return the current html in the editor
+    func getHTML() -> String
+
+    /// Cancels all ongoing uploads
+    func cancelUploadOfAllMedia(for post: AbstractPost)
+
+    func removeFailedMedia()
+
+    /// Returns the word counts of the content in the editor.
+    var wordCount: UInt { get }
+
+    /// Debouncer used to save the post locally with a delay
+    var debouncer: Debouncer { get }
+}
+
+extension PublishingEditor where Self: UIViewController {
+
+    func removeFailedMedia() {
+        // TODO: we can only implement this when GB bridge allows removal of blocks
+    }
 
     // The debouncer will perform this callback every 500ms in order to save the post locally with a delay.
     var debouncerCallback: (() -> Void) {
@@ -27,6 +74,8 @@ extension PostEditor where Self: UIViewController {
             dismissWhenDone: action.dismissesEditor,
             analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
     }
+
+
 
     func publishPost(
         action: PostEditorAction,
@@ -155,12 +204,18 @@ extension PostEditor where Self: UIViewController {
         // End editing to avoid issues with accessibility
         view.endEditing(true)
 
-        let prepublishing = PrepublishingViewController(post: post) { _ in
+        let prepublishing = PrepublishingViewController(post: post) { post in
+            self.post = post
             publishAction()
         }
+
         let prepublishingNavigationController = PrepublishingNavigationController(rootViewController: prepublishing)
         let bottomSheet = BottomSheetViewController(childViewController: prepublishingNavigationController, customHeaderSpacing: 0)
-        bottomSheet.show(from: self, sourceView: navigationBarManager.publishButton)
+        if let sourceView = prepublishingSourceView {
+            bottomSheet.show(from: self, sourceView: sourceView)
+        } else {
+            bottomSheet.show(from: self.topmostPresentedViewController)
+        }
     }
 
     /// Displays a publish confirmation alert with two options: "Keep Editing" and String for Action.
@@ -334,7 +389,7 @@ extension PostEditor where Self: UIViewController {
             self.discardUnsavedChangesAndUpdateGUI()
         }
 
-        alertController.popoverPresentationController?.barButtonItem = navigationBarManager.closeBarButtonItem
+        alertController.popoverPresentationController?.barButtonItem = alertBarButtonItem
         present(alertController, animated: true, completion: nil)
     }
 
@@ -351,7 +406,7 @@ extension PostEditor where Self: UIViewController {
     }
 }
 
-extension PostEditor where Self: UIViewController {
+extension PublishingEditor where Self: UIViewController {
     func presentationController(forPresented presented: UIViewController, presenting: UIViewController?) -> UIPresentationController? {
         guard presented is FancyAlertViewController else {
             return nil
@@ -363,7 +418,7 @@ extension PostEditor where Self: UIViewController {
 
 // MARK: - Publishing
 
-extension PostEditor where Self: UIViewController {
+extension PublishingEditor where Self: UIViewController {
 
     /// Shows the publishing overlay and starts the publishing process.
     ///
@@ -507,6 +562,14 @@ extension PostEditor where Self: UIViewController {
 
             ContextManager.sharedInstance().save(managedObjectContext)
         }
+    }
+
+    var uploadFailureNoticeTag: Notice.Tag {
+        return "PostEditor.UploadFailed"
+    }
+
+    func uploadFailureNotice(action: PostEditorAction) -> Notice {
+        return Notice(title: action.publishingErrorLabel, tag: uploadFailureNoticeTag)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -19,15 +19,11 @@ typealias EditorViewController = UIViewController & PostEditor
 
 /// Common interface to all editors
 ///
-protocol PostEditor: class, UIViewControllerTransitioningDelegate {
+protocol PostEditor: PublishingEditor, UIViewControllerTransitioningDelegate {
 
     /// The post being edited.
     ///
     var post: AbstractPost { get set }
-
-    /// Closure to be executed when the editor gets closed.
-    ///
-    var onClose: ((_ changesSaved: Bool, _ shouldShowPostPost: Bool) -> Void)? { get set }
 
     /// Whether the editor should open directly to the media picker.
     ///
@@ -63,8 +59,6 @@ protocol PostEditor: class, UIViewControllerTransitioningDelegate {
 
     var isUploadingMedia: Bool { get }
 
-    func removeFailedMedia()
-
     /// Verification prompt helper
     var verificationPromptHelper: VerificationPromptHelper? { get }
 
@@ -95,9 +89,6 @@ protocol PostEditor: class, UIViewControllerTransitioningDelegate {
     /// Returns the media attachment removed version of html
     func contentByStrippingMediaAttachments() -> String
 
-    /// Debouncer used to save the post locally with a delay
-    var debouncer: Debouncer { get }
-
     /// Navigation bar manager for this post editor
     var navigationBarManager: PostEditorNavigationBarManager { get }
 
@@ -111,9 +102,6 @@ protocol PostEditor: class, UIViewControllerTransitioningDelegate {
     var autosaver: Autosaver { get set }
     /// true if the post is the result of a reblog
     var postIsReblogged: Bool { get set }
-
-    /// Returns the word counts of the content in the editor.
-    var wordCount: UInt { get }
 }
 
 extension PostEditor {
@@ -144,11 +132,11 @@ extension PostEditor {
         return currentBlogCount <= 1 || post.hasRemote()
     }
 
-    var uploadFailureNoticeTag: Notice.Tag {
-        return "PostEditor.UploadFailed"
+    var alertBarButtonItem: UIBarButtonItem? {
+        return navigationBarManager.closeBarButtonItem
     }
 
-    func uploadFailureNotice(action: PostEditorAction) -> Notice {
-        return Notice(title: action.publishingErrorLabel, tag: uploadFailureNoticeTag)
+    var prepublishingSourceView: UIView? {
+        return navigationBarManager.publishButton
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -108,6 +108,7 @@ private extension PostEditorAnalyticsSession {
 extension PostEditorAnalyticsSession {
     enum Editor: String {
         case gutenberg
+        case stories
         case classic
         case html
     }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -29,7 +29,12 @@ class PrepublishingViewController: UITableViewController {
         return (navigationController as? PrepublishingNavigationController)?.presentedVC
     }()
 
-    private let completion: (AbstractPost) -> ()
+    enum CompletionResult {
+        case completed(AbstractPost)
+        case dismissed
+    }
+
+    private let completion: (CompletionResult) -> ()
 
     private let options: [PrepublishingOption] = [
         PrepublishingOption(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility")),
@@ -47,7 +52,7 @@ class PrepublishingViewController: UITableViewController {
         return nuxButton
     }()
 
-    init(post: Post, completion: @escaping (AbstractPost) -> ()) {
+    init(post: Post, completion: @escaping (CompletionResult) -> ()) {
         self.post = post
         self.completion = completion
         super.init(nibName: nil, bundle: nil)
@@ -291,7 +296,7 @@ class PrepublishingViewController: UITableViewController {
         didTapPublish = true
         navigationController?.dismiss(animated: true) {
             WPAnalytics.track(.editorPostPublishNowTapped)
-            self.completion(self.post)
+            self.completion(.completed(self.post))
         }
     }
 
@@ -359,6 +364,7 @@ extension PrepublishingViewController: PrepublishingHeaderViewDelegate {
 
 extension PrepublishingViewController: PrepublishingDismissible {
     func handleDismiss() {
+        defer { completion(.dismissed) }
         guard
             !didTapPublish,
             post.status == .publishPrivate,

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -64,15 +64,14 @@ extension WPTabBarController {
                 StoriesIntroViewController.trackShown()
             })
         } else {
-            //TODO: Show the stories feature
             guard let blog = inBlog ?? self.currentOrLastBlog() else { return }
             let blogID = blog.dotComID?.intValue ?? 0 as Any
 
             WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: source, WPAppAnalyticsKeyBlogID: blogID, WPAppAnalyticsKeyPostType: "story"])
 
-            let viewController = UIViewController()
-            viewController.view.backgroundColor = .red
-            present(viewController, animated: true)
+            let controller = StoryEditor.editor(blog: blog, context: ContextManager.shared.mainContext)
+
+            present(controller, animated: true, completion: nil)
         }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2253,7 +2253,7 @@
 		F1F083F6241FFE930056D3B1 /* AtomicAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F083F5241FFE930056D3B1 /* AtomicAuthenticationServiceTests.swift */; };
 		F1F163C125658B4D003DC13B /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F163C025658B4D003DC13B /* IntentHandler.swift */; };
 		F1F163D625658B4D003DC13B /* WordPressIntents.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F1F163BE25658B4D003DC13B /* WordPressIntents.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		F504D2F525D6346400A2764C /* StoriesEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F504D2AD25D60C5900A2764C /* StoriesEditor.swift */; };
+		F504D2F525D6346400A2764C /* StoryEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F504D2AD25D60C5900A2764C /* StoryEditor.swift */; };
 		F504D43725D717EF00A2764C /* PostEditor+BlogPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84321A6A7840062F134 /* PostEditor+BlogPicker.swift */; };
 		F504D44825D717F600A2764C /* PostEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13ACCD31EE5672100CCE985 /* PostEditor.swift */; };
 		F50B0E7B246212B8006601DD /* NoticeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50B0E7A246212B8006601DD /* NoticeAnimator.swift */; };
@@ -5175,7 +5175,7 @@
 		F262DFCA1F94418CE76D1D78 /* Pods-WordPressNotificationContentExtension.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationContentExtension.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationContentExtension/Pods-WordPressNotificationContentExtension.release-internal.xcconfig"; sourceTree = "<group>"; };
 		F373612EEEEF10E500093FF3 /* Pods-WordPress.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F504D2AD25D60C5900A2764C /* StoriesEditor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoriesEditor.swift; sourceTree = "<group>"; };
+		F504D2AD25D60C5900A2764C /* StoryEditor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryEditor.swift; sourceTree = "<group>"; };
 		F50B0E7A246212B8006601DD /* NoticeAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAnimator.swift; sourceTree = "<group>"; };
 		F511F8A32356A4F400895E73 /* PublishSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSettingsViewController.swift; sourceTree = "<group>"; };
 		F52CACC9244FA7AA00661380 /* ReaderManageScenePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderManageScenePresenter.swift; sourceTree = "<group>"; };
@@ -11319,7 +11319,7 @@
 		F504D2A925D60C5900A2764C /* Stories */ = {
 			isa = PBXGroup;
 			children = (
-				F504D2AD25D60C5900A2764C /* StoriesEditor.swift */,
+				F504D2AD25D60C5900A2764C /* StoryEditor.swift */,
 				F5AE42DA25DCFD7E003675F4 /* CameraHandler.swift */,
 			);
 			path = Stories;
@@ -13673,7 +13673,7 @@
 				98906502237CC1DF00218CD2 /* WidgetUnconfiguredCell.swift in Sources */,
 				FFDA7E501B8DF6E500B83C56 /* BlogSiteVisibilityHelper.m in Sources */,
 				E66E2A691FE432BC00788F22 /* TitleBadgeDisclosureCell.swift in Sources */,
-				F504D2F525D6346400A2764C /* StoriesEditor.swift in Sources */,
+				F504D2F525D6346400A2764C /* StoryEditor.swift in Sources */,
 				7E4123BF20F4097B00DF8486 /* FormattableContent.swift in Sources */,
 				D82253DF2199418B0014D0E2 /* WebAddressWizardContent.swift in Sources */,
 				400A2C782217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1265,7 +1265,6 @@
 		9123471B221449E200BD9F97 /* GutenbergInformativeDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9123471A221449E200BD9F97 /* GutenbergInformativeDialogTests.swift */; };
 		912347762216E27200BD9F97 /* GutenbergViewController+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912347752216E27200BD9F97 /* GutenbergViewController+Localization.swift */; };
 		91D8364121946EFB008340B2 /* GutenbergMediaPickerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */; };
-		91DCE84421A6A7840062F134 /* PostEditor+BlogPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84321A6A7840062F134 /* PostEditor+BlogPicker.swift */; };
 		91DCE84621A6A7F50062F134 /* PostEditor+MoreOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84521A6A7F50062F134 /* PostEditor+MoreOptions.swift */; };
 		91DCE84821A6C58C0062F134 /* PostEditor+Publish.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84721A6C58C0062F134 /* PostEditor+Publish.swift */; };
 		930F09171C7D110E00995926 /* ShareExtensionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930F09161C7D110E00995926 /* ShareExtensionService.swift */; };
@@ -1994,7 +1993,6 @@
 		E137B1661F8B77D4006AC7FC /* WebNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E137B1651F8B77D4006AC7FC /* WebNavigationDelegate.swift */; };
 		E1389ADB1C59F7C200FB2466 /* PlanListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1389ADA1C59F7C200FB2466 /* PlanListViewController.swift */; };
 		E13A8C9B1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13A8C9A1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift */; };
-		E13ACCD41EE5672100CCE985 /* PostEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13ACCD31EE5672100CCE985 /* PostEditor.swift */; };
 		E14200781C117A2E00B3B115 /* ManagedAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14200771C117A2E00B3B115 /* ManagedAccountSettings.swift */; };
 		E142007A1C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = E14200791C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift */; };
 		E1468DE71E794A4D0044D80F /* LanguageSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1468DE61E794A4D0044D80F /* LanguageSelectorViewController.swift */; };
@@ -2255,6 +2253,9 @@
 		F1F083F6241FFE930056D3B1 /* AtomicAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F083F5241FFE930056D3B1 /* AtomicAuthenticationServiceTests.swift */; };
 		F1F163C125658B4D003DC13B /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F163C025658B4D003DC13B /* IntentHandler.swift */; };
 		F1F163D625658B4D003DC13B /* WordPressIntents.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F1F163BE25658B4D003DC13B /* WordPressIntents.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		F504D2F525D6346400A2764C /* StoriesEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F504D2AD25D60C5900A2764C /* StoriesEditor.swift */; };
+		F504D43725D717EF00A2764C /* PostEditor+BlogPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84321A6A7840062F134 /* PostEditor+BlogPicker.swift */; };
+		F504D44825D717F600A2764C /* PostEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13ACCD31EE5672100CCE985 /* PostEditor.swift */; };
 		F50B0E7B246212B8006601DD /* NoticeAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50B0E7A246212B8006601DD /* NoticeAnimator.swift */; };
 		F511F8A42356A4F400895E73 /* PublishSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F511F8A32356A4F400895E73 /* PublishSettingsViewController.swift */; };
 		F52CACCA244FA7AA00661380 /* ReaderManageScenePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52CACC9244FA7AA00661380 /* ReaderManageScenePresenter.swift */; };
@@ -2286,6 +2287,7 @@
 		F5A738BD244DF75400EDE065 /* OffsetTableViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A738BC244DF75400EDE065 /* OffsetTableViewHandler.swift */; };
 		F5A738BF244DF7E400EDE065 /* ReaderTagsTableViewController+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A738BE244DF7E400EDE065 /* ReaderTagsTableViewController+Cells.swift */; };
 		F5A738C3244E7A6F00EDE065 /* ReaderTagsTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A738C2244E7A6F00EDE065 /* ReaderTagsTableViewModel.swift */; };
+		F5AE42DB25DCFD7E003675F4 /* CameraHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AE42DA25DCFD7E003675F4 /* CameraHandler.swift */; };
 		F5B390EA2537E30B0097049E /* GridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B390E92537E30B0097049E /* GridCell.swift */; };
 		F5B8A60F23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B8A60E23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift */; };
 		F5B9151F244653C100179876 /* TabbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B9151E244653C100179876 /* TabbedViewController.swift */; };
@@ -5173,6 +5175,7 @@
 		F262DFCA1F94418CE76D1D78 /* Pods-WordPressNotificationContentExtension.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationContentExtension.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationContentExtension/Pods-WordPressNotificationContentExtension.release-internal.xcconfig"; sourceTree = "<group>"; };
 		F373612EEEEF10E500093FF3 /* Pods-WordPress.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F504D2AD25D60C5900A2764C /* StoriesEditor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoriesEditor.swift; sourceTree = "<group>"; };
 		F50B0E7A246212B8006601DD /* NoticeAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAnimator.swift; sourceTree = "<group>"; };
 		F511F8A32356A4F400895E73 /* PublishSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishSettingsViewController.swift; sourceTree = "<group>"; };
 		F52CACC9244FA7AA00661380 /* ReaderManageScenePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderManageScenePresenter.swift; sourceTree = "<group>"; };
@@ -5205,6 +5208,7 @@
 		F5A738BC244DF75400EDE065 /* OffsetTableViewHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffsetTableViewHandler.swift; sourceTree = "<group>"; };
 		F5A738BE244DF7E400EDE065 /* ReaderTagsTableViewController+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTagsTableViewController+Cells.swift"; sourceTree = "<group>"; };
 		F5A738C2244E7A6F00EDE065 /* ReaderTagsTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTagsTableViewModel.swift; sourceTree = "<group>"; };
+		F5AE42DA25DCFD7E003675F4 /* CameraHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraHandler.swift; sourceTree = "<group>"; };
 		F5B390E92537E30B0097049E /* GridCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridCell.swift; sourceTree = "<group>"; };
 		F5B8A60E23CE56A1001B7359 /* PreviewDeviceSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDeviceSelectionViewController.swift; sourceTree = "<group>"; };
 		F5B9151E244653C100179876 /* TabbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedViewController.swift; sourceTree = "<group>"; };
@@ -8420,6 +8424,7 @@
 				F1D690131F828FF000200E30 /* BuildInformation */,
 				B5ECA6CB1DBAA0110062D7E0 /* CoreData */,
 				B5DB8AF51C949DC70059196A /* ImmuTable */,
+				F504D2D625D60CD900A2764C /* Kanvas */,
 				59DD94311AC479DC0032DD6B /* Logging */,
 				08F8CD281EBD22EF0049D0C0 /* Media */,
 				E159D1011309AAF200F498E2 /* Migrations */,
@@ -8761,6 +8766,7 @@
 		93FA59DA18D88BDB001446BC /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				F504D2A925D60C5900A2764C /* Stories */,
 				B5EFB1C31B31B99D007608A3 /* Facades */,
 				93C1147D18EC5DD500DAC95C /* AccountService.h */,
 				93C1147E18EC5DD500DAC95C /* AccountService.m */,
@@ -11310,6 +11316,22 @@
 			path = WordPressIntents;
 			sourceTree = "<group>";
 		};
+		F504D2A925D60C5900A2764C /* Stories */ = {
+			isa = PBXGroup;
+			children = (
+				F504D2AD25D60C5900A2764C /* StoriesEditor.swift */,
+				F5AE42DA25DCFD7E003675F4 /* CameraHandler.swift */,
+			);
+			path = Stories;
+			sourceTree = "<group>";
+		};
+		F504D2D625D60CD900A2764C /* Kanvas */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Kanvas;
+			sourceTree = "<group>";
+		};
 		F53FF3A623EA722F001AD596 /* Detail Header */ = {
 			isa = PBXGroup;
 			children = (
@@ -12986,6 +13008,7 @@
 				"${PODS_ROOT}/Gutenberg/src/block-support/supported-blocks.json",
 				"${PODS_ROOT}/Gutenberg/resources/unsupported-block-editor/extra-localstorage-entries.js",
 				"${PODS_ROOT}/Gutenberg/resources/unsupported-block-editor/remove-nux.js",
+				"${PODS_CONFIGURATION_BUILD_DIR}/Kanvas/Kanvas.bundle",
 				"${BUILT_PRODUCTS_DIR}/MediaEditor/MediaEditor.framework/MediaEditorDrawing.storyboardc",
 				"${BUILT_PRODUCTS_DIR}/MediaEditor/MediaEditor.framework/MediaEditorFilters.storyboardc",
 				"${BUILT_PRODUCTS_DIR}/MediaEditor/MediaEditor.framework/MediaEditorHub.storyboardc",
@@ -13019,6 +13042,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/supported-blocks.json",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/extra-localstorage-entries.js",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/remove-nux.js",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Kanvas.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MediaEditorDrawing.storyboardc",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MediaEditorFilters.storyboardc",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MediaEditorHub.storyboardc",
@@ -13414,6 +13438,7 @@
 				43FB3F471EC10F1E00FC8A62 /* LoginEpilogueTableViewController.swift in Sources */,
 				9A8ECE112254A3260043C8DA /* JetpackRemoteInstallViewModel.swift in Sources */,
 				5727EAF82284F5AC00822104 /* InteractivePostViewDelegate.swift in Sources */,
+				F504D43725D717EF00A2764C /* PostEditor+BlogPicker.swift in Sources */,
 				93C486511810445D00A24725 /* ActivityLogViewController.m in Sources */,
 				9A162F2521C26F5F00FDC035 /* UIViewController+ChildViewController.swift in Sources */,
 				086C4D101E81F9240011D960 /* Media+Blog.swift in Sources */,
@@ -13648,6 +13673,7 @@
 				98906502237CC1DF00218CD2 /* WidgetUnconfiguredCell.swift in Sources */,
 				FFDA7E501B8DF6E500B83C56 /* BlogSiteVisibilityHelper.m in Sources */,
 				E66E2A691FE432BC00788F22 /* TitleBadgeDisclosureCell.swift in Sources */,
+				F504D2F525D6346400A2764C /* StoriesEditor.swift in Sources */,
 				7E4123BF20F4097B00DF8486 /* FormattableContent.swift in Sources */,
 				D82253DF2199418B0014D0E2 /* WebAddressWizardContent.swift in Sources */,
 				400A2C782217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift in Sources */,
@@ -13770,7 +13796,6 @@
 				F5E29036243E4F5F00C19CA5 /* FilterProvider.swift in Sources */,
 				027AC51D227896540033E56E /* DomainCreditEligibilityChecker.swift in Sources */,
 				83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */,
-				91DCE84421A6A7840062F134 /* PostEditor+BlogPicker.swift in Sources */,
 				B56994451B7A7EF200FF26FA /* WPStyleGuide+Comments.swift in Sources */,
 				8B05D29123A9417E0063B9AA /* WPMediaEditor.swift in Sources */,
 				D816C1EC20E0887C00C4D82F /* ApproveComment.swift in Sources */,
@@ -14428,6 +14453,7 @@
 				D80BC7A22074739400614A59 /* MediaLibraryStrings.swift in Sources */,
 				9A09F915230C3E9700F42AB7 /* StoreFetchingStatus.swift in Sources */,
 				F582060223A85495005159A9 /* SiteDateFormatters.swift in Sources */,
+				F504D44825D717F600A2764C /* PostEditor.swift in Sources */,
 				400A2C8B2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift in Sources */,
 				FAD9458E25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift in Sources */,
 				5DB3BA0518D0E7B600F3F3E9 /* WPPickerView.m in Sources */,
@@ -14549,6 +14575,7 @@
 				3F43602F23F31D48001DEE70 /* ScenePresenter.swift in Sources */,
 				9A4E271D22EF33F5001F6A6B /* AccountSettingsStore.swift in Sources */,
 				4319AADE2090F00C0025D68E /* FancyAlertViewController+NotificationPrimer.swift in Sources */,
+				F5AE42DB25DCFD7E003675F4 /* CameraHandler.swift in Sources */,
 				73FF7032221F469100541798 /* Charts+Support.swift in Sources */,
 				F16601C423E9E783007950AE /* SharingAuthorizationWebViewController.swift in Sources */,
 				171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */,
@@ -14601,7 +14628,6 @@
 				730D290F22976F1A0004BB1E /* BottomScrollAnalyticsTracker.swift in Sources */,
 				E6311C431ECA017E00122529 /* UserProfile.swift in Sources */,
 				B5CABB171C0E382C0050AB9F /* PickerTableViewCell.swift in Sources */,
-				E13ACCD41EE5672100CCE985 /* PostEditor.swift in Sources */,
 				E1D95EB817A28F5E00A3E9F3 /* WPActivityDefaults.m in Sources */,
 				436D56302117410C00CEAA33 /* RegisterDomainDetailsViewModel+CellIndex.swift in Sources */,
 				1714F8D020E6DA8900226DCB /* RouteMatcher.swift in Sources */,

--- a/WordPress/WordPressTest/PrepublishingNudgesViewControllerTests.swift
+++ b/WordPress/WordPressTest/PrepublishingNudgesViewControllerTests.swift
@@ -18,9 +18,17 @@ class PrepublishingNudgesViewControllerTests: XCTestCase {
     /// Call the completion block when the "Publish" button is pressed
     ///
     func testCallCompletionBlockWhenButtonTapped() {
-        let post = PostBuilder().build()
+        var post = PostBuilder().build()
         var returnedPost: AbstractPost?
-        let prepublishingViewController = PrepublishingViewController(post: post) { post in
+        let prepublishingViewController = PrepublishingViewController(post: post) { result in
+            switch result {
+            case .completed(let completedPost):
+                if let completedPost = completedPost as? Post {
+                    post = completedPost
+                }
+            case .dismissed:
+                ()
+            }
             returnedPost = post
         }
         _ = UINavigationController(rootViewController: prepublishingViewController)


### PR DESCRIPTION
Adds the Kanvas editor for Story creation, does not hook up editing or other advanced functionality.

### Overview

The `StoryEditor` is a new type of Editor which displays the Kanvas `CameraController`. It handles the default settings, setting up the delegate (`CameraHandler`) and handling blog/post types for WPiOS. The `PublishingEditor` protocol splits out common publishing logic so it can be shared amongst the editors.

### Testing

* Open to the Blog Detail page
* Tap the FAB
* Select the "Story post" option
* Ensure that the Kanvas Editor shows up and basic photo, video, and media import options work.
* Hit the blue confirm button from the edit screen.
* Confirm that the Prepublishing sheet is shown.

Note that publishing will _NOT_ work with these changes. This is focused on pulling in Kanvas and properly displaying the interfaces. A subsequent PR will focus on publishing + Gutenberg editing.

https://user-images.githubusercontent.com/3250/108170984-15627700-70b8-11eb-969d-8921250fed9b.mp4

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
