### PR TITLE
Reader Post Details: show initial Likes summary

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,6 +17,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case milestoneNotifications
     case newLikeNotifications
     case bloggingReminders
+    case readerPostLikes
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -54,6 +55,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .newLikeNotifications:
             return true
         case .bloggingReminders:
+            return false
+        case .readerPostLikes:
             return false
         }
     }
@@ -111,6 +114,8 @@ extension FeatureFlag {
             return "New Like Notifications"
         case .bloggingReminders:
             return "Blogging Reminders"
+        case .readerPostLikes:
+            return "Reader Post Likes"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -24,13 +24,6 @@
                                         <rect key="frame" x="0.0" y="0.0" width="446" height="222.5"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
-                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="CpT-U7-bfv" customClass="IntrinsicTableView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" placeholder="YES" id="tci-Li-Egi"/>
-                                        </constraints>
-                                    </tableView>
                                     <wkWebView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iSu-TI-yew" customClass="ReaderWebView" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
                                         <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -44,6 +37,19 @@
                                             <wkPreferences key="preferences"/>
                                         </wkWebViewConfiguration>
                                     </wkWebView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qXQ-id-Ffz" userLabel="Likes Container View">
+                                        <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" placeholder="YES" id="C8J-Hu-daf"/>
+                                        </constraints>
+                                    </view>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="CpT-U7-bfv" customClass="IntrinsicTableView" customModule="WordPress" customModuleProvider="target">
+                                        <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" placeholder="YES" id="tci-Li-Egi"/>
+                                        </constraints>
+                                    </tableView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="O4e-BA-8jp">
                                         <rect key="frame" x="16" y="238.5" width="414" height="20.5"/>
                                         <subviews>
@@ -85,7 +91,9 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="CpT-U7-bfv" firstAttribute="bottom" secondItem="O4e-BA-8jp" secondAttribute="top" id="167-j2-IYs"/>
+                                    <constraint firstItem="qXQ-id-Ffz" firstAttribute="width" secondItem="iSu-TI-yew" secondAttribute="width" id="2pM-dV-doK"/>
                                     <constraint firstItem="O4e-BA-8jp" firstAttribute="centerX" secondItem="iSu-TI-yew" secondAttribute="centerX" id="5DL-7x-ujm"/>
+                                    <constraint firstItem="qXQ-id-Ffz" firstAttribute="top" secondItem="iSu-TI-yew" secondAttribute="bottom" id="5ig-aY-DHW"/>
                                     <constraint firstItem="CpT-U7-bfv" firstAttribute="centerX" secondItem="iSu-TI-yew" secondAttribute="centerX" id="6NH-H7-oE8"/>
                                     <constraint firstItem="O4e-BA-8jp" firstAttribute="width" secondItem="iSu-TI-yew" secondAttribute="width" id="8SP-Rw-zUY"/>
                                     <constraint firstItem="iSu-TI-yew" firstAttribute="leading" secondItem="9JA-VQ-zzw" secondAttribute="leading" constant="16" placeholder="YES" id="9Vy-Wt-ZIb"/>
@@ -94,8 +102,9 @@
                                     <constraint firstItem="Xyq-y6-zPR" firstAttribute="top" secondItem="9JA-VQ-zzw" secondAttribute="top" id="JZU-vN-GKO"/>
                                     <constraint firstItem="Xyq-y6-zPR" firstAttribute="centerX" secondItem="iSu-TI-yew" secondAttribute="centerX" id="RTC-cI-v2j"/>
                                     <constraint firstAttribute="bottom" secondItem="O4e-BA-8jp" secondAttribute="bottom" id="eFL-lL-cEF"/>
-                                    <constraint firstItem="CpT-U7-bfv" firstAttribute="top" secondItem="iSu-TI-yew" secondAttribute="bottom" id="kb8-se-lIJ"/>
+                                    <constraint firstItem="qXQ-id-Ffz" firstAttribute="centerX" secondItem="iSu-TI-yew" secondAttribute="centerX" id="hjJ-VB-Pf0"/>
                                     <constraint firstItem="eXr-4k-Adq" firstAttribute="bottom" secondItem="O4e-BA-8jp" secondAttribute="bottom" constant="509" placeholder="YES" id="pTD-l7-TPF"/>
+                                    <constraint firstItem="CpT-U7-bfv" firstAttribute="top" secondItem="qXQ-id-Ffz" secondAttribute="bottom" id="vOe-88-MUA"/>
                                     <constraint firstItem="CpT-U7-bfv" firstAttribute="width" secondItem="iSu-TI-yew" secondAttribute="width" id="wUK-AO-ZOc"/>
                                     <constraint firstItem="Xyq-y6-zPR" firstAttribute="width" secondItem="iSu-TI-yew" secondAttribute="width" constant="32" id="xfj-7c-Lke"/>
                                 </constraints>
@@ -305,6 +314,7 @@
                         <outlet property="actionStackView" destination="O4e-BA-8jp" id="Ro3-aL-ekY"/>
                         <outlet property="attributionView" destination="Ewc-f7-89P" id="Pwq-Hm-VfQ"/>
                         <outlet property="headerContainerView" destination="Xyq-y6-zPR" id="duy-5z-Fdl"/>
+                        <outlet property="likesContainerView" destination="qXQ-id-Ffz" id="DL3-un-wtF"/>
                         <outlet property="loadingView" destination="qnQ-Ld-x9K" id="D1T-sa-IvL"/>
                         <outlet property="scrollView" destination="9JA-VQ-zzw" id="lCO-o1-bLB"/>
                         <outlet property="tableView" destination="CpT-U7-bfv" id="rQo-rr-Bjb"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -411,10 +411,13 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         likesContainerView.addSubview(likesSummary)
         likesContainerView.translatesAutoresizingMaskIntoConstraints = false
-        likesSummary.topAnchor.constraint(equalTo: likesContainerView.topAnchor).isActive = true
-        likesSummary.bottomAnchor.constraint(equalTo: likesContainerView.bottomAnchor).isActive = true
-        likesSummary.leadingAnchor.constraint(equalTo: likesContainerView.leadingAnchor).isActive = true
-        likesSummary.trailingAnchor.constraint(lessThanOrEqualTo: likesContainerView.trailingAnchor).isActive = true
+
+        NSLayoutConstraint.activate([
+            likesSummary.topAnchor.constraint(equalTo: likesContainerView.topAnchor),
+            likesSummary.bottomAnchor.constraint(equalTo: likesContainerView.bottomAnchor),
+            likesSummary.leadingAnchor.constraint(equalTo: likesContainerView.leadingAnchor),
+            likesSummary.trailingAnchor.constraint(lessThanOrEqualTo: likesContainerView.trailingAnchor)
+        ])
     }
 
     private func configureRelatedPosts() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -32,6 +32,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Wrapper for the toolbar
     @IBOutlet weak var toolbarContainerView: UIView!
 
