### PR TITLE
Add large title to the Reader

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -40,7 +40,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .gutenbergXposts:
             return true
         case .newNavBarAppearance:
-            return false
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .unifiedPrologueCarousel:
             return false
         case .stories:

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -715,7 +715,8 @@ private extension ReaderDetailViewController {
         } else {
             navigationItem.leftBarButtonItem = dismissButtonItem()
         }
-
+        navigationItem.largeTitleDisplayMode = .never
+        //navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.rightBarButtonItems = rightItems.compactMap({ $0 })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -716,7 +716,6 @@ private extension ReaderDetailViewController {
             navigationItem.leftBarButtonItem = dismissButtonItem()
         }
         navigationItem.largeTitleDisplayMode = .never
-        //navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.rightBarButtonItems = rightItems.compactMap({ $0 })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -99,6 +99,7 @@ import Gridicons
         super.viewDidLoad()
 
         navigationItem.title = NSLocalizedString("Search", comment: "Title of the Reader's search feature")
+        navigationItem.largeTitleDisplayMode = .never
 
         WPStyleGuide.configureColors(view: view, tableView: nil)
         setupSearchBar()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -303,6 +303,8 @@ import WordPressFlux
         // pull to refresh animation.
         view.isUserInteractionEnabled = readerTopic != nil
 
