### PR TITLE
Likes: Add pagination support to Post and Comment services

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.34.0-beta.1'
+  pod 'WordPressKit', '~> 4.34.0-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/likes_endpoint_pagination'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.33.0-beta.1'
+    # pod 'WordPressKit', '~> 4.34.0-beta.1'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/likes_endpoint_pagination'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -499,7 +499,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.37.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/likes_endpoint_pagination`)
+  - WordPressKit (~> 4.34.0-beta)
   - WordPressMocks (~> 0.0.11)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.0-beta.1)
@@ -511,6 +511,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressUI
   trunk:
     - 1PasswordExtension
@@ -650,9 +651,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.53.0
-  WordPressKit:
-    :branch: feature/likes_endpoint_pagination
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.53.0/third-party-podspecs/Yoga.podspec.json
 
@@ -668,9 +666,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.53.0
-  WordPressKit:
-    :commit: d8aee6b38f3b8577c70fa65426791cee4c43d8fd
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -752,7 +747,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 2674c56cad016118fb4725b866b380b612db66fc
-  WordPressKit: b5a404df6c73a58e58d446c81a09eff2754685c7
+  WordPressKit: 3458e5cc42be650a5fdd5a1b63e7a57cb983abf0
   WordPressMocks: ff54a0fc44ed8968b5b685c34c6e56318e05dd8b
   WordPressShared: 4fd83a8f572dfd8209fa6ca5c891194b29d15961
   WordPressUI: 7152b1a8cdf44b958ceaa8f5bf5428fae9782c49
