### PR TITLE
Comments: always deselect comment row.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -218,16 +218,16 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    [tableView deselectSelectedRowWithAnimation:YES];
+    
     // Failsafe: Make sure that the Comment (still) exists
     NSArray *sections = self.tableViewHandler.resultsController.sections;
     if (indexPath.section >= sections.count) {
-        [tableView deselectSelectedRowWithAnimation:YES];
         return;
     }
     
     id<NSFetchedResultsSectionInfo> sectionInfo = sections[indexPath.section];
     if (indexPath.row >= sectionInfo.numberOfObjects) {
-        [tableView deselectSelectedRowWithAnimation:YES];
         return;
     }
     


### PR DESCRIPTION
Ref: #15909

This fixes an issue where row selection would persist after selecting a Comment from the list.

To test:
- Go to Site > Comments.
- Select a Comment.
- Return to the list.
- Verify the Comment row is deselected.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
