### PR TITLE
Comments: show toast message when successfully deleted

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -418,8 +418,6 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
 - (void)openWebViewWithURL:(NSURL *)url
 {
-    NSParameterAssert([url isKindOfClass:[NSURL class]]);
-
     if (![url isKindOfClass:[NSURL class]]) {
         DDLogError(@"CommentsViewController: Attempted to open an invalid URL [%@]", url);
         return;


### PR DESCRIPTION
Fixes #n/a

A toast message is now shown when Comment deletion is successful. 

Also, I removed an `NSParameterAssert` that stopped the app when attempting to view the site on a deleted comment, so that the behavior was the same in dev as in production. It was a bit hard to test with it crashing. 😄 

To test:

---
- Go to My Site > Comments and select an untrashed comment.
- Tap the Trash button, and confirm the deletion on the alert.
- Verify a `Successfully deleted comment` toast message appears.

| ![alert](https://user-images.githubusercontent.com/1816888/120871696-9d7e6680-c559-11eb-984b-207bcc261093.png) | ![toast](https://user-images.githubusercontent.com/1816888/120871703-a4a57480-c559-11eb-8de6-708c26b4e585.png) |
|--------|-------|

---
- Tap on the site table header row (after deleting the comment, while still viewing the comment).
- Verify the app doesn't crash (it will just ignore the tap and do nothing).

<img width="448" alt="comment_header" src="https://user-images.githubusercontent.com/1816888/120871469-f0a3e980-c558-11eb-83f1-807380034d6e.png">


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
