### PR TITLE
Reader: Don't fetch recommended posts for p2 articles.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -254,7 +254,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             return
         }
 
-        coordinator?.fetchRelatedPosts(for: post)
+        if post.organizationID.intValue != SiteOrganizationType.p2.rawValue {
+            coordinator?.fetchRelatedPosts(for: post)
+        }
     }
 
     /// Shown an error

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -250,13 +250,14 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             self.loadingView.alpha = 1.0
         }
 
-        guard let post = post else {
+        guard
+            let post = post,
+            post.organizationID.intValue == SiteOrganizationType.none.rawValue // Skip related posts for p2s.
+        else {
             return
         }
 
-        if post.organizationID.intValue != SiteOrganizationType.p2.rawValue {
-            coordinator?.fetchRelatedPosts(for: post)
-        }
+        coordinator?.fetchRelatedPosts(for: post)
     }
 
     /// Shown an error


### PR DESCRIPTION
Fixes #16114 

This PR checks to see if the current reader post belongs to a P2.  If so it skips loading recommended posts. 

To test:
- First, ensure you are following a new p2. It should be one that appears in the Followed P2s reader menu.
- Confirm that related posts are not loaded for p2 articles (including the a8c p2s)
- Confirm that related posts are still loaded for other reader posts. :) 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
