### PR TITLE
Fix testBasicPostPublish UI Test

### DIFF
--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -128,7 +128,6 @@ class BlockEditorScreen: BaseScreen {
      Select Image from Camera Roll by its ID. Starts with 0
      */
     private func addImageByOrder(id: Int) {
-        imagePlaceholder.tap()
         imageDeviceButton.tap()
 
         // Allow access to device media


### PR DESCRIPTION
UI test `EditorGutenbergTests-testBasicPostPublish` was breaking because test was trying to tap image block after adding it to pop up the bottom sheet, whereas now the bottom sheet seems to pop up automatically after adding the block. Fixed by removing the tap (this is the only test that uses that function).

To test:
Run all UI tests

### SS
![Screen Shot 2021-04-30 at 6 58 31 PM](https://user-images.githubusercontent.com/13263478/116764528-0157c180-a9e7-11eb-9ccb-97a222cd55f6.png)


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
