### PR TITLE
Changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
@@ -27,7 +27,7 @@ final class TableViewOffsetCoordinator {
 
     /// Tracks the content offset introduced by the keyboard being presented
     private var keyboardContentOffset = CGFloat(0)
-    
+
     /// Track scroll position of tableview for reloads
     private var scrollPosition = CGPoint(x: 0, y: 0)
 
@@ -61,17 +61,17 @@ final class TableViewOffsetCoordinator {
         guard let tableView = tableView, keyboardContentOffset > 0, tableViewHasBeenAdjusted == false else {
             return
         }
-        
+
         // if table is taller than screen, apply an inset to make the search field at the bottom visible
         if UIScreen.main.bounds.height < tableView.bounds.height {
             // no change
         } else {
             tableView.contentInset.bottom = keyboardContentOffset*1.5
         }
-        
+
         tableViewHasBeenAdjusted = true
         scrollPosition = tableView.contentOffset
-        
+
         // removed insets that had been here, as they made content disappear with large text sizes
         // replaced with contentoffset and scroll of tableview
     }
@@ -82,27 +82,27 @@ final class TableViewOffsetCoordinator {
         guard WPDeviceIdentification.isiPhone(), tableViewHasBeenAdjusted == true else {
             return
         }
-        
+
         var offset = false
-    
+
         UIView.animate(withDuration: Constants.headerAnimationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
             guard let self = self, let tableView = self.tableView else {
                 return
             }
-            
+
             // if table is taller than screen, an offset has been applied
             if UIScreen.main.bounds.height < tableView.bounds.height {
                 offset = false
             } else {
                 offset = true
             }
-            
+
             if WPDeviceIdentification.isiPhone(), let header = tableView.tableHeaderView as? TitleSubtitleTextfieldHeader {
                 header.titleSubtitle.alpha = 1.0
             }
         }, completion: { [weak self] _ in
             self?.tableViewHasBeenAdjusted = false
-            
+
             // if offset has been applied, set scroll position to previous placement to ensure search field is visible
             if offset {
                 self?.tableView?.layoutIfNeeded()
@@ -116,7 +116,7 @@ final class TableViewOffsetCoordinator {
         guard let payload = KeyboardInfo(notification) else {
             return
         }
-        
+
         let keyboardScreenFrame = payload.frameEnd
         keyboardContentOffset = keyboardScreenFrame.height
 
@@ -140,7 +140,7 @@ final class TableViewOffsetCoordinator {
 
         let bottomInset = footerControlContainer.safeAreaInsets.bottom
         constraintConstant -= bottomInset
-        
+
 
         if let header = tableView?.tableHeaderView as? TitleSubtitleTextfieldHeader {
             let textFieldFrame = header.textField.frame
@@ -149,7 +149,7 @@ final class TableViewOffsetCoordinator {
 
             toolbarBottomConstraint?.constant = constraintConstant
             footerControlContainer.setNeedsUpdateConstraints()
-            
+
             UIView.animate(withDuration: Constants.headerAnimationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
                 guard let self = self, let tableView = self.tableView else {
                     return

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
@@ -28,6 +28,7 @@ final class TableViewOffsetCoordinator {
     /// Tracks the content offset introduced by the keyboard being presented
     private var keyboardContentOffset = CGFloat(0)
     
+    /// Track scroll position of tableview for reloads
     private var scrollPosition = CGPoint(x: 0, y: 0)
 
     /// To avoid wasted animations, we track whether or not we have already adjusted the table view
@@ -50,8 +51,6 @@ final class TableViewOffsetCoordinator {
         self.footerControlContainer = footerControlContainer
         self.footerControl = footerControl
         self.toolbarBottomConstraint = toolbarBottomConstraint
-        
-        print("init")
     }
 
     // MARK: Internal behavior
@@ -60,56 +59,21 @@ final class TableViewOffsetCoordinator {
     ///
     func adjustTableOffsetIfNeeded() {
         guard let tableView = tableView, keyboardContentOffset > 0, tableViewHasBeenAdjusted == false else {
-            print("stopped at guard")
             return
         }
-        
-        print("adjust offset")
         
         // if table is taller than screen, apply an inset to make the search field at the bottom visible
         if UIScreen.main.bounds.height < tableView.bounds.height {
             // no change
         } else {
             tableView.contentInset.bottom = keyboardContentOffset*1.5
-            print(keyboardContentOffset*1.5)
         }
         
         tableViewHasBeenAdjusted = true
         scrollPosition = tableView.contentOffset
         
-        /*let topInset: CGFloat
-        if WPDeviceIdentification.isiPhone(), let header = tableView.tableHeaderView as? TitleSubtitleTextfieldHeader {
-            let textfieldFrame = header.textField.frame
-            topInset = textfieldFrame.origin.y - Constants.topMargin
-        } else {
-            topInset = 0
-        }
-        
-        let bottomInset: CGFloat
-        if WPDeviceIdentification.isiPad() && UIDevice.current.orientation.isPortrait {
-            bottomInset = 0
-        } else {
-            bottomInset = keyboardContentOffset
-        }
-        
-        
-        let targetInsets = UIEdgeInsets(top: -topInset, left: 0, bottom: bottomInset, right: 0)
-
-        UIView.animate(withDuration: Constants.headerAnimationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
-            guard let self = self, let tableView = self.tableView else {
-                return
-            }
-            
-            
-            tableView.contentInset = targetInsets
-            tableView.scrollIndicatorInsets = targetInsets
-            if WPDeviceIdentification.isiPhone(), let header = tableView.tableHeaderView as? TitleSubtitleTextfieldHeader {
-                header.titleSubtitle.alpha = 0.0
-                tableView.headerView(forSection: Constants.domainHeaderSection)?.isHidden = true
-            }
-        }, completion: { [weak self] _ in
-            self?.tableViewHasBeenAdjusted = true
-        })*/
+        // removed insets that had been here, as they made content disappear with large text sizes
+        // replaced with contentoffset and scroll of tableview
     }
 
     /// This method resets the table view header and the content offset to the default state.
@@ -120,8 +84,6 @@ final class TableViewOffsetCoordinator {
         }
         
         var offset = false
-        
-        print("reset table offset")
     
         UIView.animate(withDuration: Constants.headerAnimationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
             guard let self = self, let tableView = self.tableView else {
@@ -134,31 +96,6 @@ final class TableViewOffsetCoordinator {
             } else {
                 offset = true
             }
-            
-            //tableView.contentOffset.y = self.keyboardContentOffset*1.5
-            
-            /*tableView.contentInset.bottom = 0
-            
-             if UIScreen.main.bounds.height < tableView.bounds.height {
-                // no change
-             } else {
-                tableView.contentInset.bottom = self.keyboardContentOffset*1.5
-             }
-            
-            print(tableView.contentInset.bottom)
-            
-    
-            let finalOffset: UIEdgeInsets
-            if let footerControl = self.footerControl, self.toolbarHasBeenAdjusted == true {
-                let toolbarHeight = footerControl.frame.size.height
-                finalOffset = UIEdgeInsets(top: -1 * toolbarHeight,
-                    left: 0, bottom: toolbarHeight, right: 0)
-            } else {
-                finalOffset = .zero
-            }*/
-           
-            //tableView.contentInset = finalOffset
-            //tableView.scrollIndicatorInsets = finalOffset
             
             if WPDeviceIdentification.isiPhone(), let header = tableView.tableHeaderView as? TitleSubtitleTextfieldHeader {
                 header.titleSubtitle.alpha = 1.0
@@ -180,8 +117,6 @@ final class TableViewOffsetCoordinator {
             return
         }
         
-        print("keyboard show")
-
         let keyboardScreenFrame = payload.frameEnd
         keyboardContentOffset = keyboardScreenFrame.height
 
@@ -194,8 +129,6 @@ final class TableViewOffsetCoordinator {
         keyboardContentOffset = 0
         toolbarHasBeenAdjusted = false
         toolbarBottomConstraint?.constant = 0
-        
-        print("keyboard hide")
     }
 
     private func adjustToolbarOffsetIfNeeded() {
@@ -203,7 +136,6 @@ final class TableViewOffsetCoordinator {
             return
         }
 
-        print("toolbar offset")
         var constraintConstant = keyboardContentOffset
 
         let bottomInset = footerControlContainer.safeAreaInsets.bottom


### PR DESCRIPTION
Fixes #15925

To test: In old code, set device text side under accessibility to use large text (use a high setting). Open the app and try to add a new site - with large text, the search field for a url is covered by the keyboard.

In this edited code, the table has had an offset applied, which pushes the search field up above the keyboard, making it visible. This code will apply if the table exceeds the height of the device, like on small devices or if the text in the site creation header is very large. It will be ignored on iPads/bigger devices.

## Regression Notes
1. Potential unintended areas of impact
The code could have applied erroneously when not needed, or caused an increasing offset.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested on different devices sizes to make sure this did not happen, and tested going back and forth between views and hiding and showing the keyboard.

3. What automated tests I added (or what prevented me from doing so)
None, as the success of the fix depended very much on the visual, as confirmed by manual testing and eyeballing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
