### PR TITLE
Comment likes: add to Core Data when fetched

### DIFF
--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -1,0 +1,90 @@
+extension CommentService {
+
+    /**
+     Fetches a list of users that liked the comment with the given ID.
+     
+     @param commentID  The ID of the comment to fetch likes for
+     @param siteID     The ID of the site that contains the post
+     @param success    A success block
+     @param failure    A failure block
+     */
+    func getLikesFor(commentID: NSNumber,
+                     siteID: NSNumber,
+                     success: @escaping (([LikeUser]) -> Void),
+                     failure: @escaping ((Error?) -> Void)) {
+
+        guard let remote = restRemote(forSite: siteID) else {
+            DDLogError("Unable to create a REST remote for comments.")
+            failure(nil)
+            return
+        }
+
+        remote.getLikesForCommentID(commentID) { remoteLikeUsers in
+            self.createNewUsers(from: remoteLikeUsers, commentID: commentID, siteID: siteID) {
+                let users = self.likeUsersFor(commentID: commentID, siteID: siteID)
+                success(users)
+            }
+        } failure: { error in
+            DDLogError(String(describing: error))
+            failure(error)
+        }
+    }
+
+}
+
+private extension CommentService {
+
+    func createNewUsers(from remoteLikeUsers: [RemoteLikeUser]?,
+                        commentID: NSNumber,
+                        siteID: NSNumber,
+                        onComplete: @escaping (() -> Void)) {
+
+        guard let remoteLikeUsers = remoteLikeUsers,
+              !remoteLikeUsers.isEmpty else {
+            onComplete()
+            return
+        }
+
+        let derivedContext = ContextManager.shared.newDerivedContext()
+
+        derivedContext.perform {
+
+            self.deleteExistingUsersFor(commentID: commentID, siteID: siteID, from: derivedContext)
+
+            remoteLikeUsers.forEach {
+                LikeUserHelper.createUserFrom(remoteUser: $0, context: derivedContext)
+            }
+
+            ContextManager.shared.save(derivedContext) {
+                DispatchQueue.main.async {
+                    onComplete()
+                }
+            }
+        }
+    }
+
+    func deleteExistingUsersFor(commentID: NSNumber, siteID: NSNumber, from context: NSManagedObjectContext) {
+        let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
+        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@", siteID, commentID)
+
+        do {
+            let users = try context.fetch(request)
+            users.forEach { context.delete($0) }
+        } catch {
+            DDLogError("Error fetching comment Like Users: \(error)")
+        }
+    }
+
+    func likeUsersFor(commentID: NSNumber, siteID: NSNumber) -> [LikeUser] {
+        let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
+        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@", siteID, commentID)
+        request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
+
+        if let users = try? managedObjectContext.fetch(request) {
+            return users
+        }
+
+        return [LikeUser]()
+    }
+
+}

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -193,4 +193,13 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
                      success:(void (^)(NSArray<RemoteUser *> *))success
                      failure:(void (^)(NSError * _Nullable))failure;
 
+/**
+ Get a CommentServiceRemoteREST for the given site.
+ This is public so it can be accessed from Swift extensions.
+ 
+ @param siteID The ID of the site the remote will be used for.
+ */
+- (CommentServiceRemoteREST *_Nullable)restRemoteForSite:(NSNumber *_Nonnull)siteID;
+
+
 @end

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -778,6 +778,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     }
 }
 
