### PR TITLE
Restore commented out publicizer sync code in SharingService

### DIFF
--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -64,7 +64,7 @@ open class SharingService: LocalCoreDataService {
             failure?(SharingServiceError.siteWithNoRemote as NSError)
             return
         }
-                
+
         remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in
 
             // Process the results

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -60,17 +60,17 @@ open class SharingService: LocalCoreDataService {
     ///
     @objc open func syncPublicizeConnectionsForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         let blogObjectID = blog.objectID
-//        guard let remote = remoteForBlog(blog) else {
+        guard let remote = remoteForBlog(blog) else {
             failure?(SharingServiceError.siteWithNoRemote as NSError)
             return
-//        }
-//                
-//        remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in
-//
-//            // Process the results
-//            self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: remoteConnections, onComplete: success)
-//        },
-//        failure: failure)
+        }
+                
+        remote.getPublicizeConnections(blog.dotComID!, success: { remoteConnections in
+
+            // Process the results
+            self.mergePublicizeConnectionsForBlog(blogObjectID, remoteConnections: remoteConnections, onComplete: success)
+        },
+        failure: failure)
     }
 
 


### PR DESCRIPTION
This PR restores code that was accidentally commented out in https://github.com/wordpress-mobile/WordPress-iOS/commit/ad15045b0e79878a82b976324a0760c13302f19e.

**To test**

* Build and run
* Navigate to a site with one or more publicize connections
* Go to Sharing, and ensure you don't see any error and that the connections are visible.

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