+    /// Wrapper for the Likes summary view
+    @IBOutlet weak var likesContainerView: UIView!
+
     /// The loading view, which contains all the ghost views
     @IBOutlet weak var loadingView: UIView!
 
@@ -49,6 +52,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// Bottom toolbar
     private let toolbar: ReaderDetailToolbar = .loadFromNib()
+
+    /// Likes summary view
+     private let likesSummary: ReaderDetailLikesView = .loadFromNib()
 
     /// A view that fills the bottom portion outside of the safe area
     @IBOutlet weak var toolbarSafeAreaView: UIView!
@@ -125,6 +131,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         configureWebView()
         configureFeaturedImage()
         configureHeader()
+        configureLikesSummary()
         configureRelatedPosts()
         configureToolbar()
         configureNoResultsViewController()
@@ -394,6 +401,20 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         headerContainerView.pinSubviewToAllEdges(header)
         headerContainerView.heightAnchor.constraint(equalTo: header.heightAnchor).isActive = true
+    }
+
+    private func configureLikesSummary() {
+        guard FeatureFlag.readerPostLikes.enabled else {
+            likesContainerView.frame.size.height = 0
+            return
+        }
+
+        likesContainerView.addSubview(likesSummary)
+        likesContainerView.translatesAutoresizingMaskIntoConstraints = false
+        likesSummary.topAnchor.constraint(equalTo: likesContainerView.topAnchor).isActive = true
+        likesSummary.bottomAnchor.constraint(equalTo: likesContainerView.bottomAnchor).isActive = true
+        likesSummary.leadingAnchor.constraint(equalTo: likesContainerView.leadingAnchor).isActive = true
+        likesSummary.trailingAnchor.constraint(lessThanOrEqualTo: likesContainerView.trailingAnchor).isActive = true
     }
 
     private func configureRelatedPosts() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -10,6 +10,11 @@ class ReaderDetailLikesView: UIView, NibLoadable {
         applyStyles()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        applyStyles()
+    }
+
 }
 
 private extension ReaderDetailLikesView {
@@ -18,7 +23,7 @@ private extension ReaderDetailLikesView {
         // Set border on all the avatar views
         for subView in avatarStackView.subviews {
             subView.layer.borderWidth = 1
-            subView.layer.borderColor = UIColor.white.cgColor
+            subView.layer.borderColor = UIColor.basicBackground.cgColor
         }
 
         summaryLabel.textColor = .secondaryLabel

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+class ReaderDetailLikesView: UIView, NibLoadable {
+
+    @IBOutlet weak var avatarStackView: UIStackView!
+    @IBOutlet weak var summaryLabel: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        applyStyles()
+    }
+
+}
+
+private extension ReaderDetailLikesView {
+
+    func applyStyles() {
+        // Set border on all the avatar views
+        for subView in avatarStackView.subviews {
+            subView.layer.borderWidth = 1
+            subView.layer.borderColor = UIColor.white.cgColor
+        }
+
+        summaryLabel.textColor = .secondaryLabel
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="V9g-yi-NfW" customClass="ReaderDetailLikesView" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="336" height="80"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-3" translatesAutoresizingMaskIntoConstraints="NO" id="ZiQ-mD-QJO" userLabel="Avatar Stack View">
+                    <rect key="frame" x="0.0" y="24" width="148" height="32"/>
+                    <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="J4T-hG-6iv" userLabel="Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="J4T-hG-6iv" secondAttribute="height" multiplier="1:1" id="Erj-G5-zsW"/>
+                                <constraint firstAttribute="width" constant="32" id="P5Z-kv-aye"/>
+                            </constraints>
+                        </imageView>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="q0R-6s-hGt" userLabel="Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="29" y="0.0" width="32" height="32"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="q0R-6s-hGt" secondAttribute="height" multiplier="1:1" id="bTt-k0-tgL"/>
+                                <constraint firstAttribute="width" constant="32" id="nSK-es-kMa"/>
+                            </constraints>
+                        </imageView>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="phg-GI-hbS" userLabel="Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="58" y="0.0" width="32" height="32"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="phg-GI-hbS" secondAttribute="height" multiplier="1:1" id="6GW-VE-wil"/>
+                                <constraint firstAttribute="width" constant="32" id="Peg-NZ-LE6"/>
+                            </constraints>
+                        </imageView>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0vX-TT-MJH" userLabel="Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="87" y="0.0" width="32" height="32"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="32" id="fJi-9t-l8g"/>
+                                <constraint firstAttribute="width" secondItem="0vX-TT-MJH" secondAttribute="height" multiplier="1:1" id="ksb-WV-X7F"/>
+                            </constraints>
+                        </imageView>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="Fsb-ih-Vxd" userLabel="Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="116" y="0.0" width="32" height="32"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="32" id="9Zr-kG-reL"/>
+                                <constraint firstAttribute="width" secondItem="Fsb-ih-Vxd" secondAttribute="height" multiplier="1:1" id="RMT-Xw-wR0"/>
+                            </constraints>
+                        </imageView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="32" id="deH-0r-cgY"/>
+                    </constraints>
+                </stackView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="999 bloggers like this." textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilc-NW-l0X" userLabel="Summary Label">
+                    <rect key="frame" x="160" y="0.0" width="135" height="80"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vd2-A8-uVO"/>
+            <constraints>
+                <constraint firstItem="ilc-NW-l0X" firstAttribute="centerY" secondItem="ZiQ-mD-QJO" secondAttribute="centerY" id="0MZ-FZ-HuG"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ilc-NW-l0X" secondAttribute="bottom" id="10Y-sE-pDS"/>
+                <constraint firstAttribute="top" relation="greaterThanOrEqual" secondItem="ilc-NW-l0X" secondAttribute="top" id="CbZ-7d-cly"/>
+                <constraint firstItem="ZiQ-mD-QJO" firstAttribute="leading" secondItem="V9g-yi-NfW" secondAttribute="leading" id="IaP-Se-6v5"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ZiQ-mD-QJO" secondAttribute="bottom" constant="24" id="j4v-s8-8Xz"/>
+                <constraint firstItem="ZiQ-mD-QJO" firstAttribute="top" relation="greaterThanOrEqual" secondItem="V9g-yi-NfW" secondAttribute="top" constant="24" id="kPA-tt-hzr"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ilc-NW-l0X" secondAttribute="trailing" id="qnT-KT-Btp"/>
+                <constraint firstItem="ilc-NW-l0X" firstAttribute="leading" secondItem="ZiQ-mD-QJO" secondAttribute="trailing" constant="12" id="tBZ-4w-7g4"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="avatarStackView" destination="ZiQ-mD-QJO" id="hMm-un-1IW"/>
+                <outlet property="summaryLabel" destination="ilc-NW-l0X" id="C48-jT-Uq7"/>
+            </connections>
+            <point key="canvasLocation" x="-1275.3623188405797" y="-383.03571428571428"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="gravatar" width="85" height="85"/>
+    </resources>
+</document>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1584,6 +1584,10 @@
 		98E082A02637545C00537BF1 /* PostService+Likes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E0829E2637545C00537BF1 /* PostService+Likes.swift */; };
 		98E419DE2399B5A700D8C822 /* Tracks+ThisWeekWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E419DD2399B5A700D8C822 /* Tracks+ThisWeekWidget.swift */; };
 		98E419DF2399B62A00D8C822 /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
+		98E54FF2265C972900B4BE9A /* ReaderDetailLikesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E54FF1265C972900B4BE9A /* ReaderDetailLikesView.swift */; };
+		98E54FF3265C972900B4BE9A /* ReaderDetailLikesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E54FF1265C972900B4BE9A /* ReaderDetailLikesView.swift */; };
+		98E55019265C977E00B4BE9A /* ReaderDetailLikesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98E55018265C977E00B4BE9A /* ReaderDetailLikesView.xib */; };
+		98E5501A265C977E00B4BE9A /* ReaderDetailLikesView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98E55018265C977E00B4BE9A /* ReaderDetailLikesView.xib */; };
 		98E58A2F2360D23400E5534B /* TodayWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E58A2E2360D23400E5534B /* TodayWidgetStats.swift */; };
 		98E58A302360D23400E5534B /* TodayWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E58A2E2360D23400E5534B /* TodayWidgetStats.swift */; };
 		98E58A442361019300E5534B /* Pods_WordPressTodayWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98E58A432361019300E5534B /* Pods_WordPressTodayWidget.framework */; };
