### PR TITLE
Jetpack: change Zendesk ticket subject

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -4,6 +4,7 @@ struct AppConstants {
     static let productTwitterHandle = "@WordPressiOS"
     static let productTwitterURL = "https://twitter.com/WordPressiOS"
     static let productBlogURL = "https://blog.wordpress.com"
+    static let ticketSubject = NSLocalizedString("WordPress for iOS Support", comment: "Subject of new Zendesk ticket.")
 }
 
 // MARK: - Localized Strings

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -1033,7 +1033,7 @@ private extension ZendeskUtils {
         static let mobileCategoryID: UInt64 = 360000041586
         static let articleLabel = "iOS"
         static let platformTag = "iOS"
-        static let ticketSubject = NSLocalizedString("WordPress for iOS Support", comment: "Subject of new Zendesk ticket.")
+        static let ticketSubject = AppConstants.ticketSubject
         static let blogSeperator = "\n----------\n"
         static let jetpackTag = "jetpack"
         static let wpComTag = "wpcom"

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -4,6 +4,7 @@ struct AppConstants {
     static let productTwitterHandle = "@jetpack"
     static let productTwitterURL = "https://twitter.com/jetpack"
     static let productBlogURL = "https://jetpack.com/blog"
+    static let ticketSubject = "Jetpack for iOS Support"
 }
 
 // MARK: - Localized Strings


### PR DESCRIPTION
This PR changes the ticket subject of Zendesk PRs to _Jetpack for iOS Support_.

### To test

1. Run Jetpack
2. Go to your profile > Help & Support > Contact Support
3. Send a message
4. Check on Zendesk if the ticket arrived with `Jetpack for iOS Support` subject
5. Delete the ticket

WordPress:

1. Run WordPress
2. Go to your profile > Help & Support > Contact Support
3. Send a message
4. Check on Zendesk if the ticket arrived with `WordPress for iOS Support` subject
5. Delete the ticket

## Regression Notes
1. Potential unintended areas of impact
WordPress.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
