### PR TITLE
Fix Notifications no results view offset (and other issues)

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1266,18 +1266,25 @@ private extension NotificationsViewController {
         addChild(noResultsViewController)
         tableView.insertSubview(noResultsViewController.view, belowSubview: tableHeaderView)
         noResultsViewController.view.frame = tableView.frame
-        adjustNoResultsViewSize()
+        setupNoResultsViewConstraints()
         noResultsViewController.didMove(toParent: self)
     }
 
-    func adjustNoResultsViewSize() {
-        noResultsViewController.view.frame.origin.y = tableHeaderView.frame.size.height
-
-        if inlinePromptView.alpha == WPAlphaFull {
-            noResultsViewController.view.frame.size.height -= tableHeaderView.frame.size.height
-        } else {
-            noResultsViewController.view.frame.size.height = tableView.frame.size.height - tableHeaderView.frame.size.height
+    func setupNoResultsViewConstraints() {
+        guard let nrv = noResultsViewController.view else {
+            return
         }
+
+        tableHeaderView.translatesAutoresizingMaskIntoConstraints = false
+        nrv.translatesAutoresizingMaskIntoConstraints = false
+        nrv.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        NSLayoutConstraint.activate([
+            nrv.widthAnchor.constraint(equalTo: view.widthAnchor),
+            nrv.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            nrv.topAnchor.constraint(equalTo: tableHeaderView.bottomAnchor),
+            nrv.bottomAnchor.constraint(equalTo: view.safeBottomAnchor)
+        ])
     }
 
     func updateSplitViewAppearanceForNoResultsView() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1501,7 +1501,10 @@ private extension NotificationsViewController {
 extension NotificationsViewController: WPSplitViewControllerDetailProvider {
     func initialDetailViewControllerForSplitView(_ splitView: WPSplitViewController) -> UIViewController? {
         guard let note = selectedNotification ?? fetchFirstNotification() else {
-            return nil
+            let controller = UIViewController()
+            controller.view.backgroundColor = .basicBackground
+            return controller
+
         }
 
         selectedNotification = note

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1205,18 +1205,18 @@ extension NotificationsViewController: WPTableViewHandlerDelegate {
 //
 private extension NotificationsViewController {
     func showFiltersSegmentedControlIfApplicable() {
-        guard tableHeaderView.alpha == WPAlphaZero && shouldDisplayFilters == true else {
+        guard filterTabBar.isHidden == true && shouldDisplayFilters == true else {
             return
         }
 
         UIView.animate(withDuration: WPAnimationDurationDefault, animations: {
-            self.tableHeaderView.alpha = WPAlphaFull
+            self.filterTabBar.isHidden = false
         })
     }
 
     func hideFiltersSegmentedControlIfApplicable() {
-        if tableHeaderView.alpha == WPAlphaFull && shouldDisplayFilters == false {
-            tableHeaderView.alpha = WPAlphaZero
+        if filterTabBar.isHidden == false && shouldDisplayFilters == false {
+            self.filterTabBar.isHidden = true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1780,3 +1780,12 @@ extension NotificationsViewController: UIViewControllerTransitioningDelegate {
         static let secondNotificationsAlertDisabled = -1
     }
 }
+
+// MARK: - Scrolling
+//
+extension NotificationsViewController: WPScrollableViewController {
+    // Used to scroll view to top when tapping on tab bar item when VC is already visible.
+    func scrollViewToTop() {
+        tableView.scrollRectToVisible(CGRect(x: 0, y: 0, width: 1, height: 1), animated: true)
+    }
+}


### PR DESCRIPTION
This PR fixes a number of issues in the Notifications section of the app, some of which were highlighted or introduced as part of the large titles / white headers changes:

- The 'no results' view in Notifications would be displayed too far down the screen, with a large gap visible between the no results view and the nav bar header
- Tapping the Notifications button when the Notifications view was already visible would scroll to an incorrect offset in the tableview, cutting off the content of some cells. Now it should scroll to the top, keeping the nav bar title small.
- On initial login to a new account with no notifications, the detail pane on iPad was gray. Now it should be white.

**Before**

<img src="https://user-images.githubusercontent.com/4780/113737956-66750b80-96f6-11eb-8935-10fa10871c4a.png" width=250>

**After**

|   |   |   |   |
|---|---|---|---|
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-06 at 16 01 51](https://user-images.githubusercontent.com/4780/113737874-52310e80-96f6-11eb-852f-184a3169b096.png) |  ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-06 at 16 03 33](https://user-images.githubusercontent.com/4780/113737870-51987800-96f6-11eb-8429-1ef27cfd26fc.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-06 at 16 10 29](https://user-images.githubusercontent.com/4780/113737845-4d6c5a80-96f6-11eb-8d89-391cbe0cc62a.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-06 at 16 10 27](https://user-images.githubusercontent.com/4780/113737848-4e04f100-96f6-11eb-9fd4-906ae8975c88.png) |
|   | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-06 at 16 32 05](https://user-images.githubusercontent.com/4780/113737769-3e85a800-96f6-11eb-929d-3bdf0307448a.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-06 at 16 32 03](https://user-images.githubusercontent.com/4780/113737774-3f1e3e80-96f6-11eb-96a5-84a06e83fd5a.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-06 at 16 33 34](https://user-images.githubusercontent.com/4780/113737765-3d547b00-96f6-11eb-9f54-fa44cb3822db.png) |

**To test**

- Build and run
- Create a new account and ensure that the Notifications screen shows a seamless white background with the no results view centered
- If you like, trigger the display of the app rating header prompt – the easiest way is to modify line 184 of NotificationsViewController to say `} else if true {`. When you run, you should see the prompt appear in the header of the table view. When you dismiss it, the gap should be closed.
- Trigger a notification to be added to this account. You could either create a site for the account, create a post, and like it from another account. Or use this account to comment on a test site and then reply to that comment from another account.
- When the notification is added, you should see the filter bar appear in this view. You should see content in some tabs, and a no results view in other tabs (for example, if you replied to this user's comment you may see a notification under Comments, but nothing under Likes).
- Also test with the `newNavAppearance` feature flag disabled and check that everything still looks okay (although this feature has already shipped, so hopefully we won't be rolling back!)

## Regression Notes

1. Potential unintended areas of impact

There are quite a few cases here with the various headers available (filter tabs and prompts), and the header has changed with the new nav bar appearance.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tried to ensure that I tested each case – the app rating prompt, the filter tab bar, both, neither, a new account with no notifications, the transition to having a notification, and an existing account with a lot of notifications.

3. What automated tests I added (or what prevented me from doing so)

This was really a purely visual change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
