### PR TITLE
Fixes minor UI issues in the Design/Layout picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -466,7 +466,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
             })
             return
         }
-
+        guard hasSelectedItem == selectedStateButtonsContainer.isHidden else { return }
         defaultActionButton.isHidden = false
         selectedStateButtonsContainer.isHidden = false
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
@@ -14,15 +14,15 @@
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="CategorySectionTableViewCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="309"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="309"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mQ0-DH-hTW" customClass="AccessibleCollectionView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="49" width="320" height="230"/>
+                        <rect key="frame" x="0.0" y="56.5" width="320" height="240"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="230" id="1rt-yd-g3n"/>
+                            <constraint firstAttribute="height" constant="240" id="1rt-yd-g3n"/>
                         </constraints>
                         <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="16" id="8Ds-sb-bxf">
                             <size key="itemSize" width="160" height="230"/>
@@ -36,7 +36,7 @@
                         </connections>
                     </collectionView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pe-2p-9as">
-                        <rect key="frame" x="20" y="20" width="80" height="13"/>
+                        <rect key="frame" x="20" y="20" width="80" height="20.5"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="13" id="Cne-bu-2aD"/>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="b0Y-Uh-CXP"/>

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
@@ -5,11 +5,15 @@ import Gutenberg
 class FilterableCategoriesViewController: CollapsableHeaderViewController {
     typealias PreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice
     let tableView: UITableView
+    private lazy var debounceSelectionChange: Debouncer = {
+        Debouncer(delay: 0.1) { [weak self] in
+            guard let `self` = self else { return }
+            self.itemSelectionChanged(self.selectedItem != nil)
+        }
+    }()
     internal var selectedItem: IndexPath? = nil {
         didSet {
-            if !(oldValue != nil && selectedItem != nil) {
-                itemSelectionChanged(selectedItem != nil)
-            }
+            debounceSelectionChange.call()
         }
     }
     private let filterBar: CollapsableHeaderFilterBar


### PR DESCRIPTION
## Description 
This resolves two minor issues related to the UI of the page / layout picker. 

## Layout warnings in the interface builder
While testing https://github.com/wordpress-mobile/WordPress-iOS/pull/16024 I noticed the layout warnings:

```
2021-03-05 13:13:27.803392-0500 WordPress[43505:405571] The behavior of the UICollectionViewFlowLayout is not defined because:
2021-03-05 13:13:27.803655-0500 WordPress[43505:405571] the item height must be less than the height of the UICollectionView minus the section insets top and bottom values, minus the content insets top and bottom values.
2021-03-05 13:13:27.804253-0500 WordPress[43505:405571] The relevant UICollectionViewFlowLayout instance is <UICollectionViewFlowLayout: 0x7faa7781add0>, and it is attached to <WordPress.AccessibleCollectionView: 0x7faaf216d400; baseClass = UICollectionView; frame = (0 56.5; 414 230); autoresize = RM+BM; gestureRecognizers = <NSArray: 0x7faa77819960>; layer = <CALayer: 0x7faa77818f40>; contentOffset: {0, 0}; contentSize: {1050, 230}; adjustedContentInset: {0, 0, 0, 0}; layout: <UICollectionViewFlowLayout: 0x7faa7781add0>; dataSource: <WordPress.CategorySectionTableViewCell: 0x7faaf218c200; baseClass = UITableViewCell; frame = (0 259.5; 414 317); autoresize = W; layer = <CALayer: 0x7faa77818c30>>>.
2021-03-05 13:13:27.804516-0500 WordPress[43505:405571] Make a symbolic breakpoint at UICollectionViewFlowLayoutBreakForInvalidSizes to catch this in the debugger.
```

https://github.com/wordpress-mobile/WordPress-iOS/commit/0a1035f3a6636fd14b86d8d4788f15c5959f36e7 resolves these by updating the `.xib` to match the new expected height

### To Test 
1. Navigate to either the site creation or page creation's choose a layout screen
2. scroll around
3. Expect to not see the error jog above

## Footer flashes to unselected and back when changing designs. 

When selecting between two layout designs the footer will flash to the default state before reanimating to the selected state. 

https://github.com/wordpress-mobile/WordPress-iOS/commit/9af00747d2e0a51587314e25c70b2f82f1e2dd35 denounces the changes to prevent the flash.

### To Test 
1. Navigate to the page creation's choose a layout screen
2. Select a layout 
3. Select a new layout 
4. Expect to not see the flash of the default button state
5. Deselect a layout 
6. Expect to see the default button return
 
### Original error

https://user-images.githubusercontent.com/3384451/110175919-7edcc800-7dd0-11eb-818a-99f0e2f478e5.mov


## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
