### PR TITLE
Jetpack App: Adds support for magic links

### DIFF
--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -26,7 +26,7 @@ class WindowManager: NSObject {
     /// Shows the initial UI for the App to be shown right after launch.  This method will present the sign-in flow if the user is not
     /// authenticated, or the actuall App UI if the user is already authenticated.
     ///
-    func showUI() {
+    public func showUI() {
         if AccountHelper.isLoggedIn {
             showAppUI()
         } else {
@@ -55,7 +55,7 @@ class WindowManager: NSObject {
 
     /// Shows the UI for authenticated users.
     ///
-    private func showAppUI(completion: Completion? = nil) {
+    func showAppUI(completion: Completion? = nil) {
         isShowingFullscreenSignIn = false
 
         show(WPTabBarController.sharedInstance(), completion: completion)
@@ -77,7 +77,7 @@ class WindowManager: NSObject {
     /// Shows the specified VC as the root VC for the managed window.  Takes care of animating the transition whenever the existing
     /// root VC isn't `nil` (this is because a `nil` VC means we're showing the initial VC on a call to this method).
     ///
-    private func show(_ viewController: UIViewController, completion: Completion?) {
+    func show(_ viewController: UIViewController, completion: Completion?) {
         // When the App is launched, the root VC will be `nil`.
         // When this is the case we'll simply show the VC without any type of animation.
         guard window.rootViewController != nil else {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -24,7 +24,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
             fatalError("The App cannot run without a window.")
         }
 
-        return WindowManager(window: window)
+        return AppDependency.windowManager(window: window)
     }()
 
     var analytics: WPAppAnalytics?

--- a/WordPress/Classes/Utility/AccountHelper.swift
+++ b/WordPress/Classes/Utility/AccountHelper.swift
@@ -31,6 +31,13 @@ import Foundation
         return blogService.blogCountSelfHosted() == 0 && blogService.hasAnyJetpackBlogs() == false
     }
 
+    static var hasBlogs: Bool {
+        let context = ContextManager.sharedInstance().mainContext
+        let blogService = BlogService(managedObjectContext: context)
+
+        return blogService.blogCountForAllAccounts() > 0
+    }
+
     @objc static var noWordPressDotComAccount: Bool {
         return !AccountHelper.isDotcomAvailable()
     }

--- a/WordPress/Classes/Utility/App Configuration/AppDependency.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppDependency.swift
@@ -4,4 +4,8 @@ import Foundation
     static func authenticationManager(windowManager: WindowManager) -> WordPressAuthenticationManager {
         return WordPressAuthenticationManager(windowManager: windowManager)
     }
+
+    static func windowManager(window: UIWindow) -> WindowManager {
+        return WindowManager(window: window)
+    }
 }

--- a/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
+++ b/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
@@ -3,7 +3,7 @@ import WordPressAuthenticator
 protocol AuthenticationHandler {
     func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void)
 
-    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void) -> Bool
+    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void, windowManager: WindowManager) -> Bool
 
     // WPAuthenticator style overrides
     var statusBarStyle: UIStatusBarStyle { get }

--- a/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
+++ b/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
@@ -3,7 +3,7 @@ import WordPressAuthenticator
 protocol AuthenticationHandler {
     func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void)
 
-    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void, windowManager: WindowManager) -> Bool
+    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, windowManager: WindowManager, onDismiss: @escaping () -> Void) -> Bool
 
     // WPAuthenticator style overrides
     var statusBarStyle: UIStatusBarStyle { get }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -315,7 +315,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     ///
     func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void) {
         if let authenticationHandler = authenticationHandler,
-           authenticationHandler.presentLoginEpilogue(in: navigationController, for: credentials, onDismiss: onDismiss, windowManager: windowManager) {
+           authenticationHandler.presentLoginEpilogue(in: navigationController, for: credentials, windowManager: windowManager, onDismiss: onDismiss) {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -315,7 +315,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     ///
     func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void) {
         if let authenticationHandler = authenticationHandler,
-           authenticationHandler.presentLoginEpilogue(in: navigationController, for: credentials, onDismiss: onDismiss) {
+           authenticationHandler.presentLoginEpilogue(in: navigationController, for: credentials, onDismiss: onDismiss, windowManager: windowManager) {
             return
         }
 

--- a/WordPress/Jetpack/AppDependency.swift
+++ b/WordPress/Jetpack/AppDependency.swift
@@ -4,4 +4,8 @@ import Foundation
     static func authenticationManager(windowManager: WindowManager) -> WordPressAuthenticationManager {
         return WordPressAuthenticationManager(windowManager: windowManager, authenticationHandler: JetpackAuthenticationManager())
     }
+
+    static func windowManager(window: UIWindow) -> WindowManager {
+        return JetpackWindowManager(window: window)
+    }
 }

--- a/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
+++ b/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
@@ -53,9 +53,14 @@ struct JetpackAuthenticationManager: AuthenticationHandler {
             return false
         }
 
+        // Exit out of the sign in process, if we don't do this we later can't
+        // display the sign in again
+        windowManager.dismissFullscreenSignIn()
+
+        // Display the no sites view
         let viewModel = JetpackNoSitesErrorViewModel()
         let controller = errorViewController(with: viewModel)
-        navigationController.pushViewController(controller, animated: true)
+        windowManager.show(controller, completion: nil)
 
         return true
     }
@@ -65,13 +70,6 @@ struct JetpackAuthenticationManager: AuthenticationHandler {
         return site.hasJetpack &&
             site.isJetpackConnected &&
             site.isJetpackActive
-    }
-
-    private func hasJetpackSites() -> Bool {
-        let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-
-        return blogService.blogCountForAllAccounts() > 0
     }
 
     private func errorViewController(with model: JetpackErrorViewModel) -> JetpackLoginErrorViewController {

--- a/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
+++ b/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
@@ -48,8 +48,8 @@ struct JetpackAuthenticationManager: AuthenticationHandler {
         onCompletion(authenticationResult)
     }
 
-    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void) -> Bool {
-        if hasJetpackSites() {
+    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void, windowManager: WindowManager) -> Bool {
+        if AccountHelper.hasBlogs {
             return false
         }
 

--- a/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
+++ b/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
@@ -48,7 +48,7 @@ struct JetpackAuthenticationManager: AuthenticationHandler {
         onCompletion(authenticationResult)
     }
 
-    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void, windowManager: WindowManager) -> Bool {
+    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, windowManager: WindowManager, onDismiss: @escaping () -> Void) -> Bool {
         if AccountHelper.hasBlogs {
             return false
         }

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+class JetpackWindowManager: WindowManager {
+}

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -1,4 +1,21 @@
 import Foundation
 
 class JetpackWindowManager: WindowManager {
+    override func showUI() {
+        // If the user is logged in and has blogs sync'd to their account
+        if AccountHelper.isLoggedIn && AccountHelper.hasBlogs {
+            showAppUI()
+            return
+        }
+
+        // Show the sign in UI if the user isn't logged in
+        guard AccountHelper.isLoggedIn else {
+            showSignInUI()
+            return
+        }
+
+        // If the user doesn't have any blogs, but they're still logged in, log them out
+        // the `logOutDefaultWordPressComAccount` method will trigger the `showSignInUI` automatically
+        AccountHelper.logOutDefaultWordPressComAccount()
+    }
 }

--- a/WordPress/Jetpack/Classes/ViewRelated/Login Error/JetpackLoginErrorViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/Login Error/JetpackLoginErrorViewController.swift
@@ -26,9 +26,6 @@ class JetpackLoginErrorViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Log the user out to prevent them being able to access the app after a restart
-        AccountHelper.logOutDefaultWordPressComAccount()
-
         configureImageView()
         configureDescriptionLabel()
         configurePrimaryButton()

--- a/WordPress/Jetpack/Classes/ViewRelated/Login Error/View Models/JetpackNoSitesErrorViewModel.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/Login Error/View Models/JetpackNoSitesErrorViewModel.swift
@@ -18,7 +18,7 @@ struct JetpackNoSitesErrorViewModel: JetpackErrorViewModel {
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        viewController?.navigationController?.popToRootViewController(animated: true)
+        AccountHelper.logOutDefaultWordPressComAccount()
     }
 
     private struct Constants {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -23192,7 +23192,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wpdebug;
+				WPCOM_SCHEME = jpdebug;
 			};
 			name = Debug;
 		};
@@ -23259,7 +23259,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wordpress;
+				WPCOM_SCHEME = jetpack;
 			};
 			name = Release;
 		};
@@ -23327,7 +23327,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wpinternal;
+				WPCOM_SCHEME = jpinternal;
 			};
 			name = "Release-Internal";
 		};
@@ -23395,7 +23395,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wpalpha;
+				WPCOM_SCHEME = jpalpha;
 			};
 			name = "Release-Alpha";
 		};

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1875,6 +1875,7 @@
 		C72A4F68264088E4009CA633 /* JetpackNotFoundErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72A4F67264088E4009CA633 /* JetpackNotFoundErrorViewModel.swift */; };
 		C72A4F7B26408943009CA633 /* JetpackNotWPErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72A4F7A26408943009CA633 /* JetpackNotWPErrorViewModel.swift */; };
 		C72A4F8E26408C73009CA633 /* JetpackNoSitesErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72A4F8D26408C73009CA633 /* JetpackNoSitesErrorViewModel.swift */; };
