### PR TITLE
Improve deep link support for mbar links

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -532,6 +532,6 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, openSettingsFor notification: UNNotification?) {
-        MeNavigationAction.notificationSettings.perform()
+        MeNavigationAction.notificationSettings.perform(router: UniversalLinkRouter.shared)
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Route+Page.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route+Page.swift
@@ -11,7 +11,7 @@ struct NewPageForSiteRoute: Route {
 }
 
 struct NewPageNavigationAction: NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController? = nil) {
+    func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
         if let blog = blog(from: values) {
             WPTabBarController.sharedInstance()?.showPageEditor(forBlog: blog)
         } else {

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -13,7 +13,7 @@ protocol Route {
 }
 
 protocol NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController?)
+    func perform(_ values: [String: String], source: UIViewController?, router: LinkRouter)
 }
 
 extension NavigationAction {
@@ -33,7 +33,7 @@ extension NavigationAction {
 }
 
 struct FailureNavigationAction: NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController?) {
+    func perform(_ values: [String: String], source: UIViewController?, router: LinkRouter) {
         // This navigation action exists only to fail navigations
     }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -18,7 +18,7 @@ struct AppBannerRoute: Route {
 }
 
 extension AppBannerRoute: NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController? = nil) {
+    func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
         guard let fragmentValue = values[MatchedRouteURLComponentKey.fragment.rawValue],
             let fragment = fragmentValue.removingPercentEncoding else {
                 return
@@ -34,7 +34,7 @@ extension AppBannerRoute: NavigationAction {
         if let url = components.url {
             // We disable tracking when passing the URL back through the router,
             // otherwise we'd be posting two stats events.
-            UniversalLinkRouter.shared.handle(url: url, shouldTrack: false)
+            router.handle(url: url, shouldTrack: false, source: source)
         }
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
@@ -1,5 +1,5 @@
 import Foundation
-
+import Alamofire
 
 /// Handles mbar redirects.  These are marketing redirects to URLs that mobile should handle.
 ///
@@ -61,6 +61,19 @@ extension MbarRoute: NavigationAction {
                 return
         }
 
-        router.handle(url: redirectUrl, shouldTrack: false, source: source)
+        // If we're handling the link in the app, fire off a request to the
+        // original URL so that any necessary tracking takes places.
+        Alamofire.request(url)
+            .validate()
+            .responseData { response in
+                switch response.result {
+                case .success:
+                    DDLogInfo("Mbar deep link request successful.")
+                case .failure(let error):
+                    DDLogError("Mbar deep link request failed: \(error.localizedDescription)")
+                }
+            }
+
+        router.handle(url: redirectUrl, shouldTrack: true, source: source)
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
@@ -20,6 +20,8 @@ import Foundation
 ///
 public struct MbarRoute: Route {
     static let redirectURLParameter = "redirect_to"
+    static let loginURLPath = "wp-login.php"
+
     let path = "/mbar"
 
     var action: NavigationAction {
@@ -39,7 +41,14 @@ public struct MbarRoute: Route {
             return nil
         }
 
-        return URL(string: redirectURL)
+        let url = URL(string: redirectURL)
+
+        // If this is a wp-login link, handle _its_ redirect_to parameter
+        if url?.lastPathComponent == MbarRoute.loginURLPath {
+            return self.redirectURL(from: redirectURL)
+        }
+
+        return url
     }
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
@@ -12,9 +12,13 @@ import Foundation
 ///     will be opened and then the default browser will be opened... but other than that, it is
 ///     a safe procedure.
 ///
+///     Many mbar links will consist of an initial redirect_to value of wp-login.php, which in turn
+///     has its own redirect_to parameter containing our final destination. For these links, we'll
+///     keep following the redirects until we find the end point.
+///
 ///   * /mbar/?redirect_to=https%3A%2F%2Fwordpress.com%2Fpost%2Fsomesite.wordpress.com
 ///
-struct MbarRoute: Route {
+public struct MbarRoute: Route {
     static let redirectURLParameter = "redirect_to"
     let path = "/mbar"
 
@@ -40,7 +44,7 @@ struct MbarRoute: Route {
 }
 
 extension MbarRoute: NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController? = nil) {
+    func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
 
         guard let url = values[MatchedRouteURLComponentKey.url.rawValue],
             let redirectUrl = redirectURL(from: url) else {
@@ -48,6 +52,6 @@ extension MbarRoute: NavigationAction {
                 return
         }
 
-        UniversalLinkRouter.shared.handle(url: redirectUrl, shouldTrack: false, source: source)
+        router.handle(url: redirectUrl, shouldTrack: false, source: source)
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
@@ -20,7 +20,7 @@ enum MeNavigationAction: NavigationAction {
     case accountSettings
     case notificationSettings
 
-    func perform(_ values: [String: String] = [:], source: UIViewController? = nil) {
+    func perform(_ values: [String: String] = [:], source: UIViewController? = nil, router: LinkRouter) {
         switch self {
         case .root:
             WPTabBarController.sharedInstance().showMeScene()

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -39,7 +39,7 @@ extension MySitesRoute: Route {
 }
 
 extension MySitesRoute: NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController? = nil) {
+    func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
         guard let coordinator = WPTabBarController.sharedInstance().mySitesCoordinator else {
             return
         }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
@@ -6,7 +6,7 @@ struct NotificationsRoute: Route {
 }
 
 struct NotificationsNavigationAction: NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController? = nil) {
+    func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
         WPTabBarController.sharedInstance().showNotificationsTab()
         WPTabBarController.sharedInstance().popNotificationsTabToRoot()
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
@@ -11,7 +11,7 @@ struct NewPostForSiteRoute: Route {
 }
 
 struct NewPostNavigationAction: NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController? = nil) {
+    func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
         if let blog = blog(from: values) {
             WPTabBarController.sharedInstance().showPostTab(for: blog)
         } else {

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -54,7 +54,7 @@ extension ReaderRoute: Route {
 }
 
 extension ReaderRoute: NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController? = nil) {
+    func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
         guard let coordinator = WPTabBarController.sharedInstance().readerCoordinator else {
             return
         }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Start.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Start.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct StartRoute: Route, NavigationAction {
+    let path = "/start"
+
+    var action: NavigationAction {
+        return self
+    }
+
+    func perform(_ values: [String : String], source: UIViewController?, router: LinkRouter) {
+        guard AccountHelper.isDotcomAvailable(),
+              let coordinator = WPTabBarController.sharedInstance().mySitesCoordinator else {
+            return
+        }
+
+        coordinator.showSiteCreation()
+    }
+}

--- a/WordPress/Classes/Utility/Universal Links/Routes+Start.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Start.swift
@@ -7,7 +7,7 @@ struct StartRoute: Route, NavigationAction {
         return self
     }
 
-    func perform(_ values: [String : String], source: UIViewController?, router: LinkRouter) {
+    func perform(_ values: [String: String], source: UIViewController?, router: LinkRouter) {
         guard AccountHelper.isDotcomAvailable(),
               let coordinator = WPTabBarController.sharedInstance().mySitesCoordinator else {
             return

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -62,7 +62,7 @@ extension StatsRoute: Route {
 }
 
 extension StatsRoute: NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController? = nil) {
+    func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
         guard let coordinator = WPTabBarController.sharedInstance().mySitesCoordinator else {
             return
         }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -1,9 +1,15 @@
 import Foundation
 
+protocol LinkRouter {
+    init(routes: [Route])
+    func canHandle(url: URL) -> Bool
+    func handle(url: URL, shouldTrack track: Bool, source: UIViewController?)
+}
+
 /// UniversalLinkRouter keeps a list of possible URL routes that are exposed
 /// via universal links, and handles incoming links to trigger the appropriate route.
 ///
-struct UniversalLinkRouter {
+struct UniversalLinkRouter: LinkRouter {
     private let matcher: RouteMatcher
 
     init(routes: [Route]) {
@@ -130,7 +136,7 @@ struct UniversalLinkRouter {
         }
 
         for matchedRoute in matches {
-            matchedRoute.action.perform(matchedRoute.values, source: source)
+            matchedRoute.action.perform(matchedRoute.values, source: source, router: self)
         }
     }
 

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -32,7 +32,8 @@ struct UniversalLinkRouter: LinkRouter {
         readerRoutes +
         statsRoutes +
         mySitesRoutes +
-        appBannerRoutes
+        appBannerRoutes +
+        startRoutes
 
     static let meRoutes: [Route] = [
         MeRoute(),
@@ -96,6 +97,10 @@ struct UniversalLinkRouter: LinkRouter {
 
     static let appBannerRoutes: [Route] = [
         AppBannerRoute()
+    ]
+
+    static let startRoutes: [Route] = [
+        StartRoute()
     ]
 
     static let redirects: [Route] = [

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -169,14 +169,15 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             image: "mysites-nosites") { noResultsViewController in
 
             noResultsViewController.actionButtonHandler = { [weak self] in
-                self?.showAddSiteAlert()
+                self?.presentInterfaceForAddingNewSite()
             }
         }
     }
 
     // MARK: - Add Site Alert
 
-    private func showAddSiteAlert() {
+    @objc
+    func presentInterfaceForAddingNewSite() {
         let addSiteAlert = AddSiteAlertFactory().makeAddSiteAlert(canCreateWPComSite: defaultAccount() != nil) { [weak self] in
             self?.launchSiteCreation()
         } addSelfHostedSite: {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -195,7 +195,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     @objc
-    private func launchSiteCreation() {
+    func launchSiteCreation() {
         let wizardLauncher = SiteCreationWizardLauncher()
         guard let wizard = wizardLauncher.ui else {
             return

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -179,10 +179,9 @@ class MySitesCoordinator: NSObject {
     }
 
     @objc
-    func showAddNewSite(from view: UIView) {
-        showSitesList()
-
-        blogListViewController.presentInterfaceForAddingNewSite(from: view)
+    func showAddNewSite() {
+        showRootViewController()
+        mySiteViewController.presentInterfaceForAddingNewSite()
     }
 
     // MARK: - My Sites

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -107,8 +107,9 @@ class MySitesCoordinator: NSObject {
         showRootViewController()
 
         if Feature.enabled(.newNavBarAppearance) {
-            blogListViewController.modalPresentationStyle = .pageSheet
-            mySiteViewController.present(blogListViewController, animated: true)
+            let navigationController = UINavigationController(rootViewController: blogListViewController)
+            navigationController.modalPresentationStyle = .formSheet;
+            mySiteViewController.present(navigationController, animated: true)
         }
     }
 
@@ -171,6 +172,12 @@ class MySitesCoordinator: NSObject {
     }
 
     // MARK: - Adding a new site
+
+    func showSiteCreation() {
+        showRootViewController()
+        mySiteViewController.launchSiteCreation()
+    }
+
     @objc
     func showAddNewSite(from view: UIView) {
         showSitesList()

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -108,7 +108,7 @@ class MySitesCoordinator: NSObject {
 
         if Feature.enabled(.newNavBarAppearance) {
             let navigationController = UINavigationController(rootViewController: blogListViewController)
-            navigationController.modalPresentationStyle = .formSheet;
+            navigationController.modalPresentationStyle = .formSheet
             mySiteViewController.present(navigationController, animated: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -300,7 +300,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     // Ignore taps on the post tab and instead show the modal.
     if ([blogService blogCountForAllAccounts] == 0) {
-        [self.mySitesCoordinator showAddNewSiteFrom:self.tabBar];
+        [self.mySitesCoordinator showAddNewSite];
     } else {
         [self showPostTabAnimated:true toMedia:false blog:nil afterDismiss:afterDismiss];
     }
@@ -311,7 +311,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     if ([blogService blogCountForAllAccounts] == 0) {
-        [self.mySitesCoordinator showAddNewSiteFrom:self.tabBar];
+        [self.mySitesCoordinator showAddNewSite];
     } else {
         [self showPostTabAnimated:YES toMedia:NO blog:blog];
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -154,6 +154,8 @@
 		1746D7771D2165AE00B11D77 /* ForcePopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */; };
 		1749965F2271BF08007021BD /* WordPressAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1749965E2271BF08007021BD /* WordPressAppDelegate.swift */; };
 		174C116F2624603400346EC6 /* MBarRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174C116E2624603400346EC6 /* MBarRouteTests.swift */; };
+		174C11932624C78900346EC6 /* Routes+Start.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174C11922624C78900346EC6 /* Routes+Start.swift */; };
+		174C11942624C78900346EC6 /* Routes+Start.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174C11922624C78900346EC6 /* Routes+Start.swift */; };
 		174C9697205A846E00CEEF6E /* PostNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174C9696205A846E00CEEF6E /* PostNoticeViewModel.swift */; };
 		1750BD6D201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */; };
 		1751E5911CE0E552000CA08D /* KeyValueDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */; };
@@ -4558,6 +4560,7 @@
 		1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForcePopoverPresenter.swift; sourceTree = "<group>"; };
 		1749965E2271BF08007021BD /* WordPressAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAppDelegate.swift; sourceTree = "<group>"; };
 		174C116E2624603400346EC6 /* MBarRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBarRouteTests.swift; sourceTree = "<group>"; };
+		174C11922624C78900346EC6 /* Routes+Start.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Start.swift"; sourceTree = "<group>"; };
 		174C9696205A846E00CEEF6E /* PostNoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticeViewModel.swift; sourceTree = "<group>"; };
 		1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaNoticeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueDatabase.swift; sourceTree = "<group>"; };
@@ -7795,6 +7798,7 @@
 			children = (
 				17B7C89F20EC1D6A0042E260 /* Route.swift */,
 				17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */,
+				174C11922624C78900346EC6 /* Routes+Start.swift */,
 				F1655B4722A6C2FA00227BFB /* Routes+Mbar.swift */,
 				17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */,
 				17E24F5320FCF1D900BD70A3 /* Routes+MySites.swift */,
@@ -16964,6 +16968,7 @@
 				E1B23B081BFB3B370006559B /* MyProfileViewController.swift in Sources */,
 				F532AE1C253E55D40013B42E /* CreateButtonActionSheet.swift in Sources */,
 				8BCB83D124C21063001581BD /* ReaderStreamViewController+Ghost.swift in Sources */,
+				174C11932624C78900346EC6 /* Routes+Start.swift in Sources */,
 				B5CC05F61962150600975CAC /* Constants.m in Sources */,
 				4326191522FCB9DC003C7642 /* MurielColor.swift in Sources */,
 				436D562B2117312700CEAA33 /* RegisterDomainDetailsErrorSectionFooter.swift in Sources */,
@@ -19043,6 +19048,7 @@
 				FABB24482602FC2C00C8785C /* MyProfileViewController.swift in Sources */,
 				FABB24492602FC2C00C8785C /* CreateButtonActionSheet.swift in Sources */,
 				FABB244A2602FC2C00C8785C /* ReaderStreamViewController+Ghost.swift in Sources */,
+				174C11942624C78900346EC6 /* Routes+Start.swift in Sources */,
 				FABB244B2602FC2C00C8785C /* Constants.m in Sources */,
 				FABB244C2602FC2C00C8785C /* MurielColor.swift in Sources */,
 				FABB244D2602FC2C00C8785C /* RegisterDomainDetailsErrorSectionFooter.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		173D82E7238EE2A7008432DA /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173D82E6238EE2A7008432DA /* FeatureFlagTests.swift */; };
 		1746D7771D2165AE00B11D77 /* ForcePopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */; };
 		1749965F2271BF08007021BD /* WordPressAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1749965E2271BF08007021BD /* WordPressAppDelegate.swift */; };
+		174C116F2624603400346EC6 /* MBarRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174C116E2624603400346EC6 /* MBarRouteTests.swift */; };
 		174C9697205A846E00CEEF6E /* PostNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174C9696205A846E00CEEF6E /* PostNoticeViewModel.swift */; };
 		1750BD6D201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */; };
 		1751E5911CE0E552000CA08D /* KeyValueDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */; };
@@ -4556,6 +4557,7 @@
 		173D82E6238EE2A7008432DA /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForcePopoverPresenter.swift; sourceTree = "<group>"; };
 		1749965E2271BF08007021BD /* WordPressAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAppDelegate.swift; sourceTree = "<group>"; };
+		174C116E2624603400346EC6 /* MBarRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBarRouteTests.swift; sourceTree = "<group>"; };
 		174C9696205A846E00CEEF6E /* PostNoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticeViewModel.swift; sourceTree = "<group>"; };
 		1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaNoticeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueDatabase.swift; sourceTree = "<group>"; };
@@ -7757,6 +7759,15 @@
 			path = Domains;
 			sourceTree = "<group>";
 		};
+		174C116D2624601000346EC6 /* Deep Linking */ = {
+			isa = PBXGroup;
+			children = (
+				1797373620EBAA4100377B4E /* RouteMatcherTests.swift */,
+				174C116E2624603400346EC6 /* MBarRouteTests.swift */,
+			);
+			name = "Deep Linking";
+			sourceTree = "<group>";
+		};
 		1759F17E1FE145F90003EC81 /* Notices */ = {
 			isa = PBXGroup;
 			children = (
@@ -10395,6 +10406,7 @@
 		852416D01A12ED2D0030700C /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				174C116D2624601000346EC6 /* Deep Linking */,
 				F93735F422D53C1800A3C312 /* Logging */,
 				93B853211B44165B0064FE72 /* Analytics */,
 				F198533B21ADAD0700DCDAE7 /* Editor */,
@@ -10408,7 +10420,6 @@
 				E1EBC3721C118ED200F638E0 /* ImmuTableTest.swift */,
 				93A379EB19FFBF7900415023 /* KeychainTest.m */,
 				1759F1711FE017F20003EC81 /* QueueTests.swift */,
-				1797373620EBAA4100377B4E /* RouteMatcherTests.swift */,
 				5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */,
 				E1E4CE0C177439D100430844 /* WPAvatarSourceTest.m */,
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
@@ -18009,6 +18020,7 @@
 				73178C3521BEE9AC00E37C9A /* TitleSubtitleHeaderTests.swift in Sources */,
 				08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */,
 				BEA0E4851BD83565000AEE81 /* WP3DTouchShortcutCreatorTests.swift in Sources */,
+				174C116F2624603400346EC6 /* MBarRouteTests.swift in Sources */,
 				46B30B782582C7DD00A25E66 /* SiteAddressServiceTests.swift in Sources */,
 				C81CCD6C243AEFBF00A83E27 /* TenorReponseData.swift in Sources */,
 				570BFD902282418A007859A8 /* PostBuilder.swift in Sources */,

--- a/WordPress/WordPressTest/MBarRouteTests.swift
+++ b/WordPress/WordPressTest/MBarRouteTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import WordPress
+
+struct MockRouter: LinkRouter {
+    let matcher: RouteMatcher
+    var completion: ((URL) -> Void)?
+
+    init(routes: [Route]) {
+        self.matcher = RouteMatcher(routes: routes)
+    }
+
+    func canHandle(url: URL) -> Bool {
+        return true
+    }
+
+    func handle(url: URL, shouldTrack track: Bool, source: UIViewController?) {
+        completion?(url)
+    }
+
+
+}
+
+class MBarRouteTests: XCTestCase {
+
+    private var router: MockRouter!
+    private var route: MbarRoute!
+    private var matcher: RouteMatcher!
+
+    override func setUp() {
+        super.setUp()
+
+        router = MockRouter(routes: [])
+        route = MbarRoute()
+        matcher = RouteMatcher(routes: [route])
+    }
+
+    func testSingleLevelPostRedirect() throws {
+        let url = URL(string: "https://wordpress.com/mbar?redirect_to=/post")!
+        let success = expectation(description: "Correct redirect URL found")
+
+        router.completion = { url in
+            if url.lastPathComponent == "post" {
+                success.fulfill()
+            }
+        }
+
+        if let match = matcher.routesMatching(url).first {
+            match.action.perform(match.values,
+                                 source: nil,
+                                 router: router)
+        }
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testSingleLevelStartRedirectWithOtherParameters() throws {
+        let url = URL(string: "https://wordpress.com/mbar?redirect_to=/start&stat=groovemails-events&bin=wpcom_email_click")!
+        let success = expectation(description: "Correct redirect URL found")
+
+        router.completion = { url in
+            if url.lastPathComponent == "start" {
+                success.fulfill()
+            }
+        }
+
+        if let match = matcher.routesMatching(url).first {
+            match.action.perform(match.values,
+                                 source: nil,
+                                 router: router)
+        }
+
+        waitForExpectations(timeout: 1.0)
+    }
+}

--- a/WordPress/WordPressTest/MBarRouteTests.swift
+++ b/WordPress/WordPressTest/MBarRouteTests.swift
@@ -71,4 +71,24 @@ class MBarRouteTests: XCTestCase {
 
         waitForExpectations(timeout: 1.0)
     }
+
+    func testMultiLevelWPLoginRedirect() throws {
+        let url = URL(string: "https://public-api.wordpress.com/mbar/?stat=groovemails-events&bin=wpcom_email_click&redirect_to=https://wordpress.com/wp-login.php?action=immediate-login%26timestamp=1617470831%26login_reason=user_first_flow%26user_id=123456789%26token=abcdef%26login_email=test%40example.com%26login_locale=en%26redirect_to=https%3A%2F%2Fwordpress.com%2Fstart%26sr=1%26signature=abcdef%26user=123456")!
+
+        let success = expectation(description: "Correct redirect URL found")
+
+        router.completion = { url in
+            if url.lastPathComponent == "start" {
+                success.fulfill()
+            }
+        }
+
+        if let match = matcher.routesMatching(url).first {
+            match.action.perform(match.values,
+                                 source: nil,
+                                 router: router)
+        }
+
+        waitForExpectations(timeout: 1.0)
+    }
 }

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -7,7 +7,7 @@ private struct TestRoute: Route {
 }
 
 private struct TestAction: NavigationAction {
-    func perform(_ values: [String: String], source: UIViewController?) {}
+    func perform(_ values: [String: String], source: UIViewController?, router: LinkRouter) {}
 }
 
 class RouteMatcherTests: XCTestCase {


### PR DESCRIPTION
This PR improves deep linking support for /mbar links from email campaigns and other sources. I also made a few small tweaks to the link router system to make these changes easier to test.

/mbar links contain a `redirect_to` parameter, which we now detect and handle like any other deep link. A special case here is links that have a `redirect_to` value of `wp-login.php` – these in turn have their _own_ `redirect_to` parameter, so we'll continue to recurse until we find the end of the chain.

**To test**

- Test on iPhone and iPad – easiest to test in simulator so you can launch links via Terminal
- Build and run
- You can test with the app in the background or foreground
- Test with an account with existing sites and with an account with no sites
- If there's no user logged in, you should be redirected to the URL in Safari

**Scenario 1: /mbar redirecting to /post**
- Launch the following URL from Terminal:

```
https://public-api.wordpress.com/mbar/?stat=groovemails-events&bin=wpcom_email_click&redirect_to=https://wordpress.com/post
```

- A user with existing sites should see the editor presented
- A user with no sites should see the site creation flow open
- You should see `Mbar deep link request successful` in the debug console

**Scenario 2: /mbar redirecting to /wp-login.php, redirecting to /post**
- Launch the following URL from Terminal:

```
https://public-api.wordpress.com/mbar/?stat=groovemails-events&bin=wpcom_email_click&redirect_to=https://wordpress.com/wp-login.php?action=immediate-login%26timestamp=1617470831%26redirect_to=https%3A%2F%2Fwordpress.com%2Fpost
```

- A user with existing sites should see the editor presented
- A user with no sites should see the site creation flow open
- You should see `Mbar deep link request successful` in the debug console

**Scenario 3: /mbar redirecting to /wp-login.php, redirecting to /start**
- Launch the following URL from Terminal:

```
https://public-api.wordpress.com/mbar/?stat=groovemails-events&bin=wpcom_email_click&redirect_to=https://wordpress.com/wp-login.php?action=immediate-login%26timestamp=1617470831%26redirect_to=https%3A%2F%2Fwordpress.com%2Fstart
```

- You should see the site creation flow open
- You should see `Mbar deep link request successful` in the debug console

**Scenario 4: Unit tests**

- I added some unit tests for the MBar routes – build and run tests and ensure they pass

## Regression Notes

1. Potential unintended areas of impact

I made some small changes to the way Add New Site and Show Site Creation are presented.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested both of these as part of the development process – one is triggered through the /post route, and one through the /start route. Magic login links shouldn't be affected, but I also tested that those continue to work as expected.

3. What automated tests I added (or what prevented me from doing so)

I added unit tests to ensure that the parsing of redirect_to parameters from the /mbar deep links is working correctly.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
