### PR TITLE
Jetpack App: Update lightAppBarTint color for Jetpack

### DIFF
--- a/WordPress/Jetpack/UIColor+JetpackColors.swift
+++ b/WordPress/Jetpack/UIColor+JetpackColors.swift
@@ -21,7 +21,7 @@ extension UIColor {
     }
 
     static var lightAppBarTint: UIColor {
-        return UIColor(light: .brand, dark: .white)
+        return .text
     }
 
     static var appBarText: UIColor {


### PR DESCRIPTION
## Description 

This PR updates the light app bar tint color to use the `.text` semantic color. 
@osullivanchris Thanks for catching this! 🙏 

Before | After 
--- | --- 
<img src="https://user-images.githubusercontent.com/6711616/114119142-0ca65880-9925-11eb-9078-c239a40ac6ce.png" width=300> | <img src="https://user-images.githubusercontent.com/6711616/114351763-04a91b80-9ba6-11eb-9bee-e6f56afc9a89.png" width=300>
<img src="https://user-images.githubusercontent.com/6711616/114119143-0d3eef00-9925-11eb-9c9e-c18553ce940a.png" width=300> | <img src="https://user-images.githubusercontent.com/6711616/114351765-0541b200-9ba6-11eb-9f2d-28a09aad75b3.png" width=300>

## How to test
1. Go to My Site > External > View Site
  - Jetpack: The webview navigation bar tint should be `.text`
  - WordPress: The webview navigation bar tint should remain the same as before

## Regression Notes
1. Potential unintended areas of impact
WordPress app light app bar tint color

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested both the WordPress and Jetpack targets

3. What automated tests I added (or what prevented me from doing so)
None, just visual changes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
