### PR TITLE
Comment detail: fix crash when replying to a comment

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -49,7 +49,10 @@ open class CommentsTableViewCell: WPTableViewCell {
         pending = (comment.status == CommentStatusPending)
         postTitle = comment.titleForDisplay() ?? Labels.noTitle
         content = comment.contentPreviewForDisplay() ?? String()
-        timestamp = comment.dateCreated.mediumString()
+
+        if let dateCreated = comment.dateCreated {
+            timestamp = dateCreated.mediumString()
+        }
 
         if let avatarURLForDisplay = comment.avatarURLForDisplay() {
             downloadGravatarWithURL(avatarURLForDisplay)


### PR DESCRIPTION
Fixes #n/a

This fixes a crash when replying to a comment from comment details.

To test:

- Go to Comments.
- Select a Comment.
- Enter a reply and send.
- Verify the app doesn't crash.
- Return to the Comments list.
- Verify your reply appears in the Comments list.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
