### PR TITLE
Add former fastlane folder to gitignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,9 @@ fastlane/metadata/review_information
 default.profraw
 derived-data/
 
+# Fastlane former location
+Scripts/fastlane/
+
 # CI Artifacts Location
 Artifacts
 


### PR DESCRIPTION
This PR adds `Scripts/fastlane` to the list of .gitignored files in order to prevent that untracked or previously ignored files in that folder get committed by mistake now that fastlane has been moved to the root folder. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
