### PR TITLE
Blogging Reminders Settings Flow i1

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Reminders.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Reminders.swift
@@ -1,0 +1,14 @@
+import UIKit
+import SwiftUI
+
+extension BlogDetailsViewController {
+    func presentBloggingRemindersSettingsFlow() {
+        // TODO: Check whether we've already presented this flow to the user. @frosty
+        let navigationController = BloggingRemindersNavigationController(rootViewController: BloggingRemindersSettingsContainerViewController(),
+                                                                         viewControllerDrawerPositions: [.collapsed, .expanded, .collapsed])
+
+        let bottomSheet = BottomSheetViewController(childViewController: navigationController,
+                                                    customHeaderSpacing: 0)
+        bottomSheet.show(from: self)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
@@ -1,0 +1,86 @@
+import UIKit
+
+class BloggingRemindersNavigationController: LightNavigationController {
+
+    private let viewControllerDrawerPositions: [DrawerPosition]
+
+    init(rootViewController: UIViewController, viewControllerDrawerPositions: [DrawerPosition]) {
+        self.viewControllerDrawerPositions = viewControllerDrawerPositions
+
+        super.init(rootViewController: rootViewController)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override public var preferredContentSize: CGSize {
+        set {
+            viewControllers.last?.preferredContentSize = newValue
+            super.preferredContentSize = newValue
+        }
+        get {
+            guard let visibleViewController = viewControllers.last else {
+                return .zero
+            }
+
+            return visibleViewController.preferredContentSize
+        }
+    }
+
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        super.pushViewController(viewController, animated: animated)
+
+        updateDrawerPosition()
+    }
+
+    override func popViewController(animated: Bool) -> UIViewController? {
+        let viewController = super.popViewController(animated: animated)
+
+        updateDrawerPosition()
+
+        return viewController
+    }
+
+    private func updateDrawerPosition() {
+        let index = max(min(viewControllers.count-1, viewControllerDrawerPositions.count-1), 0)
+        let newPosition = viewControllerDrawerPositions[index]
+
+        if let viewController = viewControllers.last {
+            preferredContentSize = viewController.preferredContentSize
+        }
+        
+        if let bottomSheet = self.parent as? BottomSheetViewController, let presentedVC = bottomSheet.presentedVC {
+            presentedVC.transition(to: newPosition)
+        }
+    }
+}
+
+
+// MARK: - DrawerPresentable
+
+extension BloggingRemindersNavigationController: DrawerPresentable {
+    var allowsUserTransition: Bool {
+        return false
+    }
+
+    var allowsDragToDismiss: Bool {
+        return true
+    }
+
+    var allowsTapToDismiss: Bool {
+        return true
+    }
+
+    var expandedHeight: DrawerHeight {
+        return .maxHeight
+    }
+
+    var collapsedHeight: DrawerHeight {
+        if let viewController = viewControllers.last as? DrawerPresentable {
+            return viewController.collapsedHeight
+        }
+
+        return .intrinsicHeight
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
@@ -49,7 +49,7 @@ class BloggingRemindersNavigationController: LightNavigationController {
         if let viewController = viewControllers.last {
             preferredContentSize = viewController.preferredContentSize
         }
-        
+
         if let bottomSheet = self.parent as? BottomSheetViewController, let presentedVC = bottomSheet.presentedVC {
             presentedVC.transition(to: newPosition)
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersSettingsFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersSettingsFlow.swift
@@ -109,7 +109,6 @@ struct BloggingRemindersSettingsView: View {
                 }
             }
             Spacer()
-                .frame(maxHeight: .infinity)
             NavigationLink(destination: BloggingRemindersSettingsCompletionView().environmentObject(coordinator)) {
                 Text(TextContent.nextButtonTitle)
                     .primaryButtonStyle()

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersSettingsFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersSettingsFlow.swift
@@ -20,7 +20,7 @@ class BloggingRemindersSettingsContainerViewController: UIViewController, Drawer
 
         view.backgroundColor = .basicBackground
 
-        let rootView = Text("").environmentObject(makeCoordinator())
+        let rootView = BloggingRemindersSettingsIntroView().environmentObject(makeCoordinator())
         let host = UIHostingController(rootView: rootView)
 
         host.view.translatesAutoresizingMaskIntoConstraints = false
@@ -43,4 +43,173 @@ class BloggingRemindersSettingsContainerViewController: UIViewController, Drawer
     var allowsDragToDismiss: Bool {
         true
     }
+}
+
+struct BloggingRemindersSettingsIntroView: View {
+    @EnvironmentObject var coordinator: BlogRemindersCoordinator
+
+    var body: some View {
+        VStack(spacing: Metrics.introStackSpacing) {
+            Image(systemName: Images.starImageName)
+                .resizable().frame(width: Metrics.topImageSize.width, height: Metrics.topImageSize.height, alignment: .center)
+            Text(TextContent.introTitle)
+                .font(TextContent.introTitleFont)
+            Text(TextContent.introDescription)
+            NavigationLink(destination: BloggingRemindersSettingsView().environmentObject(coordinator)) {
+                Text(TextContent.getStartedButtonTitle)
+                    .primaryButtonStyle()
+            }
+            Spacer()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationBarHidden(true)
+    }
+}
+
+struct BloggingRemindersSettingsView: View {
+    @EnvironmentObject var coordinator: BlogRemindersCoordinator
+
+    // TODO: This will be replaced by some observable object or similar that
+    // coordinates with our reminders store. @frosty
+    @SwiftUI.State private var toggles: [Bool] = [false, false, false, false, false, false, false]
+
+    let days: [String] = {
+        var calendar = Calendar.current
+        calendar.locale = Locale.autoupdatingCurrent
+        let firstWeekday = calendar.firstWeekday
+        var symbols = calendar.shortWeekdaySymbols
+
+        let localizedWeekdays: [String] = Array(symbols[firstWeekday - 1 ..< Calendar.current.shortWeekdaySymbols.count] + symbols[0 ..< firstWeekday - 1])
+
+        return localizedWeekdays
+    }()
+
+    var body: some View {
+        VStack(spacing: Metrics.settingsStackSpacing) {
+            Spacer()
+            Image(systemName: Images.calendarImageName)
+                .resizable()
+                .frame(width: Metrics.topImageSize.width, height: Metrics.topImageSize.height, alignment: .center)
+            VStack(spacing: Metrics.settingsInnerStackSpacing) {
+                Text(TextContent.settingsPrompt)
+                    .font(TextContent.settingsPromptFont)
+                    .fontWeight(.semibold)
+                    .lineLimit(nil)
+                    .multilineTextAlignment(.center)
+                Text(TextContent.settingsUpdatePrompt)
+                    .foregroundColor(.gray)
+                    .lineLimit(2)
+            }
+            HStack {
+                ForEach(days.indices, id: \.self) { index in
+                    Toggle(days[index].uppercased(), isOn: $toggles[index])
+                        .toggleStyle(CheckboxToggleStyle())
+                        .frame(minWidth: 0, maxWidth: .infinity)
+                }
+            }
+            Spacer()
+                .frame(maxHeight: .infinity)
+            NavigationLink(destination: BloggingRemindersSettingsCompletionView().environmentObject(coordinator)) {
+                Text(TextContent.nextButtonTitle)
+                    .primaryButtonStyle()
+            }
+            Spacer()
+        }
+        .padding()
+        .navigationBarHidden(true)
+    }
+}
+
+struct BloggingRemindersSettingsCompletionView: View {
+    @EnvironmentObject var coordinator: BlogRemindersCoordinator
+
+    var body: some View {
+        VStack(spacing: Metrics.completionStackSpacing) {
+            Image(systemName: Images.clockImageName)
+            Text(TextContent.completionTitle)
+                .font(TextContent.completionTitleFont)
+                .bold()
+            // TODO: This needs to be constructed with the correct information in it
+            // based on the user's choices. @frosty
+            Text("You'll get reminders to blog 2 times a week on Wednesday and Thursday.")
+            Text(TextContent.completionUpdatePrompt)
+                .foregroundColor(.gray)
+                .lineLimit(2)
+            Button(action: {
+                coordinator.dismiss()
+            }) {
+                Text(TextContent.doneButtonTitle)
+                    .primaryButtonStyle()
+            }
+            Spacer()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .navigationBarHidden(true)
+    }
+}
+
+/// A custom checkbox style show a label in the center of a circle.
+///
+struct CheckboxToggleStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        return Circle()
+            .fill(configuration.isOn ? Color.green : Color(UIColor.lightGray))
+            .frame(width: Metrics.checkboxSize.width, height: Metrics.checkboxSize.height)
+            .onTapGesture { configuration.isOn.toggle() }
+            .overlay(
+                configuration.label
+                    .foregroundColor(configuration.isOn ? .white : Color(UIColor.darkGray))
+            )
+    }
+}
+
+private enum TextContent {
+
+    static let introTitle = NSLocalizedString("Set your blogging goals",
+                                              comment: "Title of the Blogging Reminders Settings screen.")
+
+    static let introTitleFont = Font.system(.title, design: .serif).bold()
+
+    static let introDescription = NSLocalizedString("Well done on your first post! Keep it going. You can now set your blogging goals, get reminders, and track your progress.",
+                                                    comment: "Description on the first screen of the Blogging Reminders Settings flow.")
+
+    static let getStartedButtonTitle = NSLocalizedString("Get Started",
+                                                         comment: "Title of the Get Started button in the Blogging Reminders Settings flow.")
+
+    static let settingsPrompt = NSLocalizedString("Select the days you want to blog on",
+                                                  comment: "Prompt shown on the Blogging Reminders Settings screen.")
+    static let settingsPromptFont = Font.system(.largeTitle, design: .serif)
+
+    static let settingsUpdatePrompt = NSLocalizedString("You can update this any time.",
+                                                        comment: "Prompt shown on the Blogging Reminders Settings screen.")
+
+    static let nextButtonTitle = NSLocalizedString("Next", comment: "Title of button to navigate to the next screen.")
+
+    static let completionTitle = NSLocalizedString("All set!", comment: "Title of the completion screen of the Blogging Reminders Settings screen.")
+
+    static let completionTitleFont = Font.system(.title, design: .serif)
+
+    static let completionUpdatePrompt = NSLocalizedString("You can update this any time via My Site > Site Settings",
+                                                          comment: "Prompt shown on the completion screen of the Blogging Reminders Settings screen.")
+
+    static let doneButtonTitle = NSLocalizedString("Done", comment: "Title for a Done button.")
+}
+
+private enum Images {
+
+    static let starImageName = "star.circle"
+    static let calendarImageName = "calendar"
+    static let clockImageName = "deskclock"
+}
+
+private enum Metrics {
+
+    static let introStackSpacing: CGFloat = 10.0
+    static let topImageSize = CGSize(width: 66.0, height: 66.0)
+    static let settingsStackSpacing: CGFloat = 50.0
+    static let settingsInnerStackSpacing: CGFloat = 50.0
+    static let completionStackSpacing: CGFloat = 10.0
+    static let checkboxSize = CGSize(width: 44.0, height: 44.0)
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersSettingsFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersSettingsFlow.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import UIKit
+
+/// This allows us to dismiss the UIKit-presented SwiftUI flow.
+/// We'll pass it through the screens as an environment object.
+///
+final class BlogRemindersCoordinator: ObservableObject {
+    var presenter: UIViewController?
+
+    func dismiss() {
+        presenter?.dismiss(animated: true)
+    }
+}
+
+/// UIKit container for the SwiftUI-based reminders setting flow.
+///
+class BloggingRemindersSettingsContainerViewController: UIViewController, DrawerPresentable {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .basicBackground
+
+        let rootView = Text("").environmentObject(makeCoordinator())
+        let host = UIHostingController(rootView: rootView)
+
+        host.view.translatesAutoresizingMaskIntoConstraints = false
+        addChild(host)
+        view.addSubview(host.view)
+        view.pinSubviewToAllEdges(host.view)
+        host.didMove(toParent: self)
+    }
+
+    func makeCoordinator() -> BlogRemindersCoordinator {
+        let coordinator = BlogRemindersCoordinator()
+        coordinator.presenter = self
+        return coordinator
+    }
+
+    var collapsedHeight: DrawerHeight {
+        .intrinsicHeight
+    }
+
+    var allowsDragToDismiss: Bool {
+        true
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reusable SwiftUI Views/ButtonStyles.swift
+++ b/WordPress/Classes/ViewRelated/Reusable SwiftUI Views/ButtonStyles.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct PrimaryButtonStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.headline)
+            .padding()
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 44.0, maxHeight: 44.0)
+            .background(Color(.primary))
+            .foregroundColor(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 8.0))
+    }
+}
+
+extension View {
+    func primaryButtonStyle() -> some View {
+        self.modifier(PrimaryButtonStyle())
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -140,6 +140,12 @@
 		1715179220F4B2EB002C4A38 /* Routes+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1715179120F4B2EB002C4A38 /* Routes+Stats.swift */; };
 		1715179420F4B5CD002C4A38 /* MySitesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1715179320F4B5CD002C4A38 /* MySitesCoordinator.swift */; };
 		1716AEFC25F2927600CF49EC /* MySiteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1716AEFB25F2927600CF49EC /* MySiteViewController.swift */; };
+		17171071265BF16900F3A022 /* BlogDetailsViewController+Reminders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17171070265BF16900F3A022 /* BlogDetailsViewController+Reminders.swift */; };
+		17171072265BF16900F3A022 /* BlogDetailsViewController+Reminders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17171070265BF16900F3A022 /* BlogDetailsViewController+Reminders.swift */; };
+		17171374265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17171373265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift */; };
+		17171375265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17171373265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift */; };
+		17171389265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17171388265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift */; };
+		1717138A265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17171388265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift */; };
 		171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1719633F1D378D5100898E8B /* SearchWrapperView.swift */; };
 		171CC15824FCEBF7008B7180 /* UINavigationBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171CC15724FCEBF7008B7180 /* UINavigationBar+Appearance.swift */; };
 		17222D80261DDDF90047B163 /* celadon-classic-icon-app-76x76.png in Resources */ = {isa = PBXBuildFile; fileRef = 17222D45261DDDF10047B163 /* celadon-classic-icon-app-76x76.png */; };
