### PR TITLE
User Profile Site: views for loading states

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -400,19 +400,24 @@ import WordPressFlux
 
     /// Fetches a site topic for the value of the `siteID` property.
     ///
-    // TODO: - READERNAV - Remove this when the new reader is released
     private func fetchSiteTopic() {
+        guard let siteID = siteID else {
+            DDLogError("A siteID is required before fetching a site topic")
+            return
+        }
+
         if isViewLoaded {
             displayLoadingStream()
         }
-        assert(siteID != nil, "A siteID is required before fetching a site topic")
+
         let service = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        service.siteTopicForSite(withID: siteID!,
+        service.siteTopicForSite(withID: siteID,
             isFeed: isFeed,
             success: { [weak self] (objectID: NSManagedObjectID?, isFollowing: Bool) in
 
                 let context = ContextManager.sharedInstance().mainContext
-                guard let objectID = objectID, let topic = (try? context.existingObject(with: objectID)) as? ReaderAbstractTopic else {
+                guard let objectID = objectID,
+                      let topic = (try? context.existingObject(with: objectID)) as? ReaderAbstractTopic else {
                     DDLogError("Reader: Error retriving an existing site topic by its objectID")
                     if self?.isLoadingDiscover ?? false {
                         self?.updateContent(synchronize: false)
@@ -1737,8 +1742,8 @@ extension ReaderStreamViewController {
     struct ResultsStatusText {
         static let fetchingPostsTitle = NSLocalizedString("Fetching posts...", comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new posts.")
         static let loadingStreamTitle = NSLocalizedString("Loading stream...", comment: "A short message to inform the user the requested stream is being loaded.")
-        static let loadingErrorTitle = NSLocalizedString("Problem loading stream", comment: "Error message title informing the user that a stream could not be loaded.")
-        static let loadingErrorMessage = NSLocalizedString("Sorry. The stream could not be loaded.", comment: "A short error message letting the user know the requested stream could not be loaded.")
+        static let loadingErrorTitle = NSLocalizedString("Problem loading content", comment: "Error message title informing the user that reader content could not be loaded.")
+        static let loadingErrorMessage = NSLocalizedString("Sorry. The content could not be loaded.", comment: "A short error message letting the user know the requested reader content could not be loaded.")
         static let manageSitesButtonTitle = NSLocalizedString("Manage Sites", comment: "Button title. Tapping lets the user manage the sites they follow.")
         static let followingButtonTitle = NSLocalizedString("Go to Following", comment: "Button title. Tapping lets the user view the sites they follow.")
         static let noConnectionTitle = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -126,7 +126,7 @@ extension UserProfileSheetViewController {
             return
         }
 
-        fetchAndShowSite()
+        showSite()
         tableView.deselectRow(at: indexPath, animated: true)
     }
 }
@@ -135,7 +135,7 @@ extension UserProfileSheetViewController {
 
 private extension UserProfileSheetViewController {
 
-    func fetchAndShowSite() {
+    func showSite() {
 
         // TODO: Remove. For testing only. Use siteID from user object.
         var stubbySiteID: NSNumber?

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -8,10 +8,6 @@ class UserProfileSheetViewController: UITableViewController {
         return ContextManager.sharedInstance().mainContext
     }()
 
-    private lazy var readerTopicService = {
-        return ReaderTopicService(managedObjectContext: mainContext)
-    }()
-
     private lazy var contentCoordinator: ContentCoordinator = {
         return DefaultContentCoordinator(controller: self, context: mainContext)
     }()
@@ -144,31 +140,20 @@ private extension UserProfileSheetViewController {
         // TODO: Remove. For testing only. Use siteID from user object.
         var stubbySiteID: NSNumber?
         // use this to test external site
-        stubbySiteID = nil
+        // stubbySiteID = nil
         // use this to test internal site
-        // stubbySiteID = NSNumber(value: 9999999999)
+        stubbySiteID = NSNumber(value: 9999999999)
 
         guard let siteID = stubbySiteID else {
             showSiteWebView()
             return
         }
 
-        readerTopicService.siteTopicForSite(withID: siteID,
-                                            isFeed: false,
-                                            success: { [weak self] (objectID: NSManagedObjectID?, isFollowing: Bool) in
-                                                guard let objectID = objectID,
-                                                      let siteTopic = (try? self?.mainContext.existingObject(with: objectID)) as? ReaderAbstractTopic else {
-                                                    DDLogError("User Profile: Error retrieving an existing site topic by its objectID.")
-                                                    return
-                                                }
-
-                                                self?.showSiteTopic(siteTopic)
-                                            },
-                                            failure: nil)
+        showSiteTopicWithID(siteID)
     }
 
-    func showSiteTopic(_ topic: ReaderAbstractTopic) {
-        let controller = ReaderStreamViewController.controllerWithTopic(topic)
+    func showSiteTopicWithID(_ siteID: NSNumber) {
+        let controller = ReaderStreamViewController.controllerWithSiteID(siteID, isFeed: false)
         let navController = UINavigationController(rootViewController: controller)
         present(navController, animated: true)
     }


### PR DESCRIPTION
Ref #16245 , #16302

Fetching a site by ID now uses the existing `ReaderStreamViewController.controllerWithSiteID:isFeed` method to instantiate the view. The site is fetched the same way it was before, but now via the `ReaderStreamViewController.fetchSiteTopic` method. The bonus is the user profile site now has views for various loading states. Namely:
- Loading
- Loading error
- Connection error

| Loading | Loading Error | Connection Error |
|--------|-------|-------|
| ![loading](https://user-images.githubusercontent.com/1816888/114931566-a1acc400-9df3-11eb-99fb-98f553e46b91.png) | ![loading_error](https://user-images.githubusercontent.com/1816888/114931520-93f73e80-9df3-11eb-9ced-6c7844f86ced.png) | ![connection_error](https://user-images.githubusercontent.com/1816888/114931585-a83b3b80-9df3-11eb-943a-ebb258606c2c.jpeg) |

---
To test:

Since we don't have real user info yet, I've stubbed in a bogus siteID. You'll need valid siteIDs for the site to show. The siteID is set in [`UserProfileSheetViewController.showSite`](https://github.com/wordpress-mobile/WordPress-iOS/blob/fa14a8e0041d0017e6383d914288067bae92240d/WordPress/Classes/ViewRelated/User%20Profile%20Sheet/UserProfileSheetViewController.swift#L145).

---
Invalid siteID (as-is):
- Enable the `newLikeNotifications` feature.
- Go to Notifications > Likes and tap a notification.
- Tap a user, then the site row.
- Verify the `Problem loading content` view is displayed.

---
Valid siteID:
- Set the siteID value as mentioned above.
- Go to Notifications > Likes and tap a notification.
- Tap a user, then the site row.
- Verify the site is displayed.

---
No connection:
- Go to Notifications > Likes and tap a notification.
- Tap a user.
- Disable internet connection.
- Tap the site row.
- Verify the connection error is displayed.

---
Slow connection:
- Go to Notifications > Likes and tap a notification.
- Tap a user.
- Slow your internet connection.
- Tap the site row.
- Verify the loading ghost view is displayed.

---
## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
