### PR TITLE
Fixes the dark mode color of the navigation bar background.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 17.3
 -----
 
+* [***] Fixed the navigation bar color in dark mode. [#16348]
 
 17.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 17.3
 -----
 
-* [***] Fixed the navigation bar color in dark mode. [#16348]
+* [*] Fixed the navigation bar color in dark mode. [#16348]
 
 17.2
 -----

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+WordPressColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+WordPressColors.swift
@@ -6,7 +6,7 @@ extension UIColor {
     /// Muriel/iOS navigation color
     static var appBarBackground: UIColor {
         if FeatureFlag.newNavBarAppearance.enabled {
-            return .secondarySystemGroupedBackground
+            return UIColor(light: .white, dark: .gray(.shade100))
         }
 
         return UIColor(light: .primary, dark: .gray(.shade100))


### PR DESCRIPTION
Brings forward the remaining issues in Large Titles: https://github.com/wordpress-mobile/WordPress-iOS/issues/15750

## To test:

Run the App and check the color change works and there are no new issues with it.

| Before | After |
| --- | --- |
|  <img src ="https://user-images.githubusercontent.com/1836005/115589854-a3cdc180-a2d0-11eb-900e-38e6360c5b26.png" width=300> | <img src="https://user-images.githubusercontent.com/1836005/115590009-cb248e80-a2d0-11eb-9f55-97904014f934.png" width=300> |
| <img src="https://user-images.githubusercontent.com/1836005/115590046-d11a6f80-a2d0-11eb-947e-98dc4079461d.png" width=300> | <img src="https://user-images.githubusercontent.com/1836005/115590064-d7105080-a2d0-11eb-9269-8758ecbe4075.png" width=300> |

## Regression Notes
1. Potential unintended areas of impact

- This will affect the color of the navigation bar accross the whole app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- Test all screens I could go into.  Search fields look a bit off in dark mode, but this was the case even before these changes.

3. What automated tests I added (or what prevented me from doing so)

- None as it's a color change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
