### PR TITLE
Issues/15356 fix dynamic font

### DIFF
--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -167,21 +167,18 @@ class InvitePersonViewController: UITableViewController {
 
     @IBOutlet private var currentInviteCell: UITableViewCell! {
         didSet {
-            setupCurrentInviteCell()
             refreshCurrentInviteCell()
         }
     }
 
     @IBOutlet private var expirationCell: UITableViewCell! {
         didSet {
-            setupExpirationCell()
             refreshExpirationCell()
         }
     }
 
     @IBOutlet private var disableLinksCell: UITableViewCell! {
         didSet {
-            setupDisableInviteLinksCell()
             refreshDisableLinkCell()
         }
     }
@@ -570,21 +567,6 @@ private extension InvitePersonViewController {
 //
 private extension InvitePersonViewController {
 
-    func setupDisableInviteLinksCell() {
-        disableLinksCell.textLabel?.text = NSLocalizedString("Disable invite link", comment: "Title. A call to action to disable invite links.")
-        disableLinksCell.textLabel?.textColor = .error
-    }
-
-    func setupCurrentInviteCell() {
-        currentInviteCell.textLabel?.text = NSLocalizedString("Role", comment: "Title. Indicates the user role an invite link is for.")
-        currentInviteCell.textLabel?.textColor = .text
-    }
-
-    func setupExpirationCell() {
-        expirationCell.textLabel?.text = NSLocalizedString("Expires on", comment: "Title. Indicates an expiration date.")
-        expirationCell.textLabel?.textColor = .text
-    }
-
     func refreshInviteLinkCell(indexPath: IndexPath) {
         guard let row = InviteLinkRow(rawValue: indexPath.row) else {
             return
@@ -608,6 +590,7 @@ private extension InvitePersonViewController {
             generateShareCell.textLabel?.text = NSLocalizedString("Share invite link", comment: "Title. A call to action to share an invite link.")
         }
         generateShareCell.textLabel?.font = WPStyleGuide.tableviewTextFont()
+        generateShareCell.textLabel?.textAlignment = .center
         generateShareCell.textLabel?.textColor = .primary
     }
 
@@ -615,6 +598,10 @@ private extension InvitePersonViewController {
         guard selectedInviteLinkIndex < availableRoles.count else {
             return
         }
+
+        currentInviteCell.textLabel?.text = NSLocalizedString("Role", comment: "Title. Indicates the user role an invite link is for.")
+        currentInviteCell.textLabel?.textColor = .text
+
         // sortedInviteLinks and availableRoles should be complimentary. We can cheat a little and
         // get the localized "display name" to use from availableRoles rather than
         // trying to capitalize the role slug from the current invite link.
@@ -632,6 +619,9 @@ private extension InvitePersonViewController {
             return
         }
 
+        expirationCell.textLabel?.text = NSLocalizedString("Expires on", comment: "Title. Indicates an expiration date.")
+        expirationCell.textLabel?.textColor = .text
+
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         let date = Date(timeIntervalSince1970: Double(invite.expiry))
@@ -641,7 +631,10 @@ private extension InvitePersonViewController {
     }
 
     func refreshDisableLinkCell() {
-        WPStyleGuide.configureTableViewCell(disableLinksCell)
+        disableLinksCell.textLabel?.text = NSLocalizedString("Disable invite link", comment: "Title. A call to action to disable invite links.")
+        disableLinksCell.textLabel?.font = WPStyleGuide.tableviewTextFont()
+        disableLinksCell.textLabel?.textColor = .error
+        disableLinksCell.textLabel?.textAlignment = .center
     }
 
     func syncInviteLinks() {

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -182,6 +182,7 @@ class InvitePersonViewController: UITableViewController {
     @IBOutlet private var disableLinksCell: UITableViewCell! {
         didSet {
             setupDisableInviteLinksCell()
+            refreshDisableLinkCell()
         }
     }
 
@@ -595,8 +596,8 @@ private extension InvitePersonViewController {
             refreshCurrentInviteCell()
         case .expires:
             refreshExpirationCell()
-        default:
-            break
+        case .disable:
+            refreshDisableLinkCell()
         }
     }
 
@@ -606,6 +607,7 @@ private extension InvitePersonViewController {
         } else {
             generateShareCell.textLabel?.text = NSLocalizedString("Share invite link", comment: "Title. A call to action to share an invite link.")
         }
+        generateShareCell.textLabel?.font = WPStyleGuide.tableviewTextFont()
         generateShareCell.textLabel?.textColor = .primary
     }
 
@@ -618,6 +620,8 @@ private extension InvitePersonViewController {
         // trying to capitalize the role slug from the current invite link.
         let role = availableRoles[selectedInviteLinkIndex]
         currentInviteCell.detailTextLabel?.text = role.name
+
+        WPStyleGuide.configureTableViewCell(currentInviteCell)
     }
 
     func refreshExpirationCell() {
@@ -632,6 +636,12 @@ private extension InvitePersonViewController {
         formatter.dateStyle = .medium
         let date = Date(timeIntervalSince1970: Double(invite.expiry))
         expirationCell.detailTextLabel?.text = formatter.string(from: date)
+
+        WPStyleGuide.configureTableViewCell(expirationCell)
+    }
+
+    func refreshDisableLinkCell() {
+        WPStyleGuide.configureTableViewCell(disableLinksCell)
     }
 
     func syncInviteLinks() {

--- a/WordPress/Classes/ViewRelated/People/People.storyboard
+++ b/WordPress/Classes/ViewRelated/People/People.storyboard
@@ -375,7 +375,7 @@
                             </tableViewSection>
                             <tableViewSection id="eT7-if-lvZ">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" textLabel="Zm5-2s-RgM" rowHeight="42" style="IBUITableViewCellStyleDefault" id="SnT-bj-ro5">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" textLabel="Zm5-2s-RgM" style="IBUITableViewCellStyleDefault" id="SnT-bj-ro5">
                                         <rect key="frame" x="0.0" y="314" width="375" height="42"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="SnT-bj-ro5" id="BXy-E7-KZb">
@@ -392,7 +392,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="g40-Lu-Tb6" detailTextLabel="ni2-FN-yoP" rowHeight="42" style="IBUITableViewCellStyleValue1" id="1pf-gg-Sfn">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="g40-Lu-Tb6" detailTextLabel="ni2-FN-yoP" style="IBUITableViewCellStyleValue1" id="1pf-gg-Sfn">
                                         <rect key="frame" x="0.0" y="356" width="375" height="42"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="1pf-gg-Sfn" id="lBf-2e-rNX">
@@ -419,7 +419,7 @@
                                             <segue destination="TOR-rB-bMi" kind="show" identifier="inviteRole" id="djZ-XX-wel"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" textLabel="iIk-xV-Xdo" detailTextLabel="t88-zf-B8l" rowHeight="42" style="IBUITableViewCellStyleValue1" id="dOH-RD-Vok">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="none" indentationWidth="10" textLabel="iIk-xV-Xdo" detailTextLabel="t88-zf-B8l" style="IBUITableViewCellStyleValue1" id="dOH-RD-Vok">
                                         <rect key="frame" x="0.0" y="398" width="375" height="42"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="dOH-RD-Vok" id="y24-Tt-Qm5">
@@ -443,7 +443,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" textLabel="JlS-gd-WUF" rowHeight="42" style="IBUITableViewCellStyleDefault" id="Kcp-F4-LVf">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" textLabel="JlS-gd-WUF" style="IBUITableViewCellStyleDefault" id="Kcp-F4-LVf">
                                         <rect key="frame" x="0.0" y="440" width="375" height="42"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Kcp-F4-LVf" id="MDM-e0-ex4">


### PR DESCRIPTION
Refs #16032 #15356

This fixes an issue with dynamic font sizes not being respected in the new invite links cells.  Dynamic fonts (and styles) are manually set like other cells and row heights are now automatically computed.

To test:
Text the branch and change dynamic font sizes.  Confirm that the cells are correctly sized.

Examples:
![Simulator Screen Shot - iPhone 11 Pro - 2021-03-09 at 12 31 18](https://user-images.githubusercontent.com/1435271/110519889-75ef3d80-80d3-11eb-8678-d98b770daff7.png)
![Simulator Screen Shot - iPhone 11 Pro - 2021-03-09 at 12 31 09](https://user-images.githubusercontent.com/1435271/110519895-7687d400-80d3-11eb-8e79-ebd58936486c.png)

@ScoutHarris would you kindly?  I'll cherry pick this change into develop and modify it to also fix the updated share icon cell.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
