### PR TITLE
Listen for the NoticeAction to track publishing

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -142,7 +142,7 @@ extension PublishingEditor where Self: UIViewController {
 
             if let analyticsStat = analyticsStat {
                 if self is StoryEditor {
-                    postPublishedReceipt = ActionDispatcher.global.subscribe({ action in
+                    postPublishedReceipt = ActionDispatcher.global.subscribe({ [self] action in
                         if let noticeAction = action as? NoticeAction {
                             switch noticeAction {
                             case .post:

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -237,10 +237,10 @@ extension PublishingEditor where Self: UIViewController {
         // End editing to avoid issues with accessibility
         view.endEditing(true)
 
-        let prepublishing = PrepublishingViewController(post: post, identifiers: prepublishingIdentifiers) { result in
+        let prepublishing = PrepublishingViewController(post: post, identifiers: prepublishingIdentifiers) { [weak self] result in
             switch result {
             case .completed(let post):
-                self.post = post
+                self?.post = post
                 publishAction()
             case .dismissed:
                 dismissAction()

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -49,6 +49,8 @@ protocol PublishingEditor where Self: UIViewController {
     var prepublishingIdentifiers: [PrepublishingIdentifier] { get }
 }
 
+var postPublishedReceipt: Receipt?
+
 extension PublishingEditor where Self: UIViewController {
 
     func publishingDismissed() {
@@ -139,7 +141,21 @@ extension PublishingEditor where Self: UIViewController {
             self.post.shouldAttemptAutoUpload = true
 
             if let analyticsStat = analyticsStat {
-                self.trackPostSave(stat: analyticsStat)
+                if self is StoryEditor {
+                    postPublishedReceipt = ActionDispatcher.global.subscribe({ action in
+                        if let noticeAction = action as? NoticeAction {
+                            switch noticeAction {
+                            case .post:
+                                self.trackPostSave(stat: analyticsStat)
+                            default:
+                                break
+                            }
+                            postPublishedReceipt = nil
+                        }
+                    })
+                } else {
+                    self.trackPostSave(stat: analyticsStat)
+                }
             }
 
             if self.post.isFirstTimePublish {


### PR DESCRIPTION
For the Stories editor, we use the `editor_post_published` event with the `post_id` property to create a dashboard of stories. This value is empty when the post is newly published.

This listens for the `NoticeAction` dispatch (the same used to show the toast at the bottom) and then removes the receipt (zeroing out the reference cycle). This ensures that the post has completed async upload and that all properties (`post_id` exist before sending..

### Testing

#### `editor_post_published` Event

* Create a new Story post
* Publish the Post
* Verify that the `editor_post_published` event is logged and that it has a `post_id` value:
```
🔵 Tracked: editor_post_published <blog_id: 123456789, editor_source: wp_stories_creator, has_gutenberg_blocks: 1, has_wp_stories_blocks: 1, post_id: 123, post_type: post, site_type: blog, with_categories: 1, with_photos: 1, with_tags: 0, with_videos: 0, word_count: 35>
```

#### StoryEditor Leak

* Create a new Story post
* Publish the Post
* Check the Memory Graph Debugger
* There should be no instances of StoryEditor

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
