### PR TITLE
Notification Likes list: update user cell UI

### DIFF
--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -163,7 +163,7 @@ extension LikesListController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return Constants.estimatedRowHeight
+        return LikeUserTableViewCell.estimatedRowHeight
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -178,11 +178,12 @@ extension LikesListController: UITableViewDataSource, UITableViewDelegate {
             return
         }
 
-        guard !isLoadingContent, indexPath.row < likingUsers.count else {
+        guard !isLoadingContent,
+              let user = likingUsers[safe: indexPath.row] else {
             return
         }
 
-        delegate?.didSelectUser(likingUsers[indexPath.row])
+        delegate?.didSelectUser(user)
     }
 
 }
@@ -219,30 +220,14 @@ private extension LikesListController {
         cell.downloadAuthorAvatar(with: mediaURL)
     }
 
-    func userCell(for indexPath: IndexPath) -> NoteBlockUserTableViewCell {
-        guard indexPath.row < likingUsers.count,
-              let cell = tableView.dequeueReusableCell(withIdentifier: NoteBlockUserTableViewCell.reuseIdentifier()) as? NoteBlockUserTableViewCell else {
-            DDLogError("Error: couldn't get a user cell or requested row is out of boundary")
-            return NoteBlockUserTableViewCell()
+    func userCell(for indexPath: IndexPath) -> UITableViewCell {
+        guard let user = likingUsers[safe: indexPath.row],
+              let cell = tableView.dequeueReusableCell(withIdentifier: LikeUserTableViewCell.defaultReuseID) as? LikeUserTableViewCell else {
+            DDLogError("Failed dequeueing LikeUserTableViewCell")
+            return UITableViewCell()
         }
 
-        let user = likingUsers[indexPath.row]
-        cell.accessoryType = .none
-        cell.name = user.displayName
-
-        cell.isFollowEnabled = false
-        cell.isFollowOn = false
-
-        // TODO: Configure blog title once the information is available.
-        cell.blogTitle = ""
-
-        if let mediaURL = URL(string: user.avatarURL) {
-            cell.downloadGravatarWithURL(mediaURL)
-        }
-
-        // configure the ending separator line
-        cell.isLastRow = (indexPath.row == likingUsers.count - 1)
-
+        cell.configure(withUser: user, isLastRow: (indexPath.row == likingUsers.endIndex - 1))
         return cell
     }
 
@@ -269,9 +254,8 @@ private extension LikesListController {
         case comment(id: NSNumber)
     }
 
-    enum Constants {
+    struct Constants {
         static let numberOfSections = 2
-        static let estimatedRowHeight: CGFloat = 44
         static let headerSectionIndex = 0
         static let headerRowIndex = 0
         static let numberOfHeaderRows = 1

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -306,7 +306,8 @@ extension NotificationDetailsViewController: UITableViewDelegate, UITableViewDat
         let group = contentGroup(for: indexPath)
         let reuseIdentifier = reuseIdentifierForGroup(group)
         guard let cell = tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath) as? NoteBlockTableViewCell else {
-            fatalError()
+            DDLogError("Failed dequeueing NoteBlockTableViewCell.")
+            return UITableViewCell()
         }
 
         setup(cell, withContentGroupAt: indexPath)
@@ -420,6 +421,11 @@ extension NotificationDetailsViewController {
             let nib = UINib(nibName: classname, bundle: Bundle.main)
 
             tableView.register(nib, forCellReuseIdentifier: cellClass.reuseIdentifier())
+        }
+
+        if FeatureFlag.newLikeNotifications.enabled {
+            tableView.register(LikeUserTableViewCell.defaultNib,
+                               forCellReuseIdentifier: LikeUserTableViewCell.defaultReuseID)
         }
     }
 
@@ -1362,7 +1368,7 @@ extension NotificationDetailsViewController: LikesListControllerDelegate {
     }
 
     func didSelectUser(_ user: RemoteUser) {
-        // TODO: display user's home blog when the information is available.
+        // TODO: display user profile bottom sheet
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+class LikeUserTableViewCell: UITableViewCell, NibReusable {
+
+    // MARK: - Properties
+
+    @IBOutlet weak var gravatarImageView: CircularImageView!
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var usernameLabel: UILabel!
+    @IBOutlet weak var separatorView: UIView!
+    @IBOutlet weak var separatorHeightConstraint: NSLayoutConstraint!
+    @IBOutlet weak var separatorLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet weak var cellStackViewLeadingConstraint: NSLayoutConstraint!
+
+    static let estimatedRowHeight: CGFloat = 80
+    private typealias Style = WPStyleGuide.Notifications
+
+    // MARK: - View
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureCell()
+    }
+
+    // MARK: - Public Methods
+
+    func configure(withUser user: RemoteUser, isLastRow: Bool = false) {
+        nameLabel.text = user.displayName
+        usernameLabel.text = String(format: Constants.usernameFormat, user.username)
+        downloadGravatarWithURL(user.avatarURL)
+        separatorLeadingConstraint.constant = isLastRow ? 0 : cellStackViewLeadingConstraint.constant
+    }
+
+}
+
+// MARK: - Private Extension
+
+private extension LikeUserTableViewCell {
+
+    func configureCell() {
+        nameLabel.textColor = Style.blockTextColor
+        usernameLabel.textColor = .textSubtle
+        backgroundColor = Style.blockBackgroundColor
+        separatorView.backgroundColor = Style.blockSeparatorColor
+        separatorHeightConstraint.constant = .hairlineBorderWidth
+    }
+
+    func downloadGravatarWithURL(_ url: String?) {
+        // Always reset gravatar
+        gravatarImageView.image = .gravatarPlaceholderImage
+
+        guard let url = url,
+              let gravatarURL = URL(string: url) else {
+            return
+        }
+
+        gravatarImageView.downloadImage(from: gravatarURL, placeholderImage: .gravatarPlaceholderImage)
+    }
+
+    struct Constants {
+        static let usernameFormat = NSLocalizedString("@%1$@", comment: "Label displaying the user's username preceeded by an '@' symbol. %1$@ is a placeholder for the username.")
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.swift
@@ -47,6 +47,7 @@ private extension LikeUserTableViewCell {
 
     func downloadGravatarWithURL(_ url: String?) {
         // Always reset gravatar
+        gravatarImageView.cancelImageDownload()
         gravatarImageView.image = .gravatarPlaceholderImage
 
         guard let url = url,

--- a/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.xib
@@ -21,7 +21,7 @@
                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="ZWJ-8F-a7O" userLabel="Cell Stack View">
                         <rect key="frame" x="20" y="12" width="395" height="62"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="pe3-Qf-lcv" userLabel="Gravatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="pe3-Qf-lcv" userLabel="Gravatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="8" width="46" height="46"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="pe3-Qf-lcv" secondAttribute="height" multiplier="1:1" id="MlL-OM-UpJ"/>

--- a/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.xib
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="-12" id="vmg-Uv-oZf" customClass="LikeUserTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="435" height="86"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vmg-Uv-oZf" id="AVd-CT-xQi">
+                <rect key="frame" x="0.0" y="0.0" width="435" height="86"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="ZWJ-8F-a7O" userLabel="Cell Stack View">
+                        <rect key="frame" x="20" y="12" width="395" height="62"/>
+                        <subviews>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="pe3-Qf-lcv" userLabel="Gravatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="8" width="46" height="46"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="pe3-Qf-lcv" secondAttribute="height" multiplier="1:1" id="MlL-OM-UpJ"/>
+                                    <constraint firstAttribute="width" constant="46" id="se3-n4-gId"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="wev-aD-HGJ" userLabel="Label Stack View">
+                                <rect key="frame" x="58" y="12" width="337" height="38.5"/>
+                                <subviews>
+                                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IUe-FJ-l5m" userLabel="Name Label">
+                                        <rect key="frame" x="0.0" y="0.0" width="45" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <color key="textColor" systemColor="darkTextColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LDG-hl-sfI" userLabel="Username Label">
+                                        <rect key="frame" x="0.0" y="20.5" width="81.5" height="18"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                        <color key="textColor" name="Gray"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                    </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7UX-Gg-MNF" userLabel="Separator">
+                        <rect key="frame" x="20" y="85" width="415" height="1"/>
+                        <color key="backgroundColor" systemColor="systemGrayColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="1" id="mB6-co-8Ym"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="ZWJ-8F-a7O" firstAttribute="leading" secondItem="AVd-CT-xQi" secondAttribute="leading" constant="20" id="GhN-Ib-f12"/>
+                    <constraint firstAttribute="trailing" secondItem="ZWJ-8F-a7O" secondAttribute="trailing" constant="20" id="P9x-je-fd1"/>
+                    <constraint firstAttribute="trailing" secondItem="7UX-Gg-MNF" secondAttribute="trailing" id="aCd-hU-kEG"/>
+                    <constraint firstItem="7UX-Gg-MNF" firstAttribute="leading" secondItem="AVd-CT-xQi" secondAttribute="leading" constant="20" id="kUW-yY-J0j"/>
+                    <constraint firstAttribute="bottom" secondItem="ZWJ-8F-a7O" secondAttribute="bottom" constant="12" id="mWv-qn-qTN"/>
+                    <constraint firstItem="ZWJ-8F-a7O" firstAttribute="top" secondItem="AVd-CT-xQi" secondAttribute="top" constant="12" id="oBa-U2-Pc3"/>
+                    <constraint firstAttribute="bottom" secondItem="7UX-Gg-MNF" secondAttribute="bottom" id="wFA-8X-y0T"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="cellStackViewLeadingConstraint" destination="GhN-Ib-f12" id="xoY-Yw-dKq"/>
+                <outlet property="gravatarImageView" destination="pe3-Qf-lcv" id="Nm7-aR-dtA"/>
+                <outlet property="nameLabel" destination="IUe-FJ-l5m" id="sey-v1-1fE"/>
+                <outlet property="separatorHeightConstraint" destination="mB6-co-8Ym" id="53f-fU-ylZ"/>
+                <outlet property="separatorLeadingConstraint" destination="kUW-yY-J0j" id="3Yg-OB-oRi"/>
+                <outlet property="separatorView" destination="7UX-Gg-MNF" id="ElU-fs-oMZ"/>
+                <outlet property="usernameLabel" destination="LDG-hl-sfI" id="lAD-3V-QRG"/>
+            </connections>
+            <point key="canvasLocation" x="-238.40579710144928" y="-22.098214285714285"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <namedColor name="Gray">
+            <color red="0.39215686274509803" green="0.41176470588235292" blue="0.4392156862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="darkTextColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1510,6 +1510,10 @@
 		98B3FA8421C05BDC00148DD4 /* ViewMoreRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B3FA8321C05BDC00148DD4 /* ViewMoreRow.swift */; };
 		98B3FA8621C05BF000148DD4 /* ViewMoreRow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98B3FA8521C05BF000148DD4 /* ViewMoreRow.xib */; };
 		98B52AE121F7AF4A006FF6B4 /* StatsDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */; };
+		98B88452261E4E09007ED7F8 /* LikeUserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B88451261E4E09007ED7F8 /* LikeUserTableViewCell.swift */; };
+		98B88453261E4E09007ED7F8 /* LikeUserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B88451261E4E09007ED7F8 /* LikeUserTableViewCell.swift */; };
+		98B88466261E4E4E007ED7F8 /* LikeUserTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98B88465261E4E4E007ED7F8 /* LikeUserTableViewCell.xib */; };
+		98B88467261E4E4E007ED7F8 /* LikeUserTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98B88465261E4E4E007ED7F8 /* LikeUserTableViewCell.xib */; };
 		98BDFF6B20D0732900C72C58 /* SupportTableViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BDFF6A20D0732900C72C58 /* SupportTableViewController+Activity.swift */; };
 		98BFF57C2398406A008A1DCB /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CF3DB1EF1BE6800AF838E /* CocoaLumberjack.swift */; };
 		98BFF57E23984345008A1DCB /* AllTimeWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */; };
