### PR TITLE
Add defaultDotComUUID to UserSettings

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -329,6 +329,8 @@
 		24A2948325D602710000A51E /* BlogTimeZoneTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 24A2948225D602710000A51E /* BlogTimeZoneTests.m */; };
 		24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */; };
 		24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */; };
+		24C69A8B2612421900312D9A /* UserSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24C69A8A2612421900312D9A /* UserSettingsTests.swift */; };
+		24C69AC22612467C00312D9A /* UserSettingsTestsObjc.m in Sources */ = {isa = PBXBuildFile; fileRef = 24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */; };
 		24CE2EB1258D687A0000C297 /* WordPressFlux in Frameworks */ = {isa = PBXBuildFile; productRef = 24CE2EB0258D687A0000C297 /* WordPressFlux */; };
 		24F3789825E6E62100A27BB7 /* NSManagedObject+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */; };
 		2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
@@ -4704,6 +4706,8 @@
 		24AD675025FC262F0056102C /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Sites.strings; sourceTree = "<group>"; };
 		24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagStore.swift; sourceTree = "<group>"; };
 		24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagTests.swift; sourceTree = "<group>"; };
+		24C69A8A2612421900312D9A /* UserSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsTests.swift; sourceTree = "<group>"; };
+		24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserSettingsTestsObjc.m; sourceTree = "<group>"; };
 		24D40491253F6CEE002843AC /* WordPressStatsWidgetsRelease-Internal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WordPressStatsWidgetsRelease-Internal.entitlements"; sourceTree = "<group>"; };
 		24D40492253F6D01002843AC /* WordPressStatsWidgets.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WordPressStatsWidgets.entitlements; sourceTree = "<group>"; };
 		24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Lookup.swift"; sourceTree = "<group>"; };
@@ -9392,6 +9396,8 @@
 				D826D67E211D21C700A5D8FE /* NullMockUserDefaults.swift */,
 				8B8C814C2318073300A0E620 /* BasePostTests.swift */,
 				24A2948225D602710000A51E /* BlogTimeZoneTests.m */,
+				24C69A8A2612421900312D9A /* UserSettingsTests.swift */,
+				24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -17670,6 +17676,7 @@
 				570265172298960B00F2214C /* PostListTableViewHandlerTests.swift in Sources */,
 				E1EBC3731C118ED200F638E0 /* ImmuTableTest.swift in Sources */,
 				F5C00EAE242179780047846F /* WeekdaysHeaderViewTests.swift in Sources */,
+				24C69AC22612467C00312D9A /* UserSettingsTestsObjc.m in Sources */,
 				E1AB5A091E0BF31E00574B4E /* ArrayTests.swift in Sources */,
 				570B037722F1FFF6009D8411 /* PostCoordinatorFailedPostsFetcherTests.swift in Sources */,
 				4054F4592214E6FE00D261AB /* TagsCategoriesStatsRecordValueTests.swift in Sources */,
@@ -17795,6 +17802,7 @@
 				D88A64B0208DA093008AE9BC /* StockPhotosResultsPageTests.swift in Sources */,
 				0879FC161E9301DD00E1EFC8 /* MediaTests.swift in Sources */,
 				B556EFCB1DCA374200728F93 /* DictionaryHelpersTests.swift in Sources */,
+				24C69A8B2612421900312D9A /* UserSettingsTests.swift in Sources */,
 				8B6BD55024293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift in Sources */,
 				8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */,
 				08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */,

