### PR TITLE
Query for authors and hide separator in post list UI for empty author names.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 17.2
 -----
 
+* [*] Fixed an issue where post author display names weren't visible. [#16297]
 * [***] Updated custom app icons. [#16261]
 
 17.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 17.2
 -----
 
-* [*] Fixed an issue where post author display names weren't visible. [#16297]
+* [*] Fixed an issue where some author display names weren't visible for self-hosted sites. [#16297]
 * [***] Updated custom app icons. [#16261]
 
 17.1

--- a/WordPress/Classes/Models/Blog+BlogAuthors.swift
+++ b/WordPress/Classes/Models/Blog+BlogAuthors.swift
@@ -3,7 +3,7 @@ import CoreData
 
 
 extension Blog {
-    @NSManaged public var authors: NSSet?
+    @NSManaged public var authors: Set<BlogAuthor>?
 
 
     @objc(addAuthorsObject:)
@@ -17,4 +17,9 @@ extension Blog {
 
     @objc(removeAuthors:)
     @NSManaged public func removeFromAuthors(_ values: NSSet)
+
+    @objc
+    func getAuthorWith(id: NSNumber) -> BlogAuthor? {
+        return authors?.first(where: { $0.userID == id })
+    }
 }

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -804,7 +804,10 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
 - (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost {
     NSNumber *previousPostID = post.postID;
     post.postID = remotePost.postID;
-    post.author = remotePost.authorDisplayName;
+    // Used to populate author information for self-hosted sites.
+    BlogAuthor *author = [post.blog getAuthorWithId:remotePost.authorID];
+
+    post.author = remotePost.authorDisplayName ?: author.displayName;
     post.authorID = remotePost.authorID;
     post.date_created_gmt = remotePost.date;
     post.dateModified = remotePost.dateModified;
@@ -824,7 +827,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     if (post.pathForDisplayImage.length == 0) {
         [post updatePathForDisplayImageBasedOnContent];
     }
-    post.authorAvatarURL = remotePost.authorAvatarURL;
+    post.authorAvatarURL = remotePost.authorAvatarURL ?: author.avatarURL;
     post.mt_excerpt = remotePost.excerpt;
     post.wp_slug = remotePost.slug;
     post.suggested_slug = remotePost.suggestedSlug;

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -40,10 +40,12 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
     private var currentLoadedFeaturedImage: String?
     private weak var interactivePostViewDelegate: InteractivePostViewDelegate?
     private weak var actionSheetDelegate: PostActionSheetDelegate?
-    var isAuthorHidden: Bool = false {
+    var shouldHideAuthor: Bool = false {
         didSet {
-            authorLabel.isHidden = isAuthorHidden
-            separatorLabel.isHidden = isAuthorHidden
+            let emptyAuthor = viewModel?.author.isEmpty ?? true
+
+            authorLabel.isHidden = shouldHideAuthor || emptyAuthor
+            separatorLabel.isHidden = shouldHideAuthor || emptyAuthor
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -549,7 +549,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             return
         }
 
-        cell.isAuthorHidden = showingJustMyPosts
+        cell.shouldHideAuthor = showingJustMyPosts
     }
 
     private func configureRestoreCell(_ cell: UITableViewCell) {

--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -96,8 +96,11 @@ private extension RevisionsTableViewController {
     }
 
     private func getAuthor(for id: NSNumber?) -> BlogAuthor? {
-        let authors: [BlogAuthor]? = post?.blog.authors?.allObjects as? [BlogAuthor]
-        return authors?.first { $0.userID == id }
+        guard let authorId = id else {
+            return nil
+        }
+
+        return post?.blog.getAuthorWith(id: authorId)
     }
 
     private func getRevisionState(at indexPath: IndexPath) -> RevisionBrowserState {
@@ -193,12 +196,13 @@ extension RevisionsTableViewController: WPTableViewHandlerDelegate {
         }
 
         let revision = getRevision(at: indexPath)
-        let authors = getAuthor(for: revision.postAuthorId)
+        let author = getAuthor(for: revision.postAuthorId)
+
         cell.title = revision.revisionDate.shortTimeString()
-        cell.subtitle = authors?.username ?? revision.revisionDate.mediumString()
+        cell.subtitle = author?.username ?? revision.revisionDate.mediumString()
         cell.totalAdd = revision.diff?.totalAdditions.intValue
         cell.totalDel = revision.diff?.totalDeletions.intValue
-        cell.avatarURL = authors?.avatarURL
+        cell.avatarURL = author?.avatarURL
     }
 
 

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -249,7 +249,7 @@ class PostCardCellTests: XCTestCase {
         let post = PostBuilder(context).with(author: "John Doe").build()
         postCell.configure(with: post)
 
-        postCell.isAuthorHidden = true
+        postCell.shouldHideAuthor = true
 
         XCTAssertTrue(postCell.authorLabel.isHidden)
         XCTAssertTrue(postCell.separatorLabel.isHidden)
@@ -259,10 +259,20 @@ class PostCardCellTests: XCTestCase {
         let post = PostBuilder(context).with(author: "John Doe").build()
         postCell.configure(with: post)
 
-        postCell.isAuthorHidden = false
+        postCell.shouldHideAuthor = false
 
         XCTAssertFalse(postCell.authorLabel.isHidden)
         XCTAssertFalse(postCell.separatorLabel.isHidden)
+    }
+
+    func testHidesAuthorSeparatorWhenAuthorEmpty() {
+        let post = PostBuilder(context).with(author: "").build()
+        postCell.configure(with: post)
+
+        postCell.shouldHideAuthor = false
+
+        XCTAssertTrue(postCell.authorLabel.isHidden)
+        XCTAssertTrue(postCell.separatorLabel.isHidden)
     }
 
     func testShowsPostWillBePublishedWarningForFailedPublishedPostsWithRemote() {


### PR DESCRIPTION
Fixes #16297

<img src="https://user-images.githubusercontent.com/2092798/114650945-17f4dd80-9cb1-11eb-86c1-97760ace6676.png" width=600 />


This PR aims to:

1. Show author names for posts (when possible) for self-hosted WordPress sites.
2. Hide the published date and author name separator when no author name is available.

To test:

1. Publish a sample blog post to a self-hosted WordPress site.
2. From the My Site view, tap "Blog Posts".
3. Observe a dot separator with no author name following. **Note:** For Administrator roles, view posts for "Everyone".

## Regression Notes
1. Potential unintended areas of impact
None identified.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
For the UI portion, existing tests.

3. What automated tests I added (or what prevented me from doing so)
A test has been added for the scenario when the author name should be shown, but no name is available.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
