### PR TITLE
Update WordPressAuthenticator pod to fix prologue tracking issue

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -198,9 +198,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-    # pod 'WordPressAuthenticator', '~> 1.35.1'
+    pod 'WordPressAuthenticator', '~> 1.35.2'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/prologue-tracking'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/prologue-tracking'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -198,9 +198,9 @@ target 'WordPress' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-    pod 'WordPressAuthenticator', '~> 1.35.1'
+    # pod 'WordPressAuthenticator', '~> 1.35.1'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/prologue-tracking'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -503,7 +503,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (~> 1.35.1)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/prologue-tracking`)
   - WordPressKit (~> 4.26)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.15.0)
@@ -552,7 +552,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -654,6 +653,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.46.2
+  WordPressAuthenticator:
+    :branch: fix/prologue-tracking
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.46.2/third-party-podspecs/Yoga.podspec.json
 
@@ -669,6 +671,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.46.2
+  WordPressAuthenticator:
+    :commit: a5456ffdc792fb513886ef098609ee6cc374cc6a
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -765,6 +770,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: 9c929e3cd3129fbdcb94b8b510b1d4e98f8fbc37
+PODFILE CHECKSUM: b0b365704af0d220038b1c27dd037353c633923c
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -394,7 +394,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.3)
   - WordPress-Editor-iOS (1.19.3):
     - WordPress-Aztec-iOS (= 1.19.3)
-  - WordPressAuthenticator (1.35.1):
+  - WordPressAuthenticator (1.35.2):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -503,7 +503,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.3)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/prologue-tracking`)
+  - WordPressAuthenticator (~> 1.35.2)
   - WordPressKit (~> 4.26)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.15.0)
@@ -552,6 +552,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -653,9 +654,6 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.46.2
-  WordPressAuthenticator:
-    :branch: fix/prologue-tracking
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.46.2/third-party-podspecs/Yoga.podspec.json
 
@@ -671,9 +669,6 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.46.2
-  WordPressAuthenticator:
-    :commit: a5456ffdc792fb513886ef098609ee6cc374cc6a
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -753,7 +748,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: b7ac8b30f746992e85d9668453ac87c2cdcecf4f
   WordPress-Editor-iOS: 1886f7fe464d79ee64ccfe7985281f8cf45f75eb
-  WordPressAuthenticator: 7b7555d43273231e968f1f890166fc3aac72b2a3
+  WordPressAuthenticator: 73887798e340abe3cf021163644e59ca5388affb
   WordPressKit: 63932c352c4199179f15855f68543e4541ec9da0
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 2d2b45d8945221b716a0e2f23932dadb750d9a74
@@ -770,6 +765,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: b1f0de4eed33e74a676f76e12559ab6b75990197
 
-PODFILE CHECKSUM: b0b365704af0d220038b1c27dd037353c633923c
+PODFILE CHECKSUM: 918124db1450ff9205be2fc2d002ab225aedfa33
 
 COCOAPODS: 1.10.0

--- a/fastlane/Deliverfile
+++ b/fastlane/Deliverfile
@@ -12,5 +12,5 @@ overwrite_screenshots true
 phased_release true
 precheck_include_in_app_purchases false
 
-api_key_path "../.configure-files/app_store_connect_fastlane_api_key.json"
+api_key_path ".configure-files/app_store_connect_fastlane_api_key.json"
 


### PR DESCRIPTION
This PR updates the version of WordPressAuthenticator to fix an issue introduced when we switched to displaying the authenticator as the window's root view controller instead of modally. That change meant that the previous check for `isBeingPresentedInAnyWay` always returned false, so we didn't track the prologue step.

The WordPressAuthenticator update reverts to the previous method of tracking whether this is the first time the view controller has appeared, using a simple property.

**To test**

- Add breakpoints to lines 102 and 105 in `LoginPrologueViewController.swift`

<img width="492" alt="image" src="https://user-images.githubusercontent.com/4780/108998221-7e3d8680-7698-11eb-8da0-ab7f061d5596.png">

- Build and run.
- If you're already logged out, ensure that the breakpoint on line 102 is hit. Otherwise, log out and ensure the same.
- Tap one of the buttons on the prologue screen, and then tap Back to return to the prologue screen.
- Ensure that the other breakpoint is hit.
- You should only see one console log for the prologue unified_login_step tracking:

```
🔵 Tracked: unified_login_step <flow: prologue, source: default, step: prologue>
```

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
