### PR TITLE
Fix outdated login UI tests

### DIFF
--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -118,7 +118,7 @@ class LoginTests: XCTestCase {
         XCTAssert(WelcomeScreen().isLoaded())
     }
 
-    // Unified WordPress.com email login fail due to incorrect password
+    // Unified WordPress.com email login failure due to incorrect password
     // Replaces testUnsuccessfulLogin
     func testWPcomInvalidPassword() {
         _ = PrologueScreen().selectContinue()

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -68,7 +68,6 @@ class LoginTests: XCTestCase {
     func testWPcomLogin() {
         _ = PrologueScreen().selectSiteAddress()
             .proceedWithWP(siteUrl: "https://wordpress.com")
-            .proceedWithWP(siteUrl: "https://wordpress.com") // this shouldn't be here. the new login flow goes straight to email.
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWith(password: WPUITestCredentials.testWPcomPassword)
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -65,7 +65,7 @@ class LoginTests: XCTestCase {
 
     // Unified WordPress.com login/out
     // Replaces testWpcomUsernamePasswordLogin
-    func testWpcomLogin() {
+    func testWPcomLogin() {
         _ = PrologueScreen().selectSiteAddress()
             .proceedWithWP(siteUrl: "https://wordpress.com")
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -118,9 +118,9 @@ class LoginTests: XCTestCase {
         XCTAssert(WelcomeScreen().isLoaded())
     }
 
-    // Unified email login fail
+    // Unified WordPress.com email login fail due to incorrect password
     // Replaces testUnsuccessfulLogin
-    func testWordPressUnsuccessfulLogin() {
+    func testWPcomInvalidPassword() {
         _ = PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .tryProceed(password: "invalidPswd")

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -66,8 +66,7 @@ class LoginTests: XCTestCase {
     // Unified WordPress.com login/out
     // Replaces testWpcomUsernamePasswordLogin
     func testWPcomLogin() {
-        _ = PrologueScreen().selectSiteAddress()
-            .proceedWithWP(siteUrl: "https://wordpress.com")
+        _ = PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWith(password: WPUITestCredentials.testWPcomPassword)
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -68,6 +68,7 @@ class LoginTests: XCTestCase {
     func testWPcomLogin() {
         _ = PrologueScreen().selectSiteAddress()
             .proceedWithWP(siteUrl: "https://wordpress.com")
+            .proceedWithWP(siteUrl: "https://wordpress.com") // this shouldn't be here. the new login flow goes straight to email.
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWith(password: WPUITestCredentials.testWPcomPassword)
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)


### PR DESCRIPTION
This PR is part of updating our login tests to account for the Unified Login & Signup flows. Context & status: paaHJt-1Kx-p2
Here I update two existing login UI tests, `testWpcomLogin()` and `testWordPressUnsuccessfulLogin()`.
`testWpcomLogin()` wasn't following the current UI flow, and needed a capital 'p', dangit! 
`testWordPressUnsuccessfulLogin()` has been renamed for clarity.

To test:
Run these two tests from LoginTests.swift in Xcode. 

This is my first PR. Please give me feedback on the code itself, but also on my PR!

## Regression Notes
1. Potential unintended areas of impact
None; changes are to LoginTests.swift only

2. What I did to test those areas of impact (or what existing automated tests I relied on)
--

3. What automated tests I added (or what prevented me from doing so)
--

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
