### PR TITLE
Jetpack App: Add dark mode variants to Jetpack Green shades

### DIFF
--- a/WordPress/ColorPalette.xcassets/JetpackGreen0.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen0.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "240",
-          "green": "242",
-          "blue": "235",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "235",
+          "green" : "242",
+          "red" : "240"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.922",
+          "green" : "0.949",
+          "red" : "0.941"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen10.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen10.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "157",
-          "green": "217",
-          "blue": "119",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "119",
+          "green" : "217",
+          "red" : "157"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.720",
+          "green" : "0.903",
+          "red" : "0.816"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen100.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen100.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "0",
-          "green": "28",
-          "blue": "9",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "9",
+          "green" : "28",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.035",
+          "green" : "0.110",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen20.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen20.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "100",
-          "green": "202",
-          "blue": "67",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "67",
+          "green" : "202",
+          "red" : "100"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.466",
+          "green" : "0.852",
+          "red" : "0.617"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen30.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen30.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "47",
-          "green": "180",
-          "blue": "31",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "31",
+          "green" : "180",
+          "red" : "47"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.265",
+          "green" : "0.794",
+          "red" : "0.391"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen40.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen40.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "6",
-          "green": "158",
-          "blue": "8",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "8",
+          "green" : "158",
+          "red" : "6"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.121",
+          "green" : "0.707",
+          "red" : "0.211"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen5.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen5.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "208",
-          "green": "230",
-          "blue": "184",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "184",
+          "green" : "230",
+          "red" : "208"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.920",
+          "green" : "0.950",
+          "red" : "0.941"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen50.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen50.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "0",
-          "green": "135",
-          "blue": "16",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "16",
+          "green" : "135",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.025",
+          "green" : "0.620",
+          "red" : "0.179"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen60.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen60.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "0",
-          "green": "113",
-          "blue": "23",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "23",
+          "green" : "113",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.064",
+          "green" : "0.528",
+          "red" : "0.148"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen70.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen70.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "0",
-          "green": "91",
-          "blue": "24",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "24",
+          "green" : "91",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.089",
+          "green" : "0.445",
+          "red" : "0.120"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen80.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen80.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "0",
-          "green": "69",
-          "blue": "21",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "21",
+          "green" : "69",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.095",
+          "green" : "0.357",
+          "red" : "0.091"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/WordPress/ColorPalette.xcassets/JetpackGreen90.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/JetpackGreen90.colorset/Contents.json
@@ -1,20 +1,38 @@
 {
-  "info": {
-    "author": "blog.color-studio",
-    "version": "2.5.0"
-  },
-  "colors": [
+  "colors" : [
     {
-      "idiom": "universal",
-      "color": {
-        "components": {
-          "red": "0",
-          "green": "48",
-          "blue": "16",
-          "alpha": 1
-        },
-        "color-space": "srgb"
-      }
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "16",
+          "green" : "48",
+          "red" : "0"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.080",
+          "green" : "0.270",
+          "red" : "0.061"
+        }
+      },
+      "idiom" : "universal"
     }
-  ]
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }


### PR DESCRIPTION
## Description

This PR updates the Jetpack Green shades to include both Any Appearance and Dark Appearance variants in the color palette assets. There are no code changes, only asset catalog updates.

The mappings below are based on same mappings as WordPress Blue :

```
- jetpackgreen0 -> jetpackGreen0
- jetpackGreen5 -> jetpackGreen0
- jetpackGreen10 -> jetpackGreen5
- jetpackGreen20 -> jetpackGreen10
- jetpackGreen30 -> jetpackGreen20
- jetpackGreen40 -> jetpackGreen30
- jetpackGreen50 -> jetpackGreen40
- jetpackGreen60 -> jetpackGreen50
- jetpackGreen70 -> jetpackGreen60
- jetpackGreen80 -> jetpackGreen70
- jetpackGreen90 -> jetpackGreen80
- jetpackGreen100 -> jetpackGreen100
```

Relevant PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16205

## Notes

- These mappings are the default light/dark mappings for the Jetpack Green shades. We can also provide custom light/dark mappings by using `UIColor(light:dark:)`.
- Please note that the following will be addressed in future PRs:
    - calendar view colors
    - backup / restore cell progress view colors
    - stats colors (pending design)    

## How to test
- For this PR, there should mostly just be slight changes to colors, so it's really just a case of looking through the app and ensuring nothing looks super out of place. Check light and dark mode for the Jetpack app.

![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 00 28](https://user-images.githubusercontent.com/6711616/114119129-0912d180-9925-11eb-83fe-7d2488623924.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 00 30](https://user-images.githubusercontent.com/6711616/114119135-0adc9500-9925-11eb-9755-f38aa01b97d0.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 00 51](https://user-images.githubusercontent.com/6711616/114119142-0ca65880-9925-11eb-9078-c239a40ac6ce.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 01 14](https://user-images.githubusercontent.com/6711616/114119143-0d3eef00-9925-11eb-9c9e-c18553ce940a.png)
-- | -- | -- | --
![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 03 02](https://user-images.githubusercontent.com/6711616/114119187-247ddc80-9925-11eb-93a0-72a1bf744029.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 03 05](https://user-images.githubusercontent.com/6711616/114119188-25167300-9925-11eb-8a62-84521bc3c47e.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 03 24](https://user-images.githubusercontent.com/6711616/114119189-25af0980-9925-11eb-8b0d-d2566b008b5a.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 03 27](https://user-images.githubusercontent.com/6711616/114119192-26e03680-9925-11eb-8294-c766ea3705b7.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 04 04](https://user-images.githubusercontent.com/6711616/114119314-5e4ee300-9925-11eb-9181-29d85c9b77f6.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 04 06](https://user-images.githubusercontent.com/6711616/114119317-5f801000-9925-11eb-84e0-c6303633cc7e.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 04 14](https://user-images.githubusercontent.com/6711616/114119318-6018a680-9925-11eb-86ec-b98fcd5e5e26.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-08 at 17 04 29](https://user-images.githubusercontent.com/6711616/114119325-6149d380-9925-11eb-8d17-42c4788e7071.png)

## Regression Notes
1. Potential unintended areas of impact
- Dark mode colors (but I think I have mapped these over correctly)
- Colors not looking 'right' in various places across the app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I checked through the app in light and dark mode and couldn't see any issues.

3. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
