### PR TITLE
Support: Show apps support site instead of zendesk docs.

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -101,42 +101,6 @@ extension NSNotification.Name {
 
     // MARK: - Show Zendesk Views
 
-    /// Displays the Zendesk Help Center from the given controller, filtered by the mobile category and articles labelled as iOS.
-    ///
-    func showHelpCenterIfPossible(from controller: UIViewController, with sourceTag: WordPressSupportSourceTag? = nil) {
-
-        presentInController = controller
-        let haveUserIdentity = ZendeskUtils.sharedInstance.haveUserIdentity && ZendeskUtils.sharedInstance.userNameConfirmed
-
-        // Since user information is not needed to display the Help Center,
-        // if a user identity has not been created, create an empty identity.
-        if !haveUserIdentity {
-            let zendeskIdentity = Identity.createAnonymous()
-            Zendesk.instance?.setIdentity(zendeskIdentity)
-        }
-
-        self.sourceTag = sourceTag
-        WPAnalytics.track(.supportHelpCenterViewed)
-
-        let helpCenterConfig = HelpCenterUiConfiguration()
-        helpCenterConfig.groupType = .category
-        helpCenterConfig.groupIds = [Constants.mobileCategoryID as NSNumber]
-        helpCenterConfig.labels = [Constants.articleLabel]
-
-        // If we don't have the user's information, disable 'Contact Us' via the Help Center and Article view.
-        helpCenterConfig.showContactOptions = haveUserIdentity
-        helpCenterConfig.showContactOptionsOnEmptySearch = haveUserIdentity
-        let articleConfig = ArticleUiConfiguration()
-        articleConfig.showContactOptions = haveUserIdentity
-
-        // Get custom request configuration so new tickets from this path have all the necessary information.
-        let newRequestConfig = self.createRequest()
-
-
-        let helpCenterController = HelpCenterUi.buildHelpCenterOverviewUi(withConfigs: [helpCenterConfig, articleConfig, newRequestConfig])
-        ZendeskUtils.showZendeskView(helpCenterController)
-    }
-
     /// Displays the Zendesk New Request view from the given controller, for users to submit new tickets.
     /// If the user's identity (i.e. contact info) was updated, inform the caller in the `identityUpdated` completion block.
     ///
@@ -1031,8 +995,6 @@ private extension ZendeskUtils {
     struct Constants {
         static let unknownValue = "unknown"
         static let noValue = "none"
-        static let mobileCategoryID: UInt64 = 360000041586
-        static let articleLabel = "iOS"
         static let platformTag = "iOS"
         static let ticketSubject = AppConstants.ticketSubject
         static let blogSeperator = "\n----------\n"

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -168,19 +168,12 @@ private extension SupportTableViewController {
     // MARK: - Row Handlers
 
     func helpCenterSelected() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [unowned self] _ in
             self.tableView.deselectSelectedRowWithAnimation(true)
-            if ZendeskUtils.zendeskEnabled {
-                guard let controllerToShowFrom = self.controllerToShowFrom() else {
-                    return
-                }
-                ZendeskUtils.sharedInstance.showHelpCenterIfPossible(from: controllerToShowFrom, with: self.sourceTag)
-            } else {
-                guard let url = Constants.appSupportURL else {
-                    return
-                }
-                UIApplication.shared.open(url)
+            guard let url = Constants.appSupportURL else {
+                return
             }
+            UIApplication.shared.open(url)
         }
     }
 
@@ -353,7 +346,7 @@ private extension SupportTableViewController {
     // MARK: - Constants
 
     struct Constants {
-        static let appSupportURL = URL(string: "https://apps.wordpress.com/support")
+        static let appSupportURL = URL(string: "https://apps.wordpress.com/mobile-app-support/")
         static let forumsURL = URL(string: "https://ios.forums.wordpress.org")
         static let automatticEmails = ["@automattic.com", "@a8c.com"]
     }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -173,6 +173,7 @@ private extension SupportTableViewController {
             guard let url = Constants.appSupportURL else {
                 return
             }
+            WPAnalytics.track(.supportHelpCenterViewed)
             UIApplication.shared.open(url)
         }
     }


### PR DESCRIPTION
Closes #16510 

This PR shows the support docs hosted at https://apps.wordpress.com/mobile-app-support/ rather than the Zendesk hosted support pages when a user tap the WordPress Help Center option in the SupportTableViewController.  The related Zendesk code is removed.

Example:
![Screen Recording 2021-05-17 at 4 09 29 PM 2021-05-17 16_36_28](https://user-images.githubusercontent.com/1435271/118559773-13976680-b72e-11eb-988d-626590726bb8.gif)

To test:
View the support center. Confirm the support site is shown and you can navigate to different articles. 

@ScoutHarris game for a review? 

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
