### PR TITLE
Jetpack App: Muriel Colors

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/MurielColor.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/MurielColor.swift
@@ -58,17 +58,17 @@ struct MurielColor {
     }
 
     // MARK: - Muriel's semantic colors
-    static let accent = MurielColor(name: .pink)
-    static let brand = MurielColor(name: .wordPressBlue)
-    static let divider = MurielColor(name: .gray, shade: .shade10)
-    static let error = MurielColor(name: .red)
-    static let gray = MurielColor(name: .gray)
-    static let primary = MurielColor(name: .blue)
-    static let success = MurielColor(name: .green)
-    static let text = MurielColor(name: .gray, shade: .shade80)
-    static let textSubtle = MurielColor(name: .gray, shade: .shade50)
-    static let warning = MurielColor(name: .yellow)
-    static let jetpackGreen = MurielColor(name: .jetpackGreen)
+    static let accent = AppStyleGuide.accent
+    static let brand = AppStyleGuide.brand
+    static let divider = AppStyleGuide.divider
+    static let error = AppStyleGuide.error
+    static let gray = AppStyleGuide.gray
+    static let primary = AppStyleGuide.primary
+    static let success = AppStyleGuide.success
+    static let text = AppStyleGuide.text
+    static let textSubtle = AppStyleGuide.textSubtle
+    static let warning = AppStyleGuide.warning
+    static let jetpackGreen = AppStyleGuide.jetpackGreen
 
     /// The full name of the color, with required shade value
     func assetName() -> String {

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -172,31 +172,6 @@ extension UIColor {
         return UIColor(light: .systemGray6, dark: .systemGray5)
     }
 
-    /// Muriel/iOS navigation color
-    static var appBarBackground: UIColor {
-        if FeatureFlag.newNavBarAppearance.enabled {
-            return .secondarySystemGroupedBackground
-        }
-
-        return UIColor(light: .brand, dark: .gray(.shade100))
-    }
-
-    static var appBarTint: UIColor {
-        if FeatureFlag.newNavBarAppearance.enabled {
-            return .primary
-        }
-
-        return .white
-    }
-
-    static var appBarText: UIColor {
-        if FeatureFlag.newNavBarAppearance.enabled {
-            return .text
-        }
-
-        return .white
-    }
-
     // MARK: - Table Views
 
     static var divider: UIColor {
@@ -240,14 +215,6 @@ extension UIColor {
 
     static var buttonIcon: UIColor {
         return .systemGray2
-    }
-
-    static var filterBarBackground: UIColor {
-        return UIColor(light: white, dark: .gray(.shade100))
-    }
-
-    static var filterBarSelected: UIColor {
-        return UIColor(light: .primary, dark: .label)
     }
 
     /// For icons that are present in a toolbar or similar view

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -222,9 +222,6 @@ extension UIColor {
         return .secondaryLabel
     }
 
-    /// Note: these values are intended to match the iOS defaults
-    static var tabUnselected: UIColor =  UIColor(light: UIColor(hexString: "999999"), dark: UIColor(hexString: "757575"))
-
     static var barButtonItemTitle: UIColor {
         return UIColor(light: UIColor.primary(.shade50), dark: UIColor.primary(.shade30))
     }

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+WordPressColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+WordPressColors.swift
@@ -39,4 +39,11 @@ extension UIColor {
     static var filterBarSelectedText: UIColor {
         return UIColor(light: .primary, dark: .label)
     }
+
+    static var tabSelected: UIColor {
+        return .primary
+    }
+
+    /// Note: these values are intended to match the iOS defaults
+    static var tabUnselected: UIColor =  UIColor(light: UIColor(hexString: "999999"), dark: UIColor(hexString: "757575"))
 }

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+WordPressColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+WordPressColors.swift
@@ -35,4 +35,8 @@ extension UIColor {
     static var filterBarSelected: UIColor {
         return UIColor(light: .primary, dark: .label)
     }
+
+    static var filterBarSelectedText: UIColor {
+        return UIColor(light: .primary, dark: .label)
+    }
 }

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+WordPressColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+WordPressColors.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+// MARK: - UI elements
+extension UIColor {
+
+    /// Muriel/iOS navigation color
+    static var appBarBackground: UIColor {
+        if FeatureFlag.newNavBarAppearance.enabled {
+            return .secondarySystemGroupedBackground
+        }
+
+        return UIColor(light: .brand, dark: .gray(.shade100))
+    }
+
+    static var appBarTint: UIColor {
+        if FeatureFlag.newNavBarAppearance.enabled {
+            return .primary
+        }
+
+        return .white
+    }
+
+    static var appBarText: UIColor {
+        if FeatureFlag.newNavBarAppearance.enabled {
+            return .text
+        }
+
+        return .white
+    }
+
+    static var filterBarBackground: UIColor {
+        return UIColor(light: .white, dark: .gray(.shade100))
+    }
+
+    static var filterBarSelected: UIColor {
+        return UIColor(light: .primary, dark: .label)
+    }
+}

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -100,7 +100,7 @@ extension WPStyleGuide {
 
     /// Style the tab bar using Muriel colors
     class func configureTabBarAppearance() {
-        UITabBar.appearance().tintColor = .primary
+        UITabBar.appearance().tintColor = .tabSelected
         UITabBar.appearance().unselectedItemTintColor = .tabUnselected
     }
 

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+FilterTabBar.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+FilterTabBar.swift
@@ -4,6 +4,7 @@ extension WPStyleGuide {
     @objc class func configureFilterTabBar(_ filterTabBar: FilterTabBar) {
         filterTabBar.backgroundColor = .filterBarBackground
         filterTabBar.tintColor = .filterBarSelected
+        filterTabBar.selectedTitleColor = .filterBarSelectedText
         filterTabBar.deselectedTabColor = .textSubtle
         filterTabBar.dividerColor = .neutral(.shade10)
     }

--- a/WordPress/Classes/Utility/App Configuration/AppStyleGuide.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppStyleGuide.swift
@@ -6,3 +6,18 @@ struct AppStyleGuide {
     static let navigationBarLargeFont: UIFont = WPStyleGuide.fixedSerifFontForTextStyle(.largeTitle, fontWeight: .semibold)
     static let blogDetailHeaderTitleFont: UIFont = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
 }
+
+// MARK: - Colors
+extension AppStyleGuide {
+    static let accent = MurielColor(name: .pink)
+    static let brand = MurielColor(name: .wordPressBlue)
+    static let divider = MurielColor(name: .gray, shade: .shade10)
+    static let error = MurielColor(name: .red)
+    static let gray = MurielColor(name: .gray)
+    static let primary = MurielColor(name: .blue)
+    static let success = MurielColor(name: .green)
+    static let text = MurielColor(name: .gray, shade: .shade80)
+    static let textSubtle = MurielColor(name: .gray, shade: .shade50)
+    static let warning = MurielColor(name: .yellow)
+    static let jetpackGreen = MurielColor(name: .jetpackGreen)
+}

--- a/WordPress/Jetpack/AppStyleGuide.swift
+++ b/WordPress/Jetpack/AppStyleGuide.swift
@@ -6,3 +6,18 @@ struct AppStyleGuide {
     static let navigationBarLargeFont: UIFont = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .semibold)
     static let blogDetailHeaderTitleFont: UIFont = WPStyleGuide.fontForTextStyle(.title2, fontWeight: .semibold)
 }
+
+// MARK: - Colors
+extension AppStyleGuide {
+    static let accent = MurielColor(name: .jetpackGreen)
+    static let brand = MurielColor(name: .jetpackGreen)
+    static let divider = MurielColor(name: .gray, shade: .shade10)
+    static let error = MurielColor(name: .red)
+    static let gray = MurielColor(name: .gray)
+    static let primary = MurielColor(name: .jetpackGreen)
+    static let success = MurielColor(name: .green)
+    static let text = MurielColor(name: .gray, shade: .shade80)
+    static let textSubtle = MurielColor(name: .gray, shade: .shade50)
+    static let warning = MurielColor(name: .yellow)
+    static let jetpackGreen = MurielColor(name: .jetpackGreen)
+}

--- a/WordPress/Jetpack/UIColor+JetpackColors.swift
+++ b/WordPress/Jetpack/UIColor+JetpackColors.swift
@@ -35,4 +35,8 @@ extension UIColor {
     static var filterBarSelected: UIColor {
         return UIColor(light: .primary, dark: .label)
     }
+
+    static var filterBarSelectedText: UIColor {
+        return .text
+    }
 }

--- a/WordPress/Jetpack/UIColor+JetpackColors.swift
+++ b/WordPress/Jetpack/UIColor+JetpackColors.swift
@@ -39,4 +39,11 @@ extension UIColor {
     static var filterBarSelectedText: UIColor {
         return .text
     }
+
+    static var tabSelected: UIColor {
+        return .text
+    }
+
+    /// Note: these values are intended to match the iOS defaults
+    static var tabUnselected: UIColor =  UIColor(light: UIColor(hexString: "999999"), dark: UIColor(hexString: "757575"))
 }

--- a/WordPress/Jetpack/UIColor+JetpackColors.swift
+++ b/WordPress/Jetpack/UIColor+JetpackColors.swift
@@ -14,7 +14,7 @@ extension UIColor {
 
     static var appBarTint: UIColor {
         if FeatureFlag.newNavBarAppearance.enabled {
-            return .primary
+            return .text
         }
 
         return .white

--- a/WordPress/Jetpack/UIColor+JetpackColors.swift
+++ b/WordPress/Jetpack/UIColor+JetpackColors.swift
@@ -1,0 +1,38 @@
+import UIKit
+
+// MARK: - UI elements
+extension UIColor {
+
+    /// Muriel/iOS navigation color
+    static var appBarBackground: UIColor {
+        if FeatureFlag.newNavBarAppearance.enabled {
+            return .secondarySystemGroupedBackground
+        }
+
+        return UIColor(light: .brand, dark: .gray(.shade100))
+    }
+
+    static var appBarTint: UIColor {
+        if FeatureFlag.newNavBarAppearance.enabled {
+            return .primary
+        }
+
+        return .white
+    }
+
+    static var appBarText: UIColor {
+        if FeatureFlag.newNavBarAppearance.enabled {
+            return .text
+        }
+
+        return .white
+    }
+
+    static var filterBarBackground: UIColor {
+        return UIColor(light: .white, dark: .gray(.shade100))
+    }
+
+    static var filterBarSelected: UIColor {
+        return UIColor(light: .primary, dark: .label)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4139,6 +4139,10 @@
 		FAD2539026116A1600EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
 		FAD2539126116A1600EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
 		FAD2544226116CEA00EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2544126116CEA00EDAF88 /* AppStyleGuide.swift */; };
+		FAD2566C2611AEC300EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
+		FAD2566D2611AEC500EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
+		FAD2566E2611AEC600EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
+		FAD2566F2611AEC700EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
 		FAD9457E25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9457D25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift */; };
 		FAD9458E25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9458D25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift */; };
 		FAD951A425B6CB3600F011B5 /* JetpackRestoreFailedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD951A325B6CB3600F011B5 /* JetpackRestoreFailedViewController.swift */; };
@@ -17328,6 +17332,7 @@
 				736584E6213752730029C9A4 /* SFHFKeychainUtils.m in Sources */,
 				73B05D2621374B960073ECAA /* Tracks.swift in Sources */,
 				1752D4FC238D703A002B79E7 /* KeyValueDatabase.swift in Sources */,
+				FAD2566F2611AEC700EDAF88 /* AppStyleGuide.swift in Sources */,
 				736584EC2137533A0029C9A4 /* Tracks+ContentExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -17573,6 +17578,7 @@
 				98906507237CC1DF00218CD2 /* WidgetTwoColumnCell.swift in Sources */,
 				433ADC1C223B2A7E00ED9DE1 /* TextBundleWrapper.m in Sources */,
 				93E5284119A7741A003A1A9C /* TodayViewController.swift in Sources */,
+				FAD2566C2611AEC300EDAF88 /* AppStyleGuide.swift in Sources */,
 				938CF3DE1EF1BE8000AF838E /* CocoaLumberjack.swift in Sources */,
 				98712D1D23DA1D0800555316 /* WidgetNoConnectionCell.swift in Sources */,
 				98C0CE9C23C559C800D0F27C /* Double+Stats.swift in Sources */,
@@ -17615,6 +17621,7 @@
 				989643E523A02F640070720A /* MurielColor.swift in Sources */,
 				983AE84D2399AC6B00E5B7F6 /* Constants.m in Sources */,
 				989643ED23A0437B0070720A /* WidgetDifferenceCell.swift in Sources */,
+				FAD2566E2611AEC600EDAF88 /* AppStyleGuide.swift in Sources */,
 				98F93183239AF64800E4E96E /* ThisWeekWidgetStats.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -17641,6 +17648,7 @@
 				98D31BC223972A79009CFF43 /* SFHFKeychainUtils.m in Sources */,
 				98D31BAE239708FB009CFF43 /* Constants.m in Sources */,
 				98C0CE9B23C559C800D0F27C /* Double+Stats.swift in Sources */,
+				FAD2566D2611AEC500EDAF88 /* AppStyleGuide.swift in Sources */,
 				985ED0E823C6964600B8D06A /* WidgetStyles.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4143,6 +4143,14 @@
 		FAD2566D2611AEC500EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
 		FAD2566E2611AEC600EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
 		FAD2566F2611AEC700EDAF88 /* AppStyleGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */; };
+		FAD256932611B01700EDAF88 /* UIColor+WordPressColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */; };
+		FAD256A62611B01A00EDAF88 /* UIColor+WordPressColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */; };
+		FAD256B82611B01B00EDAF88 /* UIColor+WordPressColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */; };
+		FAD256CA2611B01C00EDAF88 /* UIColor+WordPressColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */; };
+		FAD256EE2611B01F00EDAF88 /* UIColor+WordPressColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */; };
+		FAD257132611B04D00EDAF88 /* UIColor+JetpackColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD257112611B04D00EDAF88 /* UIColor+JetpackColors.swift */; };
+		FAD257F42611B54100EDAF88 /* UIColor+WordPressColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */; };
+		FAD257F52611B54200EDAF88 /* UIColor+WordPressColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */; };
 		FAD9457E25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9457D25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift */; };
 		FAD9458E25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD9458D25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift */; };
 		FAD951A425B6CB3600F011B5 /* JetpackRestoreFailedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD951A325B6CB3600F011B5 /* JetpackRestoreFailedViewController.swift */; };
