### PR TITLE
Reader Post details: reduce the spacing around the Likes summary

### DIFF
--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -44,10 +44,6 @@ class LikesListController: NSObject {
         return totalLikesFetched < totalLikes
     }
 
-    private var showingNotificationLikes: Bool {
-        return notification != nil
-    }
-
     private var isLoadingContent = false {
         didSet {
             if isLoadingContent != oldValue {
@@ -71,6 +67,20 @@ class LikesListController: NSObject {
     private lazy var commentService: CommentService = {
         CommentService(managedObjectContext: ContextManager.shared.mainContext)
     }()
+
+    // Notification Likes has a table header. Post Likes does not.
+    // Thus this is used to determine table layout depending on which is being shown.
+    private var showingNotificationLikes: Bool {
+        return notification != nil
+    }
+
+    private var usersSectionIndex: Int {
+        return showingNotificationLikes ? 1 : 0
+    }
+
+    private var numberOfSections: Int {
+        return showingNotificationLikes ? 2 : 1
+    }
 
     // MARK: Init
 
@@ -256,7 +266,7 @@ class LikesListController: NSObject {
 extension LikesListController: UITableViewDataSource, UITableViewDelegate {
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return showingNotificationLikes ? 2 : 1
+        return numberOfSections
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -278,9 +288,6 @@ extension LikesListController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-
-        let usersSectionIndex = showingNotificationLikes ? 1 : 0
-
         let isUsersSection = indexPath.section == usersSectionIndex
         let isLastRow = indexPath.row == totalLikesFetched - 1
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -42,6 +42,9 @@ private extension ReaderDetailLikesListController {
         tableView.delegate = likesListController
         tableView.dataSource = likesListController
 
+        // The separator is controlled by LikeUserTableViewCell
+        tableView.separatorStyle = .none
+
         // Call refresh to ensure that the controller fetches the data.
         likesListController?.refresh()
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
@@ -11,11 +11,11 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="V9g-yi-NfW" customClass="ReaderDetailLikesView" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="336" height="80"/>
+            <rect key="frame" x="0.0" y="0.0" width="336" height="42"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="-3" translatesAutoresizingMaskIntoConstraints="NO" id="ZiQ-mD-QJO" userLabel="Avatar Stack View">
-                    <rect key="frame" x="0.0" y="24" width="148" height="32"/>
+                    <rect key="frame" x="0.0" y="5" width="148" height="32"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="J4T-hG-6iv" userLabel="Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
@@ -58,7 +58,7 @@
                     </constraints>
                 </stackView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilc-NW-l0X" userLabel="Summary Label">
-                    <rect key="frame" x="160" y="0.0" width="0.0" height="80"/>
+                    <rect key="frame" x="160" y="0.0" width="0.0" height="42"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <nil key="highlightedColor"/>
@@ -70,8 +70,8 @@
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ilc-NW-l0X" secondAttribute="bottom" id="10Y-sE-pDS"/>
                 <constraint firstAttribute="top" relation="greaterThanOrEqual" secondItem="ilc-NW-l0X" secondAttribute="top" id="CbZ-7d-cly"/>
                 <constraint firstItem="ZiQ-mD-QJO" firstAttribute="leading" secondItem="V9g-yi-NfW" secondAttribute="leading" id="IaP-Se-6v5"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ZiQ-mD-QJO" secondAttribute="bottom" constant="24" id="j4v-s8-8Xz"/>
-                <constraint firstItem="ZiQ-mD-QJO" firstAttribute="top" relation="greaterThanOrEqual" secondItem="V9g-yi-NfW" secondAttribute="top" constant="24" id="kPA-tt-hzr"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ZiQ-mD-QJO" secondAttribute="bottom" constant="5" id="j4v-s8-8Xz"/>
+                <constraint firstItem="ZiQ-mD-QJO" firstAttribute="top" relation="greaterThanOrEqual" secondItem="V9g-yi-NfW" secondAttribute="top" constant="5" id="kPA-tt-hzr"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ilc-NW-l0X" secondAttribute="trailing" id="qnT-KT-Btp"/>
                 <constraint firstItem="ilc-NW-l0X" firstAttribute="leading" secondItem="ZiQ-mD-QJO" secondAttribute="trailing" constant="12" id="tBZ-4w-7g4"/>
             </constraints>
@@ -80,7 +80,7 @@
                 <outlet property="avatarStackView" destination="ZiQ-mD-QJO" id="hMm-un-1IW"/>
                 <outlet property="summaryLabel" destination="ilc-NW-l0X" id="C48-jT-Uq7"/>
             </connections>
-            <point key="canvasLocation" x="-1275.3623188405797" y="-383.03571428571428"/>
+            <point key="canvasLocation" x="-1275.3623188405797" y="-395.75892857142856"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
Ref #16561 , https://github.com/wordpress-mobile/WordPress-iOS/pull/16608#issuecomment-853307035

The top and bottom margins on the Likes summary view are reduced since the content view above and Related Posts view below have ample margins.

Also, the separator line color in the Post likes list is now the same as in the Notifications likes list.

To test:
- Go to Reader and select a post with likes.
- Verify the Likes summary top and bottom space is less.

I also modified the Likes list logic a bit. There should be no visible change, but if you'd like to confirm:
- Verify the post details likes list does not have a header.
- Verify the notification likes list does have a header.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
