### PR TITLE
Add missing event to track "This Week" widget installation

### DIFF
--- a/WordPress/WordPressStatsWidgets/Tracks/Tracks+TodayHomeWidget.swift
+++ b/WordPress/WordPressStatsWidgets/Tracks/Tracks+TodayHomeWidget.swift
@@ -70,6 +70,8 @@ extension Tracks {
         case todayWidgetUpdated = "wpios_today_home_extension_widget_updated"
         // User installs an instance of the all time widget
         case allTimeWidgetUpdated = "wpios_alltime_home_extension_widget_updated"
+        // Users installs an instance of the this week widget
+        case thisWeekWidgetUpdated = "wpios_thisweek_home_extension_widget_updated"
 
         case noEvent
 
@@ -79,6 +81,8 @@ extension Tracks {
                 return .todayWidgetUpdated
             case WPHomeWidgetAllTimeProperties:
                 return .allTimeWidgetUpdated
+            case WPHomeWidgetThisWeekProperties:
+                return .thisWeekWidgetUpdated
             default:
                 return .noEvent
             }


### PR DESCRIPTION
Fixes #NA

To test:

- Build/run and install this week widget
- Go to tracks live update and make sure that the event `wpios_thisweek_home_extension_widget_updated` shows up (might need to wait 5 minutes or more)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
