### PR TITLE
Add semibold style for site names in notification subjects

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SubjectContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SubjectContentStyles.swift
@@ -13,6 +13,7 @@ class SubjectContentStyles: FormattableContentStyles {
         return [
             .user: WPStyleGuide.Notifications.subjectSemiBoldStyle,
             .post: WPStyleGuide.Notifications.subjectSemiBoldStyle,
+            .site: WPStyleGuide.Notifications.subjectSemiBoldStyle,
             .comment: WPStyleGuide.Notifications.subjectSemiBoldStyle,
             .blockquote: WPStyleGuide.Notifications.subjectQuotedStyle,
             .noticon: WPStyleGuide.Notifications.subjectNoticonStyle


### PR DESCRIPTION
This PR adds a semibold style to site names in notification subjects, which is present on the web but was missing in the app.

| **Before**  | **After** |
|:-:|:-:|
| ![IMG_0020](https://user-images.githubusercontent.com/4780/108767347-3e6a8800-754e-11eb-8689-8ef1086d93ba.PNG)  | ![IMG_0022](https://user-images.githubusercontent.com/4780/108767343-3dd1f180-754e-11eb-8002-480b9eb2390f.PNG) |
| ![IMG_0019](https://user-images.githubusercontent.com/4780/108767349-3f031e80-754e-11eb-95a1-fec876bddb03.PNG)  |  ![IMG_0021](https://user-images.githubusercontent.com/4780/108767344-3e6a8800-754e-11eb-8b98-dde7ffe07776.PNG) |

**To test**

- Build and run
- View a notification in your notifications list that contains a site title, like an achievement as shown above.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
