### PR TITLE
Jetpack App (Emphasis): Disable "What's New" announcements

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -14,4 +14,5 @@ import Foundation
     @objc static let showsCreateButton: Bool = true
     @objc static let showsQuickActions: Bool = true
     @objc static let showsFollowedSitesSettings: Bool = true
+    @objc static let showsWhatIsNew: Bool = true
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -430,7 +430,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self scrollToElement:QuickStartTourElementViewSite];
         self.shouldScrollToViewSite = NO;
     }
-    if (![Feature enabled:FeatureFlagNewNavBarAppearance]) {
+    if (![Feature enabled:FeatureFlagNewNavBarAppearance] &&
+        [AppConfiguration showsWhatIsNew]) {
         [WPTabBarController.sharedInstance presentWhatIsNewOn:self];
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -71,7 +71,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         guard FeatureFlag.newNavBarAppearance.enabled else {
             return
         }
-        WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
+
+        if AppConfiguration.showsWhatIsNew {
+            WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
+        }
 
         FancyAlertViewController.presentCustomAppIconUpgradeAlertIfNecessary(from: self)
     }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -480,7 +480,8 @@ private extension AppSettingsViewController {
         }
 
         if let presenter = WPTabBarController.sharedInstance()?.whatIsNewScenePresenter as? WhatIsNewScenePresenter,
-            presenter.versionHasAnnouncements {
+            presenter.versionHasAnnouncements,
+            AppConfiguration.showsWhatIsNew {
             let whatIsNewRow = NavigationItemRow(title: NSLocalizedString("What's New in WordPress",
                                                                           comment: "Opens the What's New / Feature Announcement modal"),
                                                  action: presentWhatIsNew())

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -188,7 +188,9 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         showNotificationPrimerAlertIfNeeded()
         showSecondNotificationsAlertIfNeeded()
 
-        WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
+        if AppConfiguration.showsWhatIsNew {
+            WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -53,7 +53,9 @@ class ReaderTabViewController: UIViewController {
 
         ReaderTracker.shared.start(.main)
 
-        WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
+        if AppConfiguration.showsWhatIsNew {
+            WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
+        }
 
         searchButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.readerSearch)
     }

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -14,4 +14,5 @@ import Foundation
     @objc static let showsCreateButton: Bool = false
     @objc static let showsQuickActions: Bool = false
     @objc static let showsFollowedSitesSettings: Bool = false
+    @objc static let showsWhatIsNew: Bool = false
 }


### PR DESCRIPTION
This PR disables the "What's New" announcements / hides the App Settings > "What's New" item in the Jetpack app.

## How to test

_Tip 1: You can use Mobile Announce 188 to test this PR_
_Tip 2: Make sure your logged in with you a11n account_

1. Go to the [mobile announce tool](https://mc.a8c.com/mobile-announce/) in mission control and create a test announcement, or reuse a test announcement like `Mobile Announce 188` (if you create a test announcement, please make sure to use a future version, and to delete it once the test is completed)
2. Manually update the Jetpack app version in Xcode to match the app version your test announcement is targeting
3. Re-run the app
4. ✅ Make sure the feature announcement DOES NOT show up at launch
5. Go to My Sites > Me > App Settings
6. ✅ Make sure the "What's New" item is NOT displayed
7. Don't forget to remove the test announcement from the mobile announce tool, if you had created one 

WP: displays "What's New" announcement | WP: displays "What's New" item | JP: no "What's New" announcement | JP: no "What's New" item
-- | -- | -- | --
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-03 at 14 54 17](https://user-images.githubusercontent.com/6711616/120599241-38a40d00-c482-11eb-9cc1-d414935b489c.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-03 at 14 54 38](https://user-images.githubusercontent.com/6711616/120599248-3a6dd080-c482-11eb-8eee-53dfa274d761.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-03 at 15 33 55](https://user-images.githubusercontent.com/6711616/120599251-3b066700-c482-11eb-8a46-6a0333173822.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-06-03 at 15 34 00](https://user-images.githubusercontent.com/6711616/120599255-3b9efd80-c482-11eb-9017-dd76db5af78a.png)


## Regression Notes
1. Potential unintended areas of impact
WordPress What's New

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I built and tested the WordPress app with the mobile announce tool

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
