### PR TITLE
Unified Prologue - Fix layout issues

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/ContentViews/Editor/UnifiedPrologueNotificationsContentView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/ContentViews/Editor/UnifiedPrologueNotificationsContentView.swift
@@ -14,8 +14,6 @@ struct UnifiedPrologueNotificationsContentView: View {
                                                design: .default)
 
             VStack {
-                Spacer(minLength: content.size.height * 0.18)
-
                 RoundRectangleView {
                     HStack {
                         NotificationIcon(image: Appearance.topImage, size: notificationIconSize)
@@ -87,9 +85,6 @@ struct UnifiedPrologueNotificationsContentView: View {
                     }
                 }
                 .fixedSize(horizontal: false, vertical: true)
-
-                // avoid bottom overlapping due to the icon offset
-                Spacer(minLength: content.size.height * 0.1)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/ContentViews/Editor/UnifiedPrologueNotificationsContentView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/ContentViews/Editor/UnifiedPrologueNotificationsContentView.swift
@@ -14,6 +14,7 @@ struct UnifiedPrologueNotificationsContentView: View {
                                                design: .default)
 
             VStack {
+                Spacer()
                 RoundRectangleView {
                     HStack {
                         NotificationIcon(image: Appearance.topImage, size: notificationIconSize)
@@ -85,6 +86,7 @@ struct UnifiedPrologueNotificationsContentView: View {
                     }
                 }
                 .fixedSize(horizontal: false, vertical: true)
+                Spacer()
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/ContentViews/Editor/UnifiedPrologueReaderContentView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/ContentViews/Editor/UnifiedPrologueReaderContentView.swift
@@ -18,8 +18,6 @@ struct UnifiedPrologueReaderContentView: View {
                                        design: .default)
 
             VStack {
-                Spacer(minLength: content.size.height * 0.1)
-
                 RoundRectangleView {
                     HStack {
                         VStack {
@@ -116,9 +114,6 @@ struct UnifiedPrologueReaderContentView: View {
                 }
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, spacingUnit)
-
-                // avoid bottom overlapping due to the icon offset
-                Spacer(minLength: content.size.height * 0.18)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
@@ -80,8 +80,21 @@ class UnifiedProloguePageViewController: UIViewController {
 
     override func viewDidLoad() {
 
-        contentViewWidthConstraint = NSLayoutConstraint(item: contentView, attribute: .width, relatedBy: .equal, toItem: view, attribute: .width, multiplier: 0.7, constant: 0)
-        contentViewHeightConstraint = NSLayoutConstraint(item: contentView, attribute: .height, relatedBy: .equal, toItem: view, attribute: .height, multiplier: 0.5, constant: 0)
+        contentViewWidthConstraint = NSLayoutConstraint(item: contentView,
+                                                        attribute: .width,
+                                                        relatedBy: .equal,
+                                                        toItem: view,
+                                                        attribute: .width,
+                                                        multiplier: 0.7,
+                                                        constant: 0)
+
+        contentViewHeightConstraint = NSLayoutConstraint(item: contentView,
+                                                         attribute: .height,
+                                                         relatedBy: .equal,
+                                                         toItem: view,
+                                                         attribute: .height,
+                                                         multiplier: 0.5,
+                                                         constant: 0)
 
         let centeredContentViewConstraint = NSLayoutConstraint(item: contentView,
                                                                attribute: .centerY,

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
@@ -36,6 +36,13 @@ class UnifiedProloguePageViewController: UIViewController {
 
     private var pageType: UnifiedProloguePageType!
 
+    let titleTopSpacer = UIView()
+    let titleContentSpacer = UIView()
+    let contentBottomSpacer = UIView()
+
+    var contentViewHeightConstraint: NSLayoutConstraint?
+    var contentViewWidthConstraint: NSLayoutConstraint?
+
     init(pageType: UnifiedProloguePageType) {
         self.pageType = pageType
 
@@ -50,13 +57,75 @@ class UnifiedProloguePageViewController: UIViewController {
         view = UIView()
         view.backgroundColor = .clear
 
+        let mainStackView = UIStackView()
+        mainStackView.axis = .vertical
+        mainStackView.alignment = .center
+        mainStackView.distribution = .fill
+        mainStackView.translatesAutoresizingMaskIntoConstraints = false
+        titleTopSpacer.translatesAutoresizingMaskIntoConstraints = false
+
+        titleContentSpacer.translatesAutoresizingMaskIntoConstraints = false
+
+        contentBottomSpacer.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(mainStackView)
+
         configureTitle()
-        configureContentView()
+        mainStackView.addArrangedSubview(titleTopSpacer)
+        mainStackView.addArrangedSubview(titleLabel)
+        mainStackView.addArrangedSubview(titleContentSpacer)
+        mainStackView.addArrangedSubview(contentView)
+        mainStackView.addArrangedSubview(contentBottomSpacer)
+        view.pinSubviewToAllEdges(mainStackView)
+    }
+
+    override func viewDidLoad() {
+
+        contentViewWidthConstraint = NSLayoutConstraint(item: contentView, attribute: .width, relatedBy: .equal, toItem: view, attribute: .width, multiplier: 0.7, constant: 0)
+        contentViewHeightConstraint = NSLayoutConstraint(item: contentView, attribute: .height, relatedBy: .equal, toItem: view, attribute: .height, multiplier: 0.5, constant: 0)
+
+        let centeredContentViewConstraint = NSLayoutConstraint(item: contentView,
+                                                               attribute: .centerY,
+                                                               relatedBy: .equal,
+                                                               toItem: view,
+                                                               attribute: .centerY,
+                                                               multiplier: 1.15,
+                                                               constant: 0)
+        centeredContentViewConstraint.priority = .init(999)
+
+        NSLayoutConstraint.activate([contentView.heightAnchor.constraint(equalTo: contentView.widthAnchor),
+                                     titleTopSpacer.heightAnchor.constraint(greaterThanOrEqualTo: contentView.heightAnchor, multiplier: 0.18),
+                                     titleContentSpacer.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.2),
+                                     centeredContentViewConstraint,
+                                     contentBottomSpacer.heightAnchor.constraint(greaterThanOrEqualTo: view.heightAnchor, multiplier: 0.1)])
+
+        if traitCollection.horizontalSizeClass == .compact {
+
+            NSLayoutConstraint.activate([contentViewWidthConstraint ?? NSLayoutConstraint()])
+        } else {
+
+            NSLayoutConstraint.activate([contentViewHeightConstraint ?? NSLayoutConstraint()])
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+
+        guard let previousTraitCollection = previousTraitCollection,
+              traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass else {
+            return
+        }
+
+        if traitCollection.horizontalSizeClass == .compact {
+
+            NSLayoutConstraint.deactivate([contentViewHeightConstraint ?? NSLayoutConstraint()])
+            NSLayoutConstraint.activate([contentViewWidthConstraint ?? NSLayoutConstraint()])
+        } else {
+            NSLayoutConstraint.deactivate([contentViewWidthConstraint ?? NSLayoutConstraint()])
+            NSLayoutConstraint.activate([contentViewHeightConstraint ?? NSLayoutConstraint()])
+        }
     }
 
     private func configureTitle() {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(titleLabel)
 
         titleLabel.font = WPStyleGuide.serifFontForTextStyle(.title1)
         titleLabel.textColor = .text
@@ -64,12 +133,6 @@ class UnifiedProloguePageViewController: UIViewController {
         titleLabel.numberOfLines = 0
 
         titleLabel.text = pageType.title
-
-        NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.topInset),
-            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Metrics.horizontalInset),
-            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.horizontalInset)
-        ])
     }
 
     private func configureContentView() {

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
@@ -90,6 +90,16 @@ class UnifiedProloguePageViewController: UIViewController {
         }
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        // change the scale of the view in regular horizontal size class (iPad) depending on the orientation
+        guard contentViewHeightConstraint?.isActive == true else {
+            return
+        }
+        contentViewHeightConstraint?.isActive = false
+        setContentViewHeightConstraint()
+        contentViewHeightConstraint?.isActive = true
+    }
+
     private func configureMainStackView() {
         mainStackView.axis = .vertical
         mainStackView.alignment = .center
@@ -119,21 +129,8 @@ class UnifiedProloguePageViewController: UIViewController {
     private func activateConstraints() {
         view.pinSubviewToAllEdges(mainStackView)
 
-        contentViewWidthConstraint = NSLayoutConstraint(item: contentView,
-                                                        attribute: .width,
-                                                        relatedBy: .equal,
-                                                        toItem: view,
-                                                        attribute: .width,
-                                                        multiplier: 0.7,
-                                                        constant: 0)
-
-        contentViewHeightConstraint = NSLayoutConstraint(item: contentView,
-                                                         attribute: .height,
-                                                         relatedBy: .equal,
-                                                         toItem: view,
-                                                         attribute: .height,
-                                                         multiplier: 0.5,
-                                                         constant: 0)
+        setContentViewWidthConstraint()
+        setContentViewHeightConstraint()
 
         let centeredContentViewConstraint = NSLayoutConstraint(item: contentView,
                                                                attribute: .centerY,
@@ -157,6 +154,31 @@ class UnifiedProloguePageViewController: UIViewController {
 
             NSLayoutConstraint.activate([contentViewHeightConstraint ?? NSLayoutConstraint()])
         }
+    }
+
+    private func setContentViewHeightConstraint() {
+        contentViewHeightConstraint = NSLayoutConstraint(item: contentView,
+                                                         attribute: .height,
+                                                         relatedBy: .equal,
+                                                         toItem: view,
+                                                         attribute: .height,
+                                                         multiplier: iPadHeightMultiplier,
+                                                         constant: 0)
+    }
+
+    private func setContentViewWidthConstraint() {
+        contentViewWidthConstraint = NSLayoutConstraint(item: contentView,
+                                                        attribute: .width,
+                                                        relatedBy: .equal,
+                                                        toItem: view,
+                                                        attribute: .width,
+                                                        multiplier: 0.7,
+                                                        constant: 0)
+    }
+
+    /// scale factor for the content view on iPad, depending on the orientation
+    private var iPadHeightMultiplier: CGFloat {
+        UIDevice.current.orientation.isPortrait ? 0.4 : 0.5
     }
 
     private func embedSwiftUIView<Content: View>(_ view: Content) -> UIView {

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
@@ -36,6 +36,7 @@ class UnifiedProloguePageViewController: UIViewController {
 
     private var pageType: UnifiedProloguePageType!
 
+    let mainStackView = UIStackView()
     let titleTopSpacer = UIView()
     let titleContentSpacer = UIView()
     let contentBottomSpacer = UIView()
@@ -57,28 +58,66 @@ class UnifiedProloguePageViewController: UIViewController {
         view = UIView()
         view.backgroundColor = .clear
 
-        let mainStackView = UIStackView()
+        titleTopSpacer.translatesAutoresizingMaskIntoConstraints = false
+        titleContentSpacer.translatesAutoresizingMaskIntoConstraints = false
+        contentBottomSpacer.translatesAutoresizingMaskIntoConstraints = false
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+
+        configureMainStackView()
+
+        configureTitle()
+    }
+
+    override func viewDidLoad() {
+        activateConstraints()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+
+        guard let previousTraitCollection = previousTraitCollection,
+              traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass else {
+
+            return
+        }
+
+        if traitCollection.horizontalSizeClass == .compact {
+
+            NSLayoutConstraint.deactivate([contentViewHeightConstraint ?? NSLayoutConstraint()])
+            NSLayoutConstraint.activate([contentViewWidthConstraint ?? NSLayoutConstraint()])
+        } else {
+            NSLayoutConstraint.deactivate([contentViewWidthConstraint ?? NSLayoutConstraint()])
+            NSLayoutConstraint.activate([contentViewHeightConstraint ?? NSLayoutConstraint()])
+        }
+    }
+
+    private func configureMainStackView() {
         mainStackView.axis = .vertical
         mainStackView.alignment = .center
         mainStackView.distribution = .fill
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
-        titleTopSpacer.translatesAutoresizingMaskIntoConstraints = false
 
-        titleContentSpacer.translatesAutoresizingMaskIntoConstraints = false
-
-        contentBottomSpacer.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(mainStackView)
-
-        configureTitle()
         mainStackView.addArrangedSubview(titleTopSpacer)
         mainStackView.addArrangedSubview(titleLabel)
         mainStackView.addArrangedSubview(titleContentSpacer)
         mainStackView.addArrangedSubview(contentView)
         mainStackView.addArrangedSubview(contentBottomSpacer)
-        view.pinSubviewToAllEdges(mainStackView)
+
+        view.addSubview(mainStackView)
     }
 
-    override func viewDidLoad() {
+    private func configureTitle() {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        titleLabel.font = WPStyleGuide.serifFontForTextStyle(.title1)
+        titleLabel.textColor = .text
+        titleLabel.textAlignment = .center
+        titleLabel.numberOfLines = 0
+
+        titleLabel.text = pageType.title
+    }
+
+    private func activateConstraints() {
+        view.pinSubviewToAllEdges(mainStackView)
 
         contentViewWidthConstraint = NSLayoutConstraint(item: contentView,
                                                         attribute: .width,
@@ -118,46 +157,6 @@ class UnifiedProloguePageViewController: UIViewController {
 
             NSLayoutConstraint.activate([contentViewHeightConstraint ?? NSLayoutConstraint()])
         }
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-
-        guard let previousTraitCollection = previousTraitCollection,
-              traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass else {
-            return
-        }
-
-        if traitCollection.horizontalSizeClass == .compact {
-
-            NSLayoutConstraint.deactivate([contentViewHeightConstraint ?? NSLayoutConstraint()])
-            NSLayoutConstraint.activate([contentViewWidthConstraint ?? NSLayoutConstraint()])
-        } else {
-            NSLayoutConstraint.deactivate([contentViewWidthConstraint ?? NSLayoutConstraint()])
-            NSLayoutConstraint.activate([contentViewHeightConstraint ?? NSLayoutConstraint()])
-        }
-    }
-
-    private func configureTitle() {
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-
-        titleLabel.font = WPStyleGuide.serifFontForTextStyle(.title1)
-        titleLabel.textColor = .text
-        titleLabel.textAlignment = .center
-        titleLabel.numberOfLines = 0
-
-        titleLabel.text = pageType.title
-    }
-
-    private func configureContentView() {
-        contentView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(contentView)
-
-        NSLayoutConstraint.activate([
-            contentView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: Metrics.titleToContentSpacing),
-            contentView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: Metrics.heightRatio),
-            contentView.widthAnchor.constraint(equalTo: view.heightAnchor, multiplier: Metrics.heightRatio),
-            contentView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        ])
     }
 
     private func embedSwiftUIView<Content: View>(_ view: Content) -> UIView {

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedProloguePages.swift
@@ -106,11 +106,11 @@ class UnifiedProloguePageViewController: UIViewController {
         mainStackView.distribution = .fill
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
 
-        mainStackView.addArrangedSubview(titleTopSpacer)
-        mainStackView.addArrangedSubview(titleLabel)
-        mainStackView.addArrangedSubview(titleContentSpacer)
-        mainStackView.addArrangedSubview(contentView)
-        mainStackView.addArrangedSubview(contentBottomSpacer)
+        mainStackView.addArrangedSubviews([titleTopSpacer,
+                                           titleLabel,
+                                           titleContentSpacer,
+                                           contentView,
+                                           contentBottomSpacer])
 
         view.addSubview(mainStackView)
     }


### PR DESCRIPTION
Ref #15056 

To test:

- build/run and logout if necessary
- make sure the layout on all prologue pages (except the intro page on some screens/orientations) look consistent with the designs (#15056)

Known issues:
- Title font is not right
- Title needs insets
- Intro page needs fixing

## Regression Notes
1. Potential unintended areas of impact
All prologue screens are affected

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Test layout on the following devices (all iPads tested in portrait, landscape, and all the allowed sizes of split screen on both orientations):
- iPad Air - 4th gen - iOS 14.4
- iPad Pro 11 inch - 2nd gen - iOS 14.4
- iPad Pro 12.9 inch - 4th gen - iOS 14.4
- iPad Pro 12.9 inch - 4th gen - iOS 13.5
- iPhone 11 - iOS 13.5
- iPhone 11 Pro Max - iOS 13.5
- iPhone 11 Pro Max - iOS 14.4
- iPhone 12 Pro Max - iOS 14.4
- iPhone 12 Pro - iOS 14.4
- iPhone SE 2nd gen - iOS 13.5
- iPhone SE 2nd gen - iOS 14.4
- iPod touch 7th gen - iOS 14.4

3. What automated tests I added (or what prevented me from doing so)
NA
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
