### PR TITLE
Implement fetch likes in CommentService

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.28-beta'
+    # pod 'WordPressKit', '~> 4.28-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/15662-notification_likes_support'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -503,7 +503,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.35.1)
-  - WordPressKit (~> 4.28-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/15662-notification_likes_support`)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.15.0)
   - WordPressUI (~> 1.9.0)
@@ -553,7 +553,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -654,6 +653,9 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.48.0-alpha1
+  WordPressKit:
+    :branch: feature/15662-notification_likes_support
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.48.0-alpha1/third-party-podspecs/Yoga.podspec.json
 
@@ -669,6 +671,9 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :submodules: true
     :tag: v1.48.0-alpha1
+  WordPressKit:
+    :commit: efb7293163830a8b1c1a87f191e8b278f769d6e4
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -766,6 +771,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 3e4e8ed46d30423393f5d7414660e486aa37b3b2
+PODFILE CHECKSUM: 878f0aec969c392a4543e60d5f12a0c80511faf9
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -10,9 +10,16 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 @class ReaderPost;
 @class BasePost;
 @class RemoteUser;
+@class CommentServiceRemoteFactory;
 
-/// <#Description#>
 @interface CommentService : LocalCoreDataService
+
+/// Initializes the instance with a custom service remote provider.
+///
+/// @param context The context this instance will use for interacting with CoreData.
+/// @param commentServiceRemoteFactory The factory this instance will use to get service remote instances from.
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context
+                 commentServiceRemoteFactory:(CommentServiceRemoteFactory *)remoteFactory NS_DESIGNATED_INITIALIZER;
 
 + (BOOL)isSyncingCommentsForBlog:(Blog *)blog;
 
@@ -171,7 +178,7 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
  Fetches a list of users that liked the comment with the given ID.
 
  @param commentID   The ID of the comment to fetch likes for
- @param siteID      The ID of the site that contains the comment
+ @param siteID      The ID of the site that contains the post
  @param success     A success block
  @param failure     A failure block
  */

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -9,7 +9,9 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 @class Comment;
 @class ReaderPost;
 @class BasePost;
+@class RemoteUser;
 
+/// <#Description#>
 @interface CommentService : LocalCoreDataService
 
 + (BOOL)isSyncingCommentsForBlog:(Blog *)blog;
@@ -164,5 +166,18 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
                             siteID:(NSNumber *)siteID
                            success:(void (^)(void))success
                            failure:(void (^)(NSError *error))failure;
+
+/**
+ Fetches a list of users that liked the comment with the given ID.
+
+ @param commentID   The ID of the comment to fetch likes for
+ @param siteID      The ID of the site that contains the comment
+ @param success     A success block
+ @param failure     A failure block
+ */
+- (void)getLikesForCommentID:(NSNumber *)commentID
+                      siteID:(NSNumber *)siteID
+                     success:(void (^)(NSArray<RemoteUser *> *))success
+                     failure:(void (^)(NSError * _Nullable))failure;
 
 @end

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -683,6 +683,18 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     }
 }
 
+- (void)getLikesForCommentID:(NSNumber *)commentID
+                      siteID:(NSNumber *)siteID
+                     success:(void (^)(NSArray<RemoteUser *> *))success
+                     failure:(void (^)(NSError * _Nullable))failure
+{
+    NSParameterAssert(commentID);
+    NSParameterAssert(siteID);
+
+    CommentServiceRemoteREST *remote = [self restRemoteForSite:siteID];
+    [remote getLikesForCommentID:commentID success:success failure:failure];
+}
+
 
 #pragma mark - Private methods
 

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -14,7 +14,30 @@ NSUInteger const WPTopLevelHierarchicalCommentsPerPage = 20;
 NSInteger const  WPNumberOfCommentsToSync = 100;
 static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minutes
 
+@interface CommentService ()
+
+@property (nonnull, strong, nonatomic) CommentServiceRemoteFactory *remoteFactory;
+
+@end
+
 @implementation CommentService
+
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context
+{
+    return [self initWithManagedObjectContext:context
+                  commentServiceRemoteFactory:[CommentServiceRemoteFactory new]];
+}
+
+- (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context
+                 commentServiceRemoteFactory:(CommentServiceRemoteFactory *)remoteFactory
+{
+    self = [super initWithManagedObjectContext:context];
+    if (self) {
+        self.remoteFactory = remoteFactory;
+    }
+
+    return self;
+}
 
 + (NSMutableSet *)syncingCommentsLocks
 {
@@ -1099,21 +1122,12 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 
 - (id<CommentServiceRemote>)remoteForBlog:(Blog *)blog
 {
-    id<CommentServiceRemote>remote;
-    // TODO: refactor API creation so it's not part of the model
-    if ([blog supports:BlogFeatureWPComRESTAPI]) {
-        if (blog.wordPressComRestApi) {
-            remote = [[CommentServiceRemoteREST alloc] initWithWordPressComRestApi:blog.wordPressComRestApi siteID:blog.dotComID];
-        }
-    } else if (blog.xmlrpcApi) {
-        remote = [[CommentServiceRemoteXMLRPC alloc] initWithApi:blog.xmlrpcApi username:blog.username password:blog.password];
-    }
-    return remote;
+    return [self.remoteFactory remoteWithBlog:blog];
 }
 
 - (CommentServiceRemoteREST *)restRemoteForSite:(NSNumber *)siteID
 {
-    return [[CommentServiceRemoteREST alloc] initWithWordPressComRestApi:[self apiForRESTRequest] siteID:siteID];
+    return [self.remoteFactory restRemoteWithSiteID:siteID api:[self apiForRESTRequest]];
 }
 
 /**

--- a/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
@@ -1,0 +1,36 @@
+import Foundation
+import WordPressKit
+
+
+/// Provides service remote instances for CommentService
+@objc class CommentServiceRemoteFactory: NSObject {
+
+    /// Returns a CommentServiceRemote for a given Blog object
+    ///
+    /// - Parameter blog: A valid Blog object
+    /// - Returns: A CommentServiceRemote instance
+    @objc func remote(blog: Blog) -> CommentServiceRemote? {
+        if blog.supports(.wpComRESTAPI),
+            let api = blog.wordPressComRestApi(),
+            let dotComID = blog.dotComID {
+            return CommentServiceRemoteREST(wordPressComRestApi: api, siteID: dotComID)
+        } else if let api = blog.xmlrpcApi,
+            let username = blog.username,
+            let password = blog.password {
+            return CommentServiceRemoteXMLRPC(api: api, username: username, password: password)
+        }
+
+        return nil
+    }
+
+    /// Returns a REST remote for a given site ID.
+    ///
+    /// - Parameters:
+    ///   - siteID: A valid siteID
+    ///   - api: An instance of WordPressComRestAPI
+    /// - Returns: An instance of CommentServiceRemoteREST
+    @objc func restRemote(siteID: NSNumber, api: WordPressComRestApi) -> CommentServiceRemoteREST {
+        return CommentServiceRemoteREST(wordPressComRestApi: api, siteID: siteID)
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1602,6 +1602,7 @@
 		A01C55480E25E0D000D411F2 /* defaultPostTemplate.html in Resources */ = {isa = PBXBuildFile; fileRef = A01C55470E25E0D000D411F2 /* defaultPostTemplate.html */; };
 		A0E293F10E21027E00C6919C /* WPAddPostCategoryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0E293F00E21027E00C6919C /* WPAddPostCategoryViewController.m */; };
 		AB2211D225ED68E300BF72FC /* CommentServiceRemoteFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2211D125ED68E300BF72FC /* CommentServiceRemoteFactory.swift */; };
+		AB2211F425ED6E7A00BF72FC /* CommentServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2211F325ED6E7A00BF72FC /* CommentServiceTests.swift */; };
 		ACBAB5FE0E121C7300F38795 /* PostSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ACBAB5FD0E121C7300F38795 /* PostSettingsViewController.m */; };
 		ADF544C2195A0F620092213D /* CustomHighlightButton.m in Sources */ = {isa = PBXBuildFile; fileRef = ADF544C1195A0F620092213D /* CustomHighlightButton.m */; };
 		B03B9234250BC593000A40AF /* SuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03B9233250BC593000A40AF /* SuggestionService.swift */; };
@@ -4348,6 +4349,7 @@
 		A27DA63A5ECD1D0262C589EC /* Pods-WordPressNotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationServiceExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationServiceExtension/Pods-WordPressNotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		A284044518BFE7F300D982B6 /* WordPress 15.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 15.xcdatamodel"; sourceTree = "<group>"; };
 		AB2211D125ED68E300BF72FC /* CommentServiceRemoteFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentServiceRemoteFactory.swift; sourceTree = "<group>"; };
+		AB2211F325ED6E7A00BF72FC /* CommentServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentServiceTests.swift; sourceTree = "<group>"; };
 		AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressScreenshotGeneration.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC6024D92F44AE4CB4A8C1B3 /* Pods-WordPressScreenshotGeneration.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressScreenshotGeneration.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressScreenshotGeneration/Pods-WordPressScreenshotGeneration.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		ACBAB5FC0E121C7300F38795 /* PostSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostSettingsViewController.h; sourceTree = "<group>"; usesTabs = 0; };
@@ -10073,6 +10075,7 @@
 				E150520B16CAC5C400D3DDDC /* BlogJetpackTest.m */,
 				930FD0A519882742000CC81D /* BlogServiceTest.m */,
 				E18549DA230FBFEF003C620E /* BlogServiceDeduplicationTests.swift */,
+				AB2211F325ED6E7A00BF72FC /* CommentServiceTests.swift */,
 				74585B981F0D58F300E7E667 /* DomainsServiceTests.swift */,
 				FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */,
 				B5772AC51C9C84900031F97E /* GravatarServiceTests.swift */,
@@ -15414,6 +15417,7 @@
 				7E987F5A2108122A00CAFB88 /* NotificationUtility.swift in Sources */,
 				7E442FC720F677CB00DEACA5 /* ActivityLogRangesTest.swift in Sources */,
 				8B25F8DA24B7683A009DD4C9 /* ReaderCSSTests.swift in Sources */,
+				AB2211F425ED6E7A00BF72FC /* CommentServiceTests.swift in Sources */,
 				08E77F471EE9D72F006F9515 /* MediaThumbnailExporterTests.swift in Sources */,
 				59FBD5621B5684F300734466 /* ThemeServiceTests.m in Sources */,
 				85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1601,6 +1601,7 @@
 		A01C542E0E24E88400D411F2 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A01C542D0E24E88400D411F2 /* SystemConfiguration.framework */; };
 		A01C55480E25E0D000D411F2 /* defaultPostTemplate.html in Resources */ = {isa = PBXBuildFile; fileRef = A01C55470E25E0D000D411F2 /* defaultPostTemplate.html */; };
 		A0E293F10E21027E00C6919C /* WPAddPostCategoryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A0E293F00E21027E00C6919C /* WPAddPostCategoryViewController.m */; };
+		AB2211D225ED68E300BF72FC /* CommentServiceRemoteFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2211D125ED68E300BF72FC /* CommentServiceRemoteFactory.swift */; };
 		ACBAB5FE0E121C7300F38795 /* PostSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ACBAB5FD0E121C7300F38795 /* PostSettingsViewController.m */; };
 		ADF544C2195A0F620092213D /* CustomHighlightButton.m in Sources */ = {isa = PBXBuildFile; fileRef = ADF544C1195A0F620092213D /* CustomHighlightButton.m */; };
 		B03B9234250BC593000A40AF /* SuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03B9233250BC593000A40AF /* SuggestionService.swift */; };
@@ -4346,6 +4347,7 @@
 		A20971B819B0BC570058F395 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		A27DA63A5ECD1D0262C589EC /* Pods-WordPressNotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationServiceExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationServiceExtension/Pods-WordPressNotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		A284044518BFE7F300D982B6 /* WordPress 15.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 15.xcdatamodel"; sourceTree = "<group>"; };
+		AB2211D125ED68E300BF72FC /* CommentServiceRemoteFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentServiceRemoteFactory.swift; sourceTree = "<group>"; };
 		AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressScreenshotGeneration.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC6024D92F44AE4CB4A8C1B3 /* Pods-WordPressScreenshotGeneration.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressScreenshotGeneration.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressScreenshotGeneration/Pods-WordPressScreenshotGeneration.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		ACBAB5FC0E121C7300F38795 /* PostSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostSettingsViewController.h; sourceTree = "<group>"; usesTabs = 0; };
@@ -8867,6 +8869,7 @@
 				7E7BEF7222E1DD27009A880D /* EditorSettingsService.swift */,
 				E1556CF0193F6FE900FC52EA /* CommentService.h */,
 				E1556CF1193F6FE900FC52EA /* CommentService.m */,
+				AB2211D125ED68E300BF72FC /* CommentServiceRemoteFactory.swift */,
 				E16A76F21FC4766900A661E3 /* CredentialsService.swift */,
 				1702BBDF1CF3034E00766A33 /* DomainsService.swift */,
 				FA00863C24EB68B100C863F2 /* FollowCommentsService.swift */,
@@ -13606,6 +13609,7 @@
 				E1DD4CCB1CAE41B800C3863E /* PagedViewController.swift in Sources */,
 				B549BA681CF7447E0086C608 /* InvitePersonViewController.swift in Sources */,
 				B535209B1AF7BBB800B33BA8 /* PushAuthenticationManager.swift in Sources */,
+				AB2211D225ED68E300BF72FC /* CommentServiceRemoteFactory.swift in Sources */,
 				319D6E8119E44C680013871C /* SuggestionsTableView.m in Sources */,
 				40E728851FF3D9070010E7C9 /* PluginDetailViewHeaderCell.swift in Sources */,
 				46183D1F251BD6A0004F9AFD /* PageTemplateCategory+CoreDataClass.swift in Sources */,

--- a/WordPress/WordPressTest/CommentServiceTests.swift
+++ b/WordPress/WordPressTest/CommentServiceTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Nimble
+
+@testable import WordPress
+
+final class CommentServiceTests: XCTestCase {
+
+    private var remoteMock: CommentServiceRemoteRESTMock!
+    private var service: CommentService!
+    private var context: NSManagedObjectContext!
+
+    // MARK: Lifecycle
+
+    override func setUp() {
+        super.setUp()
+
+        context = TestContextManager().mainContext
+        remoteMock = CommentServiceRemoteRESTMock()
+
+        let remoteFactory = CommentServiceRemoteFactoryMock()
+        remoteFactory.restRemote = remoteMock
+        service = CommentService(managedObjectContext: context, commentServiceRemoteFactory: remoteFactory)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        service = nil
+        remoteMock = nil
+        context = nil
+        ContextManager.overrideSharedInstance(nil)
+    }
+
+    // MARK: Helpers
+
+    private func createRemoteUser() -> RemoteUser {
+         let remoteUser = RemoteUser()
+         remoteUser.userID = NSNumber(value: 123)
+         remoteUser.primaryBlogID = NSNumber(value: 456)
+         remoteUser.username = "johndoe"
+         remoteUser.displayName = "John Doe"
+         remoteUser.avatarURL = "avatar URL"
+
+         return remoteUser
+     }
+}
+
+// MARK: - Tests
+
+extension CommentServiceTests {
+
+    // MARK: Fetch Likes
+
+    func testFetchingCommentLikesSuccessfullyShouldCallSuccessBlock() {
+        // Arrange
+        let commentID = NSNumber(value: 1)
+        let siteID = NSNumber(value: 2)
+        let expectedUsers = [createRemoteUser()]
+        try! context.save()
+        remoteMock.remoteUsersToReturnOnGetLikes = expectedUsers
+
+        // Act
+        waitUntil(timeout: 2) { done in
+            self.service.getLikesForCommentID(commentID, siteID: siteID, success: { users in
+                // Assert
+                expect(users).toNot(beNil())
+                expect(users?.count) == 1
+                done()
+            },
+            failure: { _ in
+                fail("This closure should not be called")
+            })
+        }
+    }
+
+    func testFailingFetchCommentLikesShouldCallFailureBlock() {
+        // Arrange
+        let commentID = NSNumber(value: 1)
+        let siteID = NSNumber(value: 2)
+        try! context.save()
+        remoteMock.fetchLikesShouldSucceed = false
+
+        // Act
+        waitUntil(timeout: 2) { done in
+            self.service.getLikesForCommentID(commentID, siteID: siteID, success: { users in
+                fail("this closure should not be called")
+            },
+            failure: { _ in
+                done()
+            })
+        }
+    }
+}
+
+// MARK: - Mocks
+
+private class CommentServiceRemoteFactoryMock: CommentServiceRemoteFactory {
+
+    var restRemote: CommentServiceRemoteREST = CommentServiceRemoteRESTMock()
+
+    override func restRemote(siteID: NSNumber, api: WordPressComRestApi) -> CommentServiceRemoteREST {
+        return restRemote
+    }
+
+}
+
+private class CommentServiceRemoteRESTMock: CommentServiceRemoteREST {
+
+    // related to fetching likes
+    var fetchLikesShouldSucceed: Bool = true
+    var remoteUsersToReturnOnGetLikes: [RemoteUser]? = nil
+
+    override func getLikesForCommentID(_ commentID: NSNumber!, success: (([RemoteUser]?) -> Void)!, failure: ((Error?) -> Void)!) {
+        DispatchQueue.global().async {
+            if self.fetchLikesShouldSucceed {
+                success(self.remoteUsersToReturnOnGetLikes)
+            } else {
+                failure(nil)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Refs #15662

Add implementation to fetch likes for a comment in `CommentService`. There's also a slight refactor that introduces `CommentServiceRemoteFactory` to make `CommentService` injectable in unit tests.

To test:

Confirm the app builds. The rest are covered through unit tests as this is a "backend" change.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
