### PR TITLE
Remove duplicate row (app color scheme) from 17.1 release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,6 @@
 * [*] Added preview device mode selector in the page layout previews [#16141]
 * [***] Block Editor: Improved the accessibility of range and step-type block settings. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3255]
 * [**] Block Editor: Added Contact Info block to sites on WPcom or with Jetpack version >= 8.5.
-* [**] We updated the app's color scheme with a brighter new blue used throughout. [#16213, #16207]
 * [**] We updated the login prologue with brand new content and graphics. [#16159, #16177, #16185, #16187, #16200, #16217, #16219, #16221, #16222]
 * [**] We updated the app's color scheme with a brighter new blue used throughout. [#16213, #16207] 
 * [**] Updated the app icon to match the new color scheme within the app. [#16220]


### PR DESCRIPTION
Fixes #NA

in the release notes for `17.1` there were two entries for:

`* [**] We updated the app's color scheme with a brighter new blue used throughout. [#16213, #16207] `

I removed one

To test:

Look at the release notes and make sure there is one (and only one) entry that matches the above description

## Regression Notes
1. Potential unintended areas of impact
Nothing

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Looked at the release notes

3. What automated tests I added (or what prevented me from doing so)
4. NA

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. - Updated

cc @jkmassel - This change should be safe enough to target 17.1
