### PR TITLE
Disables the ability to open the editor for Post Pages

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [**] Reader Post details: now shows a summary of Likes for the post. Tapping it displays the full list of Likes. [#16628]
 * [*] Fix notice overlapping the ActionSheet that displays the Site Icon controls. [#16579]
 * [*] Fix login error for WordPress.org sites to show inline. [#16614]
+* [*] Disables the ability to open the editor for Post Pages [#16369]
 
 17.5
 -----

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -755,7 +755,9 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     private func addEditAction(to controller: UIAlertController, for page: AbstractPost) {
-        if page.status == .trash {
+        guard let page = page as? Page else { return }
+
+        if page.status == .trash || page.isSitePostsPage {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -419,6 +419,9 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             }
 
             tableView.reloadRows(at: [indexPath], with: .automatic)
+        } else if page.isSitePostsPage {
+            showSitePostPageUneditableNotice()
+            return
         } else {
             QuickStartTourGuide.shared.endCurrentTour()
             tableView.reloadData()
@@ -429,6 +432,12 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         }
 
         editPage(page)
+    }
+
+    private func showSitePostPageUneditableNotice() {
+        let sitePostPageUneditableNotice =  NSLocalizedString("The content of your latest posts page is automatically generated and cannot be edited.", comment: "Message informing the user that posts page cannot be edited")
+        let notice = Notice(title: sitePostPageUneditableNotice, feedbackType: .warning)
+        ActionDispatcher.global.dispatch(NoticeAction.post(notice))
     }
 
     @objc func tableView(_ tableView: UITableView, cellForRowAtIndexPath indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
Fixes #16369

## Desctiption
This PR disables the ability to open the editor for Post Pages and shows a notice when the user tries to do so

## To test:
1. Open *Site Pages*
2. Tap on Actions and set a page as *Posts page*
3. Tap on Actions again
4. **Verify** that there is no Edit option
5. Tap on the page on the list
6. **Verify** that the editor does not open and a notice is presented

## Screenshots

|Notice|Actions for Post Pages|
|---|---|
|![IMG_0162](https://user-images.githubusercontent.com/304044/120341542-a1af4780-c2ff-11eb-9e09-b85f1d55535f.PNG)|![IMG_0161](https://user-images.githubusercontent.com/304044/120341553-a3790b00-c2ff-11eb-8c8a-9861dea5da8c.PNG)|

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
