### PR TITLE
Username picker loader UI change

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -206,7 +206,7 @@ abstract_target 'Apps' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-     pod 'WordPressAuthenticator', '~> 1.37.0'
+    pod 'WordPressAuthenticator', '~> 1.38.0-beta-3'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''

--- a/Podfile
+++ b/Podfile
@@ -206,7 +206,7 @@ abstract_target 'Apps' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-    pod 'WordPressAuthenticator', '~> 1.38.0-beta-3'
+    pod 'WordPressAuthenticator', '~> 1.38.0-beta.3'
     # While in PR
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -65,7 +65,7 @@ PODS:
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
   - Gridicons (1.1.0)
-  - GTMAppAuth (1.2.1):
+  - GTMAppAuth (1.2.2):
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
   - GTMSessionFetcher/Core (1.5.0)
@@ -389,7 +389,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.4)
   - WordPress-Editor-iOS (1.19.4):
     - WordPress-Aztec-iOS (= 1.19.4)
-  - WordPressAuthenticator (1.37.0):
+  - WordPressAuthenticator (1.38.0-beta.3):
     - 1PasswordExtension (~> 1.8.6)
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
@@ -498,7 +498,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
-  - WordPressAuthenticator (~> 1.37.0)
+  - WordPressAuthenticator (~> 1.38.0-beta-3)
   - WordPressKit (~> 4.35.0-beta.1)
   - WordPressMocks (~> 0.0.12)
   - WordPressShared (~> 1.16.0)
@@ -691,7 +691,7 @@ SPEC CHECKSUMS:
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
-  GTMAppAuth: 5b53231ef6920f149ab84b2969cb0ab572da3077
+  GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   Gutenberg: 66f55b7ce837e146e9d6c2add58f93991e0bd8ab
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
@@ -746,7 +746,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
-  WordPressAuthenticator: 2674c56cad016118fb4725b866b380b612db66fc
+  WordPressAuthenticator: d57d732d4c2db1fd7bb4a0382de956b63a2d61df
   WordPressKit: 5894cd7385898bc7dfaf75073bcce0ffdd1a1807
   WordPressMocks: 2783c51aaa34eca64d6ebbad13837951c374baf2
   WordPressShared: 0f7f10e96f8354d64f951c223ae61e8de7495a46
