### PR TITLE
Switch Prologue strings to use NSLocalizedString

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/ContentViews/Editor/UnifiedPrologueEditorContentView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/ContentViews/Editor/UnifiedPrologueEditorContentView.swift
@@ -94,8 +94,8 @@ struct UnifiedPrologueEditorContentView: View {
 private extension UnifiedPrologueEditorContentView {
 
     enum Appearance {
-        static let topElementTitle: LocalizedStringKey = "Getting Inspired"
-        static let middleElementTitle: LocalizedStringKey = "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next"
+        static let topElementTitle = NSLocalizedString("Getting Inspired", comment: "Example post title used in the login prologue screens.")
+        static let middleElementTitle = NSLocalizedString("I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next", comment: "Example post content used in the login prologue screens.")
         static let middleElementTerminator = "|"
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/ContentViews/Editor/UnifiedPrologueReaderContentView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/ContentViews/Editor/UnifiedPrologueReaderContentView.swift
@@ -142,9 +142,9 @@ private extension UnifiedPrologueReaderContentView {
         static let tagMusic: String = NSLocalizedString("Music", comment: "An example tag used in the login prologue screens.")
         static let tagPolitics: String = NSLocalizedString("Politics", comment: "An example tag used in the login prologue screens.")
 
-        static let firstPostTitle: LocalizedStringKey = "My Top Ten Cafes"
-        static let secondPostTitle: LocalizedStringKey = "The World's Best Fans"
-        static let thirdPostTitle: LocalizedStringKey = "Museums to See In London"
+        static let firstPostTitle: String = NSLocalizedString("My Top Ten Cafes", comment: "Example post title used in the login prologue screens.")
+        static let secondPostTitle: String = NSLocalizedString("The World's Best Fans", comment: "Example post title used in the login prologue screens. This is a post about football fans.")
+        static let thirdPostTitle: String = NSLocalizedString("Museums to See In London", comment: "Example post title used in the login prologue screens.")
     }
 }
 
@@ -204,7 +204,7 @@ extension View {
 ///
 private struct PostView: View {
     let image: String
-    let title: LocalizedStringKey
+    let title: String
     let size: CGFloat
     let font: Font
 


### PR DESCRIPTION
Fixes #16378. Some of the strings in the new prologue view were not being localized. It turns out that our localization workflows currently don't support `LocalizedStringKey`, which is what we were using here. I've modified these to use `NSLocalizedString` now, matching the sections of the prologue that _were_ being localized.

**To test**

* Check the code changes
* You can test that the strings are able to be localized by editing the scheme and changing the language to something like Accented Pseudolanguage:

<img src="https://user-images.githubusercontent.com/4780/116296477-30c1c080-a792-11eb-8820-4155231dddee.png" width=250>

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