@@ -6030,6 +6034,8 @@
 		98B3FA8321C05BDC00148DD4 /* ViewMoreRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMoreRow.swift; sourceTree = "<group>"; };
 		98B3FA8521C05BF000148DD4 /* ViewMoreRow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ViewMoreRow.xib; sourceTree = "<group>"; };
 		98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsDataHelper.swift; sourceTree = "<group>"; };
+		98B88451261E4E09007ED7F8 /* LikeUserTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeUserTableViewCell.swift; sourceTree = "<group>"; };
+		98B88465261E4E4E007ED7F8 /* LikeUserTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LikeUserTableViewCell.xib; sourceTree = "<group>"; };
 		98BBB642258047DD0084FF72 /* WordPress 107.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 107.xcdatamodel"; sourceTree = "<group>"; };
 		98BDFF6A20D0732900C72C58 /* SupportTableViewController+Activity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SupportTableViewController+Activity.swift"; sourceTree = "<group>"; };
 		98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllTimeWidgetStats.swift; sourceTree = "<group>"; };
@@ -12186,28 +12192,30 @@
 		B5FD4523199D0F1100286FBB /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				98B88451261E4E09007ED7F8 /* LikeUserTableViewCell.swift */,
+				98B88465261E4E4E007ED7F8 /* LikeUserTableViewCell.xib */,
 				2FA37B19215724E900C80377 /* LongPressGestureLabel.swift */,
