### PR TITLE
Related Posts: Fix section display logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -221,7 +221,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     func renderRelatedPosts(_ posts: [RemoteReaderSimplePost]) {
         let groupedPosts = Dictionary(grouping: posts, by: { $0.postType })
-        relatedPosts = groupedPosts.map { RelatedPostsSection(postType: $0.key, posts: $0.value) }
+        let sections = groupedPosts.map { RelatedPostsSection(postType: $0.key, posts: $0.value) }
+        relatedPosts = sections.sorted { $0.postType.rawValue < $1.postType.rawValue }
         tableView.reloadData()
         tableView.invalidateIntrinsicContentSize()
     }


### PR DESCRIPTION
Refs p5T066-21h-p2#comment-7545

## Description
- Fixed a bug where the "More from [site title]" was the only info displayed when viewing a post from a site that only has a single post

## How to test

###  Site with only one post

1. On the Reader tab, find a post from a site that has only one post
2. Tap on the post to view the post details
3. Scroll to the bottom of the post details screen
4. ✅ The "More from [Site title]" section should be hidden, and the "More on WordPress.com" section should display two related posts

### Regression testing (Site with more than one post)

1. Go to the Reader tab an tap on a post to view post details
2. Scroll to the bottom of the post details screen
3. ✅ The "More from [Site title]" section and the "More on WordPress.com" section should be displayed in that order

## Screenshots

Before | After
--- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-03-12 at 13 02 34](https://user-images.githubusercontent.com/6711616/110894233-d92ed900-833a-11eb-8e6a-88ed19707adb.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-12 at 13 51 38](https://user-images.githubusercontent.com/6711616/110894243-dcc26000-833a-11eb-8c27-2a8434d3080a.png)


## PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
