### PR TITLE
Reader: avoid duplicate requests

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -197,7 +197,6 @@ private extension ReaderTabView {
             resetFilterButton.isHidden = false
             setFilterButtonTitle(existingFilter.topic.title)
         } else {
-            didTapResetFilterButton()
             addContentToContainerView()
         }
 


### PR DESCRIPTION
Fixes #16466

As explained in the issue, requests to the Reader API are being made twice. This results in: more data consumption and duplicated posts for lists.

The reason is that `didTapResetFilterButton()` is called everytime, which triggers the `setContent`. I removed the call to this method, this fixes the issue.

### To test:

Make sure you're following any list. Use Charles to intercept requests or add a `print` here: https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Utility/WPContentSyncHelper.swift#L51

2. Open Reader
3. Go to your list
4. Make sure no duplicated requests are made to retrieve posts for this list
5. Play around and make sure the functionality is still the same

Test also a change in the Reader behavior after this change:

1. Go to Following
2. Apply any filter
3. Go to another tab
4. Go back to following
5. The filter should not be reset*

*I'm not sure if that was the intended behavior when implementing this functionality. Tbh I like more to keep the filter applied, open to suggestions anyway. :) 

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
I haven't. The overall code in Reader needs a lot of refactoring in order to be able to include automated tests. :(

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
