### PR TITLE
Align UI test elements

### DIFF
--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -20,6 +20,7 @@ private struct ElementStringIDs {
 
 class MySiteScreen: BaseScreen {
     let tabBar: TabNavComponent
+    let navBar: XCUIElement
     let removeSiteButton: XCUIElement
     let removeSiteSheet: XCUIElement
     let removeSiteAlert: XCUIElement
@@ -57,8 +58,9 @@ class MySiteScreen: BaseScreen {
         createButton = app.buttons[ElementStringIDs.createButton]
         readerButton = app.buttons[ElementStringIDs.ReaderButton]
         switchSiteButton = app.buttons[ElementStringIDs.switchSiteButton]
+        navBar = app.navigationBars[ElementStringIDs.navBarTitle]
 
-        super.init(element: switchSiteButton)
+        super.init(element: navBar)
     }
 
     func showSiteSwitcher() -> MySitesScreen {


### PR DESCRIPTION
This PR addresses a (very) minor inconsistency in how UI Testing for the "My Site" screen works. It _may_ be part of the reason why https://github.com/wordpress-mobile/WordPress-iOS/pull/16504 was required.

**To test:**
- Ensure UI tests pass in CI

## Regression Notes
1. Potential unintended areas of impact
Might break UI tests

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ran the UI tests in CI

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
