### PR TITLE
Allow MySiteViewController to handle the result of the site creation process

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -144,6 +144,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)configureTableViewData;
 - (void)scrollToElement:(QuickStartTourElement)element;
 
+- (void)switchToBlog:(Blog *)blog;
 - (void)showInitialDetailsForBlog;
 - (void)showPostListFromSource:(BlogDetailsNavigationSource)source;
 - (void)showPageListFromSource:(BlogDetailsNavigationSource)source;

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -45,6 +45,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     override func viewDidLoad() {
         setupNavigationItem()
+        subscribeToPostSignupNotifications()
         subscribeToModelChanges()
     }
 
@@ -60,6 +61,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         super.viewDidAppear(animated)
 
         workaroundLargeTitleCollapseBug()
+    }
+
+    private func subscribeToPostSignupNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(launchSiteCreation), name: .createSite, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(showAddSelfHostedSite), name: .addSelfHosted, object: nil)
     }
 
     // MARK: - Navigation Item
@@ -178,6 +184,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         present(addSiteAlert, animated: true)
     }
 
+    @objc
     private func launchSiteCreation() {
         let wizardLauncher = SiteCreationWizardLauncher()
         guard let wizard = wizardLauncher.ui else {
@@ -185,6 +192,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
         present(wizard, animated: true)
         WPAnalytics.track(.enhancedSiteCreationAccessed)
+    }
+
+    @objc
+    private func showAddSelfHostedSite() {
+        WordPressAuthenticator.showLoginForSelfHostedSite(self)
     }
 
     // MARK: - Blog Details UI Logic
@@ -226,7 +238,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             return blogDetailsViewController
         }
 
-        blogDetailsViewController.blog = blog
+        blogDetailsViewController.switch(to: blog)
         return blogDetailsViewController
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -120,6 +120,9 @@ class MySitesCoordinator: NSObject {
 
         if Feature.enabled(.newNavBarAppearance) {
             mySiteViewController.blog = blog
+            if mySiteViewController.presentedViewController != nil {
+                mySiteViewController.dismiss(animated: true, completion: nil)
+            }
         } else {
             blogListViewController.setSelectedBlog(blog, animated: false)
         }


### PR DESCRIPTION
This PR fixes two issues introduced by the new My Site view hierarchy:

- When creating an account and choosing an option on the post signup interstitial screen, nothing happens. Now, MySiteViewController picks up those notifications and displays the relevant screen.
- When adding a new site from the new site switcher, the site switcher wouldn't be dismissed automatically. Now, it gets dismissed and the site detail screen updates to show info for the new site.

**To test**

- Build and run
- Create a new account, and tap the 'create a site' button on the post-signup screen. Ensure that you're shown the site creation flow.
- Complete that flow or log into a different account so that you see the site details screen. Tap the new site switcher, then tap + and create a new site. After tapping Done and dismissing the site creation wizard, ensure you see the details for the new site.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
