### PR TITLE
Notification Likes list: show user profile in bottom sheet when user tapped.

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -965,6 +965,7 @@ extension NotificationDetailsViewController {
 // MARK: - Resources
 //
 private extension NotificationDetailsViewController {
+
     func displayURL(_ url: URL?) {
         guard let url = url else {
             tableView.deselectSelectedRowWithAnimation(true)
@@ -980,8 +981,16 @@ private extension NotificationDetailsViewController {
             tableView.deselectSelectedRowWithAnimation(true)
         }
     }
-}
 
+    func displayUserProfile(_ user: RemoteUser) {
+        let userProfileVC = UserProfileSheetViewController(user: user)
+        let bottomSheet = BottomSheetViewController(childViewController: userProfileVC)
+
+        // TODO: add sourceView for iPad
+        bottomSheet.show(from: self)
+    }
+
+}
 
 
 // MARK: - Helpers
@@ -1368,8 +1377,9 @@ extension NotificationDetailsViewController: LikesListControllerDelegate {
     }
 
     func didSelectUser(_ user: RemoteUser) {
-        // TODO: display user profile bottom sheet
+        displayUserProfile(user)
     }
+
 }
 
 

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSectionHeader.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSectionHeader.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+class UserProfileSectionHeader: UITableViewHeaderFooterView, NibReusable {
+
+    @IBOutlet weak var titleLabel: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        titleLabel.textColor = .textSubtle
+        contentView.backgroundColor = .basicBackground
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSectionHeader.xib
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSectionHeader.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view userInteractionEnabled="NO" contentMode="scaleToFill" id="kPA-oR-TOp" customClass="UserProfileSectionHeader" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="394" height="102"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SITE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QfN-CJ-PfS">
+                    <rect key="frame" x="20" y="59" width="354" height="28"/>
+                    <constraints>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="10" id="itQ-Bj-pPT"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                    <color key="textColor" red="0.30980392159999998" green="0.4549019608" blue="0.5568627451" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="epR-21-48u"/>
+            <constraints>
+                <constraint firstItem="epR-21-48u" firstAttribute="trailing" secondItem="QfN-CJ-PfS" secondAttribute="trailing" constant="20" id="00m-PJ-fLJ"/>
+                <constraint firstItem="QfN-CJ-PfS" firstAttribute="leading" secondItem="epR-21-48u" secondAttribute="leading" constant="20" id="Gh8-nd-6Kk"/>
+                <constraint firstItem="QfN-CJ-PfS" firstAttribute="top" secondItem="epR-21-48u" secondAttribute="top" constant="15" id="Ode-gE-Yfd"/>
+                <constraint firstItem="epR-21-48u" firstAttribute="bottom" secondItem="QfN-CJ-PfS" secondAttribute="bottom" constant="15" id="YHh-Zx-Rq0"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="titleLabel" destination="QfN-CJ-PfS" id="13k-63-kjJ"/>
+            </connections>
+            <point key="canvasLocation" x="36.231884057971016" y="102.45535714285714"/>
+        </view>
+    </objects>
+</document>

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -32,10 +32,9 @@ extension UserProfileSheetViewController: DrawerPresentable {
     var collapsedHeight: DrawerHeight {
         if traitCollection.verticalSizeClass == .compact {
             return .maxHeight
-        } else {
-            return .contentHeight(300)
-
         }
+
+        return .contentHeight(300)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -1,0 +1,138 @@
+class UserProfileSheetViewController: UITableViewController {
+
+    // MARK: - Properties
+
+    private let user: RemoteUser
+
+    // MARK: - Init
+
+    init(user: RemoteUser) {
+        self.user = user
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTable()
+        registerTableCells()
+    }
+
+}
+
+// MARK: - DrawerPresentable Extension
+
+extension UserProfileSheetViewController: DrawerPresentable {
+
+    var collapsedHeight: DrawerHeight {
+        if traitCollection.verticalSizeClass == .compact {
+            return .maxHeight
+        } else {
+            return .contentHeight(300)
+
+        }
+    }
+
+}
+
+// MARK: - UITableViewDataSource methods
+
+extension UserProfileSheetViewController {
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // TODO: if no site, return 1.
+        return 2
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+        // User Info Row
+        if indexPath.section == Constants.userInfoSection {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: UserProfileUserInfoCell.defaultReuseID) as? UserProfileUserInfoCell else {
+                return UITableViewCell()
+            }
+
+            cell.configure(withUser: user)
+            return cell
+        }
+
+        // Site Row
+        // TODO: replace with site cell.
+        return UITableViewCell()
+    }
+
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+
+        // Don't show section header for User Info
+        guard section != Constants.userInfoSection,
+              let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: UserProfileSectionHeader.defaultReuseID) as? UserProfileSectionHeader else {
+            return nil
+        }
+
+        // TODO: Don't show section header if there are no sites.
+
+        header.titleLabel.text = Constants.siteSectionTitle
+        return header
+    }
+
+    override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        // TODO: replace 44 with estimated row height for site cell.
+        return indexPath.section == Constants.userInfoSection ? UserProfileUserInfoCell.estimatedRowHeight : 44
+    }
+
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+
+        // TODO: return 0 if there are no sites.
+        if section == Constants.userInfoSection {
+            return 0
+        }
+
+        return UITableView.automaticDimension
+    }
+
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // TODO: show site if site row selected.
+    }
+
+}
+
+// MARK: - Private Extension
+
+private extension UserProfileSheetViewController {
+
+    func configureTable() {
+        tableView.backgroundColor = .basicBackground
+        tableView.separatorStyle = .none
+    }
+
+    func registerTableCells() {
+        tableView.register(UserProfileUserInfoCell.defaultNib,
+                           forCellReuseIdentifier: UserProfileUserInfoCell.defaultReuseID)
+
+        tableView.register(UserProfileSectionHeader.defaultNib,
+                           forHeaderFooterViewReuseIdentifier: UserProfileSectionHeader.defaultReuseID)
+    }
+
+    enum Constants {
+        static let userInfoSection = 0
+        static let siteSectionTitle = NSLocalizedString("Site", comment: "Header for a single site, shown in Notification user profile.").localizedUppercase
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
@@ -1,0 +1,62 @@
+class UserProfileUserInfoCell: UITableViewCell, NibReusable {
+
+    // MARK: - Properties
+
+    @IBOutlet weak var gravatarImageView: CircularImageView!
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var usernameLabel: UILabel!
+    @IBOutlet weak var userBioLabel: UILabel!
+
+    static let estimatedRowHeight: CGFloat = 200
+
+    // MARK: - View
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureCell()
+    }
+
+    // MARK: - Public Methods
+
+    func configure(withUser user: RemoteUser) {
+        nameLabel.text = user.displayName
+        usernameLabel.text = String(format: Constants.usernameFormat, user.username)
+
+        // TODO:
+        // - replace with actual bio.
+        // - hide label if no bio.
+        userBioLabel.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Consectetur purus ut faucibus pulvinar. Tincidunt eget nullam non nisi est sit amet facilisis magna. Morbi tincidunt augue interdum velit euismod in pellentesque. Sed adipiscing diam donec adipiscing."
+
+        downloadGravatarWithURL(user.avatarURL)
+    }
+
+}
+
+// MARK: - Private Extension
+
+private extension UserProfileUserInfoCell {
+
+    func configureCell() {
+        nameLabel.textColor = .text
+        usernameLabel.textColor = .textSubtle
+        userBioLabel.textColor = .text
+    }
+
+    func downloadGravatarWithURL(_ url: String?) {
+        // Always reset gravatar
+        gravatarImageView.cancelImageDownload()
+        gravatarImageView.image = .gravatarPlaceholderImage
+
+        guard let url = url,
+              let gravatarURL = URL(string: url) else {
+            return
+        }
+
+        gravatarImageView.downloadImage(from: gravatarURL, placeholderImage: .gravatarPlaceholderImage)
+    }
+
+    struct Constants {
+        static let usernameFormat = NSLocalizedString("@%1$@", comment: "Label displaying the user's username preceeded by an '@' symbol. %1$@ is a placeholder for the username.")
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
@@ -38,6 +38,7 @@ private extension UserProfileUserInfoCell {
 
     func configureCell() {
         nameLabel.textColor = .text
+        nameLabel.font = WPStyleGuide.serifFontForTextStyle(.title3, fontWeight: .medium)
         usernameLabel.textColor = .textSubtle
         userBioLabel.textColor = .text
     }

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
@@ -38,7 +38,7 @@ private extension UserProfileUserInfoCell {
 
     func configureCell() {
         nameLabel.textColor = .text
-        nameLabel.font = WPStyleGuide.serifFontForTextStyle(.title3, fontWeight: .medium)
+        nameLabel.font = WPStyleGuide.serifFontForTextStyle(.title3, fontWeight: .semibold)
         usernameLabel.textColor = .textSubtle
         userBioLabel.textColor = .text
     }

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.xib
@@ -18,29 +18,29 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="4Ut-AW-P1h" userLabel="Cell Stack View">
-                        <rect key="frame" x="20" y="0.0" width="395" height="156"/>
+                        <rect key="frame" x="20" y="5" width="395" height="151"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="YVe-Xq-IHC" userLabel="Top Stack View">
-                                <rect key="frame" x="0.0" y="0.0" width="395" height="123"/>
+                                <rect key="frame" x="0.0" y="0.0" width="395" height="118"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="10J-wX-NYd" userLabel="Gravatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="38.5" width="46" height="46"/>
+                                        <rect key="frame" x="0.0" y="31" width="56" height="56"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="10J-wX-NYd" secondAttribute="height" multiplier="1:1" id="14o-d5-L9V"/>
-                                            <constraint firstAttribute="width" constant="46" id="QaL-PC-gK7"/>
+                                            <constraint firstAttribute="width" constant="56" id="QaL-PC-gK7"/>
                                         </constraints>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="hys-IH-x9N" userLabel="Label Stack View">
-                                        <rect key="frame" x="58" y="42.5" width="337" height="38.5"/>
+                                        <rect key="frame" x="68" y="38" width="327" height="42"/>
                                         <subviews>
                                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xXR-ER-499" userLabel="Name Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="45" height="20.5"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="52" height="24"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IVR-fR-wh6" userLabel="Username Label">
-                                                <rect key="frame" x="0.0" y="20.5" width="81.5" height="18"/>
+                                                <rect key="frame" x="0.0" y="24" width="81.5" height="18"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" name="Gray"/>
                                                 <nil key="highlightedColor"/>
@@ -50,7 +50,7 @@
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User bio" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HPd-4P-tnS" userLabel="Bio Label">
-                                <rect key="frame" x="0.0" y="138" width="395" height="18"/>
+                                <rect key="frame" x="0.0" y="133" width="395" height="18"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" name="Black"/>
                                 <nil key="highlightedColor"/>
@@ -59,7 +59,7 @@
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="4Ut-AW-P1h" firstAttribute="top" secondItem="L1j-z8-YLw" secondAttribute="top" id="4VA-bk-yYq"/>
+                    <constraint firstItem="4Ut-AW-P1h" firstAttribute="top" secondItem="L1j-z8-YLw" secondAttribute="top" constant="5" id="4VA-bk-yYq"/>
                     <constraint firstAttribute="bottom" secondItem="4Ut-AW-P1h" secondAttribute="bottom" id="8cw-B8-bS8"/>
                     <constraint firstItem="4Ut-AW-P1h" firstAttribute="leading" secondItem="L1j-z8-YLw" secondAttribute="leading" constant="20" id="EJu-am-2SP"/>
                     <constraint firstAttribute="trailing" secondItem="4Ut-AW-P1h" secondAttribute="trailing" constant="20" id="LUA-Hx-nkW"/>

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.xib
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Hmh-TK-Qpg" customClass="UserProfileUserInfoCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="435" height="156"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Hmh-TK-Qpg" id="L1j-z8-YLw">
+                <rect key="frame" x="0.0" y="0.0" width="435" height="156"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="4Ut-AW-P1h" userLabel="Cell Stack View">
+                        <rect key="frame" x="20" y="0.0" width="395" height="156"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="YVe-Xq-IHC" userLabel="Top Stack View">
+                                <rect key="frame" x="0.0" y="0.0" width="395" height="123"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="10J-wX-NYd" userLabel="Gravatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="38.5" width="46" height="46"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="10J-wX-NYd" secondAttribute="height" multiplier="1:1" id="14o-d5-L9V"/>
+                                            <constraint firstAttribute="width" constant="46" id="QaL-PC-gK7"/>
+                                        </constraints>
+                                    </imageView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="hys-IH-x9N" userLabel="Label Stack View">
+                                        <rect key="frame" x="58" y="42.5" width="337" height="38.5"/>
+                                        <subviews>
+                                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xXR-ER-499" userLabel="Name Label">
+                                                <rect key="frame" x="0.0" y="0.0" width="45" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <color key="textColor" systemColor="darkTextColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" clipsSubviews="YES" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="@username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IVR-fR-wh6" userLabel="Username Label">
+                                                <rect key="frame" x="0.0" y="20.5" width="81.5" height="18"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                <color key="textColor" name="Gray"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User bio" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HPd-4P-tnS" userLabel="Bio Label">
+                                <rect key="frame" x="0.0" y="138" width="395" height="18"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                <color key="textColor" name="Black"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="4Ut-AW-P1h" firstAttribute="top" secondItem="L1j-z8-YLw" secondAttribute="top" id="4VA-bk-yYq"/>
+                    <constraint firstAttribute="bottom" secondItem="4Ut-AW-P1h" secondAttribute="bottom" id="8cw-B8-bS8"/>
+                    <constraint firstItem="4Ut-AW-P1h" firstAttribute="leading" secondItem="L1j-z8-YLw" secondAttribute="leading" constant="20" id="EJu-am-2SP"/>
+                    <constraint firstAttribute="trailing" secondItem="4Ut-AW-P1h" secondAttribute="trailing" constant="20" id="LUA-Hx-nkW"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="gravatarImageView" destination="10J-wX-NYd" id="4ys-ft-O1f"/>
+                <outlet property="nameLabel" destination="xXR-ER-499" id="5Qk-b8-Qwr"/>
+                <outlet property="userBioLabel" destination="HPd-4P-tnS" id="F6c-9u-gZs"/>
+                <outlet property="usernameLabel" destination="IVR-fR-wh6" id="tP9-SL-xTp"/>
+            </connections>
+            <point key="canvasLocation" x="-239.85507246376812" y="-16.071428571428569"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <namedColor name="Black">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Gray">
+            <color red="0.39215686274509803" green="0.41176470588235292" blue="0.4392156862745098" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <systemColor name="darkTextColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1413,6 +1413,12 @@
 		984F86FB21DEDB070070E0E3 /* TopTotalsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984F86FA21DEDB060070E0E3 /* TopTotalsCell.swift */; };
 		98563DDD21BF30C40006F5E9 /* TabbedTotalsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */; };
 		98563DDE21BF30C40006F5E9 /* TabbedTotalsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98563DDC21BF30C40006F5E9 /* TabbedTotalsCell.xib */; };
+		9856A389261FC206008D6354 /* UserProfileUserInfoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9856A388261FC206008D6354 /* UserProfileUserInfoCell.xib */; };
+		9856A38A261FC206008D6354 /* UserProfileUserInfoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9856A388261FC206008D6354 /* UserProfileUserInfoCell.xib */; };
+		9856A39D261FC21E008D6354 /* UserProfileUserInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9856A39C261FC21E008D6354 /* UserProfileUserInfoCell.swift */; };
+		9856A39E261FC21E008D6354 /* UserProfileUserInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9856A39C261FC21E008D6354 /* UserProfileUserInfoCell.swift */; };
+		9856A3E4261FD27A008D6354 /* UserProfileSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9856A3E3261FD27A008D6354 /* UserProfileSectionHeader.swift */; };
+		9856A3E5261FD27A008D6354 /* UserProfileSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9856A3E3261FD27A008D6354 /* UserProfileSectionHeader.swift */; };
 		985793C822F23D7000643DBF /* CustomizeInsightsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985793C622F23D7000643DBF /* CustomizeInsightsCell.swift */; };
 		985793C922F23D7000643DBF /* CustomizeInsightsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 985793C722F23D7000643DBF /* CustomizeInsightsCell.xib */; };
 		98579BC7203DD86F004086E4 /* EpilogueSectionHeaderFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98579BC5203DD86D004086E4 /* EpilogueSectionHeaderFooter.swift */; };
