### PR TITLE
Enable large headers / white nav bar feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] Fixed an issue where password text on Post Settings was showing as black in dark mode. [#15768]
 * [*] Added a thumbnail device mode selector in the page layout, and use a default setting based on the current device. [#16019]
 * [**] Comments can now be filtered by status (All, Pending, Approved, Trashed, or Spam). [#15955, #16110]
+* [***] We updated the app's design, with fresh new headers throughout and a new site switcher in My Site. [#15750] 
 
 16.9
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -40,7 +40,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .gutenbergXposts:
             return true
         case .newNavBarAppearance:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .unifiedPrologueCarousel:
             return false
         case .stories:


### PR DESCRIPTION
Refs #15750. This PR enables the large headers / white navigation bars feature flag for all users, for 17.0.

**To test**

There shouldn't be much to rest here, as the feature itself has been tested during implementation through other PRS.

- Build and run. Ensure you see white navigation bars, serif fonts in the navigation bars, and large header text for My Site, Reader, and Notifications.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
