### PR TITLE
Add Jetpack CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,32 @@ jobs:
       - store_artifacts:
           path: Artifacts
           destination: Artifacts
-
+  jetpack-pr-build:
+    executor:
+      name: ios/default
+      <<: *xcode_version
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - fix-image
+      - git/shallow-checkout
+      - ios/install-dependencies:
+            bundle-install: true
+            pod-install: true
+            cache-prefix: cache-prefix-{{ checksum ".circleci/cache-version" }}
+      - run:
+          name: Copy Secrets
+          command: bundle exec fastlane run configure_apply
+      - run:
+          name: Install other tools
+          command: |
+            brew install imagemagick
+            brew install ghostscript
+            curl -sL https://sentry.io/get-cli/ | bash
+      - run:
+          name: Build
+          command: bundle exec fastlane build_jetpack_for_testing
+          no_output_timeout: 60m
 workflows:
   wordpress_ios:
     when:
@@ -334,7 +359,6 @@ workflows:
                 - /^release.*/
       - jetpack-installable-build
       - jetpack-pr-build
-
       #Optionally run UI tests on PRs
       - Optional Tests:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ workflows:
                 - /^release.*/
       - jetpack-installable-build
       - jetpack-pr-build
+
       #Optionally run UI tests on PRs
       - Optional Tests:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,35 @@ jobs:
       - store_artifacts:
           path: Artifacts
           destination: Artifacts
+  jetpack-installable-build:
+    executor:
+      name: ios/default
+      <<: *xcode_version
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - fix-image
+      - git/shallow-checkout
+      - ios/install-dependencies:
+            bundle-install: true
+            pod-install: true
+            cache-prefix: cache-prefix-{{ checksum ".circleci/cache-version" }}
+      - run:
+          name: Copy Secrets
+          command: bundle exec fastlane run configure_apply
+      - run:
+          name: Install other tools
+          command: |
+            brew install imagemagick
+            brew install ghostscript
+            curl -sL https://sentry.io/get-cli/ | bash
+      - run:
+          name: Build
+          command: bundle exec fastlane build_and_upload_jetpack_installable_build
+          no_output_timeout: 60m
+      - store_artifacts:
+          path: Artifacts
+          destination: Artifacts
 
 workflows:
   wordpress_ios:
@@ -303,6 +332,8 @@ workflows:
               only:
                 - develop
                 - /^release.*/
+      - jetpack-installable-build
+      - jetpack-pr-build
       #Optionally run UI tests on PRs
       - Optional Tests:
           type: approval
@@ -346,3 +377,14 @@ workflows:
     when: << pipeline.parameters.translation_review_build >>
     jobs:
       - translation-review-build
+  Jetpack Nightly:
+    triggers:
+       - schedule:
+           cron: "0 0 * * *"
+           filters:
+             branches:
+               only:
+                 - develop
+    jobs:
+      - jetpack-installable-build
+

