### PR TITLE
Guards against integer overflow error

### DIFF
--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -656,6 +656,12 @@ static CGFloat const DefaultCellHeight = 44.0;
         return;
     }
 
+    // Prevents a crash where index path rows could end with an integer overflow error.
+    // See https://github.com/wordpress-mobile/WordPress-iOS/issues/15366
+    if (indexPath.row == NSUIntegerMax || newIndexPath.row == NSUIntegerMax) {
+        return;
+    }
+
     if (NSFetchedResultsChangeUpdate == type && newIndexPath && ![newIndexPath isEqual:indexPath]) {
         // Seriously, Apple?
         // http://developer.apple.com/library/ios/#releasenotes/iPhone/NSFetchedResultsChangeMoveReportedAsNSFetchedResultsChangeUpdate/_index.html


### PR DESCRIPTION
Fixes #15366

In the majority of these cases, the `NSIndexPath.row` ends up being the max integer upon an overflow error in a calculation prior to the `didChangeObject` delegate method.

This doesn't completely fix all cases of #15366, but I think it brings the numbers down to reasonable levels.

Over the last 14 days, these were the row values from the crashing index path:

|row|count|
|-|-|
|18446744073709551615|362|
|18446744073709551614|2|
|18446744073709551610|1|
|1|1|
|18446744073709551601|1|
|18446744073709551604|1|
|18446744073709551608|1|
|18446744073709551613|1|

`18446744073709551615` is the maximum unsigned integer on a 64-bit device. There are discussions about similar issues in [several](https://stackoverflow.com/questions/36546037/row-1-or-nsuintegermax-given-by-uitableviewdelegate-tableviewtitlefordeletec) [places](https://developer.apple.com/forums/thread/98184). I believe we should ignore this value for now and possibly look further up the stack for issues. I don't think it's likely any users will run into this guard in normal use in a a table view with `18446744073709551615` rows.

## Testing

* Test any lists using table views (Posts, reader, etc.)

## Regression Notes
1. Potential unintended areas of impact

Any table view where content is reloaded. Posts, Reader, etc.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing.

3. What automated tests I added (or what prevented me from doing so)

No automated tests added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
