### PR TITLE
Reader: fix unfollowing external sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 17.0
 -----
 * [internal] Updated Zendesk to latest version. Should be no functional changes. [#16051]
+* [*] Reader: fixed an issue that caused unfollowing external sites to fail. [#16060]
 
 16.9
 -----

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -337,13 +337,22 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
         return;
     }
 
-    ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:self.managedObjectContext];
+
     // If this post belongs to a site topic, let the topic service do the work.
+    ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:self.managedObjectContext];
+
     if ([readerPost.topic isKindOfClass:[ReaderSiteTopic class]]) {
         ReaderSiteTopic *siteTopic = (ReaderSiteTopic *)readerPost.topic;
         [topicService toggleFollowingForSite:siteTopic success:success failure:failure];
         return;
     }
+
+    ReaderSiteTopic *feedSiteTopic = [topicService findSiteTopicWithFeedID:post.feedID];
+    if (feedSiteTopic) {
+        [topicService toggleFollowingForSite:feedSiteTopic success:success failure:failure];
+        return;
+    }
+
 
     // Keep previous values in case of failure
     BOOL oldValue = readerPost.isFollowing;


### PR DESCRIPTION
Fixes #15738

This fixes an issue where unfollowing an external site from the Reader didn't actually unfollow the site.

Long boring details:

Unfollowing external sites works from the `Manage` view because the topic is represented as a `ReaderSiteTopic`, which has the needed `feedURL` property. However, when unfollowing from a post card/details, the topic is represented as a `ReaderDefaultTopic` which does not have `feedURL`. 

Now, when unfollowing from post card/details, it attempts to find a `ReaderSiteTopic` for the `feedID`. If found, it uses the same method `Manage` does to unfollow (`ReaderTopicService:toggleFollowingForSite`).

To test:
- Go to Reader > Manage and follow an external site (ex: cnn.com).
- In the `Following` stream, find a post for the site.
- Either:
  - In the card's options menu, select `Unfollow Site`.
  - Tap the card. In the post details options menu, select `Unfollow Site`.
- Verify the site's posts are removed from `Following` (it may take a few seconds to refresh).
- Verify the site no longer appears in `Manage`.
- Verify unfollowing other site types (WP, self-hosted) works as expected.


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
