### PR TITLE
Stories: Fixes StoryEditor reference in Gutenberg

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -702,7 +702,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
     }
 
     func showEditor(files: [MediaFile]) throws {
-        let controller = try StoryEditor.editor(post: post, mediaFiles: files, publishOnCompletion: false, updated: { [weak self] result in
+        storyEditor = try StoryEditor.editor(post: post, mediaFiles: files, publishOnCompletion: false, updated: { [weak self] result in
             switch result {
             case .success:
                 self?.dismiss(animated: true, completion: nil)


### PR DESCRIPTION
Fixes a missing reference to StoryEditor in Gutenberg.

This was line was chosen incorrectly during a merge of `16.8` -> `android-compatibility`.

### Testing
* Create a Story Post
* Publish Story Post
* Edit the Story Post
* Tap on the Story block and make sure the Story Editor is shown.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
