### PR TITLE
AB testing: fix refreshIfNeeded

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -193,7 +193,7 @@ target 'WordPress' do
 
     # Production
 
-    pod 'Automattic-Tracks-iOS', '~> 0.8.3'
+    pod 'Automattic-Tracks-iOS', '~> 0.8.4'
     # While in PR
     # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => ''
     # Local Development

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - AppCenter/Core
   - AppCenter/Distribute (4.1.1):
     - AppCenter/Core
-  - Automattic-Tracks-iOS (0.8.3):
+  - Automattic-Tracks-iOS (0.8.4):
     - CocoaLumberjack (~> 3)
     - Reachability (~> 3)
     - Sentry (~> 6)
@@ -442,7 +442,7 @@ DEPENDENCIES:
   - AMScrollingNavbar (= 5.6.0)
   - AppCenter (= 4.1.1)
   - AppCenter/Distribute (= 4.1.1)
-  - Automattic-Tracks-iOS (~> 0.8.3)
+  - Automattic-Tracks-iOS (~> 0.8.4)
   - Charts (~> 3.2.2)
   - CocoaLumberjack (~> 3.0)
   - CropViewController (= 2.5.3)
@@ -678,7 +678,7 @@ SPEC CHECKSUMS:
   AMScrollingNavbar: cf0ec5a5ee659d76ba2509f630bf14fba7e16dc3
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   AppCenter: cd53e3ed3563cc720bcb806c9731a12389b40d44
-  Automattic-Tracks-iOS: c5fce3a171dd92ab76a0b5bcffcebcb323ea004e
+  Automattic-Tracks-iOS: 87e14e4f06f753f02a6e0f747824e766bae7f939
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
   CocoaLumberjack: e8955b9d337ac307103b0a34fd141c32f27e53c5
@@ -766,6 +766,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 46b470ab6e73cfd34dad0b0ef06d9306055b53b5
+PODFILE CHECKSUM: 6e7339efd66a364270d922d06823cf158be37630
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
This PR fixes a bug in `refreshIfNeeded` that wasn't respecting the `ttl`.

### To test:

Put a breakpoint on `ExPlat.swift:44` and `ExPlat.swift:49`

1. Open the app
2. Put the app in the background
3. Open the app again
4. Check that one of the breakpoints is hit, check the value of ttl
5. Repeat the same process
6. Note that TTL had decreased and after reaching 0 or a negative number the refresh will be performed

A unit test for it was added here to avoid the same issue in the future: https://github.com/Automattic/Automattic-Tracks-iOS/pull/176#event-4529573331

## Regression Notes
1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Unit test in https://github.com/Automattic/Automattic-Tracks-iOS/pull/176#event-4529573331

3. What automated tests I added (or what prevented me from doing so)

One unit test here: https://github.com/Automattic/Automattic-Tracks-iOS/pull/176#event-4529573331

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
