### PR TITLE
InviteLinks: Ensure cell separator is visible in darkmode.

### DIFF
--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -191,7 +191,9 @@ class InvitePersonViewController: UITableViewController {
         setupDefaultRole()
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
-
+        // Use the system separator color rather than the one defined by WPStyleGuide
+        // so cell separators stand out in darkmode.
+        tableView.separatorColor = .separator
         if blog.isWPForTeams() {
             syncInviteLinks()
         }


### PR DESCRIPTION
Refs p5T066-21h-p2#comment-7534

The InvitePersonViewController, like most tableView controllers, is styled via `WPStyleGuide.configureColors(view: view, tableView: tableView)`, which assigns the tableView the `systemGroupedBackground` color and cell separators a `neutral` murial color of `UIColor(light: muriel(color: .gray, .shade10), dark: muriel(color: .gray, .shade80))` rather than the system's `.separator` color.  This is normally fine, but the separators with this color can be hard to see when the controller is presented modally, with elevated system colors. 

This PR overrides the murial color set by WPStyleGuide in favor of the system separator color.  Examples:

![Simulator Screen Shot - iPhone 11 Pro - 2021-03-11 at 18 03 44](https://user-images.githubusercontent.com/1435271/110871682-74b93e80-8294-11eb-90c6-43faa17ef4ee.png)
![Simulator Screen Shot - iPhone 11 Pro - 2021-03-11 at 18 03 52](https://user-images.githubusercontent.com/1435271/110871683-7551d500-8294-11eb-8955-ea1197e95eed.png)

To test:
Run the branch and confirm the separator color looks good in light and dark modes. 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
