### PR TITLE
Enabling contact info in prod by toggling on feature flag.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 17.3
 -----
+* [*] Fixed bug where contact info wasn't showing up in block inserter due to feature flag [https://github.com/wordpress-mobile/WordPress-iOS/pull/16347]
 
 
 17.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,5 @@
 17.3
 -----
-* [*] Fixed bug where contact info wasn't showing up in block inserter due to feature flag [https://github.com/wordpress-mobile/WordPress-iOS/pull/16347]
 
 
 17.2

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -43,7 +43,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .stories:
             return true
         case .contactInfo:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .siteCreationHomePagePicker:
             return true
         case .todayWidget:


### PR DESCRIPTION
Fixes [#3395](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3395)

To test:
1. Open block inserter on site with Jetpack >= 8.5.
2. See that contact info is in block inserter.

## Regression Notes
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
