### PR TITLE
Reader Post details: add Tracks for Likes List actions

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -170,6 +170,9 @@ import Foundation
     // Blog preview by URL (that is, in a WebView)
     case blogUrlPreviewed
 
+    // Likes list shown from Reader Post details
+    case likeListOpened
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -464,6 +467,10 @@ import Foundation
         // Blog preview by URL (that is, in a WebView)
         case .blogUrlPreviewed:
             return "blog_url_previewed"
+
+        // Likes list shown from Reader Post details
+        case .likeListOpened:
+            return "like_list_opened"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -987,6 +987,7 @@ private extension NotificationDetailsViewController {
 
     func displayUserProfile(_ user: LikeUser, from indexPath: IndexPath) {
         let userProfileVC = UserProfileSheetViewController(user: user)
+        userProfileVC.blogUrlPreviewedSource = "notif_like_list_user_profile"
         let bottomSheet = BottomSheetViewController(childViewController: userProfileVC)
 
         let sourceView = tableView.cellForRow(at: indexPath) ?? view

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -22,6 +22,7 @@ class ReaderDetailLikesListController: UITableViewController, NoResultsViewHost 
     override func viewDidLoad() {
         configureViewTitle()
         configureTable()
+        WPAnalytics.track(.likeListOpened, properties: ["list_type": "post", "source": "like_reader_list"])
     }
 
 }
@@ -47,9 +48,11 @@ private extension ReaderDetailLikesListController {
 
     func displayUserProfile(_ user: LikeUser, from indexPath: IndexPath) {
         let userProfileVC = UserProfileSheetViewController(user: user)
+        userProfileVC.blogUrlPreviewedSource = "reader_like_list_user_profile"
         let bottomSheet = BottomSheetViewController(childViewController: userProfileVC)
         let sourceView = tableView.cellForRow(at: indexPath) ?? view
         bottomSheet.show(from: self, sourceView: sourceView)
+        WPAnalytics.track(.userProfileSheetShown, properties: ["source": "like_reader_list"])
     }
 
     struct TitleFormats {

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -3,7 +3,9 @@ class UserProfileSheetViewController: UITableViewController {
     // MARK: - Properties
 
     private let user: LikeUser
-    private let statSource = ReaderStreamViewController.StatSource.notif_like_list_user_profile
+
+    // Used for the `source` property in Stats when a Blog is previewed by URL (that is, in a WebView).
+    var blogUrlPreviewedSource: String?
 
     private lazy var mainContext = {
         return ContextManager.sharedInstance().mainContext
@@ -148,7 +150,7 @@ private extension UserProfileSheetViewController {
 
     func showSiteTopicWithID(_ siteID: NSNumber) {
         let controller = ReaderStreamViewController.controllerWithSiteID(siteID, isFeed: false)
-        controller.statSource = statSource
+        controller.statSource = ReaderStreamViewController.StatSource.notif_like_list_user_profile
         let navController = UINavigationController(rootViewController: controller)
         present(navController, animated: true)
     }
@@ -161,7 +163,7 @@ private extension UserProfileSheetViewController {
             return
         }
 
-        WPAnalytics.track(.blogUrlPreviewed, properties: ["source": statSource.rawValue])
+        WPAnalytics.track(.blogUrlPreviewed, properties: ["source": blogUrlPreviewedSource as Any])
         contentCoordinator.displayWebViewWithURL(siteURL)
     }
 


### PR DESCRIPTION
Ref #16561 

(Please review  #16616 first.)

This adds track events for Like List actions from Reader Post details.

To test:
- Go to the Reader and select a post with Likes.
- Tap the Likes summary. Verify this is logged: `🔵 Tracked: like_list_opened <list_type: post, source: like_reader_list>`
- Select a user. Verify this is logged: `🔵 Tracked: user_profile_sheet_shown <source: like_reader_list>`
- Select a user with an external site. View the site. Verify this is logged: `🔵 Tracked: blog_url_previewed <source: reader_like_list_user_profile>`


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
