### PR TITLE
Notification Likes: show cached before refetching

### DIFF
--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -1,7 +1,7 @@
 extension CommentService {
 
     /**
-     Fetches a list of users that liked the comment with the given ID.
+     Fetches a list of users from remote that liked the comment with the given IDs.
      
      @param commentID  The ID of the comment to fetch likes for
      @param siteID     The ID of the site that contains the post
@@ -29,6 +29,24 @@ extension CommentService {
             DDLogError(String(describing: error))
             failure(error)
         }
+    }
+
+    /**
+     Fetches a list of users from Core Data that liked the comment with the given IDs.
+     
+     @param commentID  The ID of the comment to fetch likes for
+     @param siteID     The ID of the site that contains the post
+     */
+    func likeUsersFor(commentID: NSNumber, siteID: NSNumber) -> [LikeUser] {
+        let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
+        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@", siteID, commentID)
+        request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
+
+        if let users = try? managedObjectContext.fetch(request) {
+            return users
+        }
+
+        return [LikeUser]()
     }
 
 }
@@ -74,18 +92,6 @@ private extension CommentService {
         } catch {
             DDLogError("Error fetching comment Like Users: \(error)")
         }
-    }
-
-    func likeUsersFor(commentID: NSNumber, siteID: NSNumber) -> [LikeUser] {
-        let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
-        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@", siteID, commentID)
-        request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
-
-        if let users = try? managedObjectContext.fetch(request) {
-            return users
-        }
-
-        return [LikeUser]()
     }
 
 }

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -1,7 +1,7 @@
 extension PostService {
 
     /**
-     Fetches a list of users that liked the post with the given ID.
+     Fetches a list of users from remote that liked the post with the given IDs.
      
      @param postID  The ID of the post to fetch likes for
      @param siteID  The ID of the site that contains the post
@@ -29,6 +29,24 @@ extension PostService {
             DDLogError(String(describing: error))
             failure(error)
         }
+    }
+
+    /**
+     Fetches a list of users from Core Data that liked the post with the given IDs.
+     
+     @param postID  The ID of the post to fetch likes for
+     @param siteID  The ID of the site that contains the post
+     */
+    func likeUsersFor(postID: NSNumber, siteID: NSNumber) -> [LikeUser] {
+        let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
+        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@", siteID, postID)
+        request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
+
+        if let users = try? managedObjectContext.fetch(request) {
+            return users
+        }
+
+        return [LikeUser]()
     }
 
 }
@@ -74,18 +92,6 @@ private extension PostService {
         } catch {
             DDLogError("Error fetching post Like Users: \(error)")
         }
-    }
-
-    func likeUsersFor(postID: NSNumber, siteID: NSNumber) -> [LikeUser] {
-        let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
-        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@", siteID, postID)
-        request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
-
-        if let users = try? managedObjectContext.fetch(request) {
-            return users
-        }
-
-        return [LikeUser]()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -107,15 +107,14 @@ class LikesListController: NSObject {
             self?.isLoadingContent = false
         }
 
-        fetchStoredLikes(success: successBlock, failure: failureBlock)
+        fetchStoredLikes(completion: successBlock)
         fetchLikes(success: successBlock, failure: failureBlock)
     }
 
     /// Fetch Likes from Core Data depending on the notification's content type.
     /// - Parameters:
