### PR TITLE
Fixes a layout issue when combining long titles and long urls.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -353,6 +353,7 @@ fileprivate extension NewBlogDetailHeaderView {
             refreshMainStackViewAxis()
             addSubview(mainStackView)
             pinSubviewToAllEdges(mainStackView)
+            setupConstraintsForSiteSwitcher()
         }
 
         private func refreshMainStackViewAxis() {
@@ -367,6 +368,15 @@ fileprivate extension NewBlogDetailHeaderView {
                 titleButton.titleLabel?.minimumScaleFactor = LabelMinimumScaleFactor.regular
                 subtitleButton.titleLabel?.minimumScaleFactor = LabelMinimumScaleFactor.regular
             }
+        }
+
+        // MARK: - Constraints
+
+        private func setupConstraintsForSiteSwitcher() {
+            NSLayoutConstraint.activate([
+                siteSwitcherButton.heightAnchor.constraint(equalToConstant: Dimensions.siteSwitcherHeight),
+                siteSwitcherButton.widthAnchor.constraint(equalToConstant: Dimensions.siteSwitcherWidth)
+            ])
         }
     }
 }


### PR DESCRIPTION
Ref p5T066-2lo-p2#comment-8551

Fixes a layout issue that arises when combining long titles and long site URLs.  The site switcher button would sometimes dissappear.

## To test:

1. If you don't have a site with a long URL, edit `NewBlogDetailHeaderView.swift:339` from this branch to look like this:

```swift
let url = "geriuxxtestingbusiness123.wpcomstaging.com"
subtitleButton.setTitle(url, for: .normal)
```

2. Run the App.
3. Go to a testing site you can edit, and edit its title to become really long.

Make sure the site switcher is still visible.

## Regression Notes

1. Potential unintended areas of impact

None I can think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
