### PR TITLE
Reader stream filter: hide filter tab bar for sheets with only one filter.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetView.swift
@@ -137,6 +137,9 @@ class FilterSheetView: UIView {
         }
         selectedFilter = filters.first
 
+        // If there is only one filter, don't show the filter tab bar.
+        filterTabBar.isHidden = filters.count == 1
+
         addSubview(stackView)
         pinSubviewToAllEdges(stackView)
 


### PR DESCRIPTION
Fixes #15496 

This removes the filter tab bar on filter sheets with only one filter. 

To test:

---
- Go to the Reader. 
- Select `Followed P2s` or `Automattic`.
- Tap `Filter`.
- Verify the filter tab bar is not displayed.

| Before | After |
|--------|-------|
| <img width="468" alt="p2_before" src="https://user-images.githubusercontent.com/1816888/110520095-489e9180-80cb-11eb-803f-7247ee795b12.png"> | <img width="472" alt="p2_after" src="https://user-images.githubusercontent.com/1816888/110519965-260c7880-80cb-11eb-95aa-45b92fcedc5f.png"> |

---
- Go to `Following` and `Filter`.
- Verify the filter tab bar is displayed.

<kbd><img width="468" alt="following" src="https://user-images.githubusercontent.com/1816888/110520259-77b50300-80cb-11eb-83e4-2d6f04b38082.png"></kbd>

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
