### PR TITLE
AB testing: update how experiments are assigned

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -192,9 +192,9 @@ abstract_target 'Apps' do
 
     # Production
 
-    #pod 'Automattic-Tracks-iOS', '~> 0.8.4'
+    pod 'Automattic-Tracks-iOS', '~> 0.8.5'
     # While in PR
-    pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'task/update_explat_endpoints'
+    # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => ''
     # Local Development
     #pod 'Automattic-Tracks-iOS', :path => '~/Projects/Automattic-Tracks-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -192,9 +192,9 @@ abstract_target 'Apps' do
 
     # Production
 
-    pod 'Automattic-Tracks-iOS', '~> 0.8.4'
+    #pod 'Automattic-Tracks-iOS', '~> 0.8.4'
     # While in PR
-    # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => ''
+    pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'task/update_explat_endpoints'
     # Local Development
     #pod 'Automattic-Tracks-iOS', :path => '~/Projects/Automattic-Tracks-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -438,7 +438,7 @@ DEPENDENCIES:
   - AMScrollingNavbar (= 5.6.0)
   - AppCenter (= 4.1.1)
   - AppCenter/Distribute (= 4.1.1)
-  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, branch `task/update_explat_endpoints`)
+  - Automattic-Tracks-iOS (~> 0.8.5)
   - Charts (~> 3.2.2)
   - CocoaLumberjack (~> 3.0)
   - CropViewController (= 2.5.3)
@@ -520,6 +520,7 @@ SPEC REPOS:
     - AMScrollingNavbar
     - AppAuth
     - AppCenter
+    - Automattic-Tracks-iOS
     - boost-for-react-native
     - Charts
     - CocoaLumberjack
@@ -565,9 +566,6 @@ SPEC REPOS:
     - ZIPFoundation
 
 EXTERNAL SOURCES:
-  Automattic-Tracks-iOS:
-    :branch: task/update_explat_endpoints
-    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   FBLazyVector:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
@@ -657,9 +655,6 @@ EXTERNAL SOURCES:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
-  Automattic-Tracks-iOS:
-    :commit: 85a0ba0d440df70374a2fbb24868eb829148d0d1
-    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
@@ -768,6 +763,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 8898781bd06b9f9068d8fefe6225faf10abb1816
+PODFILE CHECKSUM: c6d4556d0c50a4b6995bca5d6315ce5441418a18
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - AppCenter/Core
   - AppCenter/Distribute (4.1.1):
     - AppCenter/Core
-  - Automattic-Tracks-iOS (0.8.4):
+  - Automattic-Tracks-iOS (0.8.5):
     - CocoaLumberjack (~> 3)
     - Reachability (~> 3)
     - Sentry (~> 6)
@@ -438,7 +438,7 @@ DEPENDENCIES:
   - AMScrollingNavbar (= 5.6.0)
   - AppCenter (= 4.1.1)
   - AppCenter/Distribute (= 4.1.1)
-  - Automattic-Tracks-iOS (~> 0.8.4)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, branch `task/update_explat_endpoints`)
   - Charts (~> 3.2.2)
   - CocoaLumberjack (~> 3.0)
   - CropViewController (= 2.5.3)
@@ -520,7 +520,6 @@ SPEC REPOS:
     - AMScrollingNavbar
     - AppAuth
     - AppCenter
-    - Automattic-Tracks-iOS
     - boost-for-react-native
     - Charts
     - CocoaLumberjack
@@ -566,6 +565,9 @@ SPEC REPOS:
     - ZIPFoundation
 
 EXTERNAL SOURCES:
+  Automattic-Tracks-iOS:
+    :branch: task/update_explat_endpoints
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   FBLazyVector:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/FBLazyVector.podspec.json
   FBReactNativeSpec:
@@ -655,6 +657,9 @@ EXTERNAL SOURCES:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.51.0/third-party-podspecs/Yoga.podspec.json
 
 CHECKOUT OPTIONS:
+  Automattic-Tracks-iOS:
+    :commit: 85a0ba0d440df70374a2fbb24868eb829148d0d1
+    :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
   FSInteractiveMap:
     :git: https://github.com/wordpress-mobile/FSInteractiveMap.git
     :tag: 0.2.0
@@ -675,7 +680,7 @@ SPEC CHECKSUMS:
   AMScrollingNavbar: cf0ec5a5ee659d76ba2509f630bf14fba7e16dc3
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   AppCenter: cd53e3ed3563cc720bcb806c9731a12389b40d44
-  Automattic-Tracks-iOS: 87e14e4f06f753f02a6e0f747824e766bae7f939
+  Automattic-Tracks-iOS: 4f079f4ca5b66d59a4959204ffec3b4465944adf
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
@@ -763,6 +768,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 2d5cb8b46a7d06c27483a62bab0c650a86cf1449
+PODFILE CHECKSUM: 8898781bd06b9f9068d8fefe6225faf10abb1816
 
 COCOAPODS: 1.10.0

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -180,8 +180,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         DDLogInfo("\(self) \(#function)")
 
         uploadsManager.resume()
-
-        ABTest.refreshIfNeeded()
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -17,14 +17,9 @@ extension ABTest {
             return
         }
 
+        let experimentNames = ABTest.allCases.filter { $0 != .unknown }.map { $0.rawValue }
+        ExPlat.shared?.register(experiments: experimentNames)
+
         ExPlat.shared?.refresh()
-    }
-
-    static func refreshIfNeeded() {
-        guard ABTest.allCases.count > 1, AccountHelper.isLoggedIn else {
-            return
-        }
-
-        ExPlat.shared?.refreshIfNeeded()
     }
 }


### PR DESCRIPTION
This PR updates how experiments are assigned.

### To test

First, add a breakpoint in `ExPlatService.swift:76`.

#### No experiments

1. Run the app
2. Put the app in the background
3. Put the app in the foreground
4. Make sure the breakpoint is never hit

#### Adding experiments

Add these experiments into `ABTest.swift`:

```swift
    case mock = "explat_test_ios_mock_experiment_1"
    case mock2 = "explat_test_ios_mock_experiment_2"
```

1. Run the app
2. The breakpoint should be hit
3. Put the app into the background and wait 1 minute (the `tll` time)
4. Put the app in the foreground
5. The breakpoint should be hit
6. Put into the background and then foreground
7. The breakpoint should not be hit

## Regression Notes
1. Potential unintended areas of impact
N/a.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/a.

3. What automated tests I added (or what prevented me from doing so)
They were added to the library's PR (https://github.com/Automattic/Automattic-Tracks-iOS/pull/178)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