@@ -4584,6 +4590,9 @@
 		1715179120F4B2EB002C4A38 /* Routes+Stats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Stats.swift"; sourceTree = "<group>"; };
 		1715179320F4B5CD002C4A38 /* MySitesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySitesCoordinator.swift; sourceTree = "<group>"; };
 		1716AEFB25F2927600CF49EC /* MySiteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MySiteViewController.swift; sourceTree = "<group>"; };
+		17171070265BF16900F3A022 /* BlogDetailsViewController+Reminders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+Reminders.swift"; sourceTree = "<group>"; };
+		17171373265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingRemindersNavigationController.swift; sourceTree = "<group>"; };
+		17171388265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingRemindersSettingsFlow.swift; sourceTree = "<group>"; };
 		1719633F1D378D5100898E8B /* SearchWrapperView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchWrapperView.swift; sourceTree = "<group>"; };
 		171CC15724FCEBF7008B7180 /* UINavigationBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationBar+Appearance.swift"; sourceTree = "<group>"; };
 		17222D45261DDDF10047B163 /* celadon-classic-icon-app-76x76.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "celadon-classic-icon-app-76x76.png"; sourceTree = "<group>"; };
@@ -8656,6 +8665,8 @@
 			children = (
 				3F170D2B2654618000F6F670 /* BloggingRemindersCell.swift */,
 				3F170EC22655DD1700F6F670 /* BloggingRemindersCard.swift */,
