### PR TITLE
Comments: save selected filter

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -150,6 +150,7 @@ import Foundation
     case commentEditorOpened
     case commentEdited
     case commentRepliedTo
+    case commentFilterChanged
 
     // InviteLinks
     case inviteLinksGetStatus
@@ -425,6 +426,8 @@ import Foundation
             return "comment_edited"
         case .commentRepliedTo:
             return "comment_replied_to"
+        case .commentFilterChanged:
+            return "comment_filter_changed"
 
         // Invite Links
         case .inviteLinksGetStatus:

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Filters.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Filters.swift
@@ -39,6 +39,7 @@ extension CommentsViewController {
             return
         }
 
+        WPAnalytics.track(.commentFilterChanged, properties: ["selected_filter": filter.title])
         refresh(with: filter.statusFilter)
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -54,9 +54,8 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     [super viewDidLoad];
 
     [self configureFilterTabBar:self.filterTabBar];
+    [self getSelectedFilterFromUserDefaults];
     [self setTableConstraints];
-    self.currentStatusFilter = CommentStatusFilterAll;
-
     [self configureNavBar];
     [self configureLoadMoreSpinner];
     [self configureNoResultsView];
@@ -490,6 +489,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
 - (void)refreshWithStatusFilter:(CommentStatusFilter)statusFilter
 {
+    [self saveSelectedFilterToUserDefaults];
     self.currentStatusFilter = statusFilter;
     [self refreshAndSyncWithInteraction];
 }
@@ -583,6 +583,19 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 {
     [self setSeletedIndex:[coder decodeIntegerForKey:RestorableFilterIndexKey] filterTabBar:self.filterTabBar];
     [super decodeRestorableStateWithCoder:coder];
+}
+
+#pragma mark - User Defaults
+
+- (void)saveSelectedFilterToUserDefaults
+{
+    [NSUserDefaults.standardUserDefaults setInteger:[self getSelectedIndex:self.filterTabBar] forKey:RestorableFilterIndexKey];
+}
+
+- (void)getSelectedFilterFromUserDefaults
+{
+    NSInteger filterIndex = [NSUserDefaults.standardUserDefaults integerForKey:RestorableFilterIndexKey] ?: 0;
+    [self setSeletedIndex:filterIndex filterTabBar:self.filterTabBar];
 }
 
 @end


### PR DESCRIPTION
Ref: #15955 

The selected Comment filter is saved to User Defaults and is used to set the Comment filter when the Comments view is loaded.

Also, filter selection is now tracked.

To test:
- With a fresh install, go to Comments.
- Verify the selected filter is `All`.
- Select a different filter.
- Verify filter selection is logged with the filter title. Ex: `🔵 Tracked: comment_filter_changed <selected_filter: Approved>`
- Muck about in other parts of the app.
- Return to Comments.
- Verify the filter is the one you last selected.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
