### PR TITLE
Update Comment and Post Likes tests to use new methods

### DIFF
--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -181,19 +181,6 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
                            failure:(void (^)(NSError *error))failure;
 
 /**
- Fetches a list of users that liked the comment with the given ID.
-
- @param commentID   The ID of the comment to fetch likes for
- @param siteID      The ID of the site that contains the post
- @param success     A success block
- @param failure     A failure block
- */
-- (void)getLikesForCommentID:(NSNumber *)commentID
-                      siteID:(NSNumber *)siteID
-                     success:(void (^)(NSArray<RemoteUser *> *))success
-                     failure:(void (^)(NSError * _Nullable))failure;
-
-/**
  Get a CommentServiceRemoteREST for the given site.
  This is public so it can be accessed from Swift extensions.
  

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -778,19 +778,6 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     }
 }
 
-// TODO: remove when CommentServiceTests is updated to use LikeUsers method.
-- (void)getLikesForCommentID:(NSNumber *)commentID
-                      siteID:(NSNumber *)siteID
-                     success:(void (^)(NSArray<RemoteUser *> *))success
-                     failure:(void (^)(NSError * _Nullable))failure
-{
-    NSParameterAssert(commentID);
-    NSParameterAssert(siteID);
-
-    CommentServiceRemoteREST *remote = [self restRemoteForSite:siteID];
-    [remote getLikesForCommentID:commentID success:success failure:failure];
-}
-
 
 #pragma mark - Private methods
 

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -13,7 +13,7 @@ extension PostService {
                      success: @escaping (([LikeUser]) -> Void),
                      failure: @escaping ((Error?) -> Void)) {
 
-        guard let remote = PostServiceRemoteFactory().restRemoteFor(siteID: siteID, context: managedObjectContext) else {
+        guard let remote = postServiceRemoteFactory.restRemoteFor(siteID: siteID, context: managedObjectContext) else {
             DDLogError("Unable to create a REST remote for posts.")
             failure(nil)
             return

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -174,19 +174,6 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
            success:(nullable void (^)(void))success
            failure:(void (^)(NSError * _Nullable error))failure;
 
-/**
- Fetches a list of users that liked the post with the given ID.
- 
- @param postID The ID of the post to fetch likes for
- @param siteID The ID of the site that contains the post
- @param success A success block
- @param failure A failure block
- */
-- (void)getLikesForPostID:(NSNumber *)postID
-                   siteID:(NSNumber *)siteID
-                  success:(void (^)(NSArray<RemoteUser *> *users))success
-                  failure:(void (^)(NSError * _Nullable error))failure;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -25,6 +25,9 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
 
 @interface PostService : LocalCoreDataService
 
+// This is public so it can be accessed from Swift extensions.
+@property (nonnull, strong, nonatomic) PostServiceRemoteFactory *postServiceRemoteFactory;
+
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context
                     postServiceRemoteFactory:(PostServiceRemoteFactory *)postServiceRemoteFactory NS_DESIGNATED_INITIALIZER;
 

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -19,8 +19,6 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
 
 @interface PostService ()
 
-@property (nonnull, strong, nonatomic) PostServiceRemoteFactory *postServiceRemoteFactory;
-
 @end
 
 @implementation PostService

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -682,29 +682,6 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     [remote restorePost:remotePost success:successBlock failure:failureBlock];
 }
 
-// TODO: remove when PostServiceWPComTests is updated to use LikeUsers method.
-- (void)getLikesForPostID:(NSNumber *)postID
-                   siteID:(NSNumber *)siteID
-                  success:(void (^)(NSArray<RemoteUser *> *))success
-                  failure:(void (^)(NSError * _Nullable))failure
-{
-    NSParameterAssert(postID);
-    NSParameterAssert(siteID);
-
-    PostServiceRemoteREST *remote = [self.postServiceRemoteFactory restRemoteForSiteID:siteID
-                                                                               context:self.managedObjectContext];
-    if (remote) {
-        [remote getLikesForPostID:postID
-                          success:success
-                          failure:failure];
-    } else {
-        NSError *error = [NSError errorWithDomain:PostServiceErrorDomain
-                                             code:0
-                                         userInfo:@{ NSLocalizedDescriptionKey : @"Unable to create a REST remote for posts." }];
-        failure(error);
-    }
-}
-
 #pragma mark - Helpers
 
 - (void)initializeDraft:(AbstractPost *)post {

--- a/WordPress/WordPressTest/CommentServiceTests.swift
+++ b/WordPress/WordPressTest/CommentServiceTests.swift
@@ -38,7 +38,8 @@ final class CommentServiceTests: XCTestCase {
                                         "login": "johndoe",
                                         "name": "John Doe",
                                         "site_ID": NSNumber(value: 456),
-                                        "avatar_URL": "avatar URL"
+                                        "avatar_URL": "avatar URL",
+                                        "date_liked": "2021-02-09 08:34:43"
         ]
 
         return RemoteLikeUser(dictionary: userDict, commentID: NSNumber(value: 1), siteID: NSNumber(value: 2))
@@ -61,10 +62,10 @@ extension CommentServiceTests {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesForCommentID(commentID, siteID: siteID, success: { users in
+            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users in
                 // Assert
                 expect(users).toNot(beNil())
-                expect(users?.count) == 1
+                expect(users.count) == 1
                 done()
             },
             failure: { _ in
@@ -82,7 +83,7 @@ extension CommentServiceTests {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesForCommentID(commentID, siteID: siteID, success: { users in
+            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users in
                 fail("this closure should not be called")
             },
             failure: { _ in

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -266,7 +266,7 @@ class PostServiceWPComTests: XCTestCase {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesForPostID(postID, siteID: siteID, success: { users in
+            self.service.getLikesFor(postID: postID, siteID: siteID, success: { users in
                 // Assert
                 expect(users.count) == 1
                 done()
@@ -286,7 +286,7 @@ class PostServiceWPComTests: XCTestCase {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesForPostID(postID, siteID: siteID, success: { users in
+            self.service.getLikesFor(postID: postID, siteID: siteID, success: { users in
                 fail("this closure should not be called")
             },
             failure: { _ in
@@ -309,7 +309,8 @@ class PostServiceWPComTests: XCTestCase {
                                         "login": "johndoe",
                                         "name": "John Doe",
                                         "site_ID": NSNumber(value: 456),
-                                        "avatar_URL": "avatar URL"
+                                        "avatar_URL": "avatar URL",
+                                        "date_liked": "2021-02-09 08:34:43"
         ]
 
         return RemoteLikeUser(dictionary: userDict, postID: NSNumber(value: 1), siteID: NSNumber(value: 2))


### PR DESCRIPTION
Ref: #15662 

This updates the Likes tests in `CommentServiceTests` and `PostServiceWPComTests` to use the new `getLikesFor` methods in their respective services.

Tech note:
I changed `PostService+Likes.getLikesFor` to use the existing `PostService.postServiceRemoteFactory` property. Recreating it caused the tests to not use the mock service, thus causing them to fail.

To test:
- Verify the `CommentServiceTests` and `PostServiceWPComTests` tests pass.
- Run the app and go to a Post like notification.
- Verify the users shown are as expected.

## Regression Notes
1. Potential unintended areas of impact
N/A. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A.

3. What automated tests I added (or what prevented me from doing so)
This. 😄 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