@@ -6143,6 +6147,8 @@
 		98E0829E2637545C00537BF1 /* PostService+Likes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PostService+Likes.swift"; sourceTree = "<group>"; };
 		98E419DD2399B5A700D8C822 /* Tracks+ThisWeekWidget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tracks+ThisWeekWidget.swift"; sourceTree = "<group>"; };
 		98E419E02399B6C300D8C822 /* ThisWeekWidgetPrefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ThisWeekWidgetPrefix.pch; sourceTree = "<group>"; };
+		98E54FF1265C972900B4BE9A /* ReaderDetailLikesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderDetailLikesView.swift; sourceTree = "<group>"; };
+		98E55018265C977E00B4BE9A /* ReaderDetailLikesView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderDetailLikesView.xib; sourceTree = "<group>"; };
 		98E58A2E2360D23400E5534B /* TodayWidgetStats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodayWidgetStats.swift; sourceTree = "<group>"; };
 		98E58A412361017500E5534B /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98E58A432361019300E5534B /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -10922,12 +10928,14 @@
 		8BD89F2C24D9E73600341C90 /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				8B0CE7D02481CFE8004C4799 /* ReaderDetailHeaderView.swift */,
-				8B0CE7D22481CFF8004C4799 /* ReaderDetailHeaderView.xib */,
-				8BA77BCE2483415400E1EBBF /* ReaderDetailToolbar.swift */,
-				8BA77BCC248340CE00E1EBBF /* ReaderDetailToolbar.xib */,
 				3223393B24FEC18000BDD4BF /* ReaderDetailFeaturedImageView.swift */,
 				3223393D24FEC2A700BDD4BF /* ReaderDetailFeaturedImageView.xib */,