@@ -1451,6 +1457,8 @@
 		98797DBC222F434500128C21 /* OverviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98797DBA222F434500128C21 /* OverviewCell.swift */; };
 		98797DBD222F434500128C21 /* OverviewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98797DBB222F434500128C21 /* OverviewCell.xib */; };
 		987C40C625E590BE002A0955 /* CommentsViewController+Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987C40C525E590BE002A0955 /* CommentsViewController+Filters.swift */; };
+		987E79CB261F8858000192B7 /* UserProfileSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987E79CA261F8857000192B7 /* UserProfileSheetViewController.swift */; };
+		987E79CC261F8858000192B7 /* UserProfileSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987E79CA261F8857000192B7 /* UserProfileSheetViewController.swift */; };
 		9880150623A840200003BD11 /* ColorPalette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 435B76292297484200511813 /* ColorPalette.xcassets */; };
 		988056032183CCE50083B643 /* SiteStatsInsightsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */; };
 		98812966219CE42A0075FF33 /* StatsTotalRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98812964219CE42A0075FF33 /* StatsTotalRow.swift */; };
@@ -1537,6 +1545,8 @@
 		98E58A2F2360D23400E5534B /* TodayWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E58A2E2360D23400E5534B /* TodayWidgetStats.swift */; };
 		98E58A302360D23400E5534B /* TodayWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E58A2E2360D23400E5534B /* TodayWidgetStats.swift */; };
 		98E58A442361019300E5534B /* Pods_WordPressTodayWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98E58A432361019300E5534B /* Pods_WordPressTodayWidget.framework */; };
