### PR TITLE
Fix crash when deleting today widget blog

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -474,7 +474,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         Blog *todayExtensionBlog = [Blog lookupWithID:todayExtensionSiteID in:self.managedObjectContext];
         NSTimeZone *timeZone = [todayExtensionBlog timeZone];
 
-        if (todayExtensionSiteID == NULL) {
+        if (todayExtensionSiteID == NULL || todayExtensionBlog == nil) {
             todayExtensionSiteID = siteId;
             todayExtensionBlogName = blogName;
             todayExtensionBlogUrl = blogUrl;


### PR DESCRIPTION
This PR fixes a crash when deleting the blog used for the today widget. To see the crash in action:

- In `StatsViewController.m`, comment out code in `addStatsViewControllerToView` so that the installWidgetsButton is visible.
- In the app select a test site, navigate to Stats, and tap the Widgets button to configure that site to be used for the widget.
- For the same site, head to Site Settings, and delete the site.
- There should be a crash in `configureTodayWidgetWithSiteID:blogName:blogUrl:siteTimeZone:andOAuth2Token:` due to a nil timeZone. This is because in account service, we weren't checking whether the todayExtensionBlog actually existed.
- The app will actually crash on each subsequent launch.

**To test**

- Build and run with this branch and follow the steps above. The app should no longer crash.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
