### PR TITLE
Reader deep links: Automatically scroll to comment if an anchor is present in URL

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -22,6 +22,19 @@ class ReaderDetailCoordinator {
     /// A post URL to be loaded and be displayed
     var postURL: URL?
 
+    /// A comment ID used to navigate to a comment
+    var commentID: Int? {
+        // Comment fragments have the form #comment-50484
+        // If one is present, we'll extract the ID and return it.
+        if let fragment = postURL?.fragment,
+           fragment.hasPrefix("comment-"),
+           let idString = fragment.components(separatedBy: "comment-").last {
+            return Int(idString)
+        }
+
+        return nil
+    }
+
     /// Called if the view controller's post fails to load
     var postLoadFailureBlock: (() -> Void)? = nil
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -112,6 +112,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Used to disable ineffective buttons when a Related post fails to load.
     var enableRightBarButtons = true
 
+    /// Track whether we've automatically navigated to the comments view or not.
+    /// This may happen if we initialize our coordinator with a postURL that
+    /// has a comment anchor fragment.
+    private var hasAutomaticallyTriggeredCommentAction = false
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -220,6 +225,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         featuredImage.load { [weak self] in
             self?.hideLoading()
         }
+
+        navigateToCommentIfNecessary()
     }
 
     func renderRelatedPosts(_ posts: [RemoteReaderSimplePost]) {
@@ -228,6 +235,19 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         relatedPosts = sections.sorted { $0.postType.rawValue < $1.postType.rawValue }
         tableView.reloadData()
         tableView.invalidateIntrinsicContentSize()
+    }
+
+    private func navigateToCommentIfNecessary() {
+        if let post = post,
+           let commentID = coordinator?.commentID,
+           !hasAutomaticallyTriggeredCommentAction {
+            hasAutomaticallyTriggeredCommentAction = true
+
+            ReaderCommentAction().execute(post: post,
+                                          origin: self,
+                                          promptToAddComment: false,
+                                          navigateToCommentID: commentID)
+        }
     }
 
     /// Show ghost cells indicating the content is loading

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentAction.swift
@@ -1,11 +1,12 @@
 /// Encapsulates a command to navigate to a post's comments
 final class ReaderCommentAction {
-    func execute(post: ReaderPost, origin: UIViewController, promptToAddComment: Bool = false) {
+    func execute(post: ReaderPost, origin: UIViewController, promptToAddComment: Bool = false, navigateToCommentID: Int? = nil) {
         guard let postInMainContext = ReaderActionHelpers.postInMainContext(post),
             let controller = ReaderCommentsViewController(post: postInMainContext) else {
             return
         }
 
+        controller.navigateToCommentID = navigateToCommentID as NSNumber?
         controller.promptToAddComment = promptToAddComment
         origin.navigationController?.pushViewController(controller, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.h
@@ -14,4 +14,7 @@
 
 /// Opens the Add Comment when the view appears
 @property (nonatomic) BOOL promptToAddComment;
+/// Navigates to the specified comment when the view appears
+@property (nonatomic, strong) NSNumber *navigateToCommentID;
+
 @end

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -237,6 +237,16 @@ class ReaderDetailCoordinatorTests: XCTestCase {
 
         expect(viewMock.didCallScrollToWith).to(equal("hash"))
     }
+
+    func testExtractCommentIDFromPostURL() {
+        let postURL = URL(string: "https://example.wordpress.com/2014/07/24/post-title/#comment-10")
+        let serviceMock = ReaderPostServiceMock()
+        let viewMock = ReaderDetailViewMock()
+        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        coordinator.postURL = postURL
+
+        expect(coordinator.commentID).to(equal(10))
+    }
 }
 
 private class ReaderPostServiceMock: ReaderPostService {


### PR DESCRIPTION
In the previous release, we added support for deep linking URLs such as `mysite.wordpress.com/2021/05/06/some-post` to the Reader. However, if these links included a comment anchor (`#comment-50547`), we didn't attempt to display the selected comment, which could cause problems if you were trying to view a comment link!

This PR fixes that by attempting to automatically present the comments view for a post and navigate to the specified comment if an anchor is present in the URL.

<img src="https://user-images.githubusercontent.com/4780/117278824-038fa500-ae59-11eb-8c36-a1a52f18d877.gif" width=250>

I know that the code to perform the final navigation is a bit on the hacky side, but I couldn't currently find a nicer way to do this. It seemed to work just fine in all my testing, though.

**To test**

- Build and run
- Find a comment on the web (that the app will be able to access), and copy its link. You can then launch it as a deeplink using the `xcrun` command. Here's the link I was using, which you can use too:

```
xcrun simctl openurl booted https://mycoastaladventures.wordpress.com/2014/07/24/dreaming-of-elsewhere/\#comment-10
```
- You should be launched into the comment view for that post and the "Great photographs" post from "markjohnson" should be scrolled to the top.
- Check a couple of different posts to ensure you're taken to the right comment.
- Also test deep links _without_ a comment fragment to ensure you're just taken to the post itself and not the comments view.
- Finally, check navigating to posts normally (manually) in the Reader and their comment views and ensure nothing automated happens.


## Regression Notes
1. Potential unintended areas of impact

I think these changes should be limited to only Reader views instantiated with a post URL that contains a comment anchor.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested normal Reader navigation, both manually and via deep links.

3. What automated tests I added (or what prevented me from doing so)

I added a test to check the code that extracts comment IDs from post URLs.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
