### PR TITLE
Quick Start: Automatically check off steps if the user completes them outside of Quick Start

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] Prevent deleting published homepages which would have the effect of breaking a site. [#15797]
 * [**] Prevent converting published homepage to a draft in the page list and settings which would have the effect of breaking a site. [#15797]
+* [*] Quick Start: Completing a step outside of a tour now automatically marks it as complete. [#15712]
 
 16.7
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
@@ -69,6 +69,9 @@ extension BlogDetailsViewController {
         blog.settings?.name = title
         headerView.setTitleLoading(true)
 
+        QuickStartTourGuide.shared.complete(tour: QuickStartSiteTitleTour(),
+                                                    silentlyForBlog: blog)
+
         let service = BlogService(managedObjectContext: context)
         service.updateSettings(for: blog, success: { [weak self] in
             NotificationCenter.default.post(name: NSNotification.Name.WPBlogUpdated, object: nil)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1233,6 +1233,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)updateBlogIconWithMedia:(Media *)media
 {
+    [[QuickStartTourGuide shared] completeSiteIconTourForBlog:self.blog];
+
     self.blog.settings.iconMediaID = media.mediaID;
     [self updateBlogSettingsAndRefreshIcon];
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1729,7 +1729,16 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self toggleSpotlightOnHeaderView];
     }];
 
-    [[QuickStartTourGuide shared] visited:QuickStartTourElementViewSite];
+    QuickStartTourGuide *guide = [QuickStartTourGuide shared];
+
+    if ([guide isCurrentElement:QuickStartTourElementViewSite]) {
+        [[QuickStartTourGuide shared] visited:QuickStartTourElementViewSite];
+    } else {
+        // Just mark as completed if we've viewed the site and aren't
+        //  currently working on the View Site tour.
+        [[QuickStartTourGuide shared] completeViewSiteTourForBlog:self.blog];
+    }
+
     self.additionalSafeAreaInsets = UIEdgeInsetsZero;
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -152,6 +152,17 @@ open class QuickStartTourGuide: NSObject {
         showCurrentStep()
     }
 
+    // Required for now because obj-c doesn't know about Quick Start tours
+    @objc func completeSiteIconTour(forBlog blog: Blog) {
+        complete(tour: QuickStartSiteIconTour(), silentlyForBlog: blog)
+    }
+
+    /// Complete the specified tour without posting a notification.
+    ///
+    func complete(tour: QuickStartTour, silentlyForBlog blog: Blog) {
+        complete(tour: tour, for: blog, postNotification: false)
+    }
+
     func complete(tour: QuickStartTour, for blog: Blog, postNotification: Bool = true) {
         guard let tourCount = blog.quickStartTours?.count, tourCount > 0 else {
             // Tours haven't been set up yet or were skipped. No reason to continue.

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -157,6 +157,14 @@ open class QuickStartTourGuide: NSObject {
         complete(tour: QuickStartSiteIconTour(), silentlyForBlog: blog)
     }
 
+    @objc func completeViewSiteTour(forBlog blog: Blog) {
+        complete(tour: QuickStartViewTour(), silentlyForBlog: blog)
+    }
+
+    @objc func completeSharingTour(forBlog blog: Blog) {
+        complete(tour: QuickStartShareTour(), silentlyForBlog: blog)
+    }
+
     /// Complete the specified tour without posting a notification.
     ///
     func complete(tour: QuickStartTour, silentlyForBlog blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -257,6 +257,8 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)sharingAuthorizationHelper:(SharingAuthorizationHelper *)helper didConnectToService:(PublicizeService *)service withPublicizeConnection:(PublicizeConnection *)keyringConnection
 {
+    [[QuickStartTourGuide shared] completeSharingTourForBlog:self.blog];
+
     self.connecting = NO;
     [self.tableView reloadData];
     [self showDetailForConnection:keyringConnection];

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -410,7 +410,13 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let page = pageAtIndexPath(indexPath)
         if page.isSiteHomepage {
-            QuickStartTourGuide.shared.visited(.editHomepage)
+            let guide = QuickStartTourGuide.shared
+            if guide.isCurrentElement(.editHomepage) {
+                QuickStartTourGuide.shared.visited(.editHomepage)
+            } else {
+                QuickStartTourGuide.shared.complete(tour: QuickStartEditHomepageTour(), silentlyForBlog: blog)
+            }
+
             tableView.reloadRows(at: [indexPath], with: .automatic)
         } else {
             QuickStartTourGuide.shared.endCurrentTour()

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -84,6 +84,11 @@ extension PostEditor where Self: UIViewController {
                 self.trackPostSave(stat: analyticsStat)
             }
 
+            if self.post.isFirstTimePublish {
+                QuickStartTourGuide.shared.complete(tour: QuickStartPublishTour(),
+                                                    silentlyForBlog: self.post.blog)
+            }
+
             if dismissWhenDone {
                 self.editorSession.end(outcome: action.analyticsEndOutcome)
             } else {


### PR DESCRIPTION
Fixes #15712. This PR adds some extra calls to complete Quick Start checklist items if the user performs those items while not actively completing their related Quick Start tour.

As an example, if Quick Start is active on a user's site and the user changes their site title, then the Site Title Quick Start checklist item should be checked off, regardless of whether that is the current 'tour' or not.

The logic here is slightly different from normal Quick Start. Ordinarily, Quick Start just navigates a user to the place in the app where they would complete an action – for example, for the Site Title or Site Icon tours, the user just has to tap the site title or the site icon in the blog detail header, and the tour is complete. For the change in this PR, however, we wanted to only check the items off if the user actually completes them – if they actually tap Save to change their site title, or site icon.

I couldn't reuse the existing `visited` method, as this expects:

- The visited element to be part of the current Quick Start tour, otherwise it's ignored.
- It follows the flow outlined above where a user might not have to necessarily complete an action.

Instead, I added a new `complete` method that simply marks off an item and doesn't post a notification about it (so that it doesn't interrupt an existing tour).

Finally, this PR adds completion actions for _most_ Quick Start tours but not _all_:

- Set your site title
- Upload a site icon
- View your Site
- Edit your homepage
- Enable post sharing
- Publish a post

If doesn't include these items because they don't really have explicit actions that the user can perform – the user could just be looking around the app and not actively trying to find those areas:

- Review site pages
- Check your site stats

It also doesn't include "Follow other sites", because if the Reader tour isn't underway, there's currently no easy way to tell which site should have its Quick Start tour checked off from the Reader (elsewhere in My Site we always have a reference to a blog that we can pass).

**To test**

- Build and run
- Either create a new site and accept Quick Start, or use the debug menu to enable Quick Start for a site
- Ignore any prompts from Quick Start from now on
- For each of these items, complete that action in the app and then look on the Quick Start lists to check that it has been marked as complete:

- [x] Set your site title
- [x] Upload a site icon
- [x] View your Site
- [x] Edit your homepage (just tap the row for your homepage in Pages)
- [x] Enable post sharing (link your site to Twitter or similar using the Sharing entry in My Site)
- [x] Publish a post

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
