### PR TITLE
Improved deep linking tracking (retarget)

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -130,7 +130,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
 
     func displayWebViewWithURL(_ url: URL) {
         if UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes).canHandle(url: url) {
-            UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes).handle(url: url, source: controller)
+            UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes).handle(url: url, source: .inApp(presenter: controller))
             return
         }
 

--- a/WordPress/Classes/Utility/Universal Links/Route+Page.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route+Page.swift
@@ -2,11 +2,13 @@ import Foundation
 
 struct NewPageRoute: Route {
     let path = "/page"
+    let section: DeepLinkSection? = .editor
     let action: NavigationAction = NewPageNavigationAction()
 }
 
 struct NewPageForSiteRoute: Route {
     let path = "/page/:domain"
+    let section: DeepLinkSection? = .editor
     let action: NavigationAction = NewPageNavigationAction()
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -11,6 +11,9 @@ import Foundation
 ///
 struct AppBannerRoute: Route {
     let path = "/get"
+    let section: DeepLinkSection? = nil
+    let source: DeepLinkSource = .banner
+    let shouldTrack: Bool = false
 
     var action: NavigationAction {
         return self
@@ -32,9 +35,7 @@ extension AppBannerRoute: NavigationAction {
         components.path = fragment
 
         if let url = components.url {
-            // We disable tracking when passing the URL back through the router,
-            // otherwise we'd be posting two stats events.
-            router.handle(url: url, shouldTrack: false, source: source)
+            router.handle(url: url, shouldTrack: true, source: .banner)
         }
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
@@ -2,16 +2,19 @@ import Foundation
 
 struct MeRoute: Route {
     let path = "/me"
+    let section: DeepLinkSection? = .me
     let action: NavigationAction = MeNavigationAction.root
 }
 
 struct MeAccountSettingsRoute: Route {
     let path = "/me/account"
+    let section: DeepLinkSection? = .me
     let action: NavigationAction = MeNavigationAction.accountSettings
 }
 
 struct MeNotificationSettingsRoute: Route {
     let path = "/me/notifications"
+    let section: DeepLinkSection? = .me
     let action: NavigationAction = MeNavigationAction.notificationSettings
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -12,6 +12,10 @@ enum MySitesRoute {
 }
 
 extension MySitesRoute: Route {
+    var section: DeepLinkSection? {
+        return .mySite
+    }
+
     var action: NavigationAction {
         return self
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct NotificationsRoute: Route {
     let path = "/notifications"
+    let section: DeepLinkSection? = .notifications
     let action: NavigationAction = NotificationsNavigationAction()
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
@@ -2,11 +2,13 @@ import Foundation
 
 struct NewPostRoute: Route {
     let path = "/post"
+    let section: DeepLinkSection? = .editor
     let action: NavigationAction = NewPostNavigationAction()
 }
 
 struct NewPostForSiteRoute: Route {
     let path = "/post/:domain"
+    let section: DeepLinkSection? = .editor
     let action: NavigationAction = NewPostNavigationAction()
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -51,6 +51,10 @@ extension ReaderRoute: Route {
         }
     }
 
+    var section: DeepLinkSection? {
+        return .reader
+    }
+
     var action: NavigationAction {
         return self
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Start.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Start.swift
@@ -3,6 +3,8 @@ import Foundation
 struct StartRoute: Route, NavigationAction {
     let path = "/start"
 
+    let section: DeepLinkSection? = .siteCreation
+
     var action: NavigationAction {
         return self
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -31,6 +31,10 @@ enum StatsRoute {
 }
 
 extension StatsRoute: Route {
+    var section: DeepLinkSection? {
+        return .stats
+    }
+
     var action: NavigationAction {
         return self
     }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -3,7 +3,7 @@ import Foundation
 protocol LinkRouter {
     init(routes: [Route])
     func canHandle(url: URL) -> Bool
-    func handle(url: URL, shouldTrack track: Bool, source: UIViewController?)
+    func handle(url: URL, shouldTrack track: Bool, source: DeepLinkSource?)
 }
 
 /// UniversalLinkRouter keeps a list of possible URL routes that are exposed
@@ -11,6 +11,8 @@ protocol LinkRouter {
 ///
 struct UniversalLinkRouter: LinkRouter {
     private let matcher: RouteMatcher
+
+    private static let extraLoggingEnabled = BuildConfiguration.current == .localDeveloper
 
     init(routes: [Route]) {
         matcher = RouteMatcher(routes: routes)
@@ -128,11 +130,12 @@ struct UniversalLinkRouter: LinkRouter {
     /// - parameter url: The URL to match against.
     /// - parameter track: If false, don't post an analytics event for this URL.
     ///
-    func handle(url: URL, shouldTrack track: Bool = true, source: UIViewController? = nil) {
+    func handle(url: URL, shouldTrack track: Bool = true, source: DeepLinkSource? = nil) {
         let matches = matcher.routesMatching(url)
 
-        if track {
-            trackDeepLink(matchCount: matches.count, url: url)
+        // We don't want to track internal links
+        if track, source?.isInternal != true {
+            trackDeepLinks(with: matches, for: url, source: source)
         }
 
         if matches.isEmpty {
@@ -141,25 +144,79 @@ struct UniversalLinkRouter: LinkRouter {
                                       completionHandler: nil)
         }
 
+        // Extract the presenter if there is one
+        var presentingViewController: UIViewController? = nil
+        if case .inApp(let viewController) = source {
+            presentingViewController = viewController
+        }
+
         for matchedRoute in matches {
-            matchedRoute.action.perform(matchedRoute.values, source: source, router: self)
+            matchedRoute.action.perform(matchedRoute.values, source: presentingViewController, router: self)
         }
     }
 
-    private func trackDeepLink(matchCount: Int, url: URL) {
-        let stat: WPAnalyticsStat = (matchCount > 0) ? .deepLinked : .deepLinkFailed
-        var properties = [TracksPropertyKeys.url: url.absoluteString]
-
-        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        if let source = components?.queryItems?.first(where: { $0.name == TracksPropertyKeys.source }) {
-            properties[TracksPropertyKeys.source] = source.value
+    private func trackDeepLinks(with matches: [MatchedRoute], for url: URL, source: DeepLinkSource? = nil) {
+        if matches.isEmpty {
+            WPAppAnalytics.track(.deepLinkFailed, withProperties: [TracksPropertyKeys.url: url.absoluteString])
+            return
         }
 
-        WPAppAnalytics.track(stat, withProperties: properties)
+        matches.forEach({ trackDeepLink(for: $0, source: source) })
+    }
+
+    private func trackDeepLink(for match: MatchedRoute, source: DeepLinkSource? = nil) {
+        // Check if the route is overridding tracking
+        if match.shouldTrack == false {
+            return
+        }
+
+        // If we've been passed a source we'll use that to override the route's original source.
+        // For example, if we've been handed a link from a banner.
+        let properties: [String: String] = [
+            TracksPropertyKeys.url: match.path,
+            TracksPropertyKeys.source: source?.tracksValue ?? match.source.tracksValue,
+            TracksPropertyKeys.sourceInfo: source?.trackingInfo ?? match.source.trackingInfo ?? "",
+            TracksPropertyKeys.section: match.section?.rawValue ?? "",
+        ]
+
+        if UniversalLinkRouter.extraLoggingEnabled {
+            logDeepLink(with: properties)
+        }
+
+        WPAppAnalytics.track(.deepLinked, withProperties: properties)
+    }
+
+    private func logDeepLink(with properties: [String: String]) {
+        let path = properties[TracksPropertyKeys.url] ?? ""
+        let section = properties[TracksPropertyKeys.section] ?? ""
+        let source = properties[TracksPropertyKeys.source] ?? ""
+        let sourceInfo = properties[TracksPropertyKeys.sourceInfo] ?? ""
+        let info = sourceInfo.isEmpty ? "" : " – \(sourceInfo)"
+
+        DDLogInfo("🔗 Deep link: \(path), source: \(source)\(info), section: \(section)")
     }
 
     private enum TracksPropertyKeys {
         static let url = "url"
         static let source = "source"
+        static let sourceInfo = "source_info"
+        static let section = "section"
+    }
+}
+
+extension DeepLinkSource {
+    var tracksValue: String {
+        switch self {
+        case .link:
+            return "link"
+        case .banner:
+            return "banner"
+        case .email:
+            return "email"
+        case .widget:
+            return "widget"
+        case .inApp:
+            return "internal"
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -384,11 +384,11 @@ class ReaderDetailCoordinator {
         } else if url.query?.contains("wp-story") ?? false {
             presentWebViewController(url)
         } else if readerLinkRouter.canHandle(url: url) {
-            readerLinkRouter.handle(url: url, shouldTrack: false, source: viewController)
+            readerLinkRouter.handle(url: url, shouldTrack: false, source: .inApp(presenter: viewController))
         } else if url.isWordPressDotComPost {
             presentReaderDetail(url)
         } else if url.isLinkProtocol {
-            readerLinkRouter.handle(url: url, shouldTrack: false, source: viewController)
+            readerLinkRouter.handle(url: url, shouldTrack: false, source: .inApp(presenter: viewController))
         } else {
             presentWebViewController(url)
         }

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -3,7 +3,10 @@ import XCTest
 
 private struct TestRoute: Route {
     let path: String
+    let section: DeepLinkSection? = .mySite
+    let source: DeepLinkSource = .link
     let action: NavigationAction = TestAction()
+    let shouldTrack = false
 }
 
 private struct TestAction: NavigationAction {
@@ -118,5 +121,29 @@ class RouteMatcherTests: XCTestCase {
         XCTAssertEqual(values1["type"], "group")
         XCTAssertEqual(values2["account"], "bobsmith")
         XCTAssertEqual(values2["test"], "group")
+    }
+
+    // MARK: - Source query item
+
+    func testRouteWithNoSourceQueryItem() {
+        routes = [ TestRoute(path: "/stats") ]
+        matcher = RouteMatcher(routes: routes)
+
+        let matches = matcher.routesMatching(URL(string: "https://wordpress.com/stats")!)
+        let values = matches.first!.values
+        XCTAssert(values.count == 1)
+        XCTAssertEqual(values[MatchedRouteURLComponentKey.url.rawValue], "https://wordpress.com/stats")
+        XCTAssertNil(values[MatchedRouteURLComponentKey.source.rawValue])
+    }
+
+    func testRouteWithSourceQueryItem() {
+        routes = [ TestRoute(path: "/stats") ]
+        matcher = RouteMatcher(routes: routes)
+
+        let matches = matcher.routesMatching(URL(string: "https://wordpress.com/stats?source=widget")!)
+        let match = matches.first!
+        XCTAssert(match.values.count == 2)
+        XCTAssertEqual(match.values[MatchedRouteURLComponentKey.source.rawValue], "widget")
+        XCTAssertEqual(match.source, DeepLinkSource.widget)
     }
 }


### PR DESCRIPTION
This PR is the same as https://github.com/wordpress-mobile/WordPress-iOS/pull/16534, but targetting the frozen branch so we can start collecting improved data as soon as possible.

**To test**

Please see [original PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/16534) for testing steps.

## Regression Notes
1. Potential unintended areas of impact

As with the original PR, this should only affect the deep linking system.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested as many possible types of links as I could, and added some new unit tests to cover some of the new code I added.

3. What automated tests I added (or what prevented me from doing so)

See above.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
