### PR TITLE
Run pod install update when pod install fails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ namespace :dependencies do
 
     task :install do
       fold("install.cocoapds") do
-        pod %w[install]
+        sh "bundle exec pod install || bundle exec pod install --repo-update"
       end
     end
 


### PR DESCRIPTION
This changes makes it so `rake dependencies` command does not fail when you you are missing pod repo updates. 

To test:


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