@@ -763,6 +763,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 4e0d122d1f71597e7f24b5221e94653023ba5757
+PODFILE CHECKSUM: cd72419ecf9eeaa3cae58c68b8144d9f433d785a
 
 COCOAPODS: 1.10.1

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -57,14 +57,12 @@ private extension ChangeUsernameViewController {
         viewModel.suggestionsListener = { [weak self] state, suggestions, reloadAllSections in
             switch state {
             case .loading:
-                let cell = self?.tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell
-                cell?.showLoader()
+                self?.showLoader(true)
             case .success:
                 if suggestions.isEmpty {
                     WPAppAnalytics.track(.accountSettingsChangeUsernameSuggestionsFailed)
                 }
-                let cell = self?.tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell
-                cell?.hideLoader()
+                self?.showLoader(false)
                 self?.suggestions = suggestions
                 self?.reloadSections(includingAllSections: reloadAllSections)
             default:

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -57,12 +57,12 @@ private extension ChangeUsernameViewController {
         viewModel.suggestionsListener = { [weak self] state, suggestions, reloadAllSections in
             switch state {
             case .loading:
-                self?.showLoader(true)
+                self?.showLoader()
             case .success:
                 if suggestions.isEmpty {
                     WPAppAnalytics.track(.accountSettingsChangeUsernameSuggestionsFailed)
                 }
-                self?.showLoader(false)
+                self?.hideLoader()
                 self?.suggestions = suggestions
                 self?.reloadSections(includingAllSections: reloadAllSections)
             default:

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -1,3 +1,5 @@
+import WordPressAuthenticator
+
 class ChangeUsernameViewController: SignupUsernameTableViewController {
     typealias CompletionBlock = (String?) -> Void
 
@@ -55,12 +57,14 @@ private extension ChangeUsernameViewController {
         viewModel.suggestionsListener = { [weak self] state, suggestions, reloadAllSections in
             switch state {
             case .loading:
-                SVProgressHUD.show(withStatus: Constants.Alert.loading)
+                let cell = self?.tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell
+                cell?.showLoader()
             case .success:
                 if suggestions.isEmpty {
                     WPAppAnalytics.track(.accountSettingsChangeUsernameSuggestionsFailed)
                 }
-                SVProgressHUD.dismiss()
+                let cell = self?.tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell
+                cell?.hideLoader()
                 self?.suggestions = suggestions
                 self?.reloadSections(includingAllSections: reloadAllSections)
             default:

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -187,6 +187,7 @@ extension SignupUsernameTableViewController {
         cell.placeholder = NSLocalizedString("Type a keyword for more ideas", comment: "Placeholder text for domain search during site creation.")
         cell.delegate = self
         cell.selectionStyle = .none
+        cell.textField.leftViewImage = UIImage(named: "icon-post-search-highlight")
 
         return cell
     }

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -279,3 +279,23 @@ extension SignupUsernameTableViewController {
         }
     }
 }
+
+extension SearchTableViewCell {
+    func showLoader() {
+        guard let leftView = textField.leftView else { return }
+        let spinner = UIActivityIndicatorView(frame: leftView.frame)
+        addSubview(spinner)
+        spinner.startAnimating()
+
+        textField.leftView?.alpha = 0
+    }
+
+    func hideLoader() {
+        for subview in subviews where subview is UIActivityIndicatorView {
+            subview.removeFromSuperview()
+            break
+        }
+
+        textField.leftView?.alpha = 1
+    }
+}

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -281,23 +281,3 @@ extension SignupUsernameTableViewController {
         }
     }
 }
-
-extension SearchTableViewCell {
-    func showLoader() {
-        guard let leftView = textField.leftView else { return }
-        let spinner = UIActivityIndicatorView(frame: leftView.frame)
-        addSubview(spinner)
-        spinner.startAnimating()
-
-        textField.leftView?.alpha = 0
-    }
-
-    func hideLoader() {
-        for subview in subviews where subview is UIActivityIndicatorView {
-            subview.removeFromSuperview()
-            break
-        }
-
-        textField.leftView?.alpha = 1
-    }
-}

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -1,7 +1,6 @@
 import SVProgressHUD
 import WordPressAuthenticator
 
-
 class SignupUsernameTableViewController: UITableViewController, SearchTableViewCellDelegate {
     open var currentUsername: String?
     open var displayName: String?
@@ -223,7 +222,8 @@ extension SignupUsernameTableViewController {
             let api = account.wordPressComRestApi else {
                 return
         }
-        SVProgressHUD.show(withStatus: NSLocalizedString("Loading usernames", comment: "Shown while the app waits for the username suggestions web service to return during the site creation process."))
+        let cell = tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell
+        cell?.showLoader()
 
         let service = AccountSettingsService(userID: account.userID.intValue, api: api)
         service.suggestUsernames(base: searchTerm) { [weak self] (newSuggestions) in
@@ -231,7 +231,8 @@ extension SignupUsernameTableViewController {
                 WordPressAuthenticator.track(.signupEpilogueUsernameSuggestionsFailed)
             }
             self?.isSearching = false
-            SVProgressHUD.dismiss()
+            let cell = self?.tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell
+            cell?.hideLoader()
             addSuggestions(newSuggestions)
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -85,18 +85,6 @@ class SignupUsernameTableViewController: UITableViewController, SearchTableViewC
         return description
     }
 
-    func showLoader(_ value: Bool) {
-        guard let cell = tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell else {
-            return
-        }
-
-        if value {
-            cell.showLoader()
-        } else {
-            cell.hideLoader()
-        }
-    }
-
     // MARK: - SearchTableViewCellDelegate
 
     func startSearch(for searchTerm: String) {
@@ -235,7 +223,7 @@ extension SignupUsernameTableViewController {
             let api = account.wordPressComRestApi else {
                 return
         }
-        showLoader(true)
+        showLoader()
 
         let service = AccountSettingsService(userID: account.userID.intValue, api: api)
         service.suggestUsernames(base: searchTerm) { [weak self] (newSuggestions) in
@@ -243,9 +231,25 @@ extension SignupUsernameTableViewController {
                 WordPressAuthenticator.track(.signupEpilogueUsernameSuggestionsFailed)
             }
             self?.isSearching = false
-            self?.showLoader(false)
+            self?.hideLoader()
             addSuggestions(newSuggestions)
         }
+    }
+}
+
+// MARK: - Loader
+
+extension SignupUsernameTableViewController {
+    func showLoader() {
+        searchCell?.showLoader()
+    }
+
+    func hideLoader() {
+        searchCell?.hideLoader()
+    }
+
+    private var searchCell: SearchTableViewCell? {
+        tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -85,6 +85,18 @@ class SignupUsernameTableViewController: UITableViewController, SearchTableViewC
         return description
     }
 
+    func showLoader(_ value: Bool) {
+        guard let cell = tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell else {
+            return
+        }
+
+        if value {
+            cell.showLoader()
+        } else {
+            cell.hideLoader()
+        }
+    }
+
     // MARK: - SearchTableViewCellDelegate
 
     func startSearch(for searchTerm: String) {
@@ -223,8 +235,7 @@ extension SignupUsernameTableViewController {
             let api = account.wordPressComRestApi else {
                 return
         }
-        let cell = tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell
-        cell?.showLoader()
+        showLoader(true)
 
         let service = AccountSettingsService(userID: account.userID.intValue, api: api)
         service.suggestUsernames(base: searchTerm) { [weak self] (newSuggestions) in
@@ -232,8 +243,7 @@ extension SignupUsernameTableViewController {
                 WordPressAuthenticator.track(.signupEpilogueUsernameSuggestionsFailed)
             }
             self?.isSearching = false
-            let cell = self?.tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? SearchTableViewCell
-            cell?.hideLoader()
+            self?.showLoader(false)
             addSuggestions(newSuggestions)
         }
     }


### PR DESCRIPTION
Fixes [#8761](https://github.com/wordpress-mobile/WordPress-iOS/issues/8761)

### Description:
This PR replaces modal loader for the username picker, with the loading indicator located in the search cell, which is shown while fetching available usernames.

Notes:

- The original issue was related to the username picker in signup flow for the new user, but it's used in 'Account settings' screen for the existing user as well, so that's fixed too.
- The fix for magnifying glass icon is also included. It was almost invisible, now it has proper color (both in light and dark mode).

### To test:
New user:
1. Sign up with email
2. Tap on sign up link from email
3. Account details screen is presented.
4. Tap on 'Username'
5. Screen with username picker is presented with desired behaviour

Existing user:
1. Log in
2. On 'My Site' tab tap on Profile button in the top right corner
3. Tap on 'Account Settings'
4. Tap on 'Username'
5. Screen with username picker is presented with desired behaviour

### Video:
(disregard 'We had trouble loading data' blue bar on the first screen)

https://user-images.githubusercontent.com/12729242/120724878-f7891880-c4d4-11eb-90ca-6a36da5e33f5.mp4


### Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
