### PR TITLE
Stories: Rendering engine changes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,9 +51,9 @@ def wordpress_kit
 end
 
 def kanvas
-  pod 'Kanvas', '~> 1.2.4'
+  #pod 'Kanvas', '~> 1.2.4'
   #pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :tag => ''
-  #pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => ''
+  pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => '164a2e'
   #pod 'Kanvas', :path => '../Kanvas-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -51,9 +51,9 @@ def wordpress_kit
 end
 
 def kanvas
-  #pod 'Kanvas', '~> 1.2.4'
+  pod 'Kanvas', '~> 1.2.5'
   #pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :tag => ''
-  pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => '680383'
+  #pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => ''
   #pod 'Kanvas', :path => '../Kanvas-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ end
 def kanvas
   #pod 'Kanvas', '~> 1.2.4'
   #pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :tag => ''
-  pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => '164a2e'
+  pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => '680383'
   #pod 'Kanvas', :path => '../Kanvas-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -456,7 +456,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.1.0)
   - Gutenberg (from `https://github.com/wordpress-mobile/gutenberg-mobile.git`, tag `v1.48.1`)
   - JTAppleCalendar (~> 8.0.2)
-  - Kanvas (from `https://github.com/tumblr/Kanvas-iOS.git`, commit `164a2e`)
+  - Kanvas (from `https://github.com/tumblr/Kanvas-iOS.git`, commit `680383`)
   - MediaEditor (~> 1.2.1)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
@@ -584,7 +584,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.48.1
   Kanvas:
-    :commit: 164a2e
+    :commit: '680383'
     :git: https://github.com/tumblr/Kanvas-iOS.git
   RCTRequired:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.48.1/third-party-podspecs/RCTRequired.podspec.json
@@ -668,7 +668,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.48.1
   Kanvas:
-    :commit: 164a2e
+    :commit: '680383'
     :git: https://github.com/tumblr/Kanvas-iOS.git
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
@@ -771,6 +771,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 9215210e72e88a6f8222b0c1703c2313792452b6
+PODFILE CHECKSUM: 7be5d7caccaa8fa3d881986f705f4348943942b8
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -79,7 +79,7 @@ PODS:
     - React-RCTImage (= 0.61.5)
     - RNTAztecView
   - JTAppleCalendar (8.0.3)
-  - Kanvas (1.2.4)
+  - Kanvas (1.2.5)
   - lottie-ios (3.1.9)
   - MediaEditor (1.2.1):
     - CropViewController (~> 2.5.3)
@@ -456,7 +456,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.1.0)
   - Gutenberg (from `https://github.com/wordpress-mobile/gutenberg-mobile.git`, tag `v1.48.1`)
   - JTAppleCalendar (~> 8.0.2)
-  - Kanvas (from `https://github.com/tumblr/Kanvas-iOS.git`, commit `680383`)
+  - Kanvas (~> 1.2.5)
   - MediaEditor (~> 1.2.1)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
@@ -535,6 +535,7 @@ SPEC REPOS:
     - GTMAppAuth
     - GTMSessionFetcher
     - JTAppleCalendar
+    - Kanvas
     - lottie-ios
     - MediaEditor
     - MRProgress
@@ -583,9 +584,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.48.1
-  Kanvas:
-    :commit: '680383'
-    :git: https://github.com/tumblr/Kanvas-iOS.git
   RCTRequired:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.48.1/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
@@ -667,9 +665,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.48.1
-  Kanvas:
-    :commit: '680383'
-    :git: https://github.com/tumblr/Kanvas-iOS.git
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
@@ -703,7 +698,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   Gutenberg: cc42276006c26734150644f1fc2fc6f856ccb5a7
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
-  Kanvas: 0e1acb8c10e15eea3365f16c086de2443c7703a8
+  Kanvas: 824801b0756bd0748d1de479d77249d0af8529e8
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
   MediaEditor: 20cdeb46bdecd040b8bc94467ac85a52b53b193a
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
@@ -771,6 +766,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 7be5d7caccaa8fa3d881986f705f4348943942b8
+PODFILE CHECKSUM: 74fb02476e668a66ac12883159edc7c82305aec1
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -456,7 +456,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.1.0)
   - Gutenberg (from `https://github.com/wordpress-mobile/gutenberg-mobile.git`, tag `v1.48.1`)
   - JTAppleCalendar (~> 8.0.2)
