### PR TITLE
Reader Post likes: show NRV where applicable

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class ReaderDetailLikesListController: UITableViewController {
+class ReaderDetailLikesListController: UITableViewController, NoResultsViewHost {
 
     // MARK: - Properties
     private let post: ReaderPost
@@ -52,6 +52,10 @@ private extension ReaderDetailLikesListController {
                                               comment: "Plural format string for view title displaying the number of post likes. %1$d is the number of likes.")
     }
 
+    struct NoResultsText {
+        static let errorTitle = NSLocalizedString("Oops", comment: "Title for the view when there's an error loading notification likes.")
+        static let errorSubtitle = NSLocalizedString("There was an error loading likes", comment: "Text displayed when there is a failure loading notification likes.")
+    }
 }
 
 // MARK: - LikesListController Delegate
@@ -63,7 +67,11 @@ extension ReaderDetailLikesListController: LikesListControllerDelegate {
     }
 
     func showErrorView() {
-        // TODO: show NRV
+        hideNoResults()
+        configureAndDisplayNoResults(on: tableView,
+                                     title: NoResultsText.errorTitle,
+                                     subtitle: NoResultsText.errorSubtitle,
+                                     image: "wp-illustration-reader-empty")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -67,7 +67,6 @@ extension ReaderDetailLikesListController: LikesListControllerDelegate {
     }
 
     func showErrorView() {
-        hideNoResults()
         configureAndDisplayNoResults(on: tableView,
                                      title: NoResultsText.errorTitle,
                                      subtitle: NoResultsText.errorSubtitle,


### PR DESCRIPTION
Ref #16561 

(Note: please review #16608 first.)

When showing the Likes List from a Reader Post:
- A no connection view is displayed if there is no connection and no cached users.
- An error view is displayed if an error occurred fetching likes.

To test:

**No connection:**

This _should_ never happen since the first page of Likes is fetched and cached when the post details is displayed, but hey you never know. 😄 Sooooo... hack time!

In `LikesListController.refresh()`, comment out the `if likingUsers.isEmpty` test:

```
        guard ReachabilityUtils.isInternetReachable() else {
            isLoadingContent = false

//            if likingUsers.isEmpty {
                delegate?.showErrorView()
//            }

            return
        }
```

- Run the app.
- Go to Reader and select a post with Likes.
- Disable connection.
- Tap on the Likes summary.
- Verify the no connection view is displayed.

<kbd>![no_connection](https://user-images.githubusercontent.com/1816888/120406062-43866280-c307-11eb-9e4c-0c6d956560da.jpeg)</kbd>

---
**Error view:**

To force the error view to show, hack time part 2!

In `LikesListController.refresh()`, replace the contents of the `success` block with `self?.delegate?.showErrorView()`:
```
        fetchLikes(success: { [weak self] users, totalLikes in
            self?.delegate?.showErrorView()
//            self?.likingUsers = users
//            self?.totalLikes = totalLikes
//            self?.totalLikesFetched = users.count
//            self?.lastFetchedDate = users.last?.dateLikedString
//            self?.isFirstLoad = false
//            self?.isLoadingContent = false
//            self?.trackUsersToExclude()
        }, failure: { [weak self] _ in
            self?.isLoadingContent = false
            self?.delegate?.showErrorView()
        })
```        

- Run the app.
- Go to Reader and select a post with Likes.
- Tap on the Likes summary.
- Verify the error view is displayed.

<kbd>![error](https://user-images.githubusercontent.com/1816888/120406144-69ac0280-c307-11eb-8cc3-811af51d62fa.jpeg)</kbd>

---

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
