### PR TITLE
Jetpack Section: Remove Feature Flags

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -14,7 +14,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case contactInfo
     case siteCreationHomePagePicker
     case jetpackScan
-    case jetpackBackupAndRestore
     case todayWidget
     case milestoneNotifications
     case commentFilters
@@ -50,8 +49,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .siteCreationHomePagePicker:
             return true
         case .jetpackScan:
-            return true
-        case .jetpackBackupAndRestore:
             return true
         case .todayWidget:
             return true
@@ -111,8 +108,6 @@ extension FeatureFlag {
             return "Site Creation: Home Page Picker"
         case .jetpackScan:
             return "Jetpack Scan"
-        case .jetpackBackupAndRestore:
-            return "Jetpack Backup and Restore"
         case .todayWidget:
             return "iOS 14 Today Widget"
         case .milestoneNotifications:

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -14,7 +14,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case contactInfo
     case siteCreationHomePagePicker
     case jetpackScan
-    case activityLogFilters
     case jetpackBackupAndRestore
     case todayWidget
     case milestoneNotifications
@@ -51,8 +50,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .siteCreationHomePagePicker:
             return true
         case .jetpackScan:
-            return true
-        case .activityLogFilters:
             return true
         case .jetpackBackupAndRestore:
             return true
@@ -114,8 +111,6 @@ extension FeatureFlag {
             return "Site Creation: Home Page Picker"
         case .jetpackScan:
             return "Jetpack Scan"
-        case .activityLogFilters:
-            return "Jetpack's Activity Log Filters"
         case .jetpackBackupAndRestore:
             return "Jetpack Backup and Restore"
         case .todayWidget:

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -13,7 +13,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case stories
     case contactInfo
     case siteCreationHomePagePicker
-    case jetpackScan
     case todayWidget
     case milestoneNotifications
     case commentFilters
@@ -47,8 +46,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .contactInfo:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .siteCreationHomePagePicker:
-            return true
-        case .jetpackScan:
             return true
         case .todayWidget:
             return true
@@ -106,8 +103,6 @@ extension FeatureFlag {
             return "Contact Info"
         case .siteCreationHomePagePicker:
             return "Site Creation: Home Page Picker"
-        case .jetpackScan:
-            return "Jetpack Scan"
         case .todayWidget:
             return "iOS 14 Today Widget"
         case .milestoneNotifications:

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -92,8 +92,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     func displayScanWithSiteID(_ siteID: NSNumber?) throws {
-        guard Feature.enabled(.jetpackScan),
-              let siteID = siteID,
+        guard let siteID = siteID,
               let blog = Blog.lookup(withID: siteID, in: mainContext),
               blog.isScanAllowed()
         else {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -108,10 +108,7 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         if activity.isRewindable {
             bottomConstaint.constant = 0
             rewindStackView.isHidden = false
-
-            if FeatureFlag.jetpackBackupAndRestore.enabled {
-                backupStackView.isHidden = false
-            }
+            backupStackView.isHidden = false
         }
 
         if let avatar = activity.actor?.avatarURL, let avatarURL = URL(string: avatar) {
@@ -144,15 +141,10 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         textView.attributedText = formattableActivity?.formattedContent(using: ActivityContentStyles())
         summaryLabel.text = activity.summary
 
-        if FeatureFlag.jetpackBackupAndRestore.enabled {
-            rewindButton.setTitle(NSLocalizedString("Restore", comment: "Title for button allowing user to restore their Jetpack site"),
-                                                    for: .normal)
-            backupButton.setTitle(NSLocalizedString("Download backup", comment: "Title for button allowing user to backup their Jetpack site"),
-                                                    for: .normal)
-        } else {
-            rewindButton.setTitle(NSLocalizedString("Rewind", comment: "Title for button allowing user to rewind their Jetpack site"),
-                                                    for: .normal)
-        }
+        rewindButton.setTitle(NSLocalizedString("Restore", comment: "Title for button allowing user to restore their Jetpack site"),
+                                                for: .normal)
+        backupButton.setTitle(NSLocalizedString("Download backup", comment: "Title for button allowing user to backup their Jetpack site"),
+                                                for: .normal)
 
         let dateFormatter = ActivityDateFormatting.longDateFormatter(for: site, withTime: false)
         dateLabel.text = dateFormatter.string(from: activity.published)

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -188,11 +188,6 @@ class ActivityListViewModel: Observable {
                     presenter?.presentDetailsFor(activity: formattableActivity)
                 },
                 actionButtonHandler: { [weak presenter] (button) in
-                    if !FeatureFlag.jetpackBackupAndRestore.enabled {
-                        presenter?.presentDetailsFor(activity: formattableActivity)
-                        return
-                    }
-
                     presenter?.presentBackupOrRestoreFor(activity: formattableActivity.activity, from: button)
                 }
             )
@@ -335,14 +330,8 @@ class ActivityListViewModel: Observable {
         if let rewindPoint = store.getActivity(site: site, rewindID: restore.id) {
             let dateString = mediumDateFormatterWithTime.string(from: rewindPoint.published)
 
-            let messageFormat: String
-            if FeatureFlag.jetpackBackupAndRestore.enabled {
-                messageFormat = NSLocalizedString("Restoring to %@",
+            let messageFormat = NSLocalizedString("Restoring to %@",
                                                   comment: "Text showing the point in time the site is being currently restored to. %@' is a placeholder that will expand to a date.")
-            } else {
-                messageFormat = NSLocalizedString("Rewinding to %@",
-                                                  comment: "Text showing the point in time the site is being currently rewinded to. %@' is a placeholder that will expand to a date.")
-            }
 
             summary = String(format: messageFormat, dateString)
         } else {
@@ -355,12 +344,7 @@ class ActivityListViewModel: Observable {
             progress: progress
         )
 
-        let headerText: String
-        if FeatureFlag.jetpackBackupAndRestore.enabled {
-            headerText = NSLocalizedString("Restore", comment: "Title of section showing restore status")
-        } else {
-            headerText = NSLocalizedString("Rewind", comment: "Title of section showing rewind status")
-        }
+        let headerText = NSLocalizedString("Restore", comment: "Title of section showing restore status")
 
         return ImmuTableSection(headerText: headerText,
                                 rows: [rewindRow],

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -42,9 +42,6 @@ open class ActivityTableViewCell: WPTableViewCell {
         actionButtonContainer.isHidden  = !activity.isRewindable
 
         actionButton.setImage(actionGridicon, for: .normal)
-        guard FeatureFlag.jetpackBackupAndRestore.enabled else {
-            return
-        }
         actionButton.tintColor = .listIcon
     }
 
@@ -58,9 +55,7 @@ open class ActivityTableViewCell: WPTableViewCell {
 
     fileprivate var activity: Activity?
     fileprivate var actionGridicon: UIImage {
-        return FeatureFlag.jetpackBackupAndRestore.enabled
-            ? UIImage.gridicon(.ellipsis)
-            : UIImage.gridicon(.history)
+        return UIImage.gridicon(.ellipsis)
     }
 
     // MARK: - IBOutlets

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -109,7 +109,7 @@ class BaseActivityListViewController: UIViewController, TableViewContainer, Immu
         view.addSubview(containerStackView)
         containerStackView.axis = .vertical
 
-        if FeatureFlag.activityLogFilters.enabled && site.shouldShowActivityLogFilter() {
+        if site.shouldShowActivityLogFilter() {
             setupFilterBar()
         }
 

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -409,29 +409,6 @@ extension BaseActivityListViewController: ActivityPresenter {
             return
         }
 
-        guard FeatureFlag.jetpackBackupAndRestore.enabled else {
-            let title = NSLocalizedString("Rewind Site",
-                                          comment: "Title displayed in the Restore Site alert, should match Calypso")
-            let rewindDate = viewModel.mediumDateFormatterWithTime.string(from: activity.published)
-            let messageFormat = NSLocalizedString("Are you sure you want to restore your site back to %@?\nAnything you changed since then will be lost.",
-                                                  comment: "Message displayed in the Rewind Site alert, the placeholder holds a date, should match Calypso.")
-            let message = String(format: messageFormat, rewindDate)
-
-            let alertController = UIAlertController(title: title,
-                                                    message: message,
-                                                    preferredStyle: .alert)
-
-            alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Verb. A button title."))
-            alertController.addDestructiveActionWithTitle(NSLocalizedString("Confirm",
-                                                                            comment: "Confirm Rewind button title"),
-                                                          handler: { action in
-                                                            self.restoreSiteToRewindID(rewindID)
-                                                          })
-            self.present(alertController, animated: true)
-
-            return
-        }
-
         let restoreOptionsVC = JetpackRestoreOptionsViewController(site: site,
                                                                    activity: activity,
                                                                    isAwaitingCredentials: store.isAwaitingCredentials(site: site))

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -838,7 +838,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                      }]];
     }
 
-    if ([self.blog isScanAllowed] && [Feature enabled:FeatureFlagJetpackScan]) {
+    if ([self.blog isScanAllowed]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Scan", @"Noun. Links to a blog's Jetpack Scan screen.")
                                                         image:[UIImage imageNamed:@"jetpack-scan-menu-icon"]
                                                      callback:^{

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -830,7 +830,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
 
 
-    if ([self.blog isBackupsAllowed] && [Feature enabled:FeatureFlagJetpackBackupAndRestore]) {
+    if ([self.blog isBackupsAllowed]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Backup", @"Noun. Links to a blog's Jetpack Backups screen.")
                                                         image:[UIImage gridiconOfType:GridiconTypeCloudUpload]
                                                      callback:^{

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
@@ -75,8 +75,7 @@ struct NotificationContentRouter {
         case .stats:
             /// Backup notifications are configured as "stat" notifications
             /// For now this is just a workaround to fix the routing
-            if url.absoluteString.matches(regex: "\\/backup\\/").count > 0 &&
-                FeatureFlag.jetpackBackupAndRestore.enabled {
+            if url.absoluteString.matches(regex: "\\/backup\\/").count > 0 {
                 try coordinator.displayBackupWithSiteID(range.siteID)
             } else {
                 try coordinator.displayStatsWithSiteID(range.siteID, url: url)


### PR DESCRIPTION
## Description

This PR removes the following Jetpack section feature flags:
  - `activityLogFilters`
  - `jetpackBackupAndRestore`
  - `jetpackScan`

## How to test

1. Switch to an account that has Jetpack Scan and Jetpack Backup
2. Go to My Site > Activity Log, smoke test the activity log filters (date range, activity type)
3. Go to My Site > Backup and smoke test Jetpack Backup/Restore
4. Go to My Site > Scan, smoke test Jetpack Scan

## Regression Notes
1. Potential unintended areas of impact
Jetpack Section features (Activity Log filters, Jetpack Backup/Restore, Jetpack Scan)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I smoke tested the Jetpack Section features and made sure that the features were removed on App Settings > Debug > Feature Flags 

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
