### PR TITLE
Fix: Notice over quickstart removal next steps

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [*] Fix login error for WordPress.org sites to show inline. [#16614]
 * [*] Disables the ability to open the editor for Post Pages [#16369]
 * [*] Fixed an issue that could cause a crash when moderating Comments. [#16645]
+* [*] Fix notice overlapping the ActionSheet that displays the QuickStart Removal. [#16609]
 
 17.5
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1457,6 +1457,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     BlogDetailsSectionHeaderView *view = [self.tableView dequeueReusableHeaderFooterViewWithIdentifier:BlogDetailsSectionHeaderViewIdentifier];
     [view setTitle:title];
     view.ellipsisButtonDidTouch = ^(BlogDetailsSectionHeaderView *header) {
+        [NoticesDispatch lock];
         [weakSelf removeQuickStartSection:header];
     };
     return view;
@@ -1472,11 +1473,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
     [removeConfirmation addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull action) {
         [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonCancelTapped];
+        [NoticesDispatch unlock];
     }];
     [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
         [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped];
-        
         [[QuickStartTourGuide shared] removeFrom:self.blog];
+        [NoticesDispatch unlock];
     }];
     
     UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
@@ -1485,7 +1487,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull action) {
         [self presentViewController:removeConfirmation animated:YES completion:nil];
     }];
-    [removeSheet addCancelActionWithTitle:cancelTitle handler:nil];
+    [removeSheet addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull action) {
+        [NoticesDispatch unlock];
+    }];
     
     [self presentViewController:removeSheet animated:YES completion:nil];
 }


### PR DESCRIPTION
This is a quick follow up on https://github.com/wordpress-mobile/WordPress-iOS/pull/16579
It fixed the found issue with the QuickStart Remove step flow.

See
https://user-images.githubusercontent.com/198826/120044921-10bd3100-bfcc-11eb-9364-31dec8e61c1b.mp4


To test:
1. Create a new site or if you have a site that has quickstart already. 
2. Update the site title. (To create a notice) See that the site title update notice shows up.  
3. Update the site title and clicking click the three dots. 
4. Cancel the flow. 
5. See that the site title update notice shows up. 
6. Update the site title and clicking click the three dots. 
7. Click the Remove Next Steps. 
8. Cancel the alert. 
9. See that the site title update notice shows up. 
10. Follow steps 5 - 7. 
11. Click remove in the alert.
12. See that the site title update notice shows up.  

See video.

https://user-images.githubusercontent.com/115071/120399431-de277700-c2f0-11eb-98f7-4e0f460f2396.mp4

Note that in the video. I had commented out the part of the code that removes the quickstart so that is why on the last step you can still it.

## Regression Notes
N/A 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
