### PR TITLE
Resolve retain cycle around the Filter bar in the Layout picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collabsable Header Filter Bar/CollapsableHeaderFilterBar.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collabsable Header Filter Bar/CollapsableHeaderFilterBar.swift
@@ -8,7 +8,7 @@ protocol CollapsableHeaderFilterBarDelegate: class {
 }
 
 class CollapsableHeaderFilterBar: UICollectionView {
-    var filterDelegate: CollapsableHeaderFilterBarDelegate?
+    weak var filterDelegate: CollapsableHeaderFilterBarDelegate?
     private let defaultCellHeight: CGFloat = 44
     private let defaultCellWidth: CGFloat = 105
 

--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignStep.swift
@@ -3,11 +3,13 @@ import Foundation
 /// Site Creation. First screen: Allows selection of the home page which translates to the initial theme as well.
 final class SiteDesignStep: WizardStep {
     typealias SiteDesignSelection = (_ design: RemoteSiteDesign?) -> Void
-    var delegate: WizardDelegate?
+    weak var delegate: WizardDelegate?
     private let creator: SiteCreator
 
     private(set) lazy var content: UIViewController = {
-        return SiteDesignContentCollectionViewController(self.didSelect)
+        return SiteDesignContentCollectionViewController { [weak self] (design) in
+            self?.didSelect(design)
+        }
     }()
 
     init(creator: SiteCreator) {

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
@@ -16,7 +16,7 @@ final class SiteAssemblyStep: WizardStep {
 
     let content: UIViewController
 
-    var delegate: WizardDelegate? = nil
+    weak var delegate: WizardDelegate? = nil
 
     // MARK: SiteAssemblyStep
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressStep.swift
@@ -5,10 +5,12 @@ final class WebAddressStep: WizardStep {
     private let service: SiteAddressService
 
     private(set) lazy var content: UIViewController = {
-        return WebAddressWizardContent(creator: creator, service: self.service, selection: didSelect)
+        return WebAddressWizardContent(creator: creator, service: self.service) { [weak self] (address) in
+            self?.didSelect(address)
+        }
     }()
 
-    var delegate: WizardDelegate?
+    weak var delegate: WizardDelegate?
 
     init(creator: SiteCreator, service: SiteAddressService) {
         self.creator = creator

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizard.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizard.swift
@@ -11,9 +11,9 @@ final class SiteCreationWizard: Wizard {
         return WizardNavigation(steps: self.steps)
     }()
 
-    lazy var content: UIViewController? = {
-        return navigation?.content
-    }()
+    var content: UIViewController? {
+        return navigation
+    }
 
     // The sequence of steps to complete the wizard.
     let steps: [WizardStep]

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
@@ -52,10 +52,6 @@ final class WizardNavigation: GutenbergLightNavigationController {
             step.delegate = self
         }
     }
-
-   var content: UIViewController? {
-        return self
-    }
 }
 
 extension WizardNavigation: WizardDelegate {

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
@@ -1,8 +1,37 @@
 import UIKit
 
-// MARK: - EnhancedSiteCreationNavigationController
+// MARK: - WizardNavigation
+final class WizardNavigation: GutenbergLightNavigationController {
+    private let steps: [WizardStep]
+    private let pointer: WizardNavigationPointer
 
-private final class EnhancedSiteCreationNavigationController: GutenbergLightNavigationController {
+    private lazy var firstContentViewController: UIViewController? = {
+        guard let firstStep = self.steps.first else {
+            return nil
+        }
+        return firstStep.content
+    }()
+
+    init(steps: [WizardStep]) {
+        self.steps = steps
+        self.pointer = WizardNavigationPointer(capacity: steps.count)
+
+        guard let firstStep = self.steps.first else {
+            fatalError("Navigation Controller was initialized with no steps.")
+        }
+
+        let root = firstStep.content
+        super.init(rootViewController: root)
+
+        delegate = self.pointer
+        configureSteps()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // Navigation Overrides
     override var shouldAutorotate: Bool {
         return WPDeviceIdentification.isiPad() ? true : false
     }
@@ -17,38 +46,6 @@ private final class EnhancedSiteCreationNavigationController: GutenbergLightNavi
         }
         return super.preferredStatusBarStyle
     }
-}
-
-// MARK: - WizardNavigation
-
-final class WizardNavigation {
-    private let steps: [WizardStep]
-    private let pointer: WizardNavigationPointer
-
-    private lazy var navigationController: UINavigationController? = {
-        guard let root = self.firstContentViewController else {
-            return nil
-        }
-
-        let returnValue = EnhancedSiteCreationNavigationController(rootViewController: root)
-        returnValue.delegate = self.pointer
-        return returnValue
-    }()
-
-    private lazy var firstContentViewController: UIViewController? = {
-        guard let firstStep = self.steps.first else {
-            return nil
-        }
-        return firstStep.content
-    }()
-
-
-    init(steps: [WizardStep]) {
-        self.steps = steps
-        self.pointer = WizardNavigationPointer(capacity: steps.count)
-
-        configureSteps()
-    }
 
     private func configureSteps() {
         for var step in steps {
@@ -56,17 +53,16 @@ final class WizardNavigation {
         }
     }
 
-    lazy var content: UIViewController? = {
-        return self.navigationController
-    }()
+   var content: UIViewController? {
+        return self
+    }
 }
 
 extension WizardNavigation: WizardDelegate {
     func nextStep() {
-        guard let navigationController = navigationController, let nextStepIndex = pointer.nextIndex else {
+        guard let nextStepIndex = pointer.nextIndex else {
             // If we find this statement in Fabric, it suggests 11388 might not have been resolved
             DDLogInfo("We've exceeded the max index of our wizard navigation steps (i.e., \(pointer.currentIndex)")
-
             return
         }
 
@@ -74,11 +70,11 @@ extension WizardNavigation: WizardDelegate {
         let nextViewController = nextStep.content
 
         // If we find this statement in Fabric, it's likely that we haven't resolved 11388
-        if navigationController.viewControllers.contains(nextViewController) {
+        if viewControllers.contains(nextViewController) {
             DDLogInfo("Attempting to push \(String(describing: nextViewController.title)) when it's already on the navigation stack!")
         }
 
-        navigationController.pushViewController(nextViewController, animated: true)
+        pushViewController(nextViewController, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Wizards/WizardDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Wizards/WizardDelegate.swift
@@ -1,3 +1,3 @@
-protocol WizardDelegate {
+protocol WizardDelegate: class {
     func nextStep()
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/16198

## To test:
1. Navigate to site creation design picker and/or the page creation page picker multiple times
2. Check the memory graph to make sure all instances of `SiteDesignContentCollectionViewController` and `GutenbergLayoutPickerViewController` (respectively) have been cleaned up.
3. Navigate to these screens and interact with the filter bar and make sure it behaves as expected.

This also adjusts the object graph for the site creation flow so to test walk-through site creation once.

## Regression Notes
1. Potential unintended areas of impact
This manages the callbacks for the filter bar in the page template picker (new page creation) and the site design picker (new site creation)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
This can be manually tested by clicking on the different filter options within this UI and verifying it behaves as expected. 

3. What automated tests I added (or what prevented me from doing so)
These are more UI-based operations. 

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
