### PR TITLE
Reader Improvements: Update the suggested topics design

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -32,7 +32,8 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         ReaderWelcomeBanner.displayIfNeeded(in: tableView)
-        tableView.register(ReaderTopicsCardCell.self, forCellReuseIdentifier: readerCardTopicsIdentifier)
+
+        tableView.register(ReaderTopicsCardCell.defaultNib, forCellReuseIdentifier: readerCardTopicsIdentifier)
         tableView.register(ReaderSitesCardCell.self, forCellReuseIdentifier: readerCardSitesIdentifier)
 
         addObservers()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -2,36 +2,126 @@ import UIKit
 
 /// A cell that displays topics the user might like
 ///
-class ReaderTopicsCardCell: ReaderTopicsTableCardCell {
-    private let cellIdentifier = "TopicCell"
+class ReaderTopicsCardCell: UITableViewCell, NibLoadable {
+    // Views
+    @IBOutlet weak var containerView: UIView!
+    @IBOutlet weak var headerLabel: UILabel!
+    @IBOutlet weak var collectionView: UICollectionView!
 
-    override func configure(_ data: [ReaderAbstractTopic]) {
-        super.configure(data)
+    private(set) var data: [ReaderAbstractTopic] = [] {
+        didSet {
+            guard oldValue != data else {
+                return
+            }
 
-        headerTitle = Constants.title
+            collectionView.reloadData()
+        }
     }
 
-    override func setupTableView() {
-        super.setupTableView()
+    weak var delegate: ReaderTopicsTableCardCellDelegate?
 
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: cellIdentifier)
+    func configure(_ data: [ReaderAbstractTopic]) {
+        self.data = data
     }
 
-    override func cell(forRowAt indexPath: IndexPath, tableView: UITableView, topic: ReaderAbstractTopic?) -> UITableViewCell {
-        guard let tagTopic = topic as? ReaderTagTopic else {
-            return UITableViewCell()
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        applyStyles()
+
+        // Configure header
+        headerLabel.text = Constants.title
+
+        // Configure collection view
+        collectionView.showsHorizontalScrollIndicator = false
+        collectionView.register(ReaderInterestsCollectionViewCell.defaultNib,
+                                forCellWithReuseIdentifier: Constants.reuseIdentifier)
+    }
+
+    private func applyStyles() {
+        headerLabel.font = WPStyleGuide.serifFontForTextStyle(.title2)
+
+        containerView.backgroundColor = .listForeground
+        headerLabel.backgroundColor = .listForeground
+        collectionView.backgroundColor = .listForeground
+
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
+    }
+
+    private struct Constants {
+        static let title = NSLocalizedString("You might like", comment: "A suggestion of topics the user might like")
+
+        static let reuseIdentifier = ReaderInterestsCollectionViewCell.classNameWithoutNamespaces()
+    }
+}
+
+// MARK: - Collection View: Datasource & Delegate
+extension ReaderTopicsCardCell: UICollectionViewDelegate, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.reuseIdentifier,
+                                                            for: indexPath) as? ReaderInterestsCollectionViewCell else {
+            fatalError("Expected a ReaderInterestsCollectionViewCell for identifier: \(Constants.reuseIdentifier)")
         }
 
-        let cell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath as IndexPath)
-        cell.textLabel?.text = tagTopic.title
-        cell.accessoryType = .disclosureIndicator
-        cell.separatorInset = UIEdgeInsets.zero
-        cell.backgroundColor = .clear
+        let title = data[indexPath.row].title
+
+        ReaderSuggestedTopicsStyleGuide.applySuggestedTopicStyle(label: cell.label,
+                                                                 with: indexPath.row)
+
+        cell.label.text = title
+        cell.label.accessibilityTraits = .button
+
+        // We need to use the calculated size for the height / corner radius because the cell size doesn't change until later
+        let size = sizeForCell(title: title)
+        cell.label.layer.cornerRadius = size.height * 0.5
 
         return cell
     }
 
