### PR TITLE
Fix webview nav bar styles when using new nav bar appearance

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 * [**] We updated the login prologue with brand new content and graphics. [#16159, #16177, #16185, #16187, #16200, #16217, #16219, #16221, #16222]
 * [**] We updated the app's color scheme with a brighter new blue used throughout. [#16213, #16207] 
 * [**] Updated the app icon to match the new color scheme within the app. [#16220]
+* [*] Fixed an issue where some webview navigation bar controls weren't visible. [#16257]
 
 17.0
 -----

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -89,7 +89,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     private var onClose: (() -> Void)?
 
     private var useLightStyle: Bool {
-        navigationController is LightNavigationController
+        navigationController is LightNavigationController || FeatureFlag.newNavBarAppearance.enabled
     }
 
     private var barButtonTintColor: UIColor {
@@ -279,6 +279,9 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
 
         if !useLightStyle {
             navigationBar.titleTextAttributes = [.foregroundColor: UIColor.neutral(.shade70)]
+        } else {
+            // Remove serif title bar formatting
+            navigationBar.standardAppearance.titleTextAttributes = [:]
         }
 
         navigationBar.shadowImage = UIImage(color: WPStyleGuide.webViewModalNavigationBarShadow())

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -262,7 +262,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         titleView.titleLabel.text = NSLocalizedString("Loading...", comment: "Loading. Verb")
 
         titleView.titleLabel.textColor = navBarTitleColor
-        titleView.subtitleLabel.textColor = .neutral(.shade30)
+        titleView.subtitleLabel.textColor = useLightStyle ? .neutral(.shade30) : .neutral(.shade5)
 
         if let title = customTitle {
             self.title = title


### PR DESCRIPTION
Fixes #16247. This PR adds an extra fix on top of #16116, to use the correct styles when the new nav bar appearance is active.

| Before | After |
|---|---|
| ![](https://user-images.githubusercontent.com/1396552/113795012-e06abc00-9719-11eb-85c2-c0c518e609da.PNG) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 13 54 40](https://user-images.githubusercontent.com/4780/114034605-39e7fd80-9876-11eb-9d8c-1c9e37df5921.png) |

**To test**

- Build and run
- Test the various scenarios outlined in #16247 and ensure that you can see the webview title, subtitle (if it has one, not all do), and left and right buttons.

## Regression Notes

1. Potential unintended areas of impact

None, as all webviews are now using the light style navigation bar.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I checked that webviews already using LightNavigationController still look correct. I also checked webviews with the `newNavBarAppearance` feature flag disabled (and pushed a small improvement for this case).

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
