### PR TITLE
Update release-toolkit to 1.1.0 + add update check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,7 +331,7 @@ DEPENDENCIES
   fastlane-plugin-appcenter (~> 1.8)
   fastlane-plugin-sentry
   fastlane-plugin-test_center
-  fastlane-plugin-wpmreleasetoolkit (~> 1.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 1.1)
   octokit (~> 4.0)
   rake
   rmagick (~> 3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     atomos (0.1.3)
     aws-eventstream (1.1.1)
     aws-partitions (1.465.0)
-    aws-sdk-core (3.114.0)
+    aws-sdk-core (3.114.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -24,7 +24,7 @@ GEM
     aws-sdk-kms (1.43.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.95.1)
+    aws-sdk-s3 (1.96.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
@@ -109,7 +109,7 @@ GEM
     faraday-net_http_persistent (1.1.0)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    fastimage (2.2.3)
+    fastimage (2.2.4)
     fastlane (2.184.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
@@ -157,7 +157,7 @@ GEM
       trainer
       xcodeproj
       xctest_list (>= 1.2.1)
-    fastlane-plugin-wpmreleasetoolkit (1.0.1)
+    fastlane-plugin-wpmreleasetoolkit (1.1.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -230,7 +230,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.0)
-    mini_portile2 (2.5.1)
+    mini_portile2 (2.5.3)
     minitest (5.14.4)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -239,7 +239,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.11.5)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     octokit (4.21.0)
@@ -338,4 +338,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.2.17
+   2.2.19

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -761,9 +761,9 @@ import "./ScreenshotFastfile"
 ########################################################################
 # Helper Lanes
 ########################################################################
-  desc "Get a list of pull request from `start_tag` to the current state"
+  desc "Get a list of pull request for a given `milestone`"
   lane :get_pullrequests_list do | options |
-    get_prs_list(repository: GHHELPER_REPO, start_tag:"#{options[:start_tag]}", report_path:"#{File.expand_path('~')}/wpios_prs_list.txt")
+    get_prs_list(repository: GHHELPER_REPO, milestone:"#{options[:milestone]}", report_path:"#{File.expand_path('~')}/wpios_prs_list.txt")
   end
 
   desc "Verifies that Gutenberg is referenced by release version and not by commit"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,20 +46,23 @@ end
 
 before_all do |lane|
   # Skip these checks/steps for test lane (not needed for testing)
-  unless lane == :test_without_building
-    # Check that the env files exist
-    unless is_ci || File.file?(USER_ENV_FILE_PATH)
-      UI.user_error!("~/.wpios-env.default not found: Please copy fastlane/env/user.env-example to #{USER_ENV_FILE_PATH} and fill in the values")
-    end
-    unless File.file?(PROJECT_ENV_FILE_PATH)
-      UI.user_error!("project.env not found: Make sure your configuration is up to date with `rake dependencies`")
-    end
+  next if lane == :test_without_building
 
-    # This allows code signing to work on CircleCI
-    # It is skipped if this isn't running on CI
-    # See https://circleci.com/docs/2.0/ios-codesigning/
-    setup_circle_ci
+  # Ensure we use the latest version of the toolkit
+  check_for_toolkit_updates unless is_ci || ENV['FASTLANE_SKIP_TOOLKIT_UPDATE_CHECK']
+
+  # Check that the env files exist
+  unless is_ci || File.file?(USER_ENV_FILE_PATH)
+    UI.user_error!("~/.wpios-env.default not found: Please copy fastlane/env/user.env-example to #{USER_ENV_FILE_PATH} and fill in the values")
   end
+  unless File.file?(PROJECT_ENV_FILE_PATH)
+    UI.user_error!("project.env not found: Make sure your configuration is up to date with `rake dependencies`")
+  end
+
+  # This allows code signing to work on CircleCI
+  # It is skipped if this isn't running on CI
+  # See https://circleci.com/docs/2.0/ios-codesigning/
+  setup_circle_ci
 end
 
 platform :ios do

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.1'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'


### PR DESCRIPTION
### What

* Update toolkit to 1.1.0
* Add a call to its new `check_for_toolkit_updates` action in `before_all`
* Bonus: Also fixed the `get_pullrequests_list` lane while I was at it

### To test

* Run any lane that doesn't risk create side effect.
   * I chose to use the `get_pullrequests_list` for testing this (which is when I realized it was broken and fixed it 😛 )
* Confirm it checks for release toolkit updates, and that it doesn't find any

### Notes

Making this PR targeting the `release` branch because that's where you will be the next time you run the toolkit lanes, so figured it made more sense.

Also, the changes in `Fastfile` include a change in indentation, so it'll be easier to review if you turn "ignore whitespaces" on.