### PR TITLE
Jetpack App (Emphasis): Update Zendesk fields

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -612,10 +612,12 @@ extension WordPressAppDelegate {
 
         let extraDebug = UserDefaults.standard.bool(forKey: "extra_debug")
 
-        let detailedVersionNumber = Bundle(for: type(of: self)).detailedVersionNumber() ?? unknown
+        let bundle = Bundle.main
+        let detailedVersionNumber = bundle.detailedVersionNumber() ?? unknown
+        let appName = bundle.object(forInfoDictionaryKey: "CFBundleName") as? String ?? unknown
 
         DDLogInfo("===========================================================================")
-        DDLogInfo("Launching WordPress for iOS \(detailedVersionNumber)...")
+        DDLogInfo("Launching \(appName) for iOS \(detailedVersionNumber)...")
         DDLogInfo("Crash count: \(crashCount)")
 
         #if DEBUG

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -6,6 +6,7 @@ import WordPressAuthenticator
     static let productTwitterURL = "https://twitter.com/WordPressiOS"
     static let productBlogURL = "https://blog.wordpress.com"
     static let ticketSubject = NSLocalizedString("WordPress for iOS Support", comment: "Subject of new Zendesk ticket.")
+    static let zendeskSourcePlatform = "mobile_-_ios"
     static let logOutAlert = NSLocalizedString("Log out of WordPress?", comment: "LogOut confirmation text, whenever there are no local changes")
     @objc static let eventNamePrefix = "wpios"
 

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -1014,7 +1014,7 @@ private extension ZendeskUtils {
         static let profileNameKey = "name"
         static let userDefaultsZendeskUnreadNotifications = "wp_zendesk_unread_notifications"
         static let nameFieldCharacterLimit = 50
-        static let sourcePlatform = "mobile_-_ios"
+        static let sourcePlatform = AppConstants.zendeskSourcePlatform
         static let gutenbergIsDefault = "mobile_gutenberg_is_default"
     }
 

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -5,6 +5,7 @@ import Foundation
     static let productTwitterURL = "https://twitter.com/jetpack"
     static let productBlogURL = "https://jetpack.com/blog"
     static let ticketSubject = "Jetpack for iOS Support"
+    static let zendeskSourcePlatform = "mobile_-_jp_ios"
     static let logOutAlert = NSLocalizedString("Log out of Jetpack?", comment: "LogOut confirmation text, whenever there are no local changes")
     @objc static let eventNamePrefix = "jpios"
 


### PR DESCRIPTION
Ref: pbMoDN-2sY-p2#comment-4948

This PR updates a couple of fields to help differentiate the WordPress and the Jetpack app on Zendesk
- The source platform tag
- The debug launch string

~⚠️ Note: Seems like the tag needs to be approved before it can show up on Zendesk. At the time of writing, the new tag isn't showing up on Zendesk.~

 🎉 The new `mobile-_-jp_ios` tag has been approved! 

## How to test

1. Build and run the app
2. ✅ You should be able to see `Jetpack for iOS` printed in your Xcode debugger console, not `WordPress for iOS`
3. Go to My Site > Me > Help & Support  > Contact Support 
4. Send a test message... something like "Testing the JPiOS app. Please ignore."
5. Go to ZD and search for the message you sent
4. ✅ There should be a `mobile-_-jp_ios` tag

## Regression Notes
1. Potential unintended areas of impact
WordPress source platform tag and debug launch string

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested the contact support flow on the WordPress app and checked the corresponding Zendesk ticket

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.