### PR TITLE
RequestAuthenticator: Remove error logging for timeouts

### DIFF
--- a/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
+++ b/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
@@ -153,9 +153,9 @@ class RequestAuthenticator: NSObject {
 
         authenticationService.loadAuthCookiesForSelfHosted(into: cookieJar, loginURL: loginURL, username: username, password: password, success: {
             done()
-        }) { error in
+        }) { [weak self] error in
             // Make sure this error scenario isn't silently ignored.
-            WordPressAppDelegate.crashLogging?.logError(error)
+            self?.logErrorIfNeeded(error)
 
             // Even if getting the auth cookies fail, we'll still try to load the URL
             // so that the user sees a reasonable error situation on screen.
@@ -183,9 +183,9 @@ class RequestAuthenticator: NSObject {
 
         authenticationService.loadAuthCookies(into: cookieJar, username: username, siteID: siteID, success: {
             done()
-        }) { error in
+        }) { [weak self] error in
             // Make sure this error scenario isn't silently ignored.
-            WordPressAppDelegate.crashLogging?.logError(error)
+            self?.logErrorIfNeeded(error)
 
             // Even if getting the auth cookies fail, we'll still try to load the URL
             // so that the user sees a reasonable error situation on screen.
@@ -213,9 +213,9 @@ class RequestAuthenticator: NSObject {
 
         authenticationService.loadAuthCookiesForWPCom(into: cookieJar, username: username, authToken: authToken, success: {
             done()
-        }) { error in
+        }) { [weak self] error in
             // Make sure this error scenario isn't silently ignored.
-            WordPressAppDelegate.crashLogging?.logError(error)
+            self?.logErrorIfNeeded(error)
 
             // Even if getting the auth cookies fail, we'll still try to load the URL
             // so that the user sees a reasonable error situation on screen.
@@ -259,9 +259,9 @@ class RequestAuthenticator: NSObject {
 
         authenticationService.loadAuthCookiesForWPCom(into: cookieJar, username: username, authToken: authToken, success: {
             done()
-        }) { error in
+        }) { [weak self] error in
             // Make sure this error scenario isn't silently ignored.
-            WordPressAppDelegate.crashLogging?.logError(error)
+            self?.logErrorIfNeeded(error)
 
             // Even if getting the auth cookies fail, we'll still try to load the URL
             // so that the user sees a reasonable error situation on screen.
@@ -280,15 +280,26 @@ class RequestAuthenticator: NSObject {
 
         authenticationService.loadAuthCookiesForWPCom(into: cookieJar, username: username, authToken: authToken, success: {
             done()
-        }) { error in
+        }) { [weak self] error in
             // Make sure this error scenario isn't silently ignored.
-            WordPressAppDelegate.crashLogging?.logError(error)
+            self?.logErrorIfNeeded(error)
 
             // Even if getting the auth cookies fail, we'll still try to load the URL
             // so that the user sees a reasonable error situation on screen.
             // We could opt to create a special screen but for now I'd rather users report
             // the issue when it happens.
             done()
+        }
+    }
+
+    private func logErrorIfNeeded(_ error: Swift.Error) {
+        let nsError = error as NSError
+
+        switch nsError.code {
+        case NSURLErrorTimedOut, NSURLErrorNotConnectedToInternet:
+            return
+        default:
+            WordPressAppDelegate.crashLogging?.logError(error)
         }
     }
 }


### PR DESCRIPTION
This PR prevents logging errors to Sentry for timeout and no internet connection errors in RequestAuthenticator. We had many of these events showing up in Sentry, but they're generally just down to the user's connectivity, and it's not really anything we can action ourselves. So, it makes sense to stop reporting them.

**To test**

- Add a breakpoint into `logErrorIfNeeded` in `RequestAuthenticator`
- Build and run
- Open a webview which should trigger one of these methods. I was able to trigger it by disabling wifi on my device and navigating into a Reader post.
- Ensure that the logError call doesn't happen due to the timeout or no internet connection error code.

## Regression Notes

1. Potential unintended areas of impact

None, the changes are very localized around this specific error scenario.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
