### PR TITLE
Stories: Add missing analytics events + Enable Story Block

### DIFF
--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -136,7 +136,7 @@ class StoryEditor: CameraController {
         super.init(settings: settings,
                  mediaPicker: WPMediaPickerForKanvas.self,
                  stickerProvider: nil,
-                 analyticsProvider: KanvasAnalyticsHandler(editorAnalyticsSession: analyticsSession),
+                 analyticsProvider: KanvasAnalyticsHandler(),
                  quickBlogSelectorCoordinator: nil,
                  tagCollection: nil,
                  saveDirectory: saveDirectory)
@@ -198,6 +198,10 @@ class StoryEditor: CameraController {
                 completion(.success(()))
             }
         }
+    }
+
+    func trackOpen() {
+        editorSession.start()
     }
 }
 

--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -8,9 +8,7 @@ class StoryEditor: CameraController {
 
     var onClose: ((Bool, Bool) -> Void)? = nil
 
-    lazy var editorSession: PostEditorAnalyticsSession = {
-        PostEditorAnalyticsSession(editor: .stories, post: post)
-    }()
+    var editorSession: PostEditorAnalyticsSession
 
     let navigationBarManager: PostEditorNavigationBarManager? = nil
 
@@ -132,10 +130,13 @@ class StoryEditor: CameraController {
             cameraPermissionsDescriptionLabel: NSLocalizedString("Allow access so you can start taking photos and videos.", comment: "Message on camera permissions screen to explain why the app needs camera and microphone permissions")
         )
 
+        let analyticsSession = PostEditorAnalyticsSession(editor: .stories, post: post)
+        self.editorSession = analyticsSession
+
         super.init(settings: settings,
                  mediaPicker: WPMediaPickerForKanvas.self,
                  stickerProvider: nil,
-                 analyticsProvider: KanvasAnalyticsHandler(),
+                 analyticsProvider: KanvasAnalyticsHandler(editorAnalyticsSession: analyticsSession),
                  quickBlogSelectorCoordinator: nil,
                  tagCollection: nil,
                  saveDirectory: saveDirectory)

--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -23,7 +23,7 @@ class StoryEditor: CameraController {
     var verificationPromptHelper: VerificationPromptHelper? = nil
 
     var analyticsEditorSource: String {
-        return "wp_stories_creator"
+        return "stories"
     }
 
     private var cameraHandler: CameraHandler?

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -4,6 +4,7 @@ import Foundation
 @objc enum WPAnalyticsEvent: Int {
 
     case createSheetShown
+    case createSheetActionTapped
     case createAnnouncementModalShown
 
     // Media Editor
@@ -86,10 +87,12 @@ import Foundation
     // What's New - Feature announcements
     case featureAnnouncementShown
     case featureAnnouncementButtonTapped
+
     // Stories
     case storyIntroShown
     case storyIntroDismissed
     case storyIntroCreateStoryButtonTapped
+    case storyAddedMedia
 
     // Jetpack
     case jetpackSettingsViewed
@@ -150,6 +153,8 @@ import Foundation
         switch self {
         case .createSheetShown:
             return "create_sheet_shown"
+        case .createSheetActionTapped:
+            return "create_sheet_action_tapped"
         case .createAnnouncementModalShown:
             return "create_announcement_modal_shown"
         // Media Editor
@@ -297,6 +302,8 @@ import Foundation
             return "story_intro_dismissed"
         case .storyIntroCreateStoryButtonTapped:
             return "story_intro_create_story_button_tapped"
+        case .storyAddedMedia:
+            return "story_added_media"
 
         // Jetpack
         case .jetpackSettingsViewed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -93,6 +93,7 @@ import Foundation
     case storyIntroDismissed
     case storyIntroCreateStoryButtonTapped
     case storyAddedMedia
+    case storyBlockAddMediaTapped
 
     // Jetpack
     case jetpackSettingsViewed
@@ -304,6 +305,8 @@ import Foundation
             return "story_intro_create_story_button_tapped"
         case .storyAddedMedia:
             return "story_added_media"
+        case .storyBlockAddMediaTapped:
+            return "story_block_add_media_tapped"
 
         // Jetpack
         case .jetpackSettingsViewed:

--- a/WordPress/Classes/Utility/Kanvas/KanvasCameraAnalyticsHandler.swift
+++ b/WordPress/Classes/Utility/Kanvas/KanvasCameraAnalyticsHandler.swift
@@ -4,12 +4,6 @@ import Kanvas
 
 final public class KanvasAnalyticsHandler: NSObject, KanvasAnalyticsProvider {
 
-    var editorAnalyticsSession: PostEditorAnalyticsSession
-
-    init(editorAnalyticsSession: PostEditorAnalyticsSession) {
-        self.editorAnalyticsSession = editorAnalyticsSession
-    }
-
     public func logCameraOpen(mode: CameraMode) {
         logString(string: "logCameraOpen mode:\(modeStringValue(mode))")
     }
@@ -95,9 +89,7 @@ final public class KanvasAnalyticsHandler: NSObject, KanvasAnalyticsProvider {
     }
 
     public func logEditorOpen() {
-        if editorAnalyticsSession.started == false {
-            editorAnalyticsSession.start()
-        }
+        logString(string: "logEditorOpen")
     }
 
     public func logEditorBack() {

--- a/WordPress/Classes/Utility/Kanvas/KanvasCameraAnalyticsHandler.swift
+++ b/WordPress/Classes/Utility/Kanvas/KanvasCameraAnalyticsHandler.swift
@@ -4,6 +4,12 @@ import Kanvas
 
 final public class KanvasAnalyticsHandler: NSObject, KanvasAnalyticsProvider {
 
+    var editorAnalyticsSession: PostEditorAnalyticsSession
+
+    init(editorAnalyticsSession: PostEditorAnalyticsSession) {
+        self.editorAnalyticsSession = editorAnalyticsSession
+    }
+
     public func logCameraOpen(mode: CameraMode) {
         logString(string: "logCameraOpen mode:\(modeStringValue(mode))")
     }
@@ -89,7 +95,9 @@ final public class KanvasAnalyticsHandler: NSObject, KanvasAnalyticsProvider {
     }
 
     public func logEditorOpen() {
-        logString(string: "logEditorOpen")
+        if editorAnalyticsSession.started == false {
+            editorAnalyticsSession.start()
+        }
     }
 
     public func logEditorBack() {
@@ -97,9 +105,8 @@ final public class KanvasAnalyticsHandler: NSObject, KanvasAnalyticsProvider {
     }
 
     public func logMediaPickerPickedMedia(ofTypes mediaTypes: [KanvasMediaType]) {
-        mediaTypes.forEach({ mediaType in
-            logString(string: "logMediaPickerPickedMedia mediaType:\(mediaType.string())")
-        })
+        let typeStrings = mediaTypes.map { $0.string() }
+        WPAnalytics.track(.storyAddedMedia, properties: ["mediaTypes": typeStrings.joined(separator: ",")])
     }
 
     public func logEditorFiltersOpen() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
@@ -24,11 +24,13 @@ extension BlogDetailsViewController {
             controller?.showStoryEditor(forBlog: blog)
         }
 
-        var actions: [ActionSheetItem] = [PostAction(handler: newPost), PageAction(handler: newPage)]
+        let source = "my_site"
+
+        var actions: [ActionSheetItem] = [PostAction(handler: newPost, source: source), PageAction(handler: newPage, source: source)]
         if shouldShowNewStory {
-            actions.append(StoryAction(handler: newStory))
+            actions.append(StoryAction(handler: newStory, source: source))
         }
-        let coordinator = CreateButtonCoordinator(self, actions: actions)
+        let coordinator = CreateButtonCoordinator(self, actions: actions, source: source)
         return coordinator
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1047,7 +1047,8 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
             .xposts: FeatureFlag.gutenbergXposts.enabled && SiteSuggestionService.shared.shouldShowSuggestions(for: post.blog),
             .unsupportedBlockEditor: isUnsupportedBlockEditorEnabled,
             .canEnableUnsupportedBlockEditor: post.blog.jetpack?.isConnected ?? false,
-            .audioBlock: !isFreeWPCom // Disable audio block until it's usable on free sites via "Insert from URL" capability
+            .audioBlock: !isFreeWPCom, // Disable audio block until it's usable on free sites via "Insert from URL" capability
+            .mediaFilesCollectionBlock: FeatureFlag.stories.enabled && post.blog.supports(.stories)
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -659,6 +659,10 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 
     func gutenbergDidRequestMediaFilesEditorLoad(_ mediaFiles: [[String: Any]], blockId: String) {
 
+        if mediaFiles.isEmpty {
+            WPAnalytics.track(.storyBlockAddMediaTapped)
+        }
+
         let files = mediaFiles.compactMap({ content -> MediaFile? in
             return MediaFile.file(from: content)
         })
@@ -690,6 +694,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             }
         })
 
+        controller.trackOpen()
         controller.populate(with: files, completion: { [weak self] result in
             switch result {
             case .success:

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -21,6 +21,11 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             static let restorePageCellNibName = "RestorePageTableViewCell"
             static let currentPageListStatusFilterKey = "CurrentPageListStatusFilterKey"
         }
+
+        struct Events {
+            static let source = "page_list"
+            static let pagePostType = "page"
+        }
     }
 
     fileprivate lazy var sectionFooterSeparatorView: UIView = {
@@ -51,9 +56,10 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }()
 
     private lazy var createButtonCoordinator: CreateButtonCoordinator = {
-        return CreateButtonCoordinator(self, actions: [PageAction(handler: { [weak self] in
+        let action = PageAction(handler: { [weak self] in
             self?.createPost()
-        })])
+        }, source: Constant.Events.source)
+        return CreateButtonCoordinator(self, actions: [action], source: Constant.Events.source)
     }()
 
     // MARK: - GUI
@@ -494,7 +500,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     // MARK: - Post Actions
 
     override func createPost() {
-        WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: "posts_view", WPAppAnalyticsKeyPostType: "page"], with: blog)
+        WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: Constant.Events.source, WPAppAnalyticsKeyPostType: Constant.Events.pagePostType], with: blog)
 
         PageCoordinator.showLayoutPickerIfNeeded(from: self, forBlog: blog) { [weak self] (selectedLayout) in
             self?.createPage(selectedLayout)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -168,7 +168,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             PostAction(handler: { [weak self] in
                     self?.dismiss(animated: false, completion: nil)
                     self?.createPost()
-            })
+            }, source: Constants.source)
         ]
         if Feature.enabled(.stories) && blog.supports(.stories) {
             actions.append(
@@ -176,11 +176,11 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
                     guard let self = self else {
                         return
                     }
-                    (self.tabBarController as? WPTabBarController)?.showStoryEditor(blog: self.blog, title: nil, content: nil, source: "post_list")
-                })
+                    (self.tabBarController as? WPTabBarController)?.showStoryEditor(blog: self.blog, title: nil, content: nil)
+                }, source: Constants.source)
             )
         }
