### PR TITLE
Jetpack App (Emphasis): Improve Server Credentials Messaging

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Jetpack.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Jetpack.swift
@@ -1,0 +1,31 @@
+import Foundation
+import WordPressShared
+
+extension WPStyleGuide {
+
+    enum Jetpack {
+
+        // MARK: - Style Methods
+
+        static func highlightString(_ substring: String, inString: String) -> NSAttributedString {
+            let attributedString = NSMutableAttributedString(string: inString)
+
+            guard let subStringRange = inString.nsRange(of: substring) else {
+                return attributedString
+            }
+
+            attributedString.addAttributes([
+                .foregroundColor: substringHighlightTextColor,
+                .font: substringHighlightFont
+            ], range: subStringRange)
+
+            return attributedString
+        }
+
+        // MARK: - Style Values
+
+        static let substringHighlightTextColor = UIColor.primary
+        static let substringHighlightFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
@@ -11,7 +11,7 @@ struct JetpackRestoreOptionsConfiguration {
     let messageDescription: String
     let generalSectionHeaderText: String
     let buttonTitle: String
-    let warningButtonTitle: String?
+    let warningButtonTitle: HighlightedText?
     let isRestoreTypesConfigurable: Bool
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
@@ -2,6 +2,8 @@ import Foundation
 import CocoaLumberjack
 import WordPressShared
 
+typealias HighlightedText = (substring: String, string: String)
+
 struct JetpackRestoreOptionsConfiguration {
     let title: String
     let iconImage: UIImage

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/JetpackRestoreOptionsViewController.swift
@@ -17,6 +17,12 @@ class JetpackRestoreOptionsViewController: BaseRestoreOptionsViewController {
     // MARK: - Initialization
 
     init(site: JetpackSiteRef, activity: Activity, isAwaitingCredentials: Bool) {
+
+        let highlightedSubstring = NSLocalizedString("Enter your server credentials", comment: "Error message displayed when site credentials aren't configured.")
+        let warningFormat = NSLocalizedString("%1$@ to enable one click site restores from backups.", comment: "Error message displayed when restoring a site fails due to credentials not being configured. %1$@ is a placeholder for the string 'Enter your server credentials'.")
+        let warningString = String(format: warningFormat, highlightedSubstring)
+        let warningButtonTitle = HighlightedText(substring: highlightedSubstring, string: warningString)
+
         let restoreOptionsConfiguration = JetpackRestoreOptionsConfiguration(
             title: NSLocalizedString("Restore", comment: "Title for the Jetpack Restore Site Screen"),
             iconImage: UIImage.gridicon(.history),
@@ -24,7 +30,7 @@ class JetpackRestoreOptionsViewController: BaseRestoreOptionsViewController {
             messageDescription: NSLocalizedString("%1$@ is the selected point for your restore.", comment: "Description for the restore action. $1$@ is a placeholder for the selected date."),
             generalSectionHeaderText: NSLocalizedString("Choose the items to restore", comment: "Restorable items: general section title"),
             buttonTitle: NSLocalizedString("Restore to this point", comment: "Button title for restore site action"),
-            warningButtonTitle: isAwaitingCredentials ? NSLocalizedString("Enter your server credentials to enable one click site restores from backups.", comment: "Error message displayed when restoring a site fails due to credentials not being configured.") : nil,
+            warningButtonTitle: isAwaitingCredentials ? warningButtonTitle : nil,
             isRestoreTypesConfigurable: !isAwaitingCredentials
         )
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/Views/JetpackRestoreHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/Views/JetpackRestoreHeaderView.swift
@@ -8,7 +8,7 @@ class JetpackRestoreHeaderView: UIView, NibReusable {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
     @IBOutlet private weak var actionButton: FancyButton!
-    @IBOutlet private weak var warningButton: UIButton!
+    @IBOutlet private weak var warningButton: MultilineButton!
 
     var actionButtonHandler: (() -> Void)?
     var warningButtonHandler: (() -> Void)?
@@ -33,19 +33,30 @@ class JetpackRestoreHeaderView: UIView, NibReusable {
 
         actionButton.isPrimary = true
 
+        warningButton.setTitleColor(.text, for: .normal)
         warningButton.titleLabel?.lineBreakMode = .byWordWrapping
+        warningButton.titleLabel?.numberOfLines = 0
     }
 
     // MARK: - Configuration
 
-    func configure(iconImage: UIImage, title: String, description: String, buttonTitle: String, warningButtonTitle: String?) {
+    func configure(iconImage: UIImage,
+                   title: String,
+                   description: String,
+                   buttonTitle: String,
+                   warningButtonTitle: HighlightedText?) {
         icon.image = iconImage
         titleLabel.text = title
         descriptionLabel.text = description
         actionButton.setTitle(buttonTitle, for: .normal)
 
         if let warningButtonTitle = warningButtonTitle {
-            warningButton.setTitle(warningButtonTitle, for: .normal)
+            let attributedTitle = WPStyleGuide.Jetpack.highlightString(warningButtonTitle.substring,
+                                                                       inString: warningButtonTitle.string)
+            warningButton.setAttributedTitle(attributedTitle, for: .normal)
+
+            warningButton.setImage(.gridicon(.plusSmall), for: .normal)
+
             warningButton.isHidden = false
         } else {
             warningButton.isHidden = true

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/Views/JetpackRestoreHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/Views/JetpackRestoreHeaderView.xib
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,26 +16,26 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="n7M-ds-fce">
-                    <rect key="frame" x="16" y="24" width="32" height="32"/>
+                    <rect key="frame" x="16" y="68" width="32" height="32"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="32" id="4tx-db-V8c"/>
                         <constraint firstAttribute="width" secondItem="n7M-ds-fce" secondAttribute="height" id="d6T-OY-eph"/>
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mst-Hr-reS">
-                    <rect key="frame" x="12" y="64" width="390" height="20.5"/>
+                    <rect key="frame" x="12" y="108" width="390" height="20.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6ag-Xy-HZc">
-                    <rect key="frame" x="12" y="88.5" width="390" height="20.5"/>
+                    <rect key="frame" x="12" y="132.5" width="390" height="20.5"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="kb2-Th-YeS">
-                    <rect key="frame" x="16" y="133" width="382" height="90"/>
+                    <rect key="frame" x="16" y="177" width="382" height="84"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZHA-ex-Sko" customClass="FancyButton" customModule="WordPressUI">
                             <rect key="frame" x="0.0" y="0.0" width="382" height="44"/>
@@ -45,9 +47,11 @@
                                 <action selector="actionButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="u3x-lF-FgS"/>
                             </connections>
                         </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5jP-J3-oaJ">
-                            <rect key="frame" x="0.0" y="60" width="382" height="30"/>
-                            <state key="normal" title="Button"/>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="top" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5jP-J3-oaJ" customClass="MultilineButton" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="60" width="382" height="24"/>
+                            <inset key="contentEdgeInsets" minX="-4" minY="0.0" maxX="0.0" maxY="0.0"/>
+                            <inset key="titleEdgeInsets" minX="2" minY="2" maxX="0.0" maxY="0.0"/>
+                            <state key="normal" title="Button" image="plus-small"/>
                             <connections>
                                 <action selector="warningButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="ehh-9G-PcQ"/>
                             </connections>
@@ -83,6 +87,7 @@
         </view>
     </objects>
     <resources>
+        <image name="plus-small" width="24" height="24"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.swift
@@ -7,7 +7,7 @@ class JetpackScanStatusCell: UITableViewCell, NibReusable {
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var primaryButton: FancyButton!
     @IBOutlet weak var secondaryButton: FancyButton!
-    @IBOutlet weak var warningButton: UIButton!
+    @IBOutlet weak var warningButton: MultilineButton!
     @IBOutlet weak var progressView: UIProgressView!
 
     private var model: JetpackScanStatusViewModel?
@@ -60,7 +60,15 @@ class JetpackScanStatusCell: UITableViewCell, NibReusable {
             return
         }
 
-        warningButton.setTitle(warningButtonTitle, for: .normal)
+        let attributedTitle = WPStyleGuide.Jetpack.highlightString(warningButtonTitle.substring,
+                                                                   inString: warningButtonTitle.string)
+
+        warningButton.setAttributedTitle(attributedTitle, for: .normal)
+        warningButton.setImage(.gridicon(.plusSmall), for: .normal)
+        warningButton.setTitleColor(.text, for: .normal)
+        warningButton.titleLabel?.numberOfLines = 0
+        warningButton.titleLabel?.lineBreakMode = .byWordWrapping
+
         warningButton.isHidden = false
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.xib
@@ -47,14 +47,14 @@
                                 </constraints>
                             </progressView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="749" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B0Y-0s-mES">
-                                <rect key="frame" x="10" y="116.5" width="425" height="31.5"/>
+                                <rect key="frame" x="10" y="116.5" width="425" height="21.5"/>
                                 <string key="text">We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time.</string>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="hhh-D4-rZn">
-                                <rect key="frame" x="10" y="158" width="425" height="132"/>
+                                <rect key="frame" x="10" y="148" width="425" height="142"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UhM-1P-HcV" customClass="FancyButton" customModule="WordPressUI">
                                         <rect key="frame" x="0.0" y="0.0" width="425" height="44"/>
@@ -73,8 +73,8 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="top" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="BEu-Yz-3GU" customClass="MultilineButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="54" width="425" height="24"/>
-                                        <inset key="contentEdgeInsets" minX="-4" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        <rect key="frame" x="0.0" y="54" width="425" height="34"/>
+                                        <inset key="contentEdgeInsets" minX="-4" minY="0.0" maxX="0.0" maxY="10"/>
                                         <inset key="titleEdgeInsets" minX="2" minY="2" maxX="0.0" maxY="0.0"/>
                                         <state key="normal" title="Button" image="plus-small"/>
                                         <connections>
@@ -82,7 +82,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="749" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gTh-o0-42f" customClass="FancyButton" customModule="WordPressUI">
-                                        <rect key="frame" x="0.0" y="88" width="425" height="44"/>
+                                        <rect key="frame" x="0.0" y="98" width="425" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="tnl-xQ-FTS"/>
                                         </constraints>

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanStatusCell.xib
@@ -47,14 +47,14 @@
                                 </constraints>
                             </progressView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="749" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B0Y-0s-mES">
-                                <rect key="frame" x="10" y="116.5" width="425" height="25.5"/>
+                                <rect key="frame" x="10" y="116.5" width="425" height="31.5"/>
                                 <string key="text">We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time.</string>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="hhh-D4-rZn">
-                                <rect key="frame" x="10" y="152" width="425" height="138"/>
+                                <rect key="frame" x="10" y="158" width="425" height="132"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UhM-1P-HcV" customClass="FancyButton" customModule="WordPressUI">
                                         <rect key="frame" x="0.0" y="0.0" width="425" height="44"/>
@@ -72,8 +72,17 @@
                                             <action selector="primaryButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="bK2-6E-P6z"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="top" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="BEu-Yz-3GU" customClass="MultilineButton" customModule="WordPress" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="54" width="425" height="24"/>
+                                        <inset key="contentEdgeInsets" minX="-4" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        <inset key="titleEdgeInsets" minX="2" minY="2" maxX="0.0" maxY="0.0"/>
+                                        <state key="normal" title="Button" image="plus-small"/>
+                                        <connections>
+                                            <action selector="warningButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="KSU-5Y-L9w"/>
+                                        </connections>
+                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="749" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gTh-o0-42f" customClass="FancyButton" customModule="WordPressUI">
-                                        <rect key="frame" x="0.0" y="54" width="425" height="44"/>
+                                        <rect key="frame" x="0.0" y="88" width="425" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="tnl-xQ-FTS"/>
                                         </constraints>
@@ -86,13 +95,6 @@
                                         </userDefinedRuntimeAttributes>
                                         <connections>
                                             <action selector="secondaryButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="f7N-nO-b4k"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="BEu-Yz-3GU">
-                                        <rect key="frame" x="0.0" y="108" width="425" height="30"/>
-                                        <state key="normal" title="Button"/>
-                                        <connections>
-                                            <action selector="warningButtonTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="KSU-5Y-L9w"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -123,6 +125,7 @@
     </objects>
     <resources>
         <image name="jetpack-scan-state-progress" width="36" height="44"/>
+        <image name="plus-small" width="24" height="24"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
@@ -38,7 +38,7 @@ class JetpackScanThreatDetailsViewController: UIViewController {
     @IBOutlet private weak var buttonsStackView: UIStackView!
     @IBOutlet private weak var fixThreatButton: FancyButton!
     @IBOutlet private weak var ignoreThreatButton: FancyButton!
-    @IBOutlet private weak var warningButton: UIButton!
+    @IBOutlet private weak var warningButton: MultilineButton!
     @IBOutlet weak var ignoreActivityIndicatorView: UIActivityIndicatorView!
 
     // MARK: - Properties
@@ -183,8 +183,14 @@ extension JetpackScanThreatDetailsViewController {
         }
 
         if let warningActionTitle = viewModel.warningActionTitle {
+
+            let attributedTitle = WPStyleGuide.Jetpack.highlightString(warningActionTitle.substring,
+                                                                       inString: warningActionTitle.string)
+
+            warningButton.setAttributedTitle(attributedTitle, for: .normal)
+
             warningButton.isHidden = false
-            warningButton.setTitle(warningActionTitle, for: .normal)
+
         } else {
             warningButton.isHidden = true
         }
@@ -255,6 +261,11 @@ extension JetpackScanThreatDetailsViewController {
         fixThreatButton.isPrimary = true
 
         ignoreThreatButton.isPrimary = false
+
+        warningButton.setTitleColor(.text, for: .normal)
+        warningButton.titleLabel?.lineBreakMode = .byWordWrapping
+        warningButton.titleLabel?.numberOfLines = 0
+        warningButton.setImage(.gridicon(.plusSmall), for: .normal)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.xib
@@ -44,10 +44,10 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xhr-6F-hsq">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="721"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="713"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="2wc-xZ-ViF">
-                                    <rect key="frame" x="16" y="24" width="382" height="673"/>
+                                    <rect key="frame" x="16" y="24" width="382" height="665"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qsb-nP-xMd">
                                             <rect key="frame" x="0.0" y="0.0" width="382" height="89"/>
@@ -166,8 +166,8 @@
                                                 </label>
                                             </subviews>
                                         </stackView>
-                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="VuK-rQ-GXS">
-                                            <rect key="frame" x="0.0" y="469" width="382" height="204"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="VuK-rQ-GXS">
+                                            <rect key="frame" x="0.0" y="469" width="382" height="196"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lSM-Kx-kG9" customClass="FancyButton" customModule="WordPressUI">
                                                     <rect key="frame" x="0.0" y="0.0" width="382" height="44"/>
@@ -180,8 +180,8 @@
                                                     </connections>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="top" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="0AT-2h-oW4" customClass="MultilineButton" customModule="WordPress" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="60" width="382" height="24"/>
-                                                    <inset key="contentEdgeInsets" minX="-4" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                    <rect key="frame" x="0.0" y="54" width="382" height="34"/>
+                                                    <inset key="contentEdgeInsets" minX="-4" minY="0.0" maxX="0.0" maxY="10"/>
                                                     <inset key="titleEdgeInsets" minX="2" minY="2" maxX="0.0" maxY="0.0"/>
                                                     <state key="normal" title="Button" image="plus-small"/>
                                                     <connections>
@@ -189,7 +189,7 @@
                                                     </connections>
                                                 </button>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UtF-fM-vn6" customClass="FancyButton" customModule="WordPressUI">
-                                                    <rect key="frame" x="0.0" y="100" width="382" height="44"/>
+                                                    <rect key="frame" x="0.0" y="98" width="382" height="44"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="44" id="rml-Co-TMA"/>
                                                     </constraints>
@@ -199,7 +199,7 @@
                                                     </connections>
                                                 </button>
                                                 <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="TJx-Vn-QMb">
-                                                    <rect key="frame" x="0.0" y="160" width="382" height="44"/>
+                                                    <rect key="frame" x="0.0" y="152" width="382" height="44"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="44" id="Xpd-PH-uoL"/>
                                                     </constraints>

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.xib
@@ -44,10 +44,10 @@
                     <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xhr-6F-hsq">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="727"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="721"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="2wc-xZ-ViF">
-                                    <rect key="frame" x="16" y="24" width="382" height="679"/>
+                                    <rect key="frame" x="16" y="24" width="382" height="673"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="qsb-nP-xMd">
                                             <rect key="frame" x="0.0" y="0.0" width="382" height="89"/>
@@ -167,7 +167,7 @@
                                             </subviews>
                                         </stackView>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="VuK-rQ-GXS">
-                                            <rect key="frame" x="0.0" y="469" width="382" height="210"/>
+                                            <rect key="frame" x="0.0" y="469" width="382" height="204"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lSM-Kx-kG9" customClass="FancyButton" customModule="WordPressUI">
                                                     <rect key="frame" x="0.0" y="0.0" width="382" height="44"/>
@@ -179,8 +179,17 @@
                                                         <action selector="fixThreatButtonTapped:" destination="-1" eventType="touchUpInside" id="ARq-1t-2nf"/>
                                                     </connections>
                                                 </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="top" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="0AT-2h-oW4" customClass="MultilineButton" customModule="WordPress" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="60" width="382" height="24"/>
+                                                    <inset key="contentEdgeInsets" minX="-4" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                                    <inset key="titleEdgeInsets" minX="2" minY="2" maxX="0.0" maxY="0.0"/>
+                                                    <state key="normal" title="Button" image="plus-small"/>
+                                                    <connections>
+                                                        <action selector="warningButtonTapped:" destination="-1" eventType="touchUpInside" id="rT7-WX-vvI"/>
+                                                    </connections>
+                                                </button>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UtF-fM-vn6" customClass="FancyButton" customModule="WordPressUI">
-                                                    <rect key="frame" x="0.0" y="60" width="382" height="44"/>
+                                                    <rect key="frame" x="0.0" y="100" width="382" height="44"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="44" id="rml-Co-TMA"/>
                                                     </constraints>
@@ -190,18 +199,11 @@
                                                     </connections>
                                                 </button>
                                                 <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="TJx-Vn-QMb">
-                                                    <rect key="frame" x="0.0" y="120" width="382" height="44"/>
+                                                    <rect key="frame" x="0.0" y="160" width="382" height="44"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="44" id="Xpd-PH-uoL"/>
                                                     </constraints>
                                                 </activityIndicatorView>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="0AT-2h-oW4">
-                                                    <rect key="frame" x="0.0" y="180" width="382" height="30"/>
-                                                    <state key="normal" title="Button"/>
-                                                    <connections>
-                                                        <action selector="warningButtonTapped:" destination="-1" eventType="touchUpInside" id="rT7-WX-vvI"/>
-                                                    </connections>
-                                                </button>
                                             </subviews>
                                         </stackView>
                                     </subviews>
@@ -237,6 +239,7 @@
         </view>
     </objects>
     <resources>
+        <image name="plus-small" width="24" height="24"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
@@ -8,7 +8,7 @@ struct JetpackScanStatusViewModel {
     private(set) var primaryButtonTitle: String?
     private(set) var primaryButtonEnabled: Bool = true
     private(set) var secondaryButtonTitle: String?
-    private(set) var warningButtonTitle: String?
+    private(set) var warningButtonTitle: HighlightedText?
     private(set) var progress: Float?
 
     private let coordinator: JetpackScanCoordinator
@@ -79,7 +79,10 @@ struct JetpackScanStatusViewModel {
                     secondaryButtonAction = .triggerScan
 
                     if !scan.hasValidCredentials {
-                        warningButtonTitle = Strings.enterServerCredentialsTitle
+                        let warningString = String(format: Strings.enterServerCredentialsFormat,
+                                                   Strings.enterServerCredentialsSubstring)
+                        warningButtonTitle = HighlightedText(substring: Strings.enterServerCredentialsSubstring,
+                                                             string: warningString)
                         warningButtonAction = .enterServerCredentials
 
                         primaryButtonEnabled = false
@@ -221,7 +224,8 @@ struct JetpackScanStatusViewModel {
 
     // MARK: - Localized Strings
     private struct Strings {
-        static let enterServerCredentialsTitle = NSLocalizedString("Enter your server credentials to fix threats.", comment: "Title for button when a site is missing server credentials")
+        static let enterServerCredentialsSubstring = NSLocalizedString("Enter your server credentials", comment: "Error message displayed when site credentials aren't configured.")
+        static let enterServerCredentialsFormat = NSLocalizedString("%1$@ to fix threats.", comment: "Title for button when a site is missing server credentials. %1$@ is a placeholder for the string 'Enter your server credentials'.")
         static let noThreatsTitle = NSLocalizedString("Don’t worry about a thing", comment: "Title for label when there are no threats on the users site")
         static let noThreatsDescriptionFormat = NSLocalizedString("The last Jetpack scan ran %1$@ and did not find any risks.\n\nTo review your site again run a manual scan, or wait for Jetpack to scan your site later today.", comment: "Description for label when there are no threats on a users site and how long ago the scan ran.")
         static let noThreatsDescription = NSLocalizedString("The last jetpack scan did not find any risks.\n\nTo review your site again run a manual scan, or wait for Jetpack to scan your site later today.",

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanThreatViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanThreatViewModel.swift
@@ -332,7 +332,7 @@ struct JetpackScanThreatViewModel {
                     static let ignore = NSLocalizedString("Ignore threat", comment: "Title for button that will ignore the threat")
                     static let fixable = NSLocalizedString("Fix threat", comment: "Title for button that will fix the threat")
                     static let enterServerCredentialsSubstring = NSLocalizedString("Enter your server credentials", comment: "Error message displayed when site credentials aren't configured.")
-                    static let enterServerCredentialsFormat = NSLocalizedString("%1$@ to fix threat.", comment: "Title for button when a site is missing server credentials. %1$@ is a placeholder for the string 'Enter your server credentials'.")
+                    static let enterServerCredentialsFormat = NSLocalizedString("%1$@ to fix this threat.", comment: "Title for button when a site is missing server credentials. %1$@ is a placeholder for the string 'Enter your server credentials'.")
                 }
 
                 struct messages {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanThreatViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanThreatViewModel.swift
@@ -30,7 +30,7 @@ struct JetpackScanThreatViewModel {
     let fixActionEnabled: Bool
     let ignoreActionTitle: String?
     let ignoreActionMessage: String
-    let warningActionTitle: String?
+    let warningActionTitle: HighlightedText?
 
     // Threat Detail Success
     let fixSuccessTitle: String
@@ -276,14 +276,20 @@ struct JetpackScanThreatViewModel {
         return Strings.details.actions.titles.ignore
     }
 
-    private static func warningActionTitle(for threat: JetpackScanThreat, hasValidCredentials: Bool?) -> String? {
+    private static func warningActionTitle(for threat: JetpackScanThreat, hasValidCredentials: Bool?) -> HighlightedText? {
         guard fixActionTitle(for: threat) != nil,
               let hasValidCredentials = hasValidCredentials,
               !hasValidCredentials else {
             return nil
         }
 
-        return Strings.details.actions.titles.enterServerCredentials
+        let warningString = String(format: Strings.details.actions.titles.enterServerCredentialsFormat,
+                                   Strings.details.actions.titles.enterServerCredentialsSubstring)
+
+        let warningActionTitle = HighlightedText(substring: Strings.details.actions.titles.enterServerCredentialsSubstring,
+                                                 string: warningString)
+
+        return warningActionTitle
     }
 
     private struct Strings {
@@ -325,7 +331,8 @@ struct JetpackScanThreatViewModel {
                 struct titles {
                     static let ignore = NSLocalizedString("Ignore threat", comment: "Title for button that will ignore the threat")
                     static let fixable = NSLocalizedString("Fix threat", comment: "Title for button that will fix the threat")
-                    static let enterServerCredentials = NSLocalizedString("Enter your server credentials to fix threat.", comment: "Title for button when a site is missing server credentials")
+                    static let enterServerCredentialsSubstring = NSLocalizedString("Enter your server credentials", comment: "Error message displayed when site credentials aren't configured.")
+                    static let enterServerCredentialsFormat = NSLocalizedString("%1$@ to fix threat.", comment: "Title for button when a site is missing server credentials. %1$@ is a placeholder for the string 'Enter your server credentials'.")
                 }
 
                 struct messages {

--- a/WordPress/Classes/ViewRelated/Views/MultilineButton.swift
+++ b/WordPress/Classes/ViewRelated/Views/MultilineButton.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+/// A `UIButton` with a multiline title label doesn't update it's height based on the number of lines.
+///
+/// The `MultilineButton` custom button calculates it's intrinsic content height based on the title label's height.
+///
+class MultilineButton: UIButton {
+
+    override var intrinsicContentSize: CGSize {
+
+        guard let labelSize = titleLabel?.sizeThatFits(CGSize(width: frame.size.width, height: CGFloat.greatestFiniteMagnitude)),
+              labelSize.height > frame.size.height else {
+            return super.intrinsicContentSize
+        }
+
+        let desiredHeight = labelSize.height + contentEdgeInsets.top + contentEdgeInsets.bottom
+
+        return CGSize(width: frame.size.width, height: desiredHeight)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4185,6 +4185,8 @@
 		FAD95D2725B91BCF00F011B5 /* JetpackRestoreStatusFailedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD95D2625B91BCF00F011B5 /* JetpackRestoreStatusFailedViewController.swift */; };
 		FADFBD26265F580500039C41 /* MultilineButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFBD25265F580500039C41 /* MultilineButton.swift */; };
 		FADFBD27265F580500039C41 /* MultilineButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFBD25265F580500039C41 /* MultilineButton.swift */; };
+		FADFBD3B265F5B2E00039C41 /* WPStyleGuide+Jetpack.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFBD3A265F5B2E00039C41 /* WPStyleGuide+Jetpack.swift */; };
+		FADFBD3C265F5B2E00039C41 /* WPStyleGuide+Jetpack.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFBD3A265F5B2E00039C41 /* WPStyleGuide+Jetpack.swift */; };
 		FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */; };
 		FAE4327425874D140039EB8C /* ReaderSavedPostCellActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */; };
 		FAF13C5325A57ABD003EE470 /* JetpackRestoreWarningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */; };
@@ -7316,6 +7318,7 @@
 		FAD954B725B7A99900F011B5 /* JetpackBackupStatusFailedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupStatusFailedViewController.swift; sourceTree = "<group>"; };
 		FAD95D2625B91BCF00F011B5 /* JetpackRestoreStatusFailedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreStatusFailedViewController.swift; sourceTree = "<group>"; };
 		FADFBD25265F580500039C41 /* MultilineButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineButton.swift; sourceTree = "<group>"; };
+		FADFBD3A265F5B2E00039C41 /* WPStyleGuide+Jetpack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Jetpack.swift"; sourceTree = "<group>"; };
 		FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartOverViewController.swift; sourceTree = "<group>"; };
 		FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostCellActions.swift; sourceTree = "<group>"; };
 		FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreWarningViewController.swift; sourceTree = "<group>"; };
@@ -9262,6 +9265,7 @@
 				17F52DB62315233300164966 /* WPStyleGuide+FilterTabBar.swift */,
 				3FD272DF24CF8F270021F0C8 /* UIColor+Notice.swift */,
 				FAD256922611B01700EDAF88 /* UIColor+WordPressColors.swift */,
+				FADFBD3A265F5B2E00039C41 /* WPStyleGuide+Jetpack.swift */,
 			);
 			path = "Colors and Styles";
 			sourceTree = "<group>";
@@ -16654,6 +16658,7 @@
 				8B8FE8582343955500F9AD2E /* PostAutoUploadMessages.swift in Sources */,
 				57D5812D2228526C002BAAD7 /* WPError+Swift.swift in Sources */,
 				988AC37922F10E2C00BC1433 /* FileDownloadsStatsRecordValue+CoreDataClass.swift in Sources */,
+				FADFBD3B265F5B2E00039C41 /* WPStyleGuide+Jetpack.swift in Sources */,
 				825327581FBF7CD600B8B7D2 /* ActivityUtils.swift in Sources */,
 				59DD94341AC479ED0032DD6B /* WPLogger.m in Sources */,
 				FAB8FD5025AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift in Sources */,
@@ -19700,6 +19705,7 @@
 				FABB25792602FC2C00C8785C /* Blog+Files.swift in Sources */,
 				FABB257A2602FC2C00C8785C /* RevisionDiffsBrowserViewController.swift in Sources */,
 				46F583AE2624CE790010A723 /* BlockEditorSettingElement+CoreDataClass.swift in Sources */,
+				FADFBD3C265F5B2E00039C41 /* WPStyleGuide+Jetpack.swift in Sources */,
 				FABB257B2602FC2C00C8785C /* WPAccount.m in Sources */,
 				FABB257C2602FC2C00C8785C /* CLPlacemark+Formatting.swift in Sources */,
 				FABB257D2602FC2C00C8785C /* SiteStatsDetailTableViewController.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4183,6 +4183,8 @@
 		FAD951A425B6CB3600F011B5 /* JetpackRestoreFailedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD951A325B6CB3600F011B5 /* JetpackRestoreFailedViewController.swift */; };
 		FAD954B825B7A99900F011B5 /* JetpackBackupStatusFailedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD954B725B7A99900F011B5 /* JetpackBackupStatusFailedViewController.swift */; };
 		FAD95D2725B91BCF00F011B5 /* JetpackRestoreStatusFailedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD95D2625B91BCF00F011B5 /* JetpackRestoreStatusFailedViewController.swift */; };
+		FADFBD26265F580500039C41 /* MultilineButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFBD25265F580500039C41 /* MultilineButton.swift */; };
+		FADFBD27265F580500039C41 /* MultilineButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADFBD25265F580500039C41 /* MultilineButton.swift */; };
 		FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */; };
 		FAE4327425874D140039EB8C /* ReaderSavedPostCellActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */; };
 		FAF13C5325A57ABD003EE470 /* JetpackRestoreWarningViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */; };
@@ -7313,6 +7315,7 @@
 		FAD951A325B6CB3600F011B5 /* JetpackRestoreFailedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreFailedViewController.swift; sourceTree = "<group>"; };
 		FAD954B725B7A99900F011B5 /* JetpackBackupStatusFailedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupStatusFailedViewController.swift; sourceTree = "<group>"; };
 		FAD95D2625B91BCF00F011B5 /* JetpackRestoreStatusFailedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreStatusFailedViewController.swift; sourceTree = "<group>"; };
+		FADFBD25265F580500039C41 /* MultilineButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineButton.swift; sourceTree = "<group>"; };
 		FAE420191C5AEFE100C1D036 /* StartOverViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StartOverViewController.swift; sourceTree = "<group>"; };
 		FAE4327325874D140039EB8C /* ReaderSavedPostCellActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostCellActions.swift; sourceTree = "<group>"; };
 		FAF13C5225A57ABD003EE470 /* JetpackRestoreWarningViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreWarningViewController.swift; sourceTree = "<group>"; };
@@ -7657,6 +7660,7 @@
 				2F161B0522CC2DC70066A5C5 /* LoadingStatusView.swift */,
 				32F2565F25012D3F006B8BC4 /* LinearGradientView.swift */,
 				F18CB8952642E58700B90794 /* FixedSizeImageView.swift */,
+				FADFBD25265F580500039C41 /* MultilineButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -16526,6 +16530,7 @@
 				E10520581F2B1CC900A948F6 /* WordPress-61-62.xcmappingmodel in Sources */,
 				3F170E242655917400F6F670 /* UIView+SwiftUI.swift in Sources */,
 				3F73BE5F24EB3B4400BE99FF /* WhatIsNewView.swift in Sources */,
+				FADFBD26265F580500039C41 /* MultilineButton.swift in Sources */,
 				B5772AC41C9C7A070031F97E /* GravatarService.swift in Sources */,
 				981676D6221B7A4300B81C3F /* CountriesCell.swift in Sources */,
 				5D2C05561AD2F56200A753FE /* NavBarTitleDropdownButton.m in Sources */,
@@ -19421,6 +19426,7 @@
 				FABB24722602FC2C00C8785C /* AutomatedTransferHelper.swift in Sources */,
 				FABB24732602FC2C00C8785C /* PostTagService.m in Sources */,
 				FABB24742602FC2C00C8785C /* ReaderTabViewModel.swift in Sources */,
+				FADFBD27265F580500039C41 /* MultilineButton.swift in Sources */,
 				FABB24752602FC2C00C8785C /* ReaderSearchSuggestionService.swift in Sources */,
 				FABB24762602FC2C00C8785C /* WPTabBarController+WhatIsNew.swift in Sources */,
 				FABB24772602FC2C00C8785C /* CachedAnimatedImageView.swift in Sources */,


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/16513

## Description

This PR updates the server credentials warning button design on the Restore Options, Scan, and Threat Detail screens.
- Added the plus-small gridicon
- Highlighted the string `Enter your server credentials` so it stands out more

_Top row: server credentials not configured, Bottom row: server credentials configured_

![Simulator Screen Shot - iPhone 12 Pro - 2021-05-27 at 16 36 48](https://user-images.githubusercontent.com/6711616/119791051-6c75b480-bf0f-11eb-9b1d-7155fc3f3128.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-27 at 16 36 59](https://user-images.githubusercontent.com/6711616/119791059-6ed80e80-bf0f-11eb-9fec-e3ac142c0e45.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-27 at 16 37 09](https://user-images.githubusercontent.com/6711616/119791067-70a1d200-bf0f-11eb-8a55-e034953d5242.png)
-- | -- | --
![Simulator Screen Shot - iPhone 12 Pro - 2021-05-27 at 16 37 39](https://user-images.githubusercontent.com/6711616/119791071-713a6880-bf0f-11eb-975b-1daaba727346.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-27 at 16 38 14](https://user-images.githubusercontent.com/6711616/119791075-726b9580-bf0f-11eb-98ed-7f8af7ac2b8a.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-27 at 16 38 17](https://user-images.githubusercontent.com/6711616/119791076-73042c00-bf0f-11eb-961d-cfac45521aa2.png)

<details>
 <summary>Expand for WordPress screenshots</summary>
 
 ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-27 at 17 32 50](https://user-images.githubusercontent.com/6711616/119793617-bb244e00-bf11-11eb-9680-fa1c35c61685.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-27 at 17 33 20](https://user-images.githubusercontent.com/6711616/119793624-bc557b00-bf11-11eb-92f0-28c609401b62.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-05-27 at 17 33 23](https://user-images.githubusercontent.com/6711616/119793631-bcee1180-bf11-11eb-980d-ca069dd797f5.png)
-- | -- | --

</details>

## How to test
1. Switch to a site without server credentials configured / backup and scan enabled / threats present
2. Go to My Site > Backup > ellipsis icon > Restore
3. ✅ The warning button should be displayed. Also, there should be a plus icon and only the `Enter your server credentials` should be highlighted
4. Go to My Site > Scan
5. ✅ The warning button should be displayed with the updated design
6. Tap on a fixable threat and go to Threat Details
7. ✅ The warning button should be displayed with the updated design

## Regression Notes
1. Potential unintended areas of impact
WordPress: Restore Options, Scan, and Threat Detail screens

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I built and tested the WP app

3. What automated tests I added (or what prevented me from doing so)
N/A, only visual changes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
