### PR TITLE
Improve deep links tracking

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -130,7 +130,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
 
     func displayWebViewWithURL(_ url: URL) {
         if UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes).canHandle(url: url) {
-            UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes).handle(url: url, source: controller)
+            UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes).handle(url: url, source: .inApp(controller))
             return
         }
 

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -130,7 +130,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
 
     func displayWebViewWithURL(_ url: URL) {
         if UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes).canHandle(url: url) {
-            UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes).handle(url: url, source: .inApp(controller))
+            UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes).handle(url: url, source: .inApp(presenter: controller))
             return
         }
 

--- a/WordPress/Classes/Utility/Universal Links/Route+Page.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route+Page.swift
@@ -2,11 +2,13 @@ import Foundation
 
 struct NewPageRoute: Route {
     let path = "/page"
+    let section: DeepLinkSection? = .editor
     let action: NavigationAction = NewPageNavigationAction()
 }
 
 struct NewPageForSiteRoute: Route {
     let path = "/page/:domain"
+    let section: DeepLinkSection? = .editor
     let action: NavigationAction = NewPageNavigationAction()
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -12,12 +12,20 @@ protocol Route {
     var section: DeepLinkSection? { get }
     var source: DeepLinkSource { get }
     var action: NavigationAction { get }
+    var shouldTrack: Bool { get }
 }
 
 extension Route {
     // Default routes to handling links rather than other source types
     var source: DeepLinkSource {
         return .link
+    }
+
+    // By default, we'll track all routes, but certain routes can override this.
+    // Routes like banner and email routes may not want to track their original
+    // link, but will instead just track any redirect that they contain.
+    var shouldTrack: Bool {
+        return true
     }
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -10,7 +10,15 @@ import Foundation
 protocol Route {
     var path: String { get }
     var section: DeepLinkSection? { get }
+    var source: DeepLinkSource { get }
     var action: NavigationAction { get }
+}
+
+extension Route {
+    // Default routes to handling links rather than other source types
+    var source: DeepLinkSource {
+        return .link
+    }
 }
 
 protocol NavigationAction {
@@ -61,6 +69,25 @@ extension Route {
 }
 
 // MARK: - Tracking
+
+/// Where did the deep link originate?
+///
+enum DeepLinkSource {
+    case link
+    case banner
+    case email
+    case widget
+    case inApp(UIViewController?)
+
+    var isInternal: Bool {
+        switch self {
+        case .inApp(_):
+            return true
+        default:
+            return false
+        }
+    }
+}
 
 /// Which broad section of the app is being linked to?
 ///

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -100,7 +100,7 @@ enum DeepLinkSource: Equatable {
 
     var isInternal: Bool {
         switch self {
-        case .inApp(_):
+        case .inApp:
             return true
         default:
             return false

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -87,8 +87,8 @@ enum DeepLinkSource: Equatable {
     case widget
     case inApp(presenter: UIViewController?)
 
-    init?(string: String) {
-        switch string {
+    init?(sourceName: String) {
+        switch sourceName {
         // We only care about widgets right now, but we could
         // add others in the future if necessary.
         case "widget":

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -83,9 +83,9 @@ extension Route {
 enum DeepLinkSource {
     case link
     case banner
-    case email
+    case email(campaign: String)
     case widget
-    case inApp(UIViewController?)
+    case inApp(presenter: UIViewController?)
 
     var isInternal: Bool {
         switch self {
@@ -93,6 +93,15 @@ enum DeepLinkSource {
             return true
         default:
             return false
+        }
+    }
+
+    var trackingInfo: Any? {
+        switch self {
+        case .email(let campaign):
+            return campaign
+        default:
+            return nil
         }
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -9,6 +9,7 @@ import Foundation
 ///
 protocol Route {
     var path: String { get }
+    var section: DeepLinkSection? { get }
     var action: NavigationAction { get }
 }
 
@@ -57,4 +58,18 @@ extension Route {
     func isEqual(to route: Route) -> Bool {
         return path == route.path
     }
+}
+
+// MARK: - Tracking
+
+/// Which broad section of the app is being linked to?
+///
+enum DeepLinkSection: String {
+    case editor
+    case me
+    case mySite = "my_site"
+    case notifications
+    case reader
+    case siteCreation = "site_creation"
+    case stats
 }

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -96,7 +96,7 @@ enum DeepLinkSource {
         }
     }
 
-    var trackingInfo: Any? {
+    var trackingInfo: String? {
         switch self {
         case .email(let campaign):
             return campaign

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -80,12 +80,23 @@ extension Route {
 
 /// Where did the deep link originate?
 ///
-enum DeepLinkSource {
+enum DeepLinkSource: Equatable {
     case link
     case banner
     case email(campaign: String)
     case widget
     case inApp(presenter: UIViewController?)
+
+    init?(string: String) {
+        switch string {
+        // We only care about widgets right now, but we could
+        // add others in the future if necessary.
+        case "widget":
+            self = .widget
+        default:
+            return nil
+        }
+    }
 
     var isInternal: Bool {
         switch self {

--- a/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
+++ b/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
@@ -96,6 +96,7 @@ struct MatchedRoute: Route {
     let section: DeepLinkSection?
     let source: DeepLinkSource
     let action: NavigationAction
+    let shouldTrack: Bool
     let values: [String: String]
 
     init(from route: Route, with values: [String: String] = [:]) {
@@ -103,6 +104,7 @@ struct MatchedRoute: Route {
         self.section = route.section
         self.source = route.source
         self.action = route.action
+        self.shouldTrack = route.shouldTrack
         self.values = values
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
+++ b/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
@@ -94,12 +94,14 @@ class RouteMatcher {
 struct MatchedRoute: Route {
     let path: String
     let section: DeepLinkSection?
+    let source: DeepLinkSource
     let action: NavigationAction
     let values: [String: String]
 
     init(from route: Route, with values: [String: String] = [:]) {
         self.path = route.path
         self.section = route.section
+        self.source = route.source
         self.action = route.action
         self.values = values
     }

--- a/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
+++ b/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
@@ -93,12 +93,14 @@ class RouteMatcher {
 ///
 struct MatchedRoute: Route {
     let path: String
+    let section: DeepLinkSection?
     let action: NavigationAction
     let values: [String: String]
 
-    init(path: String, action: NavigationAction, values: [String: String] = [:]) {
-        self.path = path
-        self.action = action
+    init(from route: Route, with values: [String: String] = [:]) {
+        self.path = route.path
+        self.section = route.section
+        self.action = route.action
         self.values = values
     }
 }
@@ -107,7 +109,7 @@ extension Route {
     /// - returns: A MatchedRoute for the current path, with optional values
     ///            extracted from the resolved path.
     fileprivate func matched(with values: [String: String] = [:]) -> MatchedRoute {
-        return MatchedRoute(path: path, action: action, values: values)
+        return MatchedRoute(from: self, with: values)
     }
 }
 

--- a/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
+++ b/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
@@ -116,7 +116,7 @@ struct MatchedRoute: Route {
         // Allows optional overriding of source based on the input URL parameters.
         // Currently used for widget links.
         let sourceValue = values[MatchedRouteURLComponentKey.source.rawValue] ?? ""
-        let source = DeepLinkSource(string: sourceValue)
+        let source = DeepLinkSource(sourceName: sourceValue)
 
         self.path = route.path
         self.section = route.section

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -13,6 +13,7 @@ struct AppBannerRoute: Route {
     let path = "/get"
     let section: DeepLinkSection? = nil
     let source: DeepLinkSource = .banner
+    let shouldTrack: Bool = false
 
     var action: NavigationAction {
         return self

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -11,6 +11,7 @@ import Foundation
 ///
 struct AppBannerRoute: Route {
     let path = "/get"
+    let section: DeepLinkSection? = nil
 
     var action: NavigationAction {
         return self

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -12,6 +12,7 @@ import Foundation
 struct AppBannerRoute: Route {
     let path = "/get"
     let section: DeepLinkSection? = nil
+    let source: DeepLinkSource = .banner
 
     var action: NavigationAction {
         return self
@@ -33,9 +34,7 @@ extension AppBannerRoute: NavigationAction {
         components.path = fragment
 
         if let url = components.url {
-            // We disable tracking when passing the URL back through the router,
-            // otherwise we'd be posting two stats events.
-            router.handle(url: url, shouldTrack: false, source: source)
+            router.handle(url: url, shouldTrack: true, source: .banner)
         }
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
@@ -30,6 +30,8 @@ public struct MbarRoute: Route {
         return self
     }
 
+    let shouldTrack: Bool = false
+
     private func redirectURL(from url: String) -> URL? {
         guard let components = URLComponents(string: url) else {
             return nil

--- a/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
@@ -24,6 +24,8 @@ public struct MbarRoute: Route {
 
     let path = "/mbar"
 
+    let section: DeepLinkSection? = nil
+
     var action: NavigationAction {
         return self
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
@@ -76,6 +76,6 @@ extension MbarRoute: NavigationAction {
                 }
             }
 
-        router.handle(url: redirectUrl, shouldTrack: true, source: source)
+        router.handle(url: redirectUrl, shouldTrack: true, source: .email)
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
@@ -64,7 +64,7 @@ public struct MbarRoute: Route {
               let campaignValue = redirectComponents.queryItems?.first(where: { $0.name == MbarRoute.campaignURLParameter })?.value?.removingPercentEncoding else {
             return MbarRoute.unknownCampaignValue
         }
-        
+
         return campaignValue
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Mbar.swift
@@ -19,8 +19,10 @@ import Alamofire
 ///   * /mbar/?redirect_to=https%3A%2F%2Fwordpress.com%2Fpost%2Fsomesite.wordpress.com
 ///
 public struct MbarRoute: Route {
-    static let redirectURLParameter = "redirect_to"
-    static let loginURLPath = "wp-login.php"
+    private static let redirectURLParameter = "redirect_to"
+    private static let campaignURLParameter = "login_reason"
+    private static let unknownCampaignValue = "unknown"
+    private static let loginURLPath = "wp-login.php"
 
     let path = "/mbar"
 
@@ -40,7 +42,7 @@ public struct MbarRoute: Route {
         return redirectURL(from: components)
     }
 
-    private func redirectURL(from components: URLComponents) -> URL? {
+    private func redirectURL(from components: URLComponents, followRedirects: Bool = true) -> URL? {
         guard let redirectURL = components.queryItems?.first(where: { $0.name == MbarRoute.redirectURLParameter })?.value?.removingPercentEncoding else {
             return nil
         }
@@ -48,11 +50,22 @@ public struct MbarRoute: Route {
         let url = URL(string: redirectURL)
 
         // If this is a wp-login link, handle _its_ redirect_to parameter
-        if url?.lastPathComponent == MbarRoute.loginURLPath {
+        if followRedirects && url?.lastPathComponent == MbarRoute.loginURLPath {
             return self.redirectURL(from: redirectURL)
         }
 
         return url
+    }
+
+    private func campaign(from url: String) -> String {
+        guard let components = URLComponents(string: url),
+              let url = redirectURL(from: components, followRedirects: false),
+              let redirectComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let campaignValue = redirectComponents.queryItems?.first(where: { $0.name == MbarRoute.campaignURLParameter })?.value?.removingPercentEncoding else {
+            return MbarRoute.unknownCampaignValue
+        }
+        
+        return campaignValue
     }
 }
 
@@ -78,6 +91,6 @@ extension MbarRoute: NavigationAction {
                 }
             }
 
-        router.handle(url: redirectUrl, shouldTrack: true, source: .email)
+        router.handle(url: redirectUrl, shouldTrack: true, source: .email(campaign: campaign(from: url)))
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
@@ -2,16 +2,19 @@ import Foundation
 
 struct MeRoute: Route {
     let path = "/me"
+    let section: DeepLinkSection? = .me
     let action: NavigationAction = MeNavigationAction.root
 }
 
 struct MeAccountSettingsRoute: Route {
     let path = "/me/account"
+    let section: DeepLinkSection? = .me
     let action: NavigationAction = MeNavigationAction.accountSettings
 }
 
 struct MeNotificationSettingsRoute: Route {
     let path = "/me/notifications"
+    let section: DeepLinkSection? = .me
     let action: NavigationAction = MeNavigationAction.notificationSettings
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -12,6 +12,10 @@ enum MySitesRoute {
 }
 
 extension MySitesRoute: Route {
+    var section: DeepLinkSection? {
+        return .mySite
+    }
+
     var action: NavigationAction {
         return self
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct NotificationsRoute: Route {
     let path = "/notifications"
+    let section: DeepLinkSection? = .notifications
     let action: NavigationAction = NotificationsNavigationAction()
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
@@ -2,11 +2,13 @@ import Foundation
 
 struct NewPostRoute: Route {
     let path = "/post"
+    let section: DeepLinkSection? = .editor
     let action: NavigationAction = NewPostNavigationAction()
 }
 
 struct NewPostForSiteRoute: Route {
     let path = "/post/:domain"
+    let section: DeepLinkSection? = .editor
     let action: NavigationAction = NewPostNavigationAction()
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -51,6 +51,10 @@ extension ReaderRoute: Route {
         }
     }
 
+    var section: DeepLinkSection? {
+        return .reader
+    }
+
     var action: NavigationAction {
         return self
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Start.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Start.swift
@@ -3,7 +3,7 @@ import Foundation
 struct StartRoute: Route, NavigationAction {
     let path = "/start"
 
-    let section: DeepLinkSection? = nil
+    let section: DeepLinkSection? = .siteCreation
 
     var action: NavigationAction {
         return self

--- a/WordPress/Classes/Utility/Universal Links/Routes+Start.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Start.swift
@@ -3,6 +3,8 @@ import Foundation
 struct StartRoute: Route, NavigationAction {
     let path = "/start"
 
+    let section: DeepLinkSection? = nil
+
     var action: NavigationAction {
         return self
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -31,6 +31,10 @@ enum StatsRoute {
 }
 
 extension StatsRoute: Route {
+    var section: DeepLinkSection? {
+        return .stats
+    }
+
     var action: NavigationAction {
         return self
     }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -173,6 +173,7 @@ struct UniversalLinkRouter: LinkRouter {
         let properties: [String: String] = [
             TracksPropertyKeys.url: match.path,
             TracksPropertyKeys.source: source?.tracksValue ?? match.source.tracksValue,
+            TracksPropertyKeys.sourceInfo: source?.trackingInfo ?? match.source.trackingInfo ?? "",
             TracksPropertyKeys.section: match.section?.rawValue ?? "",
         ]
 
@@ -182,6 +183,7 @@ struct UniversalLinkRouter: LinkRouter {
     private enum TracksPropertyKeys {
         static let url = "url"
         static let source = "source"
+        static let sourceInfo = "source_info"
         static let section = "section"
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -215,9 +215,8 @@ extension DeepLinkSource {
             return "email"
         case .widget:
             return "widget"
-        case .inApp(_):
+        case .inApp:
             return "internal"
         }
     }
 }
-

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -161,5 +161,6 @@ struct UniversalLinkRouter: LinkRouter {
     private enum TracksPropertyKeys {
         static let url = "url"
         static let source = "source"
+        static let section = "section"
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -163,6 +163,9 @@ struct UniversalLinkRouter: LinkRouter {
     }
 
     private func trackDeepLink(for match: MatchedRoute, source: DeepLinkSource? = nil) {
+        // Check if the route is overridding tracking
+        if match.shouldTrack == false {
+            return
         }
 
         // If we've been passed a source we'll use that to override the route's original source.

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -384,11 +384,11 @@ class ReaderDetailCoordinator {
         } else if url.query?.contains("wp-story") ?? false {
             presentWebViewController(url)
         } else if readerLinkRouter.canHandle(url: url) {
-            readerLinkRouter.handle(url: url, shouldTrack: false, source: viewController)
+            readerLinkRouter.handle(url: url, shouldTrack: false, source: .inApp(viewController))
         } else if url.isWordPressDotComPost {
             presentReaderDetail(url)
         } else if url.isLinkProtocol {
-            readerLinkRouter.handle(url: url, shouldTrack: false, source: viewController)
+            readerLinkRouter.handle(url: url, shouldTrack: false, source: .inApp(viewController))
         } else {
             presentWebViewController(url)
         }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -384,11 +384,11 @@ class ReaderDetailCoordinator {
         } else if url.query?.contains("wp-story") ?? false {
             presentWebViewController(url)
         } else if readerLinkRouter.canHandle(url: url) {
-            readerLinkRouter.handle(url: url, shouldTrack: false, source: .inApp(viewController))
+            readerLinkRouter.handle(url: url, shouldTrack: false, source: .inApp(presenter: viewController))
         } else if url.isWordPressDotComPost {
             presentReaderDetail(url)
         } else if url.isLinkProtocol {
-            readerLinkRouter.handle(url: url, shouldTrack: false, source: .inApp(viewController))
+            readerLinkRouter.handle(url: url, shouldTrack: false, source: .inApp(presenter: viewController))
         } else {
             presentWebViewController(url)
         }

--- a/WordPress/WordPressTest/MBarRouteTests.swift
+++ b/WordPress/WordPressTest/MBarRouteTests.swift
@@ -108,7 +108,7 @@ class MBarRouteTests: XCTestCase {
 
         router.completion = { url, source in
             if url.lastPathComponent == "start",
-               let trackingInfo = source?.trackingInfo as? String,
+               let trackingInfo = source?.trackingInfo,
                trackingInfo == "user_first_flow" {
                 success.fulfill()
             }

--- a/WordPress/WordPressTest/MBarRouteTests.swift
+++ b/WordPress/WordPressTest/MBarRouteTests.swift
@@ -4,7 +4,7 @@ import OHHTTPStubs
 
 struct MockRouter: LinkRouter {
     let matcher: RouteMatcher
-    var completion: ((URL) -> Void)?
+    var completion: ((URL, DeepLinkSource?) -> Void)?
 
     init(routes: [Route]) {
         self.matcher = RouteMatcher(routes: routes)
@@ -14,8 +14,8 @@ struct MockRouter: LinkRouter {
         return true
     }
 
-    func handle(url: URL, shouldTrack track: Bool, source: UIViewController?) {
-        completion?(url)
+    func handle(url: URL, shouldTrack track: Bool, source: DeepLinkSource?) {
+        completion?(url, source)
     }
 }
 
@@ -48,7 +48,7 @@ class MBarRouteTests: XCTestCase {
         let url = URL(string: "https://public-api.wordpress.com/mbar?redirect_to=/post")!
         let success = expectation(description: "Correct redirect URL found")
 
-        router.completion = { url in
+        router.completion = { url, _ in
             if url.lastPathComponent == "post" {
                 success.fulfill()
             }
@@ -67,7 +67,7 @@ class MBarRouteTests: XCTestCase {
         let url = URL(string: "https://public-api.wordpress.com/mbar?redirect_to=/start&stat=groovemails-events&bin=wpcom_email_click")!
         let success = expectation(description: "Correct redirect URL found")
 
-        router.completion = { url in
+        router.completion = { url, _ in
             if url.lastPathComponent == "start" {
                 success.fulfill()
             }
@@ -87,7 +87,7 @@ class MBarRouteTests: XCTestCase {
 
         let success = expectation(description: "Correct redirect URL found")
 
-        router.completion = { url in
+        router.completion = { url, _ in
             if url.lastPathComponent == "start" {
                 success.fulfill()
             }
@@ -98,6 +98,28 @@ class MBarRouteTests: XCTestCase {
                                  source: nil,
                                  router: router)
         }
+
+        waitForExpectations(timeout: 1.0)
+    }
+
+    func testExtractEmailCampaignFromURL() throws {
+        let url = URL(string: "https://public-api.wordpress.com/mbar/?stat=groovemails-events&bin=wpcom_email_click&redirect_to=https://wordpress.com/wp-login.php?action=immediate-login%26timestamp=1617470831%26login_reason=user_first_flow%26user_id=123456789%26token=abcdef%26login_email=test%40example.com%26login_locale=en%26redirect_to=https%3A%2F%2Fwordpress.com%2Fstart%26sr=1%26signature=abcdef%26user=123456")!
+        let success = expectation(description: "Email campaign found")
+
+        router.completion = { url, source in
+            if url.lastPathComponent == "start",
+               let trackingInfo = source?.trackingInfo as? String,
+               trackingInfo == "user_first_flow" {
+                success.fulfill()
+            }
+        }
+
+        if let match = matcher.routesMatching(url).first {
+            match.action.perform(match.values,
+                                 source: nil,
+                                 router: router)
+        }
+
 
         waitForExpectations(timeout: 1.0)
     }

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -122,4 +122,28 @@ class RouteMatcherTests: XCTestCase {
         XCTAssertEqual(values2["account"], "bobsmith")
         XCTAssertEqual(values2["test"], "group")
     }
+
+    // MARK: - Source query item
+
+    func testRouteWithNoSourceQueryItem() {
+        routes = [ TestRoute(path: "/stats") ]
+        matcher = RouteMatcher(routes: routes)
+
+        let matches = matcher.routesMatching(URL(string: "https://wordpress.com/stats")!)
+        let values = matches.first!.values
+        XCTAssert(values.count == 1)
+        XCTAssertEqual(values[MatchedRouteURLComponentKey.url.rawValue], "https://wordpress.com/stats")
+        XCTAssertNil(values[MatchedRouteURLComponentKey.source.rawValue])
+    }
+
+    func testRouteWithSourceQueryItem() {
+        routes = [ TestRoute(path: "/stats") ]
+        matcher = RouteMatcher(routes: routes)
+
+        let matches = matcher.routesMatching(URL(string: "https://wordpress.com/stats?source=widget")!)
+        let match = matches.first!
+        XCTAssert(match.values.count == 2)
+        XCTAssertEqual(match.values[MatchedRouteURLComponentKey.source.rawValue], "widget")
+        XCTAssertEqual(match.source, DeepLinkSource.widget)
+    }
 }

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -3,7 +3,10 @@ import XCTest
 
 private struct TestRoute: Route {
     let path: String
+    let section: DeepLinkSection? = .mySite
+    let source: DeepLinkSource = .link
     let action: NavigationAction = TestAction()
+    let shouldTrack = false
 }
 
 private struct TestAction: NavigationAction {


### PR DESCRIPTION
This PR improves tracking for deep links. It took quite a few changes to get what we need!

Deep link routes can now have a section (e.g. Reader), a source (e.g. link or email), and disable tracking if required. For example, a deep link to Reader via a banner would track a source of `banner`, a path of `/read` and a section of `reader`. It would also prevent tracking of the original `/get` banner URL, and only track the redirected URL to the Reader.

All deep link routes default to a source of `link`, but this can be overridden in several ways:

- By passing a different source to the link router's `handle` method – this is how banners and emails provide the source of their redirected URLs.
- Via a `source` URL parameter in the original URL – this is how widgets mark that they are widget links (e.g. `https://wordpress.com/stats?source=widget`.

I also added some extra debugging output for development builds, to aid in testing.

**To test**

- Build and run on a device
- Filter your debugger with the test 'deep link' to make it easier to see 
- Test the following URLs and ensure you see the correct output in the debugger:

### Normal links

Some examples, with output below:

https://wordpress.com/post

```
🔗 Deep link: /post, source: link, section: editor
```

https://wordpress.com/me

```
🔗 Deep link: /me, source: link, section: me
```

https://wordpress.com/start

```
🔗 Deep link: /start, source: link, section: site_creation
```

https://wordpress.com/notifications

```
🔗 Deep link: /notifications, source: link, section: notifications
```

https://wordpress.com/read

```
🔗 Deep link: /read, source: link, section: reader
```

https://galacticmap.wordpress.com/2016/08/22/to-boldly-go/

```
🔗 Deep link: /:post_year/:post_month/:post_day/:post_name, source: link, section: reader
```

### Widgets

Add a widget to your home screen and tap it

```
🔗 Deep link: /stats/day/:domain, source: widget, section: stats
```

### Banners

https://apps.wordpress.com/get#/read

```
🔗 Deep link: /read, source: banner, section: reader
```

https://apps.wordpress.com/get#/stats

```
🔗 Deep link: /stats, source: banner, section: stats
```

### Email

https://public-api.wordpress.com/mbar/?stat=groovemails-events&bin=wpcom_email_click&redirect_to=https%3A%2F%2Fwordpress.com%2Fwp-login.php%3Faction%3Dimmediate-login%26login_reason%3Duser_first_flow%26redirect_to%3Dhttps%253A%252F%252Fwordpress.com%252Fstart

```
🔗 Deep link: /start, source: email – user_first_flow, section: 
```

https://public-api.wordpress.com/mbar/?stat=groovemails-events&bin=wpcom_email_click&redirect_to=https%3A%2F%2Fwordpress.com%2Fwp-login.php%3Faction%3Dimmediate-login%26redirect_to%3Dhttps%253A%252F%252Fwordpress.com%252Fstart

```
🔗 Deep link: /start, source: email – unknown, section:
```

## Regression Notes
1. Potential unintended areas of impact

This should only affect anything that uses the deep linking system.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested as many possible types of links as I could, and added some new unit tests to cover some of the new code I added.

3. What automated tests I added (or what prevented me from doing so)

See above.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
