### PR TITLE
Add WPAccount Lookup

### DIFF
--- a/WordPress/Classes/Models/WPAccount+Lookup.swift
+++ b/WordPress/Classes/Models/WPAccount+Lookup.swift
@@ -126,6 +126,7 @@ public extension WPAccount {
     /// An Objective-C wrapper around the `lookupDefaultWordPressComAccount` method.
     ///
     /// Prefer using `lookupDefaultWordPressComAccount` directly
+    @available(swift, obsoleted: 1.0)
     @objc(lookupDefaultWordPressComAccountInContext:)
     static func objc_lookupDefaultWordPressComAccount(in context: NSManagedObjectContext) -> WPAccount? {
         return try? lookupDefaultWordPressComAccount(in: context)
@@ -134,6 +135,7 @@ public extension WPAccount {
     /// An Objective-C wrapper around the `lookupHasDefaultWordPressComAccount` method.
     ///
     /// Prefer using `lookupHasDefaultWordPressComAccount` directly
+    @available(swift, obsoleted: 1.0)
     @objc(lookupHasDefaultWordPressComAccountInContext:)
     static func objc_lookupHasDefaultWordPressComAccount(in context: NSManagedObjectContext) -> Bool {
         return (try? lookupHasDefaultWordPressComAccount(in: context)) ?? false
@@ -142,6 +144,7 @@ public extension WPAccount {
     /// An Objective-C wrapper around the `lookupDefaultWordPressComAccount` method.
     ///
     /// Prefer using `lookupDefaultWordPressComAccount` directly
+    @available(swift, obsoleted: 1.0)
     @objc(lookupNumberOfAccountsInContext:)
     static func objc_lookupNumberOfAccounts(in context: NSManagedObjectContext) -> Int {
         return (try? lookupNumberOfAccounts(in: context)) ?? 0
@@ -150,6 +153,7 @@ public extension WPAccount {
     /// An Objective-C wrapper around the `lookup(withUsername:context:)` method.
     ///
     /// Prefer using `lookup(withUsername:context:)` directly
+    @available(swift, obsoleted: 1.0)
     @objc(lookupWithUsername:context:)
     static func objc_lookupWithUsername(username: String, context: NSManagedObjectContext) -> WPAccount? {
         return try? lookup(withUsername: username, in: context)

--- a/WordPress/Classes/Models/WPAccount+Lookup.swift
+++ b/WordPress/Classes/Models/WPAccount+Lookup.swift
@@ -29,7 +29,7 @@ public extension WPAccount {
     /// The default WordPress.com account is the one used for Reader and Notifications.
     ///
     static func lookupDefaultWordPressComAccount(in context: NSManagedObjectContext) throws -> WPAccount? {
-        guard let uuid = UserSettings.defaultDotComUUID, uuid.count > 0 else {
+        guard let uuid = UserSettings.defaultDotComUUID, !uuid.isEmpty else {
             // No account, or no default account set. Clear the defaults key.
             UserSettings.defaultDotComUUID = nil
             return nil

--- a/WordPress/Classes/Models/WPAccount+Lookup.swift
+++ b/WordPress/Classes/Models/WPAccount+Lookup.swift
@@ -8,7 +8,7 @@ public extension WPAccount {
     ///
     @objc
     var isDefaultWordPressComAccount: Bool {
-        guard let uuid = UserSettings.defaultDotComUUID, uuid.count > 0 else {
+        guard let uuid = UserSettings.defaultDotComUUID else {
             return false
         }
 

--- a/WordPress/Classes/Models/WPAccount+Lookup.swift
+++ b/WordPress/Classes/Models/WPAccount+Lookup.swift
@@ -71,7 +71,6 @@ public extension WPAccount {
     static func lookup(withUsername username: String, in context: NSManagedObjectContext) throws -> WPAccount? {
         let fetchRequest = NSFetchRequest<Self>(entityName: WPAccount.entityName())
         fetchRequest.predicate = NSPredicate(format: "username = [c] %@ || email = [c] %@", username, username)
-        fetchRequest.includesPendingChanges = true // TODO: this shouldn't be necessary, it was copied from the `AccountService`
 
         guard let account = try context.fetch(fetchRequest).first else {
             return nil
@@ -90,7 +89,6 @@ public extension WPAccount {
     static func lookup(withUserID userID: Int64, in context: NSManagedObjectContext) throws -> WPAccount? {
         let fetchRequest = NSFetchRequest<Self>(entityName: WPAccount.entityName())
         fetchRequest.predicate = NSPredicate(format: "userID = %ld", userID)
-        fetchRequest.includesPendingChanges = true // TODO: this shouldn't be necessary, it was copied from the `AccountService`
 
         guard let account = try context.fetch(fetchRequest).first else {
             return nil

--- a/WordPress/Classes/Models/WPAccount+Lookup.swift
+++ b/WordPress/Classes/Models/WPAccount+Lookup.swift
@@ -38,14 +38,6 @@ public extension WPAccount {
         return try lookup(withUUIDString: uuid, in: context)
     }
 
-    /// Does a default WordPress.com account exist?
-    ///
-    /// The default WordPress.com account is the one used for Reader and Notifications.
-    ///
-    static func lookupHasDefaultWordPressComAccount(in context: NSManagedObjectContext) throws -> Bool {
-        return try lookupDefaultWordPressComAccount(in: context) != nil
-    }
-
     /// Lookup a WPAccount by its local uuid
     ///
     /// - Parameters:
@@ -130,15 +122,6 @@ public extension WPAccount {
     @objc(lookupDefaultWordPressComAccountInContext:)
     static func objc_lookupDefaultWordPressComAccount(in context: NSManagedObjectContext) -> WPAccount? {
         return try? lookupDefaultWordPressComAccount(in: context)
-    }
-
-    /// An Objective-C wrapper around the `lookupHasDefaultWordPressComAccount` method.
-    ///
-    /// Prefer using `lookupHasDefaultWordPressComAccount` directly
-    @available(swift, obsoleted: 1.0)
-    @objc(lookupHasDefaultWordPressComAccountInContext:)
-    static func objc_lookupHasDefaultWordPressComAccount(in context: NSManagedObjectContext) -> Bool {
-        return (try? lookupHasDefaultWordPressComAccount(in: context)) ?? false
     }
 
     /// An Objective-C wrapper around the `lookupDefaultWordPressComAccount` method.

--- a/WordPress/Classes/Models/WPAccount+Lookup.swift
+++ b/WordPress/Classes/Models/WPAccount+Lookup.swift
@@ -1,0 +1,157 @@
+import CoreData
+
+public extension WPAccount {
+
+    // MARK: - Relationship Lookups
+
+    /// Is this `WPAccount` object the default WordPress.com account?
+    ///
+    @objc
+    var isDefaultWordPressComAccount: Bool {
+        guard let uuid = UserSettings.defaultDotComUUID, uuid.count > 0 else {
+            return false
+        }
+
+        return self.uuid == uuid
+    }
+
+    /// Does this `WPAccount` object have any associated blogs?
+    ///
+    @objc
+    var hasBlogs: Bool {
+        return !blogs.isEmpty
+    }
+
+    // MARK: - Object Lookups
+
+    /// Returns the default WordPress.com account, if one exists
+    ///
+    /// The default WordPress.com account is the one used for Reader and Notifications.
+    ///
+    static func lookupDefaultWordPressComAccount(in context: NSManagedObjectContext) throws -> WPAccount? {
+        guard let uuid = UserSettings.defaultDotComUUID, uuid.count > 0 else {
+            // No account, or no default account set. Clear the defaults key.
+            UserSettings.defaultDotComUUID = nil
+            return nil
+        }
+
+        return try lookup(withUUIDString: uuid, in: context)
+    }
+
+    /// Does a default WordPress.com account exist?
+    ///
+    /// The default WordPress.com account is the one used for Reader and Notifications.
+    ///
+    static func lookupHasDefaultWordPressComAccount(in context: NSManagedObjectContext) throws -> Bool {
+        return try lookupDefaultWordPressComAccount(in: context) != nil
+    }
+
+    /// Lookup a WPAccount by its local uuid
+    ///
+    /// - Parameters:
+    ///   - uuidString: The UUID (in string form) associated with the account
+    ///   - context: An NSManagedObjectContext containing the `WPAccount` object with the given `uuidString`.
+    /// - Returns: The `WPAccount` object associated with the given `uuidString`, if it exists.
+    ///
+    static func lookup(withUUIDString uuidString: String, in context: NSManagedObjectContext) throws -> WPAccount? {
+        let fetchRequest = NSFetchRequest<Self>(entityName: WPAccount.entityName())
+        fetchRequest.predicate = NSPredicate(format: "uuid = %@", uuidString)
+
+        guard let defaultAccount = try context.fetch(fetchRequest).first else {
+            return nil
+        }
+
+        /// This was brought over from the `AccountService`, but can (and probably should) be moved to an accessor for the property
+        if let displayName = defaultAccount.displayName {
+            defaultAccount.displayName = displayName.stringByDecodingXMLCharacters()
+        }
+
+        return defaultAccount
+    }
+
+    /// Lookup a WPAccount with the specified username, if it exists
+    ///
+    /// - Parameters:
+    ///   - username: The username associated with the account
+    ///   - context: An NSManagedObjectContext containing the `WPAccount` object with the given `username`.
+    /// - Returns: The `WPAccount` object associated with the given `username`, if it exists.
+    ///
+    static func lookup(withUsername username: String, in context: NSManagedObjectContext) throws -> WPAccount? {
+        let fetchRequest = NSFetchRequest<Self>(entityName: WPAccount.entityName())
+        fetchRequest.predicate = NSPredicate(format: "username = [c] %@ || email = [c] %@", username, username)
+        fetchRequest.includesPendingChanges = true // TODO: this shouldn't be necessary, it was copied from the `AccountService`
+
+        guard let account = try context.fetch(fetchRequest).first else {
+            return nil
+        }
+
+        return account
+    }
+
+    /// Lookup a WPAccount with the specified userID, if it exists
+    ///
+    /// - Parameters:
+    ///   - userID: The userID associated with the account
+    ///   - context: An NSManagedObjectContext containing the `WPAccount` object with the given `userID`.
+    /// - Returns: The `WPAccount` object associated with the given `userID`, if it exists.
+    ///
+    static func lookup(withUserID userID: Int64, in context: NSManagedObjectContext) throws -> WPAccount? {
+        let fetchRequest = NSFetchRequest<Self>(entityName: WPAccount.entityName())
+        fetchRequest.predicate = NSPredicate(format: "userID = %ld", userID)
+        fetchRequest.includesPendingChanges = true // TODO: this shouldn't be necessary, it was copied from the `AccountService`
+
+        guard let account = try context.fetch(fetchRequest).first else {
+            return nil
+        }
+
+        return account
+    }
+
+    /// Lookup the total number of `WPAccount` objects in the given `context`.
+    ///
+    /// If none exist, this method returns `0`.
+    ///
+    /// - Parameters:
+    ///   - context: An NSManagedObjectContext that may or may not contain `WPAccount` objects.
+    /// - Returns: The number of `WPAccount` objects in the given `context`.
+    ///
+    static func lookupNumberOfAccounts(in context: NSManagedObjectContext) throws -> Int {
+        let fetchRequest = NSFetchRequest<Self>(entityName: WPAccount.entityName())
+        fetchRequest.includesSubentities = false
+        return try context.count(for: fetchRequest)
+    }
+
+    // MARK: - Objective-C Compatibility Wrappers
+
+    /// An Objective-C wrapper around the `lookupDefaultWordPressComAccount` method.
+    ///
+    /// Prefer using `lookupDefaultWordPressComAccount` directly
+    @objc(lookupDefaultWordPressComAccountInContext:)
+    static func objc_lookupDefaultWordPressComAccount(in context: NSManagedObjectContext) -> WPAccount? {
+        return try? lookupDefaultWordPressComAccount(in: context)
+    }
+
+    /// An Objective-C wrapper around the `lookupHasDefaultWordPressComAccount` method.
+    ///
+    /// Prefer using `lookupHasDefaultWordPressComAccount` directly
+    @objc(lookupHasDefaultWordPressComAccountInContext:)
+    static func objc_lookupHasDefaultWordPressComAccount(in context: NSManagedObjectContext) -> Bool {
+        return (try? lookupHasDefaultWordPressComAccount(in: context)) ?? false
+    }
+
+    /// An Objective-C wrapper around the `lookupDefaultWordPressComAccount` method.
+    ///
+    /// Prefer using `lookupDefaultWordPressComAccount` directly
+    @objc(lookupNumberOfAccountsInContext:)
+    static func objc_lookupNumberOfAccounts(in context: NSManagedObjectContext) -> Int {
+        return (try? lookupNumberOfAccounts(in: context)) ?? 0
+    }
+
+    /// An Objective-C wrapper around the `lookup(withUsername:context:)` method.
+    ///
+    /// Prefer using `lookup(withUsername:context:)` directly
+    @objc(lookupWithUsername:context:)
+    static func objc_lookupWithUsername(username: String, context: NSManagedObjectContext) -> WPAccount? {
+        return try? lookup(withUsername: username, in: context)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -326,6 +326,11 @@
 		241E60B325CA0D2900912CEB /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 241E60B225CA0D2900912CEB /* UserSettings.swift */; };
 		2420BEF125D8DAB300966129 /* Blog+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2420BEF025D8DAB300966129 /* Blog+Lookup.swift */; };
 		246D0A0325E97D5D0028B83F /* Blog+ObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 246D0A0225E97D5D0028B83F /* Blog+ObjcTests.m */; };
+		2481B17F260D4D4E00AE59DB /* WPAccount+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2481B17E260D4D4E00AE59DB /* WPAccount+Lookup.swift */; };
+		2481B180260D4D4E00AE59DB /* WPAccount+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2481B17E260D4D4E00AE59DB /* WPAccount+Lookup.swift */; };
+		2481B1D5260D4E8B00AE59DB /* AccountBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2481B1D4260D4E8B00AE59DB /* AccountBuilder.swift */; };
+		2481B1E8260D4EAC00AE59DB /* WPAccount+LookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2481B1E7260D4EAC00AE59DB /* WPAccount+LookupTests.swift */; };
+		2481B20C260D8FED00AE59DB /* WPAccount+ObjCLookupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2481B20B260D8FED00AE59DB /* WPAccount+ObjCLookupTests.m */; };
 		24A2948325D602710000A51E /* BlogTimeZoneTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 24A2948225D602710000A51E /* BlogTimeZoneTests.m */; };
 		24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */; };
 		24B1AE3124FEC79900B9F334 /* RemoteFeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */; };
@@ -4693,6 +4698,10 @@
 		241E60B225CA0D2900912CEB /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
 		2420BEF025D8DAB300966129 /* Blog+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Lookup.swift"; sourceTree = "<group>"; };
 		246D0A0225E97D5D0028B83F /* Blog+ObjcTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "Blog+ObjcTests.m"; sourceTree = "<group>"; };
+		2481B17E260D4D4E00AE59DB /* WPAccount+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPAccount+Lookup.swift"; sourceTree = "<group>"; };
+		2481B1D4260D4E8B00AE59DB /* AccountBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountBuilder.swift; sourceTree = "<group>"; };
+		2481B1E7260D4EAC00AE59DB /* WPAccount+LookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPAccount+LookupTests.swift"; sourceTree = "<group>"; };
+		2481B20B260D8FED00AE59DB /* WPAccount+ObjCLookupTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "WPAccount+ObjCLookupTests.m"; sourceTree = "<group>"; };
 		24A2948225D602710000A51E /* BlogTimeZoneTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BlogTimeZoneTests.m; sourceTree = "<group>"; };
 		24AD66BE25FC25FD0056102C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Sites.strings; sourceTree = "<group>"; };
 		24AD66C025FC25FE0056102C /* sq */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sq; path = sq.lproj/Sites.strings; sourceTree = "<group>"; };
@@ -8224,6 +8233,7 @@
 				82FFBF4C1F434BDA00F4573F /* ThemeIdHelper.swift */,
 				E105E9CD1726955600C0D9E7 /* WPAccount.h */,
 				E105E9CE1726955600C0D9E7 /* WPAccount.m */,
+				2481B17E260D4D4E00AE59DB /* WPAccount+Lookup.swift */,
 				E12DB07A1C48D1C200A6C1D4 /* WPAccount+AccountSettings.swift */,
 				73FEC870220B358500CEF791 /* WPAccount+RestApi.swift */,
 				46F84612185A8B7E009D0DA5 /* PostContentProvider.h */,
@@ -9263,6 +9273,7 @@
 				57B71D4D230DB5F200789A68 /* BlogBuilder.swift */,
 				F11023A223186BCA00C4E84A /* MediaBuilder.swift */,
 				57889AB723589DF100DAE56D /* PageBuilder.swift */,
+				2481B1D4260D4E8B00AE59DB /* AccountBuilder.swift */,
 			);
 			name = TestUtilities;
 			sourceTree = "<group>";
@@ -9449,6 +9460,8 @@
 				24A2948225D602710000A51E /* BlogTimeZoneTests.m */,
 				24C69A8A2612421900312D9A /* UserSettingsTests.swift */,
 				24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */,
+				2481B1E7260D4EAC00AE59DB /* WPAccount+LookupTests.swift */,
+				2481B20B260D8FED00AE59DB /* WPAccount+ObjCLookupTests.m */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -16538,6 +16551,7 @@
 				43DC0EF12040B23200896C9C /* SignupUsernameViewController.swift in Sources */,
 				1782BE841E70063100A91E7D /* MediaItemViewController.swift in Sources */,
 				E10A2E9B134E8AD3007643F9 /* PostAnnotation.m in Sources */,
+				2481B17F260D4D4E00AE59DB /* WPAccount+Lookup.swift in Sources */,
 				7E3E9B702177C9DC00FD5797 /* GutenbergViewController.swift in Sources */,
 				7D21280D251CF0850086DD2C /* EditPageViewController.swift in Sources */,
 				738B9A4F21B85CF20005062B /* SiteCreator.swift in Sources */,
@@ -17762,6 +17776,7 @@
 				E66969CD1B9E2EBF00EC9C00 /* SafeReaderTopicToReaderTopic.m in Sources */,
 				E6A215901D1065F200DE5270 /* AbstractPostTest.swift in Sources */,
 				D8BA274D20FDEA2E007A5C77 /* NotificationTextContentTests.swift in Sources */,
+				2481B1D5260D4E8B00AE59DB /* AccountBuilder.swift in Sources */,
 				E66969C81B9E0A6800EC9C00 /* ReaderTopicServiceTest.swift in Sources */,
 				931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */,
 				570265172298960B00F2214C /* PostListTableViewHandlerTests.swift in Sources */,
@@ -17853,6 +17868,7 @@
 				8B69F100255C4870006B1CEF /* ActivityStoreTests.swift in Sources */,
 				B5C0CF3F204DB92F00DB0362 /* NotificationReplyStoreTests.swift in Sources */,
 				575E126322973EBB0041B3EB /* PostCompactCellGhostableTests.swift in Sources */,
+				2481B20C260D8FED00AE59DB /* WPAccount+ObjCLookupTests.m in Sources */,
 				40ACCF14224E167900190713 /* FlagsTest.swift in Sources */,
 				E15027651E03E54100B847E3 /* PinghubTests.swift in Sources */,
 				E1B642131EFA5113001DC6D7 /* ModelTestHelper.swift in Sources */,
@@ -17900,6 +17916,7 @@
 				F543AF5723A84E4D0022F595 /* PublishSettingsControllerTests.swift in Sources */,
 				027AC5212278983F0033E56E /* DomainCreditEligibilityTests.swift in Sources */,
 				F551E7F723FC9A5C00751212 /* Collection+RotateTests.swift in Sources */,
+				2481B1E8260D4EAC00AE59DB /* WPAccount+LookupTests.swift in Sources */,
 				E10F3DA11E5C2CE0008FAADA /* PostListFilterTests.swift in Sources */,
 				57D66B9D234BB78B005A2D74 /* PostServiceWPComTests.swift in Sources */,
 				8B939F4323832E5D00ACCB0F /* PostListViewControllerTests.swift in Sources */,
@@ -19331,6 +19348,7 @@
 				FABB25DE2602FC2C00C8785C /* UserProfile.swift in Sources */,
 				FABB25DF2602FC2C00C8785C /* PickerTableViewCell.swift in Sources */,
 				FABB25E02602FC2C00C8785C /* StoryEditor.swift in Sources */,
+				2481B180260D4D4E00AE59DB /* WPAccount+Lookup.swift in Sources */,
 				FABB25E12602FC2C00C8785C /* WPActivityDefaults.m in Sources */,
 				FABB25E22602FC2C00C8785C /* RegisterDomainDetailsViewModel+CellIndex.swift in Sources */,
 				FABB25E32602FC2C00C8785C /* RouteMatcher.swift in Sources */,

--- a/WordPress/WordPressTest/AccountBuilder.swift
+++ b/WordPress/WordPressTest/AccountBuilder.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+@testable import WordPress
+
+/// Builds an Account for use with testing
+///
+@objc
+class AccountBuilder: NSObject {
+    private let coreDataStack: CoreDataStack
+    private var account: WPAccount
+
+    @objc
+    init(_ coreDataStack: CoreDataStack) {
+        self.coreDataStack = coreDataStack
+
+        account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: coreDataStack.mainContext) as! WPAccount
+        account.uuid = UUID().uuidString
+
+        super.init()
+    }
+
+    @objc
+    func with(id: Int64) -> AccountBuilder {
+        account.userID = NSNumber(value: id)
+        return self
+    }
+
+    @objc
+    func with(uuid: String) -> AccountBuilder {
+        account.uuid = uuid
+        return self
+    }
+
+    @objc
+    func with(username: String) -> AccountBuilder {
+        account.username = username
+        return self
+    }
+
+    @objc
+    func with(email: String) -> AccountBuilder {
+        account.email = email
+        return self
+    }
+
+    @objc
+    func with(blogs: [Blog]) -> AccountBuilder {
+        account.blogs = Set(blogs)
+        return self
+    }
+
+    @objc
+    @discardableResult
+    func build() -> WPAccount {
+        account
+    }
+}

--- a/WordPress/WordPressTest/WPAccount+LookupTests.swift
+++ b/WordPress/WordPressTest/WPAccount+LookupTests.swift
@@ -53,18 +53,6 @@ final class WPAccountLookupTests: XCTestCase {
         XCTAssertNil(UserSettings.defaultDotComUUID)
     }
 
-    func testLookupHasDefaultWordPressComAccountIsFalseWhereNoneExists() throws {
-        let _ = AccountBuilder(contextManager).build()
-        try XCTAssertFalse(WPAccount.lookupHasDefaultWordPressComAccount(in: contextManager.mainContext))
-    }
-
-    func testLookupHasDefaultWordPressComAccountIsTrueWhenAccountIsSet() throws {
-        let account = AccountBuilder(contextManager).build()
-        UserSettings.defaultDotComUUID = account.uuid
-
-        try XCTAssertTrue(WPAccount.lookupHasDefaultWordPressComAccount(in: contextManager.mainContext))
-    }
-
     func testLookupAccountByUUIDReturnsNilForInvalidAccount() throws {
         AccountBuilder(contextManager).build()
         try XCTAssertNil(WPAccount.lookup(withUUIDString: "", in: contextManager.mainContext))

--- a/WordPress/WordPressTest/WPAccount+LookupTests.swift
+++ b/WordPress/WordPressTest/WPAccount+LookupTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import WordPress
+
+final class WPAccountLookupTests: XCTestCase {
+
+    private var contextManager: TestContextManager!
+
+    override func setUp() {
+        super.setUp()
+        contextManager = TestContextManager()
+    }
+
+    func testIsDefaultWordPressComAccountIsFalseWhenNoAccountIsSet() {
+        UserSettings.defaultDotComUUID = nil
+        let account = AccountBuilder(contextManager).build()
+        XCTAssertFalse(account.isDefaultWordPressComAccount)
+    }
+
+    func testIsDefaultWordPressComAccountIsTrueWhenUUIDMatches() {
+        let account = AccountBuilder(contextManager).build()
+        UserSettings.defaultDotComUUID = account.uuid
+        XCTAssertTrue(account.isDefaultWordPressComAccount)
+    }
+
+    func testHasBlogsReturnsFalseWhenNoBlogsArePresentForAccount() {
+        let account = AccountBuilder(contextManager).build()
+        XCTAssertFalse(account.hasBlogs)
+    }
+
+    func testHasBlogsReturnsTrueWhenBlogsArePresentForAccount() {
+        let blog = BlogBuilder(contextManager.mainContext)
+            .withAnAccount()
+            .build()
+        XCTAssertTrue(blog.account!.hasBlogs)
+    }
+
+    func testLookupDefaultWordPressComAccountReturnsNilWhenNoAccountIsSet() throws {
+        let _ = AccountBuilder(contextManager).build()
+        try XCTAssertNil(WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext))
+    }
+
+    func testLookupDefaultWordPressComAccountReturnsAccount() throws {
+        let account = AccountBuilder(contextManager).build()
+        UserSettings.defaultDotComUUID = account.uuid
+
+        try XCTAssertEqual(WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext)?.uuid, account.uuid)
+    }
+
+    /// This is a test for a side effect – that the user setting is deleted by default
+    func testLookupDefaultWordPressComAccountMakesDefaultUUIDNilForInvalidValue() throws {
+        UserSettings.defaultDotComUUID = ""
+        _ = try WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext)
+        XCTAssertNil(UserSettings.defaultDotComUUID)
+    }
+
+    func testLookupHasDefaultWordPressComAccountIsFalseWhereNoneExists() throws {
+        let _ = AccountBuilder(contextManager).build()
+        try XCTAssertFalse(WPAccount.lookupHasDefaultWordPressComAccount(in: contextManager.mainContext))
+    }
+
+    func testLookupHasDefaultWordPressComAccountIsTrueWhenAccountIsSet() throws {
+        let account = AccountBuilder(contextManager).build()
+        UserSettings.defaultDotComUUID = account.uuid
+
+        try XCTAssertTrue(WPAccount.lookupHasDefaultWordPressComAccount(in: contextManager.mainContext))
+    }
+
+    func testLookupAccountByUUIDReturnsNilForInvalidAccount() throws {
+        AccountBuilder(contextManager).build()
+        try XCTAssertNil(WPAccount.lookup(withUUIDString: "", in: contextManager.mainContext))
+    }
+
+    func testLookupAccountByUUIDReturnsAccount() throws {
+        let uuid = UUID().uuidString
+        AccountBuilder(contextManager).with(uuid: uuid).build()
+        try XCTAssertEqual(WPAccount.lookup(withUUIDString: uuid, in: contextManager.mainContext)?.uuid, uuid)
+    }
+
+    func testLookupAccountByUsernameReturnsNilIfNotFound() throws {
+        AccountBuilder(contextManager).build()
+        try XCTAssertNil(WPAccount.lookup(withUsername: "", in: contextManager.mainContext))
+    }
+
+    func testLookupAccountByUsernameReturnsAccountForUsername() throws {
+        let username = UUID().uuidString
+        AccountBuilder(contextManager).with(username: username).build()
+        try XCTAssertEqual(WPAccount.lookup(withUsername: username, in: contextManager.mainContext)?.username, username)
+    }
+
+    func testLookupAccountByUsernameReturnsAccountForEmailAddress() throws {
+        let email = UUID().uuidString
+        AccountBuilder(contextManager).with(email: email).build()
+        try XCTAssertEqual(WPAccount.lookup(withUsername: email, in: contextManager.mainContext)?.email, email)
+    }
+
+    func testLookupByUserIdReturnsNilIfNotFound() throws {
+        AccountBuilder(contextManager).with(id: 1).build() // Make a test account that we don't want to match
+        try XCTAssertNil(WPAccount.lookup(withUserID: 2, in: contextManager.mainContext))
+    }
+
+    func testLookupByUserIdReturnsAccount() throws {
+        AccountBuilder(contextManager).with(id: 1).build()
+        try XCTAssertEqual(WPAccount.lookup(withUserID: 1, in: contextManager.mainContext)?.userID, 1)
+    }
+
+    func testLookupNumberOfAccountsReturnsZeroByDefault() throws {
+        try XCTAssertEqual(WPAccount.lookupNumberOfAccounts(in: contextManager.mainContext), 0)
+    }
+
+    func testLookupNumberOfAccountsReturnsCorrectValue() throws {
+        let _ = AccountBuilder(contextManager).build()
+        let _ = AccountBuilder(contextManager).build()
+        let _ = AccountBuilder(contextManager).build()
+
+        try XCTAssertEqual(WPAccount.lookupNumberOfAccounts(in: contextManager.mainContext), 3)
+    }
+}

--- a/WordPress/WordPressTest/WPAccount+ObjCLookupTests.m
+++ b/WordPress/WordPressTest/WPAccount+ObjCLookupTests.m
@@ -1,0 +1,57 @@
+#import <XCTest/XCTest.h>
+#import "WordPressTest-Swift.h"
+
+@interface WPAccount_ObjCLookupTests : XCTestCase
+
+@property(strong, nonatomic) TestContextManager *contextManager;
+
+@end
+
+@implementation WPAccount_ObjCLookupTests
+
+- (void) setUp {
+    [super setUp];
+    _contextManager = [TestContextManager new];
+}
+
+- (void) testLookupDefaultWordPressComAccountReturnsNilWhenNoAccountIsSet {
+    [[[AccountBuilder alloc] init: self.contextManager] build];
+    XCTAssertNil([WPAccount lookupDefaultWordPressComAccountInContext: self.contextManager.mainContext]);
+}
+
+- (void) testLookupDefaultWordPressComAccountReturnsAccount {
+    WPAccount *account = [[[AccountBuilder alloc] init: self.contextManager] build];
+    [UserSettings setDefaultDotComUUID: account.uuid];
+    XCTAssertEqual([WPAccount lookupDefaultWordPressComAccountInContext:self.contextManager.mainContext].uuid, account.uuid);
+}
+
+- (void) testLookupNumberOfAccountsReturnsZeroByDefault {
+    XCTAssertEqual([WPAccount lookupNumberOfAccountsInContext:self.contextManager.mainContext], 0);
+}
+
+- (void) testLookupNumberOfAccountsReturnsCorrectValue {
+    [[[AccountBuilder alloc] init: self.contextManager] build];
+    [[[AccountBuilder alloc] init: self.contextManager] build];
+    [[[AccountBuilder alloc] init: self.contextManager] build];
+
+    XCTAssertEqual([WPAccount lookupNumberOfAccountsInContext: self.contextManager.mainContext], 3);
+}
+
+- (void) testLookupAccountByUsernameReturnsNilIfNotFound {
+    [[[AccountBuilder alloc] init: self.contextManager] build];
+    XCTAssertNil([WPAccount lookupWithUsername:@"" context:self.contextManager.mainContext]);
+}
+
+- (void) testLookupAccountByUsernameReturnsAccountForUsername {
+    NSString *username = [[NSUUID new] UUIDString];
+    [[[[AccountBuilder alloc] init:self.contextManager] withUsername: username] build];
+    XCTAssertEqual([WPAccount lookupWithUsername:username context:self.contextManager.mainContext].username, username);
+}
+
+- (void) testLookupAccountByUsernameReturnsAccountForEmailAddress {
+    NSString *email = [[NSUUID new] UUIDString];
+    [[[[AccountBuilder alloc] init: self.contextManager] withEmail:email] build];
+    XCTAssertEqual([WPAccount lookupWithUsername:email context:self.contextManager.mainContext].email, email);
+}
+
+@end


### PR DESCRIPTION
This PR works further toward #16168, which does the same sort of work as #15887, but for Accounts.

Because #16168 got so big, I've split this change out of it. This PR contains only the new methods that'll be called once #16168 is merged.

To test:
- Ensure unit tests pass – they cover the full functionality of the changes.

## Regression Notes
1. Potential unintended areas of impact
- None possible, given that this is entirely new code that doesn't touch anything else

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Not applicable to this PR

3. What automated tests I added (or what prevented me from doing so)
- Added automated tests to cover all cases I could think of for the new code.
 
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
