### PR TITLE
SharingService: Ensure a completion block is called during sync

### DIFF
--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -60,16 +60,17 @@ open class SharingService: LocalCoreDataService {
     ///
     @objc open func syncPublicizeConnectionsForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         let blogObjectID = blog.objectID
-        guard let remote = remoteForBlog(blog) else {
-            failure?(nil)
+//        guard let remote = remoteForBlog(blog) else {
+            failure?(SharingServiceError.siteWithNoRemote as NSError)
             return
-        }
-        remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in
-
-            // Process the results
-            self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: remoteConnections, onComplete: success)
-        },
-        failure: failure)
+//        }
+//                
+//        remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in
+//
+//            // Process the results
+//            self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: remoteConnections, onComplete: success)
+//        },
+//        failure: failure)
     }
 
 
@@ -725,5 +726,10 @@ open class SharingService: LocalCoreDataService {
         }
 
         return SharingServiceRemote(wordPressComRestApi: api)
+    }
+
+    // Error for failure states
+    enum SharingServiceError: Error {
+        case siteWithNoRemote
     }
 }

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -61,6 +61,7 @@ open class SharingService: LocalCoreDataService {
     @objc open func syncPublicizeConnectionsForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         let blogObjectID = blog.objectID
         guard let remote = remoteForBlog(blog) else {
+            failure?(nil)
             return
         }
         remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -305,6 +305,7 @@
 		17F52DB72315233300164966 /* WPStyleGuide+FilterTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F52DB62315233300164966 /* WPStyleGuide+FilterTabBar.swift */; };
 		17F67C56203D81430072001E /* PostCardStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F67C55203D81430072001E /* PostCardStatusViewModel.swift */; };
 		17F7C24922770B68002E5C2E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F7C24822770B68002E5C2E /* main.swift */; };
+		17FC0032264D728E00FCBD37 /* SharingServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FC0031264D728E00FCBD37 /* SharingServiceTests.swift */; };
 		17FCA6811FD84B4600DBA9C8 /* NoticeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */; };
 		1A433B1D2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */; };
 		1A82EC9F229EBAFB000F141E /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2B4EA11FD6654A007AE3E4 /* Logger.swift */; };
@@ -4730,6 +4731,7 @@
 		17F52DB62315233300164966 /* WPStyleGuide+FilterTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+FilterTabBar.swift"; sourceTree = "<group>"; };
 		17F67C55203D81430072001E /* PostCardStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardStatusViewModel.swift; sourceTree = "<group>"; };
 		17F7C24822770B68002E5C2E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		17FC0031264D728E00FCBD37 /* SharingServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingServiceTests.swift; sourceTree = "<group>"; };
 		17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStore.swift; sourceTree = "<group>"; };
 		1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComRestApi+Defaults.swift"; sourceTree = "<group>"; };
 		1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressUIBundleTests.swift; sourceTree = "<group>"; };
@@ -12310,6 +12312,7 @@
 				57240223234E5BE200227067 /* PostServiceSelfHostedTests.swift */,
 				575802122357C41200E4C63C /* MediaCoordinatorTests.swift */,
 				46B30B772582C7DD00A25E66 /* SiteAddressServiceTests.swift */,
+				17FC0031264D728E00FCBD37 /* SharingServiceTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -18253,6 +18256,7 @@
 				E180BD4C1FB462FF00D0D781 /* CookieJarTests.swift in Sources */,
 				9813512E22F0FC2700F7425D /* FileDownloadsStatsRecordValueTests.swift in Sources */,
 				9363113F19FA996700B0C739 /* AccountServiceTests.swift in Sources */,
+				17FC0032264D728E00FCBD37 /* SharingServiceTests.swift in Sources */,
 				D88A649C208D7D81008AE9BC /* StockPhotosDataSourceTests.swift in Sources */,
 				3236F7A124B61B950088E8F3 /* ReaderInterestsDataSourceTests.swift in Sources */,
 				40E7FEC52211DF790032834E /* StatsRecordTests.swift in Sources */,

--- a/WordPress/WordPressTest/SharingServiceTests.swift
+++ b/WordPress/WordPressTest/SharingServiceTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import WordPress
+
+class SharingServiceTests: XCTestCase {
+    var contextManager: TestContextManager!
+    var context: NSManagedObjectContext {
+        return contextManager.mainContext
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        contextManager = TestContextManager()
+    }
+
+    func testSyncingPublicizeConnectionsForNonDotComBlogCallsACompletionBlock() throws {
+        let blogService = BlogService(managedObjectContext: context)
+        let blog = blogService.createBlog()
+        let sharingService = SharingService(managedObjectContext: context)
+
+        let expect = expectation(description: "Sharing service completion block called.")
+
+        sharingService.syncPublicizeConnectionsForBlog(blog) {
+            expect.fulfill()
+        } failure: { (error) in
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}

--- a/WordPress/WordPressTest/SharingServiceTests.swift
+++ b/WordPress/WordPressTest/SharingServiceTests.swift
@@ -16,10 +16,11 @@ class SharingServiceTests: XCTestCase {
     func testSyncingPublicizeConnectionsForNonDotComBlogCallsACompletionBlock() throws {
         let blogService = BlogService(managedObjectContext: context)
         let blog = blogService.createBlog()
-        let sharingService = SharingService(managedObjectContext: context)
+        blog.account = nil
 
         let expect = expectation(description: "Sharing service completion block called.")
 
+        let sharingService = SharingService(managedObjectContext: context)
         sharingService.syncPublicizeConnectionsForBlog(blog) {
             expect.fulfill()
         } failure: { (error) in


### PR DESCRIPTION
I spotted an issue where `syncBlogAndAllMetadata` may never complete. One of the sync calls in this method is to the sharing service. If this method is called on a site for which sharing isn't possible, the SharingService sync returns but never calls a completion block. This means that the `dispatch_group_notify` in `syncBlogAndAllMetadata` is never hit.

**To test**

* Put a breakpoint in the `dispatch_group_notify` at the end of `syncBlogAndAllMetadata` in `BlogService.m`.
* Add a self hosted site to the app.
* Navigate to Blog Details for that site. This will call the blog sync method and your breakpoint should be hit.
* You can also test on develop following the same steps, and you'll see that your breakpoint is never hit.

## Regression Notes
1. Potential unintended areas of impact

I can't really see any here. Whether we fail or succeed the SharingService sync, both outcomes trigger a `dispatch_group_leave`. And exiting the dispatch group at the end is more correct than our current behaviour.
I've also checked all the places where we use the sharing service sync, and they also don't differentiate the outcome based on success / failure, so the fact we call the failure block shouldn't matter.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested syncing publicize connections, and reviewed the code where this method is called.

3. What automated tests I added (or what prevented me from doing so)

I added a new sharing service test to ensure that a completion block is always called for a non-dotcom site.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
