### PR TITLE
Dismiss suggestions on space keystroke

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergSuggestionsViewController.swift
@@ -114,6 +114,13 @@ extension GutenbergSuggestionsViewController: UITextFieldDelegate {
             return true
         }
         let searchWord = nsString.replacingCharacters(in: range, with: string)
+
+        let dismissSequence = suggestionType.trigger + " "
+        guard searchWord != dismissSequence else {
+            onCompletion?(.success(""))
+            return true
+        }
+
         if searchWord.hasPrefix(suggestionType.trigger) {
             suggestionsView.showSuggestions(forWord: searchWord)
         } else {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergSuggestionsViewController.swift
@@ -115,6 +115,16 @@ extension GutenbergSuggestionsViewController: UITextFieldDelegate {
         }
         let searchWord = nsString.replacingCharacters(in: range, with: string)
 
+        // This feels a bit hacky, so I'll explain what's being done here:
+        //     1. If the user types "@ ", the so-called "dismiss sequence",
+        //        the user probably typed the space to dismiss the suggestions UI.
+        //     2. So when this happens, we call the success handler and
+        //        pass in an empty string.
+        // We pass in an empty string because on the RN side here, the success
+        // handler inserts the @, followed by the username, followed by a space.
+        // Since we're essentially passing in an empty username, the result is
+        // that a "@ " is inserted into the post, which is the desired result.
+        // The same applies for cross-posts, with "+ " instead of "@ ".
         let dismissSequence = suggestionType.trigger + " "
         guard searchWord != dismissSequence else {
             onCompletion?(.success(""))

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -246,8 +246,15 @@ CGFloat const STVSeparatorHeight = 1.f;
         self.searchText = word;
         if (self.searchText.length > 1) {
             NSString *searchQuery = [word substringFromIndex:1];
-            NSPredicate *predicate = [self predicateFor: searchQuery];
-            self.searchResults = [[self.suggestions filteredArrayUsingPredicate:predicate] mutableCopy];
+
+            // Users type a space after a trigger character to dismiss the suggestions UI
+            if ([searchQuery isEqualToString:@" "]) {
+                self.searchText = @"";
+                [self.searchResults removeAllObjects];
+            } else {
+                NSPredicate *predicate = [self predicateFor: searchQuery];
+                self.searchResults = [[self.suggestions filteredArrayUsingPredicate:predicate] mutableCopy];
+            }
         } else {
             self.searchResults = [self.suggestions mutableCopy];
         }

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -246,15 +246,8 @@ CGFloat const STVSeparatorHeight = 1.f;
         self.searchText = word;
         if (self.searchText.length > 1) {
             NSString *searchQuery = [word substringFromIndex:1];
-
-            // Users type a space after a trigger character to dismiss the suggestions UI
-            if ([searchQuery isEqualToString:@" "]) {
-                self.searchText = @"";
-                [self.searchResults removeAllObjects];
-            } else {
-                NSPredicate *predicate = [self predicateFor: searchQuery];
-                self.searchResults = [[self.suggestions filteredArrayUsingPredicate:predicate] mutableCopy];
-            }
+            NSPredicate *predicate = [self predicateFor: searchQuery];
+            self.searchResults = [[self.suggestions filteredArrayUsingPredicate:predicate] mutableCopy];
         } else {
             self.searchResults = [self.suggestions mutableCopy];
         }


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/issues/24425 (for iOS)

This PR allows users to easily dismiss the suggestion UI by typing a space character after triggering the UI. This means it will now be easier to add a `@` character to a post without triggering the mentions suggestions UI, or add a `+` character without triggering the cross-post suggestions UI.

I added this change to suggestions in the block editor, but didn't apply it to other parts of the app (e.g. comments, notification replies, etc) because that felt too far out-of-scope here. It would also make the testing steps much longer.

## To test:

1. Verify that in the block editor, typing a space after a `@` character dismisses the mentions suggestions list
2. Verify that in the block editor, typing a space after a `+` character dismisses the cross-positing suggestions list
3. Verify that mentions still works, ensuring that the intended recipient gets notified
4. Verify that cross-posting still works, ensuring that the intended recipient gets notified

## Regression Notes

1. Potential unintended areas of impact

This change could conceivably break suggestions (both mentions and cross-posting).

2. What I did to test those areas of impact (or what existing automated tests I relied on)

The above manual tests.

3. What automated tests I added (or what prevented me from doing so)

This change affects the UI so a UI test would be best, but we only add UI tests to core flows.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
