### PR TITLE
Comments: fix content spacing

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -32,6 +32,7 @@ open class CommentsTableViewCell: WPTableViewCell {
     // MARK: - Public Properties
 
     @objc static let reuseIdentifier = "CommentsTableViewCell"
+    @objc static let estimatedRowHeight = 150
 
     // MARK: - Public Methods
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -94,7 +94,8 @@ private extension CommentsTableViewCell {
 
     func configureCommentLabels() {
         titleLabel.attributedText = attributedTitle()
-        detailLabel.text = content
+        // Some Comment content has leading newlines. Let's nix that.
+        detailLabel.text = content.trimmingCharacters(in: .whitespacesAndNewlines)
         detailLabel.font = Style.detailFont
         detailLabel.textColor = Style.detailTextColor
     }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="107" id="Upg-EE-wRd" customClass="CommentsTableViewCell" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="Upg-EE-wRd" customClass="CommentsTableViewCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="107"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -26,7 +26,6 @@ static NSInteger const CommentsFetchBatchSize                   = 10;
 @property (nonatomic, strong) NoResultsViewController   *noResultsViewController;
 @property (nonatomic, strong) UIActivityIndicatorView   *footerActivityIndicator;
 @property (nonatomic, strong) UIView                    *footerView;
-@property (nonatomic, strong) NSCache                   *estimatedRowHeights;
 @end
 
 @implementation CommentsViewController
@@ -43,7 +42,6 @@ static NSInteger const CommentsFetchBatchSize                   = 10;
     if (self) {
         self.restorationClass = [self class];
         self.restorationIdentifier = NSStringFromClass([self class]);
-        self.estimatedRowHeights = [[NSCache alloc] init];
     }
     return self;
 }
@@ -166,11 +164,7 @@ static NSInteger const CommentsFetchBatchSize                   = 10;
 
 - (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    NSNumber *cachedHeight = [self.estimatedRowHeights objectForKey:indexPath];
-    if (cachedHeight.doubleValue) {
-        return cachedHeight.doubleValue;
-    }
-    return WPTableViewDefaultRowHeight;
+    return CommentsTableViewCell.estimatedRowHeight;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
@@ -192,8 +186,6 @@ static NSInteger const CommentsFetchBatchSize                   = 10;
 
 - (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    [self.estimatedRowHeights setObject:@(cell.frame.size.height) forKey:indexPath];
-
     // Refresh only when we reach the last 3 rows in the last section
     NSInteger numberOfRowsInSection     = [self.tableViewHandler tableView:tableView numberOfRowsInSection:indexPath.section];
     NSInteger lastSection               = [self.tableViewHandler numberOfSectionsInTableView:tableView] - 1;


### PR DESCRIPTION
Ref: #15909 

This fixes an issue where there appeared to be extra space around the Comment content (as noted on https://github.com/wordpress-mobile/WordPress-iOS/pull/15923). The problem is that some content has leading newlines. You can see this in the existing Comments, it's just not very obvious:

| <img width="473" alt="Screen Shot 2021-02-19 at 3 16 35 PM" src="https://user-images.githubusercontent.com/1816888/108568414-48c72080-72c7-11eb-994b-cd5de77a5592.png"> | <img width="471" alt="Screen Shot 2021-02-19 at 3 16 53 PM" src="https://user-images.githubusercontent.com/1816888/108568430-4ebd0180-72c7-11eb-872b-551c9fb64c65.png"> |
|--------|-------|

The newlines are now trimmed, allowing the content to be displayed correctly.

| Before | After |
|--------|-------|
| <img width="469" alt="Screen Shot 2021-02-19 at 3 23 48 PM" src="https://user-images.githubusercontent.com/1816888/108568624-a5c2d680-72c7-11eb-93d5-c3c6fac055c9.png"> | <img width="473" alt="Screen Shot 2021-02-19 at 3 25 43 PM" src="https://user-images.githubusercontent.com/1816888/108568646-af4c3e80-72c7-11eb-8093-f4e604711cb2.png"> |

To test:
- Go to Site > Comments.
- Verify there is not extra space above the Comment content.
- This seems to only happen on P2s (both old and new). My personal sites didn't have this issue. 🤷 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