+				B57AF5F91ACDC73D0075A7D2 /* NoteBlockActionsTableViewCell.swift */,
+				B5C66B731ACF071F00F68370 /* NoteBlockActionsTableViewCell.xib */,
+				176CF39925E0005F00E1E598 /* NoteBlockButtonTableViewCell.swift */,
+				176CF3AB25E0079600E1E598 /* NoteBlockButtonTableViewCell.xib */,
+				B532D4E5199D4357006E4DF6 /* NoteBlockCommentTableViewCell.swift */,
+				B5C66B751ACF072C00F68370 /* NoteBlockCommentTableViewCell.xib */,
+				B532D4E6199D4357006E4DF6 /* NoteBlockHeaderTableViewCell.swift */,
+				B5C66B6F1ACF06CA00F68370 /* NoteBlockHeaderTableViewCell.xib */,
+				B532D4ED199D4418006E4DF6 /* NoteBlockImageTableViewCell.swift */,
+				B5C66B771ACF073900F68370 /* NoteBlockImageTableViewCell.xib */,
+				B532D4E7199D4357006E4DF6 /* NoteBlockTableViewCell.swift */,
+				B532D4E8199D4357006E4DF6 /* NoteBlockTextTableViewCell.swift */,
+				B5C66B711ACF071000F68370 /* NoteBlockTextTableViewCell.xib */,
+				B52C4C7C199D4CD3009FD823 /* NoteBlockUserTableViewCell.swift */,
+				B5C66B791ACF074600F68370 /* NoteBlockUserTableViewCell.xib */,
 				B57B99D419A2C20200506504 /* NoteTableHeaderView.swift */,
 				B5683DB71B6C03810043447C /* NoteTableHeaderView.xib */,
 				B52C4C7E199D74AE009FD823 /* NoteTableViewCell.swift */,
 				B5E23BDE19AD0D00000D6879 /* NoteTableViewCell.xib */,
 				B50421E81B68170F008EEA82 /* NoteUndoOverlayView.swift */,
 				B50421E61B680839008EEA82 /* NoteUndoOverlayView.xib */,
