### PR TITLE
Jetpack App (Emphasis): Hide Followed Sites Section in Notificiation Settings

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -13,4 +13,5 @@ import Foundation
     @objc static let showsReader: Bool = true
     @objc static let showsCreateButton: Bool = true
     @objc static let showsQuickActions: Bool = true
+    @objc static let showsFollowedSites: Bool = true
 }

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -13,5 +13,5 @@ import Foundation
     @objc static let showsReader: Bool = true
     @objc static let showsCreateButton: Bool = true
     @objc static let showsQuickActions: Bool = true
-    @objc static let showsFollowedSites: Bool = true
+    @objc static let showsFollowedSitesSettings: Bool = true
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -70,7 +70,7 @@ open class NotificationSettingsViewController: UIViewController {
 
         activityIndicatorView.startAnimating()
 
-        if AppConfiguration.showsFollowedSites {
+        if AppConfiguration.showsFollowedSitesSettings {
             dispatchGroup.enter()
             siteService.fetchFollowedSites(success: {
                 dispatchGroup.leave()
@@ -135,9 +135,9 @@ open class NotificationSettingsViewController: UIViewController {
     //
     fileprivate func setupSections() {
         var section: [Section] = groupedSettings.isEmpty ? [] : [.blog, .other, .wordPressCom]
-        if !followedSites.isEmpty && !section.isEmpty && AppConfiguration.showsFollowedSites {
+        if !followedSites.isEmpty && !section.isEmpty && AppConfiguration.showsFollowedSitesSettings {
             section.insert(.followedSites, at: 1)
-        } else if !followedSites.isEmpty && section.isEmpty && AppConfiguration.showsFollowedSites {
+        } else if !followedSites.isEmpty && section.isEmpty && AppConfiguration.showsFollowedSitesSettings {
             section.append(.followedSites)
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -135,9 +135,9 @@ open class NotificationSettingsViewController: UIViewController {
     //
     fileprivate func setupSections() {
         var section: [Section] = groupedSettings.isEmpty ? [] : [.blog, .other, .wordPressCom]
-        if !followedSites.isEmpty && !section.isEmpty {
+        if !followedSites.isEmpty && !section.isEmpty && AppConfiguration.showsFollowedSites {
             section.insert(.followedSites, at: 1)
-        } else if !followedSites.isEmpty && section.isEmpty {
+        } else if !followedSites.isEmpty && section.isEmpty && AppConfiguration.showsFollowedSites {
             section.append(.followedSites)
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -111,6 +111,9 @@ open class NotificationSettingsViewController: UIViewController {
         for setting in settings {
             switch setting.channel {
             case let .blog(blogId):
+                guard setting.blog != nil else {
+                    continue
+                }
                 // Make sure that the Primary Blog is the first one in its category
                 if blogId == primaryBlogId {
                     blogSettings.insert(setting, at: 0)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -70,13 +70,15 @@ open class NotificationSettingsViewController: UIViewController {
 
         activityIndicatorView.startAnimating()
 
-        dispatchGroup.enter()
-        siteService.fetchFollowedSites(success: {
-            dispatchGroup.leave()
-        }, failure: { (error) in
-            dispatchGroup.leave()
-            DDLogError("Could not sync sites: \(String(describing: error))")
-        })
+        if AppConfiguration.showsFollowedSites {
+            dispatchGroup.enter()
+            siteService.fetchFollowedSites(success: {
+                dispatchGroup.leave()
+            }, failure: { (error) in
+                dispatchGroup.leave()
+                DDLogError("Could not sync sites: \(String(describing: error))")
+            })
+        }
 
         dispatchGroup.enter()
         service.getAllSettings({ [weak self] (settings: [NotificationSettings]) in

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -13,4 +13,5 @@ import Foundation
     @objc static let showsReader: Bool = false
     @objc static let showsCreateButton: Bool = false
     @objc static let showsQuickActions: Bool = false
+    @objc static let showsFollowedSites: Bool = false
 }

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -13,5 +13,5 @@ import Foundation
     @objc static let showsReader: Bool = false
     @objc static let showsCreateButton: Bool = false
     @objc static let showsQuickActions: Bool = false
-    @objc static let showsFollowedSites: Bool = false
+    @objc static let showsFollowedSitesSettings: Bool = false
 }


### PR DESCRIPTION
Resolves #16511

This PR hides the Followed Sites section under Notification Settings for the Jetpack app.

## How to test
1. Build and run the Jetpack target
2. Go to Notifications and tap on the settings icon
3. ✅ The Followed Sites section should NOT be displayed

Jetpack | WordPress
-- | --
![Simulator Screen Shot - iPhone 12 Pro - 2021-05-21 at 16 04 31](https://user-images.githubusercontent.com/6711616/119096536-adbd1e80-ba4e-11eb-8082-91abf6d74a1a.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-21 at 16 05 21](https://user-images.githubusercontent.com/6711616/119096539-aeee4b80-ba4e-11eb-8916-bb74365b6e22.png)


## Regression Notes
1. Potential unintended areas of impact
WordPress Notification Settings

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested the WordPress app and made sure the Followed Sites section is displayed

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
