### PR TITLE
Fixes #16071: Switch from Metal to OpenGL

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ end
 def kanvas
   #pod 'Kanvas', '~> 1.2.4'
   #pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :tag => ''
-  pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => '443c5f6'
+  pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => '6c2abc'
   #pod 'Kanvas', :path => '../Kanvas-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -51,9 +51,9 @@ def wordpress_kit
 end
 
 def kanvas
-  pod 'Kanvas', '~> 1.2.4'
+  #pod 'Kanvas', '~> 1.2.4'
   #pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :tag => ''
-  #pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => ''
+  pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => '443c5f6'
   #pod 'Kanvas', :path => '../Kanvas-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -456,7 +456,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.1.0)
   - Gutenberg (from `https://github.com/wordpress-mobile/gutenberg-mobile.git`, tag `v1.48.1`)
   - JTAppleCalendar (~> 8.0.2)
-  - Kanvas (from `https://github.com/tumblr/Kanvas-iOS.git`, commit `443c5f6`)
+  - Kanvas (from `https://github.com/tumblr/Kanvas-iOS.git`, commit `6c2abc`)
   - MediaEditor (~> 1.2.1)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
@@ -584,7 +584,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.48.1
   Kanvas:
-    :commit: 443c5f6
+    :commit: 6c2abc
     :git: https://github.com/tumblr/Kanvas-iOS.git
   RCTRequired:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.48.1/third-party-podspecs/RCTRequired.podspec.json
@@ -668,7 +668,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.48.1
   Kanvas:
-    :commit: 443c5f6
+    :commit: 6c2abc
     :git: https://github.com/tumblr/Kanvas-iOS.git
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
@@ -771,6 +771,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: df24f6db7606e90a1dea4f0dc184f031b93417d7
+PODFILE CHECKSUM: 437d59a280bf9943874e8f6ff7128b672b2d3645
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -456,7 +456,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.1.0)
   - Gutenberg (from `https://github.com/wordpress-mobile/gutenberg-mobile.git`, tag `v1.48.1`)
   - JTAppleCalendar (~> 8.0.2)
-  - Kanvas (~> 1.2.4)
+  - Kanvas (from `https://github.com/tumblr/Kanvas-iOS.git`, commit `443c5f6`)
   - MediaEditor (~> 1.2.1)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
@@ -535,7 +535,6 @@ SPEC REPOS:
     - GTMAppAuth
     - GTMSessionFetcher
     - JTAppleCalendar
-    - Kanvas
     - lottie-ios
     - MediaEditor
     - MRProgress
@@ -584,6 +583,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.48.1
+  Kanvas:
+    :commit: 443c5f6
+    :git: https://github.com/tumblr/Kanvas-iOS.git
   RCTRequired:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.48.1/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
@@ -665,6 +667,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.48.1
+  Kanvas:
+    :commit: 443c5f6
+    :git: https://github.com/tumblr/Kanvas-iOS.git
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
@@ -766,6 +771,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 3330690f53d6fb37708730f725677a20e8a85ee7
+PODFILE CHECKSUM: df24f6db7606e90a1dea4f0dc184f031b93417d7
 
 COCOAPODS: 1.10.0

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,8 @@
 * [*] Reader: Added a way to discover new topics from the Manage Topics view
 * [*] P2 users can create and share group invite links via the Invite Person screen under the People Management feature. [#16005]
 * [*] Fixed an issue that prevented searching for plugins and the Popular Plugins section from appearing: [#16070]
+* [*] Stories: Fixed a video playback issue when recording on iPhone 7, 8, and SE devices. [#16099]
+* [*] Stories: Fixed a video playback issue when selecting an exported Story video from a site's library. [#16099]
 
 16.8.1
 -----

--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -52,7 +52,7 @@ class StoryEditor: CameraController {
         return StoryMediaLoader()
     }()
 
-    private static let useMetal = true
+    private static let useMetal = false
 
     static var cameraSettings: CameraSettings {
         let settings = CameraSettings()

--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -85,6 +85,7 @@ class StoryEditor: CameraController {
         settings.animateEditorControls = false
         settings.exportStopMotionPhotoAsVideo = false
         settings.fontSelectorUsesFont = true
+        settings.aspectRatio = 9/16
 
         return settings
     }


### PR DESCRIPTION
Fixes #16071 

The code change is minor but switches the rendering pipeline used in the Story editor from Metal to OpenGL.

There were a few issues identified in 16.8 which are fixed by this change:
* Videos created on an iPhone 7 do not play back in editing.
* Videos created by the Story editor and then selected from the media library do not play back when editing.

We need to investigate the Metal issues more carefully but want to resolve these bugs for users in the meantime.

## Testing

### Record Video
* Create a new Story post.
* Record video from the Camera Capture screen.
* Ensure that the video plays back in the editing screen.
* Publish the Story
* Ensure that media is exported as expected from the editing view (layers are in alignment and photo is framed correctly).

### Import Video from Photo Library
* Create a new Story post.
* Add existing video from the Photo Library
* Ensure that the video plays back in the editing screen.
* Publish the Story
* Ensure that media is exported as expected from the editing view (layers are in alignment and photo is framed correctly).

### Import Video from created Story
* Create a new Story post.
* Add video created from one of the stories above from your WordPress Library.
* Ensure that the video plays back in the editing screen.
* Publish the Story
* Ensure that media is exported as expected from the editing view (layers are in alignment and photo is framed correctly).

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