-    private enum Constants {
-        static let title = NSLocalizedString("You might like", comment: "A suggestion of topics the user might like")
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return data.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let topic = data[indexPath.row]
+
+        delegate?.didSelect(topic: topic)
+    }
+}
+
+// MARK: - Collection View: Flow Layout Delegate
+extension ReaderTopicsCardCell: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return sizeForCell(title: data[indexPath.row].title)
+    }
+
+    // Calculates the dynamic size of the collection view cell based on the provided title
+    private func sizeForCell(title: String) -> CGSize {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: ReaderSuggestedTopicsStyleGuide.topicFont
+        ]
+
+        let title: NSString = title as NSString
+
+        var size = title.size(withAttributes: attributes)
+        size.height += (CellConstants.marginY * 2)
+
+        // Prevent 1 token from being too long
+        let maxWidth = collectionView.bounds.width * CellConstants.maxWidthMultiplier
+        let width = min(size.width, maxWidth)
+        size.width = width + (CellConstants.marginX * 2)
+
+        return size
+    }
+
+    private struct CellConstants {
+        static let maxWidthMultiplier: CGFloat = 0.8
+        static let marginX: CGFloat = 16
+        static let marginY: CGFloat = 8
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -79,6 +79,14 @@ extension ReaderTopicsCardCell: UICollectionViewDelegate, UICollectionViewDataSo
         return cell
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            collectionView.reloadData()
+        }
+    }
+
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 1
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.swift
@@ -35,7 +35,7 @@ class ReaderTopicsCardCell: UITableViewCell, NibLoadable {
         // Configure collection view
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.register(ReaderInterestsCollectionViewCell.defaultNib,
-                                forCellWithReuseIdentifier: Constants.reuseIdentifier)
+                                forCellWithReuseIdentifier: ReaderInterestsCollectionViewCell.defaultReuseID)
     }
 
     private func applyStyles() {
@@ -52,7 +52,7 @@ class ReaderTopicsCardCell: UITableViewCell, NibLoadable {
     private struct Constants {
         static let title = NSLocalizedString("You might like", comment: "A suggestion of topics the user might like")
 
-        static let reuseIdentifier = ReaderInterestsCollectionViewCell.classNameWithoutNamespaces()
+        static let reuseIdentifier = ReaderInterestsCollectionViewCell.defaultReuseID
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTopicsCardCell.xib
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="Jkk-B5-Y8k" customClass="ReaderTopicsCardCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="98"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Jkk-B5-Y8k" id="BFp-m3-dFd">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="98"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AgX-9a-n5G">
+                        <rect key="frame" x="0.0" y="8" width="414" height="90"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Y8a-D5-VDq">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="90"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Header Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KG8-hu-VFJ">
+                                        <rect key="frame" x="15" y="8" width="384" height="12.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" verticalHuggingPriority="251" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="dmG-5a-GZN">
+                                        <rect key="frame" x="15" y="28.5" width="384" height="53.5"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="gaT-G0-s53"/>
+                                        </constraints>
+                                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="HUe-Kb-sHp">
+                                            <size key="itemSize" width="128" height="128"/>
+                                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        </collectionViewFlowLayout>
+                                        <connections>
+                                            <outlet property="dataSource" destination="Jkk-B5-Y8k" id="8vb-sX-kb4"/>
+                                            <outlet property="delegate" destination="Jkk-B5-Y8k" id="6aG-MN-tfd"/>
+                                        </connections>
+                                    </collectionView>
+                                </subviews>
+                                <edgeInsets key="layoutMargins" top="8" left="15" bottom="8" right="15"/>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Y8a-D5-VDq" firstAttribute="leading" secondItem="AgX-9a-n5G" secondAttribute="leading" id="UAK-CR-5U5"/>
+                            <constraint firstAttribute="bottom" secondItem="Y8a-D5-VDq" secondAttribute="bottom" id="dx8-hA-x9H"/>
+                            <constraint firstItem="Y8a-D5-VDq" firstAttribute="top" secondItem="AgX-9a-n5G" secondAttribute="top" id="iQh-qh-FoJ"/>
+                            <constraint firstAttribute="trailing" secondItem="Y8a-D5-VDq" secondAttribute="trailing" id="nQB-jH-R6t"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="AgX-9a-n5G" firstAttribute="leading" secondItem="BFp-m3-dFd" secondAttribute="leading" id="SK3-9X-l1a"/>
+                    <constraint firstAttribute="trailing" secondItem="AgX-9a-n5G" secondAttribute="trailing" id="VR2-IL-NSL"/>
+                    <constraint firstItem="AgX-9a-n5G" firstAttribute="top" secondItem="BFp-m3-dFd" secondAttribute="top" constant="8" id="bxb-LY-Hcf"/>
+                    <constraint firstAttribute="bottom" secondItem="AgX-9a-n5G" secondAttribute="bottom" id="kSi-Q7-LGj"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="collectionView" destination="dmG-5a-GZN" id="hwa-c5-qM7"/>
+                <outlet property="containerView" destination="AgX-9a-n5G" id="u5R-Xf-Xx2"/>
+                <outlet property="headerLabel" destination="KG8-hu-VFJ" id="gch-dc-hVr"/>
+            </connections>
+            <point key="canvasLocation" x="-684" y="-173"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class ReaderInterestsCollectionViewCell: UICollectionViewCell, NibLoadable {
+class ReaderInterestsCollectionViewCell: UICollectionViewCell, NibReusable {
     @IBOutlet weak var label: UILabel!
 
     override func awakeFromNib() {

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsCollectionViewCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class ReaderInterestsCollectionViewCell: UICollectionViewCell {
+class ReaderInterestsCollectionViewCell: UICollectionViewCell, NibLoadable {
     @IBOutlet weak var label: UILabel!
 
     override func awakeFromNib() {

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -77,7 +77,7 @@ class ReaderSuggestedTopicsStyleGuide {
               backgroundColor: .init(colorName: .green, section: .background),
               borderColor: .init(colorName: .green, section: .border)),
 
-        // Blue
+        // Purple
         .init(textColor: .init(colorName: .purple, section: .text),
               backgroundColor: .init(colorName: .purple, section: .background),
               borderColor: .init(colorName: .purple, section: .border)),

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -68,35 +68,30 @@ class ReaderInterestsStyleGuide {
 }
 
 class ReaderSuggestedTopicsStyleGuide {
-    struct TopicStyle {
-        let textColor: UIColor
-        let backgroundColor: UIColor
-        let borderColor: UIColor
-    }
-
     /// The array of colors from the designs
     /// Note: I am explictly using the MurielColor names instead of using the semantic ones
     ///       since these are explicit and not semantic colors.
     static let colors: [TopicStyle] = [
         // Green
-        .init(textColor: .muriel(color: MurielColor(name: .green), .shade50),
-              backgroundColor: .muriel(color: MurielColor(name: .green), .shade0),
-              borderColor: .muriel(color: MurielColor(name: .green), .shade5)),
+        .init(textColor: .init(colorName: .green, section: .text),
+              backgroundColor: .init(colorName: .green, section: .background),
+              borderColor: .init(colorName: .green, section: .border)),
 
         // Blue
-        .init(textColor: .muriel(color: MurielColor(name: .blue), .shade50),
-              backgroundColor: .muriel(color: MurielColor(name: .blue), .shade0),
-              borderColor: .muriel(color: MurielColor(name: .blue), .shade5)),
+        .init(textColor: .init(colorName: .purple, section: .text),
+              backgroundColor: .init(colorName: .purple, section: .background),
+              borderColor: .init(colorName: .purple, section: .border)),
+
 
         // Yellow
-        .init(textColor: .muriel(color: MurielColor(name: .yellow), .shade50),
-              backgroundColor: .muriel(color: MurielColor(name: .yellow), .shade0),
-              borderColor: .muriel(color: MurielColor(name: .yellow), .shade5)),
+        .init(textColor: .init(colorName: .yellow, section: .text),
+              backgroundColor: .init(colorName: .yellow, section: .background),
+              borderColor: .init(colorName: .yellow, section: .border)),
 
         // Orange
-        .init(textColor: .muriel(color: MurielColor(name: .orange), .shade50),
-              backgroundColor: .muriel(color: MurielColor(name: .orange), .shade0),
-              borderColor: .muriel(color: MurielColor(name: .orange), .shade5)),
+        .init(textColor: .init(colorName: .orange, section: .text),
+              backgroundColor: .init(colorName: .orange, section: .background),
+              borderColor: .init(colorName: .orange, section: .border)),
     ]
 
     private class func topicStyle(for index: Int) -> TopicStyle {
@@ -107,16 +102,54 @@ class ReaderSuggestedTopicsStyleGuide {
         return Self.colors[index % colorCount]
     }
 
-    public static var topicFont: UIFont = WPStyleGuide.fontForTextStyle(.body)
+    public static var topicFont: UIFont = WPStyleGuide.fontForTextStyle(.footnote)
 
     public class func applySuggestedTopicStyle(label: UILabel, with index: Int) {
         let style = Self.topicStyle(for: index)
 
-        label.font = WPStyleGuide.fontForTextStyle(.body)
-        label.textColor = style.textColor
+        label.font = Self.topicFont
+        label.textColor = style.textColor.color()
 
-        label.layer.borderColor = style.borderColor.cgColor
+        label.layer.borderColor = style.borderColor.color().cgColor
         label.layer.borderWidth = .hairlineBorderWidth
-        label.layer.backgroundColor = style.backgroundColor.cgColor
+        label.layer.backgroundColor = style.backgroundColor.color().cgColor
+    }
+
+    // MARK: - Color Representation
+    struct TopicStyle {
+        let textColor: TopicColor
+        let backgroundColor: TopicColor
+        let borderColor: TopicColor
+
+        struct TopicColor {
+            enum StyleSection {
+                case text, background, border
+            }
+
+            let colorName: MurielColorName
+            let section: StyleSection
+
+            func color() -> UIColor {
+                let lightShade: MurielColorShade
+                let darkShade: MurielColorShade
+
+                switch section {
+                    case .text:
+                        lightShade = .shade50
+                        darkShade = .shade40
+
+                    case .border:
+                        lightShade = .shade5
+                        darkShade = .shade100
+
+                    case .background:
+                        lightShade = .shade0
+                        darkShade = .shade90
+                }
+
+                return UIColor(light: .muriel(color: MurielColor(name: colorName, shade: lightShade)),
+                               dark: .muriel(color: MurielColor(name: colorName, shade: darkShade)))
+            }
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -66,3 +66,57 @@ class ReaderInterestsStyleGuide {
         indicator.color = UIColor(light: .black, dark: .white)
     }
 }
+
+class ReaderSuggestedTopicsStyleGuide {
+    struct TopicStyle {
+        let textColor: UIColor
+        let backgroundColor: UIColor
+        let borderColor: UIColor
+    }
+
+    /// The array of colors from the designs
+    /// Note: I am explictly using the MurielColor names instead of using the semantic ones
+    ///       since these are explicit and not semantic colors.
+    static let colors: [TopicStyle] = [
+        // Green
+        .init(textColor: .muriel(color: MurielColor(name: .green), .shade50),
+              backgroundColor: .muriel(color: MurielColor(name: .green), .shade0),
+              borderColor: .muriel(color: MurielColor(name: .green), .shade5)),
+
+        // Blue
+        .init(textColor: .muriel(color: MurielColor(name: .blue), .shade50),
+              backgroundColor: .muriel(color: MurielColor(name: .blue), .shade0),
+              borderColor: .muriel(color: MurielColor(name: .blue), .shade5)),
+
+        // Yellow
+        .init(textColor: .muriel(color: MurielColor(name: .yellow), .shade50),
+              backgroundColor: .muriel(color: MurielColor(name: .yellow), .shade0),
+              borderColor: .muriel(color: MurielColor(name: .yellow), .shade5)),
+
+        // Orange
+        .init(textColor: .muriel(color: MurielColor(name: .orange), .shade50),
+              backgroundColor: .muriel(color: MurielColor(name: .orange), .shade0),
+              borderColor: .muriel(color: MurielColor(name: .orange), .shade5)),
+    ]
+
+    private class func topicStyle(for index: Int) -> TopicStyle {
+        let colorCount = Self.colors.count
+
+        // Safety feature if for some reason the count of returned topics ever increases past 4 we will
+        // loop through the list colors again. 
+        return Self.colors[index % colorCount]
+    }
+
+    public static var topicFont: UIFont = WPStyleGuide.fontForTextStyle(.body)
+
+    public class func applySuggestedTopicStyle(label: UILabel, with index: Int) {
+        let style = Self.topicStyle(for: index)
+
+        label.font = WPStyleGuide.fontForTextStyle(.body)
+        label.textColor = style.textColor
+
+        label.layer.borderColor = style.borderColor.cgColor
+        label.layer.borderWidth = .hairlineBorderWidth
+        label.layer.backgroundColor = style.backgroundColor.cgColor
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -199,9 +199,9 @@
 		17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */; };
 		17BD4A0820F76A4700975AC3 /* Routes+Banners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */; };
 		17BD4A192101D31B00975AC3 /* NavigationActionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BD4A182101D31B00975AC3 /* NavigationActionHelpers.swift */; };
+		17C2FF0925D4852400CDB712 /* UnifiedProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2FF0825D4852400CDB712 /* UnifiedProloguePages.swift */; };
 		17C3F8BF25E4438200EFFE12 /* notifications-button-text-content.json in Resources */ = {isa = PBXBuildFile; fileRef = 17C3F8BE25E4438100EFFE12 /* notifications-button-text-content.json */; };
 		17C3FA6F25E591D200EFFE12 /* UIFont+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C3FA6E25E591D200EFFE12 /* UIFont+Styles.swift */; };
-		17C2FF0925D4852400CDB712 /* UnifiedProloguePages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C2FF0825D4852400CDB712 /* UnifiedProloguePages.swift */; };
 		17C64BD2248E26A200AF09D7 /* AppAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C64BD1248E26A200AF09D7 /* AppAppearance.swift */; };
 		17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */; };
 		17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */; };
@@ -1789,6 +1789,7 @@
 		C700F9EE257FD64E0090938E /* JetpackScanViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C700F9ED257FD64E0090938E /* JetpackScanViewController.swift */; };
 		C700FAB2258020DB0090938E /* JetpackScanThreatCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C700FAB0258020DB0090938E /* JetpackScanThreatCell.swift */; };
 		C700FAB3258020DB0090938E /* JetpackScanThreatCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C700FAB1258020DB0090938E /* JetpackScanThreatCell.xib */; };
+		C7192ECF25E8432D00C3020D /* ReaderTopicsCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C7192ECE25E8432D00C3020D /* ReaderTopicsCardCell.xib */; };
 		C71BC73F25A652410023D789 /* JetpackScanStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71BC73E25A652410023D789 /* JetpackScanStatusViewModel.swift */; };
 		C73868C525C9F9820072532C /* JetpackScanThreatSectionGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73868C425C9F9820072532C /* JetpackScanThreatSectionGrouping.swift */; };
 		C768B5B425828A5D00556E75 /* JetpackScanStatusCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C768B5B225828A5D00556E75 /* JetpackScanStatusCell.swift */; };
