### PR TITLE
Fetch blog metadata when switching sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1141,6 +1141,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     
     [self showInitialDetailsForBlog];
     [self.tableView reloadData];
+    [self preloadMetadata];
 }
 
 - (void)showInitialDetailsForBlog


### PR DESCRIPTION
## Description

Before the site picker was made a modal screen (enabled in v17.0), the app would call the `syncBlogAndAllMetadata:completionHandler:` method via `viewDidLoad` when the user switched from one blog to another, because when a site was picked, the blog details view controller was pushed onto the navigation stack. This sync method made multiple network calls to [fetch various bits of data](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Services/BlogService.m#L190-L308) from the backend including the site's editor preference setting, publicize data, and some others I'm not too familiar with.

After the site picker changed to a modal, this sync method was no longer called. This is because upon dismissing the modal, neither of the following methods are executed:
- `viewDidLoad`: `viewDidLoad` > `preloadMetadata` > `syncBlogAndAllMetadata:completionHandler:`
- `viewWillAppear`: `viewWillAppear` > `preloadBlogData` > `preloadMetadata` > `syncBlogAndAllMetadata:completionHandler:`

I'm not sure if this was a deliberate change or not, but what this PR proposes is add a call to `preloadMetadata` when the user switches blogs, restoring functionality to how it worked before.

## To test

### Verify the previous sync functionality is restored

**Testing steps**

1. Log into an account that has access to multiple sites
2. Put a breakpoint in the `syncBlogAndAllMetadata:completionHandler:` method in `BlogDetailsViewController`
3. Ensure the break point is hit each time every time you switch sites

### Verify the Unsupported Block Editor works as expected

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3461

This PR has the side-effect of resolving the above issue, where the Unsupported Block Editor failed to load properly due to the missing editor preference setting.

**Prerequisites**
1. An WP.com account created later in 2019 or later. Account creation date is found at https://wordpress.com/me/account. This is needed to avoid the https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425 bug.
2. This account must have access to an Atomic site
3. Important: The bug this PR fixes is only present if the (Atomic) site in question is not the account's default site. Please go to https://wordpress.com/me/account and ensure a different site (any other site) is the account's default site.

**Testing steps**

1. On the site described above, on the web, add a post, then add a block that's not yet supported on mobile (e.g. Jetpack Markdown at time of writing)
2. Log into the WordPress mobile app using the WP.com account
3. Open the post and expect to see the block rendered as a placeholder with the text "Unsupported"
4. Tap the `(?)` icon and expect the option to edit the block in a web browser to be shown
5. Tap the edit in a web browser button and expect the block to be shown, ready to edit, on a new screen
6. Edit the block content in some way 
7. Tap the Continue button and expect to be taken back to the block editor
8. Publish the post and verify it contains the edits

(Taken from test case [TC003](https://github.com/wordpress-mobile/test-cases/blob/trunk/test-cases/gutenberg/unsupported-block-editing.md#editing-unsupported-blocks-is-allowed-on-gutenberg-enabled-atomic-sites).)

## Regression Notes

1. Potential unintended areas of impact

This change aims to restore previous functionality. In 17.0, the app stopped fetching site metadata when switching between sites.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I manually checked that switching between blogs without an internet connection didn't result in any unhanded errors from the network calls.

3. What automated tests I added (or what prevented me from doing so)

Since this is prefetched data, arguably it's not data that the app should require to be fetched so I don't think tests are worthwhile (while some of this data was relied upon for the Unsupported Block Editor, see https://github.com/wordpress-mobile/gutenberg-mobile/issues/3461, it was possibly a bad design choice to rely on pre-fetched data and not have a fallback to fetch the data if it wasn't there).

## PR submission checklist

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
