### PR TITLE
Update historic Migration models that were missed

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -111,6 +111,22 @@ data model as well as any custom migrations.
 - Add a new `SiteSuggestion` entity to support Gutenberg's xpost implementation
 - Add a one-to-many relationship between `Blog` and `SiteSuggestion`
 
+## WordPress 102
+
+@chipsnyder 2020-10-20
+
+- Added one-to-many relationship between `Blog` and `PageTemplateCategory`
+  - `Blog`
+    - `pageTemplateCategories` (optional, to-many, cascade on delete)
+  - `PageTemplateCategory`
+    - `blog` (required, to-one, nullify on delete)
+
+- Updated the many-to-many relationship between `PageTemplateLayout` and `PageTemplateCategory`
+  - `PageTemplateLayout`
+    - `categories` (optional, to-many, nullify on delete)
+  - `PageTemplateCategory`
+  - `layouts` (optional, to-many, ***cascade*** on delete)
+
 ## WordPress 101
 
 @emilylaguna 2020-10-09
@@ -122,6 +138,27 @@ data model as well as any custom migrations.
 
 - Add a new `UserSuggestion` entity
 - Add a one-to-many relationship between `Blog` and `UserSuggestion`
+
+## WordPress 99
+
+@chipsnyder 2020-10-05
+
+- Created a new entity `PageTemplateCategory` with:
+  - `desc` (optional, `String`) short for "description"
+  - `emoji` (optional, `String`)
+  - `slug` (required, no default, `String`)
+  - `title` ( required, no default, `String`)
+- Created a new entity `PageTemplateLayout` with:
+  - `content` (required, no default, `String`)
+  - `preview` (required, no default, `String`)
+  - `slug` (required, no default, `String`)
+  - `title` ( required, no default, `String`)
+
+- Created many-to-many relationship between `PageTemplateLayout` and `PageTemplateCategory`
+  - `PageTemplateLayout`
+    - `categories` (optional, to-many, nullify on delete)
+  - `PageTemplateCategory`
+    - `layouts` (optional, to-many, nullify on delete)
 
 ## WordPress 98
 
@@ -143,6 +180,12 @@ data model as well as any custom migrations.
 @Gio2018 2020-06-12
 
 - Add fields `supportPriority`, `supportName` and `nonLocalizedShortname` to the `Plan` entity for Zendesk integration.
+
+## WordPress 95
+
+@aerych 2020-03-21
+
+- `ReaderPost` added the property `isBlogAtomic` (optional, `Boolean`).
 
 ## WordPress 94
 


### PR DESCRIPTION
Updates some historical Changes in the `MIGRATIONS.md` file. Not super critical but cleaning up some holes I wasn't aware of at the time. 

@aerych I noticed there was only one other gap from when we started this process so I updated that as well. 

### Original changes:
- **95** https://github.com/wordpress-mobile/WordPress-iOS/pull/14163 
- **99** https://github.com/wordpress-mobile/WordPress-iOS/pull/14987 
- **102** https://github.com/wordpress-mobile/WordPress-iOS/pull/15129

### To test:
Nothing to Test

### PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