-  - Kanvas (~> 1.2.4)
+  - Kanvas (from `https://github.com/tumblr/Kanvas-iOS.git`, commit `164a2e`)
   - MediaEditor (~> 1.2.1)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
@@ -535,7 +535,6 @@ SPEC REPOS:
     - GTMAppAuth
     - GTMSessionFetcher
     - JTAppleCalendar
-    - Kanvas
     - lottie-ios
     - MediaEditor
     - MRProgress
@@ -584,6 +583,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.48.1
+  Kanvas:
+    :commit: 164a2e
+    :git: https://github.com/tumblr/Kanvas-iOS.git
   RCTRequired:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.48.1/third-party-podspecs/RCTRequired.podspec.json
   RCTTypeSafety:
@@ -665,6 +667,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.48.1
+  Kanvas:
+    :commit: 164a2e
+    :git: https://github.com/tumblr/Kanvas-iOS.git
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
@@ -766,6 +771,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: dcb2596ad05a63d662e8c7924357babbf327b421
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 3330690f53d6fb37708730f725677a20e8a85ee7
+PODFILE CHECKSUM: 9215210e72e88a6f8222b0c1703c2313792452b6
 
 COCOAPODS: 1.10.0

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,8 @@
 * [*] Reader: Added a way to discover new topics from the Manage Topics view
 * [*] P2 users can create and share group invite links via the Invite Person screen under the People Management feature. [#16005]
 * [*] Fixed an issue that prevented searching for plugins and the Popular Plugins section from appearing: [#16070]
+* [**] Stories: Fixed a video playback issue when recording on iPhone 7, 8, and SE devices. [#16109]
+* [*] Stories: Fixed a video playback issue when selecting an exported Story video from a site's library. [#16109]
 
 16.8.1
 -----

--- a/WordPress/Classes/Services/Stories/StoryEditor.swift
+++ b/WordPress/Classes/Services/Stories/StoryEditor.swift
@@ -52,7 +52,7 @@ class StoryEditor: CameraController {
         return StoryMediaLoader()
     }()
 
-    private static let useMetal = true
+    private static let useMetal = false
 
     static var cameraSettings: CameraSettings {
         let settings = CameraSettings()


### PR DESCRIPTION
Fixes #16071

Kanvas PR: https://github.com/tumblr/kanvas-ios/pull/106

* Switches the rendering engine to OpenGL. (which fixes #16071)
* Fixes a text positioning bug when using the `scaleToFill` `contentMode` with OpenGL.
* Fixes a bug where text was lost after dismissing the Prepublishing Sheet instead of publishing.

## Testing

### Record Video
* Create a new Story post.
* Record video from the Camera Capture screen.
* Ensure that the video plays back in the editing screen.
* Publish the Story
* Ensure that media is exported as expected from the editing view (layers are in alignment and photo is framed correctly).

### Import Video from Photo Library
* Create a new Story post.
* Add existing video from the Photo Library
* Ensure that the video plays back in the editing screen.
* Publish the Story
* Ensure that media is exported as expected from the editing view (layers are in alignment and photo is framed correctly).

### Import Video from created Story
* Create a new Story post.
* Add video created from one of the stories above from your WordPress Library.
* Ensure that the video plays back in the editing screen.
* Publish the Story
* Ensure that media is exported as expected from the editing view (layers are in alignment and photo is framed correctly).

### Cancelled Publishing Text Overlays
* Create a new Story post
* Add media
* Add text to any of the media
* Tap the Confirm button in the top right
* Dismiss the Prepublishing sheet instead of publishing (by swiping down).
* Verify that the text remains after dismissing

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
