### PR TITLE
Merge 17.5 release notes into develop

### DIFF
--- a/WordPress/Resources/AppStoreStrings.po
+++ b/WordPress/Resources/AppStoreStrings.po
@@ -15,8 +15,7 @@ msgstr ""
 
 #. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_subtitle"
-msgid "Build a website or blog
-"
+msgid "Build a website or blog"
 msgstr ""
 
 #. translators: Multi-paragraph text used to display in the Apple App Store.

--- a/WordPress/Resources/AppStoreStrings.po
+++ b/WordPress/Resources/AppStoreStrings.po
@@ -15,7 +15,8 @@ msgstr ""
 
 #. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_subtitle"
-msgid "Build a website or blog"
+msgid "Build a website or blog
+"
 msgstr ""
 
 #. translators: Multi-paragraph text used to display in the Apple App Store.
@@ -40,17 +41,25 @@ msgctxt "app_store_keywords"
 msgid "social,notes,jetpack,writing,geotagging,media,blog,website,blogging,journal"
 msgstr ""
 
-msgctxt "v17.4-whats-new"
+msgctxt "v17.5-whats-new"
 msgid ""
-"What’s new in this update?\n"
+"What’s new in WordPress release 17.5?\n"
 "\n"
-"Keep up-to-date on any sites you’ve recently been added to by pulling down to refresh on the New Sites screen.\n"
+"Reusable blocks are here! Create content once, save your block, and reuse it over and over again in any posts or pages. In 17.5, you’ll find reusable blocks ready to go in the block inserter menu.\n"
 "\n"
-"On sites with more than one author, you’ll now be able to switch the author assigned to any Post or Page.\n"
+"If tapping to add new blocks is a menu tap too far, 17.5 lets you add them with a slash command right from the editor. Add a forward slash as you’re crafting your post or page, start tapping in the name of the block, and you’re all set. No menus necessary.\n"
 "\n"
-"You can now authenticate login requests while you're using the app.\n"
+"Audio gets some love, too. Got a link for that audio file? In 17.5 just paste your URL into the Audio Block, and WordPress will pull it into your post.\n"
 "\n"
-"Finally, we fixed a bug with the Quick Start tour. When you follow a site from the reader, the Quick Start checklist will now update your progress (instead of remaining unchecked.)\n"
+"Like notifications also got some extra sparkle in 17.5. You’ll now be able to see exactly who liked every post and comment on your site as soon as they roll in.\n"
+"\n"
+"We’ve also been hard at work bug-wrangling. Here’s what we fixed:\n"
+"\n"
+"Screen readers can now select the stepper cell in the block editor.\n"
+"\n"
+"We made sure that large text doesn’t become ENORMOUS text, whatever font you’re using. Large text support in the blog details header of the My Sites screen has also been improved.\n"
+"\n"
+"Finally, item selection and fixed scrolling in the Plugins directory are now behaving themselves, and the Noticons font will no longer crash the app in rich notifications.\n"
 msgstr ""
 
 #. translators: This is a standard chunk of text used to tell a user what's new with a release when nothing major has changed.

--- a/WordPress/Resources/release_notes.txt
+++ b/WordPress/Resources/release_notes.txt
@@ -1,9 +1,17 @@
-What’s new in this update?
+What’s new in WordPress release 17.5?
 
-Keep up-to-date on any sites you’ve recently been added to by pulling down to refresh on the New Sites screen.
+Reusable blocks are here! Create content once, save your block, and reuse it over and over again in any posts or pages. In 17.5, you’ll find reusable blocks ready to go in the block inserter menu.
 
-On sites with more than one author, you’ll now be able to switch the author assigned to any Post or Page.
+If tapping to add new blocks is a menu tap too far, 17.5 lets you add them with a slash command right from the editor. Add a forward slash as you’re crafting your post or page, start tapping in the name of the block, and you’re all set. No menus necessary.
 
-You can now authenticate login requests while you're using the app.
+Audio gets some love, too. Got a link for that audio file? In 17.5 just paste your URL into the Audio Block, and WordPress will pull it into your post.
 
-Finally, we fixed a bug with the Quick Start tour. When you follow a site from the reader, the Quick Start checklist will now update your progress (instead of remaining unchecked.)
+Like notifications also got some extra sparkle in 17.5. You’ll now be able to see exactly who liked every post and comment on your site as soon as they roll in.
+
+We’ve also been hard at work bug-wrangling. Here’s what we fixed:
+
+Screen readers can now select the stepper cell in the block editor.
+
+We made sure that large text doesn’t become ENORMOUS text, whatever font you’re using. Large text support in the blog details header of the My Sites screen has also been improved.
+
+Finally, item selection and fixed scrolling in the Plugins directory are now behaving themselves, and the Noticons font will no longer crash the app in rich notifications.


### PR DESCRIPTION
While we wait for #16605, this PR merges the release notes into `develop`