+				17171373265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift */,
+				17171388265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift */,
 			);
 			path = "Blogging Reminders";
 			sourceTree = "<group>";
@@ -8846,6 +8857,7 @@
 				02D75D9822793EA2003FF09A /* BlogDetailsSectionFooterView.swift */,
 				4349BFF4221205540084F200 /* BlogDetailsSectionHeaderView.xib */,
 				F53FF3A623EA722F001AD596 /* Detail Header */,
+				17171070265BF16900F3A022 /* BlogDetailsViewController+Reminders.swift */,
 			);
 			path = "Blog Details";
 			sourceTree = "<group>";
@@ -17239,6 +17251,7 @@
 				E61084BE1B9B47BA008050C5 /* ReaderAbstractTopic.swift in Sources */,
 				2F08ECFC2283A4FB000F8E11 /* PostService+UnattachedMedia.swift in Sources */,
 				E61084BF1B9B47BA008050C5 /* ReaderDefaultTopic.swift in Sources */,
+				17171389265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift in Sources */,
 				8BB185D624B66FE600A4CCE8 /* ReaderCard+CoreDataClass.swift in Sources */,
 				D816C1F220E0894D00C4D82F /* ReplyToComment.swift in Sources */,
 				E1BB92321FDAAFFA00F2D817 /* TextWithAccessoryButtonCell.swift in Sources */,
