### PR TITLE
Notification Likes list: show user profile sheet from selected row

### DIFF
--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -183,7 +183,7 @@ extension LikesListController: UITableViewDataSource, UITableViewDelegate {
             return
         }
 
-        delegate?.didSelectUser(user)
+        delegate?.didSelectUser(user, at: indexPath)
     }
 
 }
@@ -241,7 +241,7 @@ protocol LikesListControllerDelegate: class {
 
     /// Reports to the delegate that the user cell has been tapped.
     /// - Parameter user: A RemoteUser instance representing the user at the selected row.
-    func didSelectUser(_ user: RemoteUser)
+    func didSelectUser(_ user: RemoteUser, at indexPath: IndexPath)
 }
 
 // MARK: - Private Definitions

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -982,12 +982,12 @@ private extension NotificationDetailsViewController {
         }
     }
 
-    func displayUserProfile(_ user: RemoteUser) {
+    func displayUserProfile(_ user: RemoteUser, from indexPath: IndexPath) {
         let userProfileVC = UserProfileSheetViewController(user: user)
         let bottomSheet = BottomSheetViewController(childViewController: userProfileVC)
 
-        // TODO: add sourceView for iPad
-        bottomSheet.show(from: self)
+        let sourceView = tableView.cellForRow(at: indexPath) ?? view
+        bottomSheet.show(from: self, sourceView: sourceView)
     }
 
 }
@@ -1376,8 +1376,8 @@ extension NotificationDetailsViewController: LikesListControllerDelegate {
         displayNotificationSource()
     }
 
-    func didSelectUser(_ user: RemoteUser) {
-        displayUserProfile(user)
+    func didSelectUser(_ user: RemoteUser, at indexPath: IndexPath) {
+        displayUserProfile(user, from: indexPath)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -23,6 +23,17 @@ class UserProfileSheetViewController: UITableViewController {
         registerTableCells()
     }
 
+    // We are using intrinsicHeight as the view's collapsedHeight which is calculated from the preferredContentSize.
+    override var preferredContentSize: CGSize {
+        set {
+            super.preferredContentSize = newValue
+        }
+        get {
+            return UIDevice.isPad() ? Constants.iPadPreferredContentSize :
+                                      Constants.iPhonePreferredContentSize
+        }
+    }
+
 }
 
 // MARK: - DrawerPresentable Extension
@@ -34,7 +45,7 @@ extension UserProfileSheetViewController: DrawerPresentable {
             return .maxHeight
         }
 
-        return .contentHeight(320)
+        return .intrinsicHeight
     }
 
     var scrollableView: UIScrollView? {
@@ -154,6 +165,8 @@ private extension UserProfileSheetViewController {
     enum Constants {
         static let userInfoSection = 0
         static let siteSectionTitle = NSLocalizedString("Site", comment: "Header for a single site, shown in Notification user profile.").localizedUppercase
+        static let iPadPreferredContentSize = CGSize(width: 300.0, height: 270.0)
+        static let iPhonePreferredContentSize = CGSize(width: UIScreen.main.bounds.width, height: 280.0)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -26,7 +26,7 @@ class UserProfileSheetViewController: UITableViewController {
     // We are using intrinsicHeight as the view's collapsedHeight which is calculated from the preferredContentSize.
     override var preferredContentSize: CGSize {
         set {
-            super.preferredContentSize = newValue
+            // no-op, but is needed to override the property.
         }
         get {
             return UIDevice.isPad() ? Constants.iPadPreferredContentSize :

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.xib
@@ -49,7 +49,7 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User bio" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HPd-4P-tnS" userLabel="Bio Label">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="User bio" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HPd-4P-tnS" userLabel="Bio Label">
                                 <rect key="frame" x="0.0" y="132" width="395" height="18"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" name="Black"/>


### PR DESCRIPTION
Ref #16244 

On iPad, the user profile sheet is now shown from the selected row.

Also:
- `preferredContentSize` is now used for all devices to set the sheet height.
- The user bio is limited to 5 lines to prevent it from taking over the sheet if someone writes a novel.

Note: I expect once real user information is used, the sheet heights will need more tweaking to accommodate missing information. But this will do for now.

To test:
- Enable the `newLikeNotifications` feature.
- Run on an iPad.
- Go to Notifications > Likes and tap a notification.
- Tap a user.
- Verify the user profile sheet is shown from the selected row.

<kbd><img width="766" alt="ipad_user_profile_sheet" src="https://user-images.githubusercontent.com/1816888/114614692-13ed9f00-9c62-11eb-9c11-4d60725fce5a.png"></kbd>

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
