### PR TITLE
Improve appearance of Reader Detail when used in Notifications

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -95,6 +95,13 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Tracks whether the webview has called -didFinish:navigation
     var isLoadingWebView = true
 
+    /// Temporary work around until white headers are shipped app-wide,
+    /// allowing Reader Detail to use a blue navbar.
+    var useCompatibilityMode: Bool {
+        // Use compatibility mode if not presented within the Reader
+        return WPTabBarController.sharedInstance()?.readerNavigationController.viewControllers.contains(self) == false
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -161,6 +168,13 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         coordinator.animate(alongsideTransition: { _ in
             self.featuredImage.deviceDidRotate()
         })
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        // Bar items may change if we're moving single pane to split view
+        self.configureNavigationBar()
     }
 
     override func accessibilityPerformEscape() -> Bool {
@@ -573,6 +587,8 @@ private extension ReaderDetailViewController {
 
         if navigationController?.viewControllers.first != self {
             navigationItem.leftBarButtonItem = backButtonItem()
+        } else {
+            navigationItem.leftBarButtonItem = nil
         }
 
         navigationItem.rightBarButtonItems = rightItems.compactMap({ $0 })

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -221,6 +221,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// Shown an error
     func showError() {
+        isLoadingWebView = false
+        hideLoading()
+
         displayLoadingView(title: LoadingText.errorLoadingTitle)
     }
 
@@ -536,6 +539,9 @@ private extension ReaderDetailViewController {
         addChild(noResultsViewController)
         view.addSubview(withFadeAnimation: noResultsViewController.view)
         noResultsViewController.didMove(toParent: self)
+
+        noResultsViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(noResultsViewController.view)
     }
 
     func hideLoadingView() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -324,6 +324,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             return
         }
 
+        featuredImage.useCompatibilityMode = useCompatibilityMode
+
         featuredImage.delegate = coordinator
 
         view.insertSubview(featuredImage, belowSubview: loadingView)
@@ -340,15 +342,17 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private func configureHeader() {
         header.delegate = coordinator
         headerContainerView.addSubview(header)
+        headerContainerView.translatesAutoresizingMaskIntoConstraints = false
+
         headerContainerView.pinSubviewToAllEdges(header)
         headerContainerView.heightAnchor.constraint(equalTo: header.heightAnchor).isActive = true
-        headerContainerView.translatesAutoresizingMaskIntoConstraints = false
     }
 
     private func configureToolbar() {
         toolbarContainerView.addSubview(toolbar)
-        toolbarContainerView.pinSubviewToAllEdges(toolbar)
         toolbarContainerView.translatesAutoresizingMaskIntoConstraints = false
+
+        toolbarContainerView.pinSubviewToAllEdges(toolbar)
         toolbarSafeAreaView.backgroundColor = toolbar.backgroundColor
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -565,7 +565,10 @@ private extension ReaderDetailViewController {
             safariButtonItem()
         ]
 
-        navigationItem.leftBarButtonItem = backButtonItem()
+        if navigationController?.viewControllers.first != self {
+            navigationItem.leftBarButtonItem = backButtonItem()
+        }
+
         navigationItem.rightBarButtonItems = rightItems.compactMap({ $0 })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -340,6 +340,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func configureHeader() {
+        header.useCompatibilityMode = useCompatibilityMode
         header.delegate = coordinator
         headerContainerView.addSubview(header)
         headerContainerView.translatesAutoresizingMaskIntoConstraints = false

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
@@ -26,6 +26,10 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
     @IBOutlet weak var collectionViewPaddingView: UIView!
     @IBOutlet weak var topicsCollectionView: TopicsCollectionView!
 
+    /// Temporary work around until white headers are shipped app-wide,
+    /// allowing Reader Detail to use a blue navbar.
+    var useCompatibilityMode: Bool = false
+
     /// The post to show details in the header
     ///
     private var post: ReaderPost?
@@ -197,7 +201,7 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
             return
         }
 
-        let featuredImageIsDisplayed = ReaderDetailFeaturedImageView.shouldDisplayFeaturedImage(with: post)
+        let featuredImageIsDisplayed = useCompatibilityMode || ReaderDetailFeaturedImageView.shouldDisplayFeaturedImage(with: post)
         collectionViewPaddingView.isHidden = !featuredImageIsDisplayed
 
         topicsCollectionView.topicDelegate = self


### PR DESCRIPTION
This PR makes a number of small (temporary!) changes to `ReaderDetailViewController` when used within the Notifications section of the app to improve consistency while we're still using blue navigation bars. It also fixes a few issues.

**Change 1: Back Button**

The back button was always shown, but when you view a notification in an expanded split view there's nowhere to go back to. The back button is now only displayed if the ReaderDetailVC isn't the first VC in its navigation controller's stack.

----

**Change 2: No Results View position**

I noticed on the iPad that if a post errored out, the no results view wasn't always in the right position. With this change, it should be fixed in the center of the view:

| Before  | After  |
|:-:|:-:|
|  ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-01 at 20 39 30](https://user-images.githubusercontent.com/4780/109558940-f0b3c980-7ad1-11eb-8688-cdd7481509e8.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-01 at 15 04 34](https://user-images.githubusercontent.com/4780/109558955-f6111400-7ad1-11eb-980c-fff789604544.png)  |

----

**Change 3: Bar colours**

The bar and its icons have been updated to match the rest of Notifications. I've added a slightly hacky `useCompatibilityMode` flag to achieve this for now, replacing some colours or disabling functionality in a few places. This should be easy to clean up when we ship white headers throughout the app, however.

I also disabled the Featured Image display as part of these changes as it's intended to work with a clear / white

| Before  | After  |
|:-:|:-:|
|  ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-01 at 20 39 16](https://user-images.githubusercontent.com/4780/109560011-518fd180-7ad3-11eb-9f89-c45f91522fab.png)  |  ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-01 at 19 09 02](https://user-images.githubusercontent.com/4780/109559947-3d4bd480-7ad3-11eb-9736-a2fa37a96c80.png)  |
|  ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-01 at 21 28 26](https://user-images.githubusercontent.com/4780/109561456-18f0f780-7ad5-11eb-8881-648f8233ef31.png)  |  ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-01 at 19 27 10](https://user-images.githubusercontent.com/4780/109559968-42108880-7ad3-11eb-94d0-7b1406f4428d.png)  |
|  ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-01 at 20 37 04](https://user-images.githubusercontent.com/4780/109560093-610f1a80-7ad3-11eb-87f4-017a10811085.png)  | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-01 at 16 41 59](https://user-images.githubusercontent.com/4780/109560078-5eacc080-7ad3-11eb-9c10-bfa716645611.png)   |

----

**To test:**

- Ensure that the `newNavBarAppearance` feature flag is disabled.
- Build and run.
- In Notifications, navigate into any New Post notifications you may have and ensure they look as above.
- Check that a post with a featured image looks okay.
- From a comment or like notification, navigate into a post by tapping on the top item in the list, and ensure that the Reader view looks correct and has a back button.
- Check the navigation bar also looks good in dark mode.
- In Reader, navigate into some articles and check that the navigation bar is still white and looks the same. Check that posts with featured images look awesome.
- For extra credit, on iPad open another app in multitasking so that the split view is collapsed. Then in Notifications, navigate into a new post and check that you see the back button. Then remove multitasking and check that the back button goes away when the split view is expanded again.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