+// TODO: remove when LikesListController is updated to use LikeUsers method.
 - (void)getLikesForCommentID:(NSNumber *)commentID
                       siteID:(NSNumber *)siteID
                      success:(void (^)(NSArray<RemoteUser *> *))success

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -71,13 +71,14 @@ private extension PostService {
             let users = try context.fetch(request)
             users.forEach { context.delete($0) }
         } catch {
-            DDLogError("Error fetching Like Users: \(error)")
+            DDLogError("Error fetching post Like Users: \(error)")
         }
     }
 
     func likeUsersFor(postID: NSNumber, siteID: NSNumber) -> [LikeUser] {
         let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
         request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@", siteID, postID)
+        request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
 
         if let users = try? managedObjectContext.fetch(request) {
             return users

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -123,11 +123,30 @@ class LikesListController: NSObject {
                                           siteID: siteID,
                                           success: success,
                                           failure: failure)
+
+            ///
+            // TODO: for testing only. Remove before merging.
+            let successBlock = { (likeUsers: [LikeUser]) -> Void in
+                print("🔴 post users count: ", likeUsers.count)
+                likeUsers.forEach { print("🔴 post user: \($0.displayName), date liked: \($0.dateLiked)") }
+            }
+            postService.getLikesFor(postID: postID, siteID: siteID, success: successBlock, failure: failure)
+           ///
         case .comment(let commentID):
             commentService.getLikesForCommentID(commentID,
                                                 siteID: siteID,
                                                 success: success,
                                                 failure: failure)
+
+            ///
+            // TODO: for testing only. Remove before merging.
+            let successBlock = { (likeUsers: [LikeUser]) -> Void in
+                print("🔴 comment users count: ", likeUsers.count)
+                likeUsers.forEach { print("🔴 comment user: \($0.displayName), date liked: \($0.dateLiked)") }
+            }
+
+            commentService.getLikesFor(commentID: commentID, siteID: siteID, success: successBlock, failure: failure)
+           ///
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -123,30 +123,11 @@ class LikesListController: NSObject {
                                           siteID: siteID,
                                           success: success,
                                           failure: failure)
-
-            ///
-            // TODO: for testing only. Remove before merging.
-            let successBlock = { (likeUsers: [LikeUser]) -> Void in
-                print("🔴 post users count: ", likeUsers.count)
-                likeUsers.forEach { print("🔴 post user: \($0.displayName), date liked: \($0.dateLiked)") }
-            }
-            postService.getLikesFor(postID: postID, siteID: siteID, success: successBlock, failure: failure)
-           ///
         case .comment(let commentID):
             commentService.getLikesForCommentID(commentID,
                                                 siteID: siteID,
                                                 success: success,
                                                 failure: failure)
-
-            ///
-            // TODO: for testing only. Remove before merging.
-            let successBlock = { (likeUsers: [LikeUser]) -> Void in
-                print("🔴 comment users count: ", likeUsers.count)
-                likeUsers.forEach { print("🔴 comment user: \($0.displayName), date liked: \($0.dateLiked)") }
-            }
-
-            commentService.getLikesFor(commentID: commentID, siteID: siteID, success: successBlock, failure: failure)
-           ///
         }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1407,6 +1407,8 @@
 		9826AE9121B5D3CD00C851FA /* PostingActivityCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9826AE8F21B5D3CD00C851FA /* PostingActivityCell.xib */; };
 		9829162F2224BC1C008736C0 /* SiteStatsDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9829162E2224BC1C008736C0 /* SiteStatsDetailsViewModel.swift */; };
 		982A4C3520227D6700B5518E /* NoResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A4C3420227D6700B5518E /* NoResultsViewController.swift */; };
+		982DA9A7263B1E2F00E5743B /* CommentService+Likes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982DA9A6263B1E2F00E5743B /* CommentService+Likes.swift */; };
+		982DA9A8263B1E2F00E5743B /* CommentService+Likes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982DA9A6263B1E2F00E5743B /* CommentService+Likes.swift */; };
 		982DDF90263238A6002B3904 /* LikeUser+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982DDF8C263238A6002B3904 /* LikeUser+CoreDataClass.swift */; };
 		982DDF91263238A6002B3904 /* LikeUser+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982DDF8C263238A6002B3904 /* LikeUser+CoreDataClass.swift */; };
 		982DDF92263238A6002B3904 /* LikeUser+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982DDF8D263238A6002B3904 /* LikeUser+CoreDataProperties.swift */; };
