### PR TITLE
Jetpack App: Disable Sign up and update the continue button title

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -208,9 +208,9 @@ abstract_target 'Apps' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-    # pod 'WordPressAuthenticator', '~> 1.36.0'
+    pod 'WordPressAuthenticator', '~> 1.37.0-beta.1'
     # While in PR
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'task/disable-sign-up'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -208,9 +208,9 @@ abstract_target 'Apps' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-    pod 'WordPressAuthenticator', '~> 1.36.0'
+    # pod 'WordPressAuthenticator', '~> 1.36.0'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/nux-button-shadows'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'task/disable-sign-up'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -498,7 +498,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
-  - WordPressAuthenticator (~> 1.36.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `task/disable-sign-up`)
   - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, tag `4.32.0-beta.1`)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.16.0)
@@ -509,8 +509,6 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -650,6 +648,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.51.0
+  WordPressAuthenticator:
+    :branch: task/disable-sign-up
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
     :tag: 4.32.0-beta.1
@@ -668,6 +669,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.51.0
+  WordPressAuthenticator:
+    :commit: 5cadb62c8945df23dfde6605f26f624e27690155
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
     :tag: 4.32.0-beta.1
@@ -751,7 +755,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
-  WordPressAuthenticator: 21d96070b30c4ce6b98de52c05779d27c2f9b399
+  WordPressAuthenticator: d80ac59ebb01f7660c7a29b6dc1ef34f5caf2983
   WordPressKit: 9ff7c4280955ec7662aae59d72763ae5eb4dea98
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 0f7f10e96f8354d64f951c223ae61e8de7495a46
@@ -768,6 +772,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 412fa67638670c44b777190edc1769865f3d07b8
+PODFILE CHECKSUM: 9d47e3aa29f0197348dc41c5e82222628f080ff3
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -389,7 +389,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.4)
   - WordPress-Editor-iOS (1.19.4):
     - WordPress-Aztec-iOS (= 1.19.4)
-  - WordPressAuthenticator (1.36.0):
+  - WordPressAuthenticator (1.37.0-beta.1):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -498,7 +498,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `task/disable-sign-up`)
+  - WordPressAuthenticator (~> 1.37.0-beta.1)
   - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, tag `4.32.0-beta.1`)
   - WordPressMocks (~> 0.0.9)
   - WordPressShared (~> 1.16.0)
@@ -509,6 +509,8 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -648,9 +650,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.51.0
-  WordPressAuthenticator:
-    :branch: task/disable-sign-up
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
     :tag: 4.32.0-beta.1
@@ -669,9 +668,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.51.0
-  WordPressAuthenticator:
-    :commit: 5cadb62c8945df23dfde6605f26f624e27690155
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   WordPressKit:
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
     :tag: 4.32.0-beta.1
@@ -755,7 +751,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
-  WordPressAuthenticator: d80ac59ebb01f7660c7a29b6dc1ef34f5caf2983
+  WordPressAuthenticator: cb9e17ac7d9b66d001e3f7abe2e860fe3b6e817e
   WordPressKit: 9ff7c4280955ec7662aae59d72763ae5eb4dea98
   WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
   WordPressShared: 0f7f10e96f8354d64f951c223ae61e8de7495a46
@@ -772,6 +768,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 9d47e3aa29f0197348dc41c5e82222628f080ff3
+PODFILE CHECKSUM: a6174e457dd39356a2b3cc8095fcc2382e856431
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressAuthenticator
 
 struct AppConstants {
     static let productTwitterHandle = "@WordPressiOS"
@@ -26,4 +27,7 @@ extension AppConstants {
         static let aboutTitle = NSLocalizedString("About WordPress for iOS", comment: "Link to About screen for WordPress for iOS")
     }
 
+    struct Login {
+        static let continueButtonTitle = WordPressAuthenticatorDisplayStrings.defaultStrings.continueWithWPButtonTitle
+    }
 }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -96,9 +96,14 @@ class WordPressAuthenticationManager: NSObject {
                                                               navButtonTextColor: FeatureFlag.newNavBarAppearance.enabled ? .appBarTint : .primary,
                                                               navTitleTextColor: FeatureFlag.newNavBarAppearance.enabled ? .appBarText : .text)
 
+        let displayStrings = WordPressAuthenticatorDisplayStrings(
+            continueWithWPButtonTitle: AppConstants.Login.continueButtonTitle
+        )
+
         WordPressAuthenticator.initialize(configuration: configuration,
                                           style: style,
-                                          unifiedStyle: unifiedStyle)
+                                          unifiedStyle: unifiedStyle,
+                                          displayStrings: displayStrings)
     }
 }
 

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -26,4 +26,10 @@ extension AppConstants {
         static let aboutTitle = NSLocalizedString("About Jetpack for iOS", comment: "Link to About screen for Jetpack for iOS")
     }
 
+    struct Login {
+        static let continueButtonTitle = NSLocalizedString(
+            "Continue With WordPress.com",
+            comment: "Button title. Takes the user to the login with WordPress.com flow."
+        )
+    }
 }


### PR DESCRIPTION
Related PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/590

## Screenshots

#### Continue Button

| Jetpack | WordPress |
|:---:|:---:|
| ![Simulator Screen Shot - iPhone 11 Pro - 2021-04-20 at 14 36 41](https://user-images.githubusercontent.com/793774/115446959-ed8dad80-a1e5-11eb-8dc6-fe9bd2bbb735.png) | ![simulator_screenshot_B888B526-A8B5-457C-9538-5F459F76FCBF](https://user-images.githubusercontent.com/793774/115446998-fa120600-a1e5-11eb-8a02-5e0b8e1e0860.png)|

#### Sign Up

| Jetpack | WordPress |
|:---:|:---:|
|![Simulator Screen Shot - iPhone 11 Pro - 2021-04-20 at 14 36 51](https://user-images.githubusercontent.com/793774/115447067-101fc680-a1e6-11eb-9f87-d4f7faccc298.png) | ![Simulator Screen Shot - iPhone 11 Pro - 2021-04-20 at 14 38 35](https://user-images.githubusercontent.com/793774/115447102-1a41c500-a1e6-11eb-9c70-18d20ee27cbe.png)|

## To test:
1. Launch the app
2. Log out if needed
3. 👁️  Notice the continue button reads 'Continue with WP.com'
4. Tap the continue button
5. Enter an email that doesn't exist
6. 👁️ You should see an error that the user doesn't exist


## Regression Notes
1. Potential unintended areas of impact
WordPress - Login

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested the affected flows on both Jetpack and WordPress.

3. What automated tests I added (or what prevented me from doing so)
None

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
