### PR TITLE
Prevent freezing when the app becomes active

### DIFF
--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -176,6 +176,8 @@ extern NSString *const WPBlogUpdatedNotification;
 
 - (NSArray *)blogsWithPredicate:(NSPredicate *)predicate;
 
+- (NSInteger)blogCountWithPredicate:(NSPredicate *)predicate;
+
 /**
  Returns every stored blog, arranged in a Dictionary by blogId.
  */

--- a/WordPress/Classes/Utility/Editor/GutenbergRollout.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergRollout.swift
@@ -29,7 +29,7 @@ struct GutenbergRollout {
     }
 
     private func atLeastOneSiteHasAztecEnabled() -> Bool {
-        let allBlogs = BlogService(managedObjectContext: context).blogsForAllAccounts()
-        return allBlogs.contains { $0.editor == .aztec }
+        let predicate = NSPredicate(format: "mobileEditor == %@", "aztec")
+        return BlogService(managedObjectContext: context).blogCount(with: predicate) > 0
     }
 }

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -41,7 +41,7 @@ class GutenbergSettings {
     }
 
     convenience init() {
-        self.init(database: UserDefaults() as KeyValueDatabase)
+        self.init(database: UserDefaults.standard as KeyValueDatabase)
     }
 
     // MARK: Public accessors


### PR DESCRIPTION
Every time the app becomes active, it calls `GuttenbergSettings.performGutenbergPhase2MigrationIfNeeded()`. One of the things this method does is go through all sites and check if there's any with Aztec as its editor.

I've been noticing the app randomly freezing when becoming active and I think this is the cause:
- `GutenbergSettings` will instantiate a new `UserDefaults` every time it initializes. This doesn't take a lot of time, but when you do it once for each of my 100+ blogs, it adds up.
- Each `Blog` will instantiate its own `GutenbergSettings` to check, even though it's all being called from a `GutenbergSettings` method.

To improve this I suggest a couple of things in this PR:

1. Make `GutenbergSettings` use `UserDefaults.standard` instead of initializing a new one each time.
2. Use a fetch request to find if there are any blogs with Aztec instead of iterating through each one. This differs from the existing implementation as the current one will autoenable Gutenberg for each blog that didn't have a set value. I'm not sure what the impact of this would be.

I'm not following the code completely, but it looks like the rollout is at 100%, so maybe the simplest alternative is to remove this logic completely and enable Gutenberg for everyone?

To test:

I don't fully understand the current desired logic for the rollout, so I'm not sure exactly what to test. Take this as a suggestion (with code) to improve performance of the existing implementation.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
