### PR TITLE
Enable new prologue feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -43,7 +43,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .newNavBarAppearance:
             return true
         case .unifiedPrologueCarousel:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .stories:
             return true
         case .contactInfo:


### PR DESCRIPTION
Refs #15056. This PR enables the new prologue carousel for all.

<img src="https://user-images.githubusercontent.com/4780/113566517-ba9fc300-9604-11eb-8a68-75a48a376da3.png" width=300>

**To test**

- Check the `unifiedPrologueCarousel` feature flag definition in the code (should be `true`)
- Build and run (log out if necessary) and ensure you see the new prologue carousel

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
