### PR TITLE
Refresh the post list after restoring a post

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1002,6 +1002,11 @@ class AbstractPostListViewController: UIViewController,
             recentlyTrashedPostObjectIDs.remove(at: index)
         }
 
+        if filterSettings.currentPostListFilter().filterType != .draft {
+            // Needed or else the post will remain in the published list.
+            updateAndPerformFetchRequest()
+        }
+
         let postService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)
 
         postService.restore(apost, success: { [weak self] in

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1005,6 +1005,7 @@ class AbstractPostListViewController: UIViewController,
         if filterSettings.currentPostListFilter().filterType != .draft {
             // Needed or else the post will remain in the published list.
             updateAndPerformFetchRequest()
+            tableView.reloadData()
         }
 
         let postService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)


### PR DESCRIPTION
Fixes #16359

This PR reflects the changes in this other one (#16358) into `17.2` as it seems to address the crash reported in #16359.

**NOTE:**
#16358 also refers to a `WordPressKit` PR that was merged afterwards, so I am not sure these changes can be merged as is in `17.2`. Also, I have not included the changes to the release notes as the RN would not change anyway.
@chipsnyder please take a look if you can to make sure these changes can be merged safely into `17.2`

cc @startuptester 

To test:
- build/run and go to My Site
- Go to Blog Posts
- Delete a Post
  a. Tap the More button
  b. Tap Move to Trash 
  c. Tap Move to Trash in the alert
- Restore the post by tapping the **Undo** cell
- Delete another post following the above instructions
- Make sure that the post is deleted and no crash happens

## Regression Notes
1. Potential unintended areas of impact
See comments above regarding the related `WordPressKit` PR

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
