### PR TITLE
Update WPKit version

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.34.0-beta'
+    pod 'WordPressKit', '~> 4.34.0-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/pointer_warnings'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 4.34.0-beta'
+    # pod 'WordPressKit', '~> 4.34.0-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/pointer_warnings'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -669,7 +669,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.53.0
   WordPressKit:
-    :commit: 4288acca7845797f2d6220e3e7c2f12829b82833
+    :commit: 700c717c57dbf8fe5412c955bcd6e4f2bf9e7f15
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -669,7 +669,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.53.0
   WordPressKit:
-    :commit: 700c717c57dbf8fe5412c955bcd6e4f2bf9e7f15
+    :commit: 63b501ff36e4b5a9e623fd542d73e913c1310f05
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -499,7 +499,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.37.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `fix/pointer_warnings`)
+  - WordPressKit (~> 4.34.0-beta)
   - WordPressMocks (~> 0.0.11)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.0-beta.1)
@@ -511,6 +511,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressUI
   trunk:
     - 1PasswordExtension
@@ -650,9 +651,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.53.0
-  WordPressKit:
-    :branch: fix/pointer_warnings
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.53.0/third-party-podspecs/Yoga.podspec.json
 
@@ -668,9 +666,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.53.0
-  WordPressKit:
-    :commit: 63b501ff36e4b5a9e623fd542d73e913c1310f05
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -752,7 +747,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 2674c56cad016118fb4725b866b380b612db66fc
-  WordPressKit: ba0eb047c40b9fa90bf8507b124bd7e92cf13a90
+  WordPressKit: 8e25ef2dd937c622c6590160e5e200e5162fc895
   WordPressMocks: ff54a0fc44ed8968b5b685c34c6e56318e05dd8b
   WordPressShared: 4fd83a8f572dfd8209fa6ca5c891194b29d15961
   WordPressUI: 7152b1a8cdf44b958ceaa8f5bf5428fae9782c49
@@ -768,6 +763,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 7fb8a63a24d332c639655cd4f0ff02ead5a35f8f
+PODFILE CHECKSUM: f195bb3e8068f2c1654604bc0f4f633518ce8947
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -401,7 +401,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.34.0-beta.1):
+  - WordPressKit (4.34.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -499,7 +499,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.37.0)
-  - WordPressKit (~> 4.34.0-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `fix/pointer_warnings`)
   - WordPressMocks (~> 0.0.11)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.0-beta.1)
@@ -511,7 +511,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressUI
   trunk:
     - 1PasswordExtension
@@ -651,6 +650,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.53.0
+  WordPressKit:
+    :branch: fix/pointer_warnings
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.53.0/third-party-podspecs/Yoga.podspec.json
 
@@ -666,6 +668,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.53.0
+  WordPressKit:
+    :commit: 4288acca7845797f2d6220e3e7c2f12829b82833
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -747,7 +752,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 2674c56cad016118fb4725b866b380b612db66fc
-  WordPressKit: 3458e5cc42be650a5fdd5a1b63e7a57cb983abf0
+  WordPressKit: ba0eb047c40b9fa90bf8507b124bd7e92cf13a90
   WordPressMocks: ff54a0fc44ed8968b5b685c34c6e56318e05dd8b
   WordPressShared: 4fd83a8f572dfd8209fa6ca5c891194b29d15961
   WordPressUI: 7152b1a8cdf44b958ceaa8f5bf5428fae9782c49
@@ -763,6 +768,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: c88f1f94407897aefeb3a198969226775981a98a
+PODFILE CHECKSUM: 7fb8a63a24d332c639655cd4f0ff02ead5a35f8f
 
 COCOAPODS: 1.10.1

--- a/WordPress/WordPressTest/CommentServiceTests.swift
+++ b/WordPress/WordPressTest/CommentServiceTests.swift
@@ -112,8 +112,8 @@ private class CommentServiceRemoteRESTMock: CommentServiceRemoteREST {
     var remoteUsersToReturnOnGetLikes = [RemoteLikeUser]()
     var totalLikes: NSNumber = 3
 
-    override func getLikesForCommentID(_ commentID: NSNumber!,
-                                       count: NSNumber!,
+    override func getLikesForCommentID(_ commentID: NSNumber,
+                                       count: NSNumber,
                                        before: String?,
                                        success: (([RemoteLikeUser], NSNumber) -> Void)!,
                                        failure: ((Error?) -> Void)!) {

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -384,7 +384,7 @@ private class PostServiceRESTMock: PostServiceRemoteREST {
         }
     }
 
-    override func autoSave(_ post: RemotePost!, success: ((RemotePost?, String?) -> Void)!, failure: ((Error?) -> Void)!) {
+    override func autoSave(_ post: RemotePost, success: ((RemotePost?, String?) -> Void)!, failure: ((Error?) -> Void)!) {
         DispatchQueue.global().async {
             self.invocationsCountOfAutoSave += 1
 
@@ -397,8 +397,8 @@ private class PostServiceRESTMock: PostServiceRemoteREST {
         }
     }
 
-    override func getLikesForPostID(_ postID: NSNumber!,
-                                    count: NSNumber!,
+    override func getLikesForPostID(_ postID: NSNumber,
+                                    count: NSNumber,
                                     before: String?,
                                     success: (([RemoteLikeUser], NSNumber) -> Void)!,
                                     failure: ((Error?) -> Void)!) {


### PR DESCRIPTION
Fixes #n/a
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/401

This updates WPKit for the pointer nullability type changes.

To test:

Verify these Comment and Post actions work as expected. 

Comments:
- Go to Reader > Post > tap Comments button.
  - Verify the Comments load.
- Go to Notifications > Comment and select a Comment. Verify these actions work:
  - Approve
  - Unapprove
  - Spam
  - Trash
  - Like
  - Unlike
  - Edit and save

Posts:
- Create a Post with media.
- Edit Post > More options > Preview.


## Regression Notes
1. Potential unintended areas of impact
Comment Notification moderation, Post creation and drafts.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified the functionality that use the updated WPKit methods.

3. What automated tests I added (or what prevented me from doing so)
Not needed. The changes just explicitly indicate what was already expected and implemented.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
