### PR TITLE
Jetpack App: Update filter bar selected color for Jetpack

### DIFF
--- a/WordPress/Jetpack/UIColor+JetpackColors.swift
+++ b/WordPress/Jetpack/UIColor+JetpackColors.swift
@@ -37,7 +37,7 @@ extension UIColor {
     }
 
     static var filterBarSelected: UIColor {
-        return UIColor(light: .primary, dark: .label)
+        return .primary
     }
 
     static var filterBarSelectedText: UIColor {


### PR DESCRIPTION
## Description

This PR updates the filter bar selected color to use `.primary` for both light/dark mode

Design ref: pcdRpT-k6-p2
> On iOS: Change segmented controls (top tabs?) to use black text with a green line (rather than green text with a green line).

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/114501684-6c726b80-9c65-11eb-8979-0d23291e116b.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/114501752-8f9d1b00-9c65-11eb-96ce-5f72b6815802.png" width=200>

## How to test
1. Go to My Site
2. Tap on Stats
3. Turn on dark mode
4. 👀 Notice the filter bar selected color is green

## Regression Notes
1. Potential unintended areas of impact
Filter bar selected color in light mode for the Jetpack App

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested and confirmed that the filter bar selected color looks correct

3. What automated tests I added (or what prevented me from doing so)
None


## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.