### PR TITLE
Fix UI tests for large title changes

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -40,7 +40,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .gutenbergXposts:
             return true
         case .newNavBarAppearance:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .unifiedPrologueCarousel:
             return false
         case .stories:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -221,6 +221,7 @@ fileprivate extension NewBlogDetailHeaderView {
             button.titleLabel?.lineBreakMode = .byTruncatingTail
 
             button.setTitleColor(.primary, for: .normal)
+            button.accessibilityHint = NSLocalizedString("Tap to view your site", comment: "Accessibility hint for button used to view the user's site")
 
             if let pointSize = button.titleLabel?.font.pointSize {
                 button.setImage(UIImage.gridicon(.external, size: CGSize(width: pointSize, height: pointSize)), for: .normal)
@@ -243,6 +244,8 @@ fileprivate extension NewBlogDetailHeaderView {
             button.titleLabel?.lineBreakMode = .byTruncatingTail
             button.titleLabel?.numberOfLines = 1
 
+            button.accessibilityHint = NSLocalizedString("Tap to change the site's title", comment: "Accessibility hint for button used to change site title")
+
             // I don't understand why this is needed, but without it the button has additional
             // vertical padding, so it's more difficult to get the spacing we want.
             button.setImage(UIImage(), for: .normal)
@@ -261,6 +264,9 @@ fileprivate extension NewBlogDetailHeaderView {
             button.contentMode = .center
             button.translatesAutoresizingMaskIntoConstraints = false
             button.tintColor = .gray
+            button.accessibilityLabel = NSLocalizedString("Switch Site", comment: "Button used to switch site")
+            button.accessibilityHint = NSLocalizedString("Tap to switch to another site, or add a new site", comment: "Accessibility hint for button used to switch site")
+            button.accessibilityIdentifier = "SwitchSiteButton"
 
             button.addTarget(self, action: #selector(siteSwitcherTapped), for: .touchUpInside)
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -138,6 +138,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func showNoSites() {
+        guard AccountHelper.isLoggedIn else {
+            WordPressAppDelegate.shared?.windowManager.showFullscreenSignIn()
+            return
+        }
+
         hideBlogDetails()
 
         addMeButtonToNavigationBar(email: defaultAccount()?.email, meScenePresenter: meScenePresenter)

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -60,6 +60,7 @@ class PostPostViewController: UIViewController {
 
         let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneTapped))
         doneButton.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.barButtonItemTitle], for: .normal)
+        doneButton.accessibilityIdentifier = "doneButton"
         navBar.topItem?.rightBarButtonItem = doneButton
     }
 

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -60,8 +60,7 @@ class LoginFlow {
                 if meScreen.isLoggedInToWpcom() {
                     _ = meScreen.logoutToPrologue()
                 } else {
-                    TabNavComponent().gotoMySiteScreen()
-                        .removeSelfHostedSite()
+                    meScreen.dismiss().removeSelfHostedSite()
                 }
                 return
             }

--- a/WordPress/WordPressUITests/Screens/MeTabScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MeTabScreen.swift
@@ -56,4 +56,16 @@ class MeTabScreen: BaseScreen {
 
         return PrologueScreen()
     }
+
+    func goToLoginFlow() -> PrologueScreen {
+        app.cells["Log In"].tap()
+        
+        return PrologueScreen()
+    }
+
+    func dismiss() -> MySiteScreen {
+        app.buttons["Done"].tap()
+
+        return MySiteScreen()
+    }
 }

--- a/WordPress/WordPressUITests/Screens/MeTabScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MeTabScreen.swift
@@ -59,7 +59,7 @@ class MeTabScreen: BaseScreen {
 
     func goToLoginFlow() -> PrologueScreen {
         app.cells["Log In"].tap()
-        
+
         return PrologueScreen()
     }
 

--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 
 private struct ElementStringIDs {
+    static let navBarTitle = "My Site"
     static let blogTable = "Blog Details Table"
     static let removeSiteButton = "BlogDetailsRemoveSiteCell"
     static let postsButton = "Blog Post Row"
@@ -10,6 +11,8 @@ private struct ElementStringIDs {
     static let settingsButton = "Settings Row"
     static let createButton = "floatingCreateButton"
     static let ReaderButton = "Reader"
+    static let switchSiteButton = "SwitchSiteButton"
+    static let addNewSiteButton = "Add new site Button"
 }
 
 class MySiteScreen: BaseScreen {
@@ -23,6 +26,7 @@ class MySiteScreen: BaseScreen {
     let siteSettingsButton: XCUIElement
     let createButton: XCUIElement
     let readerButton: XCUIElement
+    let switchSiteButton: XCUIElement
 
     static var isVisible: Bool {
         let app = XCUIApplication()
@@ -43,12 +47,13 @@ class MySiteScreen: BaseScreen {
         siteSettingsButton = app.cells[ElementStringIDs.settingsButton]
         createButton = app.buttons[ElementStringIDs.createButton]
         readerButton = app.buttons[ElementStringIDs.ReaderButton]
+        switchSiteButton = app.buttons[ElementStringIDs.switchSiteButton]
 
-        super.init(element: blogTable)
+        super.init(element: XCUIApplication().navigationBars[ElementStringIDs.navBarTitle])
     }
 
     func showSiteSwitcher() -> MySitesScreen {
-        navBackButton.tap()
+        switchSiteButton.tap()
         return MySitesScreen()
     }
 
@@ -87,6 +92,6 @@ class MySiteScreen: BaseScreen {
     }
 
     static func isLoaded() -> Bool {
-        return XCUIApplication().tables[ElementStringIDs.blogTable].exists
+        return XCUIApplication().navigationBars[ElementStringIDs.navBarTitle].exists
     }
 }

--- a/WordPress/WordPressUITests/Screens/MySitesScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySitesScreen.swift
@@ -2,10 +2,7 @@ import Foundation
 import XCTest
 
 class MySitesScreen: BaseScreen {
-    let tabBar: TabNavComponent
-
     init() {
-        tabBar = TabNavComponent()
         let blogsTable = XCUIApplication().tables["Blogs"]
 
         super.init(element: blogsTable)

--- a/WordPress/WordPressUITests/Screens/TabNavComponent.swift
+++ b/WordPress/WordPressUITests/Screens/TabNavComponent.swift
@@ -16,8 +16,7 @@ class TabNavComponent: BaseScreen {
     }
 
     func gotoMeScreen() -> MeTabScreen {
-        gotoMySitesScreen()
-        app.cells[WPUITestCredentials.testWPcomSitePrimaryAddress].tap()
+        gotoMySiteScreen()
         let meButton = app.navigationBars.buttons["meBarButton"]
         meButton.tap()
         return MeTabScreen()
@@ -25,18 +24,8 @@ class TabNavComponent: BaseScreen {
 
     @discardableResult
     func gotoMySiteScreen() -> MySiteScreen {
-        // Avoid transitioning to the sites list if MySites is already on screen
-        if !MySiteScreen.isVisible {
-            gotoMySitesScreen().switchToSite(withTitle: WPUITestCredentials.testWPcomSiteAddress)
-        }
+        mySitesTabButton.tap()
         return MySiteScreen()
-    }
-
-    @discardableResult
-    func gotoMySitesScreen() -> MySitesScreen {
-        mySitesTabButton.tap()
-        mySitesTabButton.tap()
-        return MySitesScreen()
     }
 
     func gotoAztecEditorScreen() -> AztecEditorScreen {


### PR DESCRIPTION
This PR fixes UI tests that were broken when enabling the large titles / white headers feature flag – primarily due to the change in view hierarchy in the My Site section of the app. Blog details / My Site is now the the top level screen in the My Site section, rather than the blog list. There is a new site switcher button to change site.

**To test**

- Run the mocks server: `rake mocks`
- Build and run tests on the WordPressUITests target
- If you like, also do a cursory look at running the app yourself. The one change I made there is when removing the last self hosted site in the app, we now return to the login screen.
- To test that, you could check that if you remove the last WordPress.com site in the app while logged in, you stay logged in but see the **Add new site** button on the My Site screen. And also check that if you add a self hosted site without being logged into wpcom, then remove that site, you're returned to login.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
