### PR TITLE
Update NewBlogDetailHeaderView sizing

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -175,7 +175,7 @@ extension UIColor {
     /// Muriel/iOS navigation color
     static var appBarBackground: UIColor {
         if FeatureFlag.newNavBarAppearance.enabled {
-            return UIColor(light: white, dark: .gray(.shade100))
+            return .secondarySystemGroupedBackground
         }
 
         return UIColor(light: .brand, dark: .gray(.shade100))

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -63,12 +63,17 @@ extension WPStyleGuide {
         appearance.largeTitleTextAttributes = largeTitleTextAttributes
 
         if FeatureFlag.newNavBarAppearance.enabled {
-            appearance.shadowColor = .clear
+            appearance.shadowColor = .separator
+
+            let scrollEdgeAppearance = appearance.copy()
+            scrollEdgeAppearance.shadowColor = .clear
+            navigationAppearance.scrollEdgeAppearance = scrollEdgeAppearance
+        } else {
+            navigationAppearance.scrollEdgeAppearance = appearance
         }
 
         navigationAppearance.standardAppearance = appearance
-        navigationAppearance.scrollEdgeAppearance = navigationAppearance.standardAppearance
-
+        navigationAppearance.compactAppearance = appearance
 
         // Makes bar buttons visible in "Other Apps" media source picker.
         // Setting title text attributes makes bar button items not go blank when switching between the tabs of the picker.

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -659,7 +659,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)sectionNum {
     BlogDetailsSection *section = self.tableSections[sectionNum];
-    if (section.showQuickStartMenu == true || [Feature enabled:FeatureFlagNewNavBarAppearance]) {
+    if (section.showQuickStartMenu == true || (sectionNum == 0 && [Feature enabled:FeatureFlagNewNavBarAppearance])) {
         return BlogDetailQuickStartSectionHeight;
     } else if (([section.title isEmpty] || section.title == nil) && sectionNum == 0) {
         // because tableView:viewForHeaderInSection: is implemented, this must explicitly be 0

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -90,6 +90,7 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
         static let interSectionSpacing: CGFloat = 32
         static let buttonsBottomPadding: CGFloat = 40
         static let buttonsSidePadding: CGFloat = 40
+        static let maxButtonWidth: CGFloat = 390
         static let siteIconSize = CGSize(width: 48, height: 48)
     }
 
@@ -142,19 +143,24 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
     }
 
     private func constraintsForActionRow() -> [NSLayoutConstraint] {
-        [
+        let widthConstraint = actionRow.widthAnchor.constraint(equalToConstant: LayoutSpacing.maxButtonWidth)
+        widthConstraint.priority = .defaultHigh
+
+        return [
             actionRow.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: LayoutSpacing.betweenTitleViewAndActionRow),
             actionRow.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -LayoutSpacing.belowActionRow),
-            actionRow.leadingAnchor.constraint(equalTo: leadingAnchor, constant: LayoutSpacing.atSides),
-            actionRow.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -LayoutSpacing.atSides)
+            actionRow.leadingAnchor.constraint(greaterThanOrEqualTo: titleView.leadingAnchor),
+            actionRow.trailingAnchor.constraint(lessThanOrEqualTo: titleView.trailingAnchor),
+            actionRow.centerXAnchor.constraint(equalTo: centerXAnchor),
+            widthConstraint
         ]
     }
 
     private func constraintsForTitleView() -> [NSLayoutConstraint] {
         [
             titleView.topAnchor.constraint(equalTo: topAnchor, constant: LayoutSpacing.top),
-            titleView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: LayoutSpacing.atSides),
-            titleView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -LayoutSpacing.atSides)
+            titleView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: LayoutSpacing.atSides),
+            titleView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -LayoutSpacing.atSides)
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -220,7 +220,7 @@ fileprivate extension NewBlogDetailHeaderView {
             button.titleLabel?.adjustsFontForContentSizeCategory = true
             button.titleLabel?.lineBreakMode = .byTruncatingTail
 
-            button.setTitleColor(WPStyleGuide.darkBlue(), for: .normal)
+            button.setTitleColor(.primary, for: .normal)
 
             if let pointSize = button.titleLabel?.font.pointSize {
                 button.setImage(UIImage.gridicon(.external, size: CGSize(width: pointSize, height: pointSize)), for: .normal)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -81,7 +81,7 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
     private enum LayoutSpacing {
         static let atSides: CGFloat = 16
         static let top: CGFloat = 16
-        static let belowActionRow: CGFloat = 16
+        static let belowActionRow: CGFloat = 24
         static let betweenTitleViewAndActionRow: CGFloat = 32
 
         static let spacingBelowIcon: CGFloat = 16

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -130,6 +130,8 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
         addSubview(titleView)
         addSubview(actionRow)
 
+        addBottomBorder(withColor: .separator)
+
         setupConstraintsForChildViews()
     }
 


### PR DESCRIPTION
A few tweaks to the new blog detail header sizing:

* TitleView constrains to safe layout guides horizontally
* Action button row either matches titleview or maxes out at 390 wide

| Device | Portrait | Landscape |
|---|---|---|
| iPhone 12 Pro | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-19 at 10 57 20](https://user-images.githubusercontent.com/4780/111772203-8312e600-88a4-11eb-8cd3-237380f488aa.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-19 at 10 57 24](https://user-images.githubusercontent.com/4780/111772208-84441300-88a4-11eb-867b-fb06dcf8ec2b.png) |
| iPhone 12 Pro Max | ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-03-19 at 11 00 00](https://user-images.githubusercontent.com/4780/111772250-945bf280-88a4-11eb-9337-5aee9b93898c.png) | ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-03-19 at 11 00 09](https://user-images.githubusercontent.com/4780/111772257-958d1f80-88a4-11eb-902b-be033cf1800f.png) |
| iPad Pro 9.7" Split screen | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-19 at 11 11 32](https://user-images.githubusercontent.com/4780/111772359-ab024980-88a4-11eb-86c2-83d0ead5df5a.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-19 at 11 11 30](https://user-images.githubusercontent.com/4780/111772365-ab9ae000-88a4-11eb-9033-e4e4ec61e616.png) |
| iPad Pro 9.7" Full screen | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-19 at 11 11 41](https://user-images.githubusercontent.com/4780/111772375-ae95d080-88a4-11eb-8128-8f6abfcf3662.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-19 at 11 11 39](https://user-images.githubusercontent.com/4780/111772383-b05f9400-88a4-11eb-9dfe-837bc08886df.png) |

**Known Issue**

The spacing of the buttons on iPhone Pro Max in landscape is a little off – ideally I'd like the trailing edge of the buttons to match the trailing edge of the title view, but I haven't got that working at this stage. It's currently balancing out the left and right spacing (because the system has large spacing on the left edge to avoid the notch).

**To test**

- Build and run
- Test on a variety of devices, including portrait and landscape

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
