### PR TITLE
Fix Unsupported Block Editor on account created prior to December 2018

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] Improved large text support in the blog details header in My Sites. [#16521]
 * [***] Block Editor: New Block: Reusable block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3490]
 * [***] Block Editor: Add reusable blocks to the block inserter menu. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3054]
+* [*] Fixed a bug where the web version of the editor did not load when using an account created before December 2018. [#16586]
 
 17.4
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1063,7 +1063,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
         let blog = post.blog
         let isJetpackSSOEnabled = (blog.jetpack?.isConnected ?? false) && (blog.settings?.jetpackSSOEnabled ?? false)
 
-        return blog.isHostedAtWPcom || (isJetpackSSOEnabled && blog.webEditor == .gutenberg)
+        return blog.isHostedAtWPcom || isJetpackSSOEnabled
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
@@ -132,7 +132,8 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
     private func showTroubleshootingInstructions() {
         let title = NSLocalizedString("Unable to load the block editor right now.", comment: "Title message shown when the Unsupported Block Editor fails to load.")
         let subtitle = NSLocalizedString("Please ensure the block editor is enabled on your site and try again.", comment: "Subtitle message shown when the Unsupported Block Editor fails to load. It asks users to verify that the block editor is enabled on their site before trying again.")
-        self.updateNoResults(title: title, subtitle: subtitle, image: "cloud")
+        // This does nothing if the "no results" screen is not currently displayed, which is the intended behavior
+        updateNoResults(title: title, subtitle: subtitle, image: "cloud")
     }
 
     private func startObservingWebView() {
@@ -154,6 +155,7 @@ extension GutenbergWebViewController {
     override func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
         super.webView(webView, didCommit: navigation)
         if webView.url?.absoluteString.contains("reauth=1") ?? false {
+            hideNoResults()
             removeCoverViewAnimated()
         }
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import WebKit
 import Gutenberg
 
-class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitAuthenticatable {
+class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitAuthenticatable, NoResultsViewHost {
     enum GutenbergWebError: Error {
         case wrongEditorUrl(String?)
     }
@@ -11,6 +11,7 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
     private let url: URL
     private let progressView = WebProgressView()
     private let userId: String
+    let gutenbergReadySemaphore = DispatchSemaphore(value: 0)
 
     init(with post: AbstractPost, block: Block) throws {
         authenticator = GutenbergRequestAuthenticator(blog: post.blog)
@@ -35,8 +36,10 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
     override func viewDidLoad() {
         super.viewDidLoad()
         addNavigationBarElements()
+        showLoadingMessage()
         addProgressView()
         startObservingWebView()
+        waitForGutenbergToLoad(fallback: showTroubleshootingInstructions)
     }
 
     deinit {
@@ -82,6 +85,10 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
     override func onGutenbergReady() {
         super.onGutenbergReady()
         navigationItem.rightBarButtonItem?.isEnabled = true
+        DispatchQueue.main.async { [weak self] in
+            self?.hideNoResults()
+            self?.gutenbergReadySemaphore.signal()
+        }
     }
 
     private func loadCustomScript(named name: String, with argument: String? = nil) -> WKUserScript? {
@@ -102,6 +109,30 @@ class GutenbergWebViewController: GutenbergWebSingleBlockViewController, WebKitA
             action: #selector(onSaveButtonPressed)
         )
         navigationItem.rightBarButtonItem?.isEnabled = false
+    }
+
+    private func showLoadingMessage() {
+        let title = NSLocalizedString("Loading the block editor.", comment: "Loading message shown while the Unsupported Block Editor is loading.")
+        let subtitle = NSLocalizedString("Please ensure the block editor is enabled on your site. If it is not enabled, it will not load.", comment: "Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly.")
+        configureAndDisplayNoResults(on: view, title: title, subtitle: subtitle, accessoryView: NoResultsViewController.loadingAccessoryView())
+    }
+
+    private func waitForGutenbergToLoad(fallback: @escaping () -> Void) {
+        DispatchQueue.global(qos: .background).async { [weak self] in
+            let timeout: TimeInterval = 15
+            // blocking call
+            if self?.gutenbergReadySemaphore.wait(timeout: .now() + timeout) == .timedOut {
+                DispatchQueue.main.async {
+                    fallback()
+                }
+            }
+        }
+    }
+
+    private func showTroubleshootingInstructions() {
+        let title = NSLocalizedString("Unable to load the block editor right now.", comment: "Title message shown when the Unsupported Block Editor fails to load.")
+        let subtitle = NSLocalizedString("Please ensure the block editor is enabled on your site and try again.", comment: "Subtitle message shown when the Unsupported Block Editor fails to load. It asks users to verify that the block editor is enabled on their site before trying again.")
+        self.updateNoResults(title: title, subtitle: subtitle, image: "cloud")
     }
 
     private func startObservingWebView() {


### PR DESCRIPTION
### Description

Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425 (fixes for iOS, not Android)

The `/sites/{site_id}/gutenberg` endpoint [is unreliable](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425#issuecomment-840223555) but was being used to check if Gutenberg was available on a site's backend, and if so, disable the Unsupported Block Editor (UBE).

Since the majority of users will have Gutenberg enabled, it makes sense to remove usage of this unreliable API endpoint. What we do instead in this PR is:
- Show a new **Loading In-Progress Screen** as the UBE loads, with a message warning users that if Gutenberg is not enabled on their site, the UBE (a.k.a. web editor) will not load.
- Show a new **Loading Failed Screen** if the UBE fails to load, e.g. because Gutenberg was not enabled on the site, including a message prompting users to check if Gutenberg is enabled on their site.

| (NEW) Loading In-Progress Screen | (NEW) Loading Failed Screen |
| - | - |
| <img width="250" src="https://user-images.githubusercontent.com/1898325/119855055-98794180-bedf-11eb-89b5-8cd1c5d723b6.jpg" /> | <img width="250" src="https://user-images.githubusercontent.com/1898325/119855475-ef7f1680-bedf-11eb-852d-69961c7fe8ab.jpg"/> |


### To test

#### Feature tests 

See https://github.com/wordpress-mobile/gutenberg-mobile/issues/3425. The testing steps here are:
1. Sign in using an account created before Dec 2018
2. Locate a post with an unsupported block on an Atomic site
3. Open the post and tap the `(?)` to open the web editor (UBE)
4. Ensure the UBE opens as expected and you can successfully edit the unsupported block

```
- [ ] UBE now works on Jetpack sites using an account created prior to December 2018
```

#### Regression tests
Go through the following test cases (taken from [here](https://github.com/wordpress-mobile/test-cases/blob/dc78dcff1c7d01a3c6f10a023b053ad4566d3ba1/test-cases/gutenberg/unsupported-block-editing.md)) and make sure the **New Loading Screen** is shown while the UBE loads. In TC004, the **Loading Failed Screen** should be shown after a 15 second timeout.

```
- [ ] TC001 - User can edit unsupported blocks on Simple WP.com sites
- [ ] TC002 - User can discard edits to an unsupported blocks on Simple WP.com sites
- [ ] TC003 - Editing unsupported blocks is allowed on Gutenberg-enabled Atomic sites
- [ ] TC004 - Editing unsupported blocks is disallowed on Classic-enabled Atomic sites
- [ ] TC005 - Editing unsupported blocks is enabled on self-hosted sites accessed via Jetpack
- [ ] TC006 – Editing unsupported blocks is disallowed on self-hosted sites accessed via their own username and password
```


## Regression Notes
1. Potential unintended areas of impact

This could somehow cause issues with the Unsupported Block Editor loading, so it's important to test this across all site types.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

The manual test cases above aim to cover these areas of impact.

3. What automated tests I added (or what prevented me from doing so)

This PR adds a loading screen that relies on the underlying network request. Mocking this seems tricky, both as a unit test or a UI test (using https://github.com/wordpress-mobile/WordPressMocks).

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
