### PR TITLE
Comments: Reorder spam and trash filtes.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Filters.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Filters.swift
@@ -5,8 +5,8 @@ extension CommentsViewController {
         case pending
         case unreplied
         case approved
-        case trashed
         case spam
+        case trashed
 
         var title: String {
             switch self {
@@ -14,8 +14,8 @@ extension CommentsViewController {
             case .pending: return NSLocalizedString("Pending", comment: "Title of pending Comments filter.")
             case .unreplied: return NSLocalizedString("Unreplied", comment: "Title of unreplied Comments filter.")
             case .approved: return NSLocalizedString("Approved", comment: "Title of approved Comments filter.")
-            case .trashed: return NSLocalizedString("Trashed", comment: "Title of trashed Comments filter.")
             case .spam: return NSLocalizedString("Spam", comment: "Title of spam Comments filter.")
+            case .trashed: return NSLocalizedString("Trashed", comment: "Title of trashed Comments filter.")
             }
         }
 
@@ -25,8 +25,8 @@ extension CommentsViewController {
             case .pending: return CommentStatusFilterUnapproved
             case .unreplied: return CommentStatusFilterAll
             case .approved: return CommentStatusFilterApproved
-            case .trashed: return CommentStatusFilterTrash
             case .spam: return CommentStatusFilterSpam
+            case .trashed: return CommentStatusFilterTrash
             }
         }
     }


### PR DESCRIPTION
This PR switches the position of the spam and trashed comment filters. 
After a brief conversation with @mattmiklic about the order of items in the list of filters we decided to switch the order of the spam and trashed filters to be consistent with the web and Android.
See slack-p1620316756147300-hummingbird for more context.

Example: 
<img width="421" alt="Screen Shot 2021-05-06 at 8 44 45 PM" src="https://user-images.githubusercontent.com/1435271/117386902-5bf09200-aead-11eb-854f-78d846c92ef5.png">

To test:
Build the app. Confirm that spam precedes trash in the comment filters.

@ScoutHarris would you kindly?

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
