### PR TITLE
Reader Post Likes: update Likes summary correctly

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -132,7 +132,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         configureWebView()
         configureFeaturedImage()
         configureHeader()
-        configureLikesSummary()
         configureRelatedPosts()
         configureToolbar()
         configureNoResultsViewController()
@@ -147,6 +146,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        fetchLikes()
+
         configureFeaturedImage()
 
         featuredImage.configure(scrollView: scrollView,
@@ -286,10 +288,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         }
 
         coordinator?.fetchRelatedPosts(for: post)
-
-        if FeatureFlag.readerPostLikes.enabled {
-            coordinator?.fetchLikes(for: post)
-        }
     }
 
     /// Shown an error
@@ -330,9 +328,13 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func updateLikes(users: [LikeUser], totalLikes: Int) {
-        guard !users.isEmpty else {
+        guard totalLikes > 0 else {
             hideLikesView()
             return
+        }
+
+        if likesSummary.superview == nil {
+            configureLikesSummary()
         }
 
         likesSummary.configure(users: users, totalLikes: totalLikes)
@@ -417,6 +419,15 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         headerContainerView.heightAnchor.constraint(equalTo: header.heightAnchor).isActive = true
     }
 
+    private func fetchLikes() {
+        guard FeatureFlag.readerPostLikes.enabled,
+              let post = post else {
+            return
+        }
+
+        coordinator?.fetchLikes(for: post)
+    }
+
     private func configureLikesSummary() {
         guard FeatureFlag.readerPostLikes.enabled else {
             hideLikesView()
@@ -439,6 +450,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         // Because the Related Posts table is constrained to the likesContainerView, simply hiding it leaves a gap.
         likesSummary.removeFromSuperview()
         likesContainerView.frame.size.height = 0
+        view.setNeedsDisplay()
     }
 
     private func configureRelatedPosts() {


### PR DESCRIPTION
Ref #16561 

(Please review #16616 first.)

When Reader Post details is displayed:
- Likes are now fetched in `viewWillAppear`.
- The Likes summary is not added to the view until Likes have been fetched.

This resolves these issues:
- As noted [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/16610#pullrequestreview-674318021), if there is no connection when post details is displayed, an empty Likes summary was displayed.
- As noted in [this](https://github.com/wordpress-mobile/WordPress-iOS/pull/16616) description, if a new like/unlike occurred after post details was displayed, the Likes summary was not updated.

To test:

No connection:
- Go to the Reader.
- Disable connection.
- Select a post with Likes.
- Verify the Likes summary is not displayed.

Likes summary:
- Go to the Reader and select a post with Likes.
- Select the Likes summary to display the Likes list.
- On the web, like/unlike the post.
- Return to the post details.
- Verify the Likes summary is updated accordingly.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
