### PR TITLE
Fix missing support options.

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -352,6 +352,10 @@ private extension ZendeskUtils {
             return false
         }
 
+        self.zdAppID = zdAppID
+        self.zdUrl = zdUrl
+        self.zdClientId = zdClientId
+
         return true
     }
 


### PR DESCRIPTION
As reported in p5T066-2hL-p2#comment-8405

We were missing some support options because the ZenDesk credentials weren't being stored anymore.

The original issue was introduced by the removal of these lines: https://github.com/wordpress-mobile/WordPress-iOS/commit/a68b7f51722e1fe5afca7946c47bbb0d2aa2041b#diff-a8966393c02a2ab855ff7a8c50e5af636646d1c75292f797c1593e7458ebc340L351-L353

## To test:

In the log in flow, tap "Help" in the top-right  corner.
Make sure you can contact support and have a "My Tickets" option as well.

## Regression Notes

1. Potential unintended areas of impact

None that I can think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
