### PR TITLE
Jetpack Section: Adds some scan improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -1,5 +1,4 @@
 import Foundation
-import WordPressFlux
 
 protocol JetpackScanView {
     func render()
@@ -10,6 +9,7 @@ protocol JetpackScanView {
     func showScanStartError()
 
     func presentAlert(_ alert: UIAlertController)
+    func presentNotice(with title: String, message: String)
 
     func showIgnoreThreatSuccess(for threat: JetpackScanThreat)
     func showIgnoreThreatError(for threat: JetpackScanThreat)
@@ -282,9 +282,7 @@ class JetpackScanCoordinator {
                 message = String(format: Strings.scanNotice.messageThreatsFound, threatCount)
         }
 
-        let notice = Notice(title: Strings.scanNotice.title, message: message)
-
-        ActionDispatcher.dispatch(NoticeAction.post(notice))
+        view.presentNotice(with: Strings.scanNotice.title, message: message)
     }
 
     // MARK: - Private: Refresh Timer
@@ -332,8 +330,8 @@ class JetpackScanCoordinator {
             static let message = NSLocalizedString("No threats found", comment: "Message for a notice informing the user their scan completed and no threats were found")
             static let messageThreatsFound = NSLocalizedString("%d potential threats found", comment: "Message for a notice informing the user their scan completed and %d threats were found")
             static let messageSingleThreatFound = NSLocalizedString("1 potential threat found", comment: "Message for a notice informing the user their scan completed and 1 threat was found")
-
         }
+
         static let fixAllAlertTitleFormat = NSLocalizedString("Please confirm you want to fix all %1$d active threats", comment: "Confirmation title presented before fixing all the threats, displays the number of threats to be fixed")
         static let fixAllSingleAlertTitle = NSLocalizedString("Please confirm you want to fix this threat", comment: "Confirmation title presented before fixing a single threat")
         static let fixAllAlertTitleMessage = NSLocalizedString("Jetpack will be fixing all the detected active threats.", comment: "Confirmation message presented before fixing all the threats, displays the number of threats to be fixed")

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -103,6 +103,10 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
         present(alert, animated: true, completion: nil)
     }
 
+    func presentNotice(with title: String, message: String) {
+        displayNotice(title: title, message: message)
+    }
+
     func showIgnoreThreatSuccess(for threat: JetpackScanThreat) {
         navigationController?.popViewController(animated: true)
         coordinator.refreshData()

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -294,7 +294,7 @@ extension JetpackScanViewController: NoResultsViewControllerDelegate {
             }
 
             if noResultsViewController.view.superview != tableView {
-                tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+                tableView.addSubview(noResultsViewController.view)
             }
 
             addChild(noResultsViewController)


### PR DESCRIPTION
This PR includes 2 improvements:
1. When first loading the scan view we no longer flash the scan status view with its initial "loading" state
2. When the scan finishes we now show a notice informing the user of the scan results

### Screenshots

| No Threats | One Threat | Multiple Threats |
|:---:|:---:|:---:|
|<img width="487" alt="Screen Shot 2021-02-18 at 2 17 07 PM" src="https://user-images.githubusercontent.com/793774/108411500-b48d8880-71f6-11eb-9a79-13a4aac6d48b.png">|<img width="487" alt="Screen Shot 2021-02-18 at 2 18 21 PM" src="https://user-images.githubusercontent.com/793774/108411499-b35c5b80-71f6-11eb-8fc8-d255d6af8e1f.png">|<img width="487" alt="Screen Shot 2021-02-18 at 2 20 49 PM" src="https://user-images.githubusercontent.com/793774/108411486-b0fa0180-71f6-11eb-9497-a161781ea802.png">|

### To test:

#### Loading 
1. Launch the app
2. Open a site with Jetpack Scan enabled
3. Tap on Scan
4. Verify you don't see the scan status view for a second before the view loads

#### Notice
1. Launch the app
2. Open a site with Jetpack Scan enabled
3. Perform a scan where the result is no threats
4. Verify the notice appears with "no threats found"
5. Perform a scan where the result is 1 threat
6. Verify the notice appears with "1 potential threat found"
7. Perform a scan where the result is more than 1 threat
8. Verify the notice appears with "X potential threats found" where X is the number of threats

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
