### PR TITLE
Complementary PR for #16521

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 17.5
 -----
 * [*] Fixed a bug that was causing some fonts to become enormous when large text was enabled.
+* [*] Improved large text support in the blog details header in My Sites. [#16521]
 
 17.4
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -230,7 +230,7 @@ fileprivate extension NewBlogDetailHeaderView {
                 // Not much we can do if we can't retrieve the font.
                 return
             }
-            
+
             let imageSize: CGFloat
 
             if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -214,6 +214,36 @@ fileprivate extension NewBlogDetailHeaderView {
             static let rtlSubtitleButtonImageInsets = UIEdgeInsets(top: 1, left: -4, bottom: 0, right: 4)
         }
 
+        // MARK: - Layout
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+
+            refreshButtonImageToMatchLabelHeight(subtitleButton)
+        }
+
+        /// WORKAROUND: This method offers a compromise solution, to make the subtitle button image resize to match the height of the subtitle label.
+        /// This is necessary to make the UI look good with Large Text enabled.
+        ///
+        private func refreshButtonImageToMatchLabelHeight(_ button: UIButton) {
+            guard let font = button.titleLabel?.font else {
+                // Not much we can do if we can't retrieve the font.
+                return
+            }
+            
+            let imageSize: CGFloat
+
+            if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+                // This looks better with large text.
+                imageSize = font.xHeight
+            } else {
+                // This looks better in regular text sizes.
+                imageSize = font.pointSize
+            }
+
+            button.setImage(UIImage.gridicon(.external, size: CGSize(width: imageSize, height: imageSize)), for: .normal)
+        }
+
         // MARK: - Child Views
 
         private lazy var mainStackView: UIStackView = {
@@ -248,8 +278,8 @@ fileprivate extension NewBlogDetailHeaderView {
             button.setTitleColor(.primary, for: .normal)
             button.accessibilityHint = NSLocalizedString("Tap to view your site", comment: "Accessibility hint for button used to view the user's site")
 
-            if let pointSize = button.titleLabel?.font.pointSize {
-                button.setImage(UIImage.gridicon(.external, size: CGSize(width: pointSize, height: pointSize)), for: .normal)
+            if let xHeight = button.titleLabel?.font.xHeight {
+                button.setImage(UIImage.gridicon(.external, size: CGSize(width: xHeight, height: xHeight)), for: .normal)
             }
 
             // Align the image to the right

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -214,23 +214,6 @@ fileprivate extension NewBlogDetailHeaderView {
             static let rtlSubtitleButtonImageInsets = UIEdgeInsets(top: 1, left: -4, bottom: 0, right: 4)
         }
 
-        // MARK: - Layout
-
-        override func layoutSubviews() {
-            super.layoutSubviews()
-
-            refreshButtonImageToMatchLabelHeight(subtitleButton)
-        }
-
-        /// WORKAROUND: This method offers a compromise solution, to make the subtitle button image resize to match the height of the subtitle label.
-        /// This is necessary to make the UI look good with Large Text enabled.
-        ///
-        private func refreshButtonImageToMatchLabelHeight(_ button: UIButton) {
-            if let xHeight = button.titleLabel?.font.xHeight {
-                button.setImage(UIImage.gridicon(.external, size: CGSize(width: xHeight, height: xHeight)), for: .normal)
-            }
-        }
-
         // MARK: - Child Views
 
         private lazy var mainStackView: UIStackView = {
@@ -265,8 +248,8 @@ fileprivate extension NewBlogDetailHeaderView {
             button.setTitleColor(.primary, for: .normal)
             button.accessibilityHint = NSLocalizedString("Tap to view your site", comment: "Accessibility hint for button used to view the user's site")
 
-            if let xHeight = button.titleLabel?.font.xHeight {
-                button.setImage(UIImage.gridicon(.external, size: CGSize(width: xHeight, height: xHeight)), for: .normal)
+            if let pointSize = button.titleLabel?.font.pointSize {
+                button.setImage(UIImage.gridicon(.external, size: CGSize(width: pointSize, height: pointSize)), for: .normal)
             }
 
             // Align the image to the right

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -214,36 +214,6 @@ fileprivate extension NewBlogDetailHeaderView {
             static let rtlSubtitleButtonImageInsets = UIEdgeInsets(top: 1, left: -4, bottom: 0, right: 4)
         }
 
-        // MARK: - Layout
-
-        override func layoutSubviews() {
-            super.layoutSubviews()
-
-            refreshButtonImageToMatchLabelHeight(subtitleButton)
-        }
-
-        /// WORKAROUND: This method offers a compromise solution, to make the subtitle button image resize to match the height of the subtitle label.
-        /// This is necessary to make the UI look good with Large Text enabled.
-        ///
-        private func refreshButtonImageToMatchLabelHeight(_ button: UIButton) {
-            guard let font = button.titleLabel?.font else {
-                // Not much we can do if we can't retrieve the font.
-                return
-            }
-
-            let imageSize: CGFloat
-
-            if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
-                // This looks better with large text.
-                imageSize = font.xHeight
-            } else {
-                // This looks better in regular text sizes.
-                imageSize = font.pointSize
-            }
-
-            button.setImage(UIImage.gridicon(.external, size: CGSize(width: imageSize, height: imageSize)), for: .normal)
-        }
-
         // MARK: - Child Views
 
         private lazy var mainStackView: UIStackView = {
@@ -278,8 +248,8 @@ fileprivate extension NewBlogDetailHeaderView {
             button.setTitleColor(.primary, for: .normal)
             button.accessibilityHint = NSLocalizedString("Tap to view your site", comment: "Accessibility hint for button used to view the user's site")
 
-            if let xHeight = button.titleLabel?.font.xHeight {
-                button.setImage(UIImage.gridicon(.external, size: CGSize(width: xHeight, height: xHeight)), for: .normal)
+            if let pointSize = button.titleLabel?.font.pointSize {
+                button.setImage(UIImage.gridicon(.external, size: CGSize(width: pointSize, height: pointSize)), for: .normal)
             }
 
             // Align the image to the right


### PR DESCRIPTION
This PR covers two pending tasks from this PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16521

1. I forgot to update the release notes. 🤦‍♂️
2. I managed to find a compromise solution that keeps the subtitle link icon looking better for both regular and large text sizes.

## To test:

1. Go to "My Site".
2. Check the subtitle link icon in your default text size.  Make sure it looks reasonably similar to the subtitle text size besides it.
3. Change to a different large text setting in `iOS Settings > Accessibility > Display & Text Size > Larger Text`.

## Regression Notes
1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
