### PR TITLE
Comments: add state restoration

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Filters.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Filters.swift
@@ -52,4 +52,12 @@ extension CommentsViewController {
         refresh(with: filter.statusFilter, andPredicate: filter.statusPredicate)
     }
 
+    @objc func getSelectedIndex(_ filterTabBar: FilterTabBar) -> Int {
+        return filterTabBar.selectedIndex
+    }
+
+    @objc func setSeletedIndex(_ selectedIndex: Int, filterTabBar: FilterTabBar) {
+        filterTabBar.setSelectedIndex(selectedIndex, animated: false)
+        selectedFilterDidChange(filterTabBar)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -13,8 +13,10 @@ static CGFloat const CommentsActivityFooterHeight               = 50.0;
 static NSInteger const CommentsRefreshRowPadding                = 4;
 static NSInteger const CommentsFetchBatchSize                   = 10;
 
+static NSString *RestorableBlogIdKey = @"restorableBlogIdKey";
+static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
-@interface CommentsViewController () <WPTableViewHandlerDelegate, WPContentSyncHelperDelegate>
+@interface CommentsViewController () <WPTableViewHandlerDelegate, WPContentSyncHelperDelegate, UIViewControllerRestoration>
 @property (nonatomic, strong) WPTableViewHandler        *tableViewHandler;
 @property (nonatomic, strong) WPContentSyncHelper       *syncHelper;
 @property (nonatomic, strong) NoResultsViewController   *noResultsViewController;
@@ -44,6 +46,7 @@ static NSInteger const CommentsFetchBatchSize                   = 10;
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"CommentsList" bundle:nil];
     CommentsViewController *controller = [storyboard instantiateInitialViewController];
     controller.blog = blog;
+    controller.restorationClass = [controller class];
     return controller;
 }
 
@@ -555,6 +558,43 @@ static NSInteger const CommentsFetchBatchSize                   = 10;
     }
     
     [self.noResultsViewController didMoveToParentViewController:self];
+}
+
+#pragma mark - State Restoration
+
++ (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
+{
+    NSString *blogID = [coder decodeObjectForKey:RestorableBlogIdKey];
+    if (!blogID) {
+        return nil;
+    }
+    
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    NSManagedObjectID *objectID = [context.persistentStoreCoordinator managedObjectIDForURIRepresentation:[NSURL URLWithString:blogID]];
+    if (!objectID) {
+        return nil;
+    }
+    
+    NSError *error = nil;
+    Blog *blog = (Blog *)[context existingObjectWithID:objectID error:&error];
+    if (error || !blog) {
+        return nil;
+    }
+
+    return [CommentsViewController controllerWithBlog:blog];
+}
+
+- (void)encodeRestorableStateWithCoder:(NSCoder *)coder
+{
+    [coder encodeObject:[[self.blog.objectID URIRepresentation] absoluteString] forKey:RestorableBlogIdKey];
+    [coder encodeInteger:[self getSelectedIndex:self.filterTabBar] forKey:RestorableFilterIndexKey];
+    [super encodeRestorableStateWithCoder:coder];
+}
+
+- (void)decodeRestorableStateWithCoder:(NSCoder *)coder
+{
+    [self setSeletedIndex:[coder decodeIntegerForKey:RestorableFilterIndexKey] filterTabBar:self.filterTabBar];
+    [super decodeRestorableStateWithCoder:coder];
 }
 
 @end


### PR DESCRIPTION
Ref: #15955 

**NOTE**: Please review #15998 first.

This adds state restoration to `CommentsViewController`.

Known issues:
- The selected filter is not saved while in app.
- Comments don't always reloaded when the view is shown. Pull to refresh will update the comments accordingly.
- As [noted](https://github.com/wordpress-mobile/WordPress-iOS/pull/15998#issuecomment-789355048) on #15998 , there's an issue on iPad where the notifications don't reload. 

To test:
- Go to Comments.
- Select a filter other than All (to be sure restoration works since All is the default).
- Background the app.
- Stop and rerun the app in Xcode.
- Comments should be displayed with the selected filter.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
