### PR TITLE
Unified prologue - add background circles

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/ContentViews/Background/UnifiedPrologueBackgroundView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/ContentViews/Background/UnifiedPrologueBackgroundView.swift
@@ -1,0 +1,9 @@
+//
+//  UnifiedPrologueBackgroundView.swift
+//  WordPress
+//
+//  Created by Giorgio Ruscigno on 3/31/21.
+//  Copyright © 2021 WordPress. All rights reserved.
+//
+
+import Foundation

--- a/WordPress/Classes/ViewRelated/NUX/ContentViews/Background/UnifiedPrologueBackgroundView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/ContentViews/Background/UnifiedPrologueBackgroundView.swift
@@ -1,9 +1,80 @@
-//
-//  UnifiedPrologueBackgroundView.swift
-//  WordPress
-//
-//  Created by Giorgio Ruscigno on 3/31/21.
-//  Copyright © 2021 WordPress. All rights reserved.
-//
+import SwiftUI
 
-import Foundation
+struct UnifiedPrologueBackgroundView: View {
+    var body: some View {
+        GeometryReader { content in
+            let height = content.size.height
+            let width = content.size.width
+            let radius = min(height, width) * 0.16
+
+            VStack {
+                // This is a bit of a hack, but without this disabled ScrollView,
+                // the position of circles would change depending on some traits changes.
+                ScrollView {
+                    CircledPathView(center: CGPoint(x: radius, y: -radius * 0.5),
+                                    radius: radius,
+                                    startAngle: 335,
+                                    endAngle: 180,
+                                    clockWise: false,
+                                    color: Color(UIColor.muriel(name: .purple, .shade10)),
+                                    lineWidth: 3.0)
+
+                    CircledPathView(center: CGPoint(x: width + radius / 4, y: height - radius * 1.5),
+                                    radius: radius,
+                                    startAngle: 90,
+                                    endAngle: 270,
+                                    clockWise: false,
+                                    color: Color(UIColor.muriel(name: .green, .shade10)),
+                                    lineWidth: 3.0)
+
+                    CircledPathView(center: CGPoint(x: 0, y: height - radius * 2),
+                                    radius: radius,
+                                    startAngle: 270,
+                                    endAngle: 90,
+                                    clockWise: false,
+                                    color: Color(UIColor.muriel(name: .blue, .shade20)),
+                                    lineWidth: 3.0)
+                }
+                .disabled(true)
+            }
+        }
+    }
+}
+
+struct CircledPathView: View {
+    let center: CGPoint
+    let radius: CGFloat
+    let startAngle: Double
+    let endAngle: Double
+    let clockWise: Bool
+    let color: Color
+    let lineWidth: CGFloat
+
+    var body: some View {
+        Path { path in
+            path.addArc(center: center,
+                        radius: radius,
+                        startAngle: .degrees(startAngle),
+                        endAngle: .degrees(endAngle),
+                        clockwise: clockWise)
+        }
+        .stroke(color, lineWidth: lineWidth)
+
+    }
+}
+
+
+struct Arc: Shape {
+    let center: CGPoint
+    let radius: CGFloat
+    let startAngle: Double
+    let endAngle: Double
+    let clockwise: Bool
+
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+
+        p.addArc(center: CGPoint(x: rect.origin.x + radius, y: rect.origin.y + radius), radius: radius, startAngle: .degrees(startAngle), endAngle: .degrees(endAngle), clockwise: clockwise)
+        return p
+    }
+}

--- a/WordPress/Classes/ViewRelated/NUX/ContentViews/Background/UnifiedPrologueBackgroundView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/ContentViews/Background/UnifiedPrologueBackgroundView.swift
@@ -7,6 +7,11 @@ struct UnifiedPrologueBackgroundView: View {
             let width = content.size.width
             let radius = min(height, width) * 0.16
 
+            let purpleCircleColor = Color(UIColor(light: .muriel(name: .purple, .shade10), dark: .muriel(name: .purple, .shade70)))
+            let greenCircleColor = Color(UIColor(light: .muriel(name: .celadon, .shade5), dark: .muriel(name: .celadon, .shade70)))
+            let blueCircleColor = Color(UIColor(light: .muriel(name: .blue, .shade20), dark: .muriel(name: .blue, .shade80)))
+            let circleOpacity: Double = 0.8
+
             VStack {
                 // This is a bit of a hack, but without this disabled ScrollView,
                 // the position of circles would change depending on some traits changes.
@@ -16,24 +21,27 @@ struct UnifiedPrologueBackgroundView: View {
                                     startAngle: 335,
                                     endAngle: 180,
                                     clockWise: false,
-                                    color: Color(UIColor.muriel(name: .purple, .shade10)),
+                                    color: purpleCircleColor,
                                     lineWidth: 3.0)
+                        .opacity(circleOpacity)
 
                     CircledPathView(center: CGPoint(x: width + radius / 4, y: height - radius * 1.5),
                                     radius: radius,
                                     startAngle: 90,
                                     endAngle: 270,
                                     clockWise: false,
-                                    color: Color(UIColor.muriel(name: .green, .shade10)),
+                                    color: greenCircleColor,
                                     lineWidth: 3.0)
+                        .opacity(circleOpacity)
 
                     CircledPathView(center: CGPoint(x: 0, y: height - radius * 2),
                                     radius: radius,
                                     startAngle: 270,
                                     endAngle: 90,
                                     clockWise: false,
-                                    color: Color(UIColor.muriel(name: .blue, .shade20)),
+                                    color: blueCircleColor,
                                     lineWidth: 3.0)
+                        .opacity(circleOpacity)
                 }
                 .disabled(true)
             }
