### PR TITLE
Dismiss alert in UI tests to ensure tests pass the first time around

### DIFF
--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -41,6 +41,7 @@ class EditorAztecTests: XCTestCase {
         let category = getCategory()
         let tag = getTag()
         editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
             .enterText(text: content)
             .addImageByOrder(id: 0)


### PR DESCRIPTION
The [new classic editor deprecation alert](https://github.com/wordpress-mobile/WordPress-iOS/pull/16008) in Aztec (classic editor) was making all UI tests fail on the first try. CircleCI then ran tests a second time and because the alert is not shown again (state is persisted on the device), tests passed the second time around.

This was causing UI tests to fail the first time around for the last 10 days: https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-iOS?branch=develop. Since tests always passed the second time, this went unnoticed.

To test:

1. Run optional UI tests (on any device)
2. View the **Run UI Tests** job and check that tests pass the first time around (there should be **no** second attempt at running UI tests, i.e. no _"Starting scan #2 with 10 tests."_)

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
