### PR TITLE
Like Notications: update tracks when site viewed from user profile

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -167,6 +167,9 @@ import Foundation
     case userProfileSheetShown
     case userProfileSheetSiteShown
 
+    // Blog preview by URL (that is, in a WebView)
+    case blogUrlPreviewed
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -457,6 +460,10 @@ import Foundation
             return "user_profile_sheet_shown"
         case .userProfileSheetSiteShown:
             return "user_profile_sheet_site_shown"
+
+        // Blog preview by URL (that is, in a WebView)
+        case .blogUrlPreviewed:
+            return "blog_url_previewed"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -185,7 +185,7 @@ import WordPressFlux
     /// Indicates where the view was shown from.
     enum StatSource: String {
         case reader
-        case user_profile
+        case notif_like_list_user_profile
     }
     var statSource: StatSource = .reader
 

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -3,6 +3,7 @@ class UserProfileSheetViewController: UITableViewController {
     // MARK: - Properties
 
     private let user: LikeUser
+    private let statSource = ReaderStreamViewController.StatSource.notif_like_list_user_profile
 
     private lazy var mainContext = {
         return ContextManager.sharedInstance().mainContext
@@ -144,13 +145,12 @@ private extension UserProfileSheetViewController {
 
     func showSiteTopicWithID(_ siteID: NSNumber) {
         let controller = ReaderStreamViewController.controllerWithSiteID(siteID, isFeed: false)
-        controller.statSource = ReaderStreamViewController.StatSource.user_profile
+        controller.statSource = statSource
         let navController = UINavigationController(rootViewController: controller)
         present(navController, animated: true)
     }
 
     func showSiteWebView(withUrl url: String?) {
-
         guard let urlString = url,
               !urlString.isEmpty,
               let siteURL = URL(string: urlString) else {
@@ -158,8 +158,9 @@ private extension UserProfileSheetViewController {
             return
         }
 
-    contentCoordinator.displayWebViewWithURL(siteURL)
-}
+        WPAnalytics.track(.blogUrlPreviewed, properties: ["source": statSource.rawValue])
+        contentCoordinator.displayWebViewWithURL(siteURL)
+    }
 
     func configureTable() {
         tableView.backgroundColor = .basicBackground


### PR DESCRIPTION
Ref: #15662 

This updates the events tracked when a user profile site is viewed to match the [Android](https://github.com/wordpress-mobile/WordPress-Android/pull/14525) events.

To test:

Internal site viewed:
- Go to Notifications > Likes.
- Select a user with an internal site, and tap the site.
- Verify this is logged:
`🔵 Tracked: reader_blog_previewed <site: site_name, source: notif_like_list_user_profile, subscription_count: 666>`

External site viewed:
- Go to Notifications > Likes.
- Select a user with an external site, and tap the site.
- Verify this is logged:
`🔵 Tracked: blog_url_previewed <source: notif_like_list_user_profile>`


## Regression Notes
1. Potential unintended areas of impact
N/A.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
