### PR TITLE
Split custom app icons into colorful and light background sections

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppIconViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppIconViewController.swift
@@ -60,7 +60,7 @@ open class AppIconViewController: UITableViewController {
 
         let cell = tableView.dequeueReusableCell(withIdentifier: Constants.cellIdentifier, for: indexPath)
 
-        cell.textLabel?.text = icon.name
+        cell.textLabel?.text = icon.displayName
 
         if let imageView = cell.imageView {
             imageView.image = UIImage(named: icon.imageName)
@@ -91,9 +91,9 @@ open class AppIconViewController: UITableViewController {
 
     open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let isOriginalIcon = self.isOriginalIcon(at: indexPath)
-        let icon = isOriginalIcon ? nil : icons[indexPath.section][indexPath.row].name
+        let iconName = isOriginalIcon ? nil : icons[indexPath.section][indexPath.row].name
 
-        UIApplication.shared.setAlternateIconName(icon, completionHandler: { [weak self] error in
+        UIApplication.shared.setAlternateIconName(iconName, completionHandler: { [weak self] error in
             if error == nil {
                 let event: WPAnalyticsStat = isOriginalIcon ? .appIconReset : .appIconChanged
                 WPAppAnalytics.track(event)
@@ -176,6 +176,10 @@ struct AppIcon {
     let name: String
     let isBordered: Bool
     let isLegacy: Bool
+
+    var displayName: String {
+        return name.replacingMatches(of: " Classic", with: "")
+    }
 
     var imageName: String {
         let lowered = name.lowercased().replacingMatches(of: " ", with: "-")


### PR DESCRIPTION
This PR splits the new custom app icons into "Colorful backgrounds" and "Light backgrounds" sections. It also hides the 'classic' suffix from the light background options, so that the names match the colorful versions. 

|   |   |
|---|---|
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-15 at 19 28 24](https://user-images.githubusercontent.com/4780/114920173-10ecdd00-9e21-11eb-8e95-c313d2c53ff9.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-15 at 19 28 28](https://user-images.githubusercontent.com/4780/114920179-134f3700-9e21-11eb-931e-1509ff59dde3.png) |

**To test**

- Build and run
- Head to Me > App Settings > App Icons
- Check the table looks as above, and that you can switch to custom icons in each section

## Regression Notes

1. Potential unintended areas of impact

Changes are limited to AppIconViewController.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
