### PR TITLE
Jetpack Install: Change error to error_type when tracking jetpack install error

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -74,7 +74,7 @@ private extension JetpackRemoteInstallViewController {
                 WPAnalytics.track(.installJetpackRemoteCompleted)
             case .failure(let error):
                 WPAnalytics.track(.installJetpackRemoteFailed,
-                                  withProperties: ["error": error.type.rawValue,
+                                  withProperties: ["error_type": error.type.rawValue,
                                                    "site_url": self?.blog.url ?? "unknown"])
                 let url = self?.blog.url ?? "unknown"
                 let title = error.title ?? "no error message"


### PR DESCRIPTION
Fixes #16028 

Fixes the tracking of the `wpios_install_jetpack_remote_failed` event by changing `error` to `error_type`.

This also matches the Android event field as well.

### To test:
1. Launch the app
2. Add a self hosted site without Jetpack installed
3. Tap on stats
4. Tap to install
5. On failure see if `wpios_install_jetpack_remote_failed` is tracked correctly online

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
