### PR TITLE
Notifications: Render bold content in badge notification titles

### DIFF
--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
@@ -85,4 +85,5 @@ extension FormattableRangeKind {
     public static let link       = FormattableRangeKind("link")
     public static let italic     = FormattableRangeKind("i")
     public static let scan       = FormattableRangeKind("scan")
+    public static let strong     = FormattableRangeKind("b")
 }

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/BadgeContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/BadgeContentStyles.swift
@@ -32,7 +32,8 @@ class BadgeContentStyles: FormattableContentStyles {
                 .post: WPStyleGuide.Notifications.badgeTitleItalicsStyle,
                 .comment: WPStyleGuide.Notifications.badgeTitleItalicsStyle,
                 .blockquote: WPStyleGuide.Notifications.badgeTitleQuotedStyle,
-                .site: WPStyleGuide.Notifications.badgeTitleBoldStyle
+                .site: WPStyleGuide.Notifications.badgeTitleBoldStyle,
+                .strong: WPStyleGuide.Notifications.badgeTitleBoldStyle
             ]
         }
 


### PR DESCRIPTION
This PR is a small tweak to render the site name in the 'title' section of a badge notification as bold text rather than a link.

| Before  |  After |
|:-:|:-:|
|  ![IMG_0036](https://user-images.githubusercontent.com/4780/109177779-1498a780-7780-11eb-820e-8425987172d8.PNG) |  ![IMG_0046](https://user-images.githubusercontent.com/4780/109177774-12364d80-7780-11eb-942f-105c6e0905e1.PNG) |

The latest version of the notification diff changes the notification to use a `<strong>` tag for the site name rather than a link, and this PR adds support for rendering strong tags.

**To test:**

- Ensure you're running the latest diff on your sandbox
- Enable the milestone notifications feature flag and build and run this PR
- Send yourself a new notification
- Ensure that the site name in the notification detail is rendered bold

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