@@ -17613,6 +17626,7 @@
 				3F43602F23F31D48001DEE70 /* ScenePresenter.swift in Sources */,
 				9A4E271D22EF33F5001F6A6B /* AccountSettingsStore.swift in Sources */,
 				4319AADE2090F00C0025D68E /* FancyAlertViewController+NotificationPrimer.swift in Sources */,
+				17171071265BF16900F3A022 /* BlogDetailsViewController+Reminders.swift in Sources */,
 				73FF7032221F469100541798 /* Charts+Support.swift in Sources */,
 				F16601C423E9E783007950AE /* SharingAuthorizationWebViewController.swift in Sources */,
 				171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */,
@@ -17708,6 +17722,7 @@
 				5D839AAB187F0D8000811F4A /* PostGeolocationCell.m in Sources */,
 				4054F4422213635000D261AB /* TopCommentsAuthorStatsRecordValue+CoreDataClass.swift in Sources */,
 				FAB8FD6E25AEB23600D5D54A /* JetpackBackupService.swift in Sources */,
+				17171374265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift in Sources */,
 				8236EB502024ED8C007C7CF9 /* NotificationsViewController+JetpackPrompt.swift in Sources */,
 				5D732F971AE84E3C00CD89E7 /* PostListFooterView.m in Sources */,
 				1767494E1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift in Sources */,