--- a/WordPress/WordPressTest/UserSettingsTests.swift
+++ b/WordPress/WordPressTest/UserSettingsTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import WordPress
+
+class UserSettingsTests: XCTestCase {
+
+    override func tearDownWithError() throws {
+        UserSettings.reset()
+        try super.tearDownWithError()
+    }
+
+    func testThatUserOptedOutOfCrashLoggingDefaultsToFalse() {
+        XCTAssertFalse(UserSettings.userHasOptedOutOfCrashLogging)
+    }
+
+    func testThatChangingUserHasOptedOutOfCrashLoggingWorks() {
+        UserSettings.userHasOptedOutOfCrashLogging = true
+        XCTAssertTrue(UserSettings.userHasOptedOutOfCrashLogging)
+        UserSettings.userHasOptedOutOfCrashLogging = false
+        XCTAssertFalse(UserSettings.userHasOptedOutOfCrashLogging)
+    }
+
+    /// Force Crash Logging is a setting for use in debug environments to send crash logs. It should never be enabled in production builds
+    func testThatUseHasForceCrashLoggingEnabledDefaultsToFalse() {
+        XCTAssertFalse(UserSettings.userHasForcedCrashLoggingEnabled)
+    }
+
+    func testThatChangingUserHasForceCrashLoggingEnabledWorks() {
+        UserSettings.userHasForcedCrashLoggingEnabled = true
+        XCTAssertTrue(UserSettings.userHasForcedCrashLoggingEnabled)
+        UserSettings.userHasForcedCrashLoggingEnabled = false
+        XCTAssertFalse(UserSettings.userHasForcedCrashLoggingEnabled)
+    }
+
+    func testThatDefaultDotComUUIDDefaultsToNil() {
+        XCTAssertNil(UserSettings.defaultDotComUUID)
+    }
+
+    func testThatChangingDefaultDotComUUIDWorks() {
+        let uuid = UUID().uuidString
+        UserSettings.defaultDotComUUID = uuid
+        XCTAssertEqual(UserSettings.defaultDotComUUID, uuid)
+    }
+
+    func testThatChangingDefaultDotComUUIDToNilWorks() {
+        UserSettings.defaultDotComUUID = UUID().uuidString
+        UserSettings.defaultDotComUUID = nil
+        XCTAssertNil(UserSettings.defaultDotComUUID)
+    }
+}

--- a/WordPress/WordPressTest/UserSettingsTestsObjc.m
+++ b/WordPress/WordPressTest/UserSettingsTestsObjc.m
@@ -1,0 +1,30 @@
+#import <XCTest/XCTest.h>
+
+@interface UserSettingsTestsObjc : XCTestCase
+
+@end
+
+@implementation UserSettingsTestsObjc
+
+- (void)tearDown {
+    [UserSettings reset];
+    [super tearDown];
+}
+
+- (void)testThatDefaultDotComUUIDDefaultsToNil {
+    XCTAssertNil([UserSettings defaultDotComUUID]);
+}
+
+- (void)testThatChangingDefaultDotComUUIDWorks {
+    NSString *uuid = [[NSUUID new] UUIDString];
+    [UserSettings setDefaultDotComUUID:uuid];
+    XCTAssertEqual([UserSettings defaultDotComUUID], uuid);
+}
+
+- (void)testThatChangingDefaultDotComUUIDToNilWorks {
+    [UserSettings setDefaultDotComUUID:[[NSUUID new] UUIDString]];
+    [UserSettings setDefaultDotComUUID:nil];
+    XCTAssertNil([UserSettings defaultDotComUUID]);
+}
+
+@end

--- a/WordPress/WordPressTest/WordPressUnitTests.xctestplan
+++ b/WordPress/WordPressTest/WordPressUnitTests.xctestplan
@@ -9,7 +9,15 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:WordPress.xcodeproj",
+          "identifier" : "1D6058900D05DD3D006BFB54",
+          "name" : "WordPress"
+        }
+      ]
+    },
     "targetForVariableExpansion" : {
       "containerPath" : "container:WordPress.xcodeproj",
       "identifier" : "1D6058900D05DD3D006BFB54",


### PR DESCRIPTION
This will be used for https://github.com/wordpress-mobile/WordPress-iOS/pull/16168 to simplify the `AccountService` by removing manual references to the `AccountDefaultDotcomUUID` key.

To test:
- Ensure unit tests pass – they cover this functionality well

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
