### PR TITLE
Jetpack App: Update calendar selected color to use semantic colors

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -209,10 +209,7 @@ class DateCell: JTACDayCell {
         static let labelSize: CGFloat = 28
         static let reuseIdentifier = "dateCell"
         static var selectedColor: UIColor {
-            UIColor(
-                light: UIColor(red: 0.91, green: 0.94, blue: 0.96, alpha: 1.00),
-                dark: UIColor(red: 0.02, green: 0.22, blue: 0.35, alpha: 1.00)
-            )
+            UIColor(light: .primary(.shade5), dark: .primary(.shade90))
         }
     }
 


### PR DESCRIPTION
## Description

This PR updates the selected color in the calendar view to use semantic colors.

- Light: Jetpack Green 5
- Dark: Jetpack Green 80

## Note

@osullivanchris Although we discussed mapping Jetpack Green to Jetpack 70, I thought Jetpack Green ~90~ 80 may be a better choice since it matches what we have now more closely. Would love your feedback, I can always change back to Jetpack 70 if that looks better!

### Light mode

Before | After (Blue 5) | After (Jetpack Green 5) 
--- | --- | ---
<img src="https://user-images.githubusercontent.com/6711616/114130459-96f9b700-993b-11eb-839e-7a0c0a56db30.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/114130474-9f51f200-993b-11eb-9ea1-3842f1142164.png" width=200>  | <img src="https://user-images.githubusercontent.com/6711616/114130471-9c570180-993b-11eb-859a-f2ad4c4efb4b.png" width=200> 

### Dark mode

Before | After (Blue 80) | After (Jetpack Green 80)
:---: | :---: | :---:
<img src="https://user-images.githubusercontent.com/6711616/114130620-ed66f580-993b-11eb-9640-415dafc67623.png" width=200>  | <img src="https://user-images.githubusercontent.com/6711616/114130643-fa83e480-993b-11eb-82e1-c127643acb42.png" width=200>  | <img src="https://user-images.githubusercontent.com/6711616/114130653-fd7ed500-993b-11eb-92d0-00167bf17ba9.png" width=200> 
|| **Alternate option <br> (Blue 70)** | **Alternate option <br> (Jetpack Green 70)**
|| <img src="https://user-images.githubusercontent.com/6711616/114336495-1c72a680-9b8a-11eb-95d9-b6cfff8ad25a.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/114336492-1a104c80-9b8a-11eb-817a-71dea8a281aa.png" width=200> 

## How to test

Repeat the following for both the Jetpack and WordPress targets:

1. Go to My Site > Activity Log
2. Tap on Date Range
3. Select a date range and note the colors for both light and dark modes

## Regression Notes
1. Potential unintended areas of impact
- Need to make sure the updated colors look good on WordPress too

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I tested both the WordPress and Jetpack apps with the updated colors, see screenshots above

3. What automated tests I added (or what prevented me from doing so)
- None, just visual changes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
