### PR TITLE
Add default BuildKite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,41 @@
+# By default, run on macOS agents
+agents:
+  os: "macOS"
+
+# This is the default pipeline – it will build and test the app
+steps:
+
+  #################
+  # Build the app
+  #################
+  - label: ":pipeline: Build"
+    key: "build"
+    command: |
+      echo "--- 🔧 Setting up Gems"
+      gem install bundler
+      bundle install
+      echo "--- 🔨 Setting up Pods"
+      bundle exec pod install --repo-update
+      echo "--- ✍️ Copy Files"
+      cp fastlane/env/project.env-example .configure-files/project.env
+      echo "--- 🛠 Building"
+      bundle exec fastlane build_for_testing
+      echo "--- 🗜 Zip Build Products"
+      tar -cf build-products.tar DerivedData/Build/Products/
+    agents:
+      os: "macOS"
+    artifact_paths:
+      - build-products.tar
+
+  #################
+  # Run Unit Tests
+  #################
+  - label: "🧪 Unit Tests"
+    command: |
+      buildkite-agent artifact download build-products.tar .
+      tar -xf build-products.tar
+      bundle install
+      bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
+    depends_on: "build"
+    agents:
+      os: "macOS"


### PR DESCRIPTION
Adds a default BuildKite build pipeline

To test:
- Ensure CI passes

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
