### PR TITLE
Discover: update Like button state

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -68,7 +68,10 @@ class ReaderCardsStreamViewController: ReaderStreamViewController {
 
         switch card.type {
         case .post:
-            return cell(for: card.post!, at: indexPath)
+            guard let post = card.post else {
+                return UITableViewCell()
+            }
+            return cell(for: post, at: indexPath)
         case .topics:
             return cell(for: card.topicsArray)
         case .sites:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderLikeAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderLikeAction.swift
@@ -9,10 +9,13 @@ final class ReaderLikeAction {
             UINotificationFeedbackGenerator().notificationOccurred(.success)
         }
         let service = ReaderPostService(managedObjectContext: context)
-        service.toggleLiked(for: post, success: nil, failure: { (error: Error?) in
+        service.toggleLiked(for: post, success: {
+            completion?()
+        }, failure: { (error: Error?) in
             if let anError = error {
                 DDLogError("Error (un)liking post: \(anError.localizedDescription)")
             }
+            completion?()
         })
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -192,6 +192,11 @@ protocol ReaderTopicsChipsDelegate: class {
         prepareForVoiceOver()
     }
 
+    func refreshLikeButton() {
+        configureLikeActionButton()
+        configureButtonTitles()
+    }
+
 }
 
 // MARK: - Configuration

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -72,7 +72,10 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         guard let post = provider as? ReaderPost else {
             return
         }
-        toggleLikeForPost(post)
+
+        ReaderLikeAction().execute(with: post, context: context, completion: {
+            cell.refreshLikeButton()
+        })
     }
 
     func readerCell(_ cell: ReaderPostCardCell, menuActionForProvider provider: ReaderPostContentProvider, fromView sender: UIView) {
@@ -147,11 +150,6 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
             return
         }
         ReaderShowAttributionAction().execute(with: post, context: context, origin: origin)
-    }
-
-
-    fileprivate func toggleLikeForPost(_ post: ReaderPost) {
-        ReaderLikeAction().execute(with: post, context: context)
     }
 
     fileprivate func sharePost(_ post: ReaderPost, fromView anchorView: UIView) {


### PR DESCRIPTION
Fixes: p5T066-21h-p2#comment-7530

This fixes an issue where liking a post in the Discover stream didn't update the like button state.

To test:
- Go to Discover.
- Like/unlike a post.
- Verify the star color and count change.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
