### PR TITLE
ABTest: fix a nil crash

### DIFF
--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -6,7 +6,7 @@ enum ABTest: String, CaseIterable {
 
     /// Returns a variation for the given experiment
     var variation: Variation {
-        return ExPlat.shared.experiment(self.rawValue)
+        return ExPlat.shared?.experiment(self.rawValue) ?? .control
     }
 }
 
@@ -18,6 +18,6 @@ extension ABTest {
             return
         }
 
-        ExPlat.shared.refresh()
+        ExPlat.shared?.refresh()
     }
 }


### PR DESCRIPTION
This PR fixes a crash that was happening if the user has opted out for Analytics tracking. This makes the ExPlat to not be configurated but the app was still trying to use it. The changes are:

1. Make the request only if ExPlat was already configured
2. Always resort to `control` if the user opted out

### To test

1. Run the app
2. Disable the "Collect information" option under Privacy
2. Run the app again
3. No crashes :)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
