### PR TITLE
Large Titles / White Headers My Site improvements

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -44,20 +44,23 @@ extension WPStyleGuide {
         navigationAppearance.isTranslucent = false
         navigationAppearance.tintColor = .appBarTint
         navigationAppearance.barTintColor = .appBarBackground
-        navigationAppearance.titleTextAttributes = [.foregroundColor: UIColor.appBarText]
 
         var textAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.appBarText]
+        let largeTitleTextAttributes: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.navigationBarLargeFont]
+        
         if FeatureFlag.newNavBarAppearance.enabled {
             textAttributes[.font] = WPStyleGuide.navigationBarStandardFont
         }
 
         navigationAppearance.titleTextAttributes = textAttributes
+        navigationAppearance.largeTitleTextAttributes = largeTitleTextAttributes
 
         // Required to fix detail navigation controller appearance due to https://stackoverflow.com/q/56615513
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = .appBarBackground
         appearance.titleTextAttributes = textAttributes
+        appearance.largeTitleTextAttributes = largeTitleTextAttributes
 
         if FeatureFlag.newNavBarAppearance.enabled {
             appearance.shadowColor = .clear

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -47,7 +47,7 @@ extension WPStyleGuide {
 
         var textAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.appBarText]
         let largeTitleTextAttributes: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.navigationBarLargeFont]
-        
+
         if FeatureFlag.newNavBarAppearance.enabled {
             textAttributes[.font] = WPStyleGuide.navigationBarStandardFont
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -37,7 +37,11 @@ extension BlogDetailsViewController {
                     self.dismiss(animated: true) {
                         self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
                         self.shouldScrollToViewSite = true
-                        navigationController.popToViewController(self, animated: true)
+                        if FeatureFlag.newNavBarAppearance.enabled {
+                            navigationController.popToRootViewController(animated: true)
+                        } else {
+                            navigationController.popToViewController(self, animated: true)
+                        }
                     }
                 default:
                     break

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1059,6 +1059,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     self.headerView = headerView;
 
     self.tableView.tableHeaderView = headerView.asView;
+    
+    if ([self.headerView isKindOfClass:[NewBlogDetailHeaderView class]]) {
+        [self.headerView.asView setTranslatesAutoresizingMaskIntoConstraints:NO];
+        [NSLayoutConstraint activateConstraints:@[
+            [self.headerView.asView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+            [self.headerView.asView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
+        ]];
+    }
 }
 
 #pragma mark BlogDetailHeaderViewDelegate

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1113,6 +1113,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self presentViewController:navigationController animated:true completion:nil];
 }
 
+- (void)visitSiteTapped
+{
+}
+
 #pragma mark Site Switching
 
 - (void)switchToBlog:(Blog*)blog

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -982,8 +982,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     BlogDetailsRow *viewSiteRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"View Site", @"Action title. Opens the user's site in an in-app browser")
                                                                   image:[UIImage gridiconOfType:GridiconTypeHouse]
                                                                callback:^{
-                                                                   [weakSelf showViewSite];
-                                                               }];
+        [weakSelf showViewSiteFromSource:BlogDetailsNavigationSourceRow];
+    }];
     viewSiteRow.quickStartIdentifier = QuickStartTourElementViewSite;
     viewSiteRow.showsSelectionState = NO;
     [rows addObject:viewSiteRow];
@@ -1123,6 +1123,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)visitSiteTapped
 {
+    [self showViewSiteFromSource:BlogDetailsNavigationSourceButton];
 }
 
 #pragma mark Site Switching
