### PR TITLE
Fixes a bug with some webviews in the reader not authenticating users properly.

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -126,8 +126,8 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         startObservingWebView()
     }
 
-    fileprivate init(url: URL, parent: WebKitViewController) {
-        webView = WKWebView(frame: .zero, configuration: parent.webView.configuration)
+    fileprivate init(url: URL, parent: WebKitViewController, configuration: WKWebViewConfiguration) {
+        webView = WKWebView(frame: .zero, configuration: configuration)
         self.url = url
         customOptionsButton = parent.customOptionsButton
         secureInteraction = parent.secureInteraction
@@ -521,9 +521,10 @@ extension WebKitViewController: WKUIDelegate {
             if opensNewInSafari {
                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
             } else {
-                let controller = WebKitViewController(url: url, parent: self)
+                let controller = WebKitViewController(url: url, parent: self, configuration: configuration)
                 let navController = UINavigationController(rootViewController: controller)
                 present(navController, animated: true)
+                return controller.webView
             }
         }
         return nil
@@ -546,7 +547,7 @@ extension WebKitViewController: WKUIDelegate {
             ReachabilityUtils.showNoInternetConnectionNotice()
             reloadWhenConnectionRestored()
         } else {
-            WPError.showAlert(withTitle: NSLocalizedString("Error", comment: "Generic error alert title"), message: error.localizedDescription)
+            DDLogError("WebView \(webView) didFailProvisionalNavigation: \(error.localizedDescription)")
         }
     }
 }


### PR DESCRIPTION
Fixes #16278

## To test:

1. Go to the reader
2. Discover
3. Pick a post from a site with a custom domain
4. Tap "..." and select "Visit"
5. If there's no like button, go back to step 3 and pick another post
6. Tap "Like"
7. A popup should be shown asking you to continue with your WP.com account.  Tap "Continue".
8. The popup should be dismissed and the post should be "liked".

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Nothing, as I don't consider there to be space for regressions with these changes.

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
