### PR TITLE
Comment Filters: remove feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -15,7 +15,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case siteCreationHomePagePicker
     case todayWidget
     case milestoneNotifications
-    case commentFilters
     case newLikeNotifications
 
     /// Returns a boolean indicating if the feature is enabled
@@ -50,8 +49,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .todayWidget:
             return true
         case .milestoneNotifications:
-            return true
-        case .commentFilters:
             return true
         case .newLikeNotifications:
             return false
@@ -107,8 +104,6 @@ extension FeatureFlag {
             return "iOS 14 Today Widget"
         case .milestoneNotifications:
             return "Milestone notifications"
-        case .commentFilters:
-            return "Comment filters"
         case .newLikeNotifications:
             return "New Like Notifications"
         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsList.storyboard
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsList.storyboard
@@ -50,7 +50,6 @@
                     <connections>
                         <outlet property="filterTabBar" destination="bno-oB-pDf" id="HTz-ai-FRw"/>
                         <outlet property="tableView" destination="7aR-Vp-g6a" id="b8S-2O-Yk9"/>
-                        <outlet property="tableViewTopConstraint" destination="Rmm-F3-kCp" id="P4H-ty-YIf"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wHe-tJ-scb" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -11,16 +11,11 @@ open class CommentsTableViewCell: WPTableViewCell {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var detailLabel: UILabel!
 
-    @IBOutlet weak var timestampStackView: UIStackView!
-    @IBOutlet private weak var timestampImageView: UIImageView!
-    @IBOutlet private weak var timestampLabel: UILabel!
-
     // MARK: - Private Properties
 
     private var author = String()
     private var postTitle = String()
     private var content = String()
-    private var timestamp: String?
     private var pending: Bool = false
     private var gravatarURL: URL?
     private typealias Style = WPStyleGuide.Comments
@@ -50,10 +45,6 @@ open class CommentsTableViewCell: WPTableViewCell {
         postTitle = comment.titleForDisplay() ?? Labels.noTitle
         content = comment.contentPreviewForDisplay() ?? String()
 
-        if let dateCreated = comment.dateCreated {
-            timestamp = dateCreated.mediumString()
-        }
-
         if let avatarURLForDisplay = comment.avatarURLForDisplay() {
             downloadGravatarWithURL(avatarURLForDisplay)
         } else {
@@ -62,7 +53,6 @@ open class CommentsTableViewCell: WPTableViewCell {
 
         configurePendingIndicator()
         configureCommentLabels()
-        configureTimestamp()
     }
 
 }
@@ -103,18 +93,6 @@ private extension CommentsTableViewCell {
         detailLabel.text = content.trimmingCharacters(in: .whitespacesAndNewlines)
         detailLabel.font = Style.detailFont
         detailLabel.textColor = Style.detailTextColor
-    }
-
-    func configureTimestamp() {
-
-        // When FeatureFlag.commentFilters is removed,
-        // all timestamp elements can be removed.
-        timestampStackView.isHidden = FeatureFlag.commentFilters.enabled
-
-        timestampLabel.text = timestamp
-        timestampLabel.font = Style.timestampFont
-        timestampLabel.textColor = Style.detailTextColor
-        timestampImageView.image = Style.timestampImage
     }
 
     func attributedTitle() -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -32,40 +32,21 @@
                             <constraint firstAttribute="width" constant="42" id="pBo-eH-W4J"/>
                         </constraints>
                     </imageView>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe" userLabel="Label Stack View">
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe" userLabel="Label Stack View">
                         <rect key="frame" x="74" y="16" width="230" height="75"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq" userLabel="Title Label">
-                                <rect key="frame" x="0.0" y="-4" width="230" height="24"/>
+                                <rect key="frame" x="0.0" y="-4" width="230" height="37"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xkp-oe-UgU">
-                                <rect key="frame" x="0.0" y="25" width="230" height="20.5"/>
+                                <rect key="frame" x="0.0" y="38" width="230" height="37"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="dIK-tl-nW4" userLabel="Timestamp Stack View">
-                                <rect key="frame" x="0.0" y="50.5" width="230" height="24.5"/>
-                                <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="rcg-tb-060">
-                                        <rect key="frame" x="0.0" y="4.5" width="16" height="16"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="16" id="YZR-zM-ndp"/>
-                                            <constraint firstAttribute="height" constant="16" id="xwF-CO-6ZI"/>
-                                        </constraints>
-                                    </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
-                                        <rect key="frame" x="20" y="4.5" width="210" height="16"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
-                            </stackView>
                         </subviews>
                         <edgeInsets key="layoutMargins" top="-4" left="0.0" bottom="0.0" right="0.0"/>
                     </stackView>
@@ -87,9 +68,6 @@
                 <outlet property="gravatarImageView" destination="0Gm-n3-CNm" id="GXM-xm-h6r"/>
                 <outlet property="pendingIndicator" destination="btO-r2-hQO" id="uEa-SX-swe"/>
                 <outlet property="pendingIndicatorWidthConstraint" destination="WeL-cC-lqa" id="NGZ-2z-ehN"/>
-                <outlet property="timestampImageView" destination="rcg-tb-060" id="cp9-u0-P57"/>
-                <outlet property="timestampLabel" destination="bDl-id-9M7" id="sk9-hl-b6r"/>
-                <outlet property="timestampStackView" destination="dIK-tl-nW4" id="3n0-tf-xMe"/>
                 <outlet property="titleLabel" destination="Wrp-Wr-ZBq" id="lVi-a7-Ppp"/>
             </connections>
             <point key="canvasLocation" x="33.600000000000001" y="70.614692653673174"/>
@@ -97,7 +75,6 @@
     </objects>
     <resources>
         <image name="gravatar" width="85" height="85"/>
-        <image name="reader-postaction-time" width="16" height="16"/>
         <systemColor name="systemYellowColor">
             <color red="1" green="0.80000000000000004" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
@@ -11,9 +11,6 @@ extension WPStyleGuide {
         static let backgroundColor = UIColor.listForeground
         static let pendingIndicatorColor = UIColor.muriel(color: MurielColor(name: .yellow, shade: .shade20))
 
-        static let timestampFont = WPStyleGuide.fontForTextStyle(.caption1)
-        static let timestampImage = UIImage(named: "reader-postaction-time") ?? UIImage()
-
         static let detailFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         static let detailTextColor = UIColor.textSubtle
 


### PR DESCRIPTION
Ref #15955 

This removes the `commentFilters` feature flag and support for it.

To test:
- Go to Site > Comments.
- Select various filters.
- Verify the comments appear as expected (as exampled in #15955).


## Regression Notes
1. Potential unintended areas of impact
Should be none. The feature flag has been enabled for two releases.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified the site comments lists appeared as expected.

3. What automated tests I added (or what prevented me from doing so)
N/A. Just removing a feature flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
