### PR TITLE
Changed the quick action button coloring.

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -264,6 +264,32 @@ extension UIColor {
         return UIColor(light: .white, dark: .black)
     }
 
+    // MARK: - Quick Action Buttons
+
+    static var quickActionButtonBackground: UIColor {
+        guard Feature.enabled(.newNavBarAppearance) else {
+            return .secondaryButtonBackground
+        }
+
+        return .clear
+    }
+
+    static var quickActionButtonBorder: UIColor {
+        guard Feature.enabled(.newNavBarAppearance) else {
+            return .secondaryButtonBorder
+        }
+
+        return .systemGray3
+    }
+
+    static var quickActionSelectedBackground: UIColor {
+        guard Feature.enabled(.newNavBarAppearance) else {
+            return .secondaryButtonDownBackground
+        }
+
+        return UIColor(light: .black, dark: .white).withAlphaComponent(0.2)
+    }
+
     // MARK: - Others
 
     static var preformattedBackground: UIColor {

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -287,7 +287,7 @@ extension UIColor {
             return .secondaryButtonDownBackground
         }
 
-        return UIColor(light: .black, dark: .white).withAlphaComponent(0.2)
+        return UIColor(light: .black, dark: .white).withAlphaComponent(0.17)
     }
 
     // MARK: - Others

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/ActionRow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/ActionRow.swift
@@ -3,9 +3,9 @@ class ActionButton: UIView {
     private enum Constants {
         static let maxButtonSize: CGFloat = 56
         static let spacing: CGFloat = 8
-        static let borderColor = UIColor.secondaryButtonBorder
-        static let backgroundColor = UIColor.secondaryButtonBackground
-        static let selectedBackgroundColor = UIColor.secondaryButtonDownBackground
+        static let borderColor = UIColor.quickActionButtonBorder
+        static let backgroundColor = UIColor.quickActionButtonBackground
+        static let selectedBackgroundColor = UIColor.quickActionSelectedBackground
         static let iconColor = UIColor.listIcon
     }
 


### PR DESCRIPTION
Addresses the issue reported here: https://github.com/wordpress-mobile/WordPress-iOS/issues/15750#issuecomment-832564747

## To test:

You should test this PR with the `newNavBarAppearance` flag ON, which is the default.  That said, setting that flag OFF should also maintain the previous appearance.

1. Go the "My Site" tab.
2. Check that the quick action buttons have the same background color as the view they're in.
3. Keep your finger on any of the buttons and make sure the "activated" color is different and looks good.

## Regression Notes
1. Potential unintended areas of impact

This PR could potentially break the quick action buttons coloring when the `newNavBarAppearance` flag is OFF.

That said, it would not be a big deal as this flag is ON for all our users, and I don't know of any plans to go back to the previous UI.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested setting the flag OFF and the buttons look good.

3. What automated tests I added (or what prevented me from doing so)

None, since it's really hard to test for this, and since the flag is staying ON as far as I'm aware.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
