### PR TITLE
Enable Stories feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [*] Quick Start: Completing a step outside of a tour now automatically marks it as complete. [#15712]
 * [internal] Site Comments: updated UI. Should be no functional changes. [#15944]
 * [***] iOS 14 Widgets: new This Week Widgets to display This Week Stats in your home screen. [#15844]
+* [***] Stories: There is now a new Story post type available to quickly and conveniently post images and videos to your blog.
 
 16.7
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -46,7 +46,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .unifiedPrologueCarousel:
             return false
         case .stories:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .siteCreationHomePagePicker:
             return true
         case .jetpackScan:


### PR DESCRIPTION
Enables the feature flag for Stories.

### Testing
* Run the app in a non-Debug configuration
* Press the FAB and verify that the "Story post" option shows up in the list

https://user-images.githubusercontent.com/3250/108747729-0554f800-74fb-11eb-9fac-a870ac848ea2.mp4

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
