### PR TITLE
Likes List: show activity indicator when content is loading.

### DIFF
--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -12,10 +12,10 @@ class LikesListController: NSObject {
     private let siteID: NSNumber
     private let notification: Notification?
     private let tableView: UITableView
+    private var loadingIndicator: UIActivityIndicatorView
     private weak var delegate: LikesListControllerDelegate?
 
     // Used to control pagination.
-    private var isLoadingContent = false
     private var isFirstLoad = true
     private var totalLikes = 0
     private var totalLikesFetched = 0
@@ -23,6 +23,16 @@ class LikesListController: NSObject {
 
     private var hasMoreLikes: Bool {
         return totalLikesFetched < totalLikes
+    }
+
+    private var isLoadingContent = false {
+        didSet {
+            if isLoadingContent != oldValue {
+                isLoadingContent ? loadingIndicator.startAnimating() : loadingIndicator.stopAnimating()
+                // Refresh the footer view's frame
+                tableView.tableFooterView = loadingIndicator
+            }
+        }
     }
 
     private var likingUsers: [LikeUser] = [] {
@@ -72,6 +82,12 @@ class LikesListController: NSObject {
         self.siteID = siteID
         self.tableView = tableView
         self.delegate = delegate
+
+        self.loadingIndicator = {
+            let loadingIndicator = UIActivityIndicatorView(style: .medium)
+            loadingIndicator.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 44)
+            return loadingIndicator
+        }()
     }
 
     // MARK: Methods
@@ -97,8 +113,6 @@ class LikesListController: NSObject {
 
             return
         }
-
-        isLoadingContent = likingUsers.isEmpty
 
         fetchLikes(success: { [weak self] users, totalLikes in
 


### PR DESCRIPTION
When Likes are loading, an activity indicator is displayed in the list table footer.

To test:
- On a slow network, go to Notifications > Likes.
- Select a notification.
  - Verify the activity indicator is displayed at the bottom until the content is loaded.
- Scroll to the bottom.
  - Verify the activity indicator is displayed at the bottom until the next page's content is loaded.

Hack Tip:
You can modify the comment/post fetching to better test pagination (thus loading) if you don't have a lot of Likes. In [`LikesListController.fetchLikes`](https://github.com/wordpress-mobile/WordPress-iOS/blob/dcce2f8856681c3ea1a1025340a99f25fa8aae66/WordPress/Classes/ViewRelated/Likes/LikesListController.swift#L150):
- Set the postID/commentID and siteID of a post/comment you know to have a lot of Likes.
- And/or add a `count` param to the `getLikesFor` methods to fetch less Likes at a time. Example:
```
postService.getLikesFor(postID: 999,
                        siteID: 999,
                        count: 12,
                        before: lastFetchedDate,
                        purgeExisting: isFirstLoad,
                        success: success,
                        failure: failure)
```

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
