### PR TITLE
Updates the placeholder dark mode colors for domain screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/SitePromptView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/SitePromptView.swift
@@ -6,6 +6,7 @@ class SitePromptView: UIView {
     private struct Parameters {
         static let cornerRadius = CGFloat(8)
         static let borderWidth = CGFloat(1)
+        static let borderColor = UIColor.primaryButtonBorder
     }
 
     @IBOutlet weak var sitePrompt: UILabel! {
@@ -19,6 +20,7 @@ class SitePromptView: UIView {
             lockIcon.image = UIImage.gridicon(.lock)
         }
     }
+    var contentView: UIView!
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -30,15 +32,22 @@ class SitePromptView: UIView {
         commonInit()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            contentView.layer.borderColor = Parameters.borderColor.cgColor
+        }
+    }
+
     private func commonInit() {
         let bundle = Bundle(for: SitePromptView.self)
         guard
             let nibViews = bundle.loadNibNamed("SitePromptView", owner: self, options: nil),
-            let contentView = nibViews.first as? UIView
+            let loadedView = nibViews.first as? UIView
         else {
             return
         }
 
+        contentView = loadedView
         addSubview(contentView)
         contentView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -46,7 +55,7 @@ class SitePromptView: UIView {
             contentView.constrainToSuperViewEdges()
         )
         contentView.layer.cornerRadius = Parameters.cornerRadius
-        contentView.layer.borderColor = UIColor.primaryButtonBorder.cgColor
+        contentView.layer.borderColor = Parameters.borderColor.cgColor
         contentView.layer.borderWidth = Parameters.borderWidth
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/SitePromptView.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/SitePromptView.xib
@@ -39,7 +39,7 @@
                             <viewLayoutGuide key="safeArea" id="6Hk-Pf-o7e"/>
                         </stackView>
                     </subviews>
-                    <color key="backgroundColor" systemColor="systemGray6Color"/>
+                    <color key="backgroundColor" systemColor="quaternarySystemFillColor"/>
                     <constraints>
                         <constraint firstItem="Woc-4J-ACa" firstAttribute="top" secondItem="v8V-S8-GVv" secondAttribute="top" constant="5" id="0Yh-f1-AIe"/>
                         <constraint firstAttribute="height" constant="28" id="4Sk-ZB-b26"/>
@@ -54,7 +54,7 @@
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ypS-iN-cUK">
                     <rect key="frame" x="10" y="90" width="100" height="25"/>
-                    <color key="backgroundColor" systemColor="systemGray6Color"/>
+                    <color key="backgroundColor" systemColor="quaternarySystemFillColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="25" id="NAY-by-Nl2"/>
                         <constraint firstAttribute="width" constant="100" id="WtL-dE-Yxh"/>
@@ -67,7 +67,7 @@
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kzX-Rf-Pzt">
                     <rect key="frame" x="354" y="90" width="50" height="25"/>
-                    <color key="backgroundColor" systemColor="systemGray6Color"/>
+                    <color key="backgroundColor" systemColor="quaternarySystemFillColor"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="50" id="cug-9C-DoG"/>
                     </constraints>
@@ -79,7 +79,7 @@
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="puR-dc-cIz">
                     <rect key="frame" x="10" y="123" width="394" height="763"/>
-                    <color key="backgroundColor" systemColor="systemGray6Color"/>
+                    <color key="backgroundColor" systemColor="quaternarySystemFillColor"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                             <integer key="value" value="8"/>
@@ -110,11 +110,11 @@
     </objects>
     <resources>
         <image name="lock.fill" catalog="system" width="128" height="128"/>
+        <systemColor name="quaternarySystemFillColor">
+            <color red="0.45490196078431372" green="0.45490196078431372" blue="0.50196078431372548" alpha="0.080000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGrayColor">
             <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/16072

To test:
- Set your device to dark mode
- Navigate to the Choose a Domain screen as part of site creation
- Notice the updated prompt color

| Light | Dark |
|--- | --- |
| <kbd><a href="https://user-images.githubusercontent.com/3384451/110952705-86422b00-8314-11eb-896e-0d23ea94dbaa.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/110952705-86422b00-8314-11eb-896e-0d23ea94dbaa.png"/></a></kbd> | <kbd><a href="https://user-images.githubusercontent.com/3384451/110952821-a5d95380-8314-11eb-9df6-7d9fa634f8c5.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/110952821-a5d95380-8314-11eb-9df6-7d9fa634f8c5.png"/></a></kbd> |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
