### PR TITLE
Jetpack App: Update backup/restore progress colors

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -96,6 +96,8 @@ open class RewindStatusTableViewCell: ActivityTableViewCell {
         iconImageView.isHidden = false
         actionButtonContainer.isHidden = true
 
+        progressView.progressTintColor = .primary
+        progressView.trackTintColor = .primary(.shade5)
         progressView.setProgress(progress, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -97,7 +97,7 @@ open class RewindStatusTableViewCell: ActivityTableViewCell {
         actionButtonContainer.isHidden = true
 
         progressView.progressTintColor = .primary
-        progressView.trackTintColor = .primary(.shade5)
+        progressView.trackTintColor = UIColor(light: (.primary(.shade5)), dark: (.primary(.shade80)))
         progressView.setProgress(progress, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/RewindStatusTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Activity/RewindStatusTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -83,8 +83,6 @@
                         <constraints>
                             <constraint firstAttribute="height" constant="4" id="wWm-ff-q3v"/>
                         </constraints>
-                        <color key="progressTintColor" red="0.0" green="0.66666666669999997" blue="0.86274509799999999" alpha="1" colorSpace="calibratedRGB"/>
-                        <color key="trackTintColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.88235294117647056" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     </progressView>
                 </subviews>
                 <constraints>


### PR DESCRIPTION
## Description

This PR updates the selected color in the backup/restore cell to use semantic colors.

## Note
- Track color tint: custom mapping
    - Light: Jetpack Green 5
    - Dark: Jetpack Green 70
- Progress color tint: default mapping
    - Light: Jetpack Green 50 
    - Dark: Jetpack Green 40

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/114135894-ded10c00-9944-11eb-902c-a7a4f28ebe2a.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/114135916-e4c6ed00-9944-11eb-934f-82760b9edbe4.png" width=200>
<img src="https://user-images.githubusercontent.com/6711616/114337973-14683600-9b8d-11eb-9ab1-bde430a13d95.png" width=200> |<img src="https://user-images.githubusercontent.com/6711616/114337970-13370900-9b8d-11eb-8ed9-71e8371028be.png" width=200>


## How to test

Repeat for both the WordPress and Jetpack targets:

1. Go to My Site > Backups > ellipsis icon > Download backup
2. Tap on the Create downloadable file button
3. Tap on Done before the download finishes
4. Notice the progress view colors for the backup/restore cell looks good on both light and dark mode.

## Regression Notes
1. Potential unintended areas of impact
- Need to make sure the updated colors look good on WordPress too


2. What I did to test those areas of impact (or what existing automated tests I relied on)
- I tested both the WordPress and Jetpack apps with the updated colors

3. What automated tests I added (or what prevented me from doing so)
- None, just visual changes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
