### PR TITLE
Jetpack: add 'jpios' tracks prefix

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -47,6 +47,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     if (self) {
         _contextManager = [TracksContextManager new];
         _tracksService = [[TracksService alloc] initWithContextManager:_contextManager];
+        _tracksService.eventNamePrefix = [AppConstants eventNamePrefix];
     }
     return self;
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -47,7 +47,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     if (self) {
         _contextManager = [TracksContextManager new];
         _tracksService = [[TracksService alloc] initWithContextManager:_contextManager];
-        _tracksService.eventNamePrefix = [AppConstants eventNamePrefix];
+        _tracksService.eventNamePrefix = AppConstants.eventNamePrefix;
     }
     return self;
 }

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-struct AppConstants {
+@objc class AppConstants: NSObject {
     static let productTwitterHandle = "@WordPressiOS"
     static let productTwitterURL = "https://twitter.com/WordPressiOS"
     static let productBlogURL = "https://blog.wordpress.com"
     static let ticketSubject = NSLocalizedString("WordPress for iOS Support", comment: "Subject of new Zendesk ticket.")
+    @objc static let eventNamePrefix = "wpios"
 
     /// Notifications Constants
     ///

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-struct AppConstants {
+@objc class AppConstants: NSObject {
     static let productTwitterHandle = "@jetpack"
     static let productTwitterURL = "https://twitter.com/jetpack"
     static let productBlogURL = "https://jetpack.com/blog"
     static let ticketSubject = "Jetpack for iOS Support"
+    @objc static let eventNamePrefix = "jpios"
 
     /// Notifications Constants
     ///


### PR DESCRIPTION
This PR adds `jpios` as the event prefix for Jetpack.

### To test

**Use Charles to intercept requests.**

1. Open Jetpack app
2. Interact with the app
3. On Charles, check `/tracks/record` request
4. Make sure it contains `jpios_*` events

WordPress:

1. Open WordPress app
2. Interact with the app
3. On Charles, check `/tracks/record` request
4. Make sure it contains `wpios_*` events

Important: an additional part of this task is to test if the events were received in the backend (thus, they're whitelisted). I already checked that using Hue:

<img src="https://user-images.githubusercontent.com/7040243/115397046-06816900-a1bc-11eb-8867-b627863f83a0.png" width="500">

If you want to test that please DM me for instructions.

## Regression Notes
1. Potential unintended areas of impact
WordPress.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual test.

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
