### PR TITLE
Jetpack App (Emphasis): Add jetpack_screenshots lane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ Preview.html
 fastlane/test_output/
 fastlane/google_cloud_keys.json
 fastlane/screenshots
+fastlane/jetpack_screenshots
 fastlane/promo_screenshots
 fastlane/metadata/review_information
 default.profraw

--- a/fastlane/ScreenshotFastfile
+++ b/fastlane/ScreenshotFastfile
@@ -71,6 +71,24 @@ platform :ios do
   end
 
   #####################################################################################
+  # jetpack_screenshots
+  # -----------------------------------------------------------------------------------
+  # This lane generates the localised Jetpack screenshots.
+  # It is the same as running bundle exec fastlane snapshot, but ensures that the app
+  # is only built once.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane jetpack_screenshots
+  #
+  # Example:
+  # bundle exec fastlane jetpack_screenshots
+  #####################################################################################
+  desc "Generate localised Jetpack screenshots"
+  lane :jetpack_screenshots do |options|
+     screenshots(scheme: "JetpackScreenshotGeneration")
+  end
+
+  #####################################################################################
   # create_promo_screenshots
   # -----------------------------------------------------------------------------------
   # This lane generates the promo screenshots. 

--- a/fastlane/ScreenshotFastfile
+++ b/fastlane/ScreenshotFastfile
@@ -21,17 +21,15 @@ platform :ios do
   #####################################################################################
   desc "Generate localised screenshots"
   lane :screenshots  do |options| 
-    fastlane_directory = File.expand_path File.dirname(__FILE__)
-    derived_data_path = File.join(fastlane_directory, "DerivedData")
 
     sh('bundle exec pod install')
-    FileUtils.rm_rf(derived_data_path)
+    FileUtils.rm_rf(DERIVED_DATA_PATH)
 
     scan(
       workspace: WORKSPACE_PATH,
       scheme: "WordPressScreenshotGeneration",
       build_for_testing: true,
-      derived_data_path: derived_data_path,
+      derived_data_path: DERIVED_DATA_PATH,
     )
 
     languages = "da de-DE en-AU en-CA en-GB es-ES fr-FR id it ja ko no nl-NL pt-BR pt-PT ru sv th tr zh-Hans zh-Hant en-US".split(" ")
@@ -50,7 +48,7 @@ platform :ios do
         workspace: WORKSPACE_PATH,
         scheme: "WordPressScreenshotGeneration",
         test_without_building: true,
-        derived_data_path: derived_data_path,
+        derived_data_path: DERIVED_DATA_PATH,
         languages: languages,
         dark_mode: dark_mode_enabled,
         override_status_bar: true,

--- a/fastlane/ScreenshotFastfile
+++ b/fastlane/ScreenshotFastfile
@@ -27,6 +27,8 @@ platform :ios do
 
     scheme = options[:scheme] || "WordPressScreenshotGeneration"
 
+    output_directory = options[:output_directory] || File.join(Dir.pwd, "/screenshots")
+
     scan(
       workspace: WORKSPACE_PATH,
       scheme: scheme,
@@ -51,6 +53,7 @@ platform :ios do
         scheme: scheme,
         test_without_building: true,
         derived_data_path: DERIVED_DATA_PATH,
+        output_directory: output_directory,
         languages: languages,
         dark_mode: dark_mode_enabled,
         override_status_bar: true,
@@ -85,7 +88,10 @@ platform :ios do
   #####################################################################################
   desc "Generate localised Jetpack screenshots"
   lane :jetpack_screenshots do |options|
-     screenshots(scheme: "JetpackScreenshotGeneration")
+    screenshots(
+      scheme: "JetpackScreenshotGeneration",
+      output_directory: File.join(Dir.pwd, "/jetpack_screenshots")
+    )
   end
 
   #####################################################################################

--- a/fastlane/ScreenshotFastfile
+++ b/fastlane/ScreenshotFastfile
@@ -25,9 +25,11 @@ platform :ios do
     sh('bundle exec pod install')
     FileUtils.rm_rf(DERIVED_DATA_PATH)
 
+    scheme = options[:scheme] || "WordPressScreenshotGeneration"
+
     scan(
       workspace: WORKSPACE_PATH,
-      scheme: "WordPressScreenshotGeneration",
+      scheme: scheme,
       build_for_testing: true,
       derived_data_path: DERIVED_DATA_PATH,
     )
@@ -46,7 +48,7 @@ platform :ios do
     [true, false].each { | dark_mode_enabled |
       capture_ios_screenshots(
         workspace: WORKSPACE_PATH,
-        scheme: "WordPressScreenshotGeneration",
+        scheme: scheme,
         test_without_building: true,
         derived_data_path: DERIVED_DATA_PATH,
         languages: languages,


### PR DESCRIPTION
Part of #16395 

## Description

This PR adds a new `jetpack_screenshots` lane that generates raw screenshots for the Jetpack app.

## How to test

_Note: You might want to comment out some of the devices and languages in the screenshots lane for testing purposes... Otherwise, it'll take a really long time to generate all the screenshots_

1. Run `rake mocks` to start a local mock server for UI tests
2. Run `bundle exec fastlane jetpack_screenshots`
3. ✅ Make sure that raw screenshots are generated in `fastlane/jetpack_screenshots`

![Screen Shot 2021-05-14 at 16 28 47](https://user-images.githubusercontent.com/6711616/118421666-73751980-b6fc-11eb-8613-817a071ebf34.png)


## Regression Notes
1. Potential unintended areas of impact
`screenshots` lane for the WordPress app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested the `screenshots` lane and made sure the WordPress screenshots are generated as expected

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
