### PR TITLE
Fix Error Handling in Site Address Entry

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -206,9 +206,9 @@ abstract_target 'Apps' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-     pod 'WordPressAuthenticator', '~> 1.37.0'
+    # pod 'WordPressAuthenticator', '~> 1.37.0'
     # While in PR
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issue/wc-3962-allow-login-override'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -65,7 +65,7 @@ PODS:
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
   - Gridicons (1.1.0)
-  - GTMAppAuth (1.2.1):
+  - GTMAppAuth (1.2.2):
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
@@ -389,7 +389,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.4)
   - WordPress-Editor-iOS (1.19.4):
     - WordPress-Aztec-iOS (= 1.19.4)
-  - WordPressAuthenticator (1.37.0):
+  - WordPressAuthenticator (1.38.0-beta.1):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -498,7 +498,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
-  - WordPressAuthenticator (~> 1.37.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issue/wc-3962-allow-login-override`)
   - WordPressKit (~> 4.34.0)
   - WordPressMocks (~> 0.0.12)
   - WordPressShared (~> 1.16.0)
@@ -510,7 +510,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressUI
   trunk:
@@ -651,6 +650,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.55.0-alpha1
+  WordPressAuthenticator:
+    :branch: issue/wc-3962-allow-login-override
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.55.0-alpha1/third-party-podspecs/Yoga.podspec.json
 
@@ -666,6 +668,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.55.0-alpha1
+  WordPressAuthenticator:
+    :commit: 968c1f2af497ac7a063c344d915a30bf7f3aecc1
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -691,7 +696,7 @@ SPEC CHECKSUMS:
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
-  GTMAppAuth: 5b53231ef6920f149ab84b2969cb0ab572da3077
+  GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   Gutenberg: 66f55b7ce837e146e9d6c2add58f93991e0bd8ab
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
@@ -746,7 +751,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
-  WordPressAuthenticator: 2674c56cad016118fb4725b866b380b612db66fc
+  WordPressAuthenticator: a70902bfd166e8c72dc077cada527b6fd1a382f2
   WordPressKit: 2e2df34159114ccb4b10b6d0aca35aa8081d12a7
   WordPressMocks: 2783c51aaa34eca64d6ebbad13837951c374baf2
   WordPressShared: 0f7f10e96f8354d64f951c223ae61e8de7495a46
@@ -763,6 +768,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 5791cc952961fd733a4772a9eedf9bf1ca2d3852
+PODFILE CHECKSUM: 1eb3e0b2accdf64e084313f024b05c51f6e18603
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
⚠️  Please review this first: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/596

Originally intended to fix https://github.com/woocommerce/woocommerce-ios/issues/4034 but apparently, WP has the same issue. So this fixes both apps. 🤸 

## Testing 

Please see https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/595 for the testing steps.

## Regression Notes

1. Potential unintended areas of impact
    - Any place where we can add a site. 
    - Logging in with a site address
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Tested WooCommerce's login flow. 
    - Tested adding a site on WP
    - Tested logging in with a site address on Jetpack
    - Tested with VoiceOver 
3. What automated tests I added (or what prevented me from doing so)
    - None. Changes are in WPAuth.

## PR submission checklist

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
