### PR TITLE
Add ratings configuration file

### DIFF
--- a/fastlane/Deliverfile
+++ b/fastlane/Deliverfile
@@ -14,3 +14,4 @@ precheck_include_in_app_purchases false
 
 api_key_path ".configure-files/app_store_connect_fastlane_api_key.json"
 
+app_rating_config_path "./fastlane/metadata/ratings_config.json"

--- a/fastlane/metadata/ratings_config.json
+++ b/fastlane/metadata/ratings_config.json
@@ -1,0 +1,17 @@
+{
+  "alcoholTobaccoOrDrugUseOrReferences": "NONE",
+  "contests": "NONE",
+  "gamblingSimulated": "NONE",
+  "horrorOrFearThemes": "NONE",
+  "matureOrSuggestiveThemes": "NONE",
+  "medicalOrTreatmentInformation": "NONE",
+  "profanityOrCrudeHumor": "NONE",
+  "sexualContentGraphicAndNudity": "NONE",
+  "sexualContentOrNudity": "NONE",
+  "violenceCartoonOrFantasy": "NONE",
+  "violenceRealisticProlongedGraphicOrSadistic": "NONE",
+  "violenceRealistic": "NONE",
+  "gambling": false,  
+  "seventeenPlus": false,
+  "unrestrictedWebAccess": true
+}


### PR DESCRIPTION
This file will ensure that the App Store Connect age rating settings are updated for each release

**To test:**
- In App Store Connect, verify that the WordPress iOS age rating is set to 4+
- Run `bundle exec fastlane deliver --skip_screenshots --skip_binary_upload` (you'll need to apply [this `.patch` file in advance](https://github.com/wordpress-mobile/WordPress-iOS/files/6610690/0001-Fix-metadata.txt))
- Note that the change does _not_ show up in the confirmation screen
- Say yes, and allow the changes to be uploaded
- Verify that the age rating is now 17+

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