@@ -2815,9 +2816,9 @@
 		17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewController.swift; sourceTree = "<group>"; };
 		17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Banners.swift"; sourceTree = "<group>"; };
 		17BD4A182101D31B00975AC3 /* NavigationActionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationActionHelpers.swift; sourceTree = "<group>"; };
+		17C2FF0825D4852400CDB712 /* UnifiedProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedProloguePages.swift; sourceTree = "<group>"; };
 		17C3F8BE25E4438100EFFE12 /* notifications-button-text-content.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-button-text-content.json"; sourceTree = "<group>"; };
 		17C3FA6E25E591D200EFFE12 /* UIFont+Styles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Styles.swift"; sourceTree = "<group>"; };
-		17C2FF0825D4852400CDB712 /* UnifiedProloguePages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedProloguePages.swift; sourceTree = "<group>"; };
 		17C64BD1248E26A200AF09D7 /* AppAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAppearance.swift; sourceTree = "<group>"; };
 		17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchService.swift; sourceTree = "<group>"; };
 		17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchViewController.swift; sourceTree = "<group>"; };
@@ -4571,6 +4572,7 @@
 		C700F9ED257FD64E0090938E /* JetpackScanViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanViewController.swift; sourceTree = "<group>"; };
 		C700FAB0258020DB0090938E /* JetpackScanThreatCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanThreatCell.swift; sourceTree = "<group>"; };
 		C700FAB1258020DB0090938E /* JetpackScanThreatCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = JetpackScanThreatCell.xib; sourceTree = "<group>"; };
+		C7192ECE25E8432D00C3020D /* ReaderTopicsCardCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderTopicsCardCell.xib; sourceTree = "<group>"; };
 		C71BC73E25A652410023D789 /* JetpackScanStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanStatusViewModel.swift; sourceTree = "<group>"; };
 		C73868C425C9F9820072532C /* JetpackScanThreatSectionGrouping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackScanThreatSectionGrouping.swift; sourceTree = "<group>"; };
 		C768B5B225828A5D00556E75 /* JetpackScanStatusCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanStatusCell.swift; sourceTree = "<group>"; };
@@ -7439,6 +7441,7 @@
 				D87A329520ABD60700F4726F /* ReaderTableContent.swift */,
 				5D42A401175E76A1005CFF05 /* WPImageViewController.h */,
 				5D42A402175E76A2005CFF05 /* WPImageViewController.m */,
