### PR TITLE
Show domain credit claim section for atomic sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Domain Credit/DomainCreditEligibilityChecker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Domain Credit/DomainCreditEligibilityChecker.swift
@@ -1,5 +1,5 @@
 class DomainCreditEligibilityChecker: NSObject {
     @objc static func canRedeemDomainCredit(blog: Blog) -> Bool {
-        return blog.isHostedAtWPcom && blog.hasDomainCredit
+        return (blog.isHostedAtWPcom || blog.isAtomic()) && blog.hasDomainCredit
     }
 }

--- a/WordPress/WordPressTest/DomainCredit/DomainCreditEligibilityTests.swift
+++ b/WordPress/WordPressTest/DomainCredit/DomainCreditEligibilityTests.swift
@@ -34,4 +34,24 @@ class DomainCreditEligibilityTests: XCTestCase {
         let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog)
         XCTAssertTrue(canRedeemDomainCredit)
     }
+
+    func testDomainCreditEligibilityOnAtomicBlog() {
+        let blog = BlogBuilder(mainContext)
+            .with(atomic: true)
+            .build()
+        blog.hasDomainCredit = false
+        blog.isHostedAtWPcom = false
+        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog)
+        XCTAssertFalse(canRedeemDomainCredit)
+    }
+
+    func testDomainCreditEligibilityOnEligibleAtomicBlog() {
+        let blog = BlogBuilder(mainContext)
+            .with(atomic: true)
+            .build()
+        blog.hasDomainCredit = true
+        blog.isHostedAtWPcom = false
+        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog)
+        XCTAssertTrue(canRedeemDomainCredit)
+    }
 }


### PR DESCRIPTION
Fixes #15476

To test:

Check non-atomic and atomic WPCom sites for domain credit offer

1. Create a new site.
1. Upgrade it to the Business plan.
1. Open the app and go to the My Site tab.
1. Notice that the domain credit is being offered.
1. On the web, convert the site to Atomic (try to install a plugin or go to Jetpack > Backup and activate it).
1. Restart the app and go back to the My Site tab.
1. Notice that the domain credit is still being offered.

Screenshot:
<img width="300" src="https://user-images.githubusercontent.com/1845482/110124510-754c6380-7dc2-11eb-88ec-aaf27fc2bf0d.png">

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
