### PR TITLE
Add feature flag for milestone notifications

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -18,6 +18,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackBackupAndRestore
     case todayWidget
     case unseenPosts
+    case milestoneNotifications
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -58,6 +59,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .unseenPosts:
             return true
+        case .milestoneNotifications:
+            return false
         }
     }
 
@@ -118,6 +121,8 @@ extension FeatureFlag {
             return "iOS 14 Today Widget"
         case .unseenPosts:
             return "Unseen Posts in Reader"
+        case .milestoneNotifications:
+            return "Milestone notifications"
         }
     }
 


### PR DESCRIPTION
Fixes #NA

To test:
This feature flag is not used at the moment and it's currently disabled
The only test is to make sure the app builds fine

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