@@ -60,21 +68,5 @@ struct CircledPathView: View {
         }
         .stroke(color, lineWidth: lineWidth)
 
-    }
-}
-
-
-struct Arc: Shape {
-    let center: CGPoint
-    let radius: CGFloat
-    let startAngle: Double
-    let endAngle: Double
-    let clockwise: Bool
-
-    func path(in rect: CGRect) -> Path {
-        var p = Path()
-
-        p.addArc(center: CGPoint(x: rect.origin.x + radius, y: rect.origin.y + radius), radius: radius, startAngle: .degrees(startAngle), endAngle: .degrees(endAngle), clockwise: clockwise)
-        return p
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/UnifiedPrologueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UnifiedPrologueViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressAuthenticator
+import SwiftUI
 
 class UnifiedPrologueViewController: UIPageViewController {
 
@@ -32,6 +33,16 @@ class UnifiedPrologueViewController: UIPageViewController {
         view.backgroundColor = .prologueBackground
 
         addPageControl()
+        let backgroundView = embedSwiftUIView(UnifiedPrologueBackgroundView())
+        view.insertSubview(backgroundView, at: 0)
+        view.pinSubviewToAllEdges(backgroundView)
+    }
+
+    private func embedSwiftUIView<Content: View>(_ view: Content) -> UIView {
+        let controller = UIHostingController(rootView: view)
+        controller.view.translatesAutoresizingMaskIntoConstraints = false
+        controller.view.backgroundColor = .clear
+        return controller.view
     }
 
     private func addPageControl() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -178,8 +178,8 @@
 		177E7DAD1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */; };
 		1782BE841E70063100A91E7D /* MediaItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1782BE831E70063100A91E7D /* MediaItemViewController.swift */; };
 		1788106F260E488B00A98BD8 /* UnifiedPrologueNotificationsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1788106E260E488B00A98BD8 /* UnifiedPrologueNotificationsContentView.swift */; };
-		178810D92612037900A98BD8 /* UnifiedPrologueReaderContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178810D82612037800A98BD8 /* UnifiedPrologueReaderContentView.swift */; };
 		178810B52611D25600A98BD8 /* Text+BoldSubString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178810B42611D25600A98BD8 /* Text+BoldSubString.swift */; };
+		178810D92612037900A98BD8 /* UnifiedPrologueReaderContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178810D82612037800A98BD8 /* UnifiedPrologueReaderContentView.swift */; };
 		1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */; };
 		1797373720EBAA4100377B4E /* RouteMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1797373620EBAA4100377B4E /* RouteMatcherTests.swift */; };
 		17A09B99238FE13B0022AE0D /* FeatureFlagOverrideStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A09B98238FE13B0022AE0D /* FeatureFlagOverrideStore.swift */; };
@@ -479,6 +479,8 @@
 		3F8CB10623A07B17007627BF /* ReaderReblogAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CB10523A07B17007627BF /* ReaderReblogAction.swift */; };
 		3F8CBE0B24EEB0EA00F71234 /* AnnouncementsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CBE0A24EEB0EA00F71234 /* AnnouncementsDataSource.swift */; };
 		3F8CBE0D24EED2CB00F71234 /* FindOutMoreCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8CBE0C24EED2CB00F71234 /* FindOutMoreCell.swift */; };
+		3F8D988926153484003619E5 /* UnifiedPrologueBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8D988826153484003619E5 /* UnifiedPrologueBackgroundView.swift */; };
+		3F8D988A26153484003619E5 /* UnifiedPrologueBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8D988826153484003619E5 /* UnifiedPrologueBackgroundView.swift */; };
 		3F8EEC4E25B4817000EC9DAE /* StatsWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8EEC4D25B4817000EC9DAE /* StatsWidgets.swift */; };
 		3F8EEC7025B4849A00EC9DAE /* SiteListProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8EEC6F25B4849A00EC9DAE /* SiteListProvider.swift */; };
 		3F9E724125A8E69900AAAB1A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3F9E724325A8E69900AAAB1A /* Localizable.strings */; };
