### PR TITLE
Comment and Notification filters: don't use translated titles for tracks

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Filters.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Filters.swift
@@ -19,6 +19,17 @@ extension CommentsViewController {
             }
         }
 
+        var analyticsTitle: String {
+            switch self {
+            case .all: return "All"
+            case .pending: return "Pending"
+            case .unreplied: return "Unreplied"
+            case .approved: return "Approved"
+            case .spam: return "Spam"
+            case .trashed: return "Trashed"
+            }
+        }
+
         var statusFilter: CommentStatusFilter {
             switch self {
             case .all: return CommentStatusFilterAll
@@ -42,7 +53,7 @@ extension CommentsViewController {
             return
         }
 
-        WPAnalytics.track(.commentFilterChanged, properties: ["selected_filter": filter.title])
+        WPAnalytics.track(.commentFilterChanged, properties: ["selected_filter": filter.analyticsTitle])
         refresh(with: filter.statusFilter)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1001,7 +1001,7 @@ extension NotificationsViewController {
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
         selectedNotification = nil
 
-        let properties = [Stats.selectedFilter: filter.title]
+        let properties = [Stats.selectedFilter: filter.analyticsTitle]
         WPAnalytics.track(.notificationsTappedSegmentedControl, withProperties: properties)
 
         updateUnreadNotificationsForFilterTabChange()
@@ -1635,6 +1635,16 @@ private extension NotificationsViewController {
             case .comment:  return NSLocalizedString("Comments", comment: "Filters Comments Notifications")
             case .follow:   return NSLocalizedString("Follows", comment: "Filters Follows Notifications")
             case .like:     return NSLocalizedString("Likes", comment: "Filters Likes Notifications")
+            }
+        }
+
+        var analyticsTitle: String {
+            switch self {
+            case .none:     return "All"
+            case .unread:   return "Unread"
+            case .comment:  return "Comments"
+            case .follow:   return "Follows"
+            case .like:     return "Likes"
             }
         }
 


### PR DESCRIPTION
Fixes #15859 for Notifications, n/a for Comments

This uses plain English filter titles when used for track properties.

To test:

For both Comments and Notifications:
- Verify the filter titles are logged in English when selected.
- Change device language to something other than English.
- Verify the displayed filter titles are translated.
- Verify the filter titles are logged in English when selected.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
