### PR TITLE
Jetpack App (Emphasis): Hide the Jetpack section header title

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -12,4 +12,5 @@ import Foundation
     @objc static let allowsCustomAppIcons: Bool = true
     @objc static let showsReader: Bool = true
     @objc static let showsCreateButton: Bool = true
+    @objc static let showsJetpackSectionHeader: Bool = true
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -860,7 +860,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
     NSString *title = @"";
 
-    if ([self.blog supports:BlogFeatureJetpackSettings]) {
+    if ([self.blog supports:BlogFeatureJetpackSettings] &&
+        AppConfiguration.showsJetpackSectionHeader) {
         title = NSLocalizedString(@"Jetpack", @"Section title for the publish table section in the blog details screen");
     }
 

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -12,4 +12,5 @@ import Foundation
     @objc static let allowsCustomAppIcons: Bool = false
     @objc static let showsReader: Bool = false
     @objc static let showsCreateButton: Bool = false
+    @objc static let showsJetpackSectionHeader: Bool = false
 }


### PR DESCRIPTION
Part of #16338 

This PR hides the Jetpack section header on the blog details screen in the Jetpack app

Jetpack | WordPress
--- | ---
<img src="https://user-images.githubusercontent.com/6711616/115503638-b684ce00-a2b1-11eb-9817-29472670e99e.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/115503640-b71d6480-a2b1-11eb-8d6f-72f7cf2873ac.png" width=200>


## Merge instructions
Merge after https://github.com/wordpress-mobile/WordPress-iOS/pull/16340

## How to test
1. Run and build the Jetpack scheme
2. Go to My Site
3. ✅ Notice that the Jetpack section (the topmost section) does not have a section header

## Regression Notes
1. Potential unintended areas of impact
WordPress

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Build and tested on both the WordPress and Jetpack apps

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
