### PR TITLE
Fix navigation bar styles for WebKitViewController

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -88,6 +88,19 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     private var widthConstraint: NSLayoutConstraint?
     private var onClose: (() -> Void)?
 
+    private var useLightStyle: Bool {
+        navigationController is LightNavigationController
+    }
+
+    private var barButtonTintColor: UIColor {
+        useLightStyle ? .listIcon : UIColor(light: .white, dark: .neutral(.shade70))
+    }
+
+    private var navBarTitleColor: UIColor {
+        useLightStyle ? .text : UIColor(light: .white, dark: .neutral(.shade70))
+    }
+
+
     private struct WebViewErrors {
         static let frameLoadInterrupted = 102
     }
@@ -247,7 +260,8 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
 
     private func setupNavBarTitleView() {
         titleView.titleLabel.text = NSLocalizedString("Loading...", comment: "Loading. Verb")
-        titleView.titleLabel.textColor = UIColor(light: .white, dark: .neutral(.shade70))
+
+        titleView.titleLabel.textColor = navBarTitleColor
         titleView.subtitleLabel.textColor = .neutral(.shade30)
 
         if let title = customTitle {
@@ -262,7 +276,11 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
             return
         }
         navigationBar.barStyle = .default
-        navigationBar.titleTextAttributes = [.foregroundColor: UIColor.neutral(.shade70)]
+
+        if !useLightStyle {
+            navigationBar.titleTextAttributes = [.foregroundColor: UIColor.neutral(.shade70)]
+        }
+
         navigationBar.shadowImage = UIImage(color: WPStyleGuide.webViewModalNavigationBarShadow())
         navigationBar.setBackgroundImage(UIImage(color: WPStyleGuide.webViewModalNavigationBarBackground()), for: .default)
 
@@ -270,6 +288,10 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     }
 
     private func styleNavBarButtons() {
+        guard !useLightStyle else {
+            return
+        }
+
         navigationItem.leftBarButtonItems?.forEach(styleBarButton)
         navigationItem.rightBarButtonItems?.forEach(styleBarButton)
     }
@@ -336,7 +358,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     }
 
     private func styleBarButton(_ button: UIBarButtonItem) {
-        button.tintColor = UIColor(light: .white, dark: .neutral(.shade70))
+        button.tintColor = barButtonTintColor
     }
 
     private func styleToolBarButton(_ button: UIBarButtonItem) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -439,7 +439,7 @@ class ReaderDetailCoordinator {
         configuration.authenticateWithDefaultAccount()
         configuration.addsWPComReferrer = true
         let controller = WebViewControllerFactory.controller(configuration: configuration)
-        let navController = UINavigationController(rootViewController: controller)
+        let navController = LightNavigationController(rootViewController: controller)
         viewController?.present(navController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderVisitSiteAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderVisitSiteAction.swift
@@ -14,7 +14,7 @@ final class ReaderVisitSiteAction {
             configuration.authenticate(account: account)
         }
         let controller = WebViewControllerFactory.controller(configuration: configuration)
-        let navController = UINavigationController(rootViewController: controller)
+        let navController = LightNavigationController(rootViewController: controller)
         origin.present(navController, animated: true)
         WPAnalytics.trackReader(.readerArticleVisited)
     }


### PR DESCRIPTION
Fixes #16078. WebKitViewController was overriding some styles defined for light navigation bars in `WPStyleGuide+ApplicationStyles`. Ideally, all places in the app should use WebKitViewControllers with light navigation controllers, however that doesn't appear to be the case. As such, I've introduced some conditional code so that this works for both types of navigation bar, which seemed like the simplest fix for this issue for now. I did however update uses in the Reader stream and detail views so that they now use LightNavigationBar.

A good next step would be to audit each use of WebKitViewController (and its subclasses) 

|    |    |
|---|---|
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-17 at 16 01 10](https://user-images.githubusercontent.com/4780/111534508-f8c16980-875f-11eb-82af-13938e9864d6.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-17 at 19 50 00](https://user-images.githubusercontent.com/4780/111534574-1098ed80-8760-11eb-917f-431769263abb.png) |

**To test**

- Build and run.
- In My Site, scroll to the bottom and choose View Site.
- Check that the title and buttons are visible in the navigation bar.
- Go to Reader.
- Tap the ... on a card in the stream and choose Visit. Check the navigation bar in the web view.
- Dismiss that, and tap into a post in Reader. Tap the globe / Safari icon in the navigation bar, and check the resulting web view.
- If you'd like to test the dark style navigation bars, you can force one to appear by adding the following line of code to `viewDidAppear` in `NotificationDetailViewController`:

`coordinator.displayWebViewWithURL(URL(string: "https://www.google.com")!)`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
