### PR TITLE
Like Notifications: use cached user info

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -778,7 +778,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     }
 }
 
-// TODO: remove when LikesListController is updated to use LikeUsers method.
+// TODO: remove when CommentServiceTests is updated to use LikeUsers method.
 - (void)getLikesForCommentID:(NSNumber *)commentID
                       siteID:(NSNumber *)siteID
                      success:(void (^)(NSArray<RemoteUser *> *))success

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -684,7 +684,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     [remote restorePost:remotePost success:successBlock failure:failureBlock];
 }
 
-// TODO: remove when LikesListController is updated to use LikeUsers method.
+// TODO: remove when PostServiceWPComTests is updated to use LikeUsers method.
 - (void)getLikesForPostID:(NSNumber *)postID
                    siteID:(NSNumber *)siteID
                   success:(void (^)(NSArray<RemoteUser *> *))success

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -8,17 +8,11 @@ import WordPressKit
 class LikesListController: NSObject {
 
     private let formatter = FormattableContentFormatter()
-
     private let content: ContentIdentifier
-
     private let siteID: NSNumber
-
     private let notification: Notification?
-
     private let tableView: UITableView
-
-    private var likingUsers: [RemoteUser] = []
-
+    private var likingUsers: [LikeUser] = []
     private weak var delegate: LikesListControllerDelegate?
 
     private lazy var postService: PostService = {
@@ -104,7 +98,7 @@ class LikesListController: NSObject {
         isLoadingContent = true
 
         fetchLikes(success: { [weak self] users in
-            self?.likingUsers = users ?? []
+            self?.likingUsers = users
             self?.isLoadingContent = false
         }, failure: { [weak self] _ in
             // TODO: Handle error state
@@ -116,18 +110,12 @@ class LikesListController: NSObject {
     /// - Parameters:
     ///   - success: Closure to be called when the fetch is successful.
     ///   - failure: Closure to be called when the fetch failed.
-    private func fetchLikes(success: @escaping ([RemoteUser]?) -> Void, failure: @escaping (Error?) -> Void) {
+    private func fetchLikes(success: @escaping ([LikeUser]) -> Void, failure: @escaping (Error?) -> Void) {
         switch content {
         case .post(let postID):
-            postService.getLikesForPostID(postID,
-                                          siteID: siteID,
-                                          success: success,
-                                          failure: failure)
+            postService.getLikesFor(postID: postID, siteID: siteID, success: success, failure: failure)
         case .comment(let commentID):
-            commentService.getLikesForCommentID(commentID,
-                                                siteID: siteID,
-                                                success: success,
-                                                failure: failure)
+            commentService.getLikesFor(commentID: commentID, siteID: siteID, success: success, failure: failure)
         }
     }
 }
@@ -240,8 +228,8 @@ protocol LikesListControllerDelegate: class {
     func didSelectHeader()
 
     /// Reports to the delegate that the user cell has been tapped.
-    /// - Parameter user: A RemoteUser instance representing the user at the selected row.
-    func didSelectUser(_ user: RemoteUser, at indexPath: IndexPath)
+    /// - Parameter user: A LikeUser instance representing the user at the selected row.
+    func didSelectUser(_ user: LikeUser, at indexPath: IndexPath)
 }
 
 // MARK: - Private Definitions

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -982,7 +982,7 @@ private extension NotificationDetailsViewController {
         }
     }
 
-    func displayUserProfile(_ user: RemoteUser, from indexPath: IndexPath) {
+    func displayUserProfile(_ user: LikeUser, from indexPath: IndexPath) {
         let userProfileVC = UserProfileSheetViewController(user: user)
         let bottomSheet = BottomSheetViewController(childViewController: userProfileVC)
 
@@ -1378,7 +1378,7 @@ extension NotificationDetailsViewController: LikesListControllerDelegate {
         displayNotificationSource()
     }
 
-    func didSelectUser(_ user: RemoteUser, at indexPath: IndexPath) {
+    func didSelectUser(_ user: LikeUser, at indexPath: IndexPath) {
         displayUserProfile(user, from: indexPath)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.swift
@@ -24,10 +24,10 @@ class LikeUserTableViewCell: UITableViewCell, NibReusable {
 
     // MARK: - Public Methods
 
-    func configure(withUser user: RemoteUser, isLastRow: Bool = false) {
+    func configure(withUser user: LikeUser, isLastRow: Bool = false) {
         nameLabel.text = user.displayName
         usernameLabel.text = String(format: Constants.usernameFormat, user.username)
-        downloadGravatarWithURL(user.avatarURL)
+        downloadGravatarWithURL(user.avatarUrl)
         separatorLeadingConstraint.constant = isLastRow ? 0 : cellStackViewLeadingConstraint.constant
     }
 

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -2,7 +2,7 @@ class UserProfileSheetViewController: UITableViewController {
 
     // MARK: - Properties
 
-    private let user: RemoteUser
+    private let user: LikeUser
 
     private lazy var mainContext = {
         return ContextManager.sharedInstance().mainContext
@@ -14,7 +14,7 @@ class UserProfileSheetViewController: UITableViewController {
 
     // MARK: - Init
 
-    init(user: RemoteUser) {
+    init(user: LikeUser) {
         self.user = user
         super.init(nibName: nil, bundle: nil)
     }
@@ -67,8 +67,7 @@ extension UserProfileSheetViewController: DrawerPresentable {
 extension UserProfileSheetViewController {
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        // TODO: if no site, return 1.
-        return 2
+        return user.preferredBlog != nil ? 2 : 1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -92,8 +91,6 @@ extension UserProfileSheetViewController {
             return nil
         }
 
-        // TODO: Don't show section header if there are no sites.
-
         header.titleLabel.text = Constants.siteSectionTitle
         return header
     }
@@ -108,13 +105,7 @@ extension UserProfileSheetViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-
-        // TODO: return 0 if there are no sites.
-        if section == Constants.userInfoSection {
-            return 0
-        }
-
-        return UITableView.automaticDimension
+        return section == Constants.userInfoSection ? 0 : UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
@@ -138,19 +129,17 @@ private extension UserProfileSheetViewController {
     func showSite() {
         WPAnalytics.track(.userProfileSheetSiteShown)
 
-        // TODO: Remove. For testing only. Use siteID from user object.
-        var stubbySiteID: NSNumber?
-        // use this to test external site
-        stubbySiteID = nil
-        // use this to test internal site
-        // stubbySiteID = NSNumber(value: 9999999999)
-
-        guard let siteID = stubbySiteID else {
-            showSiteWebView()
+        guard let blog = user.preferredBlog else {
             return
         }
 
-        showSiteTopicWithID(siteID)
+        guard blog.blogID > 0 else {
+            showSiteWebView(withUrl: blog.blogUrl)
+            return
+        }
+
+        showSiteTopicWithID(NSNumber(value: blog.blogID))
+
     }
 
     func showSiteTopicWithID(_ siteID: NSNumber) {
@@ -160,17 +149,17 @@ private extension UserProfileSheetViewController {
         present(navController, animated: true)
     }
 
-    func showSiteWebView() {
-        // TODO: Remove. For testing only. Use URL from user object.
-        let siteUrl = "https://www.funnycatpix.com/"
+    func showSiteWebView(withUrl url: String?) {
 
-        guard let url = URL(string: siteUrl) else {
+        guard let urlString = url,
+              !urlString.isEmpty,
+              let siteURL = URL(string: urlString) else {
             DDLogError("User Profile: Error creating URL from site string.")
             return
         }
 
-        contentCoordinator.displayWebViewWithURL(url)
-    }
+    contentCoordinator.displayWebViewWithURL(siteURL)
+}
 
     func configureTable() {
         tableView.backgroundColor = .basicBackground
@@ -198,11 +187,12 @@ private extension UserProfileSheetViewController {
     }
 
     func siteCell() -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: UserProfileSiteCell.defaultReuseID) as? UserProfileSiteCell else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: UserProfileSiteCell.defaultReuseID) as? UserProfileSiteCell,
+              let blog = user.preferredBlog else {
             return UITableViewCell()
         }
 
-        cell.configure()
+        cell.configure(withBlog: blog)
         return cell
     }
 

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSiteCell.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSiteCell.swift
@@ -19,8 +19,10 @@ class UserProfileSiteCell: UITableViewCell, NibReusable {
 
     // MARK: - Public Methods
 
-    func configure() {
-        downloadIconWithURL(nil)
+    func configure(withBlog blog: LikeUserPreferredBlog) {
+        siteNameLabel.text = blog.blogName
+        siteUrlLabel.text = blog.blogUrl
+        downloadIconWithURL(blog.iconUrl)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
@@ -18,16 +18,14 @@ class UserProfileUserInfoCell: UITableViewCell, NibReusable {
 
     // MARK: - Public Methods
 
-    func configure(withUser user: RemoteUser) {
+    func configure(withUser user: LikeUser) {
         nameLabel.text = user.displayName
         usernameLabel.text = String(format: Constants.usernameFormat, user.username)
 
-        // TODO:
-        // - replace with actual bio.
-        // - hide label if no bio.
-        userBioLabel.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Consectetur purus ut faucibus pulvinar. Tincidunt eget nullam non nisi est sit amet facilisis magna. Morbi tincidunt augue interdum velit euismod in pellentesque. Sed adipiscing diam donec adipiscing."
+        userBioLabel.text = user.bio
+        userBioLabel.isHidden = user.bio.isEmpty
 
-        downloadGravatarWithURL(user.avatarURL)
+        downloadGravatarWithURL(user.avatarUrl)
     }
 
 }


### PR DESCRIPTION
Ref: #15662, #16244, #16245

This updates the Notifications like list to use the cached `LikeUser` instead of `RemoteUser` to obtain and display user info.

Outstanding issues to be addressed later:
- The user profile sheet needs to be resized per the design if info is missing.
- The tests need to be updated to use the new fetch methods.

To test:
- Go to Notifications > Likes.
- Select a notification.
- Verify the list of users as is expected, and in the right order.
- Select various users that have different pieces of information. 
- In the user profile sheet, verify:
  - If a user has a bio, it is displayed. If not, the bio field is hidden.
  - If a user has a preferred blog, it is displayed in the `SITE` section. If not, the `SITE` section is not displayed.
  - If the preferred blog is internal, it is displayed in a Reader blog view.
  - If the preferred blog is external, it is displayed in a webView.
 

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
