### PR TITLE
Related Posts: Update related posts section header styling

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderRelatedPostsSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderRelatedPostsSectionHeaderView.swift
@@ -5,7 +5,7 @@ class ReaderRelatedPostsSectionHeaderView: UITableViewHeaderFooterView, NibReusa
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var backgroundColorView: UIView!
 
-    static let height: CGFloat = 40
+    static let height: CGFloat = 50
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -14,7 +14,7 @@ class ReaderRelatedPostsSectionHeaderView: UITableViewHeaderFooterView, NibReusa
 
     private func applyStyles() {
         titleLabel.numberOfLines = 0
-        titleLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
+        titleLabel.font = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .semibold)
         titleLabel.textColor = .text
         titleLabel.textAlignment = .natural
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderRelatedPostsSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderRelatedPostsSectionHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,15 +11,15 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="a9P-L3-LHn" customClass="ReaderRelatedPostsSectionHeaderView" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7uD-Fr-xJb">
-                    <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
                     <color key="backgroundColor" name="Gray0"/>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dXt-RE-kiw">
-                    <rect key="frame" x="0.0" y="16" width="320" height="16"/>
+                    <rect key="frame" x="0.0" y="26" width="320" height="16"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>


### PR DESCRIPTION
Refs p5T066-21h-p2#comment-7560

Design refs I5jpMcL84tYRh3FQJZs0fF-fi-315%3A89

## Description
- Updated related posts section header styling so that headers are more distinguishable

Before<br>Height: 40px<br>Font Weight: normal | After<br>Height: 50px<br>Font Weight: semibold
--- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-03-15 at 10 11 01](https://user-images.githubusercontent.com/6711616/111092399-55aefb00-8579-11eb-8a8e-9499e6e87144.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-15 at 10 20 53](https://user-images.githubusercontent.com/6711616/111092404-59428200-8579-11eb-8cd0-e694aa55e292.png)

## How to test
1. Go to the Reader tab
2. Tap on a post to view post details
3. Scroll to the bottom of the post detail
4. ✅ Related post section headers don't "blend in" with the post details

## PR submission checklist

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
