### PR TITLE
Jetpack App (Emphasis): Update Jetpack screenshots

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -358,9 +358,9 @@ end
 ## ===================
 ##
 def wordpress_mocks
-  pod 'WordPressMocks', '~> 0.0.9'
+  # pod 'WordPressMocks', '~> 0.0.9'
   # pod 'WordPressMocks', :git => 'https://github.com/wordpress-mobile/WordPressMocks.git', :commit => ''
-  # pod 'WordPressMocks', :git => 'https://github.com/wordpress-mobile/WordPressMocks.git', :branch => ''
+  pod 'WordPressMocks', :git => 'https://github.com/wordpress-mobile/WordPressMocks.git', :branch => 'task/jetpack-screenshots'
   # pod 'WordPressMocks', :path => '../WordPressMocks'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -360,7 +360,7 @@ end
 def wordpress_mocks
   # pod 'WordPressMocks', '~> 0.0.9'
   # pod 'WordPressMocks', :git => 'https://github.com/wordpress-mobile/WordPressMocks.git', :commit => ''
-  pod 'WordPressMocks', :git => 'https://github.com/wordpress-mobile/WordPressMocks.git', :branch => 'task/jetpack-screenshots'
+  pod 'WordPressMocks', :git => 'https://github.com/wordpress-mobile/WordPressMocks.git', :branch => 'task/add-jetpack-screenshot-stubs'
   # pod 'WordPressMocks', :path => '../WordPressMocks'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -500,7 +500,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.37.0)
   - WordPressKit (~> 4.32.0)
-  - WordPressMocks (from `https://github.com/wordpress-mobile/WordPressMocks.git`, branch `task/jetpack-screenshots`)
+  - WordPressMocks (from `https://github.com/wordpress-mobile/WordPressMocks.git`, branch `task/add-jetpack-screenshot-stubs`)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.10.0)
   - WPMediaPicker (~> 1.7.2)
@@ -651,7 +651,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.52.1
   WordPressMocks:
-    :branch: task/jetpack-screenshots
+    :branch: task/add-jetpack-screenshot-stubs
     :git: https://github.com/wordpress-mobile/WordPressMocks.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.52.1/third-party-podspecs/Yoga.podspec.json
@@ -669,7 +669,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.52.1
   WordPressMocks:
-    :commit: 0355d30e1417d57416df605ca662120a14790692
+    :commit: b70df51e5b78d1639257d6f4105d892e658e246e
     :git: https://github.com/wordpress-mobile/WordPressMocks.git
 
 SPEC CHECKSUMS:
@@ -753,7 +753,7 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 2674c56cad016118fb4725b866b380b612db66fc
   WordPressKit: 8094512e5498e5df57b52dae507a850fc0b38b18
-  WordPressMocks: cdb4647ae7a0ec35875e021f3d4ea061bd0dfcc5
+  WordPressMocks: 4ace035ba0d8e9127491842a124749db548176e4
   WordPressShared: 0f7f10e96f8354d64f951c223ae61e8de7495a46
   WordPressUI: 7735014eb5a518a8346b1179b36ba77abcb49ee5
   WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
@@ -768,6 +768,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 26916cc8eef1ad92ffcb797b648d117f114c8cd7
+PODFILE CHECKSUM: e8b9b12afff7caa083680bd015d54c1c4bf66f1e
 
 COCOAPODS: 1.10.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -408,7 +408,7 @@ PODS:
     - UIDeviceIdentifier (~> 1.4)
     - WordPressShared (~> 1.15-beta)
     - wpxmlrpc (~> 0.9)
-  - WordPressMocks (0.0.9)
+  - WordPressMocks (0.0.10-beta.1)
   - WordPressShared (1.16.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
@@ -500,7 +500,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.37.0)
   - WordPressKit (~> 4.32.0)
-  - WordPressMocks (~> 0.0.9)
+  - WordPressMocks (from `https://github.com/wordpress-mobile/WordPressMocks.git`, branch `task/jetpack-screenshots`)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.10.0)
   - WPMediaPicker (~> 1.7.2)
