### PR TITLE
Reader > Related Posts: fix button states when post fails to load

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -184,10 +184,17 @@ class ReaderDetailCoordinator {
     /// Open the postURL in a separated view controller
     ///
     func openInBrowser() {
-        guard
-            let permaLink = post?.permaLink,
-            let postURL = URL(string: permaLink)
-        else {
+
+        let url: URL? = {
+            // For Reader posts, use post link.
+            if let permaLink = post?.permaLink {
+                return URL(string: permaLink)
+            }
+            // For Related posts, use postURL.
+            return postURL
+        }()
+
+        guard let postURL = url else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -109,6 +109,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         return WPTabBarController.sharedInstance()?.readerNavigationController.viewControllers.contains(self) == false
     }
 
+    /// Used to disable ineffective buttons when a Related post fails to load.
+    var enableRightBarButtons = true
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -488,6 +491,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         coordinator.remoteSimplePost = simplePost
         controller.coordinator = coordinator
 
+        controller.postLoadFailureBlock = {
+            controller.enableRightBarButtons = false
+        }
+
         return controller
     }
 
@@ -704,9 +711,11 @@ private extension ReaderDetailViewController {
 private extension ReaderDetailViewController {
 
     func configureNavigationBar() {
+
+        // If a Related post fails to load, disable the More and Share buttons as they won't do anything.
         let rightItems = [
-            moreButtonItem(),
-            shareButtonItem(),
+            moreButtonItem(enabled: enableRightBarButtons),
+            shareButtonItem(enabled: enableRightBarButtons),
             safariButtonItem()
         ]
 
@@ -748,19 +757,22 @@ private extension ReaderDetailViewController {
         return button
     }
 
-    func moreButtonItem() -> UIBarButtonItem? {
+    func moreButtonItem(enabled: Bool = true) -> UIBarButtonItem? {
         guard let icon = UIImage(named: "icon-menu-vertical-ellipsis") else {
             return nil
         }
 
         let button = barButtonItem(with: icon, action: #selector(didTapMenuButton(_:)))
         button.accessibilityLabel = Strings.moreButtonAccessibilityLabel
+        button.isEnabled = enabled
+
         return button
     }
 
-    func shareButtonItem() -> UIBarButtonItem? {
+    func shareButtonItem(enabled: Bool = true) -> UIBarButtonItem? {
         let button = barButtonItem(with: .gridicon(.shareiOS), action: #selector(didTapShareButton(_:)))
         button.accessibilityLabel = Strings.shareButtonAccessibilityLabel
+        button.isEnabled = enabled
 
         return button
     }


### PR DESCRIPTION
Fixes #16098 
Ref: p5T066-21h-p2#comment-7554

This fixes the button states when a Related post fails to load.
- The `Open in browser` button now opens the site in a browser.
- The More and Share nav bar buttons are now disabled.
- The Safari nav bar button is still enabled, and now opens the site in a browser.

To test:
- Go to the Reader and select a post.
- Scroll down to the Related posts.
- Select a post that fails to load.
  - Failures seem to be random, and may take a few tries of different Related posts. But in my testing, it wasn't very hard to find one.
- Verify:
  - The `Open in browser` button opens the site in a browser.
  - The More and Share nav bar buttons are disabled.
  - The Safari nav bar button opens the site in a browser.

<kbd>![post_fail](https://user-images.githubusercontent.com/1816888/113220239-156d9f00-9240-11eb-8cf2-62ea17e44b1d.png)</kbd>

## Regression Notes
1. Potential unintended areas of impact
The right nav bar buttons on the post details view should not be impacted. i.e. they should all be enabled and work as expected.

<kbd><img width="460" alt="Screen Shot 2021-03-31 at 4 35 45 PM" src="https://user-images.githubusercontent.com/1816888/113219775-4ac5bd00-923f-11eb-844d-d808dff103bc.png"></kbd>

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified the buttons worked as expected.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