-				B532D4E7199D4357006E4DF6 /* NoteBlockTableViewCell.swift */,
-				176CF39925E0005F00E1E598 /* NoteBlockButtonTableViewCell.swift */,
-				176CF3AB25E0079600E1E598 /* NoteBlockButtonTableViewCell.xib */,
-				B532D4E6199D4357006E4DF6 /* NoteBlockHeaderTableViewCell.swift */,
-				B5C66B6F1ACF06CA00F68370 /* NoteBlockHeaderTableViewCell.xib */,
-				B532D4E8199D4357006E4DF6 /* NoteBlockTextTableViewCell.swift */,
-				B5C66B711ACF071000F68370 /* NoteBlockTextTableViewCell.xib */,
-				B57AF5F91ACDC73D0075A7D2 /* NoteBlockActionsTableViewCell.swift */,
-				B5C66B731ACF071F00F68370 /* NoteBlockActionsTableViewCell.xib */,
-				B532D4E5199D4357006E4DF6 /* NoteBlockCommentTableViewCell.swift */,
-				B5C66B751ACF072C00F68370 /* NoteBlockCommentTableViewCell.xib */,
-				B532D4ED199D4418006E4DF6 /* NoteBlockImageTableViewCell.swift */,
-				B5C66B771ACF073900F68370 /* NoteBlockImageTableViewCell.xib */,
-				B52C4C7C199D4CD3009FD823 /* NoteBlockUserTableViewCell.swift */,
-				B5C66B791ACF074600F68370 /* NoteBlockUserTableViewCell.xib */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -14377,6 +14385,7 @@
 				17E363E422C4280A000E0C79 /* pride_icon_29pt@3x.png in Resources */,
 				E66E2A6A1FE432BC00788F22 /* TitleBadgeDisclosureCell.xib in Resources */,
 				40640046200ED30300106789 /* TextWithAccessoryButtonCell.xib in Resources */,
