### PR TITLE
My Site: New Site Picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -144,6 +144,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)configureTableViewData;
 - (void)scrollToElement:(QuickStartTourElement)element;
 
+- (void)showInitialDetailsForBlog;
 - (void)showPostListFromSource:(BlogDetailsNavigationSource)source;
 - (void)showPageListFromSource:(BlogDetailsNavigationSource)source;
 - (void)showMediaLibraryFromSource:(BlogDetailsNavigationSource)source;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1099,6 +1099,30 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self showSiteTitleSettings];
 }
 
+- (void)siteSwitcherTapped
+{
+    BlogListViewController* blogListViewController = [[BlogListViewController alloc] initWithMeScenePresenter:self.meScenePresenter];
+    __weak __typeof(self) weakSelf = self;
+    blogListViewController.blogSelected = ^(BlogListViewController* blogListViewController, Blog *blog) {
+        [weakSelf switchToBlog:blog];
+        [blogListViewController dismissViewControllerAnimated:true completion:nil];
+    };
+    
+    UINavigationController* navigationController = [[UINavigationController alloc] initWithRootViewController:blogListViewController];
+    navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
+    [self presentViewController:navigationController animated:true completion:nil];
+}
+
+#pragma mark Site Switching
+
+- (void)switchToBlog:(Blog*)blog
+{
+    self.headerView.blog = blog;
+    self.blog = blog;
+    
+    [self.tableView reloadData];
+}
+
 #pragma mark Site Icon Update Management
 
 - (void)showUpdateSiteIconAlert

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1120,7 +1120,17 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     self.headerView.blog = blog;
     self.blog = blog;
     
+    [self showInitialDetailsForBlog];
     [self.tableView reloadData];
