### PR TITLE
3D Touch Shortcuts: Fix stats shortcut for new nav appearance feature

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -220,6 +220,20 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         self.blogDetailsViewController = nil
     }
 
+    /// Shows the specified `BlogDetailsSubsection` for a `Blog`.
+    ///
+    /// - Parameters:
+    ///         - blog: The blog to show the details of.
+    ///         - subsection: The specific subsection to show.
+    ///
+    func showBlogDetailsSubsection(_ subsection: BlogDetailsSubsection) {
+        guard let blogDetailsViewController = blogDetailsViewController else {
+            return
+        }
+
+        blogDetailsViewController.showDetailView(for: subsection)
+    }
+
     /// Shows a `BlogDetailsViewController` for the specified `Blog`.  If the VC doesn't exist, this method also takes care
     /// of creating it.
     ///

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -223,7 +223,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     /// Shows the specified `BlogDetailsSubsection` for a `Blog`.
     ///
     /// - Parameters:
-    ///         - blog: The blog to show the details of.
     ///         - subsection: The specific subsection to show.
     ///
     func showBlogDetailsSubsection(_ subsection: BlogDetailsSubsection) {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -226,11 +226,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     ///         - subsection: The specific subsection to show.
     ///
     func showBlogDetailsSubsection(_ subsection: BlogDetailsSubsection) {
-        guard let blogDetailsViewController = blogDetailsViewController else {
-            return
-        }
-
-        blogDetailsViewController.showDetailView(for: subsection)
+        blogDetailsViewController?.showDetailView(for: subsection)
     }
 
     /// Shows a `BlogDetailsViewController` for the specified `Blog`.  If the VC doesn't exist, this method also takes care

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -131,14 +131,11 @@ class MySitesCoordinator: NSObject {
     func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection) {
         showBlogDetails(for: blog)
 
-        if Feature.enabled(.newNavBarAppearance) {
-            if let mySiteViewController = navigationController.topViewController as? MySiteViewController {
-                mySiteViewController.showBlogDetailsSubsection(subsection)
-            }
-        } else {
-            if let blogDetailsViewController = navigationController.topViewController as? BlogDetailsViewController {
-                blogDetailsViewController.showDetailView(for: subsection)
-            }
+        if Feature.enabled(.newNavBarAppearance),
+           let mySiteViewController = navigationController.topViewController as? MySiteViewController {
+            mySiteViewController.showBlogDetailsSubsection(subsection)
+        } else if let blogDetailsViewController = navigationController.topViewController as? BlogDetailsViewController {
+            blogDetailsViewController.showDetailView(for: subsection)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -131,15 +131,15 @@ class MySitesCoordinator: NSObject {
     func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection) {
         showBlogDetails(for: blog)
 
-        let blogDetailsViewController: BlogDetailsViewController?
-
         if Feature.enabled(.newNavBarAppearance) {
-            blogDetailsViewController = navigationController.topViewController?.children.first as? BlogDetailsViewController
+            if let mySiteViewController = navigationController.topViewController as? MySiteViewController {
+                mySiteViewController.showBlogDetailsSubsection(subsection)
+            }
         } else {
-            blogDetailsViewController = navigationController.topViewController as? BlogDetailsViewController
+            if let blogDetailsViewController = navigationController.topViewController as? BlogDetailsViewController {
+                blogDetailsViewController.showDetailView(for: subsection)
+            }
         }
-
-        blogDetailsViewController?.showDetailView(for: subsection)
     }
 
     // MARK: - Stats

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -131,9 +131,15 @@ class MySitesCoordinator: NSObject {
     func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection) {
         showBlogDetails(for: blog)
 
-        if let blogDetailsViewController = navigationController.topViewController as? BlogDetailsViewController {
-            blogDetailsViewController.showDetailView(for: subsection)
+        let blogDetailsViewController: BlogDetailsViewController?
+
+        if Feature.enabled(.newNavBarAppearance) {
+            blogDetailsViewController = navigationController.topViewController?.children.first as? BlogDetailsViewController
+        } else {
+            blogDetailsViewController = navigationController.topViewController as? BlogDetailsViewController
         }
+
+        blogDetailsViewController?.showDetailView(for: subsection)
     }
 
     // MARK: - Stats


### PR DESCRIPTION
Fixes #16225 

This PR fixes a bug where the stats shortcut was opening the My Site screen instead of the Stats screen.

## How to test:
1. Long press on the WP app icon to bring up shortcuts
2. Tap on the Stats shortcut
3. ✅ The Stats screen should be displayed


https://user-images.githubusercontent.com/6711616/113539987-05780580-961a-11eb-89ae-12bc5f812807.mov



## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested for both newNavAppearance enabled and disabled, made sure that the stats shortcut opens up the stats screen as expected

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
