### PR TITLE
Remove the New badge from the Story post option

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
@@ -55,11 +55,9 @@ struct StoryAction: ActionSheetItem {
     private let action = "create_new_story"
 
     func makeButton() -> ActionSheetButton {
-        let badge = StoryAction.newBadge(title: NSLocalizedString("New", comment: "New button badge on Stories Post button"))
         return ActionSheetButton(title: NSLocalizedString("Story post", comment: "Create new Story button title"),
                                             image: .gridicon(.story),
                                             identifier: "storyButton",
-                                            badge: badge,
                                             action: {
                                                 WPAnalytics.track(.createSheetActionTapped, properties: ["source": source, "action": action])
                                                 handler()


### PR DESCRIPTION
Removes the "New" badge from the Story post option.

| Before | After |
| --- | --- |
| <img width="224" alt="Screen Shot 2021-04-30 at 4 12 35 PM" src="https://user-images.githubusercontent.com/3250/116759192-014bc780-a9cf-11eb-8ad5-f3f8595850aa.png"> | <img width="239" alt="Screen Shot 2021-04-30 at 4 19 01 PM" src="https://user-images.githubusercontent.com/3250/116759545-d3b34e00-a9cf-11eb-8d86-245547c3f52f.png"> |



## Testing

1. Tap the FAB button on an iPhone
2. Ensure that the "Story post" option does not show a red "new" badge

## Regression Notes
1. Potential unintended areas of impact

FAB button options.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Verified that FAB options appear and 

3. What automated tests I added (or what prevented me from doing so)

No automated tests added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~ Don't think we need a release note for this small change.
