### PR TITLE
Jetpack App (Emphasis): Hide Quick Actions

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -12,6 +12,5 @@ import Foundation
     @objc static let allowsCustomAppIcons: Bool = true
     @objc static let showsReader: Bool = true
     @objc static let showsCreateButton: Bool = true
-    @objc static let showsJetpackSectionHeader: Bool = true
     @objc static let showsQuickActions: Bool = true
 }

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -13,4 +13,5 @@ import Foundation
     @objc static let showsReader: Bool = true
     @objc static let showsCreateButton: Bool = true
     @objc static let showsJetpackSectionHeader: Bool = true
+    @objc static let showsQuickActions: Bool = true
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Header.swift
@@ -3,24 +3,8 @@ import WordPressFlux
 
 extension BlogDetailsViewController {
     @objc func configureHeaderView() -> BlogDetailHeader {
-        let actionItems: [ActionRow.Item] = [
-            .init(image: .gridicon(.statsAlt), title: NSLocalizedString("Stats", comment: "Noun. Abbv. of Statistics. Links to a blog's Stats screen.")) { [weak self] in
-                self?.tableView.deselectSelectedRowWithAnimation(false)
-                self?.showStats(from: .button)
-            },
-            .init(image: .gridicon(.posts), title: NSLocalizedString("Posts", comment: "Noun. Title. Links to the blog's Posts screen.")) { [weak self] in
-                self?.tableView.deselectSelectedRowWithAnimation(false)
-                self?.showPostList(from: .button)
-            },
-            .init(image: .gridicon(.image), title: NSLocalizedString("Media", comment: "Noun. Title. Links to the blog's Media library.")) { [weak self] in
-                self?.tableView.deselectSelectedRowWithAnimation(false)
-                self?.showMediaLibrary(from: .button)
-            },
-            .init(image: .gridicon(.pages), title: NSLocalizedString("Pages", comment: "Noun. Title. Links to the blog's Pages screen.")) { [weak self] in
-                self?.tableView.deselectSelectedRowWithAnimation(false)
-                self?.showPageList(from: .button)
-            }
-        ]
+
+        let actionItems = createActionItems()
 
         guard Feature.enabled(.newNavBarAppearance) else {
             return BlogDetailHeaderView(items: actionItems)
@@ -47,6 +31,33 @@ extension BlogDetailsViewController {
         let navigationController = UINavigationController(rootViewController: controller)
         navigationController.modalPresentationStyle = .formSheet
         present(navigationController, animated: true)
+    }
+
+    private func createActionItems() -> [ActionRow.Item] {
+        guard AppConfiguration.showsQuickActions else {
+            return []
+        }
+
+        let actionItems: [ActionRow.Item] = [
+            .init(image: .gridicon(.statsAlt), title: NSLocalizedString("Stats", comment: "Noun. Abbv. of Statistics. Links to a blog's Stats screen.")) { [weak self] in
+                self?.tableView.deselectSelectedRowWithAnimation(false)
+                self?.showStats(from: .button)
+            },
+            .init(image: .gridicon(.posts), title: NSLocalizedString("Posts", comment: "Noun. Title. Links to the blog's Posts screen.")) { [weak self] in
+                self?.tableView.deselectSelectedRowWithAnimation(false)
+                self?.showPostList(from: .button)
+            },
+            .init(image: .gridicon(.image), title: NSLocalizedString("Media", comment: "Noun. Title. Links to the blog's Media library.")) { [weak self] in
+                self?.tableView.deselectSelectedRowWithAnimation(false)
+                self?.showMediaLibrary(from: .button)
+            },
+            .init(image: .gridicon(.pages), title: NSLocalizedString("Pages", comment: "Noun. Title. Links to the blog's Pages screen.")) { [weak self] in
+                self?.tableView.deselectSelectedRowWithAnimation(false)
+                self?.showPageList(from: .button)
+            }
+        ]
+
+        return actionItems
     }
 
     private func saveSiteTitleSettings(_ title: String) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -860,8 +860,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
     NSString *title = @"";
 
-    if ([self.blog supports:BlogFeatureJetpackSettings] &&
-        AppConfiguration.showsJetpackSectionHeader) {
+    if ([self.blog supports:BlogFeatureJetpackSettings]) {
         title = NSLocalizedString(@"Jetpack", @"Section title for the publish table section in the blog details screen");
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -82,7 +82,9 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
         static let atSides: CGFloat = 16
         static let top: CGFloat = 16
         static let belowActionRow: CGFloat = 24
-        static let betweenTitleViewAndActionRow: CGFloat = 32
+        static func betweenTitleViewAndActionRow(_ showsActionRow: Bool) -> CGFloat {
+            return showsActionRow ? 32 : 0
+        }
 
         static let spacingBelowIcon: CGFloat = 16
         static let spacingBelowTitle: CGFloat = 8
@@ -132,24 +134,25 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
 
         addBottomBorder(withColor: .separator)
 
-        setupConstraintsForChildViews()
+        let showsActionRow = items.count > 0
+        setupConstraintsForChildViews(showsActionRow)
     }
 
     // MARK: - Constraints
 
-    private func setupConstraintsForChildViews() {
-        let actionRowConstraints = constraintsForActionRow()
+    private func setupConstraintsForChildViews(_ showsActionRow: Bool) {
+        let actionRowConstraints = constraintsForActionRow(showsActionRow)
         let titleViewContraints = constraintsForTitleView()
 
         NSLayoutConstraint.activate(actionRowConstraints + titleViewContraints)
     }
 
-    private func constraintsForActionRow() -> [NSLayoutConstraint] {
+    private func constraintsForActionRow(_ showsActionRow: Bool) -> [NSLayoutConstraint] {
         let widthConstraint = actionRow.widthAnchor.constraint(equalToConstant: LayoutSpacing.maxButtonWidth)
         widthConstraint.priority = .defaultHigh
 
         return [
-            actionRow.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: LayoutSpacing.betweenTitleViewAndActionRow),
+            actionRow.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: LayoutSpacing.betweenTitleViewAndActionRow(showsActionRow)),
             actionRow.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -LayoutSpacing.belowActionRow),
             actionRow.leadingAnchor.constraint(greaterThanOrEqualTo: titleView.leadingAnchor),
             actionRow.trailingAnchor.constraint(lessThanOrEqualTo: titleView.trailingAnchor),

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -13,4 +13,5 @@ import Foundation
     @objc static let showsReader: Bool = false
     @objc static let showsCreateButton: Bool = false
     @objc static let showsJetpackSectionHeader: Bool = false
+    @objc static let showsQuickActions: Bool = false
 }

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -12,6 +12,5 @@ import Foundation
     @objc static let allowsCustomAppIcons: Bool = false
     @objc static let showsReader: Bool = false
     @objc static let showsCreateButton: Bool = false
-    @objc static let showsJetpackSectionHeader: Bool = false
     @objc static let showsQuickActions: Bool = false
 }


### PR DESCRIPTION
Part of #16338 
Ref: p1619100117195900/1619069690.172700-slack-C0180B5PRJ4

This PR does the following:
- Hides the Quick Actions in the Jetpack app
- Shows the Jetpack list heading (reverts #16346)

Jetpack | WordPress
--- | ---
 <img src="https://user-images.githubusercontent.com/6711616/116016888-fd3f4300-a678-11eb-96cb-c13fff82ee63.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/115807750-29ae5180-a424-11eb-9507-11d639dc254d.png" width=200>

## How to test
1. Run and build the Jetpack scheme
2. Go to My Site
3. ✅ Notice that the Quick Actions are hidden

## Regression Notes
1. Potential unintended areas of impact
WordPress Quick Actions

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Built and tested on both the WordPress and Jetpack apps

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.