### PR TITLE
Fixes video format upload problem

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] Fixed the Follow Sites Quick Start Tour so that Reader Search is highlighted. [#16391]
 * [*] Enabled approving login authentication requests via push notification while the app is in the foreground. [#16075] 
 * [**] Added pull-to-refresh to the My Site screen when a user has no sites. [#16241]
+* [***] Fixed a bug that was causing uploaded videos to not be viewable in other platforms. [#16548]
 
 17.3
 -----

--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -29,7 +29,7 @@ class MediaSettings: NSObject {
             case .size3840x2160:
                 return AVAssetExportPreset3840x2160
             case .sizeOriginal:
-                return AVAssetExportPresetPassthrough
+                return AVAssetExportPresetHighestQuality
             }
         }
 

--- a/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
@@ -167,8 +167,7 @@ class MediaAssetExporter: MediaExporter {
         }
 
         // Configure a video exporter to handle an export session.
-        var exporterVideoOptions = videoOptions ?? MediaVideoExporter.Options()
-
+        let exporterVideoOptions = videoOptions ?? MediaVideoExporter.Options()
         let originalFilename = videoResource.originalFilename
 
         // Request an export session, which may take time to download the complete video data.

--- a/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
@@ -169,10 +169,6 @@ class MediaAssetExporter: MediaExporter {
         // Configure a video exporter to handle an export session.
         var exporterVideoOptions = videoOptions ?? MediaVideoExporter.Options()
 
-        if exporterVideoOptions.preferredExportVideoType == nil {
-            exporterVideoOptions.preferredExportVideoType = videoResource.uniformTypeIdentifier
-        }
-
         let originalFilename = videoResource.originalFilename
 
         // Request an export session, which may take time to download the complete video data.

--- a/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
@@ -86,6 +86,7 @@ class MediaVideoExporter: MediaExporter {
             onError(exporterErrorWith(error: VideoExportError.videoAssetWasDetectedAsNotExportable))
             return Progress.discreteCompletedProgress()
         }
+
         guard let session = AVAssetExportSession(asset: asset, presetName: options.exportPreset) else {
             onError(exporterErrorWith(error: VideoExportError.failedToInitializeVideoExportSession))
             return Progress.discreteCompletedProgress()


### PR DESCRIPTION
Fixes an issue first reported by @elibud with video uploads that weren't viewable from Firefox or Android devices.

The actual issue was twofold:

- We weren't converting our videos to an open video compression standard.  We were passing the video through in Apple's default compression format.  I've addressed this issue by forcing videos to be converted to H264, which is broadly supported.
- We were allowing videos to retain their original storage format (.mov).  This is less of an issue than the previous point since `.mov` support has grown considerably over time, but I've taken the opportunity to force the storage format to be forced to `.mp4` since it's even more broadly supported, and less likely to cause issues.

Upsides:
- Better compatibility of uploaded videos

Downsides:
- The compression time is now longer than it was before.

## To reproduce the original issue:

Test in `release/17.4`.

1. Create a post.
2. Upload a video.
3. Publish the post
4. View the post in Firefox or using an Android device.  You'll notice the video doesn't  display properly.

## To test:

Repeat the reproduction steps in this branch.  The video should work just fine.

## Regression Notes

1. Potential unintended areas of impact

Slower video uploads.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Nothing much to do, other than to recognize the tradeoff.

3. What automated tests I added (or what prevented me from doing so)

None.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
