### PR TITLE
User Profile: show site in webView if there is no siteID

### DIFF
--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -3,8 +3,18 @@ class UserProfileSheetViewController: UITableViewController {
     // MARK: - Properties
 
     private let user: RemoteUser
-    private lazy var context = ContextManager.sharedInstance().mainContext
-    private lazy var readerTopicService = ReaderTopicService(managedObjectContext: context)
+
+    private lazy var mainContext = {
+        ContextManager.sharedInstance().mainContext
+    }()
+
+    private lazy var readerTopicService = {
+        ReaderTopicService(managedObjectContext: mainContext)
+    }()
+
+    private lazy var contentCoordinator: ContentCoordinator = {
+        return DefaultContentCoordinator(controller: self, context: mainContext)
+    }()
 
     // MARK: - Init
 
@@ -132,13 +142,22 @@ private extension UserProfileSheetViewController {
     func fetchAndShowSite() {
 
         // TODO: Remove. For testing only. Use siteID from user object.
-        let siteID = NSNumber(value: 999999999999999999)
+        var stubbySiteID: NSNumber?
+        // use this to test external site
+        stubbySiteID = nil
+        // use this to test internal site
+        // stubbySiteID = NSNumber(value: 9999999999)
+
+        guard let siteID = stubbySiteID else {
+            showSiteWebView()
+            return
+        }
 
         readerTopicService.siteTopicForSite(withID: siteID,
                                             isFeed: false,
                                             success: { [weak self] (objectID: NSManagedObjectID?, isFollowing: Bool) in
                                                 guard let objectID = objectID,
-                                                      let siteTopic = (try? self?.context.existingObject(with: objectID)) as? ReaderAbstractTopic else {
+                                                      let siteTopic = (try? self?.mainContext.existingObject(with: objectID)) as? ReaderAbstractTopic else {
                                                     DDLogError("User Profile: Error retrieving an existing site topic by its objectID.")
                                                     return
                                                 }
@@ -152,6 +171,18 @@ private extension UserProfileSheetViewController {
         let controller = ReaderStreamViewController.controllerWithTopic(topic)
         let navController = UINavigationController(rootViewController: controller)
         present(navController, animated: true)
+    }
+
+    func showSiteWebView() {
+        // TODO: Remove. For testing only. Use URL from user object.
+        let siteUrl = "http://www.peopleofwalmart.com/"
+
+        guard let url = URL(string: siteUrl) else {
+            DDLogError("User Profile: Error creating URL from site string.")
+            return
+        }
+
+        contentCoordinator.displayWebViewWithURL(url)
     }
 
     func configureTable() {

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -5,11 +5,11 @@ class UserProfileSheetViewController: UITableViewController {
     private let user: RemoteUser
 
     private lazy var mainContext = {
-        ContextManager.sharedInstance().mainContext
+        return ContextManager.sharedInstance().mainContext
     }()
 
     private lazy var readerTopicService = {
-        ReaderTopicService(managedObjectContext: mainContext)
+        return ReaderTopicService(managedObjectContext: mainContext)
     }()
 
     private lazy var contentCoordinator: ContentCoordinator = {


### PR DESCRIPTION
Ref #16245 

When the site is tapped on the User Profile, if there is no siteID (ex: external, private), the site URL is used to display the site in a webView.

To test:

Since we don't have real user info yet, I've stubbed in a site URL. Feel free to use different URLs by changing it in [`UserProfileSheetViewController:showSiteWebView`](https://github.com/wordpress-mobile/WordPress-iOS/blob/a2accd6899617fab4592d247d2f4e2bfe75f9a50/WordPress/Classes/ViewRelated/User%20Profile%20Sheet/UserProfileSheetViewController.swift#L178).


- Enable the `newLikeNotifications` feature.
- Go to Notifications > Likes and tap a notification.
- Tap a user, then the site row.
- Verify the site is displayed in a webView.

| External | Private |
|--------|-------|
| ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-04-14 at 18 33 50](https://user-images.githubusercontent.com/1816888/114797303-19c1ae00-9d50-11eb-975a-755d8e56f498.png) | ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-04-14 at 18 35 31](https://user-images.githubusercontent.com/1816888/114797378-48d81f80-9d50-11eb-81fd-a233911be909.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
