### PR TITLE
Add Search step to Follow Other Sites Quick Start tour

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 17.4
 -----
 * [**] A new author can be chosen for Posts and Pages on multi-author sites. [#16281]
+* [*] Fixed the Follow Sites Quick Start Tour so that Reader Search is highlighted. [#16391]
 
 
 17.3

--- a/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
@@ -9,8 +9,7 @@ class SpotlightableButton: UIButton, Spotlightable {
     var spotlight: QuickStartSpotlightView?
     var originalTitle: String?
 
-    /// The default offset is (-10, 0).
-    /// If this property is set, the default will be overridden.
+    /// If this property is set, the default offset will be overridden.
     ///
     var spotlightOffset: UIOffset?
     private var spotlightXConstraint: NSLayoutConstraint?
@@ -73,10 +72,10 @@ class SpotlightableButton: UIButton, Spotlightable {
         let newSpotlightHeight = spotlightView.heightAnchor.constraint(equalToConstant: Constants.spotlightDiameter)
 
         NSLayoutConstraint.activate([
-                                        spotlightXConstraint,
-                                        spotlightYConstraint,
-                                        newSpotlightWidth,
-                                        newSpotlightHeight
+            spotlightXConstraint,
+            spotlightYConstraint,
+            newSpotlightWidth,
+            newSpotlightHeight
         ])
 
         spotlight = spotlightView

--- a/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
@@ -9,6 +9,13 @@ class SpotlightableButton: UIButton, Spotlightable {
     var spotlight: QuickStartSpotlightView?
     var originalTitle: String?
 
+    /// The default offset is (-10, 0).
+    /// If this property is set, the default will be overridden.
+    ///
+    var spotlightOffset: UIOffset?
+    private var spotlightXConstraint: NSLayoutConstraint?
+    private var spotlightYConstraint: NSLayoutConstraint?
+
     var shouldShowSpotlight: Bool {
         get {
             spotlight != nil
@@ -55,17 +62,35 @@ class SpotlightableButton: UIButton, Spotlightable {
         addSubview(spotlightView)
         spotlightView.translatesAutoresizingMaskIntoConstraints = false
 
-        let newSpotlightCenterX = spotlightView.centerXAnchor.constraint(equalTo: self.leadingAnchor, constant: Constants.leftOffset)
-        let newSpotlightCenterY = spotlightView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        let spotlightXConstraint = spotlightView.centerXAnchor.constraint(equalTo: leadingAnchor)
+        let spotlightYConstraint = spotlightView.centerYAnchor.constraint(equalTo: centerYAnchor)
+
+        self.spotlightXConstraint = spotlightXConstraint
+        self.spotlightYConstraint = spotlightYConstraint
+        updateConstraintConstants()
+
         let newSpotlightWidth = spotlightView.widthAnchor.constraint(equalToConstant: Constants.spotlightDiameter)
         let newSpotlightHeight = spotlightView.heightAnchor.constraint(equalToConstant: Constants.spotlightDiameter)
 
-        NSLayoutConstraint.activate([newSpotlightCenterX, newSpotlightCenterY, newSpotlightWidth, newSpotlightHeight])
+        NSLayoutConstraint.activate([
+                                        spotlightXConstraint,
+                                        spotlightYConstraint,
+                                        newSpotlightWidth,
+                                        newSpotlightHeight
+        ])
+
         spotlight = spotlightView
+    }
+
+    private func updateConstraintConstants() {
+        let offset = spotlightOffset ?? Constants.defaultOffset
+
+        spotlightXConstraint?.constant = offset.horizontal
+        spotlightYConstraint?.constant = offset.vertical
     }
 
     private enum Constants {
         static let spotlightDiameter: CGFloat = 40
-        static let leftOffset: CGFloat = -10
+        static let defaultOffset = UIOffset(horizontal: -10, vertical: 0)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -223,11 +223,6 @@ open class QuickStartTourGuide: NSObject {
         }
         currentTourState = nextStep
 
-        // Don't show a notice for the step after readerTab
-        if element == .readerTab {
-            return
-        }
-
         showCurrentStep()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -11,7 +11,7 @@ class ReaderTabViewController: UIViewController {
         return makeReaderTabView(viewModel)
     }()
 
-    private var searchButton: SpotlightableButton?
+    private let searchButton: SpotlightableButton = SpotlightableButton(type: .custom)
 
     init(viewModel: ReaderTabViewModel, readerTabViewFactory: @escaping (ReaderTabViewModel) -> ReaderTabView) {
         self.viewModel = viewModel
@@ -55,7 +55,7 @@ class ReaderTabViewController: UIViewController {
 
         WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
 
-        searchButton?.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.readerSearch)
+        searchButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.readerSearch)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -73,12 +73,10 @@ class ReaderTabViewController: UIViewController {
         settingsButton.accessibilityIdentifier = ReaderTabConstants.settingsButtonIdentifier
 
         // Search Button
-        let searchButton = SpotlightableButton(type: .custom)
         searchButton.spotlightOffset = UIOffset(horizontal: 20, vertical: -10)
         searchButton.setImage(.gridicon(.search), for: .normal)
         searchButton.addTarget(self, action: #selector(didTapSearchButton), for: .touchUpInside)
         searchButton.accessibilityIdentifier = ReaderTabConstants.searchButtonAccessibilityIdentifier
-        self.searchButton = searchButton
 
         let searchBarButton = UIBarButtonItem(customView: searchButton)
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Gridicons
 
 class ReaderTabViewController: UIViewController {
 
@@ -9,6 +10,8 @@ class ReaderTabViewController: UIViewController {
     private lazy var readerTabView: ReaderTabView = {
         return makeReaderTabView(viewModel)
     }()
+
+    private var searchButton: SpotlightableButton?
 
     init(viewModel: ReaderTabViewModel, readerTabViewFactory: @escaping (ReaderTabViewModel) -> ReaderTabView) {
         self.viewModel = viewModel
@@ -51,6 +54,8 @@ class ReaderTabViewController: UIViewController {
         ReaderTracker.shared.start(.main)
 
         WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
+
+        searchButton?.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.readerSearch)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -68,11 +73,16 @@ class ReaderTabViewController: UIViewController {
         settingsButton.accessibilityIdentifier = ReaderTabConstants.settingsButtonIdentifier
 
         // Search Button
-        let searchButton = UIBarButtonItem(barButtonSystemItem: .search,
-                                           target: self,
-                                           action: #selector(didTapSearchButton))
+        let searchButton = SpotlightableButton(type: .custom)
+        searchButton.spotlightOffset = UIOffset(horizontal: 20, vertical: -10)
+        searchButton.setImage(.gridicon(.search), for: .normal)
+        searchButton.addTarget(self, action: #selector(didTapSearchButton), for: .touchUpInside)
         searchButton.accessibilityIdentifier = ReaderTabConstants.searchButtonAccessibilityIdentifier
-        navigationItem.rightBarButtonItems = [searchButton, settingsButton]
+        self.searchButton = searchButton
+
+        let searchBarButton = UIBarButtonItem(customView: searchButton)
+
+        navigationItem.rightBarButtonItems = [searchBarButton, settingsButton]
     }
 
     override func loadView() {


### PR DESCRIPTION
Fixes #16391. This PR enables the Search step for the 'follow other sites' Quick Start tour, by allowing the search button to be spotlightable.

![reader-search](https://user-images.githubusercontent.com/4780/117712772-aa16d580-b1cc-11eb-8f13-b45b10d9f304.gif)

**To test**

- Build and run
- Using the Me > App Settings > Debug menu, enable Quick Start for a site
- Tap on the Grow Your Audience quick start list and then Follow Other Sites
- Follow the steps to complete the tour, and ensure that it is checked off
- Also begin the Site title tour and ensure the spotlight is correctly placed just to the left of the site title. This is the only other place that uses SpotlightableButton.

## Regression Notes
1. Potential unintended areas of impact

To improve the appearance of the spotlight image, I added an optional offset to Spotlightable button. The only other place that uses this button is the site title tour.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I verified that the site title tour still looked as expected.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
