### PR TITLE
Comments: show yellow dot to indicate Pending comment.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -35,6 +35,12 @@ open class CommentsTableViewCell: WPTableViewCell {
 
     // MARK: - Public Methods
 
+    open override func awakeFromNib() {
+        super.awakeFromNib()
+        backgroundColor = Style.backgroundColor
+        pendingIndicator.layer.cornerRadius = pendingIndicatorWidthConstraint.constant / 2
+    }
+
     @objc func configureWithComment(_ comment: Comment) {
         author = comment.authorForDisplay() ?? String()
         approved = (comment.status == CommentStatusApproved)
@@ -48,7 +54,6 @@ open class CommentsTableViewCell: WPTableViewCell {
             downloadGravatarWithGravatarEmail(comment.gravatarEmailForDisplay())
         }
 
-        backgroundColor = Style.backgroundColor
         configurePendingIndicator()
         configureCommentLabels()
         configureTimestamp()
@@ -83,7 +88,6 @@ private extension CommentsTableViewCell {
     // MARK: - Configure UI
 
     func configurePendingIndicator() {
-        pendingIndicator.layer.cornerRadius = pendingIndicatorWidthConstraint.constant / 2
         pendingIndicator.backgroundColor = approved ? .clear : Style.pendingIndicatorColor
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -5,6 +5,8 @@ open class CommentsTableViewCell: WPTableViewCell {
 
     // MARK: - IBOutlets
 
+    @IBOutlet private weak var pendingIndicator: UIView!
+    @IBOutlet private weak var pendingIndicatorWidthConstraint: NSLayoutConstraint!
     @IBOutlet private weak var gravatarImageView: CircularImageView!
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var detailLabel: UILabel!
@@ -47,9 +49,9 @@ open class CommentsTableViewCell: WPTableViewCell {
         }
 
         backgroundColor = Style.backgroundColor
-        refreshCommentLabels()
-        refreshTimestampLabel()
-        refreshImages()
+        configurePendingIndicator()
+        configureCommentLabels()
+        configureTimestamp()
     }
 
 }
@@ -78,38 +80,26 @@ private extension CommentsTableViewCell {
         gravatarImageView.downloadGravatarWithEmail(unwrappedEmail, placeholderImage: placeholderImage)
     }
 
-    // MARK: - Refresh UI
+    // MARK: - Configure UI
 
-    func refreshCommentLabels() {
+    func configurePendingIndicator() {
+        pendingIndicator.layer.cornerRadius = pendingIndicatorWidthConstraint.constant / 2
+        pendingIndicator.backgroundColor = approved ? .clear : Style.pendingIndicatorColor
+    }
+
+    func configureCommentLabels() {
         titleLabel.attributedText = attributedTitle()
         detailLabel.text = content
         detailLabel.font = Style.detailFont
         detailLabel.textColor = Style.detailTextColor
     }
 
-    func refreshTimestampLabel() {
-        guard let timestamp = timestamp else {
-            return
-        }
+    func configureTimestamp() {
+        timestampLabel.text = timestamp
+        timestampLabel.font = Style.timestampFont
+        timestampLabel.textColor = Style.detailTextColor
+        timestampImageView.image = Style.timestampImage
 
-        let style = Style.timestampStyle(isApproved: approved)
-        let formattedTimestamp: String
-
-        if approved {
-            formattedTimestamp = timestamp
-        } else {
-            let pendingLabel = NSLocalizedString("Pending", comment: "Status name for a comment that hasn't yet been approved.")
-            formattedTimestamp = "\(timestamp) · \(pendingLabel)"
-        }
-
-        timestampLabel?.attributedText = NSAttributedString(string: formattedTimestamp, attributes: style)
-    }
-
-    func refreshImages() {
-        timestampImageView.image = Style.timestampImage(isApproved: approved)
-        if !approved {
-            timestampImageView.tintColor = WPStyleGuide.alertYellowDark()
-        }
     }
 
     func attributedTitle() -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -4,91 +4,101 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="Upg-EE-wRd" customClass="CommentsTableViewCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="146"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="107" id="Upg-EE-wRd" customClass="CommentsTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="107"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="146"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="107"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="dsX-LD-1XZ" userLabel="Content Stack View">
-                        <rect key="frame" x="16" y="11" width="288" height="124"/>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="btO-r2-hQO" userLabel="Pending Indicator">
+                        <rect key="frame" x="5" y="31" width="12" height="12"/>
+                        <color key="backgroundColor" systemColor="systemYellowColor"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="btO-r2-hQO" secondAttribute="height" multiplier="1:1" id="Fuu-CE-1fC"/>
+                            <constraint firstAttribute="width" constant="12" id="WeL-cC-lqa"/>
+                        </constraints>
+                    </view>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                        <rect key="frame" x="22" y="16" width="42" height="42"/>
+                        <constraints>
+                            <constraint firstAttribute="width" secondItem="0Gm-n3-CNm" secondAttribute="height" multiplier="1:1" id="TZC-zi-UQA"/>
+                            <constraint firstAttribute="width" constant="42" id="pBo-eH-W4J"/>
+                        </constraints>
+                    </imageView>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe" userLabel="Label Stack View">
+                        <rect key="frame" x="74" y="16" width="230" height="75"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="42" height="42"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="0Gm-n3-CNm" secondAttribute="height" multiplier="1:1" id="TZC-zi-UQA"/>
-                                    <constraint firstAttribute="width" constant="42" id="pBo-eH-W4J"/>
-                                </constraints>
-                            </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe" userLabel="Label Stack View">
-                                <rect key="frame" x="52" y="0.0" width="236" height="66.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq" userLabel="Title Label">
+                                <rect key="frame" x="0.0" y="-4" width="230" height="24"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xkp-oe-UgU">
+                                <rect key="frame" x="0.0" y="25" width="230" height="20.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="dIK-tl-nW4" userLabel="Timestamp Stack View">
+                                <rect key="frame" x="0.0" y="50.5" width="230" height="24.5"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq" userLabel="Title Label">
-                                        <rect key="frame" x="0.0" y="-4" width="236" height="24"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="rcg-tb-060">
+                                        <rect key="frame" x="0.0" y="4.5" width="16" height="16"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="16" id="YZR-zM-ndp"/>
+                                            <constraint firstAttribute="height" constant="16" id="xwF-CO-6ZI"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
+                                        <rect key="frame" x="20" y="4.5" width="210" height="16"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xkp-oe-UgU">
-                                        <rect key="frame" x="0.0" y="25" width="236" height="20.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="dIK-tl-nW4" userLabel="Timestamp Stack View">
-                                        <rect key="frame" x="0.0" y="50.5" width="236" height="16"/>
-                                        <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="rcg-tb-060">
-                                                <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="16" id="YZR-zM-ndp"/>
-                                                    <constraint firstAttribute="height" constant="16" id="xwF-CO-6ZI"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
-                                                <rect key="frame" x="20" y="0.0" width="216" height="16"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
-                                    </stackView>
                                 </subviews>
-                                <edgeInsets key="layoutMargins" top="-4" left="0.0" bottom="0.0" right="0.0"/>
+                                <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
                             </stackView>
                         </subviews>
-                        <constraints>
-                            <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="dsX-LD-1XZ" secondAttribute="top" id="9dw-Qk-yyT"/>
-                        </constraints>
+                        <edgeInsets key="layoutMargins" top="-4" left="0.0" bottom="0.0" right="0.0"/>
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="dsX-LD-1XZ" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leadingMargin" id="WVn-it-RvF"/>
-                    <constraint firstAttribute="bottomMargin" secondItem="dsX-LD-1XZ" secondAttribute="bottom" id="YbA-Pd-ZGu"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="dsX-LD-1XZ" secondAttribute="trailing" id="mUy-WB-D5x"/>
-                    <constraint firstItem="dsX-LD-1XZ" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="topMargin" id="qkF-E2-4Jc"/>
+                    <constraint firstAttribute="bottom" secondItem="TCy-wp-wTe" secondAttribute="bottom" constant="16" id="0jH-3l-Byh"/>
+                    <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="top" constant="16" id="2A1-34-eCB"/>
+                    <constraint firstAttribute="trailing" secondItem="TCy-wp-wTe" secondAttribute="trailing" constant="16" id="JIi-rX-zaD"/>
+                    <constraint firstItem="btO-r2-hQO" firstAttribute="centerY" secondItem="0Gm-n3-CNm" secondAttribute="centerY" id="R5k-6J-G5m"/>
+                    <constraint firstItem="btO-r2-hQO" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leading" constant="5" id="bYE-0r-D2f"/>
+                    <constraint firstItem="0Gm-n3-CNm" firstAttribute="leading" secondItem="btO-r2-hQO" secondAttribute="trailing" constant="5" id="mf3-C6-VyD"/>
+                    <constraint firstItem="TCy-wp-wTe" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="top" constant="16" id="p7L-HY-qIn"/>
+                    <constraint firstItem="TCy-wp-wTe" firstAttribute="leading" secondItem="0Gm-n3-CNm" secondAttribute="trailing" constant="10" id="zUJ-4Q-fMK"/>
                 </constraints>
             </tableViewCellContentView>
             <inset key="separatorInset" minX="78" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
                 <outlet property="detailLabel" destination="xkp-oe-UgU" id="Y28-DD-nEF"/>
                 <outlet property="gravatarImageView" destination="0Gm-n3-CNm" id="GXM-xm-h6r"/>
+                <outlet property="pendingIndicator" destination="btO-r2-hQO" id="uEa-SX-swe"/>
+                <outlet property="pendingIndicatorWidthConstraint" destination="WeL-cC-lqa" id="NGZ-2z-ehN"/>
                 <outlet property="timestampImageView" destination="rcg-tb-060" id="cp9-u0-P57"/>
                 <outlet property="timestampLabel" destination="bDl-id-9M7" id="sk9-hl-b6r"/>
                 <outlet property="titleLabel" destination="Wrp-Wr-ZBq" id="lVi-a7-Ppp"/>
             </connections>
-            <point key="canvasLocation" x="33.600000000000001" y="88.15592203898052"/>
+            <point key="canvasLocation" x="33.600000000000001" y="70.614692653673174"/>
         </tableViewCell>
     </objects>
     <resources>
         <image name="gravatar" width="85" height="85"/>
         <image name="reader-postaction-time" width="16" height="16"/>
+        <systemColor name="systemYellowColor">
+            <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -18,11 +18,11 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="btO-r2-hQO" userLabel="Pending Indicator">
-                        <rect key="frame" x="5" y="31" width="12" height="12"/>
+                        <rect key="frame" x="6" y="32" width="10" height="10"/>
                         <color key="backgroundColor" systemColor="systemYellowColor"/>
                         <constraints>
                             <constraint firstAttribute="width" secondItem="btO-r2-hQO" secondAttribute="height" multiplier="1:1" id="Fuu-CE-1fC"/>
-                            <constraint firstAttribute="width" constant="12" id="WeL-cC-lqa"/>
+                            <constraint firstAttribute="width" constant="10" id="WeL-cC-lqa"/>
                         </constraints>
                     </view>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -75,8 +75,8 @@
                     <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="top" constant="16" id="2A1-34-eCB"/>
                     <constraint firstAttribute="trailing" secondItem="TCy-wp-wTe" secondAttribute="trailing" constant="16" id="JIi-rX-zaD"/>
                     <constraint firstItem="btO-r2-hQO" firstAttribute="centerY" secondItem="0Gm-n3-CNm" secondAttribute="centerY" id="R5k-6J-G5m"/>
-                    <constraint firstItem="btO-r2-hQO" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leading" constant="5" id="bYE-0r-D2f"/>
-                    <constraint firstItem="0Gm-n3-CNm" firstAttribute="leading" secondItem="btO-r2-hQO" secondAttribute="trailing" constant="5" id="mf3-C6-VyD"/>
+                    <constraint firstItem="btO-r2-hQO" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leading" constant="6" id="bYE-0r-D2f"/>
+                    <constraint firstItem="0Gm-n3-CNm" firstAttribute="leading" secondItem="btO-r2-hQO" secondAttribute="trailing" constant="6" id="mf3-C6-VyD"/>
                     <constraint firstItem="TCy-wp-wTe" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="top" constant="16" id="p7L-HY-qIn"/>
                     <constraint firstItem="TCy-wp-wTe" firstAttribute="leading" secondItem="0Gm-n3-CNm" secondAttribute="trailing" constant="10" id="zUJ-4Q-fMK"/>
                 </constraints>

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
@@ -9,6 +9,10 @@ extension WPStyleGuide {
 
         static let gravatarPlaceholderImage = UIImage(named: "gravatar") ?? UIImage()
         static let backgroundColor = UIColor.listForeground
+        static let pendingIndicatorColor = UIColor.muriel(color: MurielColor(name: .yellow, shade: .shade20))
+
+        static let timestampFont = WPStyleGuide.fontForTextStyle(.caption1)
+        static let timestampImage = UIImage(named: "reader-postaction-time") ?? UIImage()
 
         static let detailFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         static let detailTextColor = UIColor.textSubtle
@@ -25,17 +29,5 @@ extension WPStyleGuide {
             .font: WPStyleGuide.fontForTextStyle(titleTextStyle, fontWeight: .regular),
             .foregroundColor: titleTextColor
         ]
-
-        static func timestampStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            return  [.font: WPStyleGuide.fontForTextStyle(.caption1),
-                     .foregroundColor: UIColor.textSubtle ]
-        }
-
-        static func timestampImage(isApproved approved: Bool) -> UIImage {
-            guard let timestampImage = UIImage(named: "reader-postaction-time") else {
-                return UIImage()
-            }
-            return approved ? timestampImage : timestampImage.withRenderingMode(.alwaysTemplate)
-        }
     }
 }


### PR DESCRIPTION
Ref: #15909 

** https://github.com/wordpress-mobile/WordPress-iOS/pull/15923 should be reviewed before this one. **

This adds an indicator (i.e a yellow dot) to pending Comments.

To test:
- Go to Site > Comments.
- For Pending comments:
  - A yellow dot appears to the left of the gravatar.
  - The timestamp image is grey.
  - The timestamp does not have `Pending` appended.

<kbd><img width="400" alt="Screen Shot 2021-02-18 at 4 54 38 PM" src="https://user-images.githubusercontent.com/1816888/108437284-3b982c00-720a-11eb-99cf-85f6bc4fbef2.png"></kbd>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
