### PR TITLE
People: Fix flashing loading screen when pulling to refresh.

### DIFF
--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -225,7 +225,6 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
 
     @IBAction
     func refresh() {
-        resetManagedPeople()
         refreshPeople()
     }
 


### PR DESCRIPTION
Fixes #16526 
This PR removes what seems to be an unnecessary call to purge core data when pulling to refresh that was causing the loading view to briefly flash on screen before the list of users was repopulated.

To test:
View the My Sites > Site > People screen.  
Smoke test the feature and confirm that it continues to work as expected. 
Confirm that pulling to refresh does not flash the loading screen unnecessarily. 
Confirm that switching between filters does not show the loading screen unnecessarily. 

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
