### PR TITLE
Like Notifications: Dynamic user profile sheet height on iPhone.

### DIFF
--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -57,6 +57,7 @@ extension UserProfileSheetViewController: DrawerPresentable {
             return .maxHeight
         }
 
+        // Force the table layout to update so the Bottom Sheet gets the right height.
         tableView.layoutIfNeeded()
         return .intrinsicHeight
     }

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -12,8 +12,6 @@ class UserProfileSheetViewController: UITableViewController {
         return DefaultContentCoordinator(controller: self, context: mainContext)
     }()
 
-    private let contentSizeKeyPath = "contentSize"
-
     // MARK: - Init
 
     init(user: LikeUser) {
@@ -31,28 +29,10 @@ class UserProfileSheetViewController: UITableViewController {
         super.viewDidLoad()
         configureTable()
         registerTableCells()
-
-        tableView.addObserver(self, forKeyPath: contentSizeKeyPath, options: .new, context: nil)
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        tableView.removeObserver(self, forKeyPath: contentSizeKeyPath)
-        super.viewWillDisappear(animated)
-    }
-
-    // Update preferredContentSize when the table size changes
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
-        guard keyPath == contentSizeKeyPath else {
-            super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
-            return
-        }
-
-        guard !UIDevice.isPad(),
-              let newSize = change?[.newKey] as? CGSize else {
-            return
-        }
-
-        preferredContentSize = newSize
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         presentedVC?.presentedView?.layoutIfNeeded()
     }
 


### PR DESCRIPTION
Ref: #16244 

The user profile sheet height on iPhone is now dynamic, and is sized per the table content.

---
To test:

iPhone:
- Go to Notifications > Likes.
- Select users with different pieces of information. Examples:
  - Has preferred site and bio.
  - No preferred site.
  - No bio.
- Verify the user profile sheet height accommodates. 

iPad:
- Verify the user profile sheet height has not changed, and is consistent.

---
| Has Both | No Bio | No Site |
|--------|-------|-------|
| ![has_both](https://user-images.githubusercontent.com/1816888/117500419-da931100-af39-11eb-9080-93f430924315.png) | ![no_bio](https://user-images.githubusercontent.com/1816888/117500440-e1218880-af39-11eb-8ba4-be31167bd700.png) | ![no_site](https://user-images.githubusercontent.com/1816888/117500453-e67ed300-af39-11eb-8ee8-f9885bae32c6.png) |

---
## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