@@ -18449,6 +18464,7 @@
 				FABB20D52602FC2C00C8785C /* TagsCategoriesStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB20D62602FC2C00C8785C /* RevisionOperation.swift in Sources */,
 				FABB20D72602FC2C00C8785C /* ZendeskUtils.swift in Sources */,
+				1717138A265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift in Sources */,
 				FABB20D82602FC2C00C8785C /* AbstractPost+Dates.swift in Sources */,
 				FABB20D92602FC2C00C8785C /* Blog+HomepageSettings.swift in Sources */,
 				FABB20DA2602FC2C00C8785C /* GutenbergRollout.swift in Sources */,
@@ -18876,6 +18892,7 @@
 				FABB226C2602FC2C00C8785C /* ParentPageSettingsViewController.swift in Sources */,
 				FABB226D2602FC2C00C8785C /* Queue.swift in Sources */,
 				FABB226E2602FC2C00C8785C /* SwitchTableViewCell.swift in Sources */,
+				17171375265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift in Sources */,
 				FABB226F2602FC2C00C8785C /* ReaderTopicToReaderSiteTopic37to38.swift in Sources */,
 				FABB22702602FC2C00C8785C /* WordPressComSyncService.swift in Sources */,
 				FABB22712602FC2C00C8785C /* AppRatingsUtility.swift in Sources */,
@@ -19801,6 +19818,7 @@
 				FABB25EA2602FC2C00C8785C /* PeopleRoleBadgeLabel.swift in Sources */,
 				FABB25EB2602FC2C00C8785C /* ActivityDetailViewController.swift in Sources */,
 				FABB25EC2602FC2C00C8785C /* BlogListViewController+BlogDetailsFactory.swift in Sources */,
+				17171072265BF16900F3A022 /* BlogDetailsViewController+Reminders.swift in Sources */,
 				FABB25ED2602FC2C00C8785C /* WebViewControllerConfiguration.swift in Sources */,
 				FABB25EE2602FC2C00C8785C /* ViewMoreRow.swift in Sources */,
 				FABB25EF2602FC2C00C8785C /* ReaderWebView.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -146,6 +146,8 @@
 		17171375265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17171373265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift */; };
 		17171389265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17171388265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift */; };
 		1717138A265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17171388265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift */; };
+		1717139F265FE59700F3A022 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1717139E265FE59700F3A022 /* ButtonStyles.swift */; };
+		171713A0265FE59700F3A022 /* ButtonStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1717139E265FE59700F3A022 /* ButtonStyles.swift */; };
 		171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1719633F1D378D5100898E8B /* SearchWrapperView.swift */; };
 		171CC15824FCEBF7008B7180 /* UINavigationBar+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171CC15724FCEBF7008B7180 /* UINavigationBar+Appearance.swift */; };
 		17222D80261DDDF90047B163 /* celadon-classic-icon-app-76x76.png in Resources */ = {isa = PBXBuildFile; fileRef = 17222D45261DDDF10047B163 /* celadon-classic-icon-app-76x76.png */; };