@@ -7139,6 +7147,8 @@
 		FACB36F01C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeWebNavigationDelegate.swift; sourceTree = "<group>"; };
 		FAD2538E26116A1600EDAF88 /* AppStyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStyleGuide.swift; sourceTree = "<group>"; };
 		FAD2544126116CEA00EDAF88 /* AppStyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStyleGuide.swift; sourceTree = "<group>"; };
+		FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+WordPressColors.swift"; sourceTree = "<group>"; };
+		FAD257112611B04D00EDAF88 /* UIColor+JetpackColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+JetpackColors.swift"; sourceTree = "<group>"; };
 		FAD9457D25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupOptionsCoordinator.swift; sourceTree = "<group>"; };
 		FAD9458D25B5678700F011B5 /* JetpackRestoreWarningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreWarningCoordinator.swift; sourceTree = "<group>"; };
 		FAD951A325B6CB3600F011B5 /* JetpackRestoreFailedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreFailedViewController.swift; sourceTree = "<group>"; };
@@ -8938,6 +8948,7 @@
 				17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */,
 				17F52DB62315233300164966 /* WPStyleGuide+FilterTabBar.swift */,
 				3FD272DF24CF8F270021F0C8 /* UIColor+Notice.swift */,
+				FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */,
 			);
 			path = "Colors and Styles";
 			sourceTree = "<group>";
