### PR TITLE
Fix UBE tracks custom event format

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -33,10 +33,14 @@ struct PostEditorAnalyticsSession {
         // Let's make sure to round the value and send an integer for consistency
         let startupTimeNanoseconds = DispatchTime.now().uptimeNanoseconds - startTime
         let startupTimeMilliseconds = Int(Double(startupTimeNanoseconds) / 1_000_000)
-        return [
-            Property.startupTime: startupTimeMilliseconds,
-            Property.unsupportedBlocks: unsupportedBlocks
-        ].merging(commonProperties, uniquingKeysWith: { $1 })
+        var properties: [String: Any] = [ Property.startupTime: startupTimeMilliseconds ]
+
+        // Tracks custom event types can't be arrays so we need to convert this to JSON
+        if let data = try? JSONSerialization.data(withJSONObject: unsupportedBlocks, options: .fragmentsAllowed) {
+            let blocksJSON = String(data: data, encoding: .utf8)
+            properties[Property.unsupportedBlocks] = blocksJSON
+        }
+        return properties.merging(commonProperties, uniquingKeysWith: { $1 })
     }
 
     mutating func `switch`(editor: Editor) {

--- a/WordPress/WordPressTest/Analytics/EditorAnalytics/PostEditorAnalyticsSessionTests.swift
+++ b/WordPress/WordPressTest/Analytics/EditorAnalytics/PostEditorAnalyticsSessionTests.swift
@@ -74,7 +74,8 @@ class PostEditorAnalyticsSessionTests: XCTestCase {
         let tracked = TestAnalyticsTracker.tracked.first
 
         XCTAssertEqual(tracked?.stat, WPAnalyticsStat.editorSessionStart)
-        XCTAssertEqual(tracked?.value(for: "unsupported_blocks"), unsupportedBlocks)
+        let serializedArray = String(data: try! JSONSerialization.data(withJSONObject: unsupportedBlocks, options: .fragmentsAllowed), encoding: .utf8)
+        XCTAssertEqual(tracked?.value(for: "unsupported_blocks"), serializedArray)
         XCTAssertEqual(tracked?.value(for: "has_unsupported_blocks"), "1")
     }
 
@@ -87,7 +88,8 @@ class PostEditorAnalyticsSessionTests: XCTestCase {
         let tracked = TestAnalyticsTracker.tracked.first
 
         XCTAssertEqual(tracked?.stat, WPAnalyticsStat.editorSessionStart)
-        XCTAssertEqual(tracked?.value(for: "unsupported_blocks"), unsupportedBlocks)
+        let serializedArray = String(data: try! JSONSerialization.data(withJSONObject: unsupportedBlocks, options: .fragmentsAllowed), encoding: .utf8)
+        XCTAssertEqual(tracked?.value(for: "unsupported_blocks"), serializedArray)
         XCTAssertEqual(tracked?.value(for: "has_unsupported_blocks"), "0")
     }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3228

The issue here was that events were being rejected by Tracks because they were malformed. The editor_session_start has both a `has_unsupported_blocks` and a `unsupported_blocks` custom event properties. `unsupported_blocks`, which is a list of unsupported blocks, was not being stringified on WPiOS before being sent to the backend, causing these events to be discarded.

## To test

Ensure that `wpios_editor_session_start` are no longer being rejected by the tracks system when a post is opened that contains unsupported blocks.

1. Open a post in the block editor that contains multiple unsupported blocks
2. Check in the Tracks backend that `wpios_editor_session_start` events are being logged in the live view (they should not appear in searches for rejected events)

## Regression Notes
1. Potential unintended areas of impact

This should only affect the `wpios_editor_session_start` event. If there was a crash in this code, it would prevent users from opening the editor.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I'm relying on the Gutenberg UI tests to make sure the editor still works fine.

3. What automated tests I added (or what prevented me from doing so)

I think the Gutenberg UI tests that CircleCI runs are enough to cover this scenario.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
