### PR TITLE
Likes List: remove duplicate likes

### DIFF
--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -37,7 +37,7 @@ extension CommentService {
                                                             commentID: commentID,
                                                             siteID: siteID,
                                                             purgeExisting: purgeExisting) {
-                                            let users = self.likeUsersFor(commentID: commentID, siteID: siteID, before: before)
+                                            let users = self.likeUsersFor(commentID: commentID, siteID: siteID)
                                             success(users, totalLikes.intValue)
                                             LikeUserHelper.purgeStaleLikes()
                                         }
@@ -52,19 +52,10 @@ extension CommentService {
      
      @param commentID   The ID of the comment to fetch likes for.
      @param siteID      The ID of the site that contains the post.
-     @param before      Filter results to likes before this date/time. Optional.
      */
-    func likeUsersFor(commentID: NSNumber, siteID: NSNumber, before: String? = nil) -> [LikeUser] {
+    func likeUsersFor(commentID: NSNumber, siteID: NSNumber) -> [LikeUser] {
         let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
-
-        request.predicate = {
-            if let beforeDate = DateUtils.date(fromISOString: before) {
-                return NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@ AND dateLiked < %@", siteID, commentID, beforeDate as CVarArg)
-            }
-
-            return NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@", siteID, commentID)
-        }()
-
+        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@", siteID, commentID)
         request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
 
         if let users = try? managedObjectContext.fetch(request) {
@@ -83,6 +74,7 @@ extension CommentService {
      */
     func likeUsersFor(commentID: NSNumber, siteID: NSNumber, after: Date) -> [LikeUser] {
         let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
+        // The date comparison is 'less than' because Likes are in descending order.
         request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@ AND dateLiked < %@", siteID, commentID, after as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
 

--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -52,30 +52,20 @@ extension CommentService {
      
      @param commentID   The ID of the comment to fetch likes for.
      @param siteID      The ID of the site that contains the post.
+     @param after       Filter results to likes after this Date. Optional.
      */
-    func likeUsersFor(commentID: NSNumber, siteID: NSNumber) -> [LikeUser] {
+    func likeUsersFor(commentID: NSNumber, siteID: NSNumber, after: Date? = nil) -> [LikeUser] {
         let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
-        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@", siteID, commentID)
-        request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
 
-        if let users = try? managedObjectContext.fetch(request) {
-            return users
-        }
+        request.predicate = {
+            if let after = after {
+                // The date comparison is 'less than' because Likes are in descending order.
+                return NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@ AND dateLiked < %@", siteID, commentID, after as CVarArg)
+            }
 
-        return [LikeUser]()
-    }
+            return NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@", siteID, commentID)
+        }()
 
-    /**
-     Fetches a list of users from Core Data that liked the post with the given IDs after the given Date.
-     
-     @param commentID   The ID of the comment to fetch likes for.
-     @param siteID      The ID of the site that contains the post.
-     @param after       Filter results to likes after this Date.
-     */
-    func likeUsersFor(commentID: NSNumber, siteID: NSNumber, after: Date) -> [LikeUser] {
-        let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
-        // The date comparison is 'less than' because Likes are in descending order.
-        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@ AND dateLiked < %@", siteID, commentID, after as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
 
         if let users = try? managedObjectContext.fetch(request) {

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -37,7 +37,7 @@ extension PostService {
                                                         postID: postID,
                                                         siteID: siteID,
                                                         purgeExisting: purgeExisting) {
-                                        let users = self.likeUsersFor(postID: postID, siteID: siteID, before: before)
+                                        let users = self.likeUsersFor(postID: postID, siteID: siteID)
                                         success(users, totalLikes.intValue)
                                         LikeUserHelper.purgeStaleLikes()
                                     }
@@ -52,19 +52,10 @@ extension PostService {
      
      @param postID  The ID of the post to fetch likes for.
      @param siteID  The ID of the site that contains the post.
-     @param before  Filter results to likes before this date/time. Optional.
      */
-    func likeUsersFor(postID: NSNumber, siteID: NSNumber, before: String? = nil) -> [LikeUser] {
+    func likeUsersFor(postID: NSNumber, siteID: NSNumber) -> [LikeUser] {
         let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
-
-        request.predicate = {
-            if let beforeDate = DateUtils.date(fromISOString: before) {
-                return NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@ AND dateLiked < %@", siteID, postID, beforeDate as CVarArg)
-            }
-
-            return NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@", siteID, postID)
-        }()
-
+        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@", siteID, postID)
         request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
 
         if let users = try? managedObjectContext.fetch(request) {
@@ -83,6 +74,7 @@ extension PostService {
      */
     func likeUsersFor(postID: NSNumber, siteID: NSNumber, after: Date) -> [LikeUser] {
         let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
+        // The date comparison is 'less than' because Likes are in descending order.
         request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@ AND dateLiked < %@", siteID, postID, after as CVarArg)
         request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
 

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -52,30 +52,20 @@ extension PostService {
      
      @param postID  The ID of the post to fetch likes for.
      @param siteID  The ID of the site that contains the post.
-     */
-    func likeUsersFor(postID: NSNumber, siteID: NSNumber) -> [LikeUser] {
-        let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
-        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@", siteID, postID)
-        request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
-
-        if let users = try? managedObjectContext.fetch(request) {
-            return users
-        }
-
-        return [LikeUser]()
-    }
-
-    /**
-     Fetches a list of users from Core Data that liked the post with the given IDs after the given Date.
-     
-     @param postID  The ID of the post to fetch likes for.
-     @param siteID  The ID of the site that contains the post.
      @param after   Filter results to likes after this Date.
      */
-    func likeUsersFor(postID: NSNumber, siteID: NSNumber, after: Date) -> [LikeUser] {
+    func likeUsersFor(postID: NSNumber, siteID: NSNumber, after: Date? = nil) -> [LikeUser] {
         let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
-        // The date comparison is 'less than' because Likes are in descending order.
-        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@ AND dateLiked < %@", siteID, postID, after as CVarArg)
+
+        request.predicate = {
+            if let after = after {
+                // The date comparison is 'less than' because Likes are in descending order.
+                return NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@ AND dateLiked < %@", siteID, postID, after as CVarArg)
+            }
+
+            return NSPredicate(format: "likedSiteID = %@ AND likedPostID = %@", siteID, postID)
+        }()
+
         request.sortDescriptors = [NSSortDescriptor(key: "dateLiked", ascending: false)]
 
         if let users = try? managedObjectContext.fetch(request) {

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -116,15 +116,9 @@ class LikesListController: NSObject {
         }
 
         fetchLikes(success: { [weak self] users, totalLikes in
-
-            // Remove cached users as they'll be replaced by the first fetch.
-            if self?.isFirstLoad == true {
-                self?.likingUsers = []
-            }
-
-            self?.likingUsers.append(contentsOf: users)
+            self?.likingUsers = users
             self?.totalLikes = totalLikes
-            self?.totalLikesFetched += users.count
+            self?.totalLikesFetched = users.count
             self?.lastFetchedDate = users.last?.dateLikedString
             self?.isFirstLoad = false
             self?.isLoadingContent = false
@@ -174,7 +168,8 @@ class LikesListController: NSObject {
                                        before: beforeStr,
                                        excludingIDs: excludeUserIDs,
                                        purgeExisting: isFirstLoad,
-                                       success: success, failure: failure)
+                                       success: success,
+                                       failure: failure)
         }
     }
 


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/pull/16553#pullrequestreview-665957914

This fixes an issue that was causing duplicate Likes in the Like Notifications liker list. As Eric mentioned in the referenced comment, the initial method of fetching Likes from Core Data filtered by the last fetch date no longer worked after https://github.com/wordpress-mobile/WordPress-iOS/pull/16553 was implemented. Now we just get _all_ Likes for a post/comment from Core Data after a new batch is fetched and created.

To test:
- Go to Notifications > Likes.
- Select a notification with more than 90 Likes so it can fetch multiple times. (* hack tip below *)
- Scroll to the bottom of the list to trigger another fetch.
- Verify there are no duplicate likes between the end of the previous page and the beginning of the next page.

I've not included screenshots as Likes include PII. And blocking it out in screenshots would just result in one big blob. 😄 But I can DM you examples if you like.

Hack tip:
If you don't have a comment/post Like Notification with more than 90 likes, there's a couple things you can do.
- Add a `count` parameter to the [`getLikesFor`](https://github.com/wordpress-mobile/WordPress-iOS/blob/2f73a7ee2532a2bcafa569ed7562655903f89f07/WordPress/Classes/ViewRelated/Likes/LikesListController.swift#L156) calls to fetch less likes at a time. Example:
```
        switch content {
        case .post(let postID):
            postService.getLikesFor(postID: xxx,
                                    siteID: xxx,
                                    count: 10,
                                    before: beforeStr,
                                    excludingIDs: excludeUserIDs,
                                    purgeExisting: isFirstLoad,
                                    success: success,
                                    failure: failure)
        case .comment(let commentID):
            commentService.getLikesFor(commentID: xxx,
                                       siteID: xxx,
                                       count: 10,
                                       before: beforeStr,
                                       excludingIDs: excludeUserIDs,
                                       purgeExisting: isFirstLoad,
                                       success: success,
                                       failure: failure)
        }
```
- And/or set the IDs to a comment/post you know to have a lot of Likes (I can DM you some if you like; I usually use something from https://wordpress.com/blog/).
  - Setting the IDs is needed in three places: 
    - When fetching from Core Data in [`fetchStoredLikes`](https://github.com/wordpress-mobile/WordPress-iOS/blob/2f73a7ee2532a2bcafa569ed7562655903f89f07/WordPress/Classes/ViewRelated/Likes/LikesListController.swift#L133) and [`trackUsersToExclude`](https://github.com/wordpress-mobile/WordPress-iOS/blob/2f73a7ee2532a2bcafa569ed7562655903f89f07/WordPress/Classes/ViewRelated/Likes/LikesListController.swift#L180).
    - When fetching from the endpoints with [`getLikesFor`](https://github.com/wordpress-mobile/WordPress-iOS/blob/2f73a7ee2532a2bcafa569ed7562655903f89f07/WordPress/Classes/ViewRelated/Likes/LikesListController.swift#L156) (same as where the `count` is set above).


## Regression Notes
1. Potential unintended areas of impact
N/A. This is a new unreleased feature.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. This is a new unreleased feature.

3. What automated tests I added (or what prevented me from doing so)
Tests added previously for this feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
