### PR TITLE
Set Reader Comments large title display mode to Never

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -272,6 +272,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     self.navigationItem.backBarButtonItem = backButton;
 
     self.title = NSLocalizedString(@"Comments", @"Title of the reader's comments screen");
+    self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
 }
 
 - (void)configurePostHeader


### PR DESCRIPTION
Refs #15750. This fixes an issue in the Reader where the Comments view was sometimes displayed with a large title.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-26 at 12 18 07](https://user-images.githubusercontent.com/4780/112630350-625f0900-8e2d-11eb-987c-a9e04a635882.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-26 at 12 17 08](https://user-images.githubusercontent.com/4780/112630361-65f29000-8e2d-11eb-84f9-dd34e730df57.png) |

**To test**

- Build and run
- Navigate to Reader Discover
- Tap the comment icon on a post card, and ensure that the comments view controller that is pushed does not have a large title.

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
