### PR TITLE
WPTabBarController -> My Sites Coordinator cleanup

### DIFF
--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
@@ -43,7 +43,9 @@ open class WP3DTouchShortcutHandler: NSObject {
                 WPAnalytics.track(.shortcutStats)
                 clearCurrentViewController()
                 let blogService: BlogService = BlogService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-                tabBarController.switchMySitesTabToStatsView(for: blogService.lastUsedOrFirstBlog())
+                if let mainBlog = blogService.lastUsedOrFirstBlog() {
+                    tabBarController.mySitesCoordinator.showStats(for: mainBlog)
+                }
                 return true
             case ShortcutIdentifier.Notifications.type:
                 WPAnalytics.track(.shortcutNotifications)

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -41,7 +41,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .gutenbergXposts:
             return true
         case .newNavBarAppearance:
-            return BuildConfiguration.current == .localDeveloper
+            return false
         case .unifiedPrologueCarousel:
             return false
         case .stories:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -253,7 +253,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     // If there's already a blog details view controller for this blog in the primary
     // navigation stack, we'll return that instead of creating a new one.
-    UISplitViewController *splitViewController = [[WPTabBarController sharedInstance] blogListSplitViewController];
+    UISplitViewController *splitViewController = [WPTabBarController sharedInstance].mySitesCoordinator.splitViewController;
     UINavigationController *navigationController = splitViewController.viewControllers.firstObject;
     if (navigationController && [navigationController isKindOfClass:[UINavigationController class]]) {
         BlogDetailsViewController *topViewController = (BlogDetailsViewController *)navigationController.topViewController;

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -37,7 +37,7 @@ static NSInteger HideSearchMinSites = 3;
 
 + (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
 {
-    return [[WPTabBarController sharedInstance] blogListViewController];
+    return [WPTabBarController sharedInstance].mySitesCoordinator.blogListViewController;
 }
 
 - (instancetype)init

--- a/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
@@ -22,7 +22,7 @@ class MediaNoticeNavigationCoordinator {
 
     static func navigateToMediaLibrary(with userInfo: NSDictionary) {
         if let blog = blog(from: userInfo) {
-            WPTabBarController.sharedInstance().switchMySitesTabToMedia(for: blog)
+            WPTabBarController.sharedInstance()?.mySitesCoordinator.showMedia(for: blog)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -117,12 +117,12 @@ class MySitesCoordinator: NSObject {
     func showActivityLog(for blog: Blog) {
         showBlogDetails(for: blog, then: .activity)
     }
-    
+
     // MARK: - Adding a new site
     @objc
     func showAddNewSite(from view: UIView) {
         showMySites()
-        
+
         blogListViewController.presentInterfaceForAddingNewSite(from: view)
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -117,6 +117,14 @@ class MySitesCoordinator: NSObject {
     func showActivityLog(for blog: Blog) {
         showBlogDetails(for: blog, then: .activity)
     }
+    
+    // MARK: - Adding a new site
+    @objc
+    func showAddNewSite(from view: UIView) {
+        showMySites()
+        
+        blogListViewController.presentInterfaceForAddingNewSite(from: view)
+    }
 
     // MARK: - My Sites
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -50,9 +50,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)showNotificationsTab;
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia;
 - (void)showReaderTabForPost:(NSNumber *)postId onBlog:(NSNumber *)blogId;
-- (void)switchMySitesTabToAddNewSite;
-- (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog;
-- (void)switchMySitesTabToMediaForBlog:(Blog *)blog;
 
 - (void)popNotificationsTabToRoot;
 - (void)switchNotificationsTabToNotificationSettings;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -25,9 +25,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 
 @interface WPTabBarController : UITabBarController <UIViewControllerTransitioningDelegate>
 
-@property (nonatomic, strong, readonly) WPSplitViewController *blogListSplitViewController;
-@property (nonatomic, strong, readonly) BlogListViewController *blogListViewController;
-@property (nonatomic, strong, readonly) UINavigationController *blogListNavigationController;
 @property (nonatomic, strong, readonly) NotificationsViewController *notificationsViewController;
 @property (nonatomic, strong, readonly) UINavigationController *readerNavigationController;
 @property (nonatomic, strong, readonly) MySitesCoordinator *mySitesCoordinator;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -318,7 +318,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     // Ignore taps on the post tab and instead show the modal.
     if ([blogService blogCountForAllAccounts] == 0) {
-        [self switchMySitesTabToAddNewSite];
+        [self.mySitesCoordinator showAddNewSiteFrom:self.tabBar];
     } else {
         [self showPostTabAnimated:true toMedia:false blog:nil afterDismiss:afterDismiss];
     }
@@ -329,7 +329,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     if ([blogService blogCountForAllAccounts] == 0) {
-        [self switchMySitesTabToAddNewSite];
+        [self.mySitesCoordinator showAddNewSiteFrom:self.tabBar];
     } else {
         [self showPostTabAnimated:YES toMedia:NO blog:blog];
     }
@@ -393,41 +393,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 - (void)popNotificationsTabToRoot
 {
     [self.notificationsNavigationController popToRootViewControllerAnimated:NO];
-}
-
-- (void)switchMySitesTabToAddNewSite
-{
-    [self setSelectedIndex:WPTabMySites];
-    [self.blogListViewController presentInterfaceForAddingNewSiteFrom:self.tabBar];
-}
-
-- (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog
-{
-    [self.mySitesCoordinator showBlogDetailsFor:blog];
-
-    BlogDetailsViewController *blogDetailVC = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
-    if ([blogDetailVC isKindOfClass:[BlogDetailsViewController class]]) {
-        [blogDetailVC showDetailViewForSubsection:BlogDetailsSubsectionStats];
-    }
-}
-
-- (void)switchMySitesTabToMediaForBlog:(Blog *)blog
-{
-    [self switchMySitesTabToBlogDetailsForBlog:blog];
-
-    BlogDetailsViewController *blogDetailVC = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
-    if ([blogDetailVC isKindOfClass:[BlogDetailsViewController class]]) {
-        [blogDetailVC showDetailViewForSubsection:BlogDetailsSubsectionMedia];
-    }
-}
- 
-- (void)switchMySitesTabToBlogDetailsForBlog:(Blog *)blog
-{
-    [self setSelectedIndex:WPTabMySites];
-
-    BlogListViewController *blogListVC = self.blogListViewController;
-    self.blogListNavigationController.viewControllers = @[blogListVC];
-    [blogListVC setSelectedBlog:blog animated:NO];
 }
 
 - (void)switchNotificationsTabToNotificationSettings

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -151,25 +151,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [super decodeRestorableStateWithCoder:coder];
 }
 
-#pragma mark - My Site View Controllers
-
-// These getters are temporary while we extract items from here to the MySiteCoordinator.
-
-- (UISplitViewController *)blogListSplitViewController
-{
-    return [self.mySitesCoordinator splitViewController];
-}
-
-- (UINavigationController *)blogListNavigationController
-{
-    return [self.mySitesCoordinator navigationController];
-}
-
-- (BlogListViewController *)blogListViewController
-{
-    return [self.mySitesCoordinator blogListViewController];
-}
-
 #pragma mark - Tab Bar Items
 
 - (UINavigationController *)readerNavigationController
@@ -429,7 +410,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         return nil;
     }
 
-    BlogDetailsViewController *blogDetailsController = (BlogDetailsViewController *)[[self.blogListNavigationController.viewControllers wp_filter:^BOOL(id obj) {
+    BlogDetailsViewController *blogDetailsController = (BlogDetailsViewController *)[[self.mySitesCoordinator.navigationController.viewControllers wp_filter:^BOOL(id obj) {
         return [obj isKindOfClass:[BlogDetailsViewController class]];
     }] firstObject];
     return blogDetailsController.blog;
@@ -489,7 +470,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     // If the user has one blog then we don't want to present them with the main "My Sites"
     // screen where they can see all their blogs. In the case of only one blog just show
     // the main blog details screen
-    UINavigationController *navController = (UINavigationController *)[self.blogListSplitViewController.viewControllers firstObject];
+    UINavigationController *navController = (UINavigationController *)[self.mySitesCoordinator.splitViewController.viewControllers firstObject];
     BlogListViewController *blogListViewController = (BlogListViewController *)[navController.viewControllers firstObject];
 
     if ([blogListViewController shouldBypassBlogListViewControllerWhenSelectedFromTabBar]) {
@@ -507,7 +488,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (BOOL)isNavigatingMySitesTab
 {
-    return (self.selectedIndex == WPTabMySites && [self.blogListViewController.navigationController.viewControllers count] > 1);
+    return (self.selectedIndex == WPTabMySites && [self.mySitesCoordinator.navigationController.viewControllers count] > 1);
 }
 
 #pragma mark - Zendesk Notifications


### PR DESCRIPTION
This PR is the next part of pulling the changes from #15751 into develop. It's just some small cleanup, removing unused properties and moving some navigation over to My Sites Coordinator.

**To test**

A little similar to the previous PR, although there aren't as big changes here:

- Test on both iPad and iPhone.
- Build and run.
- Ensure that you can log in and out and back into the app and the blog details screens show up as expected.
- Try moving the iPad into multitasking to collapse the split view and back out and ensure that a detail view controller is restored in My Site.
- Ensure you can access the Add A New Site UI from the blog list view controller
- Check that you can automatically navigate into the media section for a site – run a deep link like: `xcrun simctl openurl booted https://wordpress.com/media/your_site_domain_here`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
