### PR TITLE
Add feature flagging to large titles for Reader and Notifications

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -461,8 +461,11 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 //
 private extension NotificationsViewController {
     func setupNavigationBar() {
-        navigationController?.navigationBar.prefersLargeTitles = true
-        navigationItem.largeTitleDisplayMode = .always
+        if FeatureFlag.newNavBarAppearance.enabled {
+            navigationController?.navigationBar.prefersLargeTitles = true
+            navigationItem.largeTitleDisplayMode = .always
+        }
+
         // Don't show 'Notifications' in the next-view back button
         // we are using a space character because we need a non-empty string to ensure a smooth
         // transition back, with large titles enabled.

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -77,8 +77,11 @@ class ReaderTabViewController: UIViewController {
 
     override func loadView() {
         view = readerTabView
-        navigationItem.largeTitleDisplayMode = .always
-        navigationController?.navigationBar.prefersLargeTitles = true
+
+        if FeatureFlag.newNavBarAppearance.enabled {
+            navigationItem.largeTitleDisplayMode = .always
+            navigationController?.navigationBar.prefersLargeTitles = true
+        }
     }
 
     @objc func willEnterForeground() {


### PR DESCRIPTION
This PR adds feature flagging to two areas we missed the first time round – large titles in Reader and Notifications.

**To test**

- Build and run, and ensure you see large titles in each of the main areas of the app
- Disable the newNavBarAppearance feature flag and build and run again. Ensure you don't see the large titles.

## Regression Notes
1. Potential unintended areas of impact

- None, very localized changes.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-
3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
