### PR TITLE
Comments: move cell configuration into cell class.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -19,9 +19,6 @@ static CGFloat const CommentsActivityFooterHeight               = 50.0;
 static NSInteger const CommentsRefreshRowPadding                = 4;
 static NSInteger const CommentsFetchBatchSize                   = 10;
 
-static NSString *CommentsReuseIdentifier                        = @"CommentsReuseIdentifier";
-static NSString *CommentsLayoutIdentifier                       = @"CommentsLayoutIdentifier";
-
 
 @interface CommentsViewController () <WPTableViewHandlerDelegate, WPContentSyncHelperDelegate>
 @property (nonatomic, strong) WPTableViewHandler        *tableViewHandler;
@@ -68,13 +65,8 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    
-    // Manually deselect the selected row. This is required due to a bug in iOS7 / iOS8
-    [self.tableView deselectSelectedRowWithAnimation:YES];
-    
-    // Refresh the UI
-    [self refreshNoResultsView];
 
+    [self refreshNoResultsView];
     [self refreshAndSyncIfNeeded];
 }
 
@@ -114,7 +106,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
     [footerView addSubview:indicator];
 
-    // Keep References!
+    // Keep References
     self.footerActivityIndicator            = indicator;
     self.footerView                         = footerView;
 }
@@ -132,7 +124,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (void)configureRefreshControl
 {
-    UIRefreshControl *refreshControl        = [UIRefreshControl new];
+    UIRefreshControl *refreshControl = [UIRefreshControl new];
     [refreshControl addTarget:self action:@selector(refreshAndSyncWithInteraction) forControlEvents:UIControlEventValueChanged];
     self.refreshControl = refreshControl;
 }
@@ -152,15 +144,14 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     
     // Register the cells
-    NSString *nibName   = [CommentsTableViewCell classNameWithoutNamespaces];
-    UINib *nibInstance  = [UINib nibWithNibName:nibName bundle:[NSBundle mainBundle]];
-    [self.tableView registerNib:nibInstance forCellReuseIdentifier:CommentsReuseIdentifier];
+    NSString *nibName = [CommentsTableViewCell classNameWithoutNamespaces];
+    UINib *nibInstance = [UINib nibWithNibName:nibName bundle:[NSBundle mainBundle]];
+    [self.tableView registerNib:nibInstance forCellReuseIdentifier:CommentsTableViewCell.reuseIdentifier];
 }
 
 - (void)configureTableViewFooter
 {
-    // Notes:
-    //  -  Hide the cellSeparators, when the table is empty
+    // Hide the cellSeparators when the table is empty
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];
 }
 
@@ -189,11 +180,13 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    CommentsTableViewCell *cell = (CommentsTableViewCell *)[tableView dequeueReusableCellWithIdentifier:CommentsReuseIdentifier];
-    NSAssert([cell isKindOfClass:[CommentsTableViewCell class]], nil);
+    CommentsTableViewCell *cell = (CommentsTableViewCell *)[tableView dequeueReusableCellWithIdentifier:CommentsTableViewCell.reuseIdentifier];
     
-    [self configureCell:cell atIndexPath:indexPath];
-    
+    if (!cell) {
+        cell = [[CommentsTableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:CommentsTableViewCell.reuseIdentifier];
+    }
+
+    [self configureCell:cell atIndexPath:indexPath];    
     return cell;
 }
 
@@ -201,7 +194,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 {
     [self.estimatedRowHeights setObject:@(cell.frame.size.height) forKey:indexPath];
 
-    // Refresh only when we reach the last 3 rows in the last section!
+    // Refresh only when we reach the last 3 rows in the last section
     NSInteger numberOfRowsInSection     = [self.tableViewHandler tableView:tableView numberOfRowsInSection:indexPath.section];
     NSInteger lastSection               = [self.tableViewHandler numberOfSectionsInTableView:tableView] - 1;
     
@@ -306,10 +299,10 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 {
     [CommentAnalytics trackCommentUnApprovedWithComment:comment];
     CommentService *service = [[CommentService alloc] initWithManagedObjectContext:self.managedObjectContext];
-        
+
     [self.tableView setEditing:NO animated:YES];
     [service approveComment:comment success:nil failure:^(NSError *error) {
-        DDLogError(@"#### Error approving comment: %@", error);
+        DDLogError(@"Error approving comment: %@", error);
     }];
 }
 
@@ -320,7 +313,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     
     [self.tableView setEditing:NO animated:YES];
     [service unapproveComment:comment success:nil failure:^(NSError *error) {
-        DDLogError(@"#### Error unapproving comment: %@", error);
+        DDLogError(@"Error unapproving comment: %@", error);
     }];
 }
 
@@ -356,29 +349,9 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     return fetchRequest;
 }
 
-- (void)configureCell:(CommentsTableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath
-{
-    NSParameterAssert(cell);
-    NSParameterAssert(indexPath);
-    
-    Comment *comment    = [self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
-    
-    cell.author         = comment.authorForDisplay;
-    cell.approved       = [comment.status isEqualToString:CommentStatusApproved];
-    cell.postTitle      = comment.titleForDisplay;
-    cell.content        = comment.contentPreviewForDisplay;
-    cell.timestamp      = [comment.dateCreated mediumString];
-    
-    // Don't download the gravatar, if it's the layout cell!
-    if ([cell.reuseIdentifier isEqualToString:CommentsLayoutIdentifier]) {
-        return;
-    }
-    
-    if (comment.avatarURLForDisplay) {
-        [cell downloadGravatarWithURL:comment.avatarURLForDisplay];
-    } else {
-        [cell downloadGravatarWithGravatarEmail:comment.gravatarEmailForDisplay];
-    }
+- (void)configureCell:(nonnull CommentsTableViewCell *)cell atIndexPath:(nonnull NSIndexPath *)indexPath {
+    Comment *comment = [self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
+    [cell configureWithComment:comment];
 }
 
 - (NSString *)entityName


### PR DESCRIPTION
Ref: #15909 

This contains miscellaneous code refactor/cleanup, but the primary goal is to move the Comment cell configuration out of `CommentsViewController` and into `CommentsTableViewCell`. This is in preparation for updating the comment UI on #15909 .

To test:
There should be no visible change, so just ensure Comments appear as they did previously.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
