### PR TITLE
Post likes: filter fetch requests when fetching and deleting likes

### DIFF
--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -123,6 +123,15 @@ class LikesListController: NSObject {
                                           siteID: siteID,
                                           success: success,
                                           failure: failure)
+
+            ///
+            // TODO: for testing only. Remove before merging.
+            let successBlock = { (likeUsers: [LikeUser]) -> Void in
+                likeUsers.forEach { print("🔴 user: ", $0.displayName) }
+            }
+            postService.getLikesFor(postID: postID, siteID: siteID, success: successBlock, failure: failure)
+        ///
+
         case .comment(let commentID):
             commentService.getLikesForCommentID(commentID,
                                                 siteID: siteID,

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -123,15 +123,6 @@ class LikesListController: NSObject {
                                           siteID: siteID,
                                           success: success,
                                           failure: failure)
-
-            ///
-            // TODO: for testing only. Remove before merging.
-            let successBlock = { (likeUsers: [LikeUser]) -> Void in
-                likeUsers.forEach { print("🔴 user: ", $0.displayName) }
-            }
-            postService.getLikesFor(postID: postID, siteID: siteID, success: successBlock, failure: failure)
-        ///
-
         case .comment(let commentID):
             commentService.getLikesForCommentID(commentID,
                                                 siteID: siteID,


### PR DESCRIPTION
Ref: #15662

This uses `siteID` and `postID` to filter fetch requests when fetching and deleting likes.

To test:

`LikesListController` still uses the old fetching method to display the likers. I've added a temporary call to the new fetch method that logs out the `displayName` for each user.

- Go to Notifications > Likes.
- Tap on a Post like notification.
- Verify the user names appear in the console (prefaced by `🔴 user:`). 
- Verify the logged users match the displayed users (i.e the fetch users request is correct).
- Verify there are no duplicate logged users (i.e. the delete users request is correct).

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
