### PR TITLE
Add APP_STORE_STRINGS_FILE_NAME env constant

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -72,7 +72,7 @@ ENV["PUBLIC_CONFIG_FILE"]=File.join(PROJECT_ROOT_FOLDER, "config", "Version.Publ
 ENV["INTERNAL_CONFIG_FILE"]=File.join(PROJECT_ROOT_FOLDER, "config", "Version.internal.xcconfig")
 ENV["DOWNLOAD_METADATA"]="./fastlane/download_metadata.swift"
 ENV["PROJECT_ROOT_FOLDER"]=PROJECT_ROOT_FOLDER + "/"
-
+ENV["APP_STORE_STRINGS_FILE_NAME"]="AppStoreStrings.po"
 
 ########################################################################
 # Screenshots


### PR DESCRIPTION
Adds the `APP_STORE_STRINGS_FILE_NAME` expected by the release toolkit.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
