### PR TITLE
Fix RTL support in NewBlogDetailHeaderView [17.1]

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -202,7 +202,8 @@ fileprivate extension NewBlogDetailHeaderView {
             static let betweenSiteIconAndTitle: CGFloat = 16
             static let betweenTitleAndSiteSwitcher: CGFloat = 16
             static let betweenSiteSwitcherAndRightPadding: CGFloat = 4
-            static let subtitleButtonImageInsets: UIEdgeInsets = UIEdgeInsets(top: 1, left: 4, bottom: 0, right: 0)
+            static let subtitleButtonImageInsets = UIEdgeInsets(top: 1, left: 4, bottom: 0, right: 0)
+            static let rtlSubtitleButtonImageInsets = UIEdgeInsets(top: 1, left: -4, bottom: 0, right: 4)
         }
 
         // MARK: - Child Views
@@ -228,8 +229,13 @@ fileprivate extension NewBlogDetailHeaderView {
             }
 
             // Align the image to the right
-            button.semanticContentAttribute = (UIApplication.shared.userInterfaceLayoutDirection == .leftToRight) ? .forceRightToLeft : .forceLeftToRight
-            button.imageEdgeInsets = LayoutSpacing.subtitleButtonImageInsets
+            if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+                button.semanticContentAttribute = .forceLeftToRight
+                button.imageEdgeInsets = LayoutSpacing.rtlSubtitleButtonImageInsets
+            } else {
+                button.semanticContentAttribute = .forceRightToLeft
+                button.imageEdgeInsets = LayoutSpacing.subtitleButtonImageInsets
+            }
 
             button.translatesAutoresizingMaskIntoConstraints = false
             button.addTarget(self, action: #selector(subtitleButtonTapped), for: .touchUpInside)
@@ -331,7 +337,7 @@ fileprivate extension NewBlogDetailHeaderView {
             [
                 siteIconView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor),
                 siteIconView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor),
-                siteIconView.leftAnchor.constraint(equalTo: leftAnchor),
+                siteIconView.leadingAnchor.constraint(equalTo: leadingAnchor),
                 siteIconView.heightAnchor.constraint(equalToConstant: Dimensions.siteIconHeight),
                 siteIconView.widthAnchor.constraint(equalToConstant: Dimensions.siteIconWidth),
             ]


### PR DESCRIPTION
This PR pulls the changes from #16280 into release/17.1. It improves the RTL support in the blog detail header, and the changes are very limited in scope (and have already been reviewed in the original PR).

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-12 at 09 53 47](https://user-images.githubusercontent.com/4780/114368206-17efc300-9b75-11eb-8d95-57c6d1fbb2a7.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-10 at 13 43 53](https://user-images.githubusercontent.com/4780/114366434-5c7a5f00-9b73-11eb-9856-49061f42a7ea.png) |

**To test**

* Edit the WordPress scheme and set the app language to Hebrew, or Right-to-Left Pseudolanguage.
* Build and run, and ensure that the blog details header in My Site both looks as expected and is functional.
* Check that the header still looks and functions as expected in English or another left-to-right language.

## Regression Notes

1. Potential unintended areas of impact

These changes should be limited to the new blog detail header, as they only affect a few constraints there.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Checked both rtl and ltr languages, as well as device rotation and different sized devices.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