+				98B88466261E4E4E007ED7F8 /* LikeUserTableViewCell.xib in Resources */,
 				98467A43221CD75200DF51AE /* SiteStatsDetailTableViewController.storyboard in Resources */,
 				17DC4C3022C5E6910059CA11 /* open_source_dark_icon_20pt.png in Resources */,
 				17E3634222C417F0000E0C79 /* jetpack_green_icon_83.5@2x.png in Resources */,
@@ -14897,6 +14906,7 @@
 				FABB200A2602FC2C00C8785C /* Noticons.ttf in Resources */,
 				FABB200B2602FC2C00C8785C /* LoginEpilogue.storyboard in Resources */,
 				FABB200C2602FC2C00C8785C /* AddressCell.xib in Resources */,
+				98B88467261E4E4E007ED7F8 /* LikeUserTableViewCell.xib in Resources */,
 				FABB200D2602FC2C00C8785C /* open_source_icon_29pt@2x.png in Resources */,
 				FABB200E2602FC2C00C8785C /* wordpress_dark_icon_40pt@3x.png in Resources */,
 				FABB200F2602FC2C00C8785C /* TopTotalsCell.xib in Resources */,
@@ -16523,6 +16533,7 @@
 				C81CCD81243BF7A600A83E27 /* TenorService.swift in Sources */,
 				8B51844525893F140085488D /* FilterBarView.swift in Sources */,
 				E105205B1F2B1CF400A948F6 /* BlogToBlogMigration_61_62.swift in Sources */,
+				98B88452261E4E09007ED7F8 /* LikeUserTableViewCell.swift in Sources */,
 				E16FB7E31F8B61040004DD9F /* WebKitViewController.swift in Sources */,
 				3F8CBE0B24EEB0EA00F71234 /* AnnouncementsDataSource.swift in Sources */,
 				7305138321C031FC006BD0A1 /* AssembledSiteView.swift in Sources */,
@@ -18597,6 +18608,7 @@
 				FABB22C92602FC2C00C8785C /* NSAttributedString+Helpers.swift in Sources */,
 				FABB22CA2602FC2C00C8785C /* TenorService.swift in Sources */,
 				FABB22CB2602FC2C00C8785C /* FilterBarView.swift in Sources */,
+				98B88453261E4E09007ED7F8 /* LikeUserTableViewCell.swift in Sources */,
 				FABB22CC2602FC2C00C8785C /* BlogToBlogMigration_61_62.swift in Sources */,
 				FABB22CD2602FC2C00C8785C /* WebKitViewController.swift in Sources */,
 				FABB22CE2602FC2C00C8785C /* AnnouncementsDataSource.swift in Sources */,


### PR DESCRIPTION
Fixes #16249 

This updates the user cell UI to the new design detailed on #16249.

To test:
- Enable the `newLikeNotifications` feature.
- Go to Notifications > Likes and tap a notification.
- Verify the user cells match the design. 
  - Tapping the row does nothing for now, and will be addressed on #16244.
- Disable the `newLikeNotifications` feature.
- Go to Notifications > Likes and tap a notification.
- Verify the user cells are the old UI, and tapping opens the user's site.

| Before | After |
|--------|-------|
| <img width="473" alt="before" src="https://user-images.githubusercontent.com/1816888/114073446-84f71600-9860-11eb-9387-b7064f55047b.png"> | <img width="472" alt="after" src="https://user-images.githubusercontent.com/1816888/114073469-8b858d80-9860-11eb-85e8-3ea0a654db4d.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
