### PR TITLE
Remove the need for a test with better types

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -56,8 +56,8 @@ class ReaderTabItemsStore: ItemsStore {
 extension ReaderTabItemsStore {
 
     /// Fetch request to extract reader menu topics from Core Data
-    private var topicsFetchRequest: NSFetchRequest<NSFetchRequestResult> {
-        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ReaderTopicsConstants.entityName)
+    private var topicsFetchRequest: NSFetchRequest<ReaderAbstractTopic> {
+        let fetchRequest = NSFetchRequest<ReaderAbstractTopic>(entityName: ReaderTopicsConstants.entityName)
         fetchRequest.predicate = NSPredicate(format: ReaderTopicsConstants.predicateFormat, NSNumber(value: ReaderHelpers.isLoggedIn()))
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: ReaderTopicsConstants.sortByKey, ascending: true)]
         return fetchRequest
@@ -66,14 +66,9 @@ extension ReaderTabItemsStore {
     /// Fetches items from the Core Data cache, if they exist, and updates the state accordingly
     private func fetchTabBarItems() {
         do {
-            guard let topics = try context.fetch(topicsFetchRequest) as? [ReaderAbstractTopic] else {
-                self.state = .error(ReaderTopicsConstants.objectTypeError)
-                DDLogError(ReaderTopicsConstants.fetchRequestError + ReaderTopicsConstants.objectTypeError.localizedDescription)
-                return
-            }
+            let topics = try context.fetch(topicsFetchRequest)
             let items = ReaderHelpers.rearrange(items: topics.map { ReaderTabItem(ReaderContent(topic: $0)) })
             self.state = .ready(items)
-
         } catch {
             DDLogError(ReaderTopicsConstants.fetchRequestError + error.localizedDescription)
             self.state = .error(error)
@@ -120,7 +115,6 @@ extension ReaderTabItemsStore {
         static let entityName = "ReaderAbstractTopic"
         static let sortByKey = "type"
         static let fetchRequestError = "There was a problem fetching topics for the menu. "
-        static let objectTypeError = NSError(domain: "ReaderTabItemsStoreDomain", code: -1, userInfo: nil)
         static let remoteServiceError = NSError(domain: WordPressComRestApiErrorDomain, code: -1, userInfo: nil)
     }
 }

--- a/WordPress/WordPressTest/ReaderTabItemsStoreTests.swift
+++ b/WordPress/WordPressTest/ReaderTabItemsStoreTests.swift
@@ -139,36 +139,4 @@ class ReaderTabItemsStoreTests: XCTestCase {
             }
         }
     }
-
-    /// fetch request succeeds but type cast to [ReaderAbstractTopic] fails
-    func testGetItemsInvalidFetchedType() {
-
-        let mockTopics = ["we", "are", "not", "topics"]
-
-        context.returnedObjects = mockTopics
-
-        service.fetchReaderMenuExpectation = expectation(description: "fetch menu items executed")
-        service.fetchMenuSuccessExpectation = expectation(description: "fetch from remote service succeeded")
-
-        let stateChangeExpectation = expectation(description: "state change emitted")
-        stateChangeExpectation.expectedFulfillmentCount = 2
-
-        subscription = store.onChange {
-            stateChangeExpectation.fulfill()
-            switch self.store.state {
-            case .ready, .loading:
-                XCTFail("failure not detected")
-            case .error(let error):
-                XCTAssertEqual(error as NSError, NSError(domain: "ReaderTabItemsStoreDomain", code: -1, userInfo: nil))
-            }
-        }
-        // When
-        store.getItems()
-        // Then
-        waitForExpectations(timeout: 4) { error in
-            if let error = error {
-                XCTFail("waitForExpectationsWithTimeout errored: \(error)")
-            }
-        }
-    }
 }


### PR DESCRIPTION
This change helps with https://github.com/wordpress-mobile/WordPress-iOS/pull/16168 by removing a test that breaks type-safe Core Data queries.

**To test:**
- Ensure remaining unit tests pass and that the updated approach makes sense

PR submission checklist:

- [x] I have considered adding unit tests where possible.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
