### PR TITLE
Fix Sharing webview nav bar colors

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -265,8 +265,10 @@ extension UIColor {
     }
 }
 
+@objc
 extension UIColor {
     // A way to create dynamic colors that's compatible with iOS 11 & 12
+    @objc
     convenience init(light: UIColor, dark: UIColor) {
         self.init { traitCollection in
             if traitCollection.userInterfaceStyle == .dark {

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColorsObjC.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColorsObjC.swift
@@ -135,4 +135,9 @@
     static func murielAppBarText() -> UIColor {
         return .appBarText
     }
+
+    @available(swift, obsoleted: 1.0)
+    static func murielAppBarBackground() -> UIColor {
+        return .appBarBackground
+    }
 }

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -109,9 +109,9 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     self.forwardButton.image                = [[UIImage gridiconOfType:GridiconTypeChevronRight] imageFlippedForRightToLeftLayoutDirection];
 
     // Toolbar: Hidden by default!
-    self.toolbar.barTintColor               = [UIColor whiteColor];
-    self.backButton.tintColor               = [UIColor murielNeutral20];
-    self.forwardButton.tintColor            = [UIColor murielNeutral20];
+    self.toolbar.barTintColor               = [[UIColor alloc] initWithLight:[UIColor whiteColor] dark:[UIColor murielAppBarBackground]];
+    self.backButton.tintColor               = [UIColor murielListIcon];
+    self.forwardButton.tintColor            = [UIColor murielListIcon];
     self.toolbarBottomConstraint.constant   = WPWebViewToolbarHiddenConstant;
 
     // Share
@@ -127,7 +127,7 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     [self loadWebViewRequest];
 
     if (UIAccessibilityIsBoldTextEnabled()) {
-        self.navigationController.navigationBar.tintColor = [UIColor murielNeutral20];
+        self.navigationController.navigationBar.tintColor = [UIColor murielListIcon];
     }
 }
 
@@ -145,19 +145,13 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
         return;
     }
 
-    UIImage *navBackgroundImage             = [UIImage imageWithColor:[WPStyleGuide webViewModalNavigationBarBackground]];
-    UIImage *navShadowImage                 = [UIImage imageWithColor:[WPStyleGuide webViewModalNavigationBarShadow]];
-
-    UINavigationBar *navigationBar          = self.navigationController.navigationBar;
-    navigationBar.shadowImage               = navShadowImage;
-    navigationBar.barStyle                  = UIBarStyleDefault;
-    [navigationBar setBackgroundImage:navBackgroundImage forBarMetrics:UIBarMetricsDefault];
-
-    self.titleView.titleLabel.textColor     = [UIColor whiteColor];
-    self.titleView.subtitleLabel.textColor  = [UIColor whiteColor];
-
-    self.dismissButton.tintColor            = [UIColor whiteColor];
-    self.optionsButton.tintColor            = [UIColor whiteColor];
+    if ([Feature enabled:FeatureFlagNewNavBarAppearance]) {
+        self.titleView.titleLabel.textColor     = [UIColor murielText];
+        self.titleView.subtitleLabel.textColor  = [UIColor murielNeutral30];
+    } else {
+        self.titleView.titleLabel.textColor     = [UIColor whiteColor];
+        self.titleView.subtitleLabel.textColor  = [UIColor whiteColor];
+    }
 
     self.navigationItem.leftBarButtonItem   = self.dismissButton;
 }

--- a/WordPress/Classes/Utility/WPWebViewController.xib
+++ b/WordPress/Classes/Utility/WPWebViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,7 +24,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IBv-yN-stu">
-                    <rect key="frame" x="20" y="20" width="280" height="416"/>
+                    <rect key="frame" x="0.0" y="44" width="320" height="392"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <wkWebViewConfiguration key="configuration" allowsInlineMediaPlayback="YES">
                         <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" audio="YES" video="YES"/>
@@ -57,15 +57,15 @@
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="IBv-yN-stu" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="Cte-l4-V7j"/>
+                <constraint firstItem="IBv-yN-stu" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="Cte-l4-V7j"/>
                 <constraint firstAttribute="trailing" secondItem="KoJ-2F-0M7" secondAttribute="trailing" id="ISH-w3-feS"/>
                 <constraint firstAttribute="bottom" secondItem="AXg-oh-s2G" secondAttribute="bottom" id="Nlf-af-GR4"/>
