### PR TITLE
Remove unified auth feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -5,7 +5,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackDisconnect
     case debugMenu
     case readerCSS
-    case unifiedAuth
     case homepageSettings
     case gutenbergMentions
     case gutenbergXposts
@@ -35,8 +34,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .readerCSS:
             return false
-        case .unifiedAuth:
-            return true
         case .homepageSettings:
             return true
         case .gutenbergMentions:
@@ -73,8 +70,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     /// This key must match the server-side one for remote feature flagging
     var remoteKey: String? {
         switch self {
-            case .unifiedAuth:
-                return "wordpress_ios_unified_login_and_signup"
             default:
                 return nil
         }
@@ -101,8 +96,6 @@ extension FeatureFlag {
             return "Debug menu"
         case .readerCSS:
             return "Ignore Reader CSS Cache"
-        case .unifiedAuth:
-            return "Unified Auth"
         case .homepageSettings:
             return "Homepage Settings"
         case .gutenbergMentions:

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -43,7 +43,7 @@ class WordPressAuthenticationManager: NSObject {
                                                                 showLoginOptions: true,
                                                                 enableSignInWithApple: enableSignInWithApple,
                                                                 enableSignupWithGoogle: true,
-                                                                enableUnifiedAuth: FeatureFlag.unifiedAuth.enabled,
+                                                                enableUnifiedAuth: true,
                                                                 enableUnifiedCarousel: FeatureFlag.unifiedPrologueCarousel.enabled)
 
         let prologueVC: UIViewController? =  FeatureFlag.unifiedPrologueCarousel.enabled ? UnifiedPrologueViewController() : nil


### PR DESCRIPTION
Fixes #n/a

This removes the `unifedAuth` feature flag.

To test:
- Log out if necessary.
- Verify the unified auth flow is still displayed.

| ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-08 at 14 56 30](https://user-images.githubusercontent.com/1816888/110388961-189ab400-8021-11eb-858e-e49dc8ded25f.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-08 at 14 56 34](https://user-images.githubusercontent.com/1816888/110388979-1d5f6800-8021-11eb-9167-1a87827b34e4.png) |
|--------|-------|

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