+        navigationItem.largeTitleDisplayMode = .never
+
         NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountDidChange(_:)), name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged, object: nil)
 
         NotificationCenter.default.addObserver(self, selector: #selector(postSeenToggled(_:)), name: .ReaderPostSeenToggled, object: nil)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -88,6 +88,7 @@ extension ReaderTabView {
 
     private func setupMainScrollView() {
         mainScrollView.translatesAutoresizingMaskIntoConstraints = false
+        mainScrollView.isScrollEnabled = true
         mainScrollView.addSubview(mainStackView)
         addSubview(mainScrollView)
     }
@@ -176,15 +177,15 @@ extension ReaderTabView {
 
     private func activateConstraints() {
         pinSubviewToAllEdges(mainScrollView)
-        mainScrollView.pinSubviewToAllEdges(mainStackView)
         NSLayoutConstraint.activate([
             buttonsStackView.heightAnchor.constraint(equalToConstant: Appearance.barHeight),
             resetFilterButton.widthAnchor.constraint(equalToConstant: Appearance.resetButtonWidth),
             horizontalDivider.heightAnchor.constraint(equalToConstant: Appearance.dividerWidth),
             horizontalDivider.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
-            NSLayoutConstraint(item: mainStackView, attribute: .centerX, relatedBy: .equal, toItem: mainScrollView, attribute: .centerX, multiplier: 1, constant: 0),
-            NSLayoutConstraint(item: mainStackView, attribute: .centerY, relatedBy: .equal, toItem: mainScrollView, attribute: .centerY, multiplier: 1, constant: 0),
-            mainStackView.widthAnchor.constraint(equalTo: mainScrollView.widthAnchor)
+            mainStackView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor),
+            mainStackView.topAnchor.constraint(equalTo: mainScrollView.topAnchor),
+            mainStackView.widthAnchor.constraint(equalTo: mainScrollView.widthAnchor),
+            mainStackView.heightAnchor.constraint(equalTo: mainScrollView.heightAnchor)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 class ReaderTabView: UIView {
 
+    private let mainScrollView: UIScrollView
     private let mainStackView: UIStackView
     private let buttonsStackView: UIStackView
     private let tabBar: FilterTabBar
@@ -26,6 +27,7 @@ class ReaderTabView: UIView {
     }
 
     init(viewModel: ReaderTabViewModel) {
+        mainScrollView = UIScrollView()
         mainStackView = UIStackView()
         buttonsStackView = UIStackView()
         tabBar = FilterTabBar()
@@ -74,6 +76,7 @@ extension ReaderTabView {
 
     private func setupViewElements() {
         backgroundColor = .filterBarBackground
+        setupMainScrollView()
         setupMainStackView()
         setupTabBar()
         setupButtonsView()
@@ -83,10 +86,16 @@ extension ReaderTabView {
         activateConstraints()
     }
 
+    private func setupMainScrollView() {
+        mainScrollView.translatesAutoresizingMaskIntoConstraints = false
+        mainScrollView.addSubview(mainStackView)
+        addSubview(mainScrollView)
+    }
+
     private func setupMainStackView() {
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
         mainStackView.axis = .vertical
-        addSubview(mainStackView)
+
         mainStackView.addArrangedSubview(tabBar)
         mainStackView.addArrangedSubview(buttonsStackView)
         mainStackView.addArrangedSubview(horizontalDivider)
@@ -166,12 +175,16 @@ extension ReaderTabView {
     }
 
     private func activateConstraints() {
-        pinSubviewToAllEdges(mainStackView)
+        pinSubviewToAllEdges(mainScrollView)
+        mainScrollView.pinSubviewToAllEdges(mainStackView)
         NSLayoutConstraint.activate([
             buttonsStackView.heightAnchor.constraint(equalToConstant: Appearance.barHeight),
             resetFilterButton.widthAnchor.constraint(equalToConstant: Appearance.resetButtonWidth),
             horizontalDivider.heightAnchor.constraint(equalToConstant: Appearance.dividerWidth),
-            horizontalDivider.widthAnchor.constraint(equalTo: mainStackView.widthAnchor)
+            horizontalDivider.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
+            NSLayoutConstraint(item: mainStackView, attribute: .centerX, relatedBy: .equal, toItem: mainScrollView, attribute: .centerX, multiplier: 1, constant: 0),
+            NSLayoutConstraint(item: mainStackView, attribute: .centerY, relatedBy: .equal, toItem: mainScrollView, attribute: .centerY, multiplier: 1, constant: 0),
+            mainStackView.widthAnchor.constraint(equalTo: mainScrollView.widthAnchor)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -3,7 +3,6 @@ import UIKit
 
 class ReaderTabView: UIView {
 
-    private let mainScrollView: UIScrollView
     private let mainStackView: UIStackView
     private let buttonsStackView: UIStackView
     private let tabBar: FilterTabBar
@@ -27,7 +26,6 @@ class ReaderTabView: UIView {
     }
 
     init(viewModel: ReaderTabViewModel) {
-        mainScrollView = UIScrollView()
         mainStackView = UIStackView()
         buttonsStackView = UIStackView()
         tabBar = FilterTabBar()
@@ -76,7 +74,6 @@ extension ReaderTabView {
 
     private func setupViewElements() {
         backgroundColor = .filterBarBackground
-        setupMainScrollView()
         setupMainStackView()
         setupTabBar()
         setupButtonsView()
@@ -86,17 +83,10 @@ extension ReaderTabView {
         activateConstraints()
     }
 
-    private func setupMainScrollView() {
-        mainScrollView.translatesAutoresizingMaskIntoConstraints = false
-        mainScrollView.isScrollEnabled = true
-        mainScrollView.addSubview(mainStackView)
-        addSubview(mainScrollView)
-    }
-
     private func setupMainStackView() {
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
         mainStackView.axis = .vertical
-
+        addSubview(mainStackView)
         mainStackView.addArrangedSubview(tabBar)
         mainStackView.addArrangedSubview(buttonsStackView)
         mainStackView.addArrangedSubview(horizontalDivider)
@@ -176,16 +166,12 @@ extension ReaderTabView {
     }
 
     private func activateConstraints() {
-        pinSubviewToAllEdges(mainScrollView)
+        pinSubviewToAllEdges(mainStackView)
         NSLayoutConstraint.activate([
             buttonsStackView.heightAnchor.constraint(equalToConstant: Appearance.barHeight),
             resetFilterButton.widthAnchor.constraint(equalToConstant: Appearance.resetButtonWidth),
             horizontalDivider.heightAnchor.constraint(equalToConstant: Appearance.dividerWidth),
-            horizontalDivider.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
-            mainStackView.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor),
-            mainStackView.topAnchor.constraint(equalTo: mainScrollView.topAnchor),
-            mainStackView.widthAnchor.constraint(equalTo: mainScrollView.widthAnchor),
-            mainStackView.heightAnchor.constraint(equalTo: mainScrollView.heightAnchor)
+            horizontalDivider.widthAnchor.constraint(equalTo: mainStackView.widthAnchor)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -45,12 +45,6 @@ class ReaderTabViewController: UIViewController {
         NotificationCenter.default.removeObserver(self)
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-//        navigationItem.largeTitleDisplayMode = .always
-//        navigationController?.navigationBar.prefersLargeTitles = true
-    }
-
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -45,6 +45,12 @@ class ReaderTabViewController: UIViewController {
         NotificationCenter.default.removeObserver(self)
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+//        navigationItem.largeTitleDisplayMode = .always
+//        navigationController?.navigationBar.prefersLargeTitles = true
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -77,6 +83,8 @@ class ReaderTabViewController: UIViewController {
 
     override func loadView() {
         view = readerTabView
+        navigationItem.largeTitleDisplayMode = .always
+        navigationController?.navigationBar.prefersLargeTitles = true
     }
 
     @objc func willEnterForeground() {


### PR DESCRIPTION
Fixes #NA

To test:

- Build and run
- make sure the large title shows up in the Reader (see screenshot)
- make sure that search, post details and sites accessible from the reader do not have large titles

<p align=center>
<img height=450 src=https://user-images.githubusercontent.com/34376330/111822782-3504df00-88b2-11eb-809a-ba5b10df59c4.PNG>
</p>

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