-                <constraint firstItem="IBv-yN-stu" firstAttribute="top" secondItem="1" secondAttribute="top" constant="20" symbolic="YES" id="PbC-8b-MZC"/>
+                <constraint firstItem="IBv-yN-stu" firstAttribute="top" secondItem="1" secondAttribute="topMargin" id="PbC-8b-MZC"/>
                 <constraint firstItem="KoJ-2F-0M7" firstAttribute="top" secondItem="1" secondAttribute="top" id="R7H-hb-JSn"/>
                 <constraint firstItem="KoJ-2F-0M7" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="XPs-kd-Qp3"/>
                 <constraint firstItem="AXg-oh-s2G" firstAttribute="top" secondItem="IBv-yN-stu" secondAttribute="bottom" symbolic="YES" id="Y8P-zj-I7e"/>
                 <constraint firstAttribute="trailing" secondItem="AXg-oh-s2G" secondAttribute="trailing" id="c0p-pM-tqz"/>
-                <constraint firstAttribute="trailing" secondItem="IBv-yN-stu" secondAttribute="trailing" constant="20" symbolic="YES" id="f9S-JN-LYn"/>
+                <constraint firstAttribute="trailing" secondItem="IBv-yN-stu" secondAttribute="trailing" id="f9S-JN-LYn"/>
                 <constraint firstItem="AXg-oh-s2G" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="hjY-y9-jer"/>
             </constraints>
             <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>

--- a/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
@@ -59,7 +59,7 @@ import WordPressShared
     fileprivate func configureNavbar() {
         let image = UIImage.gridicon(.cross)
         let closeButton = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(SharingAccountViewController.handleCloseTapped(_:)))
-        closeButton.tintColor = UIColor.white
+        closeButton.tintColor = FeatureFlag.newNavBarAppearance.enabled ? .appBarTint : UIColor.white
         navigationItem.leftBarButtonItem = closeButton
 
         // The preceding WPWebViewController changes the default navbar appearance. Restore it.

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationHelper.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationHelper.m
@@ -93,7 +93,11 @@
 {
     SharingAuthorizationWebViewController *webViewController = [[SharingAuthorizationWebViewController alloc] initWith:self.publicizeService url:connectionURL for:self.blog delegate:self];
 
-    self.navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
+    if ([Feature enabled:FeatureFlagNewNavBarAppearance]) {
+        self.navController = [[LightNavigationController alloc] initWithRootViewController:webViewController];
+    } else {
+        self.navController = [[UINavigationController alloc] initWithRootViewController:webViewController];
+    }
     self.navController.modalPresentationStyle = UIModalPresentationFormSheet;
     [self.viewController presentViewController:self.navController animated:YES completion:nil];
 }


### PR DESCRIPTION
This PR fixes an issue in the Sharing section of My Site, where content in the navigation bar of presented webviews was invisible.

|    |    |    |
|---|---|---|
| ![IMG_0066](https://user-images.githubusercontent.com/4780/113193404-d6e3de80-9257-11eb-83e0-a07427cab731.PNG) | ![IMG_0065](https://user-images.githubusercontent.com/4780/113194009-87ea7900-9258-11eb-9b10-22a67e964877.PNG) | ![IMG_0067](https://user-images.githubusercontent.com/4780/113194021-8e78f080-9258-11eb-98f7-2934ed02ce94.PNG) |

I also fixed a layout issue where the webview didn't extend all the way to the edges of its container.

**To test**

- Test with `newNavBarAppearance` feature flag both on and off
- Build and run
- Navigate to My Site > Sharing
- Tap a connection type to present the web view (e.g. Twitter). Connect a site and ensure the nav bar items are visible the whole time.
- Check the code to see that WPWebViewController isn't used anywhere else, so these changes should affect other areas of the app.

## Regression Notes

1. Potential unintended areas of impact

Other webviews or navigation bars.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I checked the code to ensure that these changes shouldn't impact other webviews. I also tested webviews in the Reader to ensure they still looked good.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
