### PR TITLE
Comments: group by date created

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] Reader: fixed an issue that caused unfollowing external sites to fail. [#16060]
 * [*] Stats: fixed an issue where an error was displayed for Latest Post Summary if the site had no posts. [#16074]
 * [*] Fixed an issue where password text on Post Settings was showing as black in dark mode. [#15768]
+* [**] Comments can now be filtered by status (All, Pending, Approved, Trashed, or Spam). [#15955, #16110]
 
 16.9
 -----

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -53,5 +53,6 @@ extern NSString * const CommentStatusDraft;
 - (NSString *)authorUrlForDisplay;
 - (BOOL)hasAuthorUrl;
 - (BOOL)isApproved;
+- (NSString *)sectionIdentifier;
 
 @end

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -97,6 +97,14 @@ NSString * const CommentStatusDraft = @"draft";
     return date;
 }
 
+- (NSString *)sectionIdentifier
+{
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    formatter.dateStyle = NSDateFormatterLongStyle;
+    formatter.timeStyle = NSDateFormatterNoStyle;
+    return [formatter stringFromDate:self.dateCreated];
+}
+
 
 #pragma mark - PostContentProvider protocol
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -58,7 +58,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .milestoneNotifications:
             return false
         case .commentFilters:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .newLikeNotifications:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -10,6 +10,8 @@ open class CommentsTableViewCell: WPTableViewCell {
     @IBOutlet private weak var gravatarImageView: CircularImageView!
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var detailLabel: UILabel!
+
+    @IBOutlet weak var timestampStackView: UIStackView!
     @IBOutlet private weak var timestampImageView: UIImageView!
     @IBOutlet private weak var timestampLabel: UILabel!
 
@@ -101,11 +103,15 @@ private extension CommentsTableViewCell {
     }
 
     func configureTimestamp() {
+
+        // When FeatureFlag.commentFilters is removed,
+        // all timestamp elements can be removed.
+        timestampStackView.isHidden = FeatureFlag.commentFilters.enabled
+
         timestampLabel.text = timestamp
         timestampLabel.font = Style.timestampFont
         timestampLabel.textColor = Style.detailTextColor
         timestampImageView.image = Style.timestampImage
-
     }
 
     func attributedTitle() -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -89,6 +89,7 @@
                 <outlet property="pendingIndicatorWidthConstraint" destination="WeL-cC-lqa" id="NGZ-2z-ehN"/>
                 <outlet property="timestampImageView" destination="rcg-tb-060" id="cp9-u0-P57"/>
                 <outlet property="timestampLabel" destination="bDl-id-9M7" id="sk9-hl-b6r"/>
+                <outlet property="timestampStackView" destination="dIK-tl-nW4" id="3n0-tf-xMe"/>
                 <outlet property="titleLabel" destination="Wrp-Wr-ZBq" id="lVi-a7-Ppp"/>
             </connections>
             <point key="canvasLocation" x="33.600000000000001" y="70.614692653673174"/>

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -355,9 +355,16 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
         fetchRequest.predicate = [NSPredicate predicateWithFormat:@"(blog == %@ AND status != %@)", self.blog, CommentStatusSpam];
     }
 
-    NSSortDescriptor *sortDescriptorStatus = [NSSortDescriptor sortDescriptorWithKey:@"status" ascending:NO];
+
     NSSortDescriptor *sortDescriptorDate = [NSSortDescriptor sortDescriptorWithKey:@"dateCreated" ascending:NO];
-    fetchRequest.sortDescriptors = @[sortDescriptorStatus, sortDescriptorDate];
+    
+    if ([Feature enabled:FeatureFlagCommentFilters]) {
+        fetchRequest.sortDescriptors = @[sortDescriptorDate];
+    } else {
+        NSSortDescriptor *sortDescriptorStatus = [NSSortDescriptor sortDescriptorWithKey:@"status" ascending:NO];
+        fetchRequest.sortDescriptors = @[sortDescriptorStatus, sortDescriptorDate];
+    }
+    
     fetchRequest.fetchBatchSize = CommentsFetchBatchSize;
     
     return fetchRequest;

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -231,6 +231,14 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
+    
+    // When FeatureFlagCommentFilters is removed, this whole method can be removed
+    // and just let WPTableViewHandler provide the height.
+
+    if ([Feature enabled:FeatureFlagCommentFilters]) {
+        return UITableViewAutomaticDimension;
+    }
+    
     // Override WPTableViewHandler's default of UITableViewAutomaticDimension,
     // which results in 30pt tall headers on iOS 11
     return 0;
@@ -375,6 +383,14 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     [self.navigationController popToViewController:self animated:YES];
 }
 
+- (NSString *)sectionNameKeyPath
+{
+    if ([Feature enabled:FeatureFlagCommentFilters]) {
+        return @"sectionIdentifier";
+    }
+    
+    return nil;
+}
 
 #pragma mark - WPContentSyncHelper Methods
 


### PR DESCRIPTION
Fixes #16110 , Ref #15955

Comments are now grouped by creation date.
- Comment lists are sectioned by date, with the date as the section title.
- Comments are now sorted solely by date, instead of status + date.
- The Comment creation date is no longer displayed in each comment cell.

This also enabled the Comments Filter feature for all. 🎉 

To test:
- Go to Comments.
- Verify the Comments are grouped by creation date in all filters.
- Disable the `commentFilters` feature flag. 
- Verify the Comments appear old school.

| Filters Enabled | Filters Disabled |
|--------|-------|
| ![New](https://user-images.githubusercontent.com/1816888/111699646-09c0b800-87fe-11eb-8012-fa210a113e13.png) | ![Old](https://user-images.githubusercontent.com/1816888/111699669-12b18980-87fe-11eb-9828-1b40b7196118.png) |


PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
