### PR TITLE
Fix wpios-env.default path in Fastlane error msg

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,7 +44,7 @@ before_all do |lane|
   unless lane == :test_without_building
     # Check that the env files exist
     unless is_ci || File.file?(USER_ENV_FILE_PATH)
-      UI.user_error!("~/.wpios-env.default not found: Please copy env/user.env-example to #{USER_ENV_FILE_PATH} and fill in the values")
+      UI.user_error!("~/.wpios-env.default not found: Please copy fastlane/env/user.env-example to #{USER_ENV_FILE_PATH} and fill in the values")
     end
     unless File.file?(PROJECT_ENV_FILE_PATH)
       UI.user_error!("project.env not found: Make sure your configuration is up to date with `rake dependencies`")


### PR DESCRIPTION
This tweaks a Fastlane error message to indicate that `wpios-env.default` lives in `fastlane/env/user.env-example`, not `env/user.env-example`, as it previously suggested.

To test:
You could switch to the `develop` branch, delete your `~/.wpios-env.default` file, run a Fastlane command such as `bundle exec fastlane register_new_device`, and notice the incorrect path in the error message.
Then switch to this branch, do the same steps, and notice the error message is now correct.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