@@ -552,7 +552,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressKit
-    - WordPressMocks
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -651,6 +650,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.52.1
+  WordPressMocks:
+    :branch: task/jetpack-screenshots
+    :git: https://github.com/wordpress-mobile/WordPressMocks.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.52.1/third-party-podspecs/Yoga.podspec.json
 
@@ -666,6 +668,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.52.1
+  WordPressMocks:
+    :commit: 0355d30e1417d57416df605ca662120a14790692
+    :git: https://github.com/wordpress-mobile/WordPressMocks.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -748,7 +753,7 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 2674c56cad016118fb4725b866b380b612db66fc
   WordPressKit: 8094512e5498e5df57b52dae507a850fc0b38b18
-  WordPressMocks: 903d2410f41a09fb2e0a1b44ad36ad80310570fb
+  WordPressMocks: cdb4647ae7a0ec35875e021f3d4ea061bd0dfcc5
   WordPressShared: 0f7f10e96f8354d64f951c223ae61e8de7495a46
   WordPressUI: 7735014eb5a518a8346b1179b36ba77abcb49ee5
   WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
@@ -763,6 +768,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: a789aefd75489c964d28b1e31eae71bee0baaf7b
+PODFILE CHECKSUM: 26916cc8eef1ad92ffcb797b648d117f114c8cd7
 
 COCOAPODS: 1.10.0

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -35,7 +35,7 @@ class JetpackScreenshotGeneration: XCTestCase {
         // Get My Site screenshot
         let mySite = MySiteScreen()
             .showSiteSwitcher()
-            .switchToSite(withTitle: "pressable-jetpack-complete.mystagingwebsite.com")
+            .switchToSite(withTitle: "yourjetpack.blog")
             .thenTakeScreenshot(1, named: "MySite")
 
         // Get Activity Log screenshot

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -34,6 +34,8 @@ class JetpackScreenshotGeneration: XCTestCase {
 
         // Get My Site screenshot
         let mySite = MySiteScreen()
+            .showSiteSwitcher()
+            .switchToSite(withTitle: "pressable-jetpack-complete.mystagingwebsite.com")
             .thenTakeScreenshot(1, named: "MySite")
 
         // Get Activity Log screenshot


### PR DESCRIPTION
Part of #16395
Follow-on to https://github.com/wordpress-mobile/WordPress-iOS/pull/16396

## Description

This PR updates the JetpackScreenshotGeneration target.
- Added new stubs to WordPressMocks (https://github.com/wordpress-mobile/WordPressMocks/pull/25)
- Updated the My Site screenshot flow to switch to a site with Jetpack Scan / Backup capabilites turned on

Design ref: pcdRpT-n0-p2

## How to test
1. Switch to the `JetpackScreenshotGeneration` target
2. Run `rake mocks` to start a local mock server for UI tests
3. ✅ Make sure that `testGenerateScreenshots()` succeeds

My Site | Activity Log | Jetpack Scan | Jetpack Backup | Stats
-- | -- | -- | -- | --
![Simulator Screen Shot - iPhone 12 Pro - 2021-05-10 at 15 05 21](https://user-images.githubusercontent.com/6711616/117614333-23013780-b1a3-11eb-9019-819bb846221f.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-10 at 15 05 42](https://user-images.githubusercontent.com/6711616/117614338-24326480-b1a3-11eb-842d-623b998e7339.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-10 at 15 05 52](https://user-images.githubusercontent.com/6711616/117614339-24326480-b1a3-11eb-87bc-04a84e437b07.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-10 at 15 06 04](https://user-images.githubusercontent.com/6711616/117614343-25639180-b1a3-11eb-8eeb-1f25be5006b4.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-10 at 15 06 21](https://user-images.githubusercontent.com/6711616/117614345-25fc2800-b1a3-11eb-9001-c57b4c159b9a.png)



## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.