### PR TITLE
Jetpack App: Update epilogue user info font

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppStyleGuide.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppStyleGuide.swift
@@ -5,6 +5,7 @@ struct AppStyleGuide {
     static let navigationBarStandardFont: UIFont = WPStyleGuide.fixedSerifFontForTextStyle(.headline, fontWeight: .semibold)
     static let navigationBarLargeFont: UIFont = WPStyleGuide.fixedSerifFontForTextStyle(.largeTitle, fontWeight: .semibold)
     static let blogDetailHeaderTitleFont: UIFont = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
+    static let epilogueTitleFont: UIFont = WPStyleGuide.fixedSerifFontForTextStyle(.largeTitle, fontWeight: .semibold)
 }
 
 // MARK: - Colors

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -103,7 +103,7 @@ private extension EpilogueUserInfoCell {
         gravatarAddIcon.backgroundColor = .basicBackground
 
         fullNameLabel.textColor = .text
-        fullNameLabel.font = WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .semibold)
+        fullNameLabel.font = AppStyleGuide.epilogueTitleFont
 
         usernameLabel.textColor = .textSubtle
         usernameLabel.font = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .headline).pointSize, weight: .regular)

--- a/WordPress/Jetpack/AppStyleGuide.swift
+++ b/WordPress/Jetpack/AppStyleGuide.swift
@@ -6,6 +6,7 @@ struct AppStyleGuide {
     static let navigationBarStandardFont: UIFont = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
     static let navigationBarLargeFont: UIFont = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .semibold)
     static let blogDetailHeaderTitleFont: UIFont = WPStyleGuide.fontForTextStyle(.title2, fontWeight: .semibold)
+    static let epilogueTitleFont: UIFont = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .semibold)
 }
 
 // MARK: - Colors


### PR DESCRIPTION
## Description

This PR updates the full name label font in the Login Epilogue screen

Before | After
-- | -- 
![Simulator Screen Shot - iPhone 12 Pro - 2021-04-12 at 15 10 27](https://user-images.githubusercontent.com/6711616/114369894-d0d7f100-9bb9-11eb-8ff3-8f79e7569314.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-12 at 17 24 14](https://user-images.githubusercontent.com/6711616/114366657-9caf0100-9bb6-11eb-8209-63d1dfc4f86f.png) 


## How to test

1. Log out, then login 
2. 👀 Note the font for the full name label (sans serif for Jetpack, serif for WordPress)

## Regression Notes
1. Potential unintended areas of impact
Wordpress app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested and checked both the WordPress and Jetpack targets (see screenshot above)

3. What automated tests I added (or what prevented me from doing so)
None, just visual changes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
