### PR TITLE
Update colours in PostPostViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -110,7 +110,11 @@ class EditPostViewController: UIViewController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return WPStyleGuide.preferredStatusBarStyle
+        if openWithPostPost {
+            return .darkContent
+        } else {
+            return WPStyleGuide.preferredStatusBarStyle
+        }
     }
 
     fileprivate func postToEdit() -> Post {

--- a/WordPress/Classes/ViewRelated/Post/PostPost.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/PostPost.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina5_5" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -44,13 +43,12 @@
                                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="28" id="GcR-J5-grU"/>
                                                                 </constraints>
                                                                 <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="22"/>
-                                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Published just now on" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IEW-y3-Pzp">
                                                                 <rect key="frame" x="0.0" y="42" width="636" height="18"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                <color key="textColor" red="0.47058823529999999" green="0.86274509799999999" blue="0.98039215690000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <color key="textColor" systemColor="secondaryLabelColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="rKW-qs-6cA">
@@ -84,7 +82,6 @@
                                                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="w6b-ZM-JsE"/>
                                                                                 </constraints>
                                                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="13"/>
-                                                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog Url" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B9s-7Y-oQQ">
@@ -93,7 +90,6 @@
                                                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="yos-Ix-MsU"/>
                                                                                 </constraints>
                                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                                                 <nil key="highlightedColor"/>
                                                                             </label>
                                                                         </subviews>
@@ -129,29 +125,32 @@
                                                         <state key="normal" title="Share">
                                                             <color key="titleColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                        </userDefinedRuntimeAttributes>
                                                         <connections>
                                                             <action selector="shareTapped" destination="0ZV-gF-7z9" eventType="touchUpInside" id="qhf-Zm-wdL"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wfC-rz-tLa" customClass="FancyButton" customModule="WordPressUI">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wfC-rz-tLa" customClass="FancyButton" customModule="WordPressUI">
                                                         <rect key="frame" x="0.0" y="66" width="636" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="vDI-tK-HOm"/>
                                                         </constraints>
                                                         <state key="normal" title="Edit Post">
-                                                            <color key="titleColor" red="0.96862745100000003" green="0.96862745100000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" systemColor="labelColor"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="editTapped" destination="0ZV-gF-7z9" eventType="touchUpInside" id="nBy-5P-2fK"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WGH-Vv-Uun" customClass="FancyButton" customModule="WordPressUI">
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WGH-Vv-Uun" customClass="FancyButton" customModule="WordPressUI">
                                                         <rect key="frame" x="0.0" y="132" width="636" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="r9K-HZ-toB"/>
                                                         </constraints>
                                                         <state key="normal" title="View Post">
-                                                            <color key="titleColor" red="0.96862745100000003" green="0.96862745100000003" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <color key="titleColor" systemColor="labelColor"/>
                                                         </state>
                                                         <connections>
                                                             <action selector="viewTapped" destination="0ZV-gF-7z9" eventType="touchUpInside" id="ABP-oS-VPb"/>
@@ -179,17 +178,10 @@
                                 </constraints>
                             </view>
                             <navigationBar contentMode="scaleToFill" barStyle="black" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FQW-wc-apn">
-                                <rect key="frame" x="0.0" y="20" width="700" height="44"/>
-                                <color key="barTintColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="calibratedRGB"/>
+                                <rect key="frame" x="0.0" y="0.0" width="700" height="44"/>
+                                <color key="barTintColor" systemColor="systemBackgroundColor"/>
                                 <items>
-                                    <navigationItem id="cdd-ao-D6H">
-                                        <barButtonItem key="rightBarButtonItem" title="Done" style="done" id="JM6-CY-cxQ">
-                                            <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                            <connections>
-                                                <action selector="doneTapped" destination="0ZV-gF-7z9" id="clo-aS-TDk"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
+                                    <navigationItem id="cdd-ao-D6H"/>
                                 </items>
                             </navigationBar>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fmh-Yp-NIl">
@@ -197,11 +189,12 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" red="0.0" green="0.52941176469999995" blue="0.74509803919999995" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="HyV-qN-PlX" firstAttribute="height" secondItem="2Pd-T6-hcw" secondAttribute="height" priority="750" constant="-32" id="2MU-G6-Bg5"/>
                             <constraint firstItem="FQW-wc-apn" firstAttribute="leading" secondItem="2Pd-T6-hcw" secondAttribute="leading" id="4vQ-ZV-a19"/>
                             <constraint firstItem="HyV-qN-PlX" firstAttribute="centerX" secondItem="2Pd-T6-hcw" secondAttribute="centerX" id="H0w-X7-Hck"/>
+                            <constraint firstItem="8Oz-au-Onc" firstAttribute="top" secondItem="HyV-qN-PlX" secondAttribute="bottom" id="Jy4-34-3F4"/>
                             <constraint firstItem="FQW-wc-apn" firstAttribute="top" secondItem="T6C-gu-aFL" secondAttribute="bottom" id="OyB-Yv-CVc"/>
                             <constraint firstItem="Fmh-Yp-NIl" firstAttribute="leading" secondItem="2Pd-T6-hcw" secondAttribute="leading" id="Rk9-It-Cw6"/>
                             <constraint firstAttribute="trailing" secondItem="Fmh-Yp-NIl" secondAttribute="trailing" id="c3V-j3-PXM"/>
@@ -211,6 +204,11 @@
                             <constraint firstItem="Fmh-Yp-NIl" firstAttribute="top" secondItem="2Pd-T6-hcw" secondAttribute="top" id="pHx-pm-5En"/>
                             <constraint firstItem="HyV-qN-PlX" firstAttribute="width" secondItem="2Pd-T6-hcw" secondAttribute="width" priority="750" constant="-64" id="rcL-v9-I3y"/>
                         </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="oJd-r7-ndv"/>
+                            </mask>
+                        </variation>
                     </view>
                     <navigationItem key="navigationItem" id="mYP-bF-EKS"/>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="lightContent"/>
@@ -239,4 +237,15 @@
             <point key="canvasLocation" x="2836.2318840579715" y="309.78260869565219"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -43,32 +43,38 @@ class PostPostViewController: UIViewController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent
+        return .darkContent
     }
