### PR TITLE
 Allow customization of NUX button view shadows constraints

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -207,9 +207,9 @@ abstract_target 'Apps' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-    pod 'WordPressAuthenticator', '~> 1.36.0-beta'
+    # pod 'WordPressAuthenticator', '~> 1.36.0-beta'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/nux-button-shadows'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -207,9 +207,9 @@ abstract_target 'Apps' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-    # pod 'WordPressAuthenticator', '~> 1.36.0-beta'
+    pod 'WordPressAuthenticator', '~> 1.36.0-beta.4'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/nux-button-shadows'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/nux-button-shadows'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -502,7 +502,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/nux-button-shadows`)
+  - WordPressAuthenticator (~> 1.36.0-beta.4)
   - WordPressKit (~> 4.30.0-beta)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.16.0-beta)
@@ -513,6 +513,8 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -653,9 +655,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.50.0
-  WordPressAuthenticator:
-    :branch: fix/nux-button-shadows
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.50.0/third-party-podspecs/Yoga.podspec.json
 
@@ -671,9 +670,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.50.0
-  WordPressAuthenticator:
-    :commit: 3f64695eaf173af3b2fa8b3c2c89c2813a16e462
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -754,7 +750,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
-  WordPressAuthenticator: da8e4dde1c3e42848f0e79741f9b07647228bb8b
+  WordPressAuthenticator: 2e394388b2d0df78e4b7d297e8a3833be544e988
   WordPressKit: 48b8661ab30257072fed0fa76643e0ba8cdf4c65
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 3ee19d177a4a12c78e9fc20e1161b8e61969635e
@@ -771,6 +767,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 589a94d49c18458561e537ed093ed312d7f939b1
+PODFILE CHECKSUM: 5466d7870e02429d46aa2429e1fe33faaaeecfc9
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -393,7 +393,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.4)
   - WordPress-Editor-iOS (1.19.4):
     - WordPress-Aztec-iOS (= 1.19.4)
-  - WordPressAuthenticator (1.36.0-beta.2):
+  - WordPressAuthenticator (1.36.0-beta.4):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -502,7 +502,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
-  - WordPressAuthenticator (~> 1.36.0-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/nux-button-shadows`)
   - WordPressKit (~> 4.30.0-beta)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.16.0-beta)
@@ -513,8 +513,6 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -655,6 +653,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.50.0
+  WordPressAuthenticator:
+    :branch: fix/nux-button-shadows
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.50.0/third-party-podspecs/Yoga.podspec.json
 
@@ -670,6 +671,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.50.0
+  WordPressAuthenticator:
+    :commit: 3f64695eaf173af3b2fa8b3c2c89c2813a16e462
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -750,7 +754,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
-  WordPressAuthenticator: 973d212f3ee787f833fa645c36baa432c671333b
+  WordPressAuthenticator: da8e4dde1c3e42848f0e79741f9b07647228bb8b
   WordPressKit: 48b8661ab30257072fed0fa76643e0ba8cdf4c65
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 3ee19d177a4a12c78e9fc20e1161b8e61969635e
@@ -767,6 +771,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 67ad92b25f58202e1882a0c958294caff4a24c27
+PODFILE CHECKSUM: 589a94d49c18458561e537ed093ed312d7f939b1
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
This PR fixes an issue where NUX button shadows were constrained to the edges of the NUX button view controller, which meant they may not extend all the way to the edges of the screen:

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2021-03-29 at 21 55 08](https://user-images.githubusercontent.com/4780/113423552-98206680-93c6-11eb-911a-c497552bc036.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2021-04-02 at 14 46 46](https://user-images.githubusercontent.com/4780/113423629-be460680-93c6-11eb-9c79-8412a1ad9a7c.png) |

See the [associated WordPressAuthenticator PR](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/586) for full details.

**To test**

- Build and run
- Ensure the shadow above the buttons on the NUX prologue screen looks as in the screenshot above. Check on iPhone and on iPad (which supports rotation). You could also check the site creation flow or the domain registration flow, which both use NUXButtonViewController.

## Regression Notes

1. Potential unintended areas of impact

- Other areas that NUXButtonViewController.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- I manually inspected each of those areas in the app to ensure that they looked as expected.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