@@ -13550,6 +13561,7 @@
 				FABB28482603068B00C8785C /* Resources */,
 				FABB268A2602FCD400C8785C /* Supporting Files */,
 				FA25FB8C2609B9CB0005E08F /* App Configuration */,
+				FAD257262611B05D00EDAF88 /* Extensions */,
 			);
 			path = Jetpack;
 			sourceTree = "<group>";
@@ -13569,6 +13581,22 @@
 				FABB28462603067C00C8785C /* Launch Screen.storyboard */,
 			);
 			name = Resources;
+			sourceTree = "<group>";
+		};
+		FAD257252611B05300EDAF88 /* Colors and Styles */ = {
+			isa = PBXGroup;
+			children = (
+				FAD257112611B04D00EDAF88 /* UIColor+JetpackColors.swift */,
+			);
+			name = "Colors and Styles";
+			sourceTree = "<group>";
+		};
+		FAD257262611B05D00EDAF88 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				FAD257252611B05300EDAF88 /* Colors and Styles */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 		FAD947A125B56A1E00F011B5 /* Coordinators */ = {
@@ -17100,6 +17128,7 @@
 				D86572172186C3600023A99C /* WizardDelegate.swift in Sources */,
 				73713583208EA4B900CCDFC8 /* Blog+Files.swift in Sources */,
 				439F4F3C219B78B500F8D0C7 /* RevisionDiffsBrowserViewController.swift in Sources */,
+				FAD256932611B01700EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				E174F6E6172A73960004F23A /* WPAccount.m in Sources */,
 				FF619DD51C75246900903B65 /* CLPlacemark+Formatting.swift in Sources */,
 				98467A3F221CD48500DF51AE /* SiteStatsDetailTableViewController.swift in Sources */,
@@ -17328,6 +17357,7 @@
 				736584EB2137533A0029C9A4 /* NotificationContentView.swift in Sources */,
 				73D5AC63212622B200ADDDD2 /* NotificationViewController.swift in Sources */,
 				436110DE22C41B02000773AD /* BuildConfiguration.swift in Sources */,
+				FAD257F52611B54200EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				73F6DD44212C714F00CE447D /* RichNotificationViewModel.swift in Sources */,
 				736584E6213752730029C9A4 /* SFHFKeychainUtils.m in Sources */,
 				73B05D2621374B960073ECAA /* Tracks.swift in Sources */,
@@ -17397,6 +17427,7 @@
 				74021A03202E1307006CC39F /* NSExtensionContext+Extensions.swift in Sources */,
 				74021A22202E1740006CC39F /* Header+WordPress.swift in Sources */,
 				74021A02202E12FF006CC39F /* Extensions.xcdatamodeld in Sources */,
+				FAD256B82611B01B00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				740219FF202E12F4006CC39F /* PostUploadOperation.swift in Sources */,
 				9822D8DE214194EB0092CBD1 /* NoResultsViewController.swift in Sources */,
 				74021A1A202E1502006CC39F /* WPStyleGuide+Gridicon.swift in Sources */,
@@ -17520,6 +17551,7 @@
 				B5FA868C1D10A4C400AB5F7E /* UIImage+Extensions.swift in Sources */,
 				B50248C21C96FFCC00AFBDED /* WordPressShare-Lumberjack.m in Sources */,
 				74FA4BE61FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */,
+				FAD256A62611B01A00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				74D06FEB1FE0788500AF1788 /* TextList+WordPress.swift in Sources */,
 				74FA2EE4200E8A6C001DDC13 /* AppExtensionsService.swift in Sources */,
 				74F89407202A1965008610FA /* ExtensionNotificationManager.swift in Sources */,
@@ -17590,6 +17622,7 @@
 				98E58A302360D23400E5534B /* TodayWidgetStats.swift in Sources */,
 				4326191722FCB9F9003C7642 /* MurielColor.swift in Sources */,
 				436110D922C3ED18000773AD /* UIColor+MurielColors.swift in Sources */,
+				FAD256CA2611B01C00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				988F073A23D0D16700AC67A6 /* WidgetUrlCell.swift in Sources */,
 				1752D4FB238D702F002B79E7 /* KeyValueDatabase.swift in Sources */,
 				170BEC89239153120017AEC1 /* FeatureFlagOverrideStore.swift in Sources */,
@@ -17616,6 +17649,7 @@
 				988F073C23D0D16800AC67A6 /* WidgetUrlCell.swift in Sources */,
 				98E419DE2399B5A700D8C822 /* Tracks+ThisWeekWidget.swift in Sources */,
 				98712D1F23DA1D0A00555316 /* WidgetNoConnectionCell.swift in Sources */,
+				FAD257F42611B54100EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				98A3C3052399A2370048D38D /* ThisWeekViewController.swift in Sources */,
 				17A4B6A324F911D5002DFB8E /* KeyValueDatabase.swift in Sources */,
 				989643E523A02F640070720A /* MurielColor.swift in Sources */,
@@ -17644,6 +17678,7 @@
 				98D31BA72396F7E2009CFF43 /* AllTimeViewController.swift in Sources */,
 				98712D1E23DA1D0900555316 /* WidgetNoConnectionCell.swift in Sources */,
 				98A6B993239881860031AEBD /* MurielColor.swift in Sources */,
+				FAD256EE2611B01F00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				17A4B6A224F911D4002DFB8E /* KeyValueDatabase.swift in Sources */,
 				98D31BC223972A79009CFF43 /* SFHFKeychainUtils.m in Sources */,
 				98D31BAE239708FB009CFF43 /* Constants.m in Sources */,
@@ -19113,6 +19148,7 @@
 				FABB254D2602FC2C00C8785C /* WPStyleGuide+Notifications.swift in Sources */,
 				FABB254E2602FC2C00C8785C /* SettingTableViewCell.m in Sources */,
 				FABB254F2602FC2C00C8785C /* CountriesMapView.swift in Sources */,
+				FAD257132611B04D00EDAF88 /* UIColor+JetpackColors.swift in Sources */,
 				FABB25502602FC2C00C8785C /* MediaLibraryViewController.swift in Sources */,
 				FABB25512602FC2C00C8785C /* TodayWidgetStats.swift in Sources */,
 				FABB25522602FC2C00C8785C /* GutenbergMediaFilesUploadProcessor.swift in Sources */,


### PR DESCRIPTION
## Description

This PR is a first pass at configuring the colors for the Jetpack target. More detailed tweaks will be addressed in future PRs.  

Design ref: pcdRpT-k6-p2

-  Muriel semantic colors
    - `.primary`: blue -> jetpackGreen 50
    - `.brand`: wordPressBlue -> jetpackGreen 50
    - `.accent`: pink -> jetpackGreen 50
- Detailed color tweaks (use black instead of green)
    - Bottom tab bar active color
    - Navigation bar tint color
    - Filter tab bar selected text color 

## Merge instructions

- Merge after https://github.com/wordpress-mobile/WordPress-iOS/pull/16161

## Notes

- The `.primary` muriel color is used for things like:
  - The global default tint color
  - The switch control "on" tint color  
  - See [WordPressAppDelegate](https://github.com/wordpress-mobile/WordPress-iOS/blob/8e1d588f86a5394571e0767c7633c2e03654e37a/WordPress/Classes/System/WordPressAppDelegate.swift#L810-L820) for more details...
- The `.brand` muriel color is used for things like:
  - The LightNavigationController tint color
  - The GutenbergLightNavigationController tint color 
- The `.accent` muriel color is used for things like:
  - WP fancy button background color (primary) 
  - The Stats bars  

## Screenshots

![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 45 46](https://user-images.githubusercontent.com/6711616/112806819-2be5f000-90b2-11eb-861e-8aa6f3109c7b.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 46 05](https://user-images.githubusercontent.com/6711616/112806834-2ee0e080-90b2-11eb-95ac-34924ae6a9d2.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 46 31](https://user-images.githubusercontent.com/6711616/112806838-30120d80-90b2-11eb-902c-457b3f5ae696.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 46 37](https://user-images.githubusercontent.com/6711616/112806841-30120d80-90b2-11eb-84f0-79e8e70a7d62.png)
--- | --- | --- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 47 07](https://user-images.githubusercontent.com/6711616/112806966-50da6300-90b2-11eb-98a4-0ee19e20ea75.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 47 10](https://user-images.githubusercontent.com/6711616/112806971-520b9000-90b2-11eb-9395-20e6373cf617.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 47 27](https://user-images.githubusercontent.com/6711616/112806973-52a42680-90b2-11eb-8382-a4c06d7dc75f.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 47 31](https://user-images.githubusercontent.com/6711616/112806979-53d55380-90b2-11eb-9ed8-96f299d9d92d.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 47 52](https://user-images.githubusercontent.com/6711616/112807068-6fd8f500-90b2-11eb-9bca-b6d6e9ee8060.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 47 54](https://user-images.githubusercontent.com/6711616/112807072-723b4f00-90b2-11eb-85f4-1e5a454cd35a.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 49 12](https://user-images.githubusercontent.com/6711616/112807075-736c7c00-90b2-11eb-8653-1fa044c6c4d3.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 49 15](https://user-images.githubusercontent.com/6711616/112807078-74051280-90b2-11eb-9f8b-ae06b639d1cc.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 49 28](https://user-images.githubusercontent.com/6711616/112807206-9ac34900-90b2-11eb-8c0d-0cf53973e5c0.png)| ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 49 35](https://user-images.githubusercontent.com/6711616/112807215-9bf47600-90b2-11eb-94ca-d4d7942ebb69.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 49 45](https://user-images.githubusercontent.com/6711616/112807217-9c8d0c80-90b2-11eb-9358-9379c943a8ca.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-29 at 16 50 03](https://user-images.githubusercontent.com/6711616/112807224-9d25a300-90b2-11eb-993c-15581e67488f.png)


## How to test

### Jetpack
1. Build and run the Jetpack scheme
2. ✅ Notice the following things have changed to Jetpack Green
    - WebView loading color
    - Filter tab bar selected color
    - Checkmark selection color (i.e. Activity Log > filter by Activity Type)
    - TableView footer text color
    - Slider color (i.e. App Settings)
    - Switch control color
    - Stats bar color (i.e. My Site > Stats > Days)
3. ✅ Notice the following things have changed to Black
    - Bottom tab bar selected color
    - Navigation bar item tint color
    - Filter tab bar selected text color

### Regression (WordPress)
1. Build and run the WordPress scheme
2. ✅ Notice the colors remain the same as before