### PR TITLE
Add GlotPress string linting

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,3 @@
-# By default, run on macOS agents
-agents:
-  os: "macOS"
 
 # This is the default pipeline – it will build and test the app
 steps:
@@ -22,8 +19,6 @@ steps:
       bundle exec fastlane build_for_testing
       echo "--- 🗜 Zip Build Products"
       tar -cf build-products.tar DerivedData/Build/Products/
-    agents:
-      os: "macOS"
     artifact_paths:
       - build-products.tar
 
@@ -37,8 +32,17 @@ steps:
       bundle install
       bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
     depends_on: "build"
+
+  #################
+  # Lint Translations
+  #################
+  - label: "🧹 Lint Translations"
+    command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
+    plugins:
+      - docker#v3.8.0:
+          image: "jkmassel/glotpress-linter:latest"
     agents:
-      os: "macOS"
+      queue: "default"
 
   #################
   # UI Tests


### PR DESCRIPTION
Adds GlotPress string linting – this will help ensure we never land invalid `.po` files in `develop` for GlotPress to pick up.

**To test:**
1. Fork this branch on your local machine and run `bundle exec fastlane update_appstore_strings version:17.5`.
2. Push your changes to GitHub
3. Note that the new test fails

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