+}
+
+- (void)showInitialDetailsForBlog
+{
+    if ([self splitViewControllerIsHorizontallyCompact]) {
+        return;
+    }
+    
+    [self showDetailViewForSubsection:BlogDetailsSubsectionStats];
 }
 
 #pragma mark Site Icon Update Management

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1586,6 +1586,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [self trackEvent:WPAnalyticsStatOpenedComments fromSource:source];
     CommentsViewController *controller = [CommentsViewController controllerWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
@@ -1595,6 +1596,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [self trackEvent:WPAnalyticsStatOpenedPosts fromSource:source];
     PostListViewController *controller = [PostListViewController controllerWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
@@ -1604,6 +1606,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [self trackEvent:WPAnalyticsStatOpenedPages fromSource:source];
     PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementPages];
@@ -1613,6 +1616,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [self trackEvent:WPAnalyticsStatOpenedMediaLibrary fromSource:source];
     MediaLibraryViewController *controller = [[MediaLibraryViewController alloc] initWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
@@ -1622,6 +1626,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [WPAppAnalytics track:WPAnalyticsStatOpenedPeople withBlog:self.blog];
     PeopleViewController *controller = [PeopleViewController controllerWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
@@ -1631,6 +1636,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [WPAppAnalytics track:WPAnalyticsStatOpenedPluginDirectory withBlog:self.blog];
     PluginDirectoryViewController *controller = [[PluginDirectoryViewController alloc] initWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
@@ -1640,6 +1646,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [self trackEvent:WPAnalyticsStatOpenedPlans fromSource:source];
     PlanListViewController *controller = [[PlanListViewController alloc] initWithStyle:UITableViewStyleGrouped];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementPlans];
@@ -1649,6 +1656,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [self trackEvent:WPAnalyticsStatOpenedSiteSettings fromSource:source];
     SiteSettingsViewController *controller = [[SiteSettingsViewController alloc] initWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
@@ -1657,6 +1665,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 -(void)showJetpackSettings
 {
     JetpackSettingsViewController *controller = [[JetpackSettingsViewController alloc] initWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 }
 
@@ -1672,6 +1681,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
 
     [self trackEvent:WPAnalyticsStatOpenedSharingManagement fromSource:source];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementSharing];
@@ -1682,6 +1692,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self trackEvent:WPAnalyticsStatStatsAccessed fromSource:source];
     StatsViewController *statsView = [StatsViewController new];
     statsView.blog = self.blog;
+    statsView.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
 
     // Calling `showDetailViewController:sender:` should do this automatically for us,
     // but when showing stats from our 3D Touch shortcut iOS sometimes incorrectly
@@ -1700,6 +1711,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)showActivity
 {
     JetpackActivityLogViewController *controller = [[JetpackActivityLogViewController alloc] initWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
@@ -1708,7 +1720,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)showScan
 {
     JetpackScanViewController *controller = [[JetpackScanViewController alloc] initWithBlog:self.blog];
-
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
@@ -1717,6 +1729,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)showBackup
 {
     BackupListViewController *controller = [[BackupListViewController alloc] initWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 }
 
@@ -1727,6 +1740,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     viewController.onWebkitViewControllerClose = ^(void) {
         [self startAlertTimer];
     };
+    viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:viewController sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementThemes];
@@ -1736,6 +1750,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [WPAppAnalytics track:WPAnalyticsStatMenusAccessed withBlog:self.blog];
     MenusViewController *viewController = [MenusViewController controllerWithBlog:self.blog];
+    viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:viewController sender:self];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -3,11 +3,14 @@
     func siteIconReceivedDroppedImage(_ image: UIImage?)
     func siteIconShouldAllowDroppedImages() -> Bool
     func siteTitleTapped()
+    func siteSwitcherTapped()
 }
 
 class BlogDetailHeaderView: UIView, BlogDetailHeader {
 
     @objc weak var delegate: BlogDetailHeaderViewDelegate?
+
+    private static let siteIconInsets = UIEdgeInsets(top: 4, left: 4, bottom: 4, right: 4)
 
     // Temporary method for migrating to NewBlogDetailHeaderView
     @objc
@@ -34,7 +37,7 @@ class BlogDetailHeaderView: UIView, BlogDetailHeader {
     }()
 
     private let siteIconView: SiteIconView = {
-        let view = SiteIconView(frame: .zero)
+        let view = SiteIconView(frame: .zero, insets: BlogDetailHeaderView.siteIconInsets)
         return view
     }()
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -1,4 +1,13 @@
+import Gridicons
+
 class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
+
+    // MARK: - Child Views
+
+    private let actionRow: ActionRow
+    private let titleView: TitleView
+
+    // MARK: - Delegate
 
     @objc weak var delegate: BlogDetailHeaderViewDelegate?
 
@@ -26,23 +35,18 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
         return label
     }()
 
-    private let siteIconView: SiteIconView = {
-        let view = SiteIconView(frame: .zero)
-        return view
-    }()
-
     @objc var updatingIcon: Bool = false {
         didSet {
             if updatingIcon {
-                siteIconView.activityIndicator.startAnimating()
+                titleView.siteIconView.activityIndicator.startAnimating()
             } else {
-                siteIconView.activityIndicator.stopAnimating()
+                titleView.siteIconView.activityIndicator.stopAnimating()
             }
         }
     }
 
     @objc var blavatarImageView: UIImageView {
-        return siteIconView.imageView
+        return titleView.siteIconView.imageView
     }
 
     @objc var blog: Blog? {
@@ -50,22 +54,25 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
             refreshIconImage()
             toggleSpotlightOnSiteTitle()
             refreshSiteTitle()
-            subtitleLabel.text = blog?.displayURL as String?
 
-            siteIconView.allowsDropInteraction = delegate?.siteIconShouldAllowDroppedImages() == true
+            if let displayURL = blog?.displayURL as String? {
+                titleView.set(url: displayURL)
+            }
+
+            titleView.siteIconView.allowsDropInteraction = delegate?.siteIconShouldAllowDroppedImages() == true
         }
     }
 
     @objc func refreshIconImage() {
         if let blog = blog,
             blog.hasIcon == true {
-            siteIconView.imageView.downloadSiteIcon(for: blog)
+            titleView.siteIconView.imageView.downloadSiteIcon(for: blog)
         } else if let blog = blog,
             blog.isWPForTeams() {
-            siteIconView.imageView.tintColor = UIColor.listIcon
-            siteIconView.imageView.image = UIImage.gridicon(.p2)
+            titleView.siteIconView.imageView.tintColor = UIColor.listIcon
+            titleView.siteIconView.imageView.image = UIImage.gridicon(.p2)
         } else {
-            siteIconView.imageView.image = UIImage.siteIconPlaceholder
+            titleView.siteIconView.imageView.image = UIImage.siteIconPlaceholder
         }
 
         toggleSpotlightOnSiteIcon()
@@ -78,7 +85,7 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
     func refreshSiteTitle() {
         let blogName = blog?.settings?.name
         let title = blogName != nil && blogName?.isEmpty == false ? blogName : blog?.displayURL as String?
-        titleButton.setTitle(title, for: .normal)
+        titleView.titleButton.setTitle(title, for: .normal)
     }
 
     @objc func toggleSpotlightOnSiteTitle() {
@@ -86,96 +93,268 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
     }
 
     @objc func toggleSpotlightOnSiteIcon() {
-        siteIconView.spotlightIsShown = QuickStartTourGuide.shared.isCurrentElement(.siteIcon)
+        titleView.siteIconView.spotlightIsShown = QuickStartTourGuide.shared.isCurrentElement(.siteIcon)
     }
 
-    private enum Constants {
+    private enum LayoutSpacing {
+        static let atSides: CGFloat = 16
+        static let top: CGFloat = 24
+        static let belowActionRow: CGFloat = 16
+        static let betweenTitleViewAndActionRow: CGFloat = 32
+
         static let spacingBelowIcon: CGFloat = 16
         static let spacingBelowTitle: CGFloat = 8
         static let minimumSideSpacing: CGFloat = 8
         static let interSectionSpacing: CGFloat = 32
         static let buttonsBottomPadding: CGFloat = 40
         static let buttonsSidePadding: CGFloat = 40
-        static let siteIconSize = CGSize(width: 64, height: 64)
+        static let siteIconSize = CGSize(width: 48, height: 48)
     }
 
-    convenience init(items: [ActionRow.Item]) {
+    // MARK: - Initializers
 
-        self.init(frame: .zero)
+    required init(items: [ActionRow.Item]) {
+        actionRow = ActionRow(items: items)
+        titleView = TitleView(frame: .zero)
 
-        siteIconView.tapped = { [weak self] in
-            QuickStartTourGuide.shared.visited(.siteIcon)
-            self?.siteIconView.spotlightIsShown = false
+        super.init(frame: .zero)
 
-            self?.delegate?.siteIconTapped()
-        }
+        backgroundColor = .appBarBackground
 
-        siteIconView.dropped = { [weak self] images in
-            self?.delegate?.siteIconReceivedDroppedImage(images.first)
-        }
-
-        let buttonsStackView = ActionRow(items: items)
-
-        let stackView = UIStackView(arrangedSubviews: [
-            siteIconView,
-            titleButton,
-            subtitleLabel,
-        ])
-
-        stackView.axis = .vertical
-        stackView.alignment = .center
-        stackView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-
-        addSubview(stackView)
-
-        addSubview(buttonsStackView)
-
-        stackView.setCustomSpacing(Constants.spacingBelowIcon, after: siteIconView)
-        stackView.setCustomSpacing(Constants.spacingBelowTitle, after: titleButton)
-
-        /// Constraints for constrained widths (iPad portrait)
-        let minimumPaddingSideConstraints: [NSLayoutConstraint] = [
-            buttonsStackView.leadingAnchor.constraint(greaterThanOrEqualTo: stackView.leadingAnchor, constant: 0),
-            buttonsStackView.trailingAnchor.constraint(lessThanOrEqualTo: stackView.trailingAnchor, constant: 0),
-        ]
-
-        let bottomConstraint = buttonsStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.buttonsBottomPadding)
-        bottomConstraint.priority = UILayoutPriority(999) // Allow to break so encapsulated height (on initial table view load) doesn't spew warnings
-
-        let widthConstraint = buttonsStackView.widthAnchor.constraint(equalToConstant: 320)
-        widthConstraint.priority = .defaultHigh
-
-        let stackViewConstraints = [
-            stackView.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
-            stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: Constants.minimumSideSpacing),
-            stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.interSectionSpacing),
-            stackView.centerXAnchor.constraint(equalTo: layoutMarginsGuide.centerXAnchor)
-        ]
-        stackViewConstraints.forEach { $0.priority = UILayoutPriority(999) }
-
-        let edgeConstraints = [
-            buttonsStackView.topAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.interSectionSpacing),
-            buttonsStackView.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
-            bottomConstraint,
-            widthConstraint
-        ]
-
-        NSLayoutConstraint.activate(minimumPaddingSideConstraints + edgeConstraints + stackViewConstraints)
-    }
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+        setupChildViews(items: items)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    @objc private func titleButtonTapped() {
+    // MARK: - Child View Initialization
+
+    private func setupChildViews(items: [ActionRow.Item]) {
+        titleView.siteIconView.tapped = { [weak self] in
+            QuickStartTourGuide.shared.visited(.siteIcon)
+            self?.titleView.siteIconView.spotlightIsShown = false
+
+            self?.delegate?.siteIconTapped()
+        }
+
+        titleView.siteIconView.dropped = { [weak self] images in
+            self?.delegate?.siteIconReceivedDroppedImage(images.first)
+        }
+
+        //titleView.axis = .vertical
+        //titleView.alignment = .center
+        //titleView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+        titleView.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(titleView)
+        addSubview(actionRow)
+
+        setupConstraintsForChildViews()
+    }
+
+    // MARK: - Constraints
+
+    private func setupConstraintsForChildViews() {
+        let actionRowConstraints = constraintsForActionRow()
+        let titleViewContraints = constraintsForTitleView()
+
+        NSLayoutConstraint.activate(actionRowConstraints + titleViewContraints)
+    }
+
+    private func constraintsForActionRow() -> [NSLayoutConstraint] {
+        [
+            actionRow.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: LayoutSpacing.betweenTitleViewAndActionRow),
+            actionRow.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -LayoutSpacing.belowActionRow),
+            actionRow.leadingAnchor.constraint(equalTo: leadingAnchor, constant: LayoutSpacing.atSides),
+            actionRow.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -LayoutSpacing.atSides)
+        ]
+    }
+
+    private func constraintsForTitleView() -> [NSLayoutConstraint] {
+        [
+            titleView.topAnchor.constraint(equalTo: topAnchor, constant: LayoutSpacing.top),
+            titleView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: LayoutSpacing.atSides),
+            titleView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -LayoutSpacing.atSides)
+        ]
+    }
+
+    // MARK: - User Action Handlers
+
+    @objc
+    private func siteSwitcherTapped() {
+        delegate?.siteSwitcherTapped()
+    }
+
+    @objc
+    private func titleButtonTapped() {
         QuickStartTourGuide.shared.visited(.siteTitle)
         titleButton.shouldShowSpotlight = false
 
         delegate?.siteTitleTapped()
+    }
+}
+
+fileprivate extension NewBlogDetailHeaderView {
+    class TitleView: UIView {
+
+        private enum Dimensions {
+            static let siteIconHeight: CGFloat = 64
+            static let siteIconWidth: CGFloat = 64
+            static let siteSwitcherHeight: CGFloat = 36
+            static let siteSwitcherWidth: CGFloat = 36
+        }
+
+        private enum LayoutSpacing {
+            static let betweenSiteIconAndTitle: CGFloat = 16
+            static let betweenTitleAndSiteSwitcher: CGFloat = 16
+            static let betweenSiteSwitcherAndRightPadding: CGFloat = 4
+            static let betweenSubtitleAndExternalIcon: CGFloat = 4
+        }
+
+        // MARK: - Child Views
+
+        let siteIconView: SiteIconView = {
+            let siteIconView = SiteIconView(frame: .zero)
+            siteIconView.translatesAutoresizingMaskIntoConstraints = false
+            return siteIconView
+        }()
+
+        let subtitleLabel: UILabel = {
+            let label = UILabel()
+
+            label.font = WPStyleGuide.fontForTextStyle(.footnote)
+            label.textColor = WPStyleGuide.darkBlue()
+            label.adjustsFontForContentSizeCategory = true
+            label.translatesAutoresizingMaskIntoConstraints = false
+
+            return label
+        }()
+
+        let titleButton: SpotlightableButton = {
+            let button = SpotlightableButton(type: .custom)
+            button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.title2, fontWeight: .bold)
+            button.titleLabel?.adjustsFontForContentSizeCategory = true
+            button.titleLabel?.lineBreakMode = .byTruncatingTail
+            button.setTitleColor(.text, for: .normal)
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.addTarget(self, action: #selector(titleButtonTapped), for: .touchUpInside)
+            return button
+        }()
+
+        let siteSwitcherButton: UIButton = {
+            let button = UIButton(frame: .zero)
+            let image = UIImage.gridicon(.chevronDown)
+
+            button.setImage(image, for: .normal)
+            button.contentMode = .center
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.tintColor = .gray
+
+            button.addTarget(self, action: #selector(siteSwitcherTapped), for: .touchUpInside)
+
+            return button
+        }()
+
+        private(set) lazy var externalLinkImage: UIImageView = {
+            let image = UIImage.gridicon(.external, size: CGSize(width: subtitleLabel.font.pointSize, height: subtitleLabel.font.pointSize))
+            let imageView = UIImageView(image: image)
+
+            imageView.contentMode = .scaleAspectFit
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+
+            return imageView
+        }()
+
+        private(set) lazy var titleStackView: UIStackView = {
+            let stackView = UIStackView(arrangedSubviews: [
+                titleButton,
+                subtitleLabel
+            ])
+
+            stackView.alignment = .leading
+            stackView.distribution = .equalSpacing
+            stackView.axis = .vertical
+            stackView.translatesAutoresizingMaskIntoConstraints = false
+
+            return stackView
+        }()
+
+        // MARK: - Initializers
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+
+            setupChildViews()
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: - Configuration
+
+        func set(url: String) {
+            subtitleLabel.text = url
+        }
+
+        // MARK: - Child View Setup
+
+        private func setupChildViews() {
+            addSubview(siteIconView)
+            addSubview(titleStackView)
+            addSubview(siteSwitcherButton)
+            addSubview(externalLinkImage)
+
+            setupConstraintsForChildViews()
+        }
+
+        // MARK: - Constraints
+
+        private func setupConstraintsForChildViews() {
+            let siteIconConstraints = constraintsForSiteIcon()
+            let titleStackViewConstraints = constraintsForTitleStackView()
+            let siteSwitcherButtonConstraints = constraintsForSiteSwitcherButton()
+            let externalIconConstraints = constraintsForExternalImage()
+
+            NSLayoutConstraint.activate(siteIconConstraints + titleStackViewConstraints + siteSwitcherButtonConstraints + externalIconConstraints)
+        }
+
+        private func constraintsForExternalImage() -> [NSLayoutConstraint] {
+            [
+                externalLinkImage.heightAnchor.constraint(equalTo: subtitleLabel.heightAnchor),
+                externalLinkImage.bottomAnchor.constraint(equalTo: subtitleLabel.bottomAnchor),
+                externalLinkImage.leadingAnchor.constraint(equalTo: subtitleLabel.trailingAnchor, constant: LayoutSpacing.betweenSubtitleAndExternalIcon),
+            ]
+        }
+
+        private func constraintsForSiteIcon() -> [NSLayoutConstraint] {
+            [
+                siteIconView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+                siteIconView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+                siteIconView.leftAnchor.constraint(equalTo: leftAnchor),
+                siteIconView.heightAnchor.constraint(equalToConstant: Dimensions.siteIconHeight),
+                siteIconView.widthAnchor.constraint(equalToConstant: Dimensions.siteIconWidth),
+            ]
+        }
+
+        private func constraintsForSiteSwitcherButton() -> [NSLayoutConstraint] {
+            [
+                siteSwitcherButton.centerYAnchor.constraint(equalTo: siteIconView.centerYAnchor),
+                siteSwitcherButton.leadingAnchor.constraint(equalTo: titleStackView.trailingAnchor, constant: LayoutSpacing.betweenTitleAndSiteSwitcher),
+                siteSwitcherButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -LayoutSpacing.betweenSiteSwitcherAndRightPadding),
+                siteSwitcherButton.heightAnchor.constraint(equalToConstant: Dimensions.siteSwitcherHeight),
+                siteSwitcherButton.widthAnchor.constraint(equalToConstant: Dimensions.siteSwitcherWidth),
+            ]
+        }
+
+        private func constraintsForTitleStackView() -> [NSLayoutConstraint] {
+            [
+                titleStackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
+                titleStackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
+                titleStackView.leadingAnchor.constraint(equalTo: siteIconView.trailingAnchor, constant: LayoutSpacing.betweenSiteIconAndTitle),
+                titleStackView.centerYAnchor.constraint(equalTo: siteIconView.centerYAnchor),
+            ]
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
@@ -4,7 +4,6 @@ class SiteIconView: UIView {
         static let imageSize: CGFloat = 64
         static let borderRadius: CGFloat = 4
         static let imageRadius: CGFloat = 2
-        static let imagePadding: CGFloat = 4
         static let spotlightOffset: CGFloat = -8
     }
 
@@ -73,13 +72,12 @@ class SiteIconView: UIView {
         }
     }
 
-    override init(frame: CGRect) {
+    init(frame: CGRect, insets: UIEdgeInsets = .zero) {
         super.init(frame: frame)
 
-        let paddingInsets = UIEdgeInsets(top: Constants.imagePadding, left: Constants.imagePadding, bottom: Constants.imagePadding, right: Constants.imagePadding)
-
         button.addSubview(imageView)
-        button.pinSubviewToAllEdges(imageView, insets: paddingInsets)
+        button.pinSubviewToAllEdges(imageView, insets: insets)
+
         button.addTarget(self, action: #selector(touchedButton), for: .touchUpInside)
         button.translatesAutoresizingMaskIntoConstraints = false
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
@@ -81,7 +81,7 @@ class BlogListDataSource: NSObject {
     // MARK: - Configuration
 
     @objc let recentSitesMinCount = 11
-    
+
     /// If this is set to `false`, the rows will never show the disclosure indicator.
     ///
     @objc var shouldShowDisclosureIndicator = true

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
@@ -81,6 +81,10 @@ class BlogListDataSource: NSObject {
     // MARK: - Configuration
 
     @objc let recentSitesMinCount = 11
+    
+    /// If this is set to `false`, the rows will never show the disclosure indicator.
+    ///
+    @objc var shouldShowDisclosureIndicator = true
 
     // MARK: - Inputs
 
@@ -338,7 +342,7 @@ extension BlogListDataSource: UITableViewDataSource {
             case .loggedIn:
                 cell.accessoryType = .none
             default:
-                cell.accessoryType = .disclosureIndicator
+                cell.accessoryType = shouldShowDisclosureIndicator ? .disclosureIndicator : .none
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.h
@@ -8,7 +8,7 @@
 
 @property (nonatomic, strong) Blog *selectedBlog;
 @property (nonatomic, strong) id<ScenePresenter> meScenePresenter;
-
+@property (nonatomic, copy) void (^blogSelected)(BlogListViewController* blogListViewController, Blog* blog);
 
 - (id)initWithMeScenePresenter:(id<ScenePresenter>)meScenePresenter;
 - (void)setSelectedBlog:(Blog *)selectedBlog animated:(BOOL)animated;

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -471,16 +471,16 @@ static NSInteger HideSearchMinSites = 3;
 
 - (BOOL)shouldBypassBlogListViewControllerWhenSelectedFromTabBar
 {
+    if ([Feature enabled:FeatureFlagNewNavBarAppearance]) {
+        // We should never bypass the list when we're using the new navigation bar
+        return false;
+    }
+
     return self.dataSource.displayedBlogsCount == 1;
 }
 
 - (void)bypassBlogListViewController
 {
-    if ([Feature enabled:FeatureFlagNewNavBarAppearance]) {
-        // We should never bypass the list when we're using the new navigation bar
-        return;
-    }
-
     if ([self shouldBypassBlogListViewControllerWhenSelectedFromTabBar]) {
         // We do a delay of 0.0 so that way this doesn't kick off until the next run loop.
         [self performSelector:@selector(selectFirstSite) withObject:nil afterDelay:0.0];

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -37,6 +37,10 @@ static NSInteger HideSearchMinSites = 3;
 
 + (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
 {
+    if ([Feature enabled:FeatureFlagNewNavBarAppearance]) {
+        return nil;
+    }
+
     return [WPTabBarController sharedInstance].mySitesCoordinator.blogListViewController;
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -65,6 +65,11 @@ static NSInteger HideSearchMinSites = 3;
 - (void)configureDataSource
 {
     self.dataSource = [BlogListDataSource new];
+    
+    if ([Feature enabled:FeatureFlagNewNavBarAppearance]) {
+        self.dataSource.shouldShowDisclosureIndicator = NO;
+    }
+    
     __weak __typeof(self) weakSelf = self;
     self.dataSource.visibilityChanged = ^(Blog *blog, BOOL visible) {
         [weakSelf setVisible:visible forBlog:blog];

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -467,6 +467,11 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)bypassBlogListViewController
 {
+    if ([Feature enabled:FeatureFlagNewNavBarAppearance]) {
+        // We should never bypass the list when we're using the new navigation bar
+        return;
+    }
+
     if ([self shouldBypassBlogListViewControllerWhenSelectedFromTabBar]) {
         // We do a delay of 0.0 so that way this doesn't kick off until the next run loop.
         [self performSelector:@selector(selectFirstSite) withObject:nil afterDelay:0.0];
@@ -792,6 +797,19 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)setSelectedBlog:(Blog *)selectedBlog animated:(BOOL)animated
 {
+    if ([Feature enabled:FeatureFlagNewNavBarAppearance]) {
+        if (self.blogSelected != nil) {
+            self.blogSelected(self, selectedBlog);
+        } else {
+            // The site picker without a site-selection callback makes no sense.  We'll dismiss the VC to keep
+            // the app running, but the user won't be able to switch sites.
+            DDLogError(@"There's no site-selection callback assigned to the site picker.");
+            [self dismissViewControllerAnimated:animated completion:nil];
+        }
+        
+        return;
+    }
+    
     if (selectedBlog != _selectedBlog || !_blogDetailsViewController) {
         _selectedBlog = selectedBlog;
         self.blogDetailsViewController = [self makeBlogDetailsViewController];

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -214,15 +214,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         blogDetailsViewController.view.translatesAutoresizingMaskIntoConstraints = false
         view.pinSubviewToAllEdges(blogDetailsViewController.view)
 
-        showInitialDetails()
-    }
-
-    private func showInitialDetails() {
-        if splitViewControllerIsHorizontallyCompact {
-            return
-        }
-
-        blogDetailsViewController?.showDetailView(for: .stats)
+        blogDetailsViewController.showInitialDetailsForBlog()
     }
 
     private func blogDetailsViewController(for blog: Blog) -> BlogDetailsViewController {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -6,7 +6,7 @@ protocol ReaderContentViewController: UIViewController {
 // MARK: - DefinesVariableStatusBarStyle Support
 extension WPTabBarController {
     override open var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
+        return FeatureFlag.newNavBarAppearance.enabled ? .default : .lightContent
     }
 
     override open var childForStatusBarStyle: UIViewController? {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -73,10 +73,12 @@ class MySitesCoordinator: NSObject {
         navigationController.tabBarItem.accessibilityIdentifier = "mySitesTabButton"
         navigationController.tabBarItem.title = NSLocalizedString("My Site", comment: "The accessibility value of the my site tab.")
 
-        let context = ContextManager.shared.mainContext
-        let service = BlogService(managedObjectContext: context)
-        if let blogToOpen = service.lastUsedOrFirstBlog() {
-            blogListViewController.selectedBlog = blogToOpen
+        if !FeatureFlag.newNavBarAppearance.enabled {
+            let context = ContextManager.shared.mainContext
+            let service = BlogService(managedObjectContext: context)
+            if let blogToOpen = service.lastUsedOrFirstBlog() {
+                blogListViewController.selectedBlog = blogToOpen
+            }
         }
 
         return navigationController

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -158,6 +158,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     if (!_readerNavigationController) {
         _readerNavigationController = [[UINavigationController alloc] initWithRootViewController:self.makeReaderTabViewController];
         _readerNavigationController.navigationBar.translucent = NO;
+        _readerNavigationController.view.backgroundColor = [UIColor murielBasicBackground];
 
         UIImage *readerTabBarImage = [UIImage imageNamed:@"icon-tab-reader"];
         _readerNavigationController.tabBarItem.image = readerTabBarImage;


### PR DESCRIPTION
This is the final PR pulling the main pieces of https://github.com/wordpress-mobile/WordPress-iOS/pull/15751 into `develop`. It introduces the NewBlogHeaderView, as a new way of picking sites. This makes the My Site (Blog Detail) view controller the top level VC in the My Site navigation stack. The blog list is currently accessed by tapping the down chevron next to the site title.

|    |   |
|---|---|
| ![IMG_0054](https://user-images.githubusercontent.com/4780/110688256-49254e00-81d9-11eb-9ac8-bf01f316fea4.PNG) | ![IMG_0592](https://user-images.githubusercontent.com/4780/110688263-4aef1180-81d9-11eb-89d1-97ee6759f208.PNG) |

This should be the final PR that is a little more involved in terms of testing. From here on out all of the major changes to the view hierarchy should be complete, so it's mostly style tweaks.

**Known issues**

- On iPad, when switching site, the correct row may not always be selected in the blog detail list for the currently displayed screen on the right. This is due to the adding of the Jetpack section to the blog details screen – I'll look at addressing it separately.
- There will almost certainly be style things that aren't quite right yet – design related PRs will be coming separately.
- The blog list picker currently doesn't have an explicit Close button – again, that'll come later. For now, you can drag down on the title to dismiss.

**To test**

- Test on iPhone and iPad
- First, test with the feature flag to `false`, that everything looks unchanged in terms of the My Site view hierarchy, switching sites, etc.
- With the feature flag on, ensure that when you log in the left and right panes of the split view are populated on iPad. Check that you can switch between different sections of the My Site screen.
- Try changing sites and check that the blog detail list and the right pane update to reflect that.
- On iPhone, try navigating in and out of sections and check that the large header collapses correctly. I wouldn't treat issues here as a blocker, as that work isn't yet final, but it would be good to have a heads-up if there's anything that needs addressing separately.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
