### PR TITLE
Milestone Notifications: Present Insights view instead of time period when showing stats

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -58,7 +58,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
         else {
             throw DisplayError.missingParameter
         }
-        
+
         // Stats URLs should be of the form /stats/:time_period/:domain
         if let url = url {
             setTimePeriodForStatsURLIfPossible(url)
@@ -68,7 +68,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
         statsViewController.blog = blog
         controller?.navigationController?.pushViewController(statsViewController, animated: true)
     }
-    
+
     private func setTimePeriodForStatsURLIfPossible(_ url: URL) {
         let matcher = RouteMatcher(routes: UniversalLinkRouter.statsRoutes)
         let matches = matcher.routesMatching(url)

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -2,7 +2,7 @@
 protocol ContentCoordinator {
     func displayReaderWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws
     func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws
-    func displayStatsWithSiteID(_ siteID: NSNumber?) throws
+    func displayStatsWithSiteID(_ siteID: NSNumber?, url: URL?) throws
     func displayFollowersWithSiteID(_ siteID: NSNumber?, expirationTime: TimeInterval) throws
     func displayStreamWithSiteID(_ siteID: NSNumber?) throws
     func displayWebViewWithURL(_ url: URL)
@@ -51,17 +51,33 @@ struct DefaultContentCoordinator: ContentCoordinator {
         controller?.navigationController?.pushViewController(commentsViewController!, animated: true)
     }
 
-    func displayStatsWithSiteID(_ siteID: NSNumber?) throws {
+    func displayStatsWithSiteID(_ siteID: NSNumber?, url: URL? = nil) throws {
         guard let siteID = siteID,
               let blog = Blog.lookup(withID: siteID, in: mainContext),
               blog.supports(.stats)
         else {
             throw DisplayError.missingParameter
         }
+        
+        // Stats URLs should be of the form /stats/:time_period/:domain
+        if let url = url {
+            setTimePeriodForStatsURLIfPossible(url)
+        }
 
         let statsViewController = StatsViewController()
         statsViewController.blog = blog
         controller?.navigationController?.pushViewController(statsViewController, animated: true)
+    }
+    
+    private func setTimePeriodForStatsURLIfPossible(_ url: URL) {
+        let matcher = RouteMatcher(routes: UniversalLinkRouter.statsRoutes)
+        let matches = matcher.routesMatching(url)
+        if let match = matches.first,
+           let action = match.action as? StatsRoute,
+           let timePeriod = action.timePeriod {
+            // Initializing a StatsPeriodType to ensure we have a valid period
+            UserDefaults.standard.set(timePeriod.rawValue, forKey: StatsPeriodType.statsPeriodTypeDefaultsKey)
+        }
     }
 
     func displayBackupWithSiteID(_ siteID: NSNumber?) throws {

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -11,6 +11,23 @@ enum StatsRoute {
     case dayCategory
     case annualStats
     case activityLog
+    
+    var timePeriod: StatsPeriodType? {
+        switch self {
+        case .daySite:
+            return .days
+        case .weekSite:
+            return .weeks
+        case .monthSite:
+            return .months
+        case .yearSite:
+            return .years
+        case .insights:
+            return .insights
+        default:
+            return nil
+        }
+    }
 }
 
 extension StatsRoute: Route {
@@ -115,30 +132,11 @@ extension StatsRoute: NavigationAction {
         // In this case, we'll check whether the last component is actually a
         // time period, and if so we'll show that time period for the default site.
         guard let component = values["domain"],
-            let timePeriod = StatsPeriodType.fromString(component),
-            let blog = defaultBlog() else {
+              let timePeriod = StatsPeriodType(from: component),
+              let blog = defaultBlog() else {
             return
         }
-
+        
         coordinator.showStats(for: blog, timePeriod: timePeriod)
-    }
-}
-
-private extension StatsPeriodType {
-    static func fromString(_ string: String) -> StatsPeriodType? {
-        switch string {
-        case "day":
-            return .days
-        case "week":
-            return .weeks
-        case "month":
-            return .months
-        case "year":
-            return .years
-        case "insights":
-            return .insights
-        default:
-            return nil
-        }
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -11,7 +11,7 @@ enum StatsRoute {
     case dayCategory
     case annualStats
     case activityLog
-    
+
     var timePeriod: StatsPeriodType? {
         switch self {
         case .daySite:
@@ -136,7 +136,7 @@ extension StatsRoute: NavigationAction {
               let blog = defaultBlog() else {
             return
         }
-        
+
         coordinator.showStats(for: blog, timePeriod: timePeriod)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
@@ -79,7 +79,7 @@ struct NotificationContentRouter {
                 FeatureFlag.jetpackBackupAndRestore.enabled {
                 try coordinator.displayBackupWithSiteID(range.siteID)
             } else {
-                try coordinator.displayStatsWithSiteID(range.siteID)
+                try coordinator.displayStatsWithSiteID(range.siteID, url: url)
             }
         case .follow:
             try coordinator.displayFollowersWithSiteID(range.siteID, expirationTime: expirationFiveMinutes)

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -17,7 +17,7 @@ enum StatsPeriodType: Int, FilterTabBarItem, CaseIterable {
         case .years: return NSLocalizedString("Years", comment: "Title of Years stats filter.")
         }
     }
-    
+
     init?(from string: String) {
         switch string {
         case "day":
@@ -34,7 +34,7 @@ enum StatsPeriodType: Int, FilterTabBarItem, CaseIterable {
             return nil
         }
     }
-    
+
     static let statsPeriodTypeDefaultsKey = "LastSelectedStatsPeriodType"
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -17,6 +17,25 @@ enum StatsPeriodType: Int, FilterTabBarItem, CaseIterable {
         case .years: return NSLocalizedString("Years", comment: "Title of Years stats filter.")
         }
     }
+    
+    init?(from string: String) {
+        switch string {
+        case "day":
+            self = .days
+        case "week":
+            self = .weeks
+        case "month":
+            self = .months
+        case "year":
+            self = .years
+        case "insights":
+            self = .insights
+        default:
+            return nil
+        }
+    }
+    
+    static let statsPeriodTypeDefaultsKey = "LastSelectedStatsPeriodType"
 }
 
 fileprivate extension StatsPeriodType {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -60,7 +60,7 @@ class MySitesCoordinator: NSObject {
             // quite complex and contains many nested child view controllers. As we're planning
             // to revamp that section in the not too distant future, I opted for this simpler
             // configuration for now. 2018-07-11 @frosty
-            UserDefaults.standard.set(timePeriod.rawValue, forKey: MySitesCoordinator.statsPeriodTypeDefaultsKey)
+            UserDefaults.standard.set(timePeriod.rawValue, forKey: StatsPeriodType.statsPeriodTypeDefaultsKey)
 
             blogDetailsViewController.showDetailView(for: .stats)
         }
@@ -69,8 +69,6 @@ class MySitesCoordinator: NSObject {
     func showActivityLog(for blog: Blog) {
         showBlogDetails(for: blog, then: .activity)
     }
-
-    private static let statsPeriodTypeDefaultsKey = "LastSelectedStatsPeriodType"
 
     // MARK: - My Sites
 

--- a/WordPress/WordPressTest/MockContentCoordinator.swift
+++ b/WordPress/WordPressTest/MockContentCoordinator.swift
@@ -21,7 +21,7 @@ class MockContentCoordinator: ContentCoordinator {
         commentSiteID = siteID
     }
 
-    func displayStatsWithSiteID(_ siteID: NSNumber?) throws {
+    func displayStatsWithSiteID(_ siteID: NSNumber?, url: URL? = nil) throws {
 
     }
 


### PR DESCRIPTION
This PR tweaks the code that presents stats from the Notifications section of the app. It reuses code from the deep link router to detect the time period present in the stats URL we're opening, and passes that through to the Stats view.

**To test**

- Enable the view milestone feature flag
- Build and run, sandboxing your simulator or device so you can view a View Milestone notification
- Tap the Take a Deep Dive button for the notification and ensure the Insights view is presented
- If possible, test with another notification that includes a stats link, such as the 'traffic is booming' notification – this one should take you to the Day period.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
