### PR TITLE
Stories: change the create sheet order

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
@@ -26,10 +26,15 @@ extension BlogDetailsViewController {
 
         let source = "my_site"
 
-        var actions: [ActionSheetItem] = [PostAction(handler: newPost, source: source), PageAction(handler: newPage, source: source)]
+        var actions: [ActionSheetItem] = []
+
         if shouldShowNewStory {
             actions.append(StoryAction(handler: newStory, source: source))
         }
+
+        actions.append(PostAction(handler: newPost, source: source))
+        actions.append(PageAction(handler: newPage, source: source))
+
         let coordinator = CreateButtonCoordinator(self, actions: actions, source: source)
         return coordinator
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -171,14 +171,13 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             }, source: Constants.source)
         ]
         if Feature.enabled(.stories) && blog.supports(.stories) {
-            actions.append(
-                StoryAction(handler: { [weak self] in
-                    guard let self = self else {
-                        return
-                    }
-                    (self.tabBarController as? WPTabBarController)?.showStoryEditor(blog: self.blog, title: nil, content: nil)
-                }, source: Constants.source)
-            )
+            actions.insert(StoryAction(handler: { [weak self] in
+                guard let self = self else {
+                    return
+                }
+                (self.tabBarController as? WPTabBarController)?.showStoryEditor(blog: self.blog, title: nil, content: nil)
+            }, source: Constants.source)
+            , at: 0)
         }
         return CreateButtonCoordinator(self, actions: actions, source: Constants.source)
     }()

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -176,8 +176,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
                     return
                 }
                 (self.tabBarController as? WPTabBarController)?.showStoryEditor(blog: self.blog, title: nil, content: nil)
-            }, source: Constants.source)
-            , at: 0)
+            }, source: Constants.source), at: 0)
         }
         return CreateButtonCoordinator(self, actions: actions, source: Constants.source)
     }()


### PR DESCRIPTION
This PR moves the "Story post" option to be the first one shown in the "Create New" sheet.

<img src="https://user-images.githubusercontent.com/7040243/116575911-7773ff80-a8e5-11eb-8345-8f265a2da33d.png" width="300">

### To test

1. Tap the FAB under "My Site" and "Blog posts"
2. Make sure "Story post" is the first option

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
UI change, no automated tests were added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
