### PR TITLE
Replace uses of WordPressBlue with Blue50

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+WordPressColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+WordPressColors.swift
@@ -9,7 +9,7 @@ extension UIColor {
             return .secondarySystemGroupedBackground
         }
 
-        return UIColor(light: .brand, dark: .gray(.shade100))
+        return UIColor(light: .primary, dark: .gray(.shade100))
     }
 
     static var appBarTint: UIColor {
@@ -18,6 +18,10 @@ extension UIColor {
         }
 
         return .white
+    }
+
+    static var lightAppBarTint: UIColor {
+        return UIColor(light: .primary, dark: .white)
     }
 
     static var appBarText: UIColor {

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -21,19 +21,6 @@ extension WPStyleGuide {
         return AppStyleGuide.navigationBarLargeFont
     }
 
-    // MARK: - styles used before Muriel colors are enabled
-    public class func navigationBarBackgroundImage() -> UIImage {
-        return UIImage(color: WPStyleGuide.wordPressBlue())
-    }
-
-    public class func navigationBarBarStyle() -> UIBarStyle {
-        return .black
-    }
-
-    public class func navigationBarShadowImage() -> UIImage {
-        return UIImage(color: UIColor(fromHex: 0x007eb1))
-    }
-
     class func configureDefaultTint() {
         UIWindow.appearance().tintColor = .primary
     }

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -110,7 +110,7 @@ extension WPStyleGuide {
         appearance.shadowColor = separatorColor
         navigationBarAppearanceProxy.standardAppearance = appearance
 
-        let tintColor = UIColor(light: .brand, dark: .white)
+        let tintColor = UIColor.lightAppBarTint
 
         let buttonBarAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [LightNavigationController.self])
         buttonBarAppearance.tintColor = tintColor

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -533,7 +533,7 @@ extension WordPressAppDelegate {
 
         appearance.actionFont = WPStyleGuide.fontForTextStyle(.headline)
         appearance.infoFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
-        appearance.infoTintColor = WPStyleGuide.wordPressBlue()
+        appearance.infoTintColor = .primary
 
         appearance.topDividerColor = .neutral(.shade5)
         appearance.bottomDividerColor = .neutral(.shade0)
@@ -800,7 +800,7 @@ extension WordPressAppDelegate {
 extension WordPressAppDelegate {
     func customizeAppearance() {
         window?.backgroundColor = .black
-        window?.tintColor = WPStyleGuide.wordPressBlue()
+        window?.tintColor = .primary
 
         // iOS 14 started rendering backgrounds for stack views, when previous versions
         // of iOS didn't show them. This is a little hacky, but ensures things keep

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -50,7 +50,7 @@ import AutomatticTracks
     @objc init(imageView: CachedAnimatedImageView, gifStrategy: GIFStrategy = .mediumGIFs) {
         self.imageView = imageView
         imageView.gifStrategy = gifStrategy
-        loadingIndicator = CircularProgressView(style: .wordPressBlue)
+        loadingIndicator = CircularProgressView(style: .primary)
 
         super.init()
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
@@ -61,13 +61,6 @@ import WordPressShared
         let closeButton = UIBarButtonItem(image: image, style: .plain, target: self, action: #selector(SharingAccountViewController.handleCloseTapped(_:)))
         closeButton.tintColor = UIColor.white
         navigationItem.leftBarButtonItem = closeButton
-
-        // The preceding WPWebViewController changes the default navbar appearance. Restore it.
-        if let navBar = navigationController?.navigationBar {
-            navBar.shadowImage = WPStyleGuide.navigationBarShadowImage()
-            navBar.setBackgroundImage(WPStyleGuide.navigationBarBackgroundImage(), for: .default)
-            navBar.barStyle = WPStyleGuide.navigationBarBarStyle()
-        }
     }
 
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLightNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLightNavigationController.swift
@@ -20,7 +20,7 @@ class GutenbergLightNavigationController: UINavigationController {
         navigationBar.barStyle = .default
         navigationBar.barTintColor = .white
 
-        let tintColor = UIColor(light: .brand, dark: .white)
+        let tintColor = UIColor.lightAppBarTint
         let barButtonItemAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [GutenbergLightNavigationController.self])
         barButtonItemAppearance.tintColor = tintColor
         barButtonItemAppearance.setTitleTextAttributes([NSAttributedString.Key.font: WPFontManager.systemRegularFont(ofSize: 17.0),

--- a/WordPress/Classes/ViewRelated/Media/CircularProgressView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CircularProgressView.swift
@@ -28,13 +28,13 @@ class CircularProgressView: UIView {
 
     @objc(CircularProgressViewStyle)
     enum Style: Int {
-        case wordPressBlue
+        case primary
         case white
         case mediaCell
 
         fileprivate var appearance: Appearance {
             switch self {
-            case .wordPressBlue:
+            case .primary:
                 return Appearance(
                     progressIndicatorAppearance: ProgressIndicatorView.Appearance(lineColor: .primary(.shade40)),
                     backgroundColor: .clear,

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -73,7 +73,7 @@ class WordPressAuthenticationManager: NSObject {
                                                 buttonViewBackgroundColor: .authButtonViewBackground,
                                                 navBarImage: .gridicon(.mySites),
                                                 navBarBadgeColor: .accent(.shade20),
-                                                navBarBackgroundColor: UIColor(light: .brand, dark: .gray(.shade100)),  // NEWBARS - This is temporary while we support old style nav bars in some of the auth flows
+                                                navBarBackgroundColor: FeatureFlag.newNavBarAppearance.enabled ? .appBarBackground : UIColor(light: .primary, dark: .gray(.shade100)),
                                                 prologueBackgroundColor: .primary,
                                                 prologueTitleColor: .textInverted,
                                                 prologueTopContainerChildViewController: prologueVC,
@@ -86,9 +86,9 @@ class WordPressAuthenticationManager: NSObject {
                                                               textButtonColor: .primary,
                                                               textButtonHighlightColor: .primaryDark,
                                                               viewControllerBackgroundColor: .basicBackground,
-                                                              navBarBackgroundColor: .basicBackground,  // TODO: NEWBARS -  Replace with .appBarBackground once new nav bar styles are merged
-                                                              navButtonTextColor: .brand,   // TODO: NEWBARS - Replace with .appBarTint
-                                                              navTitleTextColor: .text)     // TODO: NEWBARS - Replace with .appBarText
+                                                              navBarBackgroundColor: FeatureFlag.newNavBarAppearance.enabled ? .appBarBackground : .basicBackground,
+                                                              navButtonTextColor: FeatureFlag.newNavBarAppearance.enabled ? .appBarTint : .primary,
+                                                              navTitleTextColor: FeatureFlag.newNavBarAppearance.enabled ? .appBarText : .text)
 
         WordPressAuthenticator.initialize(configuration: configuration,
                                           style: style,

--- a/WordPress/Classes/ViewRelated/Notifications/Milestone Notifications/ConfettiView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Milestone Notifications/ConfettiView.swift
@@ -190,14 +190,14 @@ extension ConfettiView {
 
         let red = UIColor(light: .muriel(name: .red, .shade10), dark: .muriel(name: .red, .shade30))
 
-        let wpBlue = UIColor(light: .muriel(name: .wordPressBlue, .shade30), dark: .muriel(name: .wordPressBlue, .shade50))
+        let blue = UIColor(light: .muriel(name: .blue, .shade30), dark: .muriel(name: .blue, .shade50))
 
         let yellow = UIColor(light: .muriel(name: .yellow, .shade10), dark: .muriel(name: .yellow, .shade30))
 
 
-        let starParticles = [purple, orange, green, wpBlue].map { Particle(image: star, tintColor: $0) }
+        let starParticles = [purple, orange, green, blue].map { Particle(image: star, tintColor: $0) }
         let circleParticles = [celadon, pink, red, yellow].map { Particle(image: circle, tintColor: $0) }
-        let hotdogParticles = [orange, pink, wpBlue, red].map { Particle(image: hotdog, tintColor: $0) }
+        let hotdogParticles = [orange, pink, blue, red].map { Particle(image: hotdog, tintColor: $0) }
 
         let particles = starParticles + circleParticles + hotdogParticles
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -316,17 +316,17 @@ extension DateCell {
             dateLabel.backgroundColor = .clear
         case .left:
             textColor = .white
-            dateLabel.backgroundColor = WPStyleGuide.wordPressBlue()
+            dateLabel.backgroundColor = .primary
             rightPlaceholder.backgroundColor = Constants.selectedColor
         case .right:
             textColor = .white
-            dateLabel.backgroundColor = WPStyleGuide.wordPressBlue()
+            dateLabel.backgroundColor = .primary
             leftPlaceholder.backgroundColor = Constants.selectedColor
         case .full:
             textColor = .textInverted
             leftPlaceholder.backgroundColor = .clear
             rightPlaceholder.backgroundColor = .clear
-            dateLabel.backgroundColor = WPStyleGuide.wordPressBlue()
+            dateLabel.backgroundColor = .primary
         case .none:
             leftPlaceholder.backgroundColor = .clear
             rightPlaceholder.backgroundColor = .clear

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Pages.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Pages.m
@@ -11,7 +11,7 @@
 + (void)applyRestorePageLabelStyle:(UILabel *)label
 {
     label.font = [WPStyleGuide regularFont];
-    label.textColor = [self grey];
+    label.textColor = [UIColor murielTextSubtle];
 }
 
 + (void)applyRestorePageButtonStyle:(UIButton *)button
@@ -19,14 +19,13 @@
     [WPStyleGuide configureLabel:button.titleLabel
                        textStyle:UIFontTextStyleCallout
                       fontWeight:UIFontWeightSemibold];
-    [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
-    [button setTitleColor:[WPStyleGuide darkBlue] forState:UIControlStateHighlighted];
+    [button setTitleColor:[UIColor murielPrimary] forState:UIControlStateNormal];
 }
 
 + (void)applyRestoreSavedPostLabelStyle:(UILabel *)label
 {
     [WPStyleGuide configureLabel:label textStyle:UIFontTextStyleCallout];
-    label.textColor = [self greyDarken10];
+    label.textColor = [UIColor murielTextSubtle];
 }
 
 + (void)applyRestoreSavedPostTitleLabelStyle:(UILabel *)label
@@ -39,7 +38,7 @@
     UIFontDescriptorSymbolicTraits traits = [descriptor symbolicTraits];
     descriptor = [descriptor fontDescriptorWithSymbolicTraits:traits | UIFontDescriptorTraitItalic];
     label.font = [UIFont fontWithDescriptor:descriptor size:label.font.pointSize];
-    label.textColor = [self greyDarken10];
+    label.textColor = [UIColor murielTextSubtle];
 }
 
 + (void)applyRestoreSavedPostButtonStyle:(UIButton *)button
@@ -47,8 +46,7 @@
     [WPStyleGuide configureLabel:button.titleLabel
                        textStyle:UIFontTextStyleCallout
                       fontWeight:UIFontWeightSemibold];
-    [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
-    [button setTitleColor:[WPStyleGuide darkBlue] forState:UIControlStateHighlighted];
+    [button setTitleColor:[UIColor murielPrimary] forState:UIControlStateNormal];
 }
 
 + (UIFont *)regularFont {

--- a/WordPress/Launch Screen.storyboard
+++ b/WordPress/Launch Screen.storyboard
@@ -25,7 +25,7 @@
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" name="WordPressBlue50"/>
+                        <color key="backgroundColor" name="Blue50"/>
                         <constraints>
                             <constraint firstItem="FfR-yo-4a1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="T0u-ej-Kyp"/>
                             <constraint firstItem="FfR-yo-4a1" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="a6p-Lx-MaV"/>
@@ -39,8 +39,8 @@
     </scenes>
     <resources>
         <image name="icon-wp" width="50" height="52"/>
-        <namedColor name="WordPressBlue50">
-            <color red="0.0" green="0.37647058823529411" blue="0.53333333333333333" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        <namedColor name="Blue50">
+            <color red="0.023529411764705882" green="0.45882352941176469" blue="0.7686274509803922" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
Fixes #15852. This PR replaces uses of WordPressBlue in the app with Blue50. For the most part I've done this by replacing uses of `brand` with `primary`.

The areas of the app affected are:

- Navigation bar background (with new nav bar appearance off) and button tint color (with new nav bar appearance on)
- Light navigation bar used in web views and new page layout creation flow
- Image circular loading indicators
- The NUX flows (nav bars and prologue background with old prologue
- Splash screen
- Confetti view
- Calendar / date selection in the editor
- Undo row when deleting a page from a site
- Undo row when ‘unsaving’ an item from the Saved view in the Reader

Note: there are a few remaining references to WordPressBlue in WordPressShared and WordPressAuthenticator, but these don't appear to actually be used. We can remove them later.

Here are some example screenshots:

|   |   |   |
|---|---|---|
| ![IMG_0069](https://user-images.githubusercontent.com/4780/113198230-971ff580-925d-11eb-8259-70aa6147e26a.PNG) | ![IMG_0070](https://user-images.githubusercontent.com/4780/113198248-9e470380-925d-11eb-81ab-521d49b2ca0d.PNG) | ![IMG_0071](https://user-images.githubusercontent.com/4780/113198254-a010c700-925d-11eb-9a23-99c6ad92b232.PNG) |
| ![IMG_0075](https://user-images.githubusercontent.com/4780/113198319-b159d380-925d-11eb-8f16-76810fa4920b.PNG) | ![IMG_0073](https://user-images.githubusercontent.com/4780/113198323-b1f26a00-925d-11eb-9656-03572ab96b53.PNG) | ![IMG_0077](https://user-images.githubusercontent.com/4780/113198336-b4ed5a80-925d-11eb-8535-9c81f7b2f2c4.PNG) |
| ![IMG_0078](https://user-images.githubusercontent.com/4780/113198347-b7e84b00-925d-11eb-8a83-b04143ba2b4c.PNG) | ![IMG_0080](https://user-images.githubusercontent.com/4780/113198360-bc146880-925d-11eb-8add-533ecc39241a.PNG) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-31 at 20 32 04](https://user-images.githubusercontent.com/4780/113200488-452c9f00-9260-11eb-9204-b0e6d4b3261a.png) |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-31 at 20 32 04](https://user-images.githubusercontent.com/4780/113200488-452c9f00-9260-11eb-9204-b0e6d4b3261a.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-31 at 20 31 54](https://user-images.githubusercontent.com/4780/113200492-45c53580-9260-11eb-8353-5ade4811df17.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-31 at 20 31 23](https://user-images.githubusercontent.com/4780/113200495-46f66280-9260-11eb-82c0-a1c77911672b.png) |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-31 at 20 31 14](https://user-images.githubusercontent.com/4780/113200498-46f66280-9260-11eb-95d4-8c212dabf9ca.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-03-31 at 20 30 40](https://user-images.githubusercontent.com/4780/113200499-478ef900-9260-11eb-98c5-27d1ca739f0f.png) | |


The old style headers look kind of odd, but if things go to plan we won't be using those again!

**To test**

- Build and run. Test in light and dark mode.
- Check each of the areas mentioned above, and ensure things look okay.
- Smoke test the rest of the app to check nothing looks out of place.

## Regression Notes

1. Potential unintended areas of impact

The changes are fairly limited, it's mainly a case of whether anything doesn't look good.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

The main place I did extra testing was navigation bars, as we use a range of different styles across the app. I also checked through each area the changes touched, and searched the codebase for other uses that could be affected or needed to be changed.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.