@@ -4551,8 +4553,8 @@
 		177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+SplitViewFullscreen.swift"; sourceTree = "<group>"; };
 		1782BE831E70063100A91E7D /* MediaItemViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaItemViewController.swift; sourceTree = "<group>"; };
 		1788106E260E488B00A98BD8 /* UnifiedPrologueNotificationsContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedPrologueNotificationsContentView.swift; sourceTree = "<group>"; };
-		178810D82612037800A98BD8 /* UnifiedPrologueReaderContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnifiedPrologueReaderContentView.swift; sourceTree = "<group>"; };
 		178810B42611D25600A98BD8 /* Text+BoldSubString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Text+BoldSubString.swift"; sourceTree = "<group>"; };
+		178810D82612037800A98BD8 /* UnifiedPrologueReaderContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnifiedPrologueReaderContentView.swift; sourceTree = "<group>"; };
 		1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Helpers.swift"; sourceTree = "<group>"; };
 		1797373620EBAA4100377B4E /* RouteMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMatcherTests.swift; sourceTree = "<group>"; };
 		17A09B98238FE13B0022AE0D /* FeatureFlagOverrideStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagOverrideStore.swift; sourceTree = "<group>"; };
@@ -4895,6 +4897,7 @@
 		3F8CB10523A07B17007627BF /* ReaderReblogAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogAction.swift; sourceTree = "<group>"; };
 		3F8CBE0A24EEB0EA00F71234 /* AnnouncementsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsDataSource.swift; sourceTree = "<group>"; };
 		3F8CBE0C24EED2CB00F71234 /* FindOutMoreCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindOutMoreCell.swift; sourceTree = "<group>"; };
+		3F8D988826153484003619E5 /* UnifiedPrologueBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedPrologueBackgroundView.swift; sourceTree = "<group>"; };
 		3F8EEC4D25B4817000EC9DAE /* StatsWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsWidgets.swift; sourceTree = "<group>"; };
 		3F8EEC6F25B4849A00EC9DAE /* SiteListProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteListProvider.swift; sourceTree = "<group>"; };
 		3F9E725425A8E6FF00AAAB1A /* it */ = {isa = PBXFileReference; explicitFileType = file.bplist; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -7680,6 +7683,7 @@
 		1705CEE6260A57F900F23763 /* ContentViews */ = {
 			isa = PBXGroup;
 			children = (
+				3F8D989C26153491003619E5 /* Background */,
 				3FC7F89C261233FC00FD8728 /* Stats */,
 				3F851413260D0A1D00A4B938 /* Editor */,
 				3F8513DD260D090000A4B938 /* Components */,
@@ -8796,6 +8800,14 @@
 				3F73BE5C24EB38E200BE99FF /* WhatIsNewScenePresenter.swift */,
 			);
 			path = Presenter;
+			sourceTree = "<group>";
+		};
+		3F8D989C26153491003619E5 /* Background */ = {
+			isa = PBXGroup;
+			children = (
+				3F8D988826153484003619E5 /* UnifiedPrologueBackgroundView.swift */,
+			);
+			path = Background;
 			sourceTree = "<group>";
 		};
 		3FA59DCC2582E53F0073772F /* Tracks */ = {
@@ -17126,6 +17138,7 @@
 				5DA3EE161925090A00294E0B /* MediaService.m in Sources */,
 				7E4123C520F4097B00DF8486 /* FormattableContentAction.swift in Sources */,
 				D8A468E521828D940094B82F /* SiteVerticalsService.swift in Sources */,
+				3F8D988926153484003619E5 /* UnifiedPrologueBackgroundView.swift in Sources */,
 				E65219FB1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift in Sources */,
 				FAF13C5325A57ABD003EE470 /* JetpackRestoreWarningViewController.swift in Sources */,
 				73C8F06321BEEF2F00DDDF7E /* SiteAssembly.swift in Sources */,
@@ -18384,6 +18397,7 @@
 				FABB22152602FC2C00C8785C /* FormattableContent.swift in Sources */,
 				FABB22162602FC2C00C8785C /* WebAddressWizardContent.swift in Sources */,
 				FABB22172602FC2C00C8785C /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift in Sources */,
+				3F8D988A26153484003619E5 /* UnifiedPrologueBackgroundView.swift in Sources */,
 				FABB22182602FC2C00C8785C /* SiteSegmentsStep.swift in Sources */,
 				FABB22192602FC2C00C8785C /* ReaderInterestsCollectionViewFlowLayout.swift in Sources */,
 				FABB221A2602FC2C00C8785C /* PHAsset+Metadata.swift in Sources */,


### PR DESCRIPTION
REF #15056 

This PR adds circles in the background of the unified prologue screens. In this implementation we are using a single background for all the prologue screens, as opposed to the initial designs that had different backgrounds for each screen. Thus there is no exact match between the circles in the designs (#15056) and the actual circles in the background, both in terms of colors (which here use our color palette) and position, but it should be close enough.

Here are some examples

light appearance | dark appearance
-- | --
<img height=450 src=https://user-images.githubusercontent.com/34376330/113360019-96936780-930e-11eb-8eb2-e65679c59bab.png>| <img height=450 src=https://user-images.githubusercontent.com/34376330/113360050-a4e18380-930e-11eb-8c9b-bb2a9657d31f.png>



To test:

- build, run and logout if needed
- test on a variety of devices, and make sure the circles look consistent with the examples above

## Regression Notes
1. Potential unintended areas of impact
This new view with circles only applies to the prologue. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
It's still a good idea to test on as many devices as possible to make sure the view looks good. I tested on a variety of simulators on both iOS 13 and iOS 14

3. What automated tests I added (or what prevented me from doing so)
NA

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
