### PR TITLE
Don't log errors on site icon 404s

### DIFF
--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -1,4 +1,5 @@
 import AlamofireImage
+import Alamofire
 import AutomatticTracks
 import Foundation
 import Gridicons
@@ -91,7 +92,12 @@ extension UIImageView {
             case .failure(let error):
                 if case .requestCancelled = (error as? AFIError) {
                     // Do not log intentionally cancelled requests as errors.
-                } else {
+                } else if case let Alamofire.AFError.responseValidationFailed(reason) = error,
+                          case let Alamofire.AFError.ResponseValidationFailureReason.unacceptableStatusCode(code) = reason,
+                          code == 404 {
+                    // Do not log 404 errors since they are expected for site icons
+                }
+                else {
                     WordPressAppDelegate.crashLogging?.logError(error)
                 }
             }


### PR DESCRIPTION
Removes error logging when receiving a 404 from the site icon request. It's expected that these icons may not exist, so we don't need to log these. The intent is to bring down the noise on some of these long running errors which may by inhibiting our ability to actually track the problem cases.

Looking at the results for #15870 over the last 14 days we can see that 404s show up > 50% of the time:

status | count
-- | --
404 | 1895
400 | 1565
403 | 201
429 | 2
500 | 5

### Testing

* Switch to a site with no site icon.
* Ensure that the 404 is not logged by checking for the console message.
* Use a proxy to rewrite the response of the site icon call to return a 400 error code.
* Ensure that this error code is shown as logged in the console.

## Regression Notes

This only impacts logging so there is no impact on users.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
