### PR TITLE
Discover posts sorting - accessibility

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -15,7 +15,6 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     private lazy var sortingButton: ReaderSortingOptionButton = {
         let view = ReaderSortingOptionButton()
         view.addTarget(self, action: #selector(didTapSortingButton), for: .touchUpInside)
-        view.accessibilityHint = NSLocalizedString("Tap to change sorting option", comment: "Accessibility hint for sorting option button.")
         return view
     }()
 

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
@@ -112,10 +112,6 @@ class ReaderSortingOptionButton: UIControl {
     private func setup() {
         translatesAutoresizingMaskIntoConstraints = false
 
-        // TODO: check if accessibility is set correctly
-        accessibilityIdentifier = "Reader sorting option button"
-        accessibilityLabel = NSLocalizedString("Choose reader sorting option", comment: "Accessibility label for sorting option button")
-
         addSubview(iconView)
         addSubview(label)
         addSubview(chevronView)
@@ -141,9 +137,26 @@ class ReaderSortingOptionButton: UIControl {
     private func bindSortingOption() {
         label.text = sortingOption.localizedDescription
         iconView.image = sortingOption.image
+
+        prepareForVoiceOver()
     }
 
     public func setLabelBottomCompensation(_ compensation: CGFloat) {
         labelBottomConstraint.constant = Constants.bottom + compensation
+    }
+}
+
+extension ReaderSortingOptionButton: Accessible {
+    func prepareForVoiceOver() {
+        isAccessibilityElement = true
+        iconView.isAccessibilityElement = false
+        label.isAccessibilityElement = false
+        chevronView.isAccessibilityElement = false
+
+        // TODO: check if accessibility is set correctly
+        accessibilityIdentifier = "Reader sorting option button"
+        accessibilityLabel = NSLocalizedString("Sorting option button", comment: "Accessibility label for sorting option button")
+        accessibilityValue = sortingOption.localizedDescription
+        accessibilityTraits = UIAccessibilityTraits.button
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionButton.swift
@@ -155,7 +155,7 @@ extension ReaderSortingOptionButton: Accessible {
 
         // TODO: check if accessibility is set correctly
         accessibilityIdentifier = "Reader sorting option button"
-        accessibilityLabel = NSLocalizedString("Sorting option button", comment: "Accessibility label for sorting option button")
+        accessibilityLabel = NSLocalizedString("Sorting option", comment: "Accessibility label for sorting option button")
         accessibilityValue = sortingOption.localizedDescription
         accessibilityTraits = UIAccessibilityTraits.button
     }

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
@@ -296,12 +296,3 @@ class ClosureControl: UIControl {
         return super.point(inside: point, with: event)
     }
 }
-
-extension ReaderSortingOption {
-    var buttonAccessibilityLabel: String? {
-        if let localizedDescription = localizedDescription {
-            return String(format: NSLocalizedString("Sorting option button - %1$@", comment: "Accessibility label for sorting option"), localizedDescription)
-        }
-        return nil
-    }
-}

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
@@ -69,9 +69,17 @@ class ReaderSortingActionSheetOptionControl: ClosureControl {
         isSelected = option.checked
         imageView.image = option.image
         label.text = option.title
+
+        isAccessibilityElement = true
+        checkView.isAccessibilityElement = false
+        imageView.isAccessibilityElement = false
+        label.isAccessibilityElement = false
+
         accessibilityIdentifier = option.identifier
-        accessibilityLabel = option.identifier
+        accessibilityLabel = option.sortingOption.accessibilityLabel
         accessibilityHint = option.sortingOption.accessibilityHint
+        accessibilityValue = option.sortingOption.accessibilityValue
+        accessibilityTraits = UIAccessibilityTraits.button
     }
 
     override init(frame: CGRect, minimalTappableHeight: CGFloat?, closure: @escaping () -> Void) {
@@ -154,7 +162,6 @@ class ReaderSortingOptionViewController: UIViewController {
             guard let image = option.image, let title = option.localizedDescription else {
                 return nil
             }
-            // TODO: what should be the accessibility label/identifer for the bottom sheet options?
             return ReaderSortingActionSheetOptionControl(option: ReaderSortingActionSheetOption(title: title, image: image, checked: option == self.preselectedOption, identifier: title, sortingOption: option)) {
                 self.optionSelected(option)
             }
@@ -186,6 +193,7 @@ class ReaderSortingOptionViewController: UIViewController {
 
         setupContent()
         refreshForTraits()
+        prepareForVoiceOver()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -249,6 +257,15 @@ class ReaderSortingOptionViewController: UIViewController {
     }
 }
 
+extension ReaderSortingOptionViewController: Accessible {
+    func prepareForVoiceOver() {
+        gripButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Accessibility label for the grip button which is used to dismiss the dialog.")
+
+        headerLabel.accessibilityLabel = headerLabel.text
+        headerLabel.accessibilityTraits = .header
+    }
+}
+
 class ClosureControl: UIControl {
     private let minimalTappableHeight: CGFloat?
     private let closure: () -> Void
@@ -288,5 +305,13 @@ extension ReaderSortingOption {
         case .noSorting:
             return nil
         }
+    }
+
+    var accessibilityLabel: String {
+        return NSLocalizedString("Sorting option", comment: "Accessibility label for sorting option")
+    }
+
+    var accessibilityValue: String? {
+        return localizedDescription
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sorting/ReaderSortingOptionSheetViewController.swift
@@ -76,9 +76,11 @@ class ReaderSortingActionSheetOptionControl: ClosureControl {
         label.isAccessibilityElement = false
 
         accessibilityIdentifier = option.identifier
-        accessibilityLabel = option.sortingOption.accessibilityLabel
-        accessibilityHint = option.sortingOption.accessibilityHint
-        accessibilityValue = option.sortingOption.accessibilityValue
+        accessibilityLabel = NSLocalizedString("Sorting option", comment: "Accessibility label for sorting option")
+        accessibilityValue = option.sortingOption.localizedDescription
+        if option.checked {
+            accessibilityHint = NSLocalizedString("Selected", comment: "Accessibility value for selected sorting option")
+        }
         accessibilityTraits = UIAccessibilityTraits.button
     }
 
@@ -259,7 +261,7 @@ class ReaderSortingOptionViewController: UIViewController {
 
 extension ReaderSortingOptionViewController: Accessible {
     func prepareForVoiceOver() {
-        gripButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Accessibility label for the grip button which is used to dismiss the dialog.")
+        gripButton.isAccessibilityElement = false
 
         headerLabel.accessibilityLabel = headerLabel.text
         headerLabel.accessibilityTraits = .header
@@ -296,22 +298,10 @@ class ClosureControl: UIControl {
 }
 
 extension ReaderSortingOption {
-    var accessibilityHint: String? {
-        switch self {
-        case .date:
-            return NSLocalizedString("Tap to sort by date", comment: "Accessibility hint for sorting option button.")
-        case .popularity:
-            return NSLocalizedString("Tap to sort by popularity", comment: "Accessibility hint for sorting option button.")
-        case .noSorting:
-            return nil
+    var buttonAccessibilityLabel: String? {
+        if let localizedDescription = localizedDescription {
+            return String(format: NSLocalizedString("Sorting option button - %1$@", comment: "Accessibility label for sorting option"), localizedDescription)
         }
-    }
-
-    var accessibilityLabel: String {
-        return NSLocalizedString("Sorting option", comment: "Accessibility label for sorting option")
-    }
-
-    var accessibilityValue: String? {
-        return localizedDescription
+        return nil
     }
 }


### PR DESCRIPTION
Ref [#14765](https://github.com/wordpress-mobile/WordPress-iOS/issues/14765)

To test:

Enable VoiceOver, open Reader tab, switch to Discover screen. Check if sorting option button on top of the posts is properly setup for VoiceOver. Tap the sorting option button and check if the sorting bottom sheet is properly setup for VoiceOver.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
