### PR TITLE
Likes List: load more Likes on scroll

### DIFF
--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -3,17 +3,20 @@ extension PostService {
     /**
      Fetches a list of users from remote that liked the post with the given IDs.
      
-     @param postID  The ID of the post to fetch likes for
-     @param siteID  The ID of the site that contains the post
-     @param count   Number of records to retrieve. Optional. Defaults to the endpoint max of 90.
-     @param before  Filter results to likes before this date/time. Optional.
-     @param success A success block
-     @param failure A failure block
+     @param postID          The ID of the post to fetch likes for
+     @param siteID          The ID of the site that contains the post
+     @param count           Number of records to retrieve. Optional. Defaults to the endpoint max of 90.
+     @param before          Filter results to likes before this date/time. Optional.
+     @param purgeExisting   Indicates if existing Likes for the given post and site should be purged before
+                            new ones are created. Defaults to false.
+     @param success         A success block
+     @param failure         A failure block
      */
     func getLikesFor(postID: NSNumber,
                      siteID: NSNumber,
                      count: Int = 90,
                      before: String? = nil,
+                     purgeExisting: Bool = false,
                      success: @escaping (([LikeUser], Int) -> Void),
                      failure: @escaping ((Error?) -> Void)) {
 
@@ -27,8 +30,10 @@ extension PostService {
                                  count: NSNumber(value: count),
                                  before: before,
                                  success: { remoteLikeUsers, totalLikes in
-                                    self.createNewUsers(from: remoteLikeUsers, postID: postID, siteID: siteID) {
-                                        let users = self.likeUsersFor(postID: postID, siteID: siteID)
+                                    self.createNewUsers(from: remoteLikeUsers,
+                                                        postID: postID,
+                                                        siteID: siteID,
+                                                        purgeExisting: purgeExisting) {
                                         success(users, totalLikes.intValue)
                                         LikeUserHelper.purgeStaleLikes()
                                     }
@@ -63,6 +68,7 @@ private extension PostService {
     func createNewUsers(from remoteLikeUsers: [RemoteLikeUser]?,
                         postID: NSNumber,
                         siteID: NSNumber,
+                        purgeExisting: Bool,
                         onComplete: @escaping (() -> Void)) {
 
         guard let remoteLikeUsers = remoteLikeUsers,
@@ -75,7 +81,9 @@ private extension PostService {
 
         derivedContext.perform {
 
-            self.deleteExistingUsersFor(postID: postID, siteID: siteID, from: derivedContext)
+            if purgeExisting {
+                self.deleteExistingUsersFor(postID: postID, siteID: siteID, from: derivedContext)
+            }
 
             remoteLikeUsers.forEach {
                 LikeUserHelper.createUserFrom(remoteUser: $0, context: derivedContext)

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -51,7 +51,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .milestoneNotifications:
             return true
         case .newLikeNotifications:
-            return false
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -22,7 +22,7 @@ class LikesListController: NSObject {
     private var lastFetchedDate: String?
 
     private var hasMoreLikes: Bool {
-        return totalLikesFetched <= totalLikes
+        return totalLikesFetched < totalLikes
     }
 
     private var likingUsers: [LikeUser] = [] {

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -12,10 +12,24 @@ class LikesListController: NSObject {
     private let siteID: NSNumber
     private let notification: Notification?
     private let tableView: UITableView
-    private var likingUsers: [LikeUser] = []
-    private var totalLikes: Int = 0
-    private var totalLikesFetched: Int = 0
     private weak var delegate: LikesListControllerDelegate?
+
+    // Used to control pagination.
+    private var isLoadingContent = false
+    private var isFirstLoad = true
+    private var totalLikes = 0
+    private var totalLikesFetched = 0
+    private var lastFetchedDate: String?
+
+    private var hasMoreLikes: Bool {
+        return totalLikesFetched <= totalLikes
+    }
+
+    private var likingUsers: [LikeUser] = [] {
+        didSet {
+            tableView.reloadData()
+        }
+    }
 
     private lazy var postService: PostService = {
         PostService(managedObjectContext: ContextManager.shared.mainContext)
@@ -23,34 +37,6 @@ class LikesListController: NSObject {
 
     private lazy var commentService: CommentService = {
         CommentService(managedObjectContext: ContextManager.shared.mainContext)
-    }()
-
-    private var isLoadingContent: Bool = false {
-        didSet {
-            isLoadingContent ? activityIndicator.startAnimating() : activityIndicator.stopAnimating()
-            tableView.reloadData()
-        }
-    }
-
-    // MARK: Views
-
-    private lazy var activityIndicator: UIActivityIndicatorView = {
-        let view = UIActivityIndicatorView(style: .medium)
-        view.translatesAutoresizingMaskIntoConstraints = false
-
-        return view
-    }()
-
-    private lazy var loadingCell: UITableViewCell = {
-        let cell = UITableViewCell()
-
-        cell.addSubview(activityIndicator)
-        NSLayoutConstraint.activate([
-            activityIndicator.safeCenterXAnchor.constraint(equalTo: cell.safeCenterXAnchor),
-            activityIndicator.safeCenterYAnchor.constraint(equalTo: cell.safeCenterYAnchor)
-        ])
-
-        return cell
     }()
 
     // MARK: Lifecycle
@@ -96,10 +82,11 @@ class LikesListController: NSObject {
             return
         }
 
-        // shows the loading cell and prevents double refresh.
         isLoadingContent = true
 
-        fetchStoredLikes()
+        if isFirstLoad {
+            fetchStoredLikes()
+        }
 
         guard ReachabilityUtils.isInternetReachable() else {
             isLoadingContent = false
@@ -111,13 +98,20 @@ class LikesListController: NSObject {
             return
         }
 
-        // If there are no cached users, continue showing the loading cell.
         isLoadingContent = likingUsers.isEmpty
 
         fetchLikes(success: { [weak self] users, totalLikes in
-            self?.likingUsers = users
+
+            // Remove cached users as they'll be replaced by the first fetch.
+            if self?.isFirstLoad == true {
+                self?.likingUsers = []
+            }
+
+            self?.likingUsers.append(contentsOf: users)
             self?.totalLikes = totalLikes
-            self?.totalLikesFetched = users.count
+            self?.totalLikesFetched += users.count
+            self?.lastFetchedDate = users.last?.dateLikedString
+            self?.isFirstLoad = false
             self?.isLoadingContent = false
         }, failure: { [weak self] _ in
             self?.isLoadingContent = false
@@ -142,9 +136,18 @@ class LikesListController: NSObject {
     private func fetchLikes(success: @escaping ([LikeUser], Int) -> Void, failure: @escaping (Error?) -> Void) {
         switch content {
         case .post(let postID):
-            postService.getLikesFor(postID: postID, siteID: siteID, success: success, failure: failure)
+            postService.getLikesFor(postID: postID,
+                                    siteID: siteID,
+                                    before: lastFetchedDate,
+                                    purgeExisting: isFirstLoad,
+                                    success: success,
+                                    failure: failure)
         case .comment(let commentID):
-            commentService.getLikesFor(commentID: commentID, siteID: siteID, success: success, failure: failure)
+            commentService.getLikesFor(commentID: commentID,
+                                       siteID: siteID,
+                                       before: lastFetchedDate,
+                                       purgeExisting: isFirstLoad,
+                                       success: success, failure: failure)
         }
     }
 }
@@ -158,13 +161,13 @@ extension LikesListController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // header section
+        // Header section
         if section == Constants.headerSectionIndex {
             return Constants.numberOfHeaderRows
         }
 
-        // users section
-        return isLoadingContent ? Constants.numberOfLoadingRows : likingUsers.count
+        // Users section
+        return likingUsers.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -172,11 +175,19 @@ extension LikesListController: UITableViewDataSource, UITableViewDelegate {
             return headerCell()
         }
 
-        if isLoadingContent {
-            return loadingCell
+        return userCell(for: indexPath)
+    }
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+
+        let isUsersSection = indexPath.section == Constants.usersSectionIndex
+        let isLastRow = indexPath.row == totalLikesFetched - 1
+
+        guard !isLoadingContent && hasMoreLikes && isUsersSection && isLastRow else {
+            return
         }
 
-        return userCell(for: indexPath)
+        refresh()
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -277,9 +288,9 @@ private extension LikesListController {
     struct Constants {
         static let numberOfSections = 2
         static let headerSectionIndex = 0
+        static let usersSectionIndex = 1
         static let headerRowIndex = 0
         static let numberOfHeaderRows = 1
-        static let numberOfLoadingRows = 1
     }
 
 }


### PR DESCRIPTION
In the Notification Likes list, when the table is scrolled to the bottom, a new page of Likes is fetched based on the last Like's date. It uses the endpoint max number of records to fetch, so 90 Likes are fetched each time.

Outstanding tasks:
- Show a loading indicator at the bottom of the list. I removed the old loading indicator since it didn't work with pagination.
- Handle scenario where multiple users might like a post or comment at the same time.

Since this feature is usable enough now, I've enabled the `newLikeNotifications` feature flag for `localDeveloper`.

To test:
- Go to Notifications > Likes.
- Select a Post notification, and a Comment notification.
- Verify the lists show the first 90 Likes.
- Verify when at the bottom of the table, more Likes are loaded and displayed.
- Verify there are no duplicates (notably, the first page where cached are replaced by fetched).

Hack Tip:
You can modify the comment/post fetching to better test pagination if you don't have a lot of Likes. In [`LikesListController.fetchLikes`](https://github.com/wordpress-mobile/WordPress-iOS/blob/2def4b3e0db3c61ae851a917a88afbca2c9e6717/WordPress/Classes/ViewRelated/Likes/LikesListController.swift#L136):
- Set the postID/commentID and siteID of a post/comment you know to have a lot of Likes. (I can DM some to you if you like.)
- And/or add a `count` param to the `getLikesFor` methods to fetch less Likes. FWIW, on an iPhone, about 12 allows for scrolling. Example:
```
postService.getLikesFor(postID: 999,
                        siteID: 999,
                        count: 12,
                        before: lastFetchedDate,
                        purgeExisting: isFirstLoad,
                        success: success,
                        failure: failure)
```

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
