### PR TITLE
Fix NoResults in PluginsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
@@ -140,19 +140,21 @@ private extension PluginViewController {
 
         noResultsViewController.bindViewModel(viewModel)
 
-        addAsSubviewIfNeeded(noResultsViewController.view)
-        addChildController(noResultsViewController)
+        addAsSubviewIfNeeded(noResultsViewController)
     }
 
-    private func addAsSubviewIfNeeded(_ view: UIView) {
-        if view.superview != tableView {
-            tableView.addSubview(withFadeAnimation: view)
+    private func addAsSubviewIfNeeded(_ noResultsViewController: NoResultsViewController) {
+        if noResultsViewController.view.superview != tableView {
+            tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+            addChild(noResultsViewController)
+            noResultsViewController.didMove(toParent: self)
+            noResultsViewController.view.translatesAutoresizingMaskIntoConstraints = false
+            tableView.pinSubviewToSafeArea(noResultsViewController.view)
         }
     }
 
     private func addChildController(_ controller: UIViewController) {
-        addChild(controller)
-        controller.didMove(toParent: self)
+
     }
 
     private func getNoResultsViewController() -> NoResultsViewController {


### PR DESCRIPTION
This PR fixes the position of the NoResultsVC inside the table of `PluginsViewController`

To test:

1. Open Activity Log
2. Select Plugin filter
3. Find an internal plugin that will display an error when tapped (the gif below show an example)
4. Tap this plugin name
5. Make sure the NoResults is displayed correctly

<img src="https://user-images.githubusercontent.com/7040243/118004576-f4f53200-b31f-11eb-8515-9d9da94b0803.gif" width="300">


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
Visual changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
