### PR TITLE
AB testing: only assign experiments to signed in users and fix a crash

### DIFF
--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -14,7 +14,7 @@ extension ABTest {
     /// Start the AB Testing platform if any experiment exists
     ///
     static func start() {
-        guard ABTest.allCases.count > 1 else {
+        guard ABTest.allCases.count > 1, AccountHelper.isLoggedIn else {
             return
         }
 
@@ -22,7 +22,7 @@ extension ABTest {
     }
 
     static func refreshIfNeeded() {
-        guard ABTest.allCases.count > 1 else {
+        guard ABTest.allCases.count > 1, AccountHelper.isLoggedIn else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -73,6 +73,9 @@ class LoginEpilogueViewController: UIViewController {
         setTableViewMargins(forWidth: view.frame.width)
         refreshInterface(with: credentials)
         WordPressAuthenticator.track(.loginEpilogueViewed)
+
+        // If the user just signed in, refresh the A/B assignments
+        ABTest.start()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
@@ -14,9 +14,10 @@ class CreateButtonActionSheet: ActionSheetViewController {
 
         /// A/B test: display story first
         var actions = actions
-        if !actions.filter({ $0 is StoryAction }).isEmpty
-            && ABTest.storyFirst.variation == .treatment(nil) {
-            actions.swapAt(0, 2)
+        if let storyAction = actions.first(where: { $0 is StoryAction }),
+           ABTest.storyFirst.variation == .treatment(nil) {
+            let actionsWithoutStory = actions.filter { !($0 is StoryAction) }
+            actions = [storyAction] + actionsWithoutStory
         }
 
         let buttons = actions.map { $0.makeButton() }


### PR DESCRIPTION
This PR changes experiment assignments to:

* Be done only for signed-in users
* Performed after a successful sign-in

It also fixes #16163

## To test

Put breakpoints on `ABTest.swift` lines `21` and `29`.

#### Logged out

1. Open the app
2. No breakpoint should be hit
3. Put it in the background and then restore it to the foreground
4. No breakpoint should be hit

Signing in:

1. Sign in
2. Check that `start` is called

#### Signed in

1. Put the app in the background and then restore it to the foreground
2. `refreshIfNeeded` should be called

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