@@ -5917,6 +5919,7 @@
 		9826AE8F21B5D3CD00C851FA /* PostingActivityCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostingActivityCell.xib; sourceTree = "<group>"; };
 		9829162E2224BC1C008736C0 /* SiteStatsDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsDetailsViewModel.swift; sourceTree = "<group>"; };
 		982A4C3420227D6700B5518E /* NoResultsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoResultsViewController.swift; sourceTree = "<group>"; };
+		982DA9A6263B1E2F00E5743B /* CommentService+Likes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentService+Likes.swift"; sourceTree = "<group>"; };
 		982DDF8C263238A6002B3904 /* LikeUser+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LikeUser+CoreDataClass.swift"; sourceTree = "<group>"; };
 		982DDF8D263238A6002B3904 /* LikeUser+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LikeUser+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		982DDF8E263238A6002B3904 /* LikeUserPreferredBlog+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LikeUserPreferredBlog+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -10909,6 +10912,7 @@
 				9A2D0B22225CB92B009E585F /* BlogService+JetpackConvenience.swift */,
 				E1556CF0193F6FE900FC52EA /* CommentService.h */,
 				E1556CF1193F6FE900FC52EA /* CommentService.m */,
+				982DA9A6263B1E2F00E5743B /* CommentService+Likes.swift */,
 				AB2211D125ED68E300BF72FC /* CommentServiceRemoteFactory.swift */,
 				E16A76F21FC4766900A661E3 /* CredentialsService.swift */,
 				1702BBDF1CF3034E00766A33 /* DomainsService.swift */,
@@ -16781,6 +16785,7 @@
 				912347192213484300BD9F97 /* GutenbergViewController+InformativeDialog.swift in Sources */,
 				2FA6511721F26A24009AA935 /* ChangePasswordViewController.swift in Sources */,
 				D816C1F020E0893A00C4D82F /* LikeComment.swift in Sources */,
+				982DA9A7263B1E2F00E5743B /* CommentService+Likes.swift in Sources */,
 				59E1D46E1CEF77B500126697 /* Page.swift in Sources */,
 				321955BF24BE234C00E3F316 /* ReaderInterestsCoordinator.swift in Sources */,
 				FAE4327425874D140039EB8C /* ReaderSavedPostCellActions.swift in Sources */,
@@ -19249,6 +19254,7 @@
 				FABB24DE2602FC2C00C8785C /* UIViewController+NoResults.swift in Sources */,
 				FABB24DF2602FC2C00C8785C /* TimeZoneStore.swift in Sources */,
 				FABB24E02602FC2C00C8785C /* UserSuggestion+CoreDataClass.swift in Sources */,
+				982DA9A8263B1E2F00E5743B /* CommentService+Likes.swift in Sources */,
 				FABB24E12602FC2C00C8785C /* MediaLibraryPicker.swift in Sources */,
 				46F583D52624D0BC0010A723 /* Blog+BlockEditorSettings.swift in Sources */,
 				FABB24E22602FC2C00C8785C /* SharingAccountViewController.swift in Sources */,


### PR DESCRIPTION
Ref: #15662 

This adds a new `CommentService+Likes` class that:
- Fetches likes for a Comment and returns an array of `LikeUser`s.
  - The new method is a Swift re-implementation of the [original](https://github.com/wordpress-mobile/WordPress-iOS/blob/8de804c16e55f31cc03da52083bbb7e5b8110983/WordPress/Classes/Services/CommentService.m#L781) `CommentService.m` method, which will be removed later.
- Purges any existing users for the Comment before creating new ones.

In addition, the Post likes are now sorted by `dateLiked`.

To test:

`LikesListController` still uses the old fetching method to display the likers. I've added temporary calls to the new fetch methods (Post and Comment) that logs out the `LikeUser`s in the format:
`🔴 post/comment user: <display name>, date liked: <date>)`. 

- Go to Notifications > Likes.
- Tap on a Comment like notification.
  - Verify the user array appears on the console. The users should match the displayed users, and in the same order.
- Tap on a Post like notification.
  - Verify the logged users are in the same order as the displayed users.


## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