+				8B0CE7D02481CFE8004C4799 /* ReaderDetailHeaderView.swift */,
+				8B0CE7D22481CFF8004C4799 /* ReaderDetailHeaderView.xib */,
+				98E54FF1265C972900B4BE9A /* ReaderDetailLikesView.swift */,
+				98E55018265C977E00B4BE9A /* ReaderDetailLikesView.xib */,
+				8BA77BCE2483415400E1EBBF /* ReaderDetailToolbar.swift */,
+				8BA77BCC248340CE00E1EBBF /* ReaderDetailToolbar.xib */,
 				FAC086D525EDFB1E00B94F2A /* ReaderRelatedPostsCell.swift */,
 				FAC086D625EDFB1E00B94F2A /* ReaderRelatedPostsCell.xib */,
 				FA6FAB3425EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift */,
@@ -14886,6 +14894,7 @@
 				9A76C32F22AFDA2100F5D819 /* world-map.svg in Resources */,
 				17222DAC261DDDF90047B163 /* blue-icon-app-60x60@2x.png in Resources */,
 				B5C66B721ACF071100F68370 /* NoteBlockTextTableViewCell.xib in Resources */,
+				98E55019265C977E00B4BE9A /* ReaderDetailLikesView.xib in Resources */,
 				E60C2ED51DE5048200488630 /* ReaderCommentCell.xib in Resources */,
 				FF37F90922385CA000AFA3DB /* RELEASE-NOTES.txt in Resources */,
 				9808655A203D075E00D58786 /* EpilogueUserInfoCell.xib in Resources */,
