### PR TITLE
Improves support for dynamic type in PrepublishingHeaderView.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
@@ -5,7 +5,7 @@ protocol PrepublishingHeaderViewDelegate: class {
     func closeButtonTapped()
 }
 
-class PrepublishingHeaderView: UIView, NibLoadable {
+class PrepublishingHeaderView: UITableViewHeaderFooterView, NibLoadable {
 
     @IBOutlet weak var blogImageView: UIImageView!
     @IBOutlet weak var publishingToLabel: UILabel!
@@ -44,6 +44,12 @@ class PrepublishingHeaderView: UIView, NibLoadable {
         configureBlogTitleLabel()
         configureBlogImage()
         configureSeparator()
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        self.delegate = nil
     }
 
     private func configureBackButton() {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,13 +16,13 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="U3e-kO-v2p">
-                    <rect key="frame" x="16" y="0.0" width="382" height="110"/>
+                    <rect key="frame" x="16" y="16" width="382" height="78"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lqd-3Z-R2I">
-                            <rect key="frame" x="0.0" y="0.0" width="48" height="110"/>
+                            <rect key="frame" x="0.0" y="0.0" width="48" height="78"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nQB-ct-GJB">
-                                    <rect key="frame" x="2" y="33" width="44" height="44"/>
+                                    <rect key="frame" x="2" y="17" width="44" height="44"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="44" id="Hzn-wu-Giy"/>
                                         <constraint firstAttribute="height" constant="44" id="nMd-Hh-E65"/>
@@ -39,10 +40,10 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ojd-6X-LSJ">
-                            <rect key="frame" x="58" y="0.0" width="38" height="110"/>
+                            <rect key="frame" x="58" y="0.0" width="38" height="78"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7Pf-bk-gek">
-                                    <rect key="frame" x="0.0" y="36" width="38" height="38"/>
+                                    <rect key="frame" x="0.0" y="20" width="38" height="38"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="38" id="Lsz-mz-2BC"/>
                                         <constraint firstAttribute="height" constant="38" id="fup-nP-Afc"/>
@@ -57,19 +58,19 @@
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zDg-a5-aiB">
-                            <rect key="frame" x="106" y="0.0" width="276" height="110"/>
+                            <rect key="frame" x="106" y="0.0" width="276" height="78"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="3YM-UU-GGo">
-                                    <rect key="frame" x="0.0" y="35.666666666666671" width="276" height="38.666666666666671"/>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="3YM-UU-GGo">
+                                    <rect key="frame" x="0.0" y="18.666666666666664" width="276" height="41"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Publishing To" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZFo-FV-nl8">
-                                            <rect key="frame" x="0.0" y="0.0" width="276" height="15.666666666666666"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Publishing To" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZFo-FV-nl8">
+                                            <rect key="frame" x="0.0" y="0.0" width="81" height="18"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" name="Gray30"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fYs-yz-ucu">
-                                            <rect key="frame" x="0.0" y="20.666666666666671" width="276" height="18"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="bottom" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Blog Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fYs-yz-ucu">
+                                            <rect key="frame" x="0.0" y="23" width="64.666666666666671" height="18"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                             <color key="textColor" name="Gray80"/>
                                             <nil key="highlightedColor"/>
@@ -77,30 +78,36 @@
                                     </subviews>
                                 </stackView>
                             </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="3YM-UU-GGo" secondAttribute="trailing" id="08r-Oh-snD"/>
+                                <constraint firstItem="3YM-UU-GGo" firstAttribute="top" relation="greaterThanOrEqual" secondItem="zDg-a5-aiB" secondAttribute="top" id="Ser-tB-aOA"/>
                                 <constraint firstItem="3YM-UU-GGo" firstAttribute="leading" secondItem="zDg-a5-aiB" secondAttribute="leading" id="oJg-wJ-uCW"/>
+                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="3YM-UU-GGo" secondAttribute="bottom" id="rz0-ZC-C4g"/>
                                 <constraint firstItem="3YM-UU-GGo" firstAttribute="centerY" secondItem="zDg-a5-aiB" secondAttribute="centerY" id="tpf-SY-Ods"/>
                             </constraints>
                         </view>
                     </subviews>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="zDg-a5-aiB" secondAttribute="bottom" id="FNJ-sP-0eT"/>
+                        <constraint firstItem="zDg-a5-aiB" firstAttribute="top" secondItem="U3e-kO-v2p" secondAttribute="top" id="gm5-rC-c5v"/>
+                        <constraint firstAttribute="trailing" secondItem="zDg-a5-aiB" secondAttribute="trailing" id="lcJ-qG-Eo6"/>
+                    </constraints>
                 </stackView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FfF-E5-Fym">
                     <rect key="frame" x="0.0" y="109" width="414" height="1"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="PaW-Rp-6In"/>
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstAttribute="top" secondItem="U3e-kO-v2p" secondAttribute="top" id="6Jf-9O-ejp"/>
-                <constraint firstAttribute="bottom" secondItem="U3e-kO-v2p" secondAttribute="bottom" id="IsF-tS-X0B"/>
+                <constraint firstAttribute="top" secondItem="U3e-kO-v2p" secondAttribute="top" constant="-16" id="6Jf-9O-ejp"/>
+                <constraint firstAttribute="bottom" secondItem="U3e-kO-v2p" secondAttribute="bottom" constant="16" id="IsF-tS-X0B"/>
                 <constraint firstAttribute="trailing" secondItem="U3e-kO-v2p" secondAttribute="trailing" constant="16" id="LSI-AS-5M2"/>
                 <constraint firstAttribute="bottom" secondItem="FfF-E5-Fym" secondAttribute="bottom" id="QyB-Vo-bfq"/>
-                <constraint firstItem="U3e-kO-v2p" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" id="nZv-tu-Nwd"/>
                 <constraint firstItem="U3e-kO-v2p" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="tyj-l1-rNT"/>
                 <constraint firstAttribute="trailing" secondItem="FfF-E5-Fym" secondAttribute="trailing" id="ufv-zd-CIh"/>
                 <constraint firstItem="FfF-E5-Fym" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="x0z-h5-7dj"/>
@@ -121,10 +128,13 @@
     </objects>
     <resources>
         <namedColor name="Gray30">
-            <color red="0.55686274509803924" green="0.56862745098039214" blue="0.58823529411764708" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.5490196078431373" green="0.5607843137254902" blue="0.58039215686274515" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="Gray80">
             <color red="0.17254901960784313" green="0.20000000000000001" blue="0.2196078431372549" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -33,11 +33,6 @@ enum PrepublishingIdentifier {
 class PrepublishingViewController: UITableViewController {
     let post: Post
 
-    lazy var header: PrepublishingHeaderView = {
-         let header = PrepublishingHeaderView.loadFromNib()
-         return header
-     }()
-
     private lazy var publishSettingsViewModel: PublishSettingsViewModel = {
         return PublishSettingsViewModel(post: post)
     }()
@@ -88,8 +83,9 @@ class PrepublishingViewController: UITableViewController {
 
         title = ""
 
-        header.delegate = self
-        header.configure(post.blog)
+        let nib = UINib(nibName: "PrepublishingHeaderView", bundle: nil)
+        tableView.register(nib, forHeaderFooterViewReuseIdentifier: Constants.headerReuseIdentifier)
+
         setupPublishButton()
         setupFooterSeparator()
 
@@ -144,11 +140,19 @@ class PrepublishingViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        // Forced unwrap copied from this guide by Apple:
+        // https://developer.apple.com/documentation/uikit/views_and_controls/table_views/adding_headers_and_footers_to_table_sections
+        //
+        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: Constants.headerReuseIdentifier) as! PrepublishingHeaderView
+
+        header.delegate = self
+        header.configure(post.blog)
+
         return header
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return Constants.headerHeight
+        return UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -429,6 +433,7 @@ class PrepublishingViewController: UITableViewController {
 
     fileprivate enum Constants {
         static let reuseIdentifier = "wpTableViewCell"
+        static let headerReuseIdentifier = "wpTableViewHeader"
         static let textFieldReuseIdentifier = "wpTextFieldCell"
         static let nuxButtonInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         static let cellMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
@@ -438,7 +443,6 @@ class PrepublishingViewController: UITableViewController {
         static let publishDateLabel = NSLocalizedString("Publish Date", comment: "Label for Publish date")
         static let scheduledLabel = NSLocalizedString("Scheduled for", comment: "Scheduled for [date]")
         static let titlePlaceholder = NSLocalizedString("Title", comment: "Placeholder for title")
-        static let headerHeight: CGFloat = 70
         static let analyticsDefaultProperty = ["via": "prepublishing_nudges"]
     }
 }


### PR DESCRIPTION
This PR improved dynamic type support in `PrepublishingHeaderView`.

Previously, the prepublish header view had a fixed height, and wasn't resizing its labels dynamically.  Now it automatically updates its height and updates the text size for its labels.

## To test:

Test this in both iPad and iPhone.

1. Create a new post
2. Tap "Publish"
3. Once the prepublishing popup is shown, go to iOS Settings > Accessibility > Large Text and start playing with the text size.
4. Go back to the App and make sure the pre-publishing popup header has updated correctly.

## Regression Notes

1. Potential unintended areas of impact

Nothing I'm aware of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Nothing.

3. What automated tests I added (or what prevented me from doing so)

None since these are layout changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
