### PR TITLE
Comments: show comment body in separate label than author and post title.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -6,22 +6,25 @@ open class CommentsTableViewCell: WPTableViewCell {
     // MARK: - IBOutlets
 
     @IBOutlet private weak var gravatarImageView: CircularImageView!
-    @IBOutlet private weak var detailsLabel: UILabel!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var detailLabel: UILabel!
     @IBOutlet private weak var timestampImageView: UIImageView!
     @IBOutlet private weak var timestampLabel: UILabel!
 
     // MARK: - Private Properties
 
-    private var author: String?
-    private var postTitle: String?
-    private var content: String?
+    private var author = String()
+    private var postTitle = String()
+    private var content = String()
     private var timestamp: String?
     private var approved: Bool = false
     private var gravatarURL: URL?
     private typealias Style = WPStyleGuide.Comments
+    private let placeholderImage = Style.gravatarPlaceholderImage
 
-    private var placeholderImage: UIImage {
-        return Style.gravatarPlaceholderImage(isApproved: approved)
+    private enum Labels {
+        static let noTitle = NSLocalizedString("(No Title)", comment: "Empty Post Title")
+        static let titleFormat = NSLocalizedString("%1$@ on %2$@", comment: "Label displaying the author and post title for a Comment. %1$@ is a placeholder for the author. %2$@ is a placeholder for the post title.")
     }
 
     // MARK: - Public Properties
@@ -33,8 +36,8 @@ open class CommentsTableViewCell: WPTableViewCell {
     @objc func configureWithComment(_ comment: Comment) {
         author = comment.authorForDisplay() ?? String()
         approved = (comment.status == CommentStatusApproved)
-        postTitle = comment.titleForDisplay()
-        content = comment.contentPreviewForDisplay()
+        postTitle = comment.titleForDisplay() ?? Labels.noTitle
+        content = comment.contentPreviewForDisplay() ?? String()
         timestamp = comment.dateCreated.mediumString()
 
         if let avatarURLForDisplay = comment.avatarURLForDisplay() {
@@ -43,24 +46,10 @@ open class CommentsTableViewCell: WPTableViewCell {
             downloadGravatarWithGravatarEmail(comment.gravatarEmailForDisplay())
         }
 
-        refreshDetailsLabel()
+        backgroundColor = Style.backgroundColor
+        refreshCommentLabels()
         refreshTimestampLabel()
-        refreshBackground()
         refreshImages()
-    }
-
-    // MARK: - Overwritten Methods
-
-    open override func setSelected(_ selected: Bool, animated: Bool) {
-        // Note: this is required, since the cell unhighlight mechanism will reset the new background color
-        super.setSelected(selected, animated: animated)
-        refreshBackground()
-    }
-
-    open override func setHighlighted(_ highlighted: Bool, animated: Bool) {
-        // Note: this is required, since the cell unhighlight mechanism will reset the new background color
-        super.setHighlighted(highlighted, animated: animated)
-        refreshBackground()
     }
 
 }
@@ -91,9 +80,11 @@ private extension CommentsTableViewCell {
 
     // MARK: - Refresh UI
 
-    func refreshDetailsLabel() {
-        detailsLabel.attributedText = attributedDetailsText(approved)
-        layoutIfNeeded()
+    func refreshCommentLabels() {
+        titleLabel.attributedText = attributedTitle()
+        detailLabel.text = content
+        detailLabel.font = Style.detailFont
+        detailLabel.textColor = Style.detailTextColor
     }
 
     func refreshTimestampLabel() {
@@ -114,10 +105,6 @@ private extension CommentsTableViewCell {
         timestampLabel?.attributedText = NSAttributedString(string: formattedTimestamp, attributes: style)
     }
 
-    func refreshBackground() {
-        backgroundColor = Style.backgroundColor(isApproved: approved)
-    }
-
     func refreshImages() {
         timestampImageView.image = Style.timestampImage(isApproved: approved)
         if !approved {
@@ -125,44 +112,23 @@ private extension CommentsTableViewCell {
         }
     }
 
-    func attributedDetailsText(_ isApproved: Bool) -> NSAttributedString {
-        // Unwrap
-        let unwrappedAuthor     = author ?? String()
-        let unwrappedTitle      = postTitle ?? NSLocalizedString("(No Title)", comment: "Empty Post Title")
-        let unwrappedContent    = content ?? String()
-
-        // Styles
-        let detailsBoldStyle    = Style.detailsBoldStyle(isApproved: isApproved)
-        let detailsItalicsStyle = Style.detailsItalicsStyle(isApproved: isApproved)
-        let detailsRegularStyle = Style.detailsRegularStyle(isApproved: isApproved)
-        let regularRedStyle     = Style.detailsRegularRedStyle(isApproved: isApproved)
-
-        // Localize the format
-        var details = NSLocalizedString("%1$@ on %2$@: %3$@", comment: "'AUTHOR on POST TITLE: COMMENT' in a comment list")
-        if unwrappedContent.isEmpty {
-            details = NSLocalizedString("%1$@ on %2$@", comment: "'AUTHOR on POST TITLE' in a comment list")
-        }
-
-        // Arrange the Replacement Map
-        let replacementMap  = [
-            "%1$@": NSAttributedString(string: unwrappedAuthor, attributes: detailsBoldStyle),
-            "%2$@": NSAttributedString(string: unwrappedTitle, attributes: detailsItalicsStyle),
-            "%3$@": NSAttributedString(string: unwrappedContent, attributes: detailsRegularStyle)
+    func attributedTitle() -> NSAttributedString {
+        let replacementMap = [
+            "%1$@": NSAttributedString(string: author, attributes: Style.titleBoldAttributes),
+            "%2$@": NSAttributedString(string: postTitle, attributes: Style.titleBoldAttributes)
         ]
 
-        // Replace Author + Title + Content
-        let attributedDetails = NSMutableAttributedString(string: details, attributes: regularRedStyle)
+        // Replace Author + Title
+        let attributedTitle = NSMutableAttributedString(string: Labels.titleFormat, attributes: Style.titleRegularAttributes)
 
         for (key, attributedString) in replacementMap {
-            let range = (attributedDetails.string as NSString).range(of: key)
-            if range.location == NSNotFound {
-                continue
+            let range = (attributedTitle.string as NSString).range(of: key)
+            if range.location != NSNotFound {
+                attributedTitle.replaceCharacters(in: range, with: attributedString)
             }
-
-            attributedDetails.replaceCharacters(in: range, with: attributedString)
         }
 
-        return attributedDetails
+        return attributedTitle
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -1,56 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="Upg-EE-wRd" customClass="CommentsTableViewCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="74"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="146"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="73.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="146"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="dsX-LD-1XZ">
-                        <rect key="frame" x="0.0" y="11" width="0.0" height="52"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="dsX-LD-1XZ" userLabel="Content Stack View">
+                        <rect key="frame" x="16" y="11" width="288" height="124"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="46" height="46"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" priority="999" constant="46" id="h59-o3-ocT"/>
+                                    <constraint firstAttribute="width" secondItem="0Gm-n3-CNm" secondAttribute="height" multiplier="1:1" id="TZC-zi-UQA"/>
                                     <constraint firstAttribute="width" constant="46" id="pBo-eH-W4J"/>
                                 </constraints>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe">
-                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="18.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe" userLabel="Label Stack View">
+                                <rect key="frame" x="56" y="0.0" width="232" height="66.5"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq">
-                                        <rect key="frame" x="0.0" y="-4" width="0.0" height="0.0"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq" userLabel="Title Label">
+                                        <rect key="frame" x="0.0" y="-4" width="232" height="24"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="dIK-tl-nW4">
-                                        <rect key="frame" x="0.0" y="-2" width="0.0" height="20.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xkp-oe-UgU">
+                                        <rect key="frame" x="0.0" y="25" width="232" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="dIK-tl-nW4" userLabel="Timestamp Stack View">
+                                        <rect key="frame" x="0.0" y="50.5" width="232" height="16"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="rcg-tb-060">
-                                                <rect key="frame" x="0.0" y="2.5" width="16" height="16"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="16" id="YZR-zM-ndp"/>
                                                     <constraint firstAttribute="height" constant="16" id="xwF-CO-6ZI"/>
                                                 </constraints>
                                             </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
-                                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
+                                                <rect key="frame" x="20" y="0.0" width="212" height="16"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
@@ -73,13 +76,15 @@
                     <constraint firstItem="dsX-LD-1XZ" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="topMargin" id="qkF-E2-4Jc"/>
                 </constraints>
             </tableViewCellContentView>
+            <inset key="separatorInset" minX="78" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
-                <outlet property="detailsLabel" destination="Wrp-Wr-ZBq" id="Fos-Bf-RYL"/>
+                <outlet property="detailLabel" destination="xkp-oe-UgU" id="Y28-DD-nEF"/>
                 <outlet property="gravatarImageView" destination="0Gm-n3-CNm" id="GXM-xm-h6r"/>
                 <outlet property="timestampImageView" destination="rcg-tb-060" id="cp9-u0-P57"/>
                 <outlet property="timestampLabel" destination="bDl-id-9M7" id="sk9-hl-b6r"/>
+                <outlet property="titleLabel" destination="Wrp-Wr-ZBq" id="lVi-a7-Ppp"/>
             </connections>
-            <point key="canvasLocation" x="34" y="56"/>
+            <point key="canvasLocation" x="33.600000000000001" y="88.15592203898052"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -20,29 +20,29 @@
                         <rect key="frame" x="16" y="11" width="288" height="124"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="46" height="46"/>
+                                <rect key="frame" x="0.0" y="0.0" width="42" height="42"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="0Gm-n3-CNm" secondAttribute="height" multiplier="1:1" id="TZC-zi-UQA"/>
-                                    <constraint firstAttribute="width" constant="46" id="pBo-eH-W4J"/>
+                                    <constraint firstAttribute="width" constant="42" id="pBo-eH-W4J"/>
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe" userLabel="Label Stack View">
-                                <rect key="frame" x="56" y="0.0" width="232" height="66.5"/>
+                                <rect key="frame" x="52" y="0.0" width="236" height="66.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq" userLabel="Title Label">
-                                        <rect key="frame" x="0.0" y="-4" width="232" height="24"/>
+                                        <rect key="frame" x="0.0" y="-4" width="236" height="24"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xkp-oe-UgU">
-                                        <rect key="frame" x="0.0" y="25" width="232" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="25" width="236" height="20.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="dIK-tl-nW4" userLabel="Timestamp Stack View">
-                                        <rect key="frame" x="0.0" y="50.5" width="232" height="16"/>
+                                        <rect key="frame" x="0.0" y="50.5" width="236" height="16"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="rcg-tb-060">
                                                 <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
@@ -52,7 +52,7 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
-                                                <rect key="frame" x="20" y="0.0" width="212" height="16"/>
+                                                <rect key="frame" x="20" y="0.0" width="216" height="16"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
@@ -6,86 +6,36 @@ import WordPressShared
 ///
 extension WPStyleGuide {
     public struct Comments {
-        // MARK: - Public Properties
-        //
-        public static func gravatarPlaceholderImage(isApproved approved: Bool) -> UIImage {
-            return approved ? gravatarApproved : gravatarUnapproved
-        }
 
-        public static func separatorsColor(isApproved approved: Bool) -> UIColor {
-            return .divider
-        }
+        static let gravatarPlaceholderImage = UIImage(named: "gravatar") ?? UIImage()
+        static let backgroundColor = UIColor.listForeground
 
-        public static func detailsRegularStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            return  [.paragraphStyle: titleParagraph,
-                     .font: titleRegularFont,
+        static let detailFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+        static let detailTextColor = UIColor.textSubtle
+
+        private static let titleTextColor = UIColor.text
+        private static let titleTextStyle = UIFont.TextStyle.headline
+
+        static let titleBoldAttributes: [NSAttributedString.Key: Any] = [
+            .font: WPStyleGuide.fontForTextStyle(titleTextStyle, fontWeight: .semibold),
+            .foregroundColor: titleTextColor
+        ]
+
+        static let titleRegularAttributes: [NSAttributedString.Key: Any] = [
+            .font: WPStyleGuide.fontForTextStyle(titleTextStyle, fontWeight: .regular),
+            .foregroundColor: titleTextColor
+        ]
+
+        static func timestampStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
+            return  [.font: WPStyleGuide.fontForTextStyle(.caption1),
                      .foregroundColor: UIColor.textSubtle ]
         }
 
-        public static func detailsRegularRedStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            return  [.paragraphStyle: titleParagraph,
-                     .font: titleRegularFont,
-                     .foregroundColor: UIColor.text ]
-        }
-
-        public static func detailsItalicsStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            return  [.paragraphStyle: titleParagraph,
-                     .font: titleItalicsFont,
-                     .foregroundColor: UIColor.text ]
-        }
-
-        public static func detailsBoldStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            return  [.paragraphStyle: titleParagraph,
-                     .font: titleBoldFont,
-                     .foregroundColor: UIColor.text ]
-        }
-
-        public static func timestampStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            return  [.font: timestampFont,
-                     .foregroundColor: UIColor.textSubtle ]
-        }
-
-        public static func backgroundColor(isApproved approved: Bool) -> UIColor {
-            return approved ? .listForeground : UIColor(light: .warning(.shade0), dark: .warning(.shade90))
-        }
-
-        public static func timestampImage(isApproved approved: Bool) -> UIImage {
-            let timestampImage = UIImage(named: "reader-postaction-time")!
+        static func timestampImage(isApproved approved: Bool) -> UIImage {
+            guard let timestampImage = UIImage(named: "reader-postaction-time") else {
+                return UIImage()
+            }
             return approved ? timestampImage : timestampImage.withRenderingMode(.alwaysTemplate)
-        }
-
-
-
-        // MARK: - Private Properties
-        //
-        fileprivate static let gravatarApproved     = UIImage(named: "gravatar")!
-        fileprivate static let gravatarUnapproved   = UIImage(named: "gravatar-unapproved")!
-
-        private static var timestampFont: UIFont {
-            return WPStyleGuide.fontForTextStyle(.caption1)
-        }
-
-        private static var titleRegularFont: UIFont {
-            return WPStyleGuide.fontForTextStyle(.footnote)
-        }
-
-        private static var titleBoldFont: UIFont {
-            return WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .semibold)
-        }
-
-        private static var titleItalicsFont: UIFont {
-            return WPStyleGuide.fontForTextStyle(.footnote, symbolicTraits: .traitItalic)
-        }
-
-        private static var titleLineSize: CGFloat {
-            return WPStyleGuide.fontSizeForTextStyle(.footnote) * 1.3
-        }
-
-        private static var titleParagraph: NSMutableParagraphStyle {
-            return NSMutableParagraphStyle(minLineHeight: titleLineSize,
-                                           maxLineHeight: titleLineSize,
-                                           lineBreakMode: .byTruncatingTail,
-                                           alignment: .natural)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
@@ -10,7 +10,7 @@ extension WPStyleGuide {
         static let gravatarPlaceholderImage = UIImage(named: "gravatar") ?? UIImage()
         static let backgroundColor = UIColor.listForeground
 
-        static let detailFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+        static let detailFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         static let detailTextColor = UIColor.textSubtle
 
         private static let titleTextColor = UIColor.text


### PR DESCRIPTION
Ref: #15909 

This is the first step in updating the Comment UI.
- Separated comment content.
  - The author and post title are concatenated into one `NSAttributedString`.
  - The comment content is now shown separately in a label below that.
- Removed the Pending background color.
- Removed the Pending placeholder gravatar. All the placeholder gravatars are now grey.
- Indented the cell separator to align with the text.

Notes:
- The timestamp label still says `Pending` and the icon is still the pending color. I'll fix this when I add the Pending indicator.
- Sometimes the cell isn't sized properly, leaving gaps around the content label. I'll look into that next.

<kbd><img width="350" alt="incorrect_cell_size" src="https://user-images.githubusercontent.com/1816888/108420405-0206f700-71f1-11eb-9ccd-c2c0bed8cea8.png"></kbd>

To test:
- Go to Site > Comments.
- Verify the Comments have the new half-finished UI as described above.

| Before | After |
|--------|-------|
| <img width="470" alt="before" src="https://user-images.githubusercontent.com/1816888/108420701-62963400-71f1-11eb-86f1-47f3a43c51ea.png"> | <img width="472" alt="after" src="https://user-images.githubusercontent.com/1816888/108426127-9cb70400-71f8-11eb-94fe-974f1147e0d1.png"> |


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