-        return CreateButtonCoordinator(self, actions: actions)
+        return CreateButtonCoordinator(self, actions: actions, source: Constants.source)
     }()
 
     override func viewDidAppear(_ animated: Bool) {
@@ -797,6 +797,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         static let searchHeaderHeight: CGFloat = 40
         static let card = "card"
         static let compact = "compact"
+        static let source = "post_list"
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -58,6 +58,7 @@ import WordPressFlux
 
     private weak var noticeContainerView: NoticeContainerView?
     private let actions: [ActionSheetItem]
+    private let source: String
 
     /// Returns a newly initialized CreateButtonCoordinator
     /// - Parameters:
@@ -65,9 +66,10 @@ import WordPressFlux
     ///   - newPost: A closure to call when the New Post button is tapped.
     ///   - newPage: A closure to call when the New Page button is tapped.
     ///   - newStory: A closure to call when the New Story button is tapped. The New Story button is hidden when value is `nil`.
-    init(_ viewController: UIViewController, actions: [ActionSheetItem]) {
+    init(_ viewController: UIViewController, actions: [ActionSheetItem], source: String) {
         self.viewController = viewController
         self.actions = actions
+        self.source = source
 
         super.init()
 
@@ -127,7 +129,7 @@ import WordPressFlux
         } else {
             let actionSheetVC = actionSheetController(with: viewController.traitCollection)
             viewController.present(actionSheetVC, animated: true, completion: { [weak self] in
-                WPAnalytics.track(.createSheetShown)
+                WPAnalytics.track(.createSheetShown, properties: ["source": self?.source ?? ""])
 
                 if let element = self?.currentTourElement {
                     QuickStartTourGuide.shared.visited(element)

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
@@ -2,6 +2,9 @@
 
 struct PostAction: ActionSheetItem {
     let handler: () -> Void
+    let source: String
+
+    private let action = "create_new_post"
 
     func makeButton() -> ActionSheetButton {
         let highlight: Bool = QuickStartTourGuide.shared.shouldSpotlight(.newpost)
@@ -9,12 +12,18 @@ struct PostAction: ActionSheetItem {
                                  image: .gridicon(.posts),
                                  identifier: "blogPostButton",
                                  highlight: highlight,
-                                 action: handler)
+                                 action: {
+                                    WPAnalytics.track(.createSheetActionTapped, properties: ["source": source, "action": action])
+                                    handler()
+                                 })
     }
 }
 
 struct PageAction: ActionSheetItem {
     let handler: () -> Void
+    let source: String
+
+    private let action = "create_new_page"
 
     func makeButton() -> ActionSheetButton {
         let highlight: Bool = QuickStartTourGuide.shared.shouldSpotlight(.newPage)
@@ -22,7 +31,10 @@ struct PageAction: ActionSheetItem {
                                             image: .gridicon(.pages),
                                             identifier: "sitePageButton",
                                             highlight: highlight,
-                                            action: handler)
+                                            action: {
+                                                WPAnalytics.track(.createSheetActionTapped, properties: ["source": source, "action": action])
+                                                handler()
+                                            })
     }
 }
 
@@ -38,13 +50,20 @@ struct StoryAction: ActionSheetItem {
     }
 
     let handler: () -> Void
+    let source: String
+
+    private let action = "create_new_story"
+
     func makeButton() -> ActionSheetButton {
         let badge = StoryAction.newBadge(title: NSLocalizedString("New", comment: "New button badge on Stories Post button"))
         return ActionSheetButton(title: NSLocalizedString("Story post", comment: "Create new Story button title"),
                                             image: .gridicon(.story),
                                             identifier: "storyButton",
                                             badge: badge,
-                                            action: handler)
+                                            action: {
+                                                WPAnalytics.track(.createSheetActionTapped, properties: ["source": source, "action": action])
+                                                handler()
+                                            })
     }
 
     static func newBadge(title: String) -> UIButton {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -67,7 +67,7 @@ extension WPTabBarController {
             guard let blog = inBlog ?? self.currentOrLastBlog() else { return }
             let blogID = blog.dotComID?.intValue ?? 0 as Any
 
-            WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: source, WPAppAnalyticsKeyBlogID: blogID, WPAppAnalyticsKeyPostType: "story"])
+            WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: source, WPAppAnalyticsKeyBlogID: blogID, WPAppAnalyticsKeyEditorSource: "stories", WPAppAnalyticsKeyPostType: "post"])
 
             let controller = StoryEditor.editor(blog: blog, context: ContextManager.shared.mainContext, updated: {_ in }, uploaded: { [weak self] result in
                 switch result {


### PR DESCRIPTION
* Adds several missing analytics events which are necessary for stories reporting.
* Enables the story block in the Gutenberg editor.

## Testing

### Story block
1. Log in to a WordPress.com site or site with Jetpack >= 9.1
2. Create a new blog post
3. Tap to add a new block
4. Verify that the Story block appears from the list

### Analytics
1. Open the Stories editor and confirm that the following events are tracked on open:

```
editor_post_created {... editor_source: stories...}
```

2. Verify the following events when publishing a new story:

```
editor_post_publish_tapped
editor_post_publish_dismissed
editor_post_published {"editor_source":"wp_stories_creator" ... "has_wp_stories_blocks":true}
```

3. Open an existing story post and edit a story block and confirm that the following event is tracked:

```
editor_session_start {... editor: stories ...}
```

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
