### PR TITLE
Fix #16248 in 17.2

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController+PresentFrom.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController+PresentFrom.swift
@@ -39,8 +39,8 @@ extension SchedulingCalendarViewController: UIViewControllerTransitioningDelegat
 class SchedulingLightNavigationController: LightNavigationController {
     var onDismiss: (() -> Void)?
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         onDismiss?()
     }
 }


### PR DESCRIPTION
Fixes #16248

A copy of https://github.com/wordpress-mobile/WordPress-iOS/pull/16334 targeting the `release/17.2` branch.

## Testing

1. Create a new story.
2. Add media to the story.
3. Tap the Publish button.
4. Tap the "Publish Date" option.
5. Select a date and hit the "Next" and then "Done" buttons.
6. Ensure that the Prepublishing sheet is not clipped on smaller devices (non-home button should be easiest to see)

## Regression Notes
1. Potential unintended areas of impact

* Post scheduling in the prepublishing sheet
* Post scheduling in the Post settings

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested the prepublishing sheet manually.

3. What automated tests I added (or what prevented me from doing so)

No automated tests were added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
