### PR TITLE
Show posts in the app via their wordpress.com subdomain link

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -14,6 +14,7 @@ enum ReaderRoute {
     case blog
     case feedsPost
     case blogsPost
+    case wpcomPost
 }
 
 extension ReaderRoute: Route {
@@ -45,6 +46,8 @@ extension ReaderRoute: Route {
             return "/read/feeds/:feed_id/posts/:post_id"
         case .blogsPost:
             return "/read/blogs/:blog_id/posts/:post_id"
+        case .wpcomPost:
+            return "/:post_year/:post_month/:post_day/:post_name"
         }
     }
 
@@ -105,6 +108,10 @@ extension ReaderRoute: NavigationAction {
         case .blogsPost:
             if let (blogID, postID) = blogAndPostID(from: values) {
                 coordinator.showPost(with: postID, for: blogID, isFeed: false)
+            }
+        case .wpcomPost:
+            if let urlString = values["matched-route-url"], let url = URL(string: urlString) {
+                coordinator.showPost(with: url)
             }
         }
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -110,7 +110,10 @@ extension ReaderRoute: NavigationAction {
                 coordinator.showPost(with: postID, for: blogID, isFeed: false)
             }
         case .wpcomPost:
-            if let urlString = values["matched-route-url"], let url = URL(string: urlString) {
+            if let urlString = values[MatchedRouteURLComponentKey.url.rawValue],
+               let url = URL(string: urlString),
+               isValidWpcomUrl(values) {
+
                 coordinator.showPost(with: url)
             }
         }
@@ -136,5 +139,26 @@ extension ReaderRoute: NavigationAction {
         }
 
         return (blogID, postID)
+    }
+
+    private func isValidWpcomUrl(_ values: [String: String]) -> Bool {
+        let year = Int(values["post_year"] ?? "") ?? 0
+        let month = Int(values["post_month"] ?? "") ?? 0
+        let day = Int(values["post_day"] ?? "") ?? 0
+
+        // we assume no posts were made in the 1800's or earlier
+        func isYear(_ year: Int) -> Bool {
+            year > 1900
+        }
+
+        func isMonth(_ month: Int) ->  Bool {
+            (1...12).contains(month)
+        }
+
+        func isDay(_ day: Int) -> Bool {
+            (1...31).contains(day)
+        }
+
+        return isYear(year) && isMonth(month) && isDay(day)
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -61,7 +61,8 @@ struct UniversalLinkRouter {
         ReaderRoute.feed,
         ReaderRoute.blog,
         ReaderRoute.feedsPost,
-        ReaderRoute.blogsPost
+        ReaderRoute.blogsPost,
+        ReaderRoute.wpcomPost
     ]
 
     static let statsRoutes: [Route] = [

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -116,14 +116,22 @@ class ReaderCoordinator: NSObject {
     }
 
     func showPost(with postID: Int, for feedID: Int, isFeed: Bool) {
+        showPost(in: ReaderDetailViewController
+                    .controllerWithPostID(postID as NSNumber,
+                                          siteID: feedID as NSNumber,
+                                          isFeed: isFeed))
+    }
+
+    func showPost(with url: URL) {
+        showPost(in: ReaderDetailViewController.controllerWithPostURL(url))
+    }
+
+    private func showPost(in detailViewController: ReaderDetailViewController) {
+
         let postLoadFailureBlock = { [weak self, failureBlock] in
             self?.readerNavigationController.popToRootViewController(animated: false)
             failureBlock?()
         }
-
-        let detailViewController = ReaderDetailViewController.controllerWithPostID(postID as NSNumber,
-                                                                                   siteID: feedID as NSNumber,
-                                                                                   isFeed: isFeed)
 
         detailViewController.postLoadFailureBlock = postLoadFailureBlock
         WPTabBarController.sharedInstance().navigateToReader(detailViewController)

--- a/WordPress/WordPress-Alpha.entitlements
+++ b/WordPress/WordPress-Alpha.entitlements
@@ -8,6 +8,7 @@
 		<string>applinks:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
+		<string>applinks:*.wordpress.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/WordPress-Internal.entitlements
+++ b/WordPress/WordPress-Internal.entitlements
@@ -10,6 +10,7 @@
 		<string>applinks:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
+		<string>applinks:*.wordpress.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/WordPress.entitlements
+++ b/WordPress/WordPress.entitlements
@@ -15,6 +15,7 @@
 		<string>applinks:apps.wordpress.com</string>
 		<string>applinks:public-api.wordpress.com</string>
 		<string>applinks:links.wp.a8cmail.com</string>
+		<string>applinks:*.wordpress.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>


### PR DESCRIPTION
This PR allows to show posts in the reader by providing a link in the following format:

`site_name.wordpress.com/post_year/post_month/post_day/post_title`

Fixes #NA

To test:

1. Find the method `handleWebActivity` in `WordPRessAppDelegate
2. Change the following call, hardcoding a valid URL of the format specified above:
    - `UniversalLinkRouter.shared.handle(url: url)`
3. Build and run in a simulator
4. in the terminal launch the following command:
    - `xcrun simctl openurl booted [currently_recognized_url]`
    where `currently_recognized_url` is an url that would be currently recognized by the app as a valid url, for example a valid url in the following form:
    - `https://wordpress.com/read/feeds/feed_id/posts/post_id` (this is needed to trigger the handling of the web activity)
5. Make sure that the post of the hardcoded link is displayed in the app, in the Reader Detail page.

## Regression Notes
1. Potential unintended areas of impact
low/none, this only adds a new route for the reader, as well a new (set) of associated domains. It also refactors an existing method used to show posts

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested that the existing routes still work as expected, especially the existing one for a reader post.


3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
