### PR TITLE
Jetpack: change "My site" icon

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppStyleGuide.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppStyleGuide.swift
@@ -21,3 +21,8 @@ extension AppStyleGuide {
     static let warning = MurielColor(name: .yellow)
     static let jetpackGreen = MurielColor(name: .jetpackGreen)
 }
+
+// MARK: - Images
+extension AppStyleGuide {
+    static let mySiteTabIcon = UIImage(named: "icon-tab-mysites")
+}

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -66,7 +66,7 @@ class MySitesCoordinator: NSObject {
         navigationController.restorationIdentifier = MySitesCoordinator.navigationControllerRestorationID
         navigationController.navigationBar.isTranslucent = false
 
-        let tabBarImage = UIImage(named: "icon-tab-mysites")
+        let tabBarImage = AppStyleGuide.mySiteTabIcon
         navigationController.tabBarItem.image = tabBarImage
         navigationController.tabBarItem.selectedImage = tabBarImage
         navigationController.tabBarItem.accessibilityLabel = NSLocalizedString("My Site", comment: "The accessibility value of the my site tab.")

--- a/WordPress/Jetpack/AppStyleGuide.swift
+++ b/WordPress/Jetpack/AppStyleGuide.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressShared
+import Gridicons
 
 struct AppStyleGuide {
     static let navigationBarStandardFont: UIFont = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
@@ -20,4 +21,9 @@ extension AppStyleGuide {
     static let textSubtle = MurielColor(name: .gray, shade: .shade50)
     static let warning = MurielColor(name: .yellow)
     static let jetpackGreen = MurielColor(name: .jetpackGreen)
+}
+
+// MARK: - Images
+extension AppStyleGuide {
+    static let mySiteTabIcon = UIImage.gridicon(.house)
 }


### PR DESCRIPTION
Depends on https://github.com/wordpress-mobile/WordPress-iOS/pull/16201

Changes the "My site" tab bar icon for Jetpack

### To test

1. Run WordPress
2. The "My Site" tab icon should be the W logo
3. Run Jetpack
4. The "My Site" tab icon should be a house

| Jetpack | WordPress |
| -------- | ----------- |
| ![Simulator Screen Shot - iPhone 11 - 2021-03-31 at 16 03 13](https://user-images.githubusercontent.com/7040243/113197465-17812f00-923b-11eb-9fea-3cae0cca2209.png) | ![Simulator Screen Shot - iPhone 11 - 2021-03-31 at 16 03 22](https://user-images.githubusercontent.com/7040243/113197498-223bc400-923b-11eb-82df-16f3f8acc7fe.png) |



## Regression Notes
1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Tested on both Jetpack and WordPress.

3. What automated tests I added (or what prevented me from doing so)

Just a visual change. I could test it with a snapshot test or a unit test, but it would be just a get test so I don't think it worths it.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
