### PR TITLE
Add alert dismiss to all Aztec UI tests

### DIFF
--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -11,6 +11,7 @@ class EditorAztecTests: XCTestCase {
             .toggleBlockEditor(to: .off)
             .goBackToMySite()
             .tabBar.gotoAztecEditorScreen()
+            .dismissNotificationAlertIfNeeded(.accept)
     }
 
     override func tearDown() {
@@ -27,7 +28,6 @@ class EditorAztecTests: XCTestCase {
         let title = getRandomPhrase()
         let content = getRandomContent()
         editorScreen
-            .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
             .enterText(text: content)
             .publish()
@@ -42,7 +42,6 @@ class EditorAztecTests: XCTestCase {
         let category = getCategory()
         let tag = getTag()
         editorScreen
-            .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
             .enterText(text: content)
             .addImageByOrder(id: 0)

--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -27,6 +27,7 @@ class EditorAztecTests: XCTestCase {
         let title = getRandomPhrase()
         let content = getRandomContent()
         editorScreen
+            .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
             .enterText(text: content)
             .publish()


### PR DESCRIPTION
A follow-up to https://github.com/wordpress-mobile/WordPress-iOS/pull/16118 to make _all_ Aztec UI tests dismiss the "classic editor deprecation" alert. Otherwise tests will fail if `testBasicPostPublish` is not run before the other tests. (Although this doesn't happen at the moment since Xcode runs tests in alphabetical order, it might happen if tests are renamed/removed/etc.)

To test:

1. (Optional) On a clean simulator (without WordPress installed), checkout this branch and run only the `testTextPostPublish` test, ensure it passes
2. Run optional UI tests (on any device) and make sure they pass (I've done this below)
3. Check The Run UI Tests job and make sure tests passed on the first run


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
