### PR TITLE
Remove unseen posts feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,7 +17,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case activityLogFilters
     case jetpackBackupAndRestore
     case todayWidget
-    case unseenPosts
     case milestoneNotifications
     case commentFilters
     case newLikeNotifications
@@ -58,8 +57,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .jetpackBackupAndRestore:
             return true
         case .todayWidget:
-            return true
-        case .unseenPosts:
             return true
         case .milestoneNotifications:
             return false
@@ -125,8 +122,6 @@ extension FeatureFlag {
             return "Jetpack Backup and Restore"
         case .todayWidget:
             return "iOS 14 Today Widget"
-        case .unseenPosts:
-            return "Unseen Posts in Reader"
         case .milestoneNotifications:
             return "Milestone notifications"
         case .commentFilters:

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -257,10 +257,7 @@ class ReaderDetailCoordinator {
 
         bumpStats()
         bumpPageViewsForPost()
-
-        if FeatureFlag.unseenPosts.enabled {
-            markPostAsSeen()
-        }
+        markPostAsSeen()
     }
 
     private func markPostAsSeen() {

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -148,10 +148,7 @@ extension ReaderSiteTopic {
                     return TableDataItem(topic: topic, configure: { cell in
                         cell.textLabel?.text = topic.title
                         cell.detailTextLabel?.text = topic.siteURL
-
-                        if FeatureFlag.unseenPosts.enabled {
-                            addUnseenPostCount(topic, with: cell)
-                        }
+                        addUnseenPostCount(topic, with: cell)
                     })
                 }
             }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -94,30 +94,28 @@ final class ReaderShowMenuAction {
         }
 
         // Seen
-        if FeatureFlag.unseenPosts.enabled {
-            if post.isSeenSupported {
-                alertController.addActionWithTitle(post.isSeen ? ReaderPostMenuButtonTitles.markUnseen : ReaderPostMenuButtonTitles.markSeen,
-                                                   style: .default,
-                                                   handler: { (action: UIAlertAction) in
+        if post.isSeenSupported {
+            alertController.addActionWithTitle(post.isSeen ? ReaderPostMenuButtonTitles.markUnseen : ReaderPostMenuButtonTitles.markSeen,
+                                               style: .default,
+                                               handler: { (action: UIAlertAction) in
 
-                                                    let event: WPAnalyticsEvent = post.isSeen ? .readerPostMarkUnseen : .readerPostMarkSeen
-                                                    WPAnalytics.track(event, properties: ["source": source.description])
+                                                let event: WPAnalyticsEvent = post.isSeen ? .readerPostMarkUnseen : .readerPostMarkSeen
+                                                WPAnalytics.track(event, properties: ["source": source.description])
 
-                                                    if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
-                                                        ReaderSeenAction().execute(with: post, context: context, completion: {
-                                                            ReaderHelpers.dispatchToggleSeenMessage(post: post, success: true)
+                                                if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
+                                                    ReaderSeenAction().execute(with: post, context: context, completion: {
+                                                        ReaderHelpers.dispatchToggleSeenMessage(post: post, success: true)
 
-                                                            // Notify Reader Stream so the post card is updated.
-                                                            NotificationCenter.default.post(name: .ReaderPostSeenToggled,
-                                                                                            object: nil,
-                                                                                            userInfo: [ReaderNotificationKeys.post: post])
-                                                        },
-                                                        failure: { _ in
-                                                            ReaderHelpers.dispatchToggleSeenMessage(post: post, success: false)
-                                                        })
-                                                    }
-                                                   })
-            }
+                                                        // Notify Reader Stream so the post card is updated.
+                                                        NotificationCenter.default.post(name: .ReaderPostSeenToggled,
+                                                                                        object: nil,
+                                                                                        userInfo: [ReaderNotificationKeys.post: post])
+                                                    },
+                                                    failure: { _ in
+                                                        ReaderHelpers.dispatchToggleSeenMessage(post: post, success: false)
+                                                    })
+                                                }
+                                               })
         }
 
         // Visit


### PR DESCRIPTION
Ref: #15355, #15483

This removes the `unseenPosts` feature flag.

To test:
- Go to Reader.
- Tap `Filter` on a filterable tab.
- Verify the unseen post count is displayed for Sites.

<img width="474" alt="sites_filter" src="https://user-images.githubusercontent.com/1816888/110391478-bb086680-8024-11eb-8765-a26bce899230.png">

- In a Reader stream, tap the options button on a post card.
- Verify `Mark as seen` / `Mark as unseen` is an option.

![menu_option](https://user-images.githubusercontent.com/1816888/110391561-dc695280-8024-11eb-8425-cd1ea82181ed.png)



PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
