### PR TITLE
Fixes deep links not working from widgets

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -340,3 +340,11 @@ extension MySiteViewController: WPSplitViewControllerDetailProvider {
         return blogDetailsViewController.initialDetailViewControllerForSplitView(splitView)
     }
 }
+
+// MARK: - My site detail views
+extension MySiteViewController {
+
+    func showDetailView(for section: BlogDetailsSubsection) {
+        blogDetailsViewController?.showDetailView(for: section)
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -145,7 +145,12 @@ class MySitesCoordinator: NSObject {
     func showStats(for blog: Blog, timePeriod: StatsPeriodType) {
         showBlogDetails(for: blog)
 
-        if let blogDetailsViewController = navigationController.topViewController as? BlogDetailsViewController {
+        if FeatureFlag.newNavBarAppearance.enabled {
+
+            UserDefaults.standard.set(timePeriod.rawValue, forKey: StatsPeriodType.statsPeriodTypeDefaultsKey)
+            mySiteViewController.showDetailView(for: .stats)
+
+        } else if let blogDetailsViewController = navigationController.topViewController as? BlogDetailsViewController {
             // Setting this user default is a bit of a hack, but it's by far the easiest way to
             // get the stats view controller displaying the correct period. I spent some time
             // trying to do it differently, but the existing stats view controller setup is


### PR DESCRIPTION
Fixes #NA

To test:

- Build/run and install one or more (iOS 14) widgets
- tap on them and make sure they take you to the correct stats page:
    - Today widget: Days
    - This Week widget: Weeks
    - All Time widget: Insights

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @jkmassel this PR targets release 17.0