### PR TITLE
Jetpack App (Emphasis): Fix iPad UI tests

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -43,6 +43,7 @@ open class ActivityTableViewCell: WPTableViewCell {
 
         actionButton.setImage(actionGridicon, for: .normal)
         actionButton.tintColor = .listIcon
+        actionButton.accessibilityIdentifier = "activity-cell-action-button"
     }
 
     @IBAction func didTapActionButton(_ sender: UIButton) {

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
@@ -43,6 +43,8 @@ class BackupListViewController: BaseActivityListViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        tableView.accessibilityIdentifier = "jetpack-backup-table"
+
         WPAnalytics.track(.backupListOpened)
     }
 }

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -43,14 +43,18 @@ class JetpackScreenshotGeneration: XCTestCase {
             .gotoActivityLog()
             .thenTakeScreenshot(2, named: "ActivityLog")
 
-        activityLog.pop()
+        if !isIpad {
+            activityLog.pop()
+        }
 
         // Get Scan screenshot
         let jetpackScan = mySite
             .gotoJetpackScan()
             .thenTakeScreenshot(3, named: "JetpackScan")
 
-        jetpackScan.pop()
+        if !isIpad {
+            jetpackScan.pop()
+        }
 
         // Get Backup screenshot
         let jetpackBackup = mySite
@@ -61,7 +65,10 @@ class JetpackScreenshotGeneration: XCTestCase {
             .thenTakeScreenshot(4, named: "JetpackBackup")
 
         jetpackBackupOptions.pop()
-        jetpackBackup.pop()
+
+        if !isIpad {
+            jetpackBackup.pop()
+        }
 
         // Get Stats screenshot
         let statsScreen = mySite.gotoStatsScreen()

--- a/WordPress/WordPressUITests/Screens/JetpackBackupScreen.swift
+++ b/WordPress/WordPressUITests/Screens/JetpackBackupScreen.swift
@@ -1,13 +1,20 @@
 import Foundation
 import XCTest
 
+private struct ElementStringIDs {
+    static let actionButton = "activity-cell-action-button"
+    static let backupTable = "jetpack-backup-table"
+}
+
 class JetpackBackupScreen: BaseScreen {
     let ellipsisButton: XCUIElement
     let downloadBackupButton: XCUIElement
 
     init() {
         let app = XCUIApplication()
-        ellipsisButton = app.cells.firstMatch.buttons.firstMatch
+        let backupTable = app.tables[ElementStringIDs.backupTable]
+        let firstCell = backupTable.cells.element(boundBy: 0)
+        ellipsisButton = firstCell.buttons[ElementStringIDs.actionButton]
         downloadBackupButton = app.sheets.buttons.element(boundBy: 1)
         super.init(element: ellipsisButton)
     }


### PR DESCRIPTION
Part of #16395 

## Description

This PR fixes an issue where the JetpackScreenshotGeneration test was failing for iPad devices.

## How to test

1. Switch to the `JetpackScreenshotGeneration` scheme
2. Run `rake mocks`
2. Run the UI test on an iPhone simulator
3. ✅ `testGenerateScreenshots()` should be green
4. Run the UI test on an iPad simulator
5. ✅ `testGenerateScreenshots()` should be green

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
