### PR TITLE
Reader post details: enable Likes feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 17.6
 -----
+* [**] Reader Post details: now shows a summary of Likes for the post. Tapping it displays the full list of Likes. [#16628]
 * [*] Fix notice overlapping the ActionSheet that displays the Site Icon controls. [#16579]
 
 17.5

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -57,7 +57,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .bloggingReminders:
             return false
         case .readerPostLikes:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         }
     }
 


### PR DESCRIPTION
Ref #16561 

(Please review #16626 first.)

This enables the feature that shows the Likes in Reader Post details.

To test:

---
- Go to the Reader and select a post with Likes.
- Verify the Likes summary appears and works as expected.

<kbd>![summary](https://user-images.githubusercontent.com/1816888/120702775-b4e22480-c471-11eb-8356-2b363cea5b3a.png)</kbd>

---
- Disable the `readerPostLikes` feature.
- Go to the Reader and select a post with Likes.
- Verify the Likes summary does not appear.

<kbd>![no_summary](https://user-images.githubusercontent.com/1816888/120702819-bf9cb980-c471-11eb-9784-2598e10d00b7.png)</kbd>

---

## Regression Notes
1. Potential unintended areas of impact
N/A. This is a new feature, so nothing else should be impacted.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested post details with the feature enabled and disabled.

3. What automated tests I added (or what prevented me from doing so)
Likes tests have been added in WP and WPKit as development went along.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
