### PR TITLE
Show categories publishing field in editors

### DIFF
--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -202,7 +202,7 @@ class StoryEditor: CameraController {
 
 extension StoryEditor: PublishingEditor {
     var prepublishingIdentifiers: [PrepublishingIdentifier] {
-        return  [.title, .visibility, .schedule, .tags]
+        return  [.title, .visibility, .schedule, .tags, .categories]
     }
 
     var prepublishingSourceView: UIView? {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -141,6 +141,6 @@ extension PostEditor {
     }
 
     var prepublishingIdentifiers: [PrepublishingIdentifier] {
-        return [.visibility, .schedule, .tags]
+        return [.visibility, .schedule, .tags, .categories]
     }
 }


### PR DESCRIPTION
Fixes a regression with the Prepublishing Sheet where the categories field was not shown.

### Testing
* Create a new Blog Post
* Hit "Publish"
* Confirm that the "categories" field is shown in the Prepublishing Sheet

<a href="https://user-images.githubusercontent.com/3250/109361918-3b6de100-7847-11eb-95ac-d38c1ca286db.jpeg"><img src="https://user-images.githubusercontent.com/3250/109361918-3b6de100-7847-11eb-95ac-d38c1ca286db.jpeg" width="300"></a>

* Create a new Story Post
* Hit "Publish"
* Confirm that the "categories" field is shown in the Prepublishing Sheet

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
