### PR TITLE
Fix a warning about accessing the main thread

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -77,6 +77,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     @objc class var shared: WordPressAppDelegate? {
+        assert(Thread.isMainThread, "WordPressAppDelegate.shared can only be accessed from the main thread")
         return UIApplication.shared.delegate as? WordPressAppDelegate
     }
 

--- a/WordPress/Classes/Utility/Logging/EventLoggingDelegate.swift
+++ b/WordPress/Classes/Utility/Logging/EventLoggingDelegate.swift
@@ -13,7 +13,11 @@ struct EventLoggingDelegate: AutomatticTracks.EventLoggingDelegate {
         NotificationCenter.default.post(name: WPLoggingStack.QueuedLogsDidChangeNotification, object: log)
         DDLogDebug("📜 Added log to queue: \(log.uuid)")
 
-        if let eventLogging = WordPressAppDelegate.eventLogging {
+        DispatchQueue.main.async {
+            guard let eventLogging = WordPressAppDelegate.eventLogging else {
+                return
+            }
+
             DDLogDebug("📜\t There are \(eventLogging.queuedLogFiles.count) logs in the queue.")
         }
     }
@@ -26,7 +30,12 @@ struct EventLoggingDelegate: AutomatticTracks.EventLoggingDelegate {
     func didFinishUploadingLog(_ log: LogFile) {
         NotificationCenter.default.post(name: WPLoggingStack.QueuedLogsDidChangeNotification, object: log)
         DDLogDebug("📜 Finished uploading encrypted log: \(log.uuid)")
-        if let eventLogging = WordPressAppDelegate.eventLogging {
+
+        DispatchQueue.main.async {
+            guard let eventLogging = WordPressAppDelegate.eventLogging else {
+                return
+            }
+
             DDLogDebug("📜\t There are \(eventLogging.queuedLogFiles.count) logs remaining in the queue.")
         }
     }


### PR DESCRIPTION
Fixes an Xcode warning

To test:
- The code should make it clear this won't happen again, but you could run it the way you triggered it last time too 😄 

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
