### PR TITLE
Fixes truncated suggested username in the change username screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -15,11 +15,7 @@ class ChangeUsernameViewController: SignupUsernameTableViewController {
     init(service: AccountSettingsService, settings: AccountSettings?, completionBlock: @escaping CompletionBlock) {
         self.viewModel = ChangeUsernameViewModel(service: service, settings: settings)
         self.completionBlock = completionBlock
-
         super.init(nibName: nil, bundle: nil)
-
-        self.suggestionCellNumberOfLines = 0
-        self.suggestionCellLineBreakMode = .byCharWrapping
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -15,7 +15,11 @@ class ChangeUsernameViewController: SignupUsernameTableViewController {
     init(service: AccountSettingsService, settings: AccountSettings?, completionBlock: @escaping CompletionBlock) {
         self.viewModel = ChangeUsernameViewModel(service: service, settings: settings)
         self.completionBlock = completionBlock
+
         super.init(nibName: nil, bundle: nil)
+
+        self.suggestionCellNumberOfLines = 0
+        self.suggestionCellLineBreakMode = .byCharWrapping
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -10,9 +10,6 @@ class SignupUsernameTableViewController: UITableViewController, SearchTableViewC
     private var service: AccountSettingsService?
     private var isSearching: Bool = false
     private var selectedCell: UITableViewCell?
-    // adapt suggestion cell layout
-    var suggestionCellNumberOfLines = 1
-    var suggestionCellLineBreakMode: NSLineBreakMode = .byTruncatingTail
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -201,8 +198,8 @@ extension SignupUsernameTableViewController {
         cell.textLabel?.text = username
         cell.textLabel?.textColor = .neutral(.shade70)
 
-        cell.textLabel?.numberOfLines = suggestionCellNumberOfLines
-        cell.textLabel?.lineBreakMode = suggestionCellLineBreakMode
+        cell.textLabel?.numberOfLines = 0
+        cell.textLabel?.lineBreakMode = .byCharWrapping
 
         cell.indentationWidth = SuggestionStyles.indentationWidth
         cell.indentationLevel = SuggestionStyles.indentationLevel

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -10,6 +10,9 @@ class SignupUsernameTableViewController: UITableViewController, SearchTableViewC
     private var service: AccountSettingsService?
     private var isSearching: Bool = false
     private var selectedCell: UITableViewCell?
+    // adapt suggestion cell layout
+    var suggestionCellNumberOfLines = 1
+    var suggestionCellLineBreakMode: NSLineBreakMode = .byTruncatingTail
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -197,8 +200,13 @@ extension SignupUsernameTableViewController {
 
         cell.textLabel?.text = username
         cell.textLabel?.textColor = .neutral(.shade70)
+
+        cell.textLabel?.numberOfLines = suggestionCellNumberOfLines
+        cell.textLabel?.lineBreakMode = suggestionCellLineBreakMode
+
         cell.indentationWidth = SuggestionStyles.indentationWidth
         cell.indentationLevel = SuggestionStyles.indentationLevel
+
         if checked {
             cell.accessoryType = .checkmark
         }


### PR DESCRIPTION
Fixes #8961

To test:
- On the device or simulator, open the "Settings" app, then go to "Accessibility -> Display & Text Size -> Large Text" and turn on the "Larger Accessibility Sizes" option
- Build/run and go to "Me -> Account Settings -> Username"
- if you don't have longer usernames in the suggestions, type a keyword to trigger them
- Make sure that the longer usernames suggestions are not truncated. You should see them wrapped at the last visible character of the first line (see example screenshot below)

<p align=center>
<img height="450" src="https://user-images.githubusercontent.com/34376330/117729669-cb69c880-b1b0-11eb-8710-841fc9d286e2.png">
</p>

## Regression Notes
1. Potential unintended areas of impact
None: the changes are made so that it will only impact the change username view


2. What I did to test those areas of impact (or what existing automated tests I relied on)
test the change username screen

3. What automated tests I added (or what prevented me from doing so)
4. NA

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
