### PR TITLE
Reader Post details: show Likes list when Likes summary view tapped

### DIFF
--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -9,7 +9,7 @@ extension CommentService {
      @param before          Filter results to likes before this date/time. Optional.
      @param excludingIDs    An array of user IDs to exclude from the returned results. Optional.
      @param purgeExisting   Indicates if existing Likes for the given post and site should be purged before
-                            new ones are created. Defaults to false.
+                            new ones are created. Defaults to true.
      @param success         A success block
      @param failure         A failure block
      */
@@ -18,7 +18,7 @@ extension CommentService {
                      count: Int = 90,
                      before: String? = nil,
                      excludingIDs: [NSNumber]? = nil,
-                     purgeExisting: Bool = false,
+                     purgeExisting: Bool = true,
                      success: @escaping (([LikeUser], Int) -> Void),
                      failure: @escaping ((Error?) -> Void)) {
 

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -5,14 +5,29 @@ import WordPressKit
 
 /// Convenience class that manages the data and display logic for likes.
 /// This is intended to be used as replacement for table view delegate and data source.
+
+
+@objc protocol LikesListControllerDelegate: class {
+    /// Reports to the delegate that the header cell has been tapped.
+    @objc optional func didSelectHeader()
+
+    /// Reports to the delegate that the user cell has been tapped.
+    /// - Parameter user: A LikeUser instance representing the user at the selected row.
+    func didSelectUser(_ user: LikeUser, at indexPath: IndexPath)
+
+    /// Ask the delegate to show an error view when fetching fails or there is no connection.
+    func showErrorView()
+}
+
 class LikesListController: NSObject {
 
     private let formatter = FormattableContentFormatter()
     private let content: ContentIdentifier
     private let siteID: NSNumber
-    private let notification: Notification?
+    private var notification: Notification? = nil
+    private var readerPost: ReaderPost? = nil
     private let tableView: UITableView
-    private var loadingIndicator: UIActivityIndicatorView
+    private var loadingIndicator = UIActivityIndicatorView()
     private weak var delegate: LikesListControllerDelegate?
 
     // Used to control pagination.
@@ -24,6 +39,10 @@ class LikesListController: NSObject {
 
     private var hasMoreLikes: Bool {
         return totalLikesFetched < totalLikes
+    }
+
+    private var showingNotificationLikes: Bool {
+        return notification != nil
     }
 
     private var isLoadingContent = false {
@@ -50,11 +69,12 @@ class LikesListController: NSObject {
         CommentService(managedObjectContext: ContextManager.shared.mainContext)
     }()
 
-    // MARK: Lifecycle
+    // MARK: Init
 
-    init?(tableView: UITableView,
-          notification: Notification,
-          delegate: LikesListControllerDelegate? = nil) {
+    /// Init with Notification
+    ///
+    init?(tableView: UITableView, notification: Notification, delegate: LikesListControllerDelegate? = nil) {
+
         guard let siteID = notification.metaSiteID else {
             return nil
         }
@@ -84,17 +104,38 @@ class LikesListController: NSObject {
         self.tableView = tableView
         self.delegate = delegate
 
-        self.loadingIndicator = {
-            let loadingIndicator = UIActivityIndicatorView(style: .medium)
-            loadingIndicator.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 44)
-            return loadingIndicator
-        }()
+        super.init()
+        configureLoadingIndicator()
+    }
+
+    /// Init with ReaderPost
+    ///
+    init?(tableView: UITableView, post: ReaderPost, delegate: LikesListControllerDelegate? = nil) {
+
+        guard let postID = post.postID else {
+            return nil
+        }
+
+        content = .post(id: postID)
+        readerPost = post
+        siteID = post.siteID
+        self.tableView = tableView
+        self.delegate = delegate
+
+        super.init()
+        configureLoadingIndicator()
+    }
+
+    private func configureLoadingIndicator() {
+        loadingIndicator = UIActivityIndicatorView(style: .medium)
+        loadingIndicator.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 44)
     }
 
     // MARK: Methods
 
     /// Load likes data from remote, and display it in the table view.
     func refresh() {
+
         guard !isLoadingContent else {
             return
         }
@@ -208,12 +249,12 @@ class LikesListController: NSObject {
 extension LikesListController: UITableViewDataSource, UITableViewDelegate {
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return Constants.numberOfSections
+        return showingNotificationLikes ? 2 : 1
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // Header section
-        if section == Constants.headerSectionIndex {
+        if showingNotificationLikes && section == Constants.headerSectionIndex {
             return Constants.numberOfHeaderRows
         }
 
@@ -222,7 +263,7 @@ extension LikesListController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.section == Constants.headerSectionIndex {
+        if showingNotificationLikes && indexPath.section == Constants.headerSectionIndex {
             return headerCell()
         }
 
@@ -231,7 +272,9 @@ extension LikesListController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
 
-        let isUsersSection = indexPath.section == Constants.usersSectionIndex
+        let usersSectionIndex = showingNotificationLikes ? 1 : 0
+
+        let isUsersSection = indexPath.section == usersSectionIndex
         let isLastRow = indexPath.row == totalLikesFetched - 1
 
         guard !isLoadingContent && hasMoreLikes && isUsersSection && isLastRow else {
@@ -252,8 +295,8 @@ extension LikesListController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        if indexPath.section == Constants.headerSectionIndex {
-            delegate?.didSelectHeader()
+        if showingNotificationLikes && indexPath.section == Constants.headerSectionIndex {
+            delegate?.didSelectHeader?()
             return
         }
 
@@ -312,20 +355,6 @@ private extension LikesListController {
 
 }
 
-// MARK: - Delegate Definitions
-
-protocol LikesListControllerDelegate: class {
-    /// Reports to the delegate that the header cell has been tapped.
-    func didSelectHeader()
-
-    /// Reports to the delegate that the user cell has been tapped.
-    /// - Parameter user: A LikeUser instance representing the user at the selected row.
-    func didSelectUser(_ user: LikeUser, at indexPath: IndexPath)
-
-    /// Ask the delegate to show an error view when fetching fails or there is no connection.
-    func showErrorView()
-}
-
 // MARK: - Private Definitions
 
 private extension LikesListController {
@@ -337,9 +366,7 @@ private extension LikesListController {
     }
 
     struct Constants {
-        static let numberOfSections = 2
         static let headerSectionIndex = 0
-        static let usersSectionIndex = 1
         static let headerRowIndex = 0
         static let numberOfHeaderRows = 1
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -92,6 +92,10 @@ class ReaderDetailCoordinator {
         return URL(string: postURLString)
     }
 
+    /// The total number of Likes for the post.
+    /// Passed to ReaderDetailLikesListController to display in the view title.
+    private var totalLikes = 0
+
     /// Initialize the Reader Detail Coordinator
     ///
     /// - Parameter service: a Reader Post Service
@@ -152,6 +156,7 @@ class ReaderDetailCoordinator {
         postService.getLikesFor(postID: postID,
                                 siteID: post.siteID,
                                 success: { [weak self] users, totalLikes in
+                                    self?.totalLikes = totalLikes
                                     self?.view?.updateLikes(users: Array(users.prefix(ReaderDetailLikesView.maxAvatarsDisplayed)), totalLikes: totalLikes)
                                 }, failure: { [weak self] error in
                                     self?.view?.updateLikes(users: [LikeUser](), totalLikes: 0)
@@ -506,6 +511,15 @@ class ReaderDetailCoordinator {
         coreDataStack.save(context)
     }
 
+    private func showLikesList() {
+        guard let post = post else {
+            return
+        }
+
+        let controller = ReaderDetailLikesListController(post: post, totalLikes: totalLikes)
+        viewController?.navigationController?.pushViewController(controller, animated: true)
+    }
+
     /// Index the post in Spotlight
     private func indexReaderPostInSpotlight() {
         guard let post = post else {
@@ -603,6 +617,13 @@ extension ReaderDetailCoordinator: ReaderDetailHeaderViewDelegate {
 extension ReaderDetailCoordinator: ReaderDetailFeaturedImageViewDelegate {
     func didTapFeaturedImage(_ sender: CachedAnimatedImageView) {
         showFeaturedImage(sender)
+    }
+}
+
+// MARK: - ReaderDetailLikesViewDelegate
+extension ReaderDetailCoordinator: ReaderDetailLikesViewDelegate {
+    func didTapLikesView() {
+        showLikesList()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -423,6 +423,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             return
         }
 
+        likesSummary.delegate = coordinator
         likesContainerView.addSubview(likesSummary)
         likesContainerView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+class ReaderDetailLikesListController: UITableViewController {
+
+    // MARK: - Properties
+    private let post: ReaderPost
+    private var likesListController: LikesListController?
+    private var totalLikes = 0
+
+    // MARK: - Init
+    init(post: ReaderPost, totalLikes: Int) {
+        self.post = post
+        self.totalLikes = totalLikes
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View
+    override func viewDidLoad() {
+        configureViewTitle()
+        configureTable()
+    }
+
+}
+
+private extension ReaderDetailLikesListController {
+
+    func configureViewTitle() {
+        let titleFormat = totalLikes == 1 ? TitleFormats.singular : TitleFormats.plural
+        navigationItem.title = String(format: titleFormat, totalLikes)
+    }
+
+    func configureTable() {
+        tableView.register(LikeUserTableViewCell.defaultNib,
+                           forCellReuseIdentifier: LikeUserTableViewCell.defaultReuseID)
+
+        likesListController = LikesListController(tableView: tableView, post: post, delegate: self)
+        tableView.delegate = likesListController
+        tableView.dataSource = likesListController
+
+        // Call refresh to ensure that the controller fetches the data.
+        likesListController?.refresh()
+    }
+
+    struct TitleFormats {
+        static let singular = NSLocalizedString("%1$d Like",
+                                                comment: "Singular format string for view title displaying the number of post likes. %1$d is the number of likes.")
+        static let plural = NSLocalizedString("%1$d Likes",
+                                              comment: "Plural format string for view title displaying the number of post likes. %1$d is the number of likes.")
+    }
+
+}
+
+// MARK: - LikesListController Delegate
+//
+extension ReaderDetailLikesListController: LikesListControllerDelegate {
+
+    func didSelectUser(_ user: LikeUser, at indexPath: IndexPath) {
+        // TODO: show user profile
+    }
+
+    func showErrorView() {
+        // TODO: show NRV
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -1,11 +1,16 @@
 import UIKit
 
+protocol ReaderDetailLikesViewDelegate {
+    func didTapLikesView()
+}
+
 class ReaderDetailLikesView: UIView, NibLoadable {
 
     @IBOutlet weak var avatarStackView: UIStackView!
     @IBOutlet weak var summaryLabel: UILabel!
 
     static let maxAvatarsDisplayed = 5
+    var delegate: ReaderDetailLikesViewDelegate?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -15,6 +20,7 @@ class ReaderDetailLikesView: UIView, NibLoadable {
     func configure(users: [LikeUser], totalLikes: Int) {
         updateSummaryLabel(totalLikes: totalLikes)
         updateAvatars(users: users)
+        addTapGesture()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -68,11 +74,23 @@ private extension ReaderDetailLikesView {
         avatarImageView.downloadImage(from: gravatarURL, placeholderImage: .gravatarPlaceholderImage)
     }
 
+    func addTapGesture() {
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapView(_:))))
+    }
+
+    @objc func didTapView(_ gesture: UITapGestureRecognizer) {
+        guard gesture.state == .ended else {
+            return
+        }
+
+        delegate?.didTapLikesView()
+    }
+
     struct SummaryLabelFormats {
         static let singular = NSLocalizedString("%1$d blogger likes this.",
                                                 comment: "Singular format string for displaying the number of post likes. %1$d is the number of likes.")
         static let plural = NSLocalizedString("%1$d bloggers like this.",
                                               comment: "Plural format string for displaying the number of post likes. %1$d is the number of likes.")
-
     }
+
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1602,6 +1602,8 @@
 		98E5D4922620C2B40074A56A /* UserProfileSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98E5D4912620C2B40074A56A /* UserProfileSectionHeader.xib */; };
 		98E5D4932620C2B40074A56A /* UserProfileSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98E5D4912620C2B40074A56A /* UserProfileSectionHeader.xib */; };
 		98EB126A20D2DC2500D2D5B5 /* NoResultsViewController+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EB126920D2DC2500D2D5B5 /* NoResultsViewController+Model.swift */; };
+		98ED5963265EBD0000A0B33E /* ReaderDetailLikesListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98ED5962265EBD0000A0B33E /* ReaderDetailLikesListController.swift */; };
+		98ED5964265EBD0000A0B33E /* ReaderDetailLikesListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98ED5962265EBD0000A0B33E /* ReaderDetailLikesListController.swift */; };
 		98F0297C2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F0297A2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.swift */; };
 		98F0297D2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98F0297B2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.xib */; };
 		98F1B12A2111017A00139493 /* NoResultsStockPhotosConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F1B1292111017900139493 /* NoResultsStockPhotosConfiguration.swift */; };
@@ -6177,6 +6179,7 @@
 		98E58A432361019300E5534B /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98E5D4912620C2B40074A56A /* UserProfileSectionHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UserProfileSectionHeader.xib; sourceTree = "<group>"; };
 		98EB126920D2DC2500D2D5B5 /* NoResultsViewController+Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NoResultsViewController+Model.swift"; sourceTree = "<group>"; };
+		98ED5962265EBD0000A0B33E /* ReaderDetailLikesListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailLikesListController.swift; sourceTree = "<group>"; };
 		98F0297A2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginEpilogueConnectSiteCell.swift; sourceTree = "<group>"; };
 		98F0297B2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoginEpilogueConnectSiteCell.xib; sourceTree = "<group>"; };
 		98F1B1292111017900139493 /* NoResultsStockPhotosConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoResultsStockPhotosConfiguration.swift; sourceTree = "<group>"; };
@@ -10980,6 +10983,7 @@
 				3223393D24FEC2A700BDD4BF /* ReaderDetailFeaturedImageView.xib */,
 				8B0CE7D02481CFE8004C4799 /* ReaderDetailHeaderView.swift */,
 				8B0CE7D22481CFF8004C4799 /* ReaderDetailHeaderView.xib */,
+				98ED5962265EBD0000A0B33E /* ReaderDetailLikesListController.swift */,
 				98E54FF1265C972900B4BE9A /* ReaderDetailLikesView.swift */,
 				98E55018265C977E00B4BE9A /* ReaderDetailLikesView.xib */,
 				8BA77BCE2483415400E1EBBF /* ReaderDetailToolbar.swift */,
@@ -17799,6 +17803,7 @@
 				1767494E1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift in Sources */,
 				0857C2781CE5375F0014AE99 /* MenuItemInsertionView.m in Sources */,
 				40E7FECF2211FFB90032834E /* AllTimeStatsRecordValue+CoreDataClass.swift in Sources */,
+				98ED5963265EBD0000A0B33E /* ReaderDetailLikesListController.swift in Sources */,
 				8B05D29323AA572A0063B9AA /* GutenbergMediaEditorImage.swift in Sources */,
 				B532D4EA199D4357006E4DF6 /* NoteBlockHeaderTableViewCell.swift in Sources */,
 				24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */,
@@ -19187,6 +19192,7 @@
 				FABB233E2602FC2C00C8785C /* DomainSuggestionsTableViewController.swift in Sources */,
 				FABB233F2602FC2C00C8785C /* AnnouncementCell.swift in Sources */,
 				FABB23402602FC2C00C8785C /* ReaderStreamViewController.swift in Sources */,
+				98ED5964265EBD0000A0B33E /* ReaderDetailLikesListController.swift in Sources */,
 				FABB23412602FC2C00C8785C /* SeparatorsView.swift in Sources */,
 				FABB23422602FC2C00C8785C /* JetpackScanCoordinator.swift in Sources */,
 				FABB23432602FC2C00C8785C /* WPStyleGuide+ReadableMargins.m in Sources */,


### PR DESCRIPTION
Ref #16561 

This shows the full Likes list when the Likes summary view is tapped in Reader Post details.

To note, there is still unfinished functionality.
- Show user profile when user selected.
- Show error/no connection view.
- Update likes count in view title if it's changed since the initial fetch.

To test:

---
Reader Post Likes:
- Enable the `readerPostLikes` feature.
- Go to the Reader, and select a post with Likes.
- Tap the Likes summary.
- Verify the Likes list is displayed.

| ![reader](https://user-images.githubusercontent.com/1816888/120399380-1fbc2000-c2f9-11eb-8669-8c18eddcc3d2.png) | ![post](https://user-images.githubusercontent.com/1816888/120399396-26e32e00-c2f9-11eb-88e9-117785a07b18.png) | ![likes](https://user-images.githubusercontent.com/1816888/120399440-437f6600-c2f9-11eb-9ca8-604503071238.png) |
|--------|-------|-------|
---
Verify Notification Likes still work as expected. Specifically:
  - The loading indicator is displayed.
  - Selecting the table header displays the comment/post.

---

## Regression Notes
1. Potential unintended areas of impact
N/A. Incomplete feature.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Incomplete feature.

3. What automated tests I added (or what prevented me from doing so)
N/A. Incomplete feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
