### PR TITLE
Remove switch to classic from gutenberg

### DIFF
--- a/WordPress/Classes/Utility/Editor/EditorFactory.swift
+++ b/WordPress/Classes/Utility/Editor/EditorFactory.swift
@@ -34,11 +34,6 @@ class EditorFactory {
         return gutenbergVC
     }
 
-    func switchToAztec(from source: EditorViewController) {
-        let replacement = AztecPostViewController(post: source.post, replaceEditor: source.replaceEditor, editorSession: source.editorSession)
-        source.replaceEditor(source, replacement)
-    }
-
     func switchToGutenberg(from source: EditorViewController) {
         let replacement = GutenbergViewController(post: source.post, replaceEditor: source.replaceEditor, editorSession: source.editorSession)
         source.replaceEditor(source, replacement)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -27,10 +27,6 @@ extension GutenbergViewController {
             }
         }
 
-        alert.addDefaultActionWithTitle(MoreSheetAlert.classicTitle) { [unowned self] _ in
-            self.savePostEditsAndSwitchToAztec()
-        }
-
         let toggleModeTitle: String = {
             if mode == .richText {
                 return MoreSheetAlert.htmlTitle
@@ -105,10 +101,6 @@ extension GutenbergViewController {
 
 extension GutenbergViewController {
     struct MoreSheetAlert {
-        static let classicTitle = NSLocalizedString(
-            "Switch to classic editor",
-            comment: "Switches from Gutenberg mobile to the classic editor"
-        )
         static let htmlTitle = NSLocalizedString("Switch to HTML Mode", comment: "Switches the Editor to HTML Mode")
         static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -13,7 +13,6 @@ class GutenbergViewController: UIViewController, PostEditor {
         case publish
         case close
         case more
-        case switchToAztec
         case switchBlog
         case autoSave
     }
@@ -501,12 +500,6 @@ class GutenbergViewController: UIViewController, PostEditor {
     @objc func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         return presentationController(forPresented: presented, presenting: presenting)
     }
-
-    // MARK: - Switch to Aztec
-
-    func savePostEditsAndSwitchToAztec() {
-        requestHTML(for: .switchToAztec)
-    }
 }
 
 // MARK: - Views setup
@@ -809,9 +802,6 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
                 cancelEditing()
             case .more:
                 displayMoreSheet()
-            case .switchToAztec:
-                editorSession.switch(editor: .classic)
-                EditorFactory().switchToAztec(from: self)
             case .switchBlog:
                 blogPickerWasPressed()
             case .autoSave:


### PR DESCRIPTION
Addresses: https://github.com/wordpress-mobile/gutenberg-mobile/issues/3048 (for iOS)

In discussion with @kyleaparker, we decided that it's best to fast-track the removal of the "switch to classic" option in the block editor. This PR will be scheduled for release in v17.1 alongside a matching change for Android.

I think this change doesn't warrant inclusion in `RELEASE-NOTES.txt`, but if anyone thinks differently I'd love to hear.

## To test

1. Select a Simple site
2. Open a new post in the block editor
3. Tap the ellipsis button to reveal the options bottom sheet
4. Verify that there is no longer an option to switch to classic
5. Repeat Steps 2-4 for Atomic, Jetpack, self-hosted sites

### Regression notes (new ✨ )

I'm adding this section to try out @startuptester's proposal to improve code quality.

- **Potential unintended areas of impact (regressions)**
  The app has a couple of different editors (block editor, classic editor, story editor, HTML editor) and this change is only intended to _prevent navigation from the block editor to the classic editor_. 

- **What you did to manually test those/ what existing automated tests you relied on** 
  I gave these the four editors (block, classic, story, HTML) a quick test, keeping an eye out for any unintended side-effects of this change.

- **What automated tests you added or what prevented you from doing so**
  There are no existing UI tests nor unit tests that cover switching from the block editor to the classic editor, so there were no tests to update. Since we're removing functionality here, there's are no tests to add, either.

## PR submission checklist

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
