### PR TITLE
[Tooling] Mute fastlane's CHANGELOG and update check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,9 @@ commands:
             chruby ruby-2.6.6
             gem install bundler
 
+            # Prevent fastlane from checking for updates, also removing the verbose fastlane changelog at the end of each invocation.
+            echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
+
 jobs:
   Build Tests:
     parameters:


### PR DESCRIPTION
This adds a magic env var that will prevent fastlane from checking for an update at the end of every invocation, and thus remove the quite verbose fastlane changelog output that gets printed at the end of every fastlane step.

Similar to https://github.com/woocommerce/woocommerce-ios/pull/3855.

## To test

Check on CI that the steps invoking `fastlane` don't print the fastlane changelog at the end anymore.

**Before:**

```
[18:12:55]: fastlane.tools finished successfully 🎉

#######################################################################
# fastlane 2.178.0 is available. You are on 2.170.0.
# You should use the latest version.
# Please update using `bundle update fastlane`.
#######################################################################

2.178.0 Improvements

…[a quite long fastlane changelog here]…
…
…
…loooooong…
…
…and probably never read by anyone…
…
…

To see all new releases, open https://github.com/fastlane/fastlane/releases

Please update using `bundle update fastlane`
CircleCI received exit code 0
```

**After:** (see CI on this PR)
```
[12:30:55]: fastlane.tools finished successfully 🎉
CircleCI received exit code 0
```