@@ -768,6 +763,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 60f71d5a7fd275e1ab8be81a7bfa1bbaae59e0b6
+PODFILE CHECKSUM: c88f1f94407897aefeb3a198969226775981a98a
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -401,7 +401,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.33.0-beta.1):
+  - WordPressKit (4.34.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -499,7 +499,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.37.0)
-  - WordPressKit (~> 4.33.0-beta.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/likes_endpoint_pagination`)
   - WordPressMocks (~> 0.0.11)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.11.0-beta)
@@ -550,7 +550,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -651,6 +650,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.53.0
+  WordPressKit:
+    :branch: feature/likes_endpoint_pagination
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.53.0/third-party-podspecs/Yoga.podspec.json
 
@@ -666,6 +668,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.53.0
+  WordPressKit:
+    :commit: d8aee6b38f3b8577c70fa65426791cee4c43d8fd
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -747,7 +752,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 2674c56cad016118fb4725b866b380b612db66fc
-  WordPressKit: a98ea46a711a1c5091a18c559eed67486ba62d52
+  WordPressKit: b5a404df6c73a58e58d446c81a09eff2754685c7
   WordPressMocks: ff54a0fc44ed8968b5b685c34c6e56318e05dd8b
   WordPressShared: 0f7f10e96f8354d64f951c223ae61e8de7495a46
   WordPressUI: 82f164f76b97b82a49f16ce5499523c280e295e9
@@ -763,6 +768,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: a123d26f80f5f584a7b54add2057f9853d571c26
+PODFILE CHECKSUM: 41a2d312771c192e6186b5b042bb3898ec9b3782
 
 COCOAPODS: 1.10.1

--- a/WordPress/Classes/Services/LikeUserHelpers.swift
+++ b/WordPress/Classes/Services/LikeUserHelpers.swift
@@ -14,7 +14,7 @@ import Foundation
         likeUser.userID = remoteUser.userID.int64Value
         likeUser.username = remoteUser.username
         likeUser.displayName = remoteUser.displayName
-        likeUser.primaryBlogID = remoteUser.primaryBlogID.int64Value
+        likeUser.primaryBlogID = remoteUser.primaryBlogID?.int64Value ?? 0
         likeUser.avatarUrl = remoteUser.avatarURL
         likeUser.bio = remoteUser.bio ?? ""
         likeUser.dateLikedString = remoteUser.dateLiked ?? ""

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -5,12 +5,16 @@ extension PostService {
      
      @param postID  The ID of the post to fetch likes for
      @param siteID  The ID of the site that contains the post
+     @param count   Number of records to retrieve. Optional. Defaults to the endpoint max of 90.
+     @param before  Filter results to likes before this date/time. Optional.
      @param success A success block
      @param failure A failure block
      */
     func getLikesFor(postID: NSNumber,
                      siteID: NSNumber,
-                     success: @escaping (([LikeUser]) -> Void),
+                     count: Int = 90,
+                     before: String? = nil,
+                     success: @escaping (([LikeUser], Int) -> Void),
                      failure: @escaping ((Error?) -> Void)) {
 
         guard let remote = postServiceRemoteFactory.restRemoteFor(siteID: siteID, context: managedObjectContext) else {
@@ -19,16 +23,19 @@ extension PostService {
             return
         }
 
-        remote.getLikesForPostID(postID) { remoteLikeUsers in
-            self.createNewUsers(from: remoteLikeUsers, postID: postID, siteID: siteID) {
-                let users = self.likeUsersFor(postID: postID, siteID: siteID)
-                success(users)
-                LikeUserHelper.purgeStaleLikes()
-            }
-        } failure: { error in
-            DDLogError(String(describing: error))
-            failure(error)
-        }
+        remote.getLikesForPostID(postID,
+                                 count: NSNumber(value: count),
+                                 before: before,
+                                 success: { remoteLikeUsers, totalLikes in
+                                    self.createNewUsers(from: remoteLikeUsers, postID: postID, siteID: siteID) {
+                                        let users = self.likeUsersFor(postID: postID, siteID: siteID)
+                                        success(users, totalLikes.intValue)
+                                        LikeUserHelper.purgeStaleLikes()
+                                    }
+                                 }, failure: { error in
+                                    DDLogError(String(describing: error))
+                                    failure(error)
+                                 })
     }
 
     /**

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -13,6 +13,8 @@ class LikesListController: NSObject {
     private let notification: Notification?
     private let tableView: UITableView
     private var likingUsers: [LikeUser] = []
+    private var totalLikes: Int = 0
+    private var totalLikesFetched: Int = 0
     private weak var delegate: LikesListControllerDelegate?
 
     private lazy var postService: PostService = {
@@ -112,8 +114,10 @@ class LikesListController: NSObject {
         // If there are no cached users, continue showing the loading cell.
         isLoadingContent = likingUsers.isEmpty
 
-        fetchLikes(success: { [weak self] users in
+        fetchLikes(success: { [weak self] users, totalLikes in
             self?.likingUsers = users
+            self?.totalLikes = totalLikes
+            self?.totalLikesFetched = users.count
             self?.isLoadingContent = false
         }, failure: { [weak self] _ in
             self?.isLoadingContent = false
@@ -135,7 +139,7 @@ class LikesListController: NSObject {
     /// - Parameters:
     ///   - success: Closure to be called when the fetch is successful.
     ///   - failure: Closure to be called when the fetch failed.
-    private func fetchLikes(success: @escaping ([LikeUser]) -> Void, failure: @escaping (Error?) -> Void) {
+    private func fetchLikes(success: @escaping ([LikeUser], Int) -> Void, failure: @escaping (Error?) -> Void) {
         switch content {
         case .post(let postID):
             postService.getLikesFor(postID: postID, siteID: siteID, success: success, failure: failure)

--- a/WordPress/WordPressTest/CommentServiceTests.swift
+++ b/WordPress/WordPressTest/CommentServiceTests.swift
@@ -62,7 +62,7 @@ extension CommentServiceTests {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users in
+            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes in
                 // Assert
                 expect(users).toNot(beNil())
                 expect(users.count) == 1
@@ -83,7 +83,7 @@ extension CommentServiceTests {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users in
+            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes in
                 fail("this closure should not be called")
             },
             failure: { _ in
@@ -109,12 +109,17 @@ private class CommentServiceRemoteRESTMock: CommentServiceRemoteREST {
 
     // related to fetching likes
     var fetchLikesShouldSucceed: Bool = true
-    var remoteUsersToReturnOnGetLikes: [RemoteLikeUser]? = nil
+    var remoteUsersToReturnOnGetLikes = [RemoteLikeUser]()
+    var totalLikes: NSNumber = 3
 
-    override func getLikesForCommentID(_ commentID: NSNumber!, success: (([RemoteLikeUser]?) -> Void)!, failure: ((Error?) -> Void)!) {
+    override func getLikesForCommentID(_ commentID: NSNumber!,
+                                       count: NSNumber!,
+                                       before: String?,
+                                       success: (([RemoteLikeUser], NSNumber) -> Void)!,
+                                       failure: ((Error?) -> Void)!) {
         DispatchQueue.global().async {
             if self.fetchLikesShouldSucceed {
-                success(self.remoteUsersToReturnOnGetLikes)
+                success(self.remoteUsersToReturnOnGetLikes, self.totalLikes)
             } else {
                 failure(nil)
             }

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -266,7 +266,7 @@ class PostServiceWPComTests: XCTestCase {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesFor(postID: postID, siteID: siteID, success: { users in
+            self.service.getLikesFor(postID: postID, siteID: siteID, success: { users, totalLikes in
                 // Assert
                 expect(users.count) == 1
                 done()
@@ -286,7 +286,7 @@ class PostServiceWPComTests: XCTestCase {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesFor(postID: postID, siteID: siteID, success: { users in
+            self.service.getLikesFor(postID: postID, siteID: siteID, success: { users, totalLikes in
                 fail("this closure should not be called")
             },
             failure: { _ in
@@ -345,7 +345,8 @@ private class PostServiceRESTMock: PostServiceRemoteREST {
 
     // related to fetching likes
     var fetchLikesShouldSucceed: Bool = true
-    var remoteUsersToReturnOnGetLikes: [RemoteLikeUser]? = nil
+    var remoteUsersToReturnOnGetLikes = [RemoteLikeUser]()
+    var totalLikes: NSNumber = 1
 
     private(set) var invocationsCountOfCreatePost = 0
     private(set) var invocationsCountOfAutoSave = 0
@@ -396,10 +397,14 @@ private class PostServiceRESTMock: PostServiceRemoteREST {
         }
     }
 
-    override func getLikesForPostID(_ postID: NSNumber!, success: (([RemoteLikeUser]?) -> Void)!, failure: ((Error?) -> Void)!) {
+    override func getLikesForPostID(_ postID: NSNumber!,
+                                    count: NSNumber!,
+                                    before: String?,
+                                    success: (([RemoteLikeUser], NSNumber) -> Void)!,
+                                    failure: ((Error?) -> Void)!) {
         DispatchQueue.global().async {
             if self.fetchLikesShouldSucceed {
-                success(self.remoteUsersToReturnOnGetLikes)
+                success(self.remoteUsersToReturnOnGetLikes, self.totalLikes)
             } else {
                 failure(nil)
             }


### PR DESCRIPTION
Fixes #n/a
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/400

This uses the updated WPKit `getLikesFor` methods in preparation for Likes pagination (which is still to come).
- The `totalLikes` value from the endpoints is saved.
- The number of Likes in the initial fetch is saved in `totalLikesFetched`.

Outstanding tasks (i.e. the actual pagination):
- In the future, `totalLikes` and `totalLikesFetched` will be used to determine if there are more Likes available. 
- More Likes will be fetched when the user scrolls down to the end of the current batch.

To test:

- Enable the `newLikeNotifications` feature flag.
- Go to Notifications > Likes.
- Select a Post and a Comment notification.
- Verify the likes lists are as expected.
- In [`LikesListController.fetchLikes`](https://github.com/wordpress-mobile/WordPress-iOS/blob/a83c17c380623a2542f72b9b4c8ef8aafd572e49/WordPress/Classes/ViewRelated/Likes/LikesListController.swift#L142), modify the `getLikesFor` calls to include the `count` and `before` params. Maybe something like:
```
let date = DateUtils.isoString(from: Calendar.current.date(byAdding: .day, value: -7, to: Date()))
postService.getLikesFor(postID: postID, siteID: siteID, count: 5, before: date, success: success, failure: failure)
```
- Verify the number of fetched `users` matches `count`.
- Verify the likes are prior to the `before` date.


## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
