### PR TITLE
AB testing: remove stories AB testing

### DIFF
--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -2,7 +2,6 @@ import AutomatticTracks
 
 enum ABTest: String, CaseIterable {
     case unknown = "unknown"
-    case storyFirst = "wpios_create_menu_story_first"
 
     /// Returns a variation for the given experiment
     var variation: Variation {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
@@ -11,15 +11,6 @@ class CreateButtonActionSheet: ActionSheetViewController {
     }
 
     init(actions: [ActionSheetItem]) {
-
-        /// A/B test: display story first
-        var actions = actions
-        if let storyAction = actions.first(where: { $0 is StoryAction }),
-           ABTest.storyFirst.variation == .treatment(nil) {
-            let actionsWithoutStory = actions.filter { !($0 is StoryAction) }
-            actions = [storyAction] + actionsWithoutStory
-        }
-
         let buttons = actions.map { $0.makeButton() }
         super.init(headerTitle: Constants.title, buttons: buttons)
     }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -129,14 +129,7 @@ import WordPressFlux
         } else {
             let actionSheetVC = actionSheetController(with: viewController.traitCollection)
             viewController.present(actionSheetVC, animated: true, completion: { [weak self] in
-                let isShowingStoryOption = self?.isShowingStoryOption() ?? false
-                WPAnalytics.track(.createSheetShown,
-                                  properties: [
-                                    "source": self?.source ?? "",
-                                    "is_showing_stories": isShowingStoryOption,
-                                    "is_showing_stories_first": isShowingStoryOption && ABTest.storyFirst.variation != .control
-                                  ]
-                )
+                WPAnalytics.track(.createSheetShown, properties: ["source": self?.source ?? ""])
 
                 if let element = self?.currentTourElement {
                     QuickStartTourGuide.shared.visited(element)


### PR DESCRIPTION
This PR removes the stories' AB testing.

### To test

1. Add breakpoints on `ABTest.swift` lines 20 and 28
2. Run the app
3. No breakpoint should be hit
4. Tap the FAB, it should display the post options (including Story as the last item, if applicable)

## Regression Notes
1. Potential unintended areas of impact
N/a.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/a.

3. What automated tests I added (or what prevented me from doing so)
N/a.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
