### PR TITLE
Add default values for non-optional template attributes

### DIFF
--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 117.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 117.xcdatamodel/contents
@@ -456,10 +456,10 @@
     </entity>
     <entity name="PageTemplateLayout" representedClassName="PageTemplateLayout" syncable="YES">
         <attribute name="content" attributeType="String" syncable="YES"/>
-        <attribute name="demoUrl" attributeType="String" syncable="YES"/>
+        <attribute name="demoUrl" attributeType="String" defaultValueString="" syncable="YES"/>
         <attribute name="preview" attributeType="String" syncable="YES"/>
-        <attribute name="previewMobile" attributeType="String" syncable="YES"/>
-        <attribute name="previewTablet" attributeType="String" syncable="YES"/>
+        <attribute name="previewMobile" attributeType="String" defaultValueString="" syncable="YES"/>
+        <attribute name="previewTablet" attributeType="String" defaultValueString="" syncable="YES"/>
         <attribute name="slug" attributeType="String" syncable="YES"/>
         <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PageTemplateCategory" inverseName="layouts" inverseEntity="PageTemplateCategory" syncable="YES"/>


### PR DESCRIPTION
This PR updates the datamodel to include default values for non-optional template attributes.

This is needed for a valid data migration from 116 -> 117, for the three attributes introduced here: https://github.com/wordpress-mobile/WordPress-iOS/pull/16019/files#diff-eefb888cd323a0362d13431acf6d3d28e2f72f48b7deb9965f832c0b68ea495dR459-R462 (`demoUrl`, `previewMobile`, and `previewTablet`).

We wipe the cache when new templates are fetched from the API, but previously cached values will not be updated at the time the migration takes place, so the migration fails with an error ([described here](https://github.com/wordpress-mobile/WordPress-iOS/pull/16156#pullrequestreview-621625677)).

To test:
Apologies in advance for these rather annoying steps to test :sweat_smile: (not sure if a coredata migration test is overkill for a lightweight one?).

* In order to test the migration, first the locally persisted data models must be at version 116, (e.g. I followed the steps here)
  * `git checkout trunk`
  * Run `rake dependencies`
  * Run `rake xcode`
  * Run the app
* Then we check the migration via this branch:
  * `git checkout fix/add-defaults-for-non-optional-template-attributes`
  * Run `rake dependencies`
  * Run `rake xcode`
  * Run the app
* Observe the logs
  * The app should not crash
  * There should not be any error reported about data migration failure

**Note**: This is currently targeting `develop`, but since this issue is already in 17.0, perhaps this needs a betafix PR as well. Wdyt?

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
