### PR TITLE
Jetpack App (Emphasis): Remove the "Create" floating action button

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -11,4 +11,5 @@ import Foundation
     @objc static let allowSignUp: Bool = true
     @objc static let allowsCustomAppIcons: Bool = true
     @objc static let showsReader: Bool = true
+    @objc static let showsCreateButton: Bool = true
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -416,7 +416,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [super viewDidAppear:animated];
     [self cancelCompletedToursIfNeeded];
     if ([self.tabBarController isKindOfClass:[WPTabBarController class]] &&
-        [AppConfiguration showsCreateButton]) {
+        AppConfiguration.showsCreateButton) {
         [self.createButtonCoordinator showCreateButtonFor:self.blog];
     }
     [self createUserActivity];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -415,7 +415,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewDidAppear:animated];
     [self cancelCompletedToursIfNeeded];
-    if ([self.tabBarController isKindOfClass:[WPTabBarController class]]) {
+    if ([self.tabBarController isKindOfClass:[WPTabBarController class]] &&
+        [AppConfiguration showsCreateButton]) {
         [self.createButtonCoordinator showCreateButtonFor:self.blog];
     }
     [self createUserActivity];

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -11,4 +11,5 @@ import Foundation
     @objc static let allowSignUp: Bool = false
     @objc static let allowsCustomAppIcons: Bool = false
     @objc static let showsReader: Bool = false
+    @objc static let showsCreateButton: Bool = false
 }


### PR DESCRIPTION
Part of #16338 

This PR removes the "Create" floating action button in the Jetpack app

Jetpack | WordPress
--- | ---
![Simulator Screen Shot - iPhone 12 Pro - 2021-04-20 at 16 40 30](https://user-images.githubusercontent.com/6711616/115358465-a9f06f00-a1f8-11eb-9ef1-637f7b55f3c9.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-20 at 16 40 41](https://user-images.githubusercontent.com/6711616/115358468-ab219c00-a1f8-11eb-8994-0b6085e52b05.png)

## Merge instructions
Merge after https://github.com/wordpress-mobile/WordPress-iOS/pull/16339

## How to test
1. Run and build the Jetpack scheme
2. Go to My Site
3. ✅ Notice that the floating action button is hidden

## Regression Notes
1. Potential unintended areas of impact
WordPress

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Build and tested the WordPress scheme and confirmed the floating action button is visible

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