@@ -4593,6 +4595,7 @@
 		17171070265BF16900F3A022 /* BlogDetailsViewController+Reminders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+Reminders.swift"; sourceTree = "<group>"; };
 		17171373265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingRemindersNavigationController.swift; sourceTree = "<group>"; };
 		17171388265FB7AC00F3A022 /* BloggingRemindersSettingsFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingRemindersSettingsFlow.swift; sourceTree = "<group>"; };
+		1717139E265FE59700F3A022 /* ButtonStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonStyles.swift; sourceTree = "<group>"; };
 		1719633F1D378D5100898E8B /* SearchWrapperView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchWrapperView.swift; sourceTree = "<group>"; };
 		171CC15724FCEBF7008B7180 /* UINavigationBar+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationBar+Appearance.swift"; sourceTree = "<group>"; };
 		17222D45261DDDF10047B163 /* celadon-classic-icon-app-76x76.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "celadon-classic-icon-app-76x76.png"; sourceTree = "<group>"; };
@@ -7850,6 +7853,14 @@
 			path = "My Site";
 			sourceTree = "<group>";
 		};
+		1717139D265FE56A00F3A022 /* Reusable SwiftUI Views */ = {
+			isa = PBXGroup;
+			children = (
+				1717139E265FE59700F3A022 /* ButtonStyles.swift */,
+			);
+			path = "Reusable SwiftUI Views";
+			sourceTree = "<group>";
+		};
 		1719633E1D378D1E00898E8B /* Search */ = {
 			isa = PBXGroup;
 			children = (
@@ -10653,6 +10664,7 @@
 		8584FDB31923EF4F0019C02E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				1717139D265FE56A00F3A022 /* Reusable SwiftUI Views */,
 				987E79C9261F8857000192B7 /* User Profile Sheet */,
 				7E3E9B6E2177C9C300FD5797 /* Gutenberg */,
 				98077B58207555E400109F95 /* Support */,
@@ -17070,6 +17082,7 @@
 				B560914C208A671F00399AE4 /* WPStyleGuide+SiteCreation.swift in Sources */,
 				B5EFB1C21B31B98E007608A3 /* NotificationSettingsService.swift in Sources */,
 				5903AE1B19B60A98009D5354 /* WPButtonForNavigationBar.m in Sources */,
+				1717139F265FE59700F3A022 /* ButtonStyles.swift in Sources */,
 				989643EC23A0437B0070720A /* WidgetDifferenceCell.swift in Sources */,
 				98906506237CC1DF00218CD2 /* WidgetTwoColumnCell.swift in Sources */,
 				B58C4ECA207C5E1A00E32E4D /* UIImage+Assets.swift in Sources */,
@@ -19669,6 +19682,7 @@
 				FABB255B2602FC2C00C8785C /* FooterContentStyles.swift in Sources */,
 				FABB255C2602FC2C00C8785C /* TenorMedia.swift in Sources */,
 				FABB255D2602FC2C00C8785C /* AbstractPost.swift in Sources */,
+				171713A0265FE59700F3A022 /* ButtonStyles.swift in Sources */,
 				FABB255E2602FC2C00C8785C /* WhatIsNewScenePresenter.swift in Sources */,
 				FABB255F2602FC2C00C8785C /* CalendarViewController.swift in Sources */,
 				FABB25602602FC2C00C8785C /* GutenbergViewController+Localization.swift in Sources */,


### PR DESCRIPTION
Refs #16565 #16566 #16567. This PR adds a first rough draft at the settings screens for blogging reminders. The main aim of this PR is to get a framework in place and allow us to share out the work of the individual screens and integrating them with the data. As such, the content of each view is not final so I'm not looking for too much feedback there at this stage. Also, I know that the positioning of elements on the initial screens isn't perfect – I'm going to be looking into that next.

![blog-reminders-1](https://user-images.githubusercontent.com/4780/119858623-8cf03f80-bf0c-11eb-83d2-33d87b1de655.gif)

- Enable the blogging reminders feature flag
- Add some code to display it. I swapped out the action of the Stats quick action button around line 43 of `BlogDetailsViewController+Header.swift` with `self?.presentBloggingRemindersSettingsFlow()`

It's currently not hooked up anywhere so you'll need to do the following to test it:

**To test**

- Follow the steps above to add this code
- Build and run
- Get the UI to appear and step through it

## Regression Notes

1. Potential unintended areas of impact

None, this is all new code.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
