### PR TITLE
Disable tracking for UI tests

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -96,7 +96,8 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
     [self initializeOptOutTracking];
 
     BOOL userHasOptedOut = [WPAppAnalytics userHasOptedOut];
-    if (!userHasOptedOut) {
+    BOOL isUITesting = [[NSProcessInfo processInfo].arguments containsObject:@"-ui-testing"];
+    if (!isUITesting && !userHasOptedOut) {
         [self registerTrackers];
         [self beginSession];
     }

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -70,7 +70,7 @@ extension XCTestCase {
         continueAfterFailure = false
 
         let app = XCUIApplication()
-        app.launchArguments = ["-wpcom-api-base-url", WireMock.URL().absoluteString, "-no-animations"]
+        app.launchArguments = ["-wpcom-api-base-url", WireMock.URL().absoluteString, "-no-animations", "-ui-testing"]
         app.activate()
 
         // Media permissions alert handler


### PR DESCRIPTION
**To test:**
* Put a breakpoint [here](https://github.com/wordpress-mobile/WordPress-iOS/commit/eb507e05a08c4662f105c0815e7ac99dfe3e139d#diff-0ee31781cb1a49ef12905892c581121070c1801058e09bc6598f21ca41a1931cR99)
* Verify tracking is enabled for WordPress app
* Verify tracking is disabled for UI tests

## Regression Notes
**1. Potential unintended areas of impact**
Tracking being disabled for everyone in the WordPress app

**2. What I did to test those areas of impact (or what existing automated tests I relied on)**
I verified [isUITesting](https://github.com/wordpress-mobile/WordPress-iOS/commit/eb507e05a08c4662f105c0815e7ac99dfe3e139d#diff-0ee31781cb1a49ef12905892c581121070c1801058e09bc6598f21ca41a1931cR99) is `false` when I run the app

**3. What automated tests I added (or what prevented me from doing so)**
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
