### PR TITLE
Disable 'Add a Topic' button if input field is empty

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -191,7 +191,7 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
 - (BOOL)textPassesValidation
 {
     BOOL isEmail = (self.mode == SettingsTextModesEmail);
-    return (self.validatesInput == false || isEmail == false || (isEmail && self.textField.text.isValidEmail));
+    return ([self.textField hasText] && (self.validatesInput == false || isEmail == false || (isEmail && self.textField.text.isValidEmail)));
 }
 
 - (void)validateTextInput:(id)sender

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -197,6 +197,12 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
 - (void)validateTextInput:(id)sender
 {
     self.doneButtonEnabled = [self textPassesValidation];
+
+    if (self.doneButtonEnabled) {
+        [_actionCell enable];
+    } else {
+        [_actionCell disable];
+    }
 }
 
 
@@ -240,7 +246,13 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     _actionCell.textLabel.textAlignment = NSTextAlignmentCenter;
     
     [WPStyleGuide configureTableViewActionCell:_actionCell];
-    
+
+    if (self.doneButtonEnabled) {
+        [_actionCell enable];
+    } else {
+        [_actionCell disable];
+    }
+
     return _actionCell;
 }
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -197,12 +197,7 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
 - (void)validateTextInput:(id)sender
 {
     self.doneButtonEnabled = [self textPassesValidation];
-
-    if (self.doneButtonEnabled) {
-        [_actionCell enable];
-    } else {
-        [_actionCell disable];
-    }
+    [self setEnabledStateForCell:_actionCell value:self.doneButtonEnabled];
 }
 
 
@@ -246,12 +241,7 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     _actionCell.textLabel.textAlignment = NSTextAlignmentCenter;
     
     [WPStyleGuide configureTableViewActionCell:_actionCell];
-
-    if (self.doneButtonEnabled) {
-        [_actionCell enable];
-    } else {
-        [_actionCell disable];
-    }
+    [self setEnabledStateForCell:_actionCell value:self.doneButtonEnabled];
 
     return _actionCell;
 }
@@ -407,6 +397,14 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     self.textField.autocorrectionType = autocorrectionType;
 }
 
+- (void)setEnabledStateForCell:(UITableViewCell *)ActionCell value:(BOOL)value
+{
+    if (value) {
+        [_actionCell enable];
+    } else {
+        [_actionCell disable];
+    }
+}
 
 #pragma mark - UITextFieldDelegate Methods
 


### PR DESCRIPTION
Fixes [#14119](https://github.com/wordpress-mobile/WordPress-iOS/issues/14119)

### Description:
This PR addresses the issue where 'Add a Topic' button doesn't react to the user input, and is enabled all the time, so it is possible to press it (and dismiss the screen) even if user hasn't entered anything.

### To test:
1. Log in
2. Go to Reader tab
3. Tap the cog in the top right corner
4. Tap the 'Add a Topic' button
5. Button should be disabled if there is no text in the input field

### Desired outcome:
https://user-images.githubusercontent.com/12729242/120711011-25fbf900-c4bf-11eb-8412-00f67b8fa441.mp4

### Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
