### PR TITLE
Jetpack: add associated domains in order for password autofill to work

### DIFF
--- a/WordPress/Jetpack/JetpackDebug.entitlements
+++ b/WordPress/Jetpack/JetpackDebug.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
+	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackDebug.entitlements
+++ b/WordPress/Jetpack/JetpackDebug.entitlements
@@ -7,8 +7,6 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
-		<string>applinks:wordpress.com</string>
-		<string>applinks:apps.wordpress.com</string>
 	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
+	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
@@ -7,8 +7,6 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
-		<string>applinks:wordpress.com</string>
-		<string>applinks:apps.wordpress.com</string>
 	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease-Internal.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Internal.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
+	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease-Internal.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Internal.entitlements
@@ -7,8 +7,6 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
-		<string>applinks:wordpress.com</string>
-		<string>applinks:apps.wordpress.com</string>
 	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease.entitlements
+++ b/WordPress/Jetpack/JetpackRelease.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
+	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease.entitlements
+++ b/WordPress/Jetpack/JetpackRelease.entitlements
@@ -7,8 +7,6 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
-		<string>applinks:wordpress.com</string>
-		<string>applinks:apps.wordpress.com</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Adds `webcredentials:wordpress.com` as an associated domain so password autofill works with the Jetpack app.

### To test

1. Delete Jetpack
2. Install it (on the device - please use AppCenter)
3. Login using WP.com
4. You should see an option to fill the field with your WP.com login

<img src="https://user-images.githubusercontent.com/7040243/117365819-3d32d100-ae96-11eb-90fa-3dd72aac2b7a.png" width="300">


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
