### PR TITLE
Adds Analytics event to capture when a category filter is selected 

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -151,6 +151,10 @@ import Foundation
     case inviteLinksShare
     case inviteLinksDisable
 
+    // Page Layout and Site Design Picker
+    case categoryFilterSelected
+    case categoryFilterDeselected
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -415,6 +419,12 @@ import Foundation
             return "invite_links_share"
         case .inviteLinksDisable:
             return "invite_links_disable"
+
+        // Page Layout and Site Design Picker
+        case .categoryFilterSelected:
+            return "category_filter_selected"
+        case .categoryFilterDeselected:
+            return "category_filter_deselected"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
@@ -3,6 +3,12 @@ import Gridicons
 import Gutenberg
 
 class FilterableCategoriesViewController: CollapsableHeaderViewController {
+    private enum CategoryFilterAnalyticsKeys {
+        static let modifiedFilter = "filter"
+        static let selectedFilters = "selected_filters"
+        static let location = "location"
+    }
+
     typealias PreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice
     let tableView: UITableView
     internal var selectedItem: IndexPath? = nil {
@@ -40,13 +46,16 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
         }
     }
 
+    let analyticsLocation: String
     init(
+        analyticsLocation: String,
         mainTitle: String,
         prompt: String,
         primaryActionTitle: String,
         secondaryActionTitle: String? = nil,
         defaultActionTitle: String? = nil
     ) {
+        self.analyticsLocation = analyticsLocation
         tableView = UITableView(frame: .zero, style: .plain)
         tableView.separatorStyle = .singleLine
         tableView.separatorInset = .zero
@@ -172,6 +181,7 @@ extension FilterableCategoriesViewController: CollapsableHeaderFilterBarDelegate
     }
 
     func didSelectFilter(withIndex selectedIndex: IndexPath, withSelectedIndexes selectedIndexes: [IndexPath]) {
+        trackFiltersChangedEvent(isSelectionEvent: true, changedIndex: selectedIndex, selectedIndexes: selectedIndexes)
         guard filteredSections == nil else {
             insertFilterRow(withIndex: selectedIndex, withSelectedIndexes: selectedIndexes)
             return
@@ -204,6 +214,7 @@ extension FilterableCategoriesViewController: CollapsableHeaderFilterBarDelegate
     }
 
     func didDeselectFilter(withIndex index: IndexPath, withSelectedIndexes selectedIndexes: [IndexPath]) {
+        trackFiltersChangedEvent(isSelectionEvent: false, changedIndex: index, selectedIndexes: selectedIndexes)
         guard selectedIndexes.count == 0 else {
             removeFilterRow(withIndex: index)
             return
@@ -214,6 +225,18 @@ extension FilterableCategoriesViewController: CollapsableHeaderFilterBarDelegate
             contentSizeWillChange()
             tableView.reloadSections([0], with: .fade)
         })
+    }
+
+    func trackFiltersChangedEvent(isSelectionEvent: Bool, changedIndex: IndexPath, selectedIndexes: [IndexPath]) {
+        let event: WPAnalyticsEvent = isSelectionEvent ? .categoryFilterSelected : .categoryFilterDeselected
+        let filter = categorySections[changedIndex.item].categorySlug
+        let selectedFilters = selectedIndexes.map({ categorySections[$0.item].categorySlug }).joined(separator: ", ")
+
+        WPAnalytics.track(event, properties: [
+            CategoryFilterAnalyticsKeys.location: analyticsLocation,
+            CategoryFilterAnalyticsKeys.modifiedFilter: filter,
+            CategoryFilterAnalyticsKeys.selectedFilters: selectedFilters
+        ])
     }
 
     func removeFilterRow(withIndex index: IndexPath) {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
@@ -45,6 +45,7 @@ class GutenbergLayoutPickerViewController: FilterableCategoriesViewController {
         self.completion = completion
 
         super.init(
+            analyticsLocation: "page_picker",
             mainTitle: NSLocalizedString("Choose a Layout", comment: "Title for the screen to pick a template for a page"),
             prompt: NSLocalizedString("Get started by choosing from a wide variety of pre-made page layouts. Or just start with a blank page.", comment: "Prompt for the screen to pick a template for a page"),
             primaryActionTitle: NSLocalizedString("Create Page", comment: "Title for button to make a page with the contents of the selected layout"),

--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
@@ -59,6 +59,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         self.completion = completion
 
         super.init(
+            analyticsLocation: "site_creation",
             mainTitle: NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site."),
             prompt: NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site."),
             primaryActionTitle: NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design"),


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3130

## To test:
### Home page picker
1. Start the site creation flow (e.g. Choose site > Add button)
1. Select the Create WordPress.com site option
1. Verify that the categories and designs are loaded
1. Press on the **Blog** category
1. **Verify** that an event is emitted: `category_filter_selected, Properties: {"location":"site_creation","filter":"blog","selected_filters":"blog"}`
1. Verify that only the blog category designs are displayed
1. Press on the **Business** category
1. **Verify** that an event is emitted: `category_filter_selected, Properties: {"location":"site_creation","filter":"business","selected_filters":"blog, business"}`
1. Verify that only blog and business designs are displayed
1. Press on the **Business** category to deselect
1. **Verify** that an event is emitted: `category_filter_deselected, Properties: {"location":"site_creation","filter":"business","selected_filters":"blog"}`
1. Verify that only the blog category designs are displayed
1. Press on the **Blog** category to deselect
1. **Verify** that an event is emitted: `category_filter_deselected, Properties: {"location":"site_creation","filter":"blog","selected_filters":""}`
1. Verify that all designs are displayed

### Layout page picker
1. Press the fab ➕  icon in the **My Site** screen and select **Site Page**
1. Verify that the categories and layouts are loaded
1. Press on the **Blog** category
1. **Verify** that an event is emitted: `category_filter_selected, Properties: {"location":"page_picker","filter":"blog","selected_filters":"blog"}`
1. Verify that only the blog category layouts are displayed
1. Press on the **Highlights** category
1. **Verify** that an event is emitted: `category_filter_selected, Properties: {"location":"page_picker","filter":"highlights","selected_filters":"blog, highlights"}`
1. Verify that only blog and highlights layouts are displayed
1. Press on the **Highlight** category to deselect
1. **Verify** that an event is emitted: `category_filter_deselected, Properties: {"location":"page_picker","filter":"highlights","selected_filters":"blog"}`
1. Verify that only the blog category layouts are displayed
1. Press on the **Blog** category to deselect
1. **Verify** that an event is emitted: `category_filter_deselected, Properties: {"location":"page_picker","filter":"blog","selected_filters":""}`
1. Verify that all layouts are displayed

## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.


---
### Discover issue:

While testing I noticed there were some UI warnings in the Console. I'll investigate those in a later PR. 

```
2021-03-05 13:13:27.803392-0500 WordPress[43505:405571] The behavior of the UICollectionViewFlowLayout is not defined because:
2021-03-05 13:13:27.803655-0500 WordPress[43505:405571] the item height must be less than the height of the UICollectionView minus the section insets top and bottom values, minus the content insets top and bottom values.
2021-03-05 13:13:27.804253-0500 WordPress[43505:405571] The relevant UICollectionViewFlowLayout instance is <UICollectionViewFlowLayout: 0x7faa7781add0>, and it is attached to <WordPress.AccessibleCollectionView: 0x7faaf216d400; baseClass = UICollectionView; frame = (0 56.5; 414 230); autoresize = RM+BM; gestureRecognizers = <NSArray: 0x7faa77819960>; layer = <CALayer: 0x7faa77818f40>; contentOffset: {0, 0}; contentSize: {1050, 230}; adjustedContentInset: {0, 0, 0, 0}; layout: <UICollectionViewFlowLayout: 0x7faa7781add0>; dataSource: <WordPress.CategorySectionTableViewCell: 0x7faaf218c200; baseClass = UITableViewCell; frame = (0 259.5; 414 317); autoresize = W; layer = <CALayer: 0x7faa77818c30>>>.
2021-03-05 13:13:27.804516-0500 WordPress[43505:405571] Make a symbolic breakpoint at UICollectionViewFlowLayoutBreakForInvalidSizes to catch this in the debugger.
```