### PR TITLE
Improve Site Title alignment and sizing

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -239,6 +239,8 @@ fileprivate extension NewBlogDetailHeaderView {
 
         let titleButton: SpotlightableButton = {
             let button = SpotlightableButton(type: .custom)
+            button.contentHorizontalAlignment = .leading
+
             button.titleLabel?.font = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
             button.titleLabel?.adjustsFontForContentSizeCategory = true
             button.titleLabel?.lineBreakMode = .byTruncatingTail
@@ -350,6 +352,7 @@ fileprivate extension NewBlogDetailHeaderView {
             [
                 titleStackView.leadingAnchor.constraint(equalTo: siteIconView.trailingAnchor, constant: LayoutSpacing.betweenSiteIconAndTitle),
                 titleStackView.centerYAnchor.constraint(equalTo: siteIconView.centerYAnchor),
+                titleButton.trailingAnchor.constraint(equalTo: siteSwitcherButton.leadingAnchor, constant: -LayoutSpacing.betweenTitleAndSiteSwitcher),
             ]
         }
     }


### PR DESCRIPTION
This PR improves an issue with the alignment of the site title in the new blog detail header view, as well as its sizing.

- Previously, the site title wasn't always entirely left aligned with the site URL button below. Sometimes it was indented slightly.
- The label would collapse horizontally when it had no content, which meant that the loading indicator would appear far over on the left hand side when changing the site title. It should now be centered.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-30 at 20 18 33](https://user-images.githubusercontent.com/4780/113044024-20b7c080-9195-11eb-84d2-b8bbc7ba5171.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-30 at 17 09 04](https://user-images.githubusercontent.com/4780/113043798-ddf5e880-9194-11eb-8328-cbd3e52ec196.png) |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-30 at 19 52 05](https://user-images.githubusercontent.com/4780/113043768-d5051700-9194-11eb-81f8-09505f2f2a40.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-30 at 19 45 23](https://user-images.githubusercontent.com/4780/113043776-d8000780-9194-11eb-932c-261456fa2ade.png) |

**To test**

- Build and run
- Check with a couple of sites that the site title appears correctly and is left aligned
- Tap the site title to change the site title and ensure that the loading indicator is centered

## Regression Notes

1. Potential unintended areas of impact

- Quick Start also uses the site title button

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- I ran through the Quick Start step that affects site title and ensured that it still worked

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
