### PR TITLE
Reader post details: show message when (un)following site

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -409,9 +409,11 @@ class ReaderDetailCoordinator {
         ReaderFollowAction().execute(with: post,
                                      context: coreDataStack.mainContext,
                                      completion: { [weak self] in
+                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: true)
                                          self?.view?.updateHeader()
                                      },
                                      failure: { [weak self] _ in
+                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: false)
                                          self?.view?.updateHeader()
                                      })
     }


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/pull/15800#pullrequestreview-584573604

This shows a toast message when following/unfollowing a site from Reader post details.

To test:

---
- Go to Reader.
- Tap a post card to display post details.
- Tap the follow/unfollow button in the header.
- Verify a message is displayed.

| ![follow](https://user-images.githubusercontent.com/1816888/110556855-9384cd00-80fc-11eb-9bb8-ddcbe970c705.jpeg) | ![unfollow](https://user-images.githubusercontent.com/1816888/110556872-9d0e3500-80fc-11eb-95e7-cb213fee5e97.jpeg) |
|--------|-------|

---
- Disable internet connection.
- Tap the follow/unfollow button in the header.
- Verify an error message is displayed.

| ![follow_fail](https://user-images.githubusercontent.com/1816888/110556700-4bfe4100-80fc-11eb-9935-9561f6143368.jpeg) | ![unfollow_fail](https://user-images.githubusercontent.com/1816888/110556724-56b8d600-80fc-11eb-9c4a-e084ad088022.jpeg) |
|--------|-------|

---
PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
