### PR TITLE
Add Prepublishing title field

### DIFF
--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -191,6 +191,10 @@ class StoryEditor: CameraController {
 }
 
 extension StoryEditor: PublishingEditor {
+    var prepublishingIdentifiers: [PrepublishingIdentifier] {
+        return  [.title, .visibility, .schedule, .tags]
+    }
+
     var prepublishingSourceView: UIView? {
         return nil
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -45,6 +45,8 @@ protocol PublishingEditor where Self: UIViewController {
 
     /// Debouncer used to save the post locally with a delay
     var debouncer: Debouncer { get }
+
+    var prepublishingIdentifiers: [PrepublishingIdentifier] { get }
 }
 
 extension PublishingEditor where Self: UIViewController {
@@ -211,7 +213,7 @@ extension PublishingEditor where Self: UIViewController {
         // End editing to avoid issues with accessibility
         view.endEditing(true)
 
-        let prepublishing = PrepublishingViewController(post: post) { result in
+        let prepublishing = PrepublishingViewController(post: post, identifiers: prepublishingIdentifiers) { result in
             switch result {
             case .completed(let post):
                 self.post = post

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -139,4 +139,8 @@ extension PostEditor {
     var prepublishingSourceView: UIView? {
         return navigationBarManager.publishButton
     }
+
+    var prepublishingIdentifiers: [PrepublishingIdentifier] {
+        return [.visibility, .schedule, .tags]
+    }
 }

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -1,12 +1,29 @@
 import UIKit
 import WordPressAuthenticator
+import Combine
 
 private struct PrepublishingOption {
     let id: PrepublishingIdentifier
     let title: String
+    let type: PrepublishingCellType
 }
 
-private enum PrepublishingIdentifier {
+private enum PrepublishingCellType {
+    case value
+    case textField
+
+    var cellType: UITableViewCell.Type {
+        switch self {
+        case .value:
+            return WPTableViewCell.self
+        case .textField:
+            return WPTextFieldTableViewCell.self
+        }
+    }
+}
+
+enum PrepublishingIdentifier {
+    case title
     case schedule
     case visibility
     case tags
@@ -36,12 +53,7 @@ class PrepublishingViewController: UITableViewController {
 
     private let completion: (CompletionResult) -> ()
 
-    private let options: [PrepublishingOption] = [
-        PrepublishingOption(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility")),
-        PrepublishingOption(id: .schedule, title: Constants.publishDateLabel),
-        PrepublishingOption(id: .tags, title: NSLocalizedString("Tags", comment: "Label for Tags")),
-        PrepublishingOption(id: .categories, title: NSLocalizedString("Categories", comment: "Label for Categories"))
-    ]
+    private let options: [PrepublishingOption]
 
     private var didTapPublish = false
 
@@ -52,8 +64,11 @@ class PrepublishingViewController: UITableViewController {
         return nuxButton
     }()
 
-    init(post: Post, completion: @escaping (CompletionResult) -> ()) {
+    init(post: Post, identifiers: [PrepublishingIdentifier], completion: @escaping (CompletionResult) -> ()) {
         self.post = post
+        self.options = identifiers.map { identifier in
+            return PrepublishingViewController.option(for: identifier)
+        }
         self.completion = completion
         super.init(nibName: nil, bundle: nil)
     }
@@ -61,6 +76,9 @@ class PrepublishingViewController: UITableViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    private var cancellables = Set<AnyCancellable>()
+    @Published private var keyboardShown: Bool = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -72,9 +90,25 @@ class PrepublishingViewController: UITableViewController {
         setupPublishButton()
         setupFooterSeparator()
 
+        updatePublishButtonLabel()
         announcePublishButton()
 
         calculatePreferredContentSize()
+
+        configureKeyboardToggle()
+    }
+
+    /// Toggles `keyboardShown` as the keyboard notifications come in
+    private func configureKeyboardToggle() {
+        NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)
+            .map { _ in return true }
+            .assign(to: \.keyboardShown, on: self)
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)
+            .map { _ in return false }
+            .assign(to: \.keyboardShown, on: self)
+            .store(in: &cancellables)
     }
 
     private func calculatePreferredContentSize() {
@@ -119,21 +153,30 @@ class PrepublishingViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: WPTableViewCell = {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.reuseIdentifier) as? WPTableViewCell else {
-                return WPTableViewCell.init(style: .value1, reuseIdentifier: Constants.reuseIdentifier)
-            }
-            return cell
-        }()
+
+        let option = options[indexPath.row]
+
+        let cell = dequeueCell(for: option.type, indexPath: indexPath)
 
         cell.preservesSuperviewLayoutMargins = false
         cell.separatorInset = .zero
         cell.layoutMargins = Constants.cellMargins
 
-        cell.accessoryType = .disclosureIndicator
-        cell.textLabel?.text = options[indexPath.row].title
+        switch option.type {
+        case .textField:
+            if let cell = cell as? WPTextFieldTableViewCell {
+                setupTextFieldCell(cell)
+            }
+        case .value:
+            cell.accessoryType = .disclosureIndicator
+            cell.textLabel?.text = option.title
+        }
 
-        switch options[indexPath.row].id {
+        switch option.id {
+        case .title:
+            if let cell = cell as? WPTextFieldTableViewCell {
+                configureTitleCell(cell)
+            }
         case .tags:
             configureTagCell(cell)
         case .visibility:
@@ -147,8 +190,25 @@ class PrepublishingViewController: UITableViewController {
         return cell
     }
 
+    private func dequeueCell(for type: PrepublishingCellType, indexPath: IndexPath) -> WPTableViewCell {
+        switch type {
+        case .textField:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.textFieldReuseIdentifier) as? WPTextFieldTableViewCell else {
+                return WPTextFieldTableViewCell.init(style: .default, reuseIdentifier: Constants.textFieldReuseIdentifier)
+            }
+            return cell
+        case .value:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: Constants.reuseIdentifier) as? WPTableViewCell else {
+                return WPTableViewCell.init(style: .value1, reuseIdentifier: Constants.reuseIdentifier)
+            }
+            return cell
+        }
+    }
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch options[indexPath.row].id {
+        case .title:
+            break
         case .tags:
             didTapTagCell()
         case .visibility:
@@ -162,6 +222,38 @@ class PrepublishingViewController: UITableViewController {
 
     private func reloadData() {
         tableView.reloadData()
+    }
+
+    private static func option(for identifier: PrepublishingIdentifier) -> PrepublishingOption {
+        switch identifier {
+        case .title:
+            return PrepublishingOption(id: .title, title: Constants.titlePlaceholder, type: .textField)
+        case .schedule:
+            return PrepublishingOption(id: .schedule, title: Constants.publishDateLabel, type: .value)
+        case .categories:
+            return PrepublishingOption(id: .categories, title: NSLocalizedString("Categories", comment: "Label for Categories"), type: .value)
+        case .visibility:
+            return PrepublishingOption(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility"), type: .value)
+        case .tags:
+            return PrepublishingOption(id: .tags, title: NSLocalizedString("Tags", comment: "Label for Tags"), type: .value)
+        }
+    }
+
+    private func setupTextFieldCell(_ cell: WPTextFieldTableViewCell) {
+        WPStyleGuide.configureTableViewTextCell(cell)
+        cell.delegate = self
+    }
+
+    // MARK: - Titls
+
+    private func configureTitleCell(_ cell: WPTextFieldTableViewCell) {
+        cell.textField.text = post.postTitle
+        cell.textField.textColor = .text
+        cell.textField.placeholder = "Title"
+        cell.textField.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        cell.textField.autocorrectionType = .yes
+        cell.textField.autocapitalizationType = .sentences
+        cell.textField.becomeFirstResponder()
     }
 
     // MARK: - Tags
@@ -344,6 +436,7 @@ class PrepublishingViewController: UITableViewController {
 
     private enum Constants {
         static let reuseIdentifier = "wpTableViewCell"
+        static let textFieldReuseIdentifier = "wpTextFieldCell"
         static let nuxButtonInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         static let cellMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         static let footerFrame = CGRect(x: 0, y: 0, width: 100, height: 80)
@@ -351,6 +444,7 @@ class PrepublishingViewController: UITableViewController {
         static let scheduleNow = NSLocalizedString("Schedule Now", comment: "Label for the button that schedules the post")
         static let publishDateLabel = NSLocalizedString("Publish Date", comment: "Label for Publish date")
         static let scheduledLabel = NSLocalizedString("Scheduled for", comment: "Scheduled for [date]")
+        static let titlePlaceholder = NSLocalizedString("Title", comment: "Placeholder for title")
         static let headerHeight: CGFloat = 70
         static let analyticsDefaultProperty = ["via": "prepublishing_nudges"]
     }
@@ -375,6 +469,18 @@ extension PrepublishingViewController: PrepublishingDismissible {
         post.status = originalStatus
     }
 }
+
+extension PrepublishingViewController: WPTextFieldTableViewCellDelegate {
+    func cellWants(toSelectNextField cell: WPTextFieldTableViewCell!) {
+
+    }
+
+    func cellTextDidChange(_ cell: WPTextFieldTableViewCell!) {
+        WPAnalytics.track(.editorPostTitleChanged, properties: Constants.analyticsDefaultProperty)
+        post.postTitle = cell.textField.text
+    }
+}
+
 extension PrepublishingViewController: PostCategoriesViewControllerDelegate {
     func postCategoriesViewController(_ controller: PostCategoriesViewController, didUpdateSelectedCategories categories: NSSet) {
         WPAnalytics.track(.editorPostCategoryChanged, properties: ["via": "prepublishing_nudges"])
@@ -398,7 +504,7 @@ extension Set {
 // MARK: - DrawerPresentable
 extension PrepublishingViewController: DrawerPresentable {
     var allowsUserTransition: Bool {
-        return true
+        return keyboardShown == false
     }
 
     var collapsedHeight: DrawerHeight {

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -64,10 +64,13 @@ class PrepublishingViewController: UITableViewController {
         return nuxButton
     }()
 
+    /// Determines whether the text has been first responder already. If it has, don't force it back on the user unless it's been selected by them.
+    private var hasSelectedText: Bool = false
+
     init(post: Post, identifiers: [PrepublishingIdentifier], completion: @escaping (CompletionResult) -> ()) {
         self.post = post
         self.options = identifiers.map { identifier in
-            return PrepublishingViewController.option(for: identifier)
+            return PrepublishingOption(identifier: identifier)
         }
         self.completion = completion
         super.init(nibName: nil, bundle: nil)
@@ -224,36 +227,26 @@ class PrepublishingViewController: UITableViewController {
         tableView.reloadData()
     }
 
-    private static func option(for identifier: PrepublishingIdentifier) -> PrepublishingOption {
-        switch identifier {
-        case .title:
-            return PrepublishingOption(id: .title, title: Constants.titlePlaceholder, type: .textField)
-        case .schedule:
-            return PrepublishingOption(id: .schedule, title: Constants.publishDateLabel, type: .value)
-        case .categories:
-            return PrepublishingOption(id: .categories, title: NSLocalizedString("Categories", comment: "Label for Categories"), type: .value)
-        case .visibility:
-            return PrepublishingOption(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility"), type: .value)
-        case .tags:
-            return PrepublishingOption(id: .tags, title: NSLocalizedString("Tags", comment: "Label for Tags"), type: .value)
-        }
-    }
-
     private func setupTextFieldCell(_ cell: WPTextFieldTableViewCell) {
         WPStyleGuide.configureTableViewTextCell(cell)
         cell.delegate = self
     }
 
-    // MARK: - Titls
+    // MARK: - Title
 
     private func configureTitleCell(_ cell: WPTextFieldTableViewCell) {
         cell.textField.text = post.postTitle
+        cell.textField.adjustsFontForContentSizeCategory = true
+        cell.textField.font = .preferredFont(forTextStyle: .body)
         cell.textField.textColor = .text
-        cell.textField.placeholder = "Title"
+        cell.textField.placeholder = Constants.titlePlaceholder
         cell.textField.heightAnchor.constraint(equalToConstant: 40).isActive = true
         cell.textField.autocorrectionType = .yes
         cell.textField.autocapitalizationType = .sentences
-        cell.textField.becomeFirstResponder()
+        if !hasSelectedText {
+            cell.textField.becomeFirstResponder()
+            hasSelectedText = true
+        }
     }
 
     // MARK: - Tags
@@ -434,7 +427,7 @@ class PrepublishingViewController: UITableViewController {
         presentedVC?.transition(to: position)
     }
 
-    private enum Constants {
+    fileprivate enum Constants {
         static let reuseIdentifier = "wpTableViewCell"
         static let textFieldReuseIdentifier = "wpTextFieldCell"
         static let nuxButtonInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
@@ -509,5 +502,22 @@ extension PrepublishingViewController: DrawerPresentable {
 
     var collapsedHeight: DrawerHeight {
         return .intrinsicHeight
+    }
+}
+
+private extension PrepublishingOption {
+    init(identifier: PrepublishingIdentifier) {
+        switch identifier {
+        case .title:
+            self.init(id: .title, title: PrepublishingViewController.Constants.titlePlaceholder, type: .textField)
+        case .schedule:
+            self.init(id: .schedule, title: PrepublishingViewController.Constants.publishDateLabel, type: .value)
+        case .categories:
+            self.init(id: .categories, title: NSLocalizedString("Categories", comment: "Label for Categories"), type: .value)
+        case .visibility:
+            self.init(id: .visibility, title: NSLocalizedString("Visibility", comment: "Label for Visibility"), type: .value)
+        case .tags:
+            self.init(id: .tags, title: NSLocalizedString("Tags", comment: "Label for Tags"), type: .value)
+        }
     }
 }

--- a/WordPress/WordPressTest/PrepublishingNudgesViewControllerTests.swift
+++ b/WordPress/WordPressTest/PrepublishingNudgesViewControllerTests.swift
@@ -20,7 +20,7 @@ class PrepublishingNudgesViewControllerTests: XCTestCase {
     func testCallCompletionBlockWhenButtonTapped() {
         var post = PostBuilder().build()
         var returnedPost: AbstractPost?
-        let prepublishingViewController = PrepublishingViewController(post: post) { result in
+        let prepublishingViewController = PrepublishingViewController(post: post, identifiers: [.schedule, .visibility, .tags, .categories]) { result in
             switch result {
             case .completed(let completedPost):
                 if let completedPost = completedPost as? Post {


### PR DESCRIPTION
Adds a title field to the Prepublishing sheet.

| Expanded | Compact |
|-|-|
| <a href="https://user-images.githubusercontent.com/3250/108464896-37860180-723e-11eb-9338-10704d33ef72.png"><img src="https://user-images.githubusercontent.com/3250/108464896-37860180-723e-11eb-9338-10704d33ef72.png" width="300"></a>|<a href="https://user-images.githubusercontent.com/3250/108464925-42d92d00-723e-11eb-94d8-451ada6777ba.png"><img src="https://user-images.githubusercontent.com/3250/108464925-42d92d00-723e-11eb-94d8-451ada6777ba.png" width="300"></a>|

* Adds a title field which is automatically selected when the sheet shows up. Editors can control which fields are shown using the `prepublishingIdentifiers` variable and it can also be specified in the `PrepublishingViewController`s initializer.
* When the keyboard is shown, the Prepublishing sheet will not allow user transition into the compact state. This prevents the sheet from getting stuck behind the keyboard.

## Testing

* Open the Blog Details page
* Tap on the FAB and select "Story Post"
* Add media and hit the confirm button in the lower right
* Fill out the title field and publish the post

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
