### PR TITLE
Fetch release toolkit from Ruby Gems with ~> 1.0 requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,3 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: eb0f24ec6c73b3454d711cc4b3276c50b9655861
-  tag: 0.18.1
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (0.18.1)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      progress_bar (~> 1.3)
-      rake (~> 12.3)
-      rake-compiler (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -110,7 +91,9 @@ GEM
     ethon (0.14.0)
       ffi (>= 1.15.0)
     excon (0.81.0)
-    faraday (1.4.1)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
@@ -119,6 +102,8 @@ GEM
     faraday-cookie_jar (0.0.7)
       faraday (>= 0.8.0)
       http-cookie (~> 1.0.0)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.1.0)
@@ -172,6 +157,19 @@ GEM
       trainer
       xcodeproj
       xctest_list (>= 1.2.1)
+    fastlane-plugin-wpmreleasetoolkit (1.0.1)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (~> 12.3)
+      rake-compiler (~> 1.0)
     ffi (1.15.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -241,7 +239,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.11.3)
+    nokogiri (1.11.5)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.21.0)
@@ -333,11 +331,11 @@ DEPENDENCIES
   fastlane-plugin-appcenter (~> 1.8)
   fastlane-plugin-sentry
   fastlane-plugin-test_center
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 1.0)
   octokit (~> 4.0)
   rake
   rmagick (~> 3.2.0)
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.2.14
+   2.2.16

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.18.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.0'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'


### PR DESCRIPTION
On top of moving to the "stable" version and using the SemVer, updating to 1.0.x brings enhancements to the `configure_*` actions to reduce the chances of accidentally tracking unencrypted secrets in Git.

To test, green CI should be enough because all of the changes that went into 1.0.0 and 1.0.1 have been tested individually.

If you want to test the `configure` updates, change the destination of a file in `.configure` to a location that is not ignored, e.g.:

```diff
     {
       "file": "iOS/WPiOS/project.env",
-      "destination": ".configure-files/project.env",
+      "destination": "./project.env",
```

And run `bundle install && bundle exec configure apply`, you should see an error like

```
[15:46:41]: -----------------------------
[15:46:41]: --- Step: configure_apply ---
[15:46:41]: -----------------------------
[15:46:41]: $ git check-ignore /Users/gio/Developer/a8c/wpios/./project.env
[15:46:41]: Exit status of command 'git check-ignore /Users/gio/Developer/a8c/wpios/./project.env' was 1 instead of 0.


[!] Attempted to decrypt iOS/WPiOS/project.env to /Users/gio/Developer/a8c/wpios/./project.env which is not ignored under Git. Please either edit your `.configure` file to use an already-ignored destination, or add that destination to the `.gitignore` manually to fix this.
```

The UI tests in this PR are failing, but that's an unrelated problem, as the failure is occurring on `develop`, too:

![image](https://user-images.githubusercontent.com/1218433/119613705-be033e00-be40-11eb-83df-1c0c8c4cd57a.png)


## Regression Notes
1. Potential unintended areas of impact
_None_

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.