+		98E5D4922620C2B40074A56A /* UserProfileSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98E5D4912620C2B40074A56A /* UserProfileSectionHeader.xib */; };
+		98E5D4932620C2B40074A56A /* UserProfileSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98E5D4912620C2B40074A56A /* UserProfileSectionHeader.xib */; };
 		98EB126A20D2DC2500D2D5B5 /* NoResultsViewController+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EB126920D2DC2500D2D5B5 /* NoResultsViewController+Model.swift */; };
 		98F0297C2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F0297A2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.swift */; };
 		98F0297D2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98F0297B2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.xib */; };
@@ -5965,6 +5975,9 @@
 		984F86FA21DEDB060070E0E3 /* TopTotalsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTotalsCell.swift; sourceTree = "<group>"; };
 		98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedTotalsCell.swift; sourceTree = "<group>"; };
 		98563DDC21BF30C40006F5E9 /* TabbedTotalsCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TabbedTotalsCell.xib; sourceTree = "<group>"; };
+		9856A388261FC206008D6354 /* UserProfileUserInfoCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UserProfileUserInfoCell.xib; sourceTree = "<group>"; };
+		9856A39C261FC21E008D6354 /* UserProfileUserInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileUserInfoCell.swift; sourceTree = "<group>"; };
+		9856A3E3261FD27A008D6354 /* UserProfileSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileSectionHeader.swift; sourceTree = "<group>"; };
 		985793C622F23D7000643DBF /* CustomizeInsightsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeInsightsCell.swift; sourceTree = "<group>"; };
 		985793C722F23D7000643DBF /* CustomizeInsightsCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CustomizeInsightsCell.xib; sourceTree = "<group>"; };
 		98579BC5203DD86D004086E4 /* EpilogueSectionHeaderFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EpilogueSectionHeaderFooter.swift; sourceTree = "<group>"; };
@@ -5989,6 +6002,7 @@
 		98797DBA222F434500128C21 /* OverviewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewCell.swift; sourceTree = "<group>"; };
 		98797DBB222F434500128C21 /* OverviewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OverviewCell.xib; sourceTree = "<group>"; };
 		987C40C525E590BE002A0955 /* CommentsViewController+Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentsViewController+Filters.swift"; sourceTree = "<group>"; };
+		987E79CA261F8857000192B7 /* UserProfileSheetViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfileSheetViewController.swift; sourceTree = "<group>"; };
 		988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsInsightsTableViewController.swift; sourceTree = "<group>"; };
 		98812964219CE42A0075FF33 /* StatsTotalRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTotalRow.swift; sourceTree = "<group>"; };
 		98812965219CE42A0075FF33 /* StatsTotalRow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StatsTotalRow.xib; sourceTree = "<group>"; };
@@ -6060,6 +6074,7 @@
 		98E58A2E2360D23400E5534B /* TodayWidgetStats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodayWidgetStats.swift; sourceTree = "<group>"; };
 		98E58A412361017500E5534B /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98E58A432361019300E5534B /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		98E5D4912620C2B40074A56A /* UserProfileSectionHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UserProfileSectionHeader.xib; sourceTree = "<group>"; };
 		98EB126920D2DC2500D2D5B5 /* NoResultsViewController+Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NoResultsViewController+Model.swift"; sourceTree = "<group>"; };
 		98F0297A2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginEpilogueConnectSiteCell.swift; sourceTree = "<group>"; };
 		98F0297B2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoginEpilogueConnectSiteCell.xib; sourceTree = "<group>"; };
@@ -10408,6 +10423,7 @@
 		8584FDB31923EF4F0019C02E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				987E79C9261F8857000192B7 /* User Profile Sheet */,
 				7E3E9B6E2177C9C300FD5797 /* Gutenberg */,
 				98077B58207555E400109F95 /* Support */,
 				D80EE638203DBB7E0094C34C /* Accessibility */,