+		C72A52CF2649B158009CA633 /* JetpackWindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72A52CE2649B157009CA633 /* JetpackWindowManager.swift */; };
 		C73868C525C9F9820072532C /* JetpackScanThreatSectionGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73868C425C9F9820072532C /* JetpackScanThreatSectionGrouping.swift */; };
 		C768B5B425828A5D00556E75 /* JetpackScanStatusCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C768B5B225828A5D00556E75 /* JetpackScanStatusCell.swift */; };
 		C768B5B525828A5D00556E75 /* JetpackScanStatusCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C768B5B325828A5D00556E75 /* JetpackScanStatusCell.xib */; };
@@ -6468,6 +6469,7 @@
 		C72A4F67264088E4009CA633 /* JetpackNotFoundErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackNotFoundErrorViewModel.swift; sourceTree = "<group>"; };
 		C72A4F7A26408943009CA633 /* JetpackNotWPErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackNotWPErrorViewModel.swift; sourceTree = "<group>"; };
 		C72A4F8D26408C73009CA633 /* JetpackNoSitesErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackNoSitesErrorViewModel.swift; sourceTree = "<group>"; };
+		C72A52CE2649B157009CA633 /* JetpackWindowManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackWindowManager.swift; sourceTree = "<group>"; };
 		C73868C425C9F9820072532C /* JetpackScanThreatSectionGrouping.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackScanThreatSectionGrouping.swift; sourceTree = "<group>"; };
 		C768B5B225828A5D00556E75 /* JetpackScanStatusCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanStatusCell.swift; sourceTree = "<group>"; };
 		C768B5B325828A5D00556E75 /* JetpackScanStatusCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = JetpackScanStatusCell.xib; sourceTree = "<group>"; };
@@ -12734,9 +12736,18 @@
 			path = "Login Error";
 			sourceTree = "<group>";
 		};
+		C72A52CD2649B14B009CA633 /* System */ = {
+			isa = PBXGroup;
+			children = (
+				C72A52CE2649B157009CA633 /* JetpackWindowManager.swift */,
+			);
+			path = System;
+			sourceTree = "<group>";
+		};
 		C7F7AC71261CF1BD00CE547F /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				C72A52CD2649B14B009CA633 /* System */,
 				C7124E4B2638527D00929318 /* NUX */,
 				C7F7ABD5261CED7A00CE547F /* JetpackAuthenticationManager.swift */,
 				C7F7AC72261CF1C900CE547F /* ViewRelated */,
