### PR TITLE
User Profile: track events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -163,8 +163,8 @@ import Foundation
     case categoryFilterDeselected
 
     // User Profile Sheet
-    case userProfileShown
-    case userProfileSiteShown
+    case userProfileSheetShown
+    case userProfileSheetSiteShown
 
     /// A String that represents the event
     var value: String {
@@ -450,10 +450,10 @@ import Foundation
             return "category_filter_deselected"
 
         // User Profile Sheet
-        case .userProfileShown:
-            return "user_profile_shown"
-        case .userProfileSiteShown:
-            return "user_profile_site_shown"
+        case .userProfileSheetShown:
+            return "user_profile_sheet_shown"
+        case .userProfileSheetSiteShown:
+            return "user_profile_sheet_site_shown"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -162,6 +162,10 @@ import Foundation
     case categoryFilterSelected
     case categoryFilterDeselected
 
+    // User Profile Sheet
+    case userProfileShown
+    case userProfileSiteShown
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -444,6 +448,12 @@ import Foundation
             return "category_filter_selected"
         case .categoryFilterDeselected:
             return "category_filter_deselected"
+
+        // User Profile Sheet
+        case .userProfileShown:
+            return "user_profile_shown"
+        case .userProfileSiteShown:
+            return "user_profile_site_shown"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -989,7 +989,7 @@ private extension NotificationDetailsViewController {
         let sourceView = tableView.cellForRow(at: indexPath) ?? view
         bottomSheet.show(from: self, sourceView: sourceView)
 
-        WPAnalytics.track(.userProfileShown, properties: ["source": "like_notification_list"])
+        WPAnalytics.track(.userProfileSheetShown, properties: ["source": "like_notification_list"])
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -988,6 +988,8 @@ private extension NotificationDetailsViewController {
 
         let sourceView = tableView.cellForRow(at: indexPath) ?? view
         bottomSheet.show(from: self, sourceView: sourceView)
+
+        WPAnalytics.track(.userProfileShown, properties: ["source": "like_notification_list"])
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -181,6 +181,14 @@ import WordPressFlux
         }
     }
 
+    /// Used for the `source` property in Stats.
+    /// Indicates where the view was shown from.
+    enum StatSource: String {
+        case reader
+        case user_profile
+    }
+    var statSource: StatSource = StatSource.reader
+
     /// Facilitates sharing of a blog via `ReaderStreamViewController+Sharing.swift`.
     let sharingController = PostSharingController()
 
@@ -718,14 +726,17 @@ import WordPressFlux
             assertionFailure("A reader topic is required")
             return nil
         }
+
         let title = topic.title
         var key: String = "list"
+
         if ReaderHelpers.isTopicTag(topic) {
             key = "tag"
         } else if ReaderHelpers.isTopicSite(topic) {
             key = "site"
         }
-        return [key: title]
+
+        return [key: title, "source": statSource.rawValue]
     }
 
     /// The fetch request can need a different predicate depending on how the content

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -187,7 +187,7 @@ import WordPressFlux
         case reader
         case user_profile
     }
-    var statSource: StatSource = StatSource.reader
+    var statSource: StatSource = .reader
 
     /// Facilitates sharing of a blog via `ReaderStreamViewController+Sharing.swift`.
     let sharingController = PostSharingController()

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -136,13 +136,14 @@ extension UserProfileSheetViewController {
 private extension UserProfileSheetViewController {
 
     func showSite() {
+        WPAnalytics.track(.userProfileSiteShown)
 
         // TODO: Remove. For testing only. Use siteID from user object.
         var stubbySiteID: NSNumber?
         // use this to test external site
-        // stubbySiteID = nil
+        stubbySiteID = nil
         // use this to test internal site
-        stubbySiteID = NSNumber(value: 9999999999)
+        // stubbySiteID = NSNumber(value: 9999999999)
 
         guard let siteID = stubbySiteID else {
             showSiteWebView()
@@ -154,13 +155,14 @@ private extension UserProfileSheetViewController {
 
     func showSiteTopicWithID(_ siteID: NSNumber) {
         let controller = ReaderStreamViewController.controllerWithSiteID(siteID, isFeed: false)
+        controller.statSource = ReaderStreamViewController.StatSource.user_profile
         let navController = UINavigationController(rootViewController: controller)
         present(navController, animated: true)
     }
 
     func showSiteWebView() {
         // TODO: Remove. For testing only. Use URL from user object.
-        let siteUrl = "http://www.peopleofwalmart.com/"
+        let siteUrl = "https://www.funnycatpix.com/"
 
         guard let url = URL(string: siteUrl) else {
             DDLogError("User Profile: Error creating URL from site string.")

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -136,7 +136,7 @@ extension UserProfileSheetViewController {
 private extension UserProfileSheetViewController {
 
     func showSite() {
-        WPAnalytics.track(.userProfileSiteShown)
+        WPAnalytics.track(.userProfileSheetSiteShown)
 
         // TODO: Remove. For testing only. Use siteID from user object.
         var stubbySiteID: NSNumber?


### PR DESCRIPTION
Ref: #15662

### New Events

Two new events are added to track:
- When the User Profile is shown.
- When a site is viewed from the User Profile.

User profile shown: 
- `Tracked: user_profile_sheet_shown <source: like_notification_list>`. 
- The `source` property is there so that in the future if the User Profile is shown from somewhere else it can be specified.

Site viewed:
- `Tracked: user_profile_sheet_site_shown <>`
- I didn't think any properties where necessary here, but I can add something if we like.

### Changed Event

I added a `source` property to the `reader_blog_previewed` event so that we know it was shown from the User Profile. Examples:
- From user profile: `Tracked: reader_blog_previewed <site: Site Name, source: user_profile, subscription_count: 99>`
- From a reader card: `Tracked: reader_blog_previewed <site: Site Name, source: reader, subscription_count: 99>`

cc @develric 

---
To test:
- Enable the `newLikeNotifications` feature.
- Go to Notifications > Likes and tap a notification.
- Tap a user.
  - Verify `Tracked: user_profile_sheet_shown <source: like_notification_list>` is logged.
- Tap the site.
  -  Verify `Tracked: user_profile_sheet_site_shown <>` is logged.
  - Verify `Tracked: reader_blog_previewed <site: Site Name, source: user_profile, subscription_count: 99>` is logged if the site is internal. (You'll have to change the siteID [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/4a310da51fc2e5fa6b52c2fb12043242c15f6c36/WordPress/Classes/ViewRelated/User%20Profile%20Sheet/UserProfileSheetViewController.swift#L146).)


---
## Regression Notes
1. Potential unintended areas of impact
N/A. Just adding some tracks.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Just adding some tracks.

3. What automated tests I added (or what prevented me from doing so)
N/A. Just adding some tracks.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
