### PR TITLE
Reader Post likes list: show user profile when user tapped

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -57,7 +57,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .bloggingReminders:
             return false
         case .readerPostLikes:
-            return false
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -17,6 +17,9 @@ import WordPressKit
 
     /// Ask the delegate to show an error view when fetching fails or there is no connection.
     func showErrorView()
+
+    /// Send likes count to delegate.
+    @objc optional func updatedTotalLikes(_ totalLikes: Int)
 }
 
 class LikesListController: NSObject {
@@ -157,6 +160,10 @@ class LikesListController: NSObject {
         }
 
         fetchLikes(success: { [weak self] users, totalLikes in
+            if self?.isFirstLoad == true {
+                self?.delegate?.updatedTotalLikes?(totalLikes)
+            }
+
             self?.likingUsers = users
             self?.totalLikes = totalLikes
             self?.totalLikesFetched = users.count

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -80,4 +80,8 @@ extension ReaderDetailLikesListController: LikesListControllerDelegate {
                                      image: "wp-illustration-reader-empty")
     }
 
+    func updatedTotalLikes(_ totalLikes: Int) {
+        self.totalLikes = totalLikes
+        configureViewTitle()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -45,6 +45,13 @@ private extension ReaderDetailLikesListController {
         likesListController?.refresh()
     }
 
+    func displayUserProfile(_ user: LikeUser, from indexPath: IndexPath) {
+        let userProfileVC = UserProfileSheetViewController(user: user)
+        let bottomSheet = BottomSheetViewController(childViewController: userProfileVC)
+        let sourceView = tableView.cellForRow(at: indexPath) ?? view
+        bottomSheet.show(from: self, sourceView: sourceView)
+    }
+
     struct TitleFormats {
         static let singular = NSLocalizedString("%1$d Like",
                                                 comment: "Singular format string for view title displaying the number of post likes. %1$d is the number of likes.")
@@ -63,7 +70,7 @@ private extension ReaderDetailLikesListController {
 extension ReaderDetailLikesListController: LikesListControllerDelegate {
 
     func didSelectUser(_ user: LikeUser, at indexPath: IndexPath) {
-        // TODO: show user profile
+        displayUserProfile(user, from: indexPath)
     }
 
     func showErrorView() {


### PR DESCRIPTION
Ref #16561 

This change includes:
- When a user is selected from the Likes list, the user profile is displayed.
- When the Likes list is displayed, the count displayed in the view title is updated after the first fetch.
- The `readerPostLikes` feature flag is enabled for dev.

To test:
User profile:
- Go to Reader and select a post with Likes.
- Tap the Likes summary view.
- Select a user.
- Verify the user profile is displayed.

<kbd>![profile](https://user-images.githubusercontent.com/1816888/120554088-90754200-c3b6-11eb-9bca-48cfc26cd34a.png)</kbd>

Likes count:
- Go to Reader and select a post with Likes.
- On the web, like/unlike the post.
- Tap the Likes summary view.
- Verify the count in the title is updated.
- Note the Likes summary on the post details does not update and will not include your new like/unlike. Coming soon.

<kbd><img width="400" alt="count" src="https://user-images.githubusercontent.com/1816888/120554540-198c7900-c3b7-11eb-953d-96e47d234891.png"></kbd>


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
