### PR TITLE
Fix wrong label in small Today and All Time widgets

### DIFF
--- a/WordPress/WordPressStatsWidgets/Views/SingleStatView.swift
+++ b/WordPress/WordPressStatsWidgets/Views/SingleStatView.swift
@@ -11,7 +11,7 @@ struct SingleStatView: View {
                 FlexibleCard(axis: .vertical, title: viewData.widgetTitle, value: .description(viewData.siteName), lineLimit: 2)
 
                 Spacer()
-                VerticalCard(title: viewData.widgetTitle, value: viewData.upperLeftValue, largeText: true)
+                VerticalCard(title: viewData.upperLeftTitle, value: viewData.upperLeftValue, largeText: true)
             }
             Spacer()
         }


### PR DESCRIPTION
Fixes #16123

To test:

- Build/run and install "Today" and "All Time" widgets
- make sure the blue label says "Views" (see example screenshot below)

<p align=center>
<img width="400" src="https://user-images.githubusercontent.com/34376330/111649526-73c36800-87d2-11eb-8dca-2e2c76d4793b.png">
</p>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @jkmassel  - This PR targets release 16.9