### PR TITLE
Add pull-to-refresh to My Site screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 * [**] A new author can be chosen for Posts and Pages on multi-author sites. [#16281]
 * [*] Fixed the Follow Sites Quick Start Tour so that Reader Search is highlighted. [#16391]
 * [*] Enabled approving login authentication requests via push notification while the app is in the foreground. [#16075] 
-
+* [**] Added pull-to-refresh to the My Site screen when a user has no sites. [#16241]
 
 17.3
 -----

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -61,7 +61,6 @@ open class SharingService: LocalCoreDataService {
     @objc open func syncPublicizeConnectionsForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         let blogObjectID = blog.objectID
         guard let remote = remoteForBlog(blog) else {
-            failure?(nil)
             return
         }
         remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -61,6 +61,7 @@ open class SharingService: LocalCoreDataService {
     @objc open func syncPublicizeConnectionsForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         let blogObjectID = blog.objectID
         guard let remote = remoteForBlog(blog) else {
+            failure?(nil)
             return
         }
         remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -173,10 +173,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     private func hideNoSites() {
         hideNoResults()
 
-        noResultsRefreshControl = nil
-
-        noResultsScrollView?.removeFromSuperview()
-        noResultsScrollView = nil
+        cleanupNoResultsView()
     }
 
     private func showNoSites() {
@@ -250,6 +247,15 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         ])
 
         noResultsViewController.didMove(toParent: self)
+    }
+
+    private func cleanupNoResultsView() {
+        noResultsRefreshControl?.removeFromSuperview()
+        noResultsRefreshControl = nil
+
+        noResultsScrollView?.refreshControl = nil
+        noResultsScrollView?.removeFromSuperview()
+        noResultsScrollView = nil
     }
 
 // MARK: - Add Site Alert

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -41,6 +41,12 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     ///
     private var blogDetailsViewController: BlogDetailsViewController?
 
+    /// When we display a no results view, we'll do so in a scrollview so that
+    /// we can allow pull to refresh to sync the user's list of sites.
+    ///
+    private var noResultsScrollView: UIScrollView?
+    private var noResultsRefreshControl: UIRefreshControl?
+
     // MARK: - View Lifecycle
 
     override func viewDidLoad() {
@@ -144,10 +150,33 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         showBlogDetails(for: mainBlog)
     }
 
+    @objc
+    private func syncBlogs() {
+        guard let account = defaultAccount() else {
+            return
+        }
+
+        let finishSync = { [weak self] in
+            self?.noResultsRefreshControl?.endRefreshing()
+        }
+
+        let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
+        blogService.syncBlogs(for: account) {
+            finishSync()
+        } failure: { (error) in
+            finishSync()
+        }
+    }
+
     // MARK: - No Sites UI logic
 
     private func hideNoSites() {
         hideNoResults()
+
+        noResultsRefreshControl = nil
+
+        noResultsScrollView?.removeFromSuperview()
+        noResultsScrollView = nil
     }
 
     private func showNoSites() {
@@ -158,25 +187,72 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         hideBlogDetails()
 
+        guard noResultsViewController.view.superview == nil else {
+            return
+        }
+
         addMeButtonToNavigationBar(email: defaultAccount()?.email, meScenePresenter: meScenePresenter)
 
-        configureAndDisplayNoResults(
-            on: view,
-            title: NSLocalizedString(
-                "Create a new site for your business, magazine, or personal blog; or connect an existing WordPress installation.",
-                comment: "Text shown when the account has no sites."),
-            buttonTitle: NSLocalizedString(
-                "Add new site",
-                comment: "Title of button to add a new site."),
-            image: "mysites-nosites") { noResultsViewController in
+        makeNoResultsScrollView()
+        configureNoResultsView()
+        addNoResultsViewAndConfigureConstraints()
+    }
 
-            noResultsViewController.actionButtonHandler = { [weak self] in
-                self?.presentInterfaceForAddingNewSite()
-            }
+    private func makeNoResultsScrollView() {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.backgroundColor = .basicBackground
+
+        view.addSubview(scrollView)
+        view.pinSubviewToAllEdges(scrollView)
+
+        let refreshControl = UIRefreshControl()
+        scrollView.refreshControl = refreshControl
+        refreshControl.addTarget(self, action: #selector(syncBlogs), for: .valueChanged)
+        noResultsRefreshControl = refreshControl
+
+        noResultsScrollView = scrollView
+    }
+
+    private func configureNoResultsView() {
+        noResultsViewController.configure(title: NSLocalizedString(
+                                            "Create a new site for your business, magazine, or personal blog; or connect an existing WordPress installation.",
+                                            comment: "Text shown when the account has no sites."),
+                                          buttonTitle: NSLocalizedString(
+                                            "Add new site",
+                                            comment: "Title of button to add a new site."),
+                                          image: "mysites-nosites")
+        noResultsViewController.actionButtonHandler = { [weak self] in
+            self?.presentInterfaceForAddingNewSite()
         }
     }
 
-    // MARK: - Add Site Alert
+    private func addNoResultsViewAndConfigureConstraints() {
+        guard let scrollView = noResultsScrollView else {
+            return
+        }
+
+        addChild(noResultsViewController)
+        scrollView.addSubview(noResultsViewController.view)
+        noResultsViewController.view.frame = scrollView.frame
+
+        guard let nrv = noResultsViewController.view else {
+            return
+        }
+
+        nrv.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            nrv.widthAnchor.constraint(equalTo: view.widthAnchor),
+            nrv.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            nrv.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            nrv.bottomAnchor.constraint(equalTo: view.safeBottomAnchor)
+        ])
+
+        noResultsViewController.didMove(toParent: self)
+    }
+
+// MARK: - Add Site Alert
 
     @objc
     func presentInterfaceForAddingNewSite() {


### PR DESCRIPTION
Fixes #16241. This PR adds pull-to-refresh to the My Site screen, so that users can refresh changes made outside of the app. For example, if a user with no sites either creates a site on the web or is added to a site by another user, they can now pull to refresh to sync those changes:

![refresh-my-site](https://user-images.githubusercontent.com/4780/118136340-eb40fc80-b3fb-11eb-8f86-1947c27911b4.gif)

**To test**

**Pull to refresh**

* Log in with a user with no sites or create a new user but don't create a site. You should see the empty My Site screen.
* Log into the web with the same user and create a site.
* Come back to the app and pull to refresh. You should now see your new site.
* You could also delete that site in the app, and check you're taken back to the My Site screen afterwards.

## Regression Notes

1. Potential unintended areas of impact

- Potential layout issues in the My Site screen, but I tested at a range of sizes after adding and removing sites and everything looked fine.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- Be sure to test the layout of the screen thoroughly.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
