### PR TITLE
InviteLinks: Add icon to share cell.

### DIFF
--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -604,9 +604,31 @@ private extension InvitePersonViewController {
         if blog.inviteLinks?.count == 0 {
             generateShareCell.textLabel?.text = NSLocalizedString("Generate new link", comment: "Title. A call to action to generate a new invite link.")
         } else {
-            generateShareCell.textLabel?.text = NSLocalizedString("Share invite link", comment: "Title. A call to action to share an invite link.")
+            generateShareCell.textLabel?.attributedText = createAttributedShareInviteText()
         }
         generateShareCell.textLabel?.textColor = .primary
+    }
+
+    func createAttributedShareInviteText() -> NSAttributedString {
+        let pStyle = NSMutableParagraphStyle()
+        pStyle.alignment = .center
+        let font = UIFont.systemFont(ofSize: 17)
+        let textAttributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .paragraphStyle: pStyle,
+            .baselineOffset: 2
+        ]
+        let attachmentAttributes: [NSAttributedString.Key: Any] = [
+            .baselineOffset: -4
+        ]
+
+        let image = UIImage.gridicon(.shareiOS)
+        let attachment = NSTextAttachment(image: image)
+        let textStr = NSAttributedString(string: NSLocalizedString("Share invite link", comment: "Title. A call to action to share an invite link."), attributes: textAttributes)
+        let attrStr = NSMutableAttributedString(attachment: attachment, attributes: attachmentAttributes)
+        attrStr.append(NSAttributedString(string: " "))
+        attrStr.append(textStr)
+        return attrStr
     }
 
     func refreshCurrentInviteCell() {


### PR DESCRIPTION
Refs #15356

This PR updates the Invite Links share cell to show a share icon.  
The icon is sourced from the gridicons share-ios glyph, as the system's share icon is available to UIButtonBarItems, not buttons, and can not be used outside of a tool or nav bar. (Unless I'm missing a trick.)

To test:
Generate some invite links and confirm you see the share icon in the cell. 
Confirm the layout is correct.  I needed to adjust the font baselines to get the text and icon to have the right vertical alignment and I'm not sure if it's off by a pixel or not.


![Simulator Screen Shot - iPhone 11 Pro - 2021-03-05 at 19 49 34](https://user-images.githubusercontent.com/1435271/110191196-c8d3a700-7dec-11eb-8324-642f043d4316.png)



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
