### PR TITLE
Fix audio file upload issues for audio block and from media library

### DIFF
--- a/WordPress/Classes/Utility/Media/MediaURLExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaURLExporter.swift
@@ -77,9 +77,10 @@ class MediaURLExporter: MediaExporter {
     ///
     func exportURL(fileURL: URL, onCompletion: @escaping OnMediaExport, onError: @escaping OnExportError) -> Progress {
         // Verify the export is permissible
-        if let fileExtension = fileURL.typeIdentifierFileExtension {
+        if let urlExportOptions = urlOptions, let fileExtension = fileURL.typeIdentifierFileExtension {
             // Check the default file types. We want to limit to supported types but mobile is not restricted to only allowed ones.
-            if !MediaImportService.defaultAllowableFileExtensions.contains(fileExtension) {
+            // `allowableFileExtensions` can be empty for self-hosted sites
+            if !MediaImportService.defaultAllowableFileExtensions.contains(fileExtension) && !urlExportOptions.allowableFileExtensions.isEmpty && !urlExportOptions.allowableFileExtensions.contains(fileExtension) {
                 onError(exporterErrorWith(error: URLExportError.unsupportedFileType))
                 return Progress.discreteCompletedProgress()
             }


### PR DESCRIPTION
Fixes audio file upload issues for audio block and from media library
Could "potentially fix" https://github.com/wordpress-mobile/WordPress-iOS/issues/16068 as well.

<sup>internal reference: p5T066-2fh-p2#comment-8147</sup>

To test:

Try to upload an .mp3 file:
1. Using Audio block in the editor
2. Through the media library

Try on different sites:
1. Personal plan
2. Business plan (atomic)
3. Self-hosted without Jetpack
4. Self-hosted with Jetpack

@bjtitus This change [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/15980/files#r583359092) in that PR seems to have caused some of the issues uploading audio files in the block editor using Audio block and also through media library. Do you think Stories could be affected by this change? 

## Regression Notes
1. Potential unintended areas of impact

- Media upload for Stories

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- Tested uploading a video from Stories

3. What automated tests I added (or what prevented me from doing so)

- I didn't add any. I saw that there are automated tests for adding an Image block, but it seems like it's relying on the example images that are already on the device and using the basic album/photo picker. Doing the same thing for Audio block would require first figuring out how to put an audio file on the simulator/device and then figuring out how to pick that file using the complicated iOS file browser interface during the automated test, which might require substantial amount of effort.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