@@ -19481,6 +19492,7 @@
 				FABB25032602FC2C00C8785C /* PostEditor+Publish.swift in Sources */,
 				FABB25042602FC2C00C8785C /* MediaCoordinator.swift in Sources */,
 				FABB25052602FC2C00C8785C /* StatsStackViewCell.swift in Sources */,
+				C72A52CF2649B158009CA633 /* JetpackWindowManager.swift in Sources */,
 				FABB25062602FC2C00C8785C /* ReaderTagsTableViewModel.swift in Sources */,
 				FABB25072602FC2C00C8785C /* SiteAssemblyService.swift in Sources */,
 				FABB25082602FC2C00C8785C /* ManagedPerson.swift in Sources */,


### PR DESCRIPTION
This PR changes the `WPCOM_SCHEME`for the Jetpack scheme to the following:
- Production: `jetpack`
- Alpha: `jpalpha`
- Internal: `jpinternal`
- Debug: `jpdebug`

During testing of magic links I found a bug where if the user logs in with no Jetpack sites and displays the no sites message, tapping the 'Try with another account' button didn't work correctly anymore. 

I've included a change to how this error is displayed in this PR as well.

### To test:

#### Testing normal login
1. Build the Jetpack scheme
2. Tap Continue with WordPress.com button
3. Enter your testing email
4. Tap the 'Get a login link by email' button
5. Once the email is received, right click and copy the 'Log in to the app' button URL
6. In Terminal run: `xcrun simctl openurl booted "LOGIN_URL"`
7. In Safari tap the 'Open in Jetpack' option
8. You should be logged in, in the app.

#### Testing new error view handling
1. Follow the steps above using a WordPress account that has no Jetpack sites
2. You should be displayed the no sites message
3. Tap the Try Again button
4. You should be brought to the prologue view
5. Follow the steps above to see the no sites message again
6. Force close the app
7. Restart it
8. You should see the prologue view again

### Regression Notes
1. Potential unintended areas of impact

WordPress Login. 


2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested all of the WordPress login flows.

3. What automated tests I added (or what prevented me from doing so)

None. I am unable to perform UI tests locally for some reason.

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