@@ -11064,6 +11080,18 @@
 				98797DBB222F434500128C21 /* OverviewCell.xib */,
 			);
 			path = Overview;
+			sourceTree = "<group>";
+		};
+		987E79C9261F8857000192B7 /* User Profile Sheet */ = {
+			isa = PBXGroup;
+			children = (
+				9856A3E3261FD27A008D6354 /* UserProfileSectionHeader.swift */,
+				98E5D4912620C2B40074A56A /* UserProfileSectionHeader.xib */,
+				987E79CA261F8857000192B7 /* UserProfileSheetViewController.swift */,
+				9856A39C261FC21E008D6354 /* UserProfileUserInfoCell.swift */,
+				9856A388261FC206008D6354 /* UserProfileUserInfoCell.xib */,
+			);
+			path = "User Profile Sheet";
 			sourceTree = "<group>";
 		};
 		98880A4722B2E3FC00464538 /* Two Column Stats */ = {
@@ -14385,6 +14413,7 @@
 				17E363E422C4280A000E0C79 /* pride_icon_29pt@3x.png in Resources */,
 				E66E2A6A1FE432BC00788F22 /* TitleBadgeDisclosureCell.xib in Resources */,
 				40640046200ED30300106789 /* TextWithAccessoryButtonCell.xib in Resources */,
+				9856A389261FC206008D6354 /* UserProfileUserInfoCell.xib in Resources */,
 				98B88466261E4E4E007ED7F8 /* LikeUserTableViewCell.xib in Resources */,
 				98467A43221CD75200DF51AE /* SiteStatsDetailTableViewController.storyboard in Resources */,
 				17DC4C3022C5E6910059CA11 /* open_source_dark_icon_20pt.png in Resources */,
@@ -14572,6 +14601,7 @@
 				981676D7221B7A4300B81C3F /* CountriesCell.xib in Resources */,
 				43D74AD420FB5ABA004AD934 /* RegisterDomainSectionHeaderView.xib in Resources */,
 				4349BFF5221205540084F200 /* BlogDetailsSectionHeaderView.xib in Resources */,
+				98E5D4922620C2B40074A56A /* UserProfileSectionHeader.xib in Resources */,
 				9A5C854922B3E42800BEE7A3 /* CountriesMapCell.xib in Resources */,
 				5D6C4B021B603D1F005E3C43 /* WPWebViewController.xib in Resources */,
 				E6D3E84B1BEBD888002692E8 /* ReaderCrossPostCell.xib in Resources */,
@@ -14836,6 +14866,7 @@
 				FABB1FC42602FC2C00C8785C /* ReaderInterestsCollectionViewCell.xib in Resources */,
 				FABB1FC52602FC2C00C8785C /* StatsGhostTopHeaderCell.xib in Resources */,
 				FABB1FC62602FC2C00C8785C /* open_source_icon_76pt@2x.png in Resources */,
+				9856A38A261FC206008D6354 /* UserProfileUserInfoCell.xib in Resources */,
 				FABB1FC72602FC2C00C8785C /* RegisterDomainDetailsFooterView.xib in Resources */,
 				FABB1FC82602FC2C00C8785C /* EpilogueSectionHeaderFooter.xib in Resources */,
 				FABB1FC92602FC2C00C8785C /* reader.css in Resources */,
@@ -15076,6 +15107,7 @@
 				FABB20B42602FC2C00C8785C /* WidgetUrlCell.xib in Resources */,
 				FABB20B52602FC2C00C8785C /* richEmbedScript.js in Resources */,
 				FABB20B62602FC2C00C8785C /* LoginEpilogueConnectSiteCell.xib in Resources */,
+				98E5D4932620C2B40074A56A /* UserProfileSectionHeader.xib in Resources */,
 				FABB20B72602FC2C00C8785C /* PluginListCell.xib in Resources */,
 				FABB20B82602FC2C00C8785C /* SiteStatsDashboard.storyboard in Resources */,
 				FABB20B92602FC2C00C8785C /* PostStatsTableViewController.storyboard in Resources */,
@@ -16167,6 +16199,7 @@
 				FFABD800213423F1003C65B6 /* LinkSettingsViewController.swift in Sources */,
 				E15644F11CE0E56600D96E64 /* FeatureItemCell.swift in Sources */,
 				E62AFB6B1DC8E593007484FC /* WPRichContentView.swift in Sources */,
+				9856A39D261FC21E008D6354 /* UserProfileUserInfoCell.swift in Sources */,
 				08B6E51A1F036CAD00268F57 /* MediaFileManager.swift in Sources */,
 				594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */,
 				4093FE40218C384200B1D224 /* AztecVerificationPromptHelper.swift in Sources */,
@@ -16475,6 +16508,7 @@
 				83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */,
 				B56994451B7A7EF200FF26FA /* WPStyleGuide+Comments.swift in Sources */,
 				8B05D29123A9417E0063B9AA /* WPMediaEditor.swift in Sources */,
+				987E79CB261F8858000192B7 /* UserProfileSheetViewController.swift in Sources */,
 				D816C1EC20E0887C00C4D82F /* ApproveComment.swift in Sources */,
 				74AF4D741FE417D200E3EBFE /* MediaUploadOperation.swift in Sources */,
 				981C986E21B9D71400A7C0C8 /* PostingActivityCollectionViewCell.swift in Sources */,
@@ -17317,6 +17351,7 @@
 				D865722E2186F96D0023A99C /* SiteSegmentsWizardContent.swift in Sources */,
 				E66969E01B9E648100EC9C00 /* ReaderTopicToReaderDefaultTopic37to38.swift in Sources */,
 				F1DB8D2B2288C24500906E2F /* UploadsManager.swift in Sources */,
+				9856A3E4261FD27A008D6354 /* UserProfileSectionHeader.swift in Sources */,
 				8B0570D3243781100021A436 /* SchedulingCalendarViewController+PresentFrom.swift in Sources */,
 				82A062DE2017BCBA0084CE7C /* ActivityListSectionHeaderView.swift in Sources */,
 				73FEC871220B358500CEF791 /* WPAccount+RestApi.swift in Sources */,
@@ -18242,6 +18277,7 @@
 				FABB21602602FC2C00C8785C /* EmptyActionView.swift in Sources */,
 				FABB21612602FC2C00C8785C /* ReaderShowAttributionAction.swift in Sources */,
 				FABB21622602FC2C00C8785C /* LinkSettingsViewController.swift in Sources */,
+				9856A39E261FC21E008D6354 /* UserProfileUserInfoCell.swift in Sources */,
 				FABB21632602FC2C00C8785C /* FeatureItemCell.swift in Sources */,
 				FABB21642602FC2C00C8785C /* WPRichContentView.swift in Sources */,
 				FABB21652602FC2C00C8785C /* MediaFileManager.swift in Sources */,
@@ -18550,6 +18586,7 @@
 				FABB22912602FC2C00C8785C /* FilterProvider.swift in Sources */,
 				FABB22922602FC2C00C8785C /* DomainCreditEligibilityChecker.swift in Sources */,
 				FABB22932602FC2C00C8785C /* SiteSettingsViewController.m in Sources */,
+				987E79CC261F8858000192B7 /* UserProfileSheetViewController.swift in Sources */,
 				FABB22942602FC2C00C8785C /* WPStyleGuide+Comments.swift in Sources */,
 				FABB22952602FC2C00C8785C /* WPMediaEditor.swift in Sources */,
 				FABB22962602FC2C00C8785C /* ApproveComment.swift in Sources */,
@@ -19392,6 +19429,7 @@
 				FABB25D32602FC2C00C8785C /* ReaderTopicToReaderDefaultTopic37to38.swift in Sources */,
 				FABB25D42602FC2C00C8785C /* UploadsManager.swift in Sources */,
 				FABB25D52602FC2C00C8785C /* SchedulingCalendarViewController+PresentFrom.swift in Sources */,
+				9856A3E5261FD27A008D6354 /* UserProfileSectionHeader.swift in Sources */,
 				FABB25D62602FC2C00C8785C /* ActivityListSectionHeaderView.swift in Sources */,
 				FABB25D72602FC2C00C8785C /* WPAccount+RestApi.swift in Sources */,
 				FABB25D82602FC2C00C8785C /* ImageCropOverlayView.swift in Sources */,


### PR DESCRIPTION
Ref #16244 

In the user list for a Like Notification, a user profile bottom sheet is shown when the user row is tapped. The view currently only shows:
- The "user information" block - gravatar, name, username, and a stub for the user bio.
- Section header for the site section.

The bottom sheet should render correctly on iPhone in portrait and landscape.

To be addressed in follow-up PRs:
- Correctly placing the sheet on iPad.
- Adding a table row for the user's site (to be displayed in the currently empty site section).

To test:
- Enable the `newLikeNotifications` feature.
- Run on an iPhone. (It will show on an iPad, just not in the right place.)
- Go to Notifications > Likes and tap a notification.
- Tap a user.
  - Verify the bottom sheet appears as described above.
  - Verify the sheet is partial height in portrait.
  - Verify the sheet is full height in landscape.
- Disable the `newLikeNotifications` feature.
- Go to Notifications > Likes and tap a notification.
  - Verify tapping the user opens the user's site.

| ![light_portrait](https://user-images.githubusercontent.com/1816888/114245476-c9acab00-994d-11eb-83b3-1de257b8b769.png) | ![dark_portrait](https://user-images.githubusercontent.com/1816888/114245482-cd403200-994d-11eb-8c83-483bad02ccfe.png) |
|--------|-------|
| ![light_landscape](https://user-images.githubusercontent.com/1816888/114245500-d5986d00-994d-11eb-9de7-5076c13c451f.png) | ![dark_landscape](https://user-images.githubusercontent.com/1816888/114245505-d92bf400-994d-11eb-935c-30566a5928e5.png) |


## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
