### PR TITLE
Handle auth notifications presented while the app is in the foreground

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] A new author can be chosen for Posts and Pages on multi-author sites. [#16281]
 * [*] Fixed the Follow Sites Quick Start Tour so that Reader Search is highlighted. [#16391]
+* [*] Enabled approving login authentication requests via push notification while the app is in the foreground. [#16075] 
 
 
 17.3

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -476,6 +476,12 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
         // If the app is open, and a Zendesk view is being shown, Zendesk will display an alert allowing the user to view the updated ticket.
         handleZendeskNotification(userInfo: userInfo)
 
+        // Otherwise see if it's an auth notification
+        if PushNotificationsManager.shared.handleAuthenticationNotification(userInfo, userInteraction: true, completionHandler: nil) {
+            return
+        }
+
+        // Otherwise a share notification
         let category = notification.request.content.categoryIdentifier
 
         guard (category == ShareNoticeConstants.categorySuccessIdentifier || category == ShareNoticeConstants.categoryFailureIdentifier),

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -287,6 +287,8 @@ extension PushNotificationsManager {
         ///
         if applicationState != .background || userInteraction {
             authenticationManager.handleAuthenticationNotification(userInfo)
+        } else {
+            DDLogInfo("Skipping handling authentication notification due to app being in background or user not interacting with it.")
         }
 
         completionHandler?(.newData)


### PR DESCRIPTION
Fixes #16075. This enables the push notification authentication alert while the app is in the foreground.

![](https://user-images.githubusercontent.com/66104034/111244095-deed1e80-85c7-11eb-9fd6-4a75d82c35e1.png)

To test:

- Build and run on a device
- Log into a wpcom account in the app and leave it in the foreground
- Attempt to log into that account in your browser until you see the auth notification screen
- Hopefully, the auth alert will appear on your device!
- Tap approve and check that you're logged in
- You can also test this in the background if you like, but that code path should be separate from this one

## Regression Notes
1. Potential unintended areas of impact

These changes are very localised, so I can't see that this could cause issues elsewhere.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