-
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupActionButtons()
+        setupLabels()
+        setupNavBar()
+    }
+
+    private func setupNavBar() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        navBar.standardAppearance = appearance
+        navBar.compactAppearance = appearance
+
+        let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneTapped))
+        doneButton.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.barButtonItemTitle], for: .normal)
+        navBar.topItem?.rightBarButtonItem = doneButton
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        view.backgroundColor = .primary
-
-        let appearance = UINavigationBarAppearance()
-        appearance.configureWithTransparentBackground()
-
-        navBar.standardAppearance = appearance
-        navBar.topItem?.rightBarButtonItem?.title = NSLocalizedString("Done", comment: "Label on button to dismiss view presented after publishing a post")
-        navBar.topItem?.rightBarButtonItem?.accessibilityIdentifier = "doneButton"
+        view.backgroundColor = .basicBackground
 
         view.alpha = WPAlphaZero
 
         shareButton.setTitle(NSLocalizedString("Share", comment: "Button label to share a post"), for: .normal)
         shareButton.accessibilityIdentifier = "sharePostButton"
         shareButton.setImage(.gridicon(.shareiOS, size: CGSize(width: 18, height: 18)), for: .normal)
+        shareButton.tintColor = .white
+
         shareButton.imageEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8)
         editButton.setTitle(NSLocalizedString("Edit Post", comment: "Button label for editing a post"), for: .normal)
         editButton.accessibilityIdentifier = "editPostButton"
@@ -85,18 +91,11 @@ class PostPostViewController: UIViewController {
         }
     }
 
-    private func setupActionButtons() {
-        shareButton.secondaryTitleColor = .primary
-        shareButton.secondaryNormalBackgroundColor = .white
-        shareButton.secondaryHighlightBackgroundColor = .white
-
-        editButton.secondaryTitleColor = .white
-        editButton.secondaryNormalBackgroundColor = .clear
-        editButton.secondaryHighlightBackgroundColor = .clear
-
-        viewButton.secondaryTitleColor = .white
-        viewButton.secondaryNormalBackgroundColor = .clear
-        viewButton.secondaryHighlightBackgroundColor = .clear
+    private func setupLabels() {
+        titleLabel.textColor = .label
+        postStatusLabel.textColor = .secondaryLabel
+        siteNameLabel.textColor = .label
+        siteUrlLabel.textColor = .label
     }
 
     @objc func animatePostPost() {


### PR DESCRIPTION
Fixes #16057. 

This PR updates the colours used in PostPostViewController:

- Change the background to white
- Text to use `labelColor` and `secondaryLabel`
- Buttons to use standard FancyButton appearance

I also moved the buttons further down the screen, so they're easier to tap one-handed.

cc @mattmiklic 

**Before**

<img src="https://user-images.githubusercontent.com/4780/111490833-41166280-8733-11eb-8b39-e1e9ac9b9e37.png" width=250>

**After**

|    |    |    |
|---|---|---|
|  ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-17 at 14 41 44](https://user-images.githubusercontent.com/4780/111486725-a49e9100-872f-11eb-8c53-7f2cf77a7cb1.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-17 at 14 46 19](https://user-images.githubusercontent.com/4780/111486711-a1a3a080-872f-11eb-85a5-ddce848c9cef.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-17 at 14 41 48](https://user-images.githubusercontent.com/4780/111486716-a36d6400-872f-11eb-888c-d59b8c9b5771.png) |

**To test**

- Build and run.
- Publish a post, and wait for the 'post published' notice to appear at the bottom of the screen.
- Tap the View button, and the post post screen should appear. Check the design is as shown above.
- Also check in dark mode.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