-    ///   - success: Closure to be called when the fetch is successful.
-    ///   - failure: Closure to be called when the fetch failed.
-    private func fetchStoredLikes(success: @escaping ([LikeUser]) -> Void, failure: @escaping (Error?) -> Void) {
+    ///   - completion: Closure to be called when the fetch is complete.
+    private func fetchStoredLikes(completion: @escaping ([LikeUser]) -> Void) {
 
         let users: [LikeUser]
 
@@ -126,7 +125,7 @@ class LikesListController: NSObject {
             users = commentService.likeUsersFor(commentID: commentID, siteID: siteID)
         }
 
-        success(users)
+        completion(users)
     }
 
     /// Fetch Likes depending on the notification's content type.

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -97,16 +97,39 @@ class LikesListController: NSObject {
         // shows the loading cell and prevents double refresh.
         isLoadingContent = true
 
-        fetchLikes(success: { [weak self] users in
+        let successBlock: ([LikeUser]) -> Void = { [weak self] users in
             self?.likingUsers = users
             self?.isLoadingContent = false
-        }, failure: { [weak self] _ in
+        }
+
+        let failureBlock: (Error?) -> Void = { [weak self] _ in
             // TODO: Handle error state
             self?.isLoadingContent = false
-        })
+        }
+
+        fetchStoredLikes(success: successBlock, failure: failureBlock)
+        fetchLikes(success: successBlock, failure: failureBlock)
     }
 
-    /// Convenient method that fetches likes data depending on the notification's content type.
+    /// Fetch Likes from Core Data depending on the notification's content type.
+    /// - Parameters:
+    ///   - success: Closure to be called when the fetch is successful.
+    ///   - failure: Closure to be called when the fetch failed.
+    private func fetchStoredLikes(success: @escaping ([LikeUser]) -> Void, failure: @escaping (Error?) -> Void) {
+
+        let users: [LikeUser]
+
+        switch content {
+        case .post(let postID):
+            users = postService.likeUsersFor(postID: postID, siteID: siteID)
+        case .comment(let commentID):
+            users = commentService.likeUsersFor(commentID: commentID, siteID: siteID)
+        }
+
+        success(users)
+    }
+
+    /// Fetch Likes depending on the notification's content type.
     /// - Parameters:
     ///   - success: Closure to be called when the fetch is successful.
     ///   - failure: Closure to be called when the fetch failed.

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -97,35 +97,28 @@ class LikesListController: NSObject {
         // shows the loading cell and prevents double refresh.
         isLoadingContent = true
 
-        let successBlock: ([LikeUser]) -> Void = { [weak self] users in
+        fetchStoredLikes()
+
+        // If there are no cached users, continue showing the loading cell.
+        isLoadingContent = likingUsers.isEmpty
+
+        fetchLikes(success: { [weak self] users in
             self?.likingUsers = users
             self?.isLoadingContent = false
-        }
-
-        let failureBlock: (Error?) -> Void = { [weak self] _ in
+        }, failure: { [weak self] _ in
             // TODO: Handle error state
             self?.isLoadingContent = false
-        }
-
-        fetchStoredLikes(completion: successBlock)
-        fetchLikes(success: successBlock, failure: failureBlock)
+        })
     }
 
     /// Fetch Likes from Core Data depending on the notification's content type.
-    /// - Parameters:
-    ///   - completion: Closure to be called when the fetch is complete.
-    private func fetchStoredLikes(completion: @escaping ([LikeUser]) -> Void) {
-
-        let users: [LikeUser]
-
+    private func fetchStoredLikes() {
         switch content {
         case .post(let postID):
-            users = postService.likeUsersFor(postID: postID, siteID: siteID)
+            likingUsers = postService.likeUsersFor(postID: postID, siteID: siteID)
         case .comment(let commentID):
-            users = commentService.likeUsersFor(commentID: commentID, siteID: siteID)
+            likingUsers = commentService.likeUsersFor(commentID: commentID, siteID: siteID)
         }
-
-        completion(users)
     }
 
     /// Fetch Likes depending on the notification's content type.


### PR DESCRIPTION
Fixes #n/a

When the Likes list is accessed, the cached Likes is now displayed before refetching.

Note: Failures aren't being handled yet, so a message is not yet displayed when fetching fails and there are no cached Likes (i.e. when there is no network connection).

To test:

You might want to start with a fresh install to clear any previously cached Likes.

- Go to Notifications > Likes.
- Disable your connection.
- Select a notification.
  - Verify the likes list is empty (only the header showing).
- Enable your connection.
- Reselect the notification.
  - Verify Likes are displayed.
- Disable your connection.
- Reselect the notification.
  - Verify the Likes are displayed.


| No cached | Cached |
|--------|-------|
| ![no_cached](https://user-images.githubusercontent.com/1816888/117736280-7760e300-b1b4-11eb-9600-ed38569475ea.jpeg) | ![cached](https://user-images.githubusercontent.com/1816888/117736292-7cbe2d80-b1b4-11eb-9715-6ff190a4827c.jpeg) |

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
