### PR TITLE
Initial use of MySiteViewController

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -59,6 +59,10 @@ extension WPStyleGuide {
         appearance.backgroundColor = .appBarBackground
         appearance.titleTextAttributes = textAttributes
 
+        if FeatureFlag.newNavBarAppearance.enabled {
+            appearance.shadowColor = .clear
+        }
+
         navigationAppearance.standardAppearance = appearance
         navigationAppearance.scrollEdgeAppearance = navigationAppearance.standardAppearance
 
@@ -132,12 +136,14 @@ extension WPStyleGuide {
         configureTableViewColors(view: view)
         configureTableViewColors(tableView: tableView)
     }
+
     class func configureTableViewColors(view: UIView?) {
         guard let view = view else {
             return
         }
         view.backgroundColor = .basicBackground
     }
+
     class func configureTableViewColors(tableView: UITableView?) {
         guard let tableView = tableView else {
             return

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
@@ -43,7 +43,9 @@ open class WP3DTouchShortcutHandler: NSObject {
                 WPAnalytics.track(.shortcutStats)
                 clearCurrentViewController()
                 let blogService: BlogService = BlogService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-                tabBarController.switchMySitesTabToStatsView(for: blogService.lastUsedOrFirstBlog())
+                if let mainBlog = blogService.lastUsedOrFirstBlog() {
+                    tabBarController.mySitesCoordinator.showStats(for: mainBlog)
+                }
                 return true
             case ShortcutIdentifier.Notifications.type:
                 WPAnalytics.track(.shortcutNotifications)

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -41,7 +41,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .gutenbergXposts:
             return true
         case .newNavBarAppearance:
-            return BuildConfiguration.current == .localDeveloper
+            return false
         case .unifiedPrologueCarousel:
             return false
         case .stories:

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -48,7 +48,7 @@ extension MySitesRoute: NavigationAction {
             WPAppAnalytics.track(.deepLinkFailed, withProperties: ["route": path])
 
             if failAndBounce(values) == false {
-                coordinator.showMySites()
+                coordinator.showRootViewController()
                 postFailureNotice(title: NSLocalizedString("Site not found",
                                                            comment: "Error notice shown if the app can't find a specific site belonging to the user"))
             }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -119,7 +119,7 @@ extension StatsRoute: NavigationAction {
         WPAppAnalytics.track(.deepLinkFailed, withProperties: ["route": path])
 
         if failAndBounce(values) == false {
-            coordinator.showMySites()
+            coordinator.showRootViewController()
             postFailureNotice(title: NSLocalizedString("Site not found",
                                                        comment: "Error notice shown if the app can't find a specific site belonging to the user"))
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -253,7 +253,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     // If there's already a blog details view controller for this blog in the primary
     // navigation stack, we'll return that instead of creating a new one.
-    UISplitViewController *splitViewController = [[WPTabBarController sharedInstance] blogListSplitViewController];
+    UISplitViewController *splitViewController = [WPTabBarController sharedInstance].mySitesCoordinator.splitViewController;
     UINavigationController *navigationController = splitViewController.viewControllers.firstObject;
     if (navigationController && [navigationController isKindOfClass:[UINavigationController class]]) {
         BlogDetailsViewController *topViewController = (BlogDetailsViewController *)navigationController.topViewController;

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -37,7 +37,7 @@ static NSInteger HideSearchMinSites = 3;
 
 + (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
 {
-    return [[WPTabBarController sharedInstance] blogListViewController];
+    return [WPTabBarController sharedInstance].mySitesCoordinator.blogListViewController;
 }
 
 - (instancetype)init

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -2,6 +2,8 @@ import WordPressAuthenticator
 
 class MySiteViewController: UIViewController, NoResultsViewHost {
 
+    private let meScenePresenter: ScenePresenter
+
     // MARK: - Initializers
 
     init(meScenePresenter: ScenePresenter) {
@@ -316,10 +318,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         self.blog = blog
     }
-
-    // MARK: - Me Bar Button
-
-    private let meScenePresenter: ScenePresenter
 }
 
 extension MySiteViewController: WPSplitViewControllerDetailProvider {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -175,7 +175,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         present(addSiteAlert, animated: true)
     }
-    
+
     private func launchSiteCreation() {
         let wizardLauncher = SiteCreationWizardLauncher()
         guard let wizard = wizardLauncher.ui else {
@@ -213,7 +213,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         blogDetailsViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.pinSubviewToAllEdges(blogDetailsViewController.view)
-        
+
         showInitialDetails()
     }
 
@@ -221,10 +221,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         if splitViewControllerIsHorizontallyCompact {
             return
         }
-        
+
         blogDetailsViewController?.showDetailView(for: .stats)
     }
-    
+
     private func blogDetailsViewController(for blog: Blog) -> BlogDetailsViewController {
         guard let blogDetailsViewController = blogDetailsViewController else {
             let blogDetailsViewController = makeBlogDetailsViewController(for: blog)
@@ -324,12 +324,12 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
 extension MySiteViewController: WPSplitViewControllerDetailProvider {
     func initialDetailViewControllerForSplitView(_ splitView: WPSplitViewController) -> UIViewController? {
-        guard let blogDetailsViewController = blogDetailsViewController as? WPSplitViewControllerDetailProvider else  {
+        guard let blogDetailsViewController = blogDetailsViewController as? WPSplitViewControllerDetailProvider else {
             let emptyViewController = UIViewController()
             WPStyleGuide.configureColors(view: emptyViewController.view, tableView: nil)
             return emptyViewController
         }
-        
+
         return blogDetailsViewController.initialDetailViewControllerForSplitView(splitView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -1,0 +1,333 @@
+import WordPressAuthenticator
+
+class MySiteViewController: UIViewController, NoResultsViewHost {
+
+    // MARK: - Initializers
+
+    init(meScenePresenter: ScenePresenter) {
+        self.meScenePresenter = meScenePresenter
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Initializer not implemented!")
+    }
+
+    // MARK: - Blog
+
+    /// Convenience setter and getter for the blog.  This calculated property takes care of showing the appropriate VC, depending
+    /// on whether there's a blog to show or not.
+    ///
+    var blog: Blog? {
+        set {
+            guard let newBlog = newValue else {
+                showBlogDetailsForMainBlogOrNoSites()
+                return
+            }
+
+            showBlogDetails(for: newBlog)
+        }
+
+        get {
+            return blogDetailsViewController?.blog
+        }
+    }
+
+    /// The VC for the blog details.  This class is written in a way that this VC will only exist if it's being shown on screen.
+    /// Please keep this in mind when making modifications.
+    ///
+    private var blogDetailsViewController: BlogDetailsViewController?
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        setupNavigationItem()
+        subscribeToModelChanges()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if blog == nil {
+            showBlogDetailsForMainBlogOrNoSites()
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        workaroundLargeTitleCollapseBug()
+    }
+
+    // MARK: - Navigation Item
+
+    /// In iPad and iOS 14, the large-title bar is collapsed when the VC is first loaded.  Call this method from
+    /// `viewDidAppear(_:)` to quickly refresh the navigation bar so that it's expanded.
+    ///
+    private func workaroundLargeTitleCollapseBug() {
+        guard !splitViewControllerIsHorizontallyCompact else {
+            return
+        }
+
+        navigationController?.navigationBar.sizeToFit()
+    }
+
+    private func setupNavigationItem() {
+        navigationItem.largeTitleDisplayMode = .always
+        navigationItem.title = NSLocalizedString("My Site", comment: "Title of My Site tab")
+
+        // Workaround:
+        //
+        // Without the next line, the large title was being lost when going into a child VC with a small
+        // title and pressing "Back" in the navigation bar.
+        //
+        // I'm not sure if this makes sense - it doesn't to me right now, so I'm adding instructions to
+        // test the issue which will be helpful for removing the issue if the workaround is no longer
+        // needed.
+        //
+        // To see the issue in action, comment the line, run the App, go into "Stats" (or any other
+        // child VC that has a small title in the navigation bar), check that the title is small,
+        // press back, and check that this VC has a large title.  If this VC still has a
+        // large title, you can remove the following line.
+        //
+        extendedLayoutIncludesOpaqueBars = true
+    }
+
+    // MARK: - Account
+
+    private func defaultAccount() -> WPAccount? {
+        let context = ContextManager.sharedInstance().mainContext
+        let service = AccountService(managedObjectContext: context)
+
+        return service.defaultWordPressComAccount()
+    }
+
+    // MARK: - Main Blog
+
+    /// Convenience method to retrieve the main blog for an account when none is selected.
+    ///
+    /// - Returns:the main blog for an account (last selected, or first blog in list).
+    ///
+    private func mainBlog() -> Blog? {
+        let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
+        return blogService.lastUsedOrFirstBlog()
+    }
+
+    /// This VC is prepared to either show the details for a blog, or show a no-results VC configured to let the user know they have no blogs.
+    /// There's no scenario where this is shown empty, for an account that HAS blogs.
+    ///
+    /// In order to adhere to this logic, if this VC is shown without a blog being set, we will try to load the "main" blog (ie in order: the last used blog,
+    /// the account's primary blog, or the first blog we find for the account).
+    ///
+    private func showBlogDetailsForMainBlogOrNoSites() {
+        guard let mainBlog = mainBlog() else {
+            showNoSites()
+            return
+        }
+
+        showBlogDetails(for: mainBlog)
+    }
+
+    // MARK: - No Sites UI logic
+
+    private func hideNoSites() {
+        hideNoResults()
+    }
+
+    private func showNoSites() {
+        hideBlogDetails()
+
+        addMeButtonToNavigationBar(email: defaultAccount()?.email, meScenePresenter: meScenePresenter)
+
+        configureAndDisplayNoResults(
+            on: view,
+            title: NSLocalizedString(
+                "Create a new site for your business, magazine, or personal blog; or connect an existing WordPress installation.",
+                comment: "Text shown when the account has no sites."),
+            buttonTitle: NSLocalizedString(
+                "Add new site",
+                comment: "Title of button to add a new site."),
+            image: "mysites-nosites") { noResultsViewController in
+
+            noResultsViewController.actionButtonHandler = { [weak self] in
+                self?.showAddSiteAlert()
+            }
+        }
+    }
+
+    // MARK: - Add Site Alert
+
+    private func showAddSiteAlert() {
+        let addSiteAlert = AddSiteAlertFactory().makeAddSiteAlert(canCreateWPComSite: defaultAccount() != nil) { [weak self] in
+            self?.launchSiteCreation()
+        } addSelfHostedSite: {
+            WordPressAuthenticator.showLoginForSelfHostedSite(self)
+        }
+
+        if let sourceView = noResultsViewController.actionButton,
+           let popoverPresentationController = addSiteAlert.popoverPresentationController {
+
+            popoverPresentationController.sourceView = sourceView
+            popoverPresentationController.sourceRect = sourceView.bounds
+            popoverPresentationController.permittedArrowDirections = .up
+        }
+
+        present(addSiteAlert, animated: true)
+    }
+    
+    private func launchSiteCreation() {
+        let wizardLauncher = SiteCreationWizardLauncher()
+        guard let wizard = wizardLauncher.ui else {
+            return
+        }
+        present(wizard, animated: true)
+        WPAnalytics.track(.enhancedSiteCreationAccessed)
+    }
+
+    // MARK: - Blog Details UI Logic
+
+    private func hideBlogDetails() {
+        guard let blogDetailsViewController = blogDetailsViewController else {
+            return
+        }
+
+        remove(blogDetailsViewController)
+        self.blogDetailsViewController = nil
+    }
+
+    /// Shows a `BlogDetailsViewController` for the specified `Blog`.  If the VC doesn't exist, this method also takes care
+    /// of creating it.
+    ///
+    /// - Parameters:
+    ///         - blog: The blog to show the details of.
+    ///
+    private func showBlogDetails(for blog: Blog) {
+        hideNoSites()
+
+        let blogDetailsViewController = self.blogDetailsViewController(for: blog)
+
+        addMeButtonToNavigationBar(email: blog.account?.email, meScenePresenter: meScenePresenter)
+
+        add(blogDetailsViewController)
+
+        blogDetailsViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(blogDetailsViewController.view)
+        
+        showInitialDetails()
+    }
+
+    private func showInitialDetails() {
+        if splitViewControllerIsHorizontallyCompact {
+            return
+        }
+        
+        blogDetailsViewController?.showDetailView(for: .stats)
+    }
+    
+    private func blogDetailsViewController(for blog: Blog) -> BlogDetailsViewController {
+        guard let blogDetailsViewController = blogDetailsViewController else {
+            let blogDetailsViewController = makeBlogDetailsViewController(for: blog)
+            self.blogDetailsViewController = blogDetailsViewController
+            return blogDetailsViewController
+        }
+
+        blogDetailsViewController.blog = blog
+        return blogDetailsViewController
+    }
+
+    private func makeBlogDetailsViewController(for blog: Blog) -> BlogDetailsViewController {
+        let blogDetailsViewController = BlogDetailsViewController(meScenePresenter: meScenePresenter)
+        blogDetailsViewController.blog = blog
+
+        return blogDetailsViewController
+    }
+
+    // MARK: - Model Changes
+
+    private func subscribeToModelChanges() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDataModelChange(notification:)),
+            name: .NSManagedObjectContextObjectsDidChange,
+            object: ContextManager.shared.mainContext)
+    }
+
+    @objc
+    private func handleDataModelChange(notification: NSNotification) {
+        if let blog = blog {
+            handlePossibleDeletion(of: blog, notification: notification)
+        } else {
+            handlePossiblePrimaryBlogCreation(notification: notification)
+        }
+    }
+
+    // MARK: - Model Changes: Blog Deletion
+
+    /// This method takes care of figuring out if the selected blog was deleted, and to address any side effect
+    /// of the selected blog being deleted.
+    ///
+    private func handlePossibleDeletion(of selectedBlog: Blog, notification: NSNotification) {
+        guard let deletedObjects = notification.userInfo?[NSDeletedObjectsKey] as? Set<NSManagedObject>,
+           deletedObjects.contains(selectedBlog) else {
+            return
+        }
+
+        self.blog = nil
+    }
+
+    // MARK: - Model Changes: Blog Creation
+
+    /// This method ensures that the received notification includes inserted blogs.
+    /// It's useful because when we call `lastUsedOrFirstBlog()` a chain of calls that ends with:
+    ///
+    ///     `AccountService.defaultWordPressComAccount()`
+    ///     > `AccountService.accountWithUUID()`
+    ///     > `NSManagedObjectContext.executeFetchRequest(...)`.
+    ///
+    /// The issue is that `executeFetchRequest` updates the managed object context, thus triggering
+    /// a `NSManagedObjectContextObjectsDidChange` notification, which caused a neverending
+    /// loop in the observer in this VC.
+    ///
+    private func verifyThatBlogsWereInserted(in notification: NSNotification) -> Bool {
+        guard let insertedObjects = notification.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject>,
+              insertedObjects.contains(where: { $0 as? Blog != nil }) else {
+            return false
+        }
+
+        return true
+    }
+
+    /// This method takes care of figuring out if a primary blog was created, in order to show the details for such
+    /// blog.
+    ///
+    private func handlePossiblePrimaryBlogCreation(notification: NSNotification) {
+        // WORKAROUND: At first sight this guard should not be needed.
+        // Please read the documentation for this method carefully.
+        guard verifyThatBlogsWereInserted(in: notification) else {
+            return
+        }
+
+        let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
+
+        guard let blog = blogService.lastUsedOrFirstBlog() else {
+            return
+        }
+
+        self.blog = blog
+    }
+
+    // MARK: - Me Bar Button
+
+    private let meScenePresenter: ScenePresenter
+}
+
+extension MySiteViewController: WPSplitViewControllerDetailProvider {
+    func initialDetailViewControllerForSplitView(_ splitView: WPSplitViewController) -> UIViewController? {
+        guard let blogDetailsViewController = blogDetailsViewController as? WPSplitViewControllerDetailProvider else  {
+            return nil
+        }
+        
+        return blogDetailsViewController.initialDetailViewControllerForSplitView(splitView)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -325,7 +325,9 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 extension MySiteViewController: WPSplitViewControllerDetailProvider {
     func initialDetailViewControllerForSplitView(_ splitView: WPSplitViewController) -> UIViewController? {
         guard let blogDetailsViewController = blogDetailsViewController as? WPSplitViewControllerDetailProvider else  {
-            return nil
+            let emptyViewController = UIViewController()
+            WPStyleGuide.configureColors(view: emptyViewController.view, tableView: nil)
+            return emptyViewController
         }
         
         return blogDetailsViewController.initialDetailViewControllerForSplitView(splitView)

--- a/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
@@ -22,7 +22,7 @@ class MediaNoticeNavigationCoordinator {
 
     static func navigateToMediaLibrary(with userInfo: NSDictionary) {
         if let blog = blog(from: userInfo) {
-            WPTabBarController.sharedInstance().switchMySitesTabToMedia(for: blog)
+            WPTabBarController.sharedInstance()?.mySitesCoordinator.showMedia(for: blog)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -117,12 +117,12 @@ class MySitesCoordinator: NSObject {
     func showActivityLog(for blog: Blog) {
         showBlogDetails(for: blog, then: .activity)
     }
-    
+
     // MARK: - Adding a new site
     @objc
     func showAddNewSite(from view: UIView) {
         showMySites()
-        
+
         blogListViewController.presentInterfaceForAddingNewSite(from: view)
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -16,9 +16,9 @@ class MySitesCoordinator: NSObject {
 
         super.init()
     }
-    
+
     // MARK: - Root View Controller
-    
+
     private var rootContentViewController: UIViewController {
         if Feature.enabled(.newNavBarAppearance) {
             return mySiteViewController
@@ -52,18 +52,18 @@ class MySitesCoordinator: NSObject {
         } else {
             splitViewController.wpPrimaryColumnWidth = .narrow
         }
-        
+
         return splitViewController
     }()
 
     @objc
     lazy var navigationController: UINavigationController = {
         let navigationController = UINavigationController(rootViewController: rootContentViewController)
-        
+
         if Feature.enabled(.newNavBarAppearance) {
             navigationController.navigationBar.prefersLargeTitles = true
         }
-        
+
         navigationController.restorationIdentifier = MySitesCoordinator.navigationControllerRestorationID
         navigationController.navigationBar.isTranslucent = false
 
@@ -87,7 +87,7 @@ class MySitesCoordinator: NSObject {
     private(set) lazy var blogListViewController: BlogListViewController = {
         BlogListViewController(meScenePresenter: self.meScenePresenter)
     }()
-    
+
     private lazy var mySiteViewController: MySiteViewController = {
         MySiteViewController(meScenePresenter: self.meScenePresenter)
     }()
@@ -101,18 +101,18 @@ class MySitesCoordinator: NSObject {
     }
 
     // MARK: - Sites List
-    
+
     private func showSitesList() {
         showRootViewController()
-        
+
         if Feature.enabled(.newNavBarAppearance) {
             blogListViewController.modalPresentationStyle = .pageSheet
             mySiteViewController.present(blogListViewController, animated: true)
         }
     }
-    
+
     // MARK: - Blog Details
-    
+
     @objc
     func showBlogDetails(for blog: Blog) {
         showRootViewController()
@@ -162,7 +162,7 @@ class MySitesCoordinator: NSObject {
     @objc
     func showAddNewSite(from view: UIView) {
         showSitesList()
-        
+
         blogListViewController.presentInterfaceForAddingNewSite(from: view)
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -43,7 +43,6 @@ class MySitesCoordinator: NSObject {
         splitViewController.restorationIdentifier = MySitesCoordinator.splitViewControllerRestorationID
         splitViewController.presentsWithGesture = false
         splitViewController.setInitialPrimaryViewController(navigationController)
-        splitViewController.wpPrimaryColumnWidth = .narrow
         splitViewController.dimsDetailViewControllerAutomatically = !FeatureFlag.newNavBarAppearance.enabled
         splitViewController.tabBarItem = navigationController.tabBarItem
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -117,6 +117,14 @@ class MySitesCoordinator: NSObject {
     func showActivityLog(for blog: Blog) {
         showBlogDetails(for: blog, then: .activity)
     }
+    
+    // MARK: - Adding a new site
+    @objc
+    func showAddNewSite(from view: UIView) {
+        showMySites()
+        
+        blogListViewController.presentInterfaceForAddingNewSite(from: view)
+    }
 
     // MARK: - My Sites
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -44,15 +44,25 @@ class MySitesCoordinator: NSObject {
         splitViewController.presentsWithGesture = false
         splitViewController.setInitialPrimaryViewController(navigationController)
         splitViewController.wpPrimaryColumnWidth = .narrow
-        splitViewController.dimsDetailViewControllerAutomatically = true
+        splitViewController.dimsDetailViewControllerAutomatically = !FeatureFlag.newNavBarAppearance.enabled
         splitViewController.tabBarItem = navigationController.tabBarItem
 
+        if Feature.enabled(.newNavBarAppearance) {
+            splitViewController.wpPrimaryColumnWidth = .default
+        } else {
+            splitViewController.wpPrimaryColumnWidth = .narrow
+        }
+        
         return splitViewController
     }()
 
     @objc
     lazy var navigationController: UINavigationController = {
         let navigationController = UINavigationController(rootViewController: rootContentViewController)
+        
+        if Feature.enabled(.newNavBarAppearance) {
+            navigationController.navigationBar.prefersLargeTitles = true
+        }
         
         navigationController.restorationIdentifier = MySitesCoordinator.navigationControllerRestorationID
         navigationController.navigationBar.isTranslucent = false

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -36,7 +36,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 + (instancetype)sharedInstance;
 
 - (NSString *)currentlySelectedScreen;
-- (BOOL)isNavigatingMySitesTab;
 
 - (void)showMySitesTab;
 - (void)showReaderTab;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -50,9 +50,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)showNotificationsTab;
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia;
 - (void)showReaderTabForPost:(NSNumber *)postId onBlog:(NSNumber *)blogId;
-- (void)switchMySitesTabToAddNewSite;
-- (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog;
-- (void)switchMySitesTabToMediaForBlog:(Blog *)blog;
 
 - (void)popNotificationsTabToRoot;
 - (void)switchNotificationsTabToNotificationSettings;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -25,9 +25,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 
 @interface WPTabBarController : UITabBarController <UIViewControllerTransitioningDelegate>
 
-@property (nonatomic, strong, readonly) WPSplitViewController *blogListSplitViewController;
-@property (nonatomic, strong, readonly) BlogListViewController *blogListViewController;
-@property (nonatomic, strong, readonly) UINavigationController *blogListNavigationController;
 @property (nonatomic, strong, readonly) NotificationsViewController *notificationsViewController;
 @property (nonatomic, strong, readonly) UINavigationController *readerNavigationController;
 @property (nonatomic, strong, readonly) MySitesCoordinator *mySitesCoordinator;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -318,7 +318,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     // Ignore taps on the post tab and instead show the modal.
     if ([blogService blogCountForAllAccounts] == 0) {
-        [self switchMySitesTabToAddNewSite];
+        [self.mySitesCoordinator showAddNewSiteFrom:self.tabBar];
     } else {
         [self showPostTabAnimated:true toMedia:false blog:nil afterDismiss:afterDismiss];
     }
@@ -329,7 +329,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     if ([blogService blogCountForAllAccounts] == 0) {
-        [self switchMySitesTabToAddNewSite];
+        [self.mySitesCoordinator showAddNewSiteFrom:self.tabBar];
     } else {
         [self showPostTabAnimated:YES toMedia:NO blog:blog];
     }
@@ -393,41 +393,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 - (void)popNotificationsTabToRoot
 {
     [self.notificationsNavigationController popToRootViewControllerAnimated:NO];
-}
-
-- (void)switchMySitesTabToAddNewSite
-{
-    [self setSelectedIndex:WPTabMySites];
-    [self.blogListViewController presentInterfaceForAddingNewSiteFrom:self.tabBar];
-}
-
-- (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog
-{
-    [self.mySitesCoordinator showBlogDetailsFor:blog];
-
-    BlogDetailsViewController *blogDetailVC = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
-    if ([blogDetailVC isKindOfClass:[BlogDetailsViewController class]]) {
-        [blogDetailVC showDetailViewForSubsection:BlogDetailsSubsectionStats];
-    }
-}
-
-- (void)switchMySitesTabToMediaForBlog:(Blog *)blog
-{
-    [self switchMySitesTabToBlogDetailsForBlog:blog];
-
-    BlogDetailsViewController *blogDetailVC = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
-    if ([blogDetailVC isKindOfClass:[BlogDetailsViewController class]]) {
-        [blogDetailVC showDetailViewForSubsection:BlogDetailsSubsectionMedia];
-    }
-}
- 
-- (void)switchMySitesTabToBlogDetailsForBlog:(Blog *)blog
-{
-    [self setSelectedIndex:WPTabMySites];
-
-    BlogListViewController *blogListVC = self.blogListViewController;
-    self.blogListNavigationController.viewControllers = @[blogListVC];
-    [blogListVC setSelectedBlog:blog animated:NO];
 }
 
 - (void)switchNotificationsTabToNotificationSettings

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -489,11 +489,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [self.notificationsViewController showDetailsForNotificationWithID:notificationID];
 }
 
-- (BOOL)isNavigatingMySitesTab
-{
-    return (self.selectedIndex == WPTabMySites && [self.mySitesCoordinator.navigationController.viewControllers count] > 1);
-}
-
 #pragma mark - Zendesk Notifications
 
 - (void)updateIconIndicators:(NSNotification *)notification

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -439,7 +439,10 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     if (selectedIndex != tabBarController.selectedIndex) {
         switch (selectedIndex) {
             case WPTabMySites: {
-                [self bypassBlogListViewControllerIfNecessary];
+                if (![Feature enabled:FeatureFlagNewNavBarAppearance]) {
+                    // We only need to bypass the blog list if we're using the old presentation style
+                    [self bypassBlogListViewControllerIfNecessary];
+                }
                 break;
             }
             case WPTabReader: {
@@ -473,7 +476,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     UINavigationController *navController = (UINavigationController *)[self.mySitesCoordinator.splitViewController.viewControllers firstObject];
     BlogListViewController *blogListViewController = (BlogListViewController *)[navController.viewControllers firstObject];
 
-    if ([blogListViewController shouldBypassBlogListViewControllerWhenSelectedFromTabBar]) {
+    if ([blogListViewController isKindOfClass:[BlogListViewController class]] && [blogListViewController shouldBypassBlogListViewControllerWhenSelectedFromTabBar]) {
         if ([navController.visibleViewController isKindOfClass:[blogListViewController class]]) {
             [blogListViewController bypassBlogListViewController];
         }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -151,25 +151,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [super decodeRestorableStateWithCoder:coder];
 }
 
-#pragma mark - My Site View Controllers
-
-// These getters are temporary while we extract items from here to the MySiteCoordinator.
-
-- (UISplitViewController *)blogListSplitViewController
-{
-    return [self.mySitesCoordinator splitViewController];
-}
-
-- (UINavigationController *)blogListNavigationController
-{
-    return [self.mySitesCoordinator navigationController];
-}
-
-- (BlogListViewController *)blogListViewController
-{
-    return [self.mySitesCoordinator blogListViewController];
-}
-
 #pragma mark - Tab Bar Items
 
 - (UINavigationController *)readerNavigationController
@@ -429,7 +410,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         return nil;
     }
 
-    BlogDetailsViewController *blogDetailsController = (BlogDetailsViewController *)[[self.blogListNavigationController.viewControllers wp_filter:^BOOL(id obj) {
+    BlogDetailsViewController *blogDetailsController = (BlogDetailsViewController *)[[self.mySitesCoordinator.navigationController.viewControllers wp_filter:^BOOL(id obj) {
         return [obj isKindOfClass:[BlogDetailsViewController class]];
     }] firstObject];
     return blogDetailsController.blog;
@@ -489,7 +470,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     // If the user has one blog then we don't want to present them with the main "My Sites"
     // screen where they can see all their blogs. In the case of only one blog just show
     // the main blog details screen
-    UINavigationController *navController = (UINavigationController *)[self.blogListSplitViewController.viewControllers firstObject];
+    UINavigationController *navController = (UINavigationController *)[self.mySitesCoordinator.splitViewController.viewControllers firstObject];
     BlogListViewController *blogListViewController = (BlogListViewController *)[navController.viewControllers firstObject];
 
     if ([blogListViewController shouldBypassBlogListViewControllerWhenSelectedFromTabBar]) {
@@ -507,7 +488,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (BOOL)isNavigatingMySitesTab
 {
-    return (self.selectedIndex == WPTabMySites && [self.blogListViewController.navigationController.viewControllers count] > 1);
+    return (self.selectedIndex == WPTabMySites && [self.mySitesCoordinator.navigationController.viewControllers count] > 1);
 }
 
 #pragma mark - Zendesk Notifications

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		1714F8D020E6DA8900226DCB /* RouteMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1714F8CF20E6DA8900226DCB /* RouteMatcher.swift */; };
 		1715179220F4B2EB002C4A38 /* Routes+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1715179120F4B2EB002C4A38 /* Routes+Stats.swift */; };
 		1715179420F4B5CD002C4A38 /* MySitesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1715179320F4B5CD002C4A38 /* MySitesCoordinator.swift */; };
+		1716AEFC25F2927600CF49EC /* MySiteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1716AEFB25F2927600CF49EC /* MySiteViewController.swift */; };
 		171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1719633F1D378D5100898E8B /* SearchWrapperView.swift */; };
 		171CC15824FCEBF7008B7180 /* UINavigationBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171CC15724FCEBF7008B7180 /* UINavigationBar+Appearance.swift */; };
 		1724DDC81C60F1200099D273 /* PlanDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */; };
@@ -2779,6 +2780,7 @@
 		1714F8CF20E6DA8900226DCB /* RouteMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMatcher.swift; sourceTree = "<group>"; };
 		1715179120F4B2EB002C4A38 /* Routes+Stats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Stats.swift"; sourceTree = "<group>"; };
 		1715179320F4B5CD002C4A38 /* MySitesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySitesCoordinator.swift; sourceTree = "<group>"; };
+		1716AEFB25F2927600CF49EC /* MySiteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MySiteViewController.swift; sourceTree = "<group>"; };
 		1719633F1D378D5100898E8B /* SearchWrapperView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchWrapperView.swift; sourceTree = "<group>"; };
 		171CC15724FCEBF7008B7180 /* UINavigationBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationBar+Appearance.swift"; sourceTree = "<group>"; };
 		1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanDetailViewController.swift; sourceTree = "<group>"; };
@@ -5838,6 +5840,14 @@
 				08E77F461EE9D72F006F9515 /* MediaThumbnailExporterTests.swift */,
 			);
 			name = Media;
+			sourceTree = "<group>";
+		};
+		1716AEFA25F2926C00CF49EC /* My Site */ = {
+			isa = PBXGroup;
+			children = (
+				1716AEFB25F2927600CF49EC /* MySiteViewController.swift */,
+			);
+			path = "My Site";
 			sourceTree = "<group>";
 		};
 		1719633E1D378D1E00898E8B /* Search */ = {
@@ -9608,6 +9618,7 @@
 		AC34397B0E11443300E5D79B /* Blog */ = {
 			isa = PBXGroup;
 			children = (
+				1716AEFA25F2926C00CF49EC /* My Site */,
 				F1863714253E49B8003D4BEF /* Add Site */,
 				3F43603423F368BF001DEE70 /* Blog Details */,
 				3F43603523F368CA001DEE70 /* Blog List */,
@@ -14213,6 +14224,7 @@
 				7E4123C220F4097B00DF8486 /* FormattableContentFormatter.swift in Sources */,
 				7E21C765202BBF4400837CF5 /* SearchAdsAttribution.swift in Sources */,
 				5DF8D26119E82B1000A2CD95 /* ReaderCommentsViewController.m in Sources */,
+				1716AEFC25F2927600CF49EC /* MySiteViewController.swift in Sources */,
 				7E3E7A6020E44E490075D159 /* FooterContentGroup.swift in Sources */,
 				59A3CADD1CD2FF0C009BFA1B /* BasePageListCell.m in Sources */,
 				436D56202117312700CEAA33 /* RegisterDomainSuggestionsTableViewController.swift in Sources */,


### PR DESCRIPTION
This PR introduces `MySiteViewController` as an alternative to `BlogListViewController` / `BlogDetailViewController` when using the `newNavBarAppearance` feature flag. A few things to note:

- This PR is mainly concerned with testing the My Site section of the app with the feature flag _disabled_, which is now the default.
- As such, there are some known issues when the feature flag is enabled, as the new site picker isn't yet in place. This means that with the feature flag enabled, you are currently unable to switch sites. This will be coming in the next PR.
- I ran into an issue with state restoration once during my testing, where the feature-flagged MySitesViewController was incorrectly restoring a BlogListViewController into the navigation stack before it. If this proves to be a problem for you too, we can address it in a future PR.
- Also note that while `MySiteViewController` contains a lot of code, it is essentially identical to @diegoreymendez's earlier code, which has already been reviewed.

|    |   |
|---|---|
|  ![IMG_0582](https://user-images.githubusercontent.com/4780/110529855-a786f980-8111-11eb-9762-e668fea4931b.PNG) |  ![IMG_0579](https://user-images.githubusercontent.com/4780/110529867-abb31700-8111-11eb-9b21-b65cd897eaa2.PNG) |
| ![IMG_BE1374C89D0B-1](https://user-images.githubusercontent.com/4780/110530223-149a8f00-8112-11eb-8a8e-e6ab4545e3b8.jpeg) | ![IMG_0583](https://user-images.githubusercontent.com/4780/110530141-00ef2880-8112-11eb-90b5-882d776c5b01.PNG) |


**To test:**

- Build and run, and do a smoke test to ensure that the My Site section looks and works as expected on iPhone and iPad.
- Main things to test include logging in and out, logging into an account with no sites and then adding one, and hiding all sites in an account to ensure the no results view is shown.
- Ensure that there is a detail view present when logging into to an account with sites, and that you see a blank (but not grey) detail pane for an account with no sites.
- Also on iPad you can test entering and exiting multitasking mode.
- You can also do a cursory test with the feature flag enabled. Main functionality I've mentioned above should all work, with the exception of switching sites.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