+				C7192ECE25E8432D00C3020D /* ReaderTopicsCardCell.xib */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -12435,6 +12438,7 @@
 				E6D2E15F1B8A9C830000ED14 /* ReaderSiteStreamHeader.xib in Resources */,
 				17E3630522C41725000E0C79 /* wordpress_dark_icon_60pt@3x.png in Resources */,
 				17E3630C22C41725000E0C79 /* wordpress_dark_icon_20pt@3x.png in Resources */,
+				C7192ECF25E8432D00C3020D /* ReaderTopicsCardCell.xib in Resources */,
 				17E3630322C41725000E0C79 /* wordpress_dark_icon_83.5@2x.png in Resources */,
 				E61507E22220A0FE00213D33 /* richEmbedTemplate.html in Resources */,
 				17E363E822C4280A000E0C79 /* pride_icon_29pt.png in Resources */,


### PR DESCRIPTION
Fixes #15964

### Notes
- I spent a lot of time today trying to get this to all work in code, but no matter what I did I could not get the constraints to work properly which is why I ended up converting it to a `.xib`. 
- I originally tried to reuse my `TopicsCollectionView` but this is doing something completely different so I ditched that effort

### Screenshots

| Light | Dark |
|:---:|:---:|
|![Simulator Screen Shot - iPhone 11 Pro - 2021-02-25 at 18 15 41](https://user-images.githubusercontent.com/793774/109232017-87604d80-7795-11eb-8f3c-569d5bca0872.png)|![Simulator Screen Shot - iPhone 11 Pro - 2021-02-25 at 18 15 39](https://user-images.githubusercontent.com/793774/109232018-87f8e400-7795-11eb-977c-539ce0d1cb49.png)|

### To test:

1. Launch the app
2. Tap on the Reader tab
3. Tap on the 'Discover' tab
4. Locate the 'You Might Like' card
5. You should now see the topics in a horizontally scrolling list
6. Tap on a topic
7. You should be brought to the topic detail view
8. Scroll down a few pages to find a set of topics where the 4th topic appears out of bounds
9. Scroll to make it visible

#### Extra credit testing
1. Open `ReaderTopicsCardCell.swift`
2. Go to line 24
3. Change it to `self.data = data + data + data + data + data`
4. Relaunch the app
5. Verify all the colors loop after the 4th one and doesn't crash

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
