### PR TITLE
Small UI component color fixes

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -55,8 +55,11 @@ open class NotificationSettingsViewController: UIViewController {
         // Style!
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
+
+        activityIndicatorView.tintColor = .textSubtle
     }
 
+    
 
     // MARK: - Service Helpers
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -59,7 +59,7 @@ open class NotificationSettingsViewController: UIViewController {
         activityIndicatorView.tintColor = .textSubtle
     }
 
-    
+
 
     // MARK: - Service Helpers
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -60,7 +60,6 @@ open class NotificationSettingsViewController: UIViewController {
     }
 
 
-
     // MARK: - Service Helpers
 
     fileprivate func reloadSettings() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.xib
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,7 +27,7 @@
                         <outlet property="delegate" destination="-1" id="jp2-Hq-Fdm"/>
                     </connections>
                 </tableView>
-                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="6HB-Vi-ACi">
+                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="6HB-Vi-ACi">
                     <rect key="frame" x="177.5" y="323.5" width="20" height="20"/>
                 </activityIndicatorView>
             </subviews>
@@ -41,6 +40,7 @@
                 <constraint firstAttribute="centerY" secondItem="6HB-Vi-ACi" secondAttribute="centerY" id="c4t-cA-hN6"/>
                 <constraint firstItem="n1E-Bx-YgH" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="kIz-he-XXG"/>
             </constraints>
+            <point key="canvasLocation" x="-161" y="-16"/>
         </view>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.m
@@ -1,6 +1,8 @@
 #import "RestorePageTableViewCell.h"
 #import "WPStyleGuide+Pages.h"
 
+@import Gridicons;
+
 @interface RestorePageTableViewCell()
 
 @property (nonatomic, strong) IBOutlet UILabel *restoreLabel;
@@ -32,6 +34,9 @@
     self.restoreLabel.text = NSLocalizedString(@"Page moved to trash.", @"A short message explaining that a page was moved to the trash bin.");
     NSString *buttonTitle = NSLocalizedString(@"Undo", @"The title of an 'undo' button. Tapping the button moves a trashed page out of the trash folder.");
     [self.restoreButton setTitle:buttonTitle forState:UIControlStateNormal];
+    [self.restoreButton setImage:[UIImage gridiconOfType:GridiconTypeUndo
+                                                withSize:CGSizeMake(18.0, 18.0)]
+                        forState:UIControlStateNormal];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/RestorePageTableViewCell.xib
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -11,19 +13,19 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="47"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="AgI-Sn-JeL" id="QqJ-JC-nik">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="46.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="47"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au3-8f-nAh">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" misplaced="YES" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="au3-8f-nAh">
                         <rect key="frame" x="15" y="10" width="219" height="26"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="26" id="qR0-Nb-d3i"/>
                         </constraints>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="textColor" red="0.3333333432674408" green="0.3333333432674408" blue="0.3333333432674408" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dPd-xc-GkE">
+                    <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dPd-xc-GkE">
                         <rect key="frame" x="234" y="10" width="86" height="26"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="86" id="E4N-1W-JWu"/>
@@ -31,16 +33,16 @@
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <inset key="contentEdgeInsets" minX="3" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <inset key="imageEdgeInsets" minX="-3" minY="0.0" maxX="3" maxY="0.0"/>
-                        <state key="normal" title="Undo" image="icon-post-undo">
-                            <color key="titleColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                            <color key="titleShadowColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                        <state key="normal" title="Undo">
+                            <color key="titleColor" red="0.3333333432674408" green="0.3333333432674408" blue="0.3333333432674408" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </state>
                         <connections>
                             <action selector="onAction:" destination="AgI-Sn-JeL" eventType="touchUpInside" id="4Wu-zq-FWn"/>
                         </connections>
                     </button>
                 </subviews>
-                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 <constraints>
                     <constraint firstAttribute="bottomMargin" secondItem="au3-8f-nAh" secondAttribute="bottom" id="89D-jc-v4X"/>
                     <constraint firstItem="au3-8f-nAh" firstAttribute="trailing" secondItem="dPd-xc-GkE" secondAttribute="leading" id="AiD-9Q-fgp"/>
@@ -59,7 +61,4 @@
             <point key="canvasLocation" x="568" y="209.5"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <image name="icon-post-undo" width="18" height="18"/>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="66"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" tableViewCell="cm8-te-h9Y" id="n47-YY-a6J">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="65.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="66"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XWn-76-OyW">
@@ -35,7 +33,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                 <inset key="contentEdgeInsets" minX="3" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <inset key="imageEdgeInsets" minX="-3" minY="0.0" maxX="3" maxY="0.0"/>
-                                <state key="normal" title="Undo" image="icon-post-undo">
+                                <state key="normal" title="Undo">
                                     <color key="titleColor" red="0.3333333432674408" green="0.3333333432674408" blue="0.3333333432674408" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
@@ -79,7 +77,4 @@
             <point key="canvasLocation" x="568" y="225"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <image name="icon-post-undo" width="18" height="18"/>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Pages.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Pages.m
@@ -20,6 +20,8 @@
                        textStyle:UIFontTextStyleCallout
                       fontWeight:UIFontWeightSemibold];
     [button setTitleColor:[UIColor murielPrimary] forState:UIControlStateNormal];
+    [button setTitleColor:[UIColor murielPrimaryDark] forState:UIControlStateHighlighted];
+    button.tintColor = [UIColor murielPrimary];
 }
 
 + (void)applyRestoreSavedPostLabelStyle:(UILabel *)label


### PR DESCRIPTION
This PR fixes two small color issues with UI components:

- The loading indicator in Notification Settings was almost invisible in dark mode.
- The icon and text for the undo button when deleting a page were different colors.

Now:

| Light | Dark |
|---|---|
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-21 at 20 25 52](https://user-images.githubusercontent.com/4780/115623530-3a11df80-a2f1-11eb-9fb6-8bfbfb64479c.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-21 at 20 21 11](https://user-images.githubusercontent.com/4780/115623537-3c743980-a2f1-11eb-958b-4d9ae65ebc72.png) |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-21 at 21 55 49](https://user-images.githubusercontent.com/4780/115623499-2fefe100-a2f1-11eb-9c3b-9d459ea4d952.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-04-21 at 21 55 44](https://user-images.githubusercontent.com/4780/115623510-33836800-a2f1-11eb-86eb-011c24a46b8c.png) |

**To test**

- Be sure to test light and dark mode
- Build and run
- Head to Notifications > Settings icon, and check the loading indicator is visible
- Head to My Site > Pages and delete a page. Ensure the undo icon and text match.
- Also do the same for My Site > Posts, as I removed the default icon in the xib file there (we replace it in code anyway).

## Regression Notes

1. Potential unintended areas of impact

- Undo icon when deleting a post. Otherwise these are very isolated changes.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- I manually tested that area of the app too.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