@@ -1768,9 +1769,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
-- (void)showViewSite
+- (void)showViewSiteFromSource:(BlogDetailsNavigationSource)source
 {
-    [WPAppAnalytics track:WPAnalyticsStatOpenedViewSite withBlog:self.blog];
+    [self trackEvent:WPAnalyticsStatOpenedViewSite fromSource:source];
+    
     NSURL *targetURL = [NSURL URLWithString:self.blog.homeURL];
 
     UIViewController *webViewController = [WebViewControllerFactory controllerWithUrl:targetURL blog:self.blog withDeviceModes:true];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -659,7 +659,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)sectionNum {
     BlogDetailsSection *section = self.tableSections[sectionNum];
-    if (section.showQuickStartMenu == true) {
+    if (section.showQuickStartMenu == true || [Feature enabled:FeatureFlagNewNavBarAppearance]) {
         return BlogDetailQuickStartSectionHeight;
     } else if (([section.title isEmpty] || section.title == nil) && sectionNum == 0) {
         // because tableView:viewForHeaderInSection: is implemented, this must explicitly be 0

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -4,6 +4,7 @@
     func siteIconShouldAllowDroppedImages() -> Bool
     func siteTitleTapped()
     func siteSwitcherTapped()
+    func visitSiteTapped()
 }
 
 class BlogDetailHeaderView: UIView, BlogDetailHeader {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -17,24 +17,6 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
         return self
     }
 
-    private let titleButton: SpotlightableButton = {
-        let button = SpotlightableButton(type: .custom)
-        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.title2, fontWeight: .bold)
-        button.titleLabel?.adjustsFontForContentSizeCategory = true
-        button.titleLabel?.lineBreakMode = .byTruncatingTail
-        button.setTitleColor(.text, for: .normal)
-        button.addTarget(self, action: #selector(titleButtonTapped), for: .touchUpInside)
-        return button
-    }()
-
-    private let subtitleLabel: UILabel = {
-        let label = UILabel()
-        label.font = WPStyleGuide.fontForTextStyle(.subheadline)
-        label.textColor = UIColor.textSubtle
-        label.adjustsFontForContentSizeCategory = true
-        return label
-    }()
-
     @objc var updatingIcon: Bool = false {
         didSet {
             if updatingIcon {
@@ -142,9 +124,6 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
             self?.delegate?.siteIconReceivedDroppedImage(images.first)
         }
 
-        //titleView.axis = .vertical
-        //titleView.alignment = .center
-        //titleView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         titleView.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(titleView)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -172,7 +172,7 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
 
         delegate?.siteTitleTapped()
     }
-    
+
     @objc
     private func subtitleButtonTapped() {
         delegate?.visitSiteTapped()
@@ -211,20 +211,20 @@ fileprivate extension NewBlogDetailHeaderView {
             button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
             button.titleLabel?.adjustsFontForContentSizeCategory = true
             button.titleLabel?.lineBreakMode = .byTruncatingTail
-        
+
             button.setTitleColor(WPStyleGuide.darkBlue(), for: .normal)
 
             if let pointSize = button.titleLabel?.font.pointSize {
                 button.setImage(UIImage.gridicon(.external, size: CGSize(width: pointSize, height: pointSize)), for: .normal)
             }
-            
+
             // Align the image to the right
             button.semanticContentAttribute = (UIApplication.shared.userInterfaceLayoutDirection == .leftToRight) ? .forceRightToLeft : .forceLeftToRight
             button.imageEdgeInsets = LayoutSpacing.subtitleButtonImageInsets
-            
+
             button.translatesAutoresizingMaskIntoConstraints = false
             button.addTarget(self, action: #selector(subtitleButtonTapped), for: .touchUpInside)
-            
+
             return button
         }()
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -61,7 +61,7 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
     }
 
     func setTitleLoading(_ isLoading: Bool) {
-        isLoading ? titleButton.startLoading() : titleButton.stopLoading()
+        isLoading ? titleView.titleButton.startLoading() : titleView.titleButton.stopLoading()
     }
 
     func refreshSiteTitle() {
@@ -71,7 +71,7 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
     }
 
     @objc func toggleSpotlightOnSiteTitle() {
-        titleButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.siteTitle)
+        titleView.titleButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.siteTitle)
     }
 
     @objc func toggleSpotlightOnSiteIcon() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -229,7 +229,7 @@ fileprivate extension NewBlogDetailHeaderView {
 
         let titleButton: SpotlightableButton = {
             let button = SpotlightableButton(type: .custom)
-            button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.title2, fontWeight: .bold)
+            button.titleLabel?.font = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
             button.titleLabel?.adjustsFontForContentSizeCategory = true
             button.titleLabel?.lineBreakMode = .byTruncatingTail
             button.titleLabel?.numberOfLines = 1

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -326,8 +326,6 @@ fileprivate extension NewBlogDetailHeaderView {
 
         private func constraintsForTitleStackView() -> [NSLayoutConstraint] {
             [
-                titleStackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
-                titleStackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
                 titleStackView.leadingAnchor.constraint(equalTo: siteIconView.trailingAnchor, constant: LayoutSpacing.betweenSiteIconAndTitle),
                 titleStackView.centerYAnchor.constraint(equalTo: siteIconView.centerYAnchor),
             ]

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -172,6 +172,11 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
 
         delegate?.siteTitleTapped()
     }
+    
+    @objc
+    private func subtitleButtonTapped() {
+        delegate?.visitSiteTapped()
+    }
 }
 
 fileprivate extension NewBlogDetailHeaderView {
@@ -188,7 +193,7 @@ fileprivate extension NewBlogDetailHeaderView {
             static let betweenSiteIconAndTitle: CGFloat = 16
             static let betweenTitleAndSiteSwitcher: CGFloat = 16
             static let betweenSiteSwitcherAndRightPadding: CGFloat = 4
-            static let betweenSubtitleAndExternalIcon: CGFloat = 4
+            static let subtitleButtonImageInsets: UIEdgeInsets = UIEdgeInsets(top: 1, left: 4, bottom: 0, right: 0)
         }
 
         // MARK: - Child Views
@@ -199,15 +204,27 @@ fileprivate extension NewBlogDetailHeaderView {
             return siteIconView
         }()
 
-        let subtitleLabel: UILabel = {
-            let label = UILabel()
+        let subtitleButton: UIButton = {
+            let button = UIButton()
 
-            label.font = WPStyleGuide.fontForTextStyle(.footnote)
-            label.textColor = WPStyleGuide.darkBlue()
-            label.adjustsFontForContentSizeCategory = true
-            label.translatesAutoresizingMaskIntoConstraints = false
+            button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
+            button.titleLabel?.adjustsFontForContentSizeCategory = true
+            button.titleLabel?.lineBreakMode = .byTruncatingTail
+        
+            button.setTitleColor(WPStyleGuide.darkBlue(), for: .normal)
 
-            return label
+            if let pointSize = button.titleLabel?.font.pointSize {
+                button.setImage(UIImage.gridicon(.external, size: CGSize(width: pointSize, height: pointSize)), for: .normal)
+            }
+            
+            // Align the image to the right
+            button.semanticContentAttribute = (UIApplication.shared.userInterfaceLayoutDirection == .leftToRight) ? .forceRightToLeft : .forceLeftToRight
+            button.imageEdgeInsets = LayoutSpacing.subtitleButtonImageInsets
+            
+            button.translatesAutoresizingMaskIntoConstraints = false
+            button.addTarget(self, action: #selector(subtitleButtonTapped), for: .touchUpInside)
+            
+            return button
         }()
 
         let titleButton: SpotlightableButton = {
@@ -235,20 +252,10 @@ fileprivate extension NewBlogDetailHeaderView {
             return button
         }()
 
-        private(set) lazy var externalLinkImage: UIImageView = {
-            let image = UIImage.gridicon(.external, size: CGSize(width: subtitleLabel.font.pointSize, height: subtitleLabel.font.pointSize))
-            let imageView = UIImageView(image: image)
-
-            imageView.contentMode = .scaleAspectFit
-            imageView.translatesAutoresizingMaskIntoConstraints = false
-
-            return imageView
-        }()
-
         private(set) lazy var titleStackView: UIStackView = {
             let stackView = UIStackView(arrangedSubviews: [
                 titleButton,
-                subtitleLabel
+                subtitleButton
             ])
 
             stackView.alignment = .leading
@@ -274,7 +281,7 @@ fileprivate extension NewBlogDetailHeaderView {
         // MARK: - Configuration
 
         func set(url: String) {
-            subtitleLabel.text = url
+            subtitleButton.setTitle(url, for: .normal)
         }
 
         // MARK: - Child View Setup
@@ -283,7 +290,6 @@ fileprivate extension NewBlogDetailHeaderView {
             addSubview(siteIconView)
             addSubview(titleStackView)
             addSubview(siteSwitcherButton)
-            addSubview(externalLinkImage)
 
             setupConstraintsForChildViews()
         }
@@ -294,17 +300,8 @@ fileprivate extension NewBlogDetailHeaderView {
             let siteIconConstraints = constraintsForSiteIcon()
             let titleStackViewConstraints = constraintsForTitleStackView()
             let siteSwitcherButtonConstraints = constraintsForSiteSwitcherButton()
-            let externalIconConstraints = constraintsForExternalImage()
 
-            NSLayoutConstraint.activate(siteIconConstraints + titleStackViewConstraints + siteSwitcherButtonConstraints + externalIconConstraints)
-        }
-
-        private func constraintsForExternalImage() -> [NSLayoutConstraint] {
-            [
-                externalLinkImage.heightAnchor.constraint(equalTo: subtitleLabel.heightAnchor),
-                externalLinkImage.bottomAnchor.constraint(equalTo: subtitleLabel.bottomAnchor),
-                externalLinkImage.leadingAnchor.constraint(equalTo: subtitleLabel.trailingAnchor, constant: LayoutSpacing.betweenSubtitleAndExternalIcon),
-            ]
+            NSLayoutConstraint.activate(siteIconConstraints + titleStackViewConstraints + siteSwitcherButtonConstraints)
         }
 
         private func constraintsForSiteIcon() -> [NSLayoutConstraint] {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -190,6 +190,7 @@ fileprivate extension NewBlogDetailHeaderView {
         }
 
         private enum LayoutSpacing {
+            static let betweenTitleAndSubtitleButtons: CGFloat = 8
             static let betweenSiteIconAndTitle: CGFloat = 16
             static let betweenTitleAndSiteSwitcher: CGFloat = 16
             static let betweenSiteSwitcherAndRightPadding: CGFloat = 4
@@ -267,7 +268,7 @@ fileprivate extension NewBlogDetailHeaderView {
             stackView.alignment = .leading
             stackView.distribution = .equalSpacing
             stackView.axis = .vertical
-            stackView.spacing = 8
+            stackView.spacing = LayoutSpacing.betweenTitleAndSubtitleButtons
             stackView.translatesAutoresizingMaskIntoConstraints = false
 
             return stackView

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -80,7 +80,7 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
 
     private enum LayoutSpacing {
         static let atSides: CGFloat = 16
-        static let top: CGFloat = 24
+        static let top: CGFloat = 16
         static let belowActionRow: CGFloat = 16
         static let betweenTitleViewAndActionRow: CGFloat = 32
 
@@ -168,7 +168,7 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
     @objc
     private func titleButtonTapped() {
         QuickStartTourGuide.shared.visited(.siteTitle)
-        titleButton.shouldShowSpotlight = false
+        titleView.titleButton.shouldShowSpotlight = false
 
         delegate?.siteTitleTapped()
     }
@@ -232,6 +232,12 @@ fileprivate extension NewBlogDetailHeaderView {
             button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.title2, fontWeight: .bold)
             button.titleLabel?.adjustsFontForContentSizeCategory = true
             button.titleLabel?.lineBreakMode = .byTruncatingTail
+            button.titleLabel?.numberOfLines = 1
+
+            // I don't understand why this is needed, but without it the button has additional
+            // vertical padding, so it's more difficult to get the spacing we want.
+            button.setImage(UIImage(), for: .normal)
+
             button.setTitleColor(.text, for: .normal)
             button.translatesAutoresizingMaskIntoConstraints = false
             button.addTarget(self, action: #selector(titleButtonTapped), for: .touchUpInside)
@@ -261,6 +267,7 @@ fileprivate extension NewBlogDetailHeaderView {
             stackView.alignment = .leading
             stackView.distribution = .equalSpacing
             stackView.axis = .vertical
+            stackView.spacing = 8
             stackView.translatesAutoresizingMaskIntoConstraints = false
 
             return stackView


### PR DESCRIPTION
This PR addresses a number of outstanding issues with the My Site white headers implementation:

|    |    |
|---|---|
| ![IMG_A28A6340575D-1](https://user-images.githubusercontent.com/4780/110961533-d090cf80-8347-11eb-9b68-87dcf6d14d4f.jpeg) | ![IMG_0057](https://user-images.githubusercontent.com/4780/110961605-e3a39f80-8347-11eb-9d3c-eb9eff9aa4a9.PNG) |

- Updates navigation bars with large titles to use the system serif font.
- Updates the header font in the new site switcher.
- Improved the spacing and positioning of items in the new site switcher header.
- The site address button in the header now opens the site in a web view.
- Adds extra grey padding between the first row in the blog details table and the white header section.

**Known issues**

- The View Site web view needs adjustments to its styling, as the title and bar button items aren't visible against the white background. I'll address this separately.
- When completing the View Site Quickstart tour, the My Site screen doesn't scroll all the way to the bottom.
- I haven't dealt with the divider at the bottom of the navigation bar yet.

**To test**

- Test on iPhone and iPad
- Double check that none of these changes affect the app with the feature flag disabled
- Enable the feature flag and build and run
- Check the appearance of the site header
- Check that you can tap the site address to view the site
- Check that the title looks okay navigating into subsections of the My Site screen

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
