### PR TITLE
Jetpack: change notification constants

### DIFF
--- a/WordPress/Classes/Services/NotificationSettingsService.swift
+++ b/WordPress/Classes/Services/NotificationSettingsService.swift
@@ -97,7 +97,7 @@ open class NotificationSettingsService: LocalCoreDataService {
         }
 
         notificationsServiceRemote?.registerDeviceForPushNotifications(token,
-                                                                       pushNotificationAppId: WPPushNotificationAppId,
+                                                                       pushNotificationAppId: AppConstants.pushNotificationAppId,
                                                                        success: success,
                                                                        failure: failure)
     }

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -20,17 +20,6 @@ NSString *const WPComReferrerURL                                    = @"https://
 NSString *const AutomatticDomain                                    = @"automattic.com";
 NSString *const WPComDomain                                         = @"wordpress.com";
 
-/// Notifications Constants
-///
-#ifdef DEBUG
-NSString *const  WPPushNotificationAppId                            = @"org.wordpress.appstore.dev";
-#else
-#ifdef INTERNAL_BUILD
-NSString *const   WPPushNotificationAppId                           = @"org.wordpress.internal";
-#else
-NSString *const WPPushNotificationAppId                             = @"org.wordpress.appstore";
-#endif
-#endif
 /// Keychain Constants
 ///
 #ifdef INTERNAL_BUILD

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -4,6 +4,18 @@ struct AppConstants {
     static let productTwitterHandle = "@WordPressiOS"
     static let productTwitterURL = "https://twitter.com/WordPressiOS"
     static let productBlogURL = "https://blog.wordpress.com"
+
+    /// Notifications Constants
+    ///
+    #if DEBUG
+    static let pushNotificationAppId = "org.wordpress.appstore.dev"
+    #else
+    #if INTERNAL_BUILD
+    static let pushNotificationAppId = "org.wordpress.internal"
+    #else
+    static let pushNotificationAppId = "org.wordpress.appstore"
+    #endif
+    #endif
 }
 
 // MARK: - Localized Strings

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -4,6 +4,18 @@ struct AppConstants {
     static let productTwitterHandle = "@jetpack"
     static let productTwitterURL = "https://twitter.com/jetpack"
     static let productBlogURL = "https://jetpack.com/blog"
+
+    /// Notifications Constants
+    ///
+    #if DEBUG
+    static let pushNotificationAppId = "com.jetpack.appstore.dev"
+    #else
+    #if INTERNAL_BUILD
+    static let pushNotificationAppId = "com.jetpack.internal"
+    #else
+    static let pushNotificationAppId = "com.jetpack.appstore"
+    #endif
+    #endif
 }
 
 // MARK: - Localized Strings


### PR DESCRIPTION
This PR changes the notifications constants for Jetpack app.

### To test

1. Run WordPress
2. Check your notifications, everything should behave as before

Jetpack:

1. Run Jetpack
2. Check your notifications, you should see the same as before (given the backend will fallback to WP) *

*@jkmassel will add the Jetpack constants on the backend. So, before we merge we will double-check if the notifications are correctly working.

## Regression Notes
1. Potential unintended areas of impact
WordPress
2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing to check notifications
3. What automated tests I added (or what prevented me from doing so)
n/a
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