@@ -15334,6 +15343,7 @@
 				FABB20972602FC2C00C8785C /* RestoreCompleteView.xib in Resources */,
 				FABB20992602FC2C00C8785C /* RegisterDomain.storyboard in Resources */,
 				FABB209A2602FC2C00C8785C /* PostListFooterView.xib in Resources */,
+				98E5501A265C977E00B4BE9A /* ReaderDetailLikesView.xib in Resources */,
 				FABB209B2602FC2C00C8785C /* acknowledgements.html in Resources */,
 				FABB209C2602FC2C00C8785C /* ReaderDetailViewController.storyboard in Resources */,
 				FABB209D2602FC2C00C8785C /* EditCommentViewController.xib in Resources */,
@@ -17619,6 +17629,7 @@
 				241E60B325CA0D2900912CEB /* UserSettings.swift in Sources */,
 				0815CF461E96F22600069916 /* MediaImportService.swift in Sources */,
 				B56F25881FBDE502005C33E4 /* NSAttributedStringKey+Conversion.swift in Sources */,
+				98E54FF2265C972900B4BE9A /* ReaderDetailLikesView.swift in Sources */,
 				FFABD80821370496003C65B6 /* SelectPostViewController.swift in Sources */,
 				D8212CBD20AA7A7A008E8AE8 /* ReaderVisitSiteAction.swift in Sources */,
 				8BB185D524B66FE600A4CCE8 /* ReaderCard+CoreDataProperties.swift in Sources */,
@@ -18483,6 +18494,7 @@
 				FABB20F62602FC2C00C8785C /* WPStyleGuide+ReaderComments.swift in Sources */,
 				FABB20F72602FC2C00C8785C /* TopViewedPostStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB20F82602FC2C00C8785C /* BaseActivityListViewController.swift in Sources */,
+				98E54FF3265C972900B4BE9A /* ReaderDetailLikesView.swift in Sources */,
 				FABB20F92602FC2C00C8785C /* RequestAuthenticator.swift in Sources */,
 				FABB20FA2602FC2C00C8785C /* SettingsTitleSubtitleController.swift in Sources */,
 				FABB20FB2602FC2C00C8785C /* WebViewControllerFactory.swift in Sources */,


### PR DESCRIPTION
Ref: #16561 

This is the first step in adding the `xxx bloggers like this` view to the post details view.

A new `ReaderDetailLikesView` has been added to display the view. If the `readerPostLikes` feature flag is enabled, it is added to post details above the related posts table. It displays:
- 5 image views with the placeholder avatar image. Each image has a white border, and slightly overlaps the previous image.
- A `999 bloggers like this.` label.

---
To test:
- Go to Reader and select any post.
  - Verify the likes summary is not displayed.
- Enable the `readerPostLikes` feature.
- Go to Reader and select any post (as there is no logic yet to conditionally display the Likes summary).
  - Verify the likes summary is displayed.
  - Verify the layout matches the design on #16561 . (Since @mattmiklic is AFK this week, I'll ping him on future PRs to get Design approval.)

<kbd><img width="400" alt="likes_summary" src="https://user-images.githubusercontent.com/1816888/119576168-7663b000-bd75-11eb-8299-fd1e6ee08809.png"></kbd>

- Rotate the device.
  - Verify the post detail content is still laid out properly.

---

| Likes Summary Disabled | Likes Summary Enabled |
|--------|-------|
| ![disabled](https://user-images.githubusercontent.com/1816888/119576442-fdb12380-bd75-11eb-99a9-d8689dc28d8d.png) | ![enabled](https://user-images.githubusercontent.com/1816888/119576432-f8ec6f80-bd75-11eb-98cf-dd90df7a0d96.png) |

---
## Regression Notes
1. Potential unintended areas of impact
N/A. Incomplete feature.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Incomplete feature.

3. What automated tests I added (or what prevented me from doing so)
N/A. Incomplete feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
