### PR TITLE
Fixing black password text in Post Settings when in dark mode

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [internal] Updated Zendesk to latest version. Should be no functional changes. [#16051]
 * [*] Reader: fixed an issue that caused unfollowing external sites to fail. [#16060]
 * [*] Stats: fixed an issue where an error was displayed for Latest Post Summary if the site had no posts. [#16074]
+* [*] Fixed an issue where password text on Post Settings was showing as black in dark mode. [#15768]
 
 16.9
 -----

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -697,6 +697,7 @@ FeaturedImageViewControllerDelegate>
     // Password
     WPTextFieldTableViewCell *textCell = [self getWPTableViewTextFieldCell];
     textCell.textLabel.text = NSLocalizedString(@"Password", @"Label for the password field. Should be the same as WP core.");
+    textCell.textField.textColor = [UIColor murielText];
     textCell.textField.text = self.apost.password;
     textCell.textField.attributedPlaceholder = nil;
     textCell.textField.placeholder = NSLocalizedString(@"Enter a password", @"");


### PR DESCRIPTION
When in Post Settings page, password field was black when in dark mode.
Fixes #15768

To test:
1. Go to dark mode.
2. Create a new post.
3. Go to Post Settings.
4. Set Visibility to "Password protected".
5. Type text in password field.
6. See that text is now gray.
7. Switch to light mode.
8. See that text is black.


### Screenshots
#### Light
| Before | After |
| - | - |
| <img src="https://user-images.githubusercontent.com/13263478/111380732-c0902d00-8672-11eb-8f33-eca1ed0f4d66.png" width="100%"/> | <img src="https://user-images.githubusercontent.com/13263478/111380471-62fbe080-8672-11eb-8bbc-78a59d420d67.png" width="100%"/> |

#### Dark
| Before | After |
| - | - |
| <img src="https://user-images.githubusercontent.com/13263478/111380447-59727880-8672-11eb-8c35-644f9a749e03.png" width="100%"/> | <img src="https://user-images.githubusercontent.com/13263478/111380380-465fa880-8672-11eb-99b0-72f539b66f57.png" width="100%"/> |

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
