### PR TITLE
WPKit Upgrade: Validate XMLRPC on HTTPS only if configured by hosting app

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.30.0'
+    # pod 'WordPressKit', '~> 4.30.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/woo/3891-check-for-secure-access'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -401,7 +401,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.30.0):
+  - WordPressKit (4.31.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -499,7 +499,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.36.0)
-  - WordPressKit (~> 4.30.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/woo/3891-check-for-secure-access`)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.9.0)
@@ -511,7 +511,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressKit
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -651,6 +650,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.50.0
+  WordPressKit:
+    :branch: issue/woo/3891-check-for-secure-access
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.50.0/third-party-podspecs/Yoga.podspec.json
 
@@ -666,6 +668,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.50.0
+  WordPressKit:
+    :commit: 1f23174d1e9b14f7eb7748b435504257d392e346
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -747,7 +752,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 21d96070b30c4ce6b98de52c05779d27c2f9b399
-  WordPressKit: 894ed4ad3af910b3e5a00fbd018724eac26a6133
+  WordPressKit: 2c85cda141fa65d938d048fe8148688765755222
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 0f7f10e96f8354d64f951c223ae61e8de7495a46
   WordPressUI: 3b70cccc4c44cff09024ca3e94ae25a8768b26c1
@@ -763,6 +768,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 483c37b687db38acd25eb3ee225978b7a15cd573
+PODFILE CHECKSUM: bef31cd7e8eb19ab60fc164380aac55b4a8151d5
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
🛑 Please see and review https://github.com/wordpress-mobile/WordPressKit-iOS/pull/382. 

I will fill in the details below when the WPKit PR is accepted. 


---

Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
