### PR TITLE
Fix announcements not showing with large titles

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -425,6 +425,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self scrollToElement:QuickStartTourElementViewSite];
         self.shouldScrollToViewSite = NO;
     }
+    if (![Feature enabled:FeatureFlagNewNavBarAppearance]) {
+        [WPTabBarController.sharedInstance presentWhatIsNewOn:self];
+    }
 }
 
 - (CreateButtonCoordinator *)createButtonCoordinator

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -425,7 +425,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self scrollToElement:QuickStartTourElementViewSite];
         self.shouldScrollToViewSite = NO;
     }
-    [WPTabBarController.sharedInstance presentWhatIsNewOn:self];
 }
 
 - (CreateButtonCoordinator *)createButtonCoordinator

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -61,7 +61,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         super.viewDidAppear(animated)
 
         workaroundLargeTitleCollapseBug()
-        guard self.children.contains(where: {$0 is BlogDetailsViewController}) else {
+
+        guard FeatureFlag.newNavBarAppearance.enabled else {
             return
         }
         WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -61,6 +61,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         super.viewDidAppear(animated)
 
         workaroundLargeTitleCollapseBug()
+        guard self.children.contains(where: {$0 is BlogDetailsViewController}) else {
+            return
+        }
+        WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
     }
 
     private func subscribeToPostSignupNotifications() {


### PR DESCRIPTION
Fixes #NA

To test:

- Build/run with the current version
- Manually update the version to one that has announcements (check the mobile announce tool for this; you can use the test announcement related to version 50.0)
- make sure that the feature announcement modal shows up.
- make sure that you also see the announcements in App Settings/What's New in WordPress
- clean the user defaults for feature announcements, log out and log in with a self hosted site, repeat the manual app update process, and make sure that when you update, if the announcement did not target all the accounts (like the aforementioned example), no announcement modal is presented.
- Optionally, feel free to add announcements in the tool with any combination of supported platforms and verify that the app matches the chosen platform(s).

TIPS:

- to clean the user defaults you can either:
    - delete the app
    - pause the debugger while the app is running from Xcode, and type: `e -l swift -- import WordPress; UserDefaults.standard.announcements = nil; UserDefaults.standard.announcementsVersionDisplayed = nil` + `return`

- If you're up for it, the manual update process can be skipped by temporarily forcing the property `didUpdateVersion` in `AppRatingUtility.swift` to always return `true`

NOTE: the milestone is set to `17.1` as we don't have iOS feature announcements in `17.0`

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