--- a/WordPress/Jetpack/JetpackDebug.entitlements
+++ b/WordPress/Jetpack/JetpackDebug.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/WordPress/Jetpack/JetpackRelease-Internal.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Internal.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/WordPress/Jetpack/JetpackRelease.entitlements
+++ b/WordPress/Jetpack/JetpackRelease.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4766,6 +4766,10 @@
 		24AD675025FC262F0056102C /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/Sites.strings; sourceTree = "<group>"; };
 		24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagStore.swift; sourceTree = "<group>"; };
 		24B1AE3024FEC79900B9F334 /* RemoteFeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagTests.swift; sourceTree = "<group>"; };
+		24B54FAD2624F8350041B18E /* JetpackRelease-Internal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "JetpackRelease-Internal.entitlements"; sourceTree = "<group>"; };
+		24B54FAE2624F8430041B18E /* JetpackRelease-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "JetpackRelease-Alpha.entitlements"; sourceTree = "<group>"; };
+		24B54FAF2624F84C0041B18E /* JetpackRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = JetpackRelease.entitlements; sourceTree = "<group>"; };
+		24B54FB02624F8690041B18E /* JetpackDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = JetpackDebug.entitlements; sourceTree = "<group>"; };
 		24C69A8A2612421900312D9A /* UserSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsTests.swift; sourceTree = "<group>"; };
 		24C69AC12612467C00312D9A /* UserSettingsTestsObjc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UserSettingsTestsObjc.m; sourceTree = "<group>"; };
 		24D40491253F6CEE002843AC /* WordPressStatsWidgetsRelease-Internal.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "WordPressStatsWidgetsRelease-Internal.entitlements"; sourceTree = "<group>"; };
@@ -13671,6 +13675,10 @@
 		FABB1F8E2602FC0100C8785C /* Jetpack */ = {
 			isa = PBXGroup;
 			children = (
+				24B54FB02624F8690041B18E /* JetpackDebug.entitlements */,
+				24B54FAF2624F84C0041B18E /* JetpackRelease.entitlements */,
+				24B54FAE2624F8430041B18E /* JetpackRelease-Alpha.entitlements */,
+				24B54FAD2624F8350041B18E /* JetpackRelease-Internal.entitlements */,
 				FABB28482603068B00C8785C /* Resources */,
 				FABB268A2602FCD400C8785C /* Supporting Files */,
 				FA25FB8C2609B9CB0005E08F /* App Configuration */,
@@ -22790,7 +22798,7 @@
 				CLANG_ENABLE_MODULES = "$(inherited)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
-				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
+				CODE_SIGN_ENTITLEMENTS = Jetpack/JetpackDebug.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
@@ -22861,7 +22869,7 @@
 				CLANG_ENABLE_MODULES = "$(inherited)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
-				CODE_SIGN_ENTITLEMENTS = WordPress.entitlements;
+				CODE_SIGN_ENTITLEMENTS = Jetpack/JetpackRelease.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution: Automattic, Inc. (PZYM8XX95Q)";
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
@@ -22928,7 +22936,7 @@
 				CLANG_ENABLE_MODULES = "$(inherited)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
-				CODE_SIGN_ENTITLEMENTS = "WordPress-Internal.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Jetpack/JetpackRelease-Internal.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
@@ -22978,7 +22986,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.jetpack.internal;
 				PRODUCT_MODULE_NAME = WordPress;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.internal";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.jetpack.internal";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -22996,7 +23004,7 @@
 				CLANG_ENABLE_MODULES = "$(inherited)";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
-				CODE_SIGN_ENTITLEMENTS = "WordPress-Alpha.entitlements";
+				CODE_SIGN_ENTITLEMENTS = "Jetpack/JetpackRelease-Alpha.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Automattic, Inc.";
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
@@ -23046,7 +23054,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.jetpack.alpha;
 				PRODUCT_MODULE_NAME = WordPress;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha";
+				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.jetpack.alpha";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,6 +20,8 @@ PROJECT_ENV_FILE_PATH = File.join(PROJECT_ROOT_FOLDER, '.configure-files', 'proj
 # Other defines used across multiple lanes
 REPOSITORY_NAME="WordPress-iOS"
 
+import "Jetpack-Fastfile"
+
 ALL_BUNDLE_IDENTIFIERS = [
       "org.wordpress",
       "org.wordpress.WordPressShare",

--- a/fastlane/Jetpack-Fastfile
+++ b/fastlane/Jetpack-Fastfile
@@ -61,6 +61,17 @@
     )
   end
 
+  desc "Build for Testing"
+  lane :build_jetpack_for_testing do | options |
+    run_tests(
+      workspace: WORKSPACE_PATH,
+      scheme: "Jetpack",
+      derived_data_path: DERIVED_DATA_PATH,
+      build_for_testing: true,
+      deployment_target_version: options[:ios_version],
+    )
+  end
+
 ########################################################################
 # Jetpack Fastlane match code signing
 ########################################################################

--- a/fastlane/Jetpack-Fastfile
+++ b/fastlane/Jetpack-Fastfile
@@ -1,0 +1,93 @@
+  #####################################################################################
+  # build_and_upload_installable_build
+  # -----------------------------------------------------------------------------------
+  # This lane builds the app and upload it for adhoc testing
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_and_upload_installable_build [version_long:<version_long>]
+  #
+  # Example:
+  # bundle exec fastlane build_and_upload_installable_build
+  # bundle exec fastlane build_and_upload_installable_build build_number:123
+  #####################################################################################
+  desc "Builds and uploads a Jetpack installable build"
+  lane :build_and_upload_jetpack_installable_build do | options |
+    jetpack_alpha_code_signing
+
+    # Get the current build version, and update it if needed
+    version_config_path = File.join(PROJECT_ROOT_FOLDER, "config", "Version.internal.xcconfig")
+    versions = Xcodeproj::Config.new(File.new(version_config_path)).to_hash
+
+    build_number = Time.new.strftime("%Y-%m-%d-%H")
+    UI.message("Updating build version to #{build_number}")
+
+    versions["VERSION_SHORT"] = "0.1"
+    versions["VERSION_LONG"] = build_number
+    new_config = Xcodeproj::Config.new(versions)
+    new_config.save_as(Pathname.new(version_config_path))
+
+    gym(
+      scheme: "Jetpack",
+      workspace: WORKSPACE_PATH,
+      export_method: "enterprise",
+      configuration: "Release-Alpha",
+      clean: true,
+      output_directory: BUILD_PRODUCTS_PATH,
+      output_name: "Jetpack Alpha",
+      derived_data_path: DERIVED_DATA_PATH,
+      export_team_id: ENV["INT_EXPORT_TEAM_ID"],
+      export_options: { method: "enterprise" }
+    )
+
+    appcenter_upload(
+      api_token: get_required_env("APPCENTER_API_TOKEN"),
+      owner_name: "automattic",
+      owner_type: "organization",
+      app_name: "jetpack-installable-builds",
+      file: lane_context[SharedValues::IPA_OUTPUT_PATH],
+      dsym: lane_context[SharedValues::DSYM_OUTPUT_PATH],
+      destinations: "Collaborators",
+      notify_testers: false
+    )
+
+    # Install SentryCLI prior to trying to upload dSYMs
+    sh("curl -sL https://sentry.io/get-cli/ | bash") unless sh("which sentry-cli")
+
+    sentry_upload_dsym(
+      auth_token: get_required_env("SENTRY_AUTH_TOKEN"),
+      org_slug: 'a8c',
+      project_slug: 'jetpack-ios',
+      dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH],
+    )
+  end
+
+########################################################################
+# Jetpack Fastlane match code signing
+########################################################################
+private_lane :jetpack_alpha_code_signing do |options|
+  match(
+    type: "enterprise",
+    team_id: get_required_env("INT_EXPORT_TEAM_ID"),
+    readonly: true,
+    app_identifier: "com.jetpack.alpha"
+  )
+end
+
+private_lane :jetpack_internal_code_signing do |options|
+  match(
+    type: "enterprise",
+    team_id: get_required_env("INT_EXPORT_TEAM_ID"),
+    readonly: true,
+    app_identifier: "com.jetpack.internal"
+  )
+end
+
+private_lane :jetpack_appstore_code_signing do |options|
+  match(
+    type: "appstore",
+    team_id: get_required_env("EXT_EXPORT_TEAM_ID"),
+    readonly: true,
+    app_identifier: "com.jetpack"
+  )
+end
+


### PR DESCRIPTION
Adds CI for the Jetpack app

To test:
- Ensure that all CI jobs pass
- Ensure that [the installable build shows up in App Center](https://appcenter.ms/orgs/automattic/apps/jetpack-installable-builds/distribute/releases) and is installable on your device

Once this PR is approved, I'll remove the installable build from PRs and only run it nightly. Jetpack builds will continue on each PR.

## Regression Notes
1. Potential unintended areas of impact: n/a
2. What I did to test those areas of impact (or what existing automated tests I relied on): n/a
3. What automated tests I added (or what prevented me from doing so): n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
