### PR TITLE
Reader Post Details: show Likes info

### DIFF
--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -9,7 +9,7 @@ extension PostService {
      @param before          Filter results to likes before this date/time. Optional.
      @param excludingIDs    An array of user IDs to exclude from the returned results. Optional.
      @param purgeExisting   Indicates if existing Likes for the given post and site should be purged before
-                            new ones are created. Defaults to false.
+                            new ones are created. Defaults to true.
      @param success         A success block
      @param failure         A failure block
      */
@@ -18,7 +18,7 @@ extension PostService {
                      count: Int = 90,
                      before: String? = nil,
                      excludingIDs: [NSNumber]? = nil,
-                     purgeExisting: Bool = false,
+                     purgeExisting: Bool = true,
                      success: @escaping (([LikeUser], Int) -> Void),
                      failure: @escaping ((Error?) -> Void)) {
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -52,7 +52,7 @@ class ReaderDetailCoordinator {
     private let coreDataStack: CoreDataStack
 
     /// Reader Post Service
-    private let service: ReaderPostService
+    private let readerPostService: ReaderPostService
 
     /// Reader Topic Service
     private let topicService: ReaderTopicService
@@ -96,14 +96,14 @@ class ReaderDetailCoordinator {
     ///
     /// - Parameter service: a Reader Post Service
     init(coreDataStack: CoreDataStack = ContextManager.shared,
-         service: ReaderPostService = ReaderPostService(managedObjectContext: ContextManager.sharedInstance().mainContext),
+         readerPostService: ReaderPostService = ReaderPostService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          topicService: ReaderTopicService = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          postService: PostService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          sharingController: PostSharingController = PostSharingController(),
          readerLinkRouter: UniversalLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes),
          view: ReaderDetailView) {
         self.coreDataStack = coreDataStack
-        self.service = service
+        self.readerPostService = readerPostService
         self.topicService = topicService
         self.postService = postService
         self.sharingController = sharingController
@@ -132,7 +132,7 @@ class ReaderDetailCoordinator {
     /// Fetch related posts for the current post
     ///
     func fetchRelatedPosts(for post: ReaderPost) {
-        service.fetchRelatedPosts(for: post) { [weak self] relatedPosts in
+        readerPostService.fetchRelatedPosts(for: post) { [weak self] relatedPosts in
             self?.view?.renderRelatedPosts(relatedPosts)
         } failure: { error in
             DDLogError("Error fetching related posts for detail: \(String(describing: error?.localizedDescription))")
@@ -264,16 +264,16 @@ class ReaderDetailCoordinator {
     /// - Parameter siteID: a site identification
     /// - Parameter isFeed: a Boolean indicating if the site is an external feed (not hosted at WPcom and not using Jetpack)
     private func fetch(postID: NSNumber, siteID: NSNumber, isFeed: Bool) {
-        service.fetchPost(postID.uintValue,
-                          forSite: siteID.uintValue,
-                          isFeed: isFeed,
-                          success: { [weak self] post in
-                            self?.post = post
-                            self?.renderPostAndBumpStats()
-        }, failure: { [weak self] _ in
-            self?.postURL == nil ? self?.view?.showError() : self?.view?.showErrorWithWebAction()
-            self?.reportPostLoadFailure()
-        })
+        readerPostService.fetchPost(postID.uintValue,
+                                    forSite: siteID.uintValue,
+                                    isFeed: isFeed,
+                                    success: { [weak self] post in
+                                        self?.post = post
+                                        self?.renderPostAndBumpStats()
+                                    }, failure: { [weak self] _ in
+                                        self?.postURL == nil ? self?.view?.showError() : self?.view?.showErrorWithWebAction()
+                                        self?.reportPostLoadFailure()
+                                    })
     }
 
 
@@ -282,15 +282,15 @@ class ReaderDetailCoordinator {
     /// Use this method to fetch a ReaderPost from a URL.
     /// - Parameter url: a post URL
     private func fetch(_ url: URL) {
-        service.fetchPost(at: url,
-                          success: { [weak self] post in
-                            self?.post = post
-                            self?.renderPostAndBumpStats()
-        }, failure: { [weak self] error in
-            DDLogError("Error fetching post for detail: \(String(describing: error?.localizedDescription))")
-            self?.postURL == nil ? self?.view?.showError() : self?.view?.showErrorWithWebAction()
-            self?.reportPostLoadFailure()
-        })
+        readerPostService.fetchPost(at: url,
+                                    success: { [weak self] post in
+                                        self?.post = post
+                                        self?.renderPostAndBumpStats()
+                                    }, failure: { [weak self] error in
+                                        DDLogError("Error fetching post for detail: \(String(describing: error?.localizedDescription))")
+                                        self?.postURL == nil ? self?.view?.showError() : self?.view?.showErrorWithWebAction()
+                                        self?.reportPostLoadFailure()
+                                    })
     }
 
     private func renderPostAndBumpStats() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -53,7 +53,6 @@ private extension ReaderDetailLikesView {
                 subView.isHidden = true
             }
         }
-
     }
 
     func downloadGravatar(for avatarImageView: UIImageView, withURL url: String?) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -5,9 +5,16 @@ class ReaderDetailLikesView: UIView, NibLoadable {
     @IBOutlet weak var avatarStackView: UIStackView!
     @IBOutlet weak var summaryLabel: UILabel!
 
+    static let maxAvatarsDisplayed = 5
+
     override func awakeFromNib() {
         super.awakeFromNib()
         applyStyles()
+    }
+
+    func configure(users: [LikeUser], totalLikes: Int) {
+        updateSummaryLabel(totalLikes: totalLikes)
+        updateAvatars(users: users)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -29,4 +36,44 @@ private extension ReaderDetailLikesView {
         summaryLabel.textColor = .secondaryLabel
     }
 
+    func updateSummaryLabel(totalLikes: Int) {
+        let summaryFormat = totalLikes == 1 ? SummaryLabelFormats.singular : SummaryLabelFormats.plural
+        summaryLabel.text = String(format: summaryFormat, totalLikes)
+    }
+
+    func updateAvatars(users: [LikeUser]) {
+        for (index, subView) in avatarStackView.subviews.enumerated() {
+            guard let avatarImageView = subView as? UIImageView else {
+                return
+            }
+
+            if let user = users[safe: index] {
+                downloadGravatar(for: avatarImageView, withURL: user.avatarUrl)
+            } else {
+                subView.isHidden = true
+            }
+        }
+
+    }
+
+    func downloadGravatar(for avatarImageView: UIImageView, withURL url: String?) {
+        // Always reset gravatar
+        avatarImageView.cancelImageDownload()
+        avatarImageView.image = .gravatarPlaceholderImage
+
+        guard let url = url,
+              let gravatarURL = URL(string: url) else {
+            return
+        }
+
+        avatarImageView.downloadImage(from: gravatarURL, placeholderImage: .gravatarPlaceholderImage)
+    }
+
+    struct SummaryLabelFormats {
+        static let singular = NSLocalizedString("%1$d blogger likes this.",
+                                                comment: "Singular format string for displaying the number of post likes. %1$d is the number of likes.")
+        static let plural = NSLocalizedString("%1$d bloggers like this.",
+                                              comment: "Plural format string for displaying the number of post likes. %1$d is the number of likes.")
+
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -50,7 +50,7 @@ private extension ReaderDetailLikesView {
             if let user = users[safe: index] {
                 downloadGravatar(for: avatarImageView, withURL: user.avatarUrl)
             } else {
-                subView.isHidden = true
+                avatarImageView.isHidden = true
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
@@ -57,8 +57,8 @@
                         <constraint firstAttribute="height" constant="32" id="deH-0r-cgY"/>
                     </constraints>
                 </stackView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="999 bloggers like this." textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilc-NW-l0X" userLabel="Summary Label">
-                    <rect key="frame" x="160" y="0.0" width="135" height="80"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilc-NW-l0X" userLabel="Summary Label">
+                    <rect key="frame" x="160" y="0.0" width="0.0" height="80"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -10,7 +10,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     func testRetrieveAReaderPostWhenSiteAndPostAreGiven() {
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.set(postID: 1, siteID: 2, isFeed: true)
 
         coordinator.start()
@@ -25,7 +25,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     func testRetrieveAReaderPostWhenURLIsGiven() {
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.postURL = URL(string: "https://wpmobilep2.wordpress.com/post/")
 
         coordinator.start()
@@ -40,7 +40,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let serviceMock = ReaderPostServiceMock()
         serviceMock.returnPost = post
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.set(postID: 1, siteID: 2, isFeed: false)
 
         coordinator.start()
@@ -54,7 +54,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let serviceMock = ReaderPostServiceMock()
         serviceMock.forceError = true
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.set(postID: 1, siteID: 2, isFeed: false)
 
         coordinator.start()
@@ -68,7 +68,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let serviceMock = ReaderPostServiceMock()
         serviceMock.forceError = true
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.postURL = URL(string: "https://wordpress.com/")
 
         coordinator.start()
@@ -83,7 +83,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let serviceMock = ReaderPostServiceMock()
         serviceMock.forceError = true
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.postURL = URL(string: "https://wordpress.com/")
         coordinator.postLoadFailureBlock = {
             didCallPostLoadFailureBlock = true
@@ -101,7 +101,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let post: ReaderPost = ReaderPostBuilder().build()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.post = post
 
         coordinator.start()
@@ -116,7 +116,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let post: ReaderPost = ReaderPostBuilder().build()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.post = post
 
         coordinator.start()
@@ -132,7 +132,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let postSharingControllerMock = PostSharingControllerMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, sharingController: postSharingControllerMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, sharingController: postSharingControllerMock, view: viewMock)
         coordinator.post = post
 
         coordinator.share(fromView: button)
@@ -151,7 +151,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let postSharingControllerMock = PostSharingControllerMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, sharingController: postSharingControllerMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, sharingController: postSharingControllerMock, view: viewMock)
         let navigationControllerMock = UINavigationControllerMock()
         viewMock.navigationController = navigationControllerMock
         coordinator.post = post
@@ -169,7 +169,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
         let postSharingControllerMock = PostSharingControllerMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, sharingController: postSharingControllerMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, sharingController: postSharingControllerMock, view: viewMock)
         let navigationControllerMock = UINavigationControllerMock()
         viewMock.navigationController = navigationControllerMock
         coordinator.post = post
@@ -185,7 +185,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let post: ReaderPost = ReaderPostBuilder().build()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.post = post
 
         coordinator.handle(URL(string: "https://wordpress.com/image.png")!)
@@ -199,7 +199,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let post: ReaderPost = ReaderPostBuilder().build()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.post = post
         let navigationControllerMock = UINavigationControllerMock()
         viewMock.navigationController = navigationControllerMock
@@ -215,7 +215,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let post: ReaderPost = ReaderPostBuilder().build()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.post = post
 
         coordinator.handle(URL(string: "https://wordpress.com")!)
@@ -230,7 +230,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let post: ReaderPost = ReaderPostBuilder().build()
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.post = post
 
         coordinator.handle(URL(string: "https://wordpress.com#hash")!)
@@ -242,7 +242,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         let postURL = URL(string: "https://example.wordpress.com/2014/07/24/post-title/#comment-10")
         let serviceMock = ReaderPostServiceMock()
         let viewMock = ReaderDetailViewMock()
-        let coordinator = ReaderDetailCoordinator(service: serviceMock, view: viewMock)
+        let coordinator = ReaderDetailCoordinator(readerPostService: serviceMock, view: viewMock)
         coordinator.postURL = postURL
 
         expect(coordinator.commentID).to(equal(10))
@@ -328,6 +328,8 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
     }
 
     func updateHeader() { }
+
+    func  updateLikes(users: [LikeUser], totalLikes: Int) { }
 
     func renderRelatedPosts(_ posts: [RemoteReaderSimplePost]) { }
 


### PR DESCRIPTION
Ref: #16561 

This updates the Post details to fetch and show Likes information.
- The most recent Like's avatars are displayed, up to 5.
- The total number of Likes is displayed.
- If there are no Likes, the Likes Summary view is not displayed.

To test:
- With the `readerPostLikes` feature disabled (the default), go to the Reader and select any post.
  - Verify the likes summary is not displayed.
- Enable the `readerPostLikes` feature. Select posts with various number of Likes. Verify the correct number of avatars and total likes count are shown.
  - More than 5 likes = 5 avatars.
  - Less than 5 likes = same number of avatars.
  - No likes = likes summary is not displayed.

<kbd><img width="437" alt="more than 5" src="https://user-images.githubusercontent.com/1816888/119686406-8a55f300-be03-11eb-9c59-27d4113cdfb4.png"></kbd>

<kbd>
<img width="436" alt="less than 5" src="https://user-images.githubusercontent.com/1816888/119686458-95108800-be03-11eb-9ef9-396719d81154.png"></kbd>


## Regression Notes
1. Potential unintended areas of impact
N/A. Incomplete feature.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Incomplete feature.

3. What automated tests I added (or what prevented me from doing so)
N/A. Incomplete feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
