### PR TITLE
Jetpack App (Emphasis): Hide Reader

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -10,4 +10,5 @@ import Foundation
     @objc static let allowSiteCreation: Bool = true
     @objc static let allowSignUp: Bool = true
     @objc static let allowsCustomAppIcons: Bool = true
+    @objc static let showsReader: Bool = true
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1311,11 +1311,17 @@ private extension NotificationsViewController {
         return filter.noResultsTitle
     }
 
-    var noResultsMessageText: String {
+    var noResultsMessageText: String? {
+        guard AppConfiguration.showsReader else {
+            return nil
+        }
         return filter.noResultsMessage
     }
 
-    var noResultsButtonText: String {
+    var noResultsButtonText: String? {
+        guard AppConfiguration.showsReader else {
+            return nil
+        }
         return filter.noResultsButtonTitle
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -274,18 +274,18 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (NSArray<UIViewController *> *)tabViewControllers
 {
-    NSArray *tabs = @[
+    if (AppConfiguration.showsReader) {
+        return @[
+            self.mySitesCoordinator.rootViewController,
+            self.readerNavigationController,
+            self.notificationsSplitViewController
+        ];
+    }
+    
+    return @[
         self.mySitesCoordinator.rootViewController,
         self.notificationsSplitViewController
     ];
-    
-    NSMutableArray *mutableTabs = [tabs mutableCopy];
-    
-    if (AppConfiguration.showsReader) {
-        [mutableTabs insertObject:self.readerNavigationController atIndex:1];
-    }
-    
-    return mutableTabs;
 }
 
 - (void)showMySitesTab

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -281,7 +281,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     
     NSMutableArray *mutableTabs = [tabs mutableCopy];
     
-    if ([AppConfiguration showsReader]) {
+    if (AppConfiguration.showsReader) {
         [mutableTabs insertObject:self.readerNavigationController atIndex:1];
     }
     

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -274,9 +274,18 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (NSArray<UIViewController *> *)tabViewControllers
 {
-    return @[self.mySitesCoordinator.rootViewController,
-             self.readerNavigationController,
-             self.notificationsSplitViewController];
+    NSArray *tabs = @[
+        self.mySitesCoordinator.rootViewController,
+        self.notificationsSplitViewController
+    ];
+    
+    NSMutableArray *mutableTabs = [tabs mutableCopy];
+    
+    if ([AppConfiguration showsReader]) {
+        [mutableTabs insertObject:self.readerNavigationController atIndex:1];
+    }
+    
+    return mutableTabs;
 }
 
 - (void)showMySitesTab

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -10,4 +10,5 @@ import Foundation
     @objc static let allowSiteCreation: Bool = false
     @objc static let allowSignUp: Bool = false
     @objc static let allowsCustomAppIcons: Bool = false
+    @objc static let showsReader: Bool = false
 }


### PR DESCRIPTION
Part of #16338 

This PR hides the Reader tab in the Jetpack app

Jetpack | WordPress
--- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-04-20 at 15 41 48](https://user-images.githubusercontent.com/6711616/115357954-23d42880-a1f8-11eb-9568-c176746f4529.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-20 at 16 04 29](https://user-images.githubusercontent.com/6711616/115357968-26368280-a1f8-11eb-942e-d012bcfce120.png)


## How to test
1. Run and build the Jetpack scheme
2. ✅ Notice that Reader tab isn't displayed

## Regression Notes
1. Potential unintended areas of impact
WordPress

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Build and tested the WordPress scheme and confirmed the Reader tab shows up

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
