### PR TITLE
Fix crash in Comment moderation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] Fix notice overlapping the ActionSheet that displays the Site Icon controls. [#16579]
 * [*] Fix login error for WordPress.org sites to show inline. [#16614]
 * [*] Disables the ability to open the editor for Post Pages [#16369]
+* [*] Fixed an issue that could cause a crash when moderating Comments. [#16645]
 
 17.5
 -----

--- a/WordPress/Classes/ViewRelated/Comments/CommentAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentAnalytics.swift
@@ -33,53 +33,54 @@ import Foundation
     }
 
     @objc static func trackCommentViewed(comment: Comment) {
-        let properties = defaultProperties(comment: comment)
-        WPAnalytics.track(.commentViewed, properties: properties, blog: comment.blog)
+        trackCommentEvent(comment: comment, event: .commentViewed)
     }
 
     @objc static func trackCommentEditorOpened(comment: Comment) {
-        let properties = defaultProperties(comment: comment)
-        WPAnalytics.track(.commentEditorOpened, properties: properties, blog: comment.blog)
+        trackCommentEvent(comment: comment, event: .commentEditorOpened)
     }
 
     @objc static func trackCommentEdited(comment: Comment) {
-        let properties = defaultProperties(comment: comment)
-        WPAnalytics.track(.commentEdited, properties: properties, blog: comment.blog)
+        trackCommentEvent(comment: comment, event: .commentEdited)
     }
 
     @objc static func trackCommentApproved(comment: Comment) {
-        let properties = defaultProperties(comment: comment)
-        WPAnalytics.track(.commentApproved, properties: properties, blog: comment.blog)
+        trackCommentEvent(comment: comment, event: .commentApproved)
     }
 
     @objc static func trackCommentUnApproved(comment: Comment) {
-        let properties = defaultProperties(comment: comment)
-        WPAnalytics.track(.commentUnApproved, properties: properties, blog: comment.blog)
+        trackCommentEvent(comment: comment, event: .commentUnApproved)
     }
 
     @objc static func trackCommentTrashed(comment: Comment) {
-        let properties = defaultProperties(comment: comment)
-        WPAnalytics.track(.commentTrashed, properties: properties, blog: comment.blog)
+        trackCommentEvent(comment: comment, event: .commentTrashed)
     }
 
     @objc static func trackCommentSpammed(comment: Comment) {
-        let properties = defaultProperties(comment: comment)
-        WPAnalytics.track(.commentSpammed, properties: properties, blog: comment.blog)
+        trackCommentEvent(comment: comment, event: .commentSpammed)
     }
 
     @objc static func trackCommentLiked(comment: Comment) {
-        let properties = defaultProperties(comment: comment)
-        WPAnalytics.track(.commentLiked, properties: properties, blog: comment.blog)
+        trackCommentEvent(comment: comment, event: .commentLiked)
     }
 
     @objc static func trackCommentUnLiked(comment: Comment) {
-        let properties = defaultProperties(comment: comment)
-        WPAnalytics.track(.commentUnliked, properties: properties, blog: comment.blog)
+        trackCommentEvent(comment: comment, event: .commentUnliked)
     }
 
     @objc static func trackCommentRepliedTo(comment: Comment) {
+        trackCommentEvent(comment: comment, event: .commentRepliedTo)
+    }
+
+    private static func trackCommentEvent(comment: Comment, event: WPAnalyticsEvent) {
         let properties = defaultProperties(comment: comment)
-        WPAnalytics.track(.commentRepliedTo, properties: properties, blog: comment.blog)
+
+        guard let blog = comment.blog else {
+            WPAnalytics.track(event, properties: properties)
+            return
+        }
+
+        WPAnalytics.track(event, properties: properties, blog: blog)
     }
 
     static func trackCommentEditorOpened(block: FormattableCommentContent) {

--- a/WordPress/Classes/ViewRelated/Comments/CommentAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentAnalytics.swift
@@ -27,7 +27,7 @@ import Foundation
     static func defaultProperties(comment: Comment) -> [AnyHashable: Any] {
         return [
             Constants.context: trackingContext(),
-            WPAppAnalyticsKeyPostID: comment.postID.intValue,
+            WPAppAnalyticsKeyPostID: comment.postID != nil ? comment.postID.intValue : 0,
             WPAppAnalyticsKeyCommentID: comment.commentID != nil ? comment.commentID.intValue : 0 // An unpublished comment could have a nil comment ID.
         ]
     }

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -13,10 +13,7 @@
 #import <WordPressUI/WordPressUI.h>
 
 
-
-#pragma mark ==========================================================================================
-#pragma mark Constants
-#pragma mark ==========================================================================================
+#pragma mark - Constants
 
 static NSInteger const CommentsDetailsNumberOfSections  = 1;
 static NSInteger const CommentsDetailsHiddenRowNumber   = -1;
@@ -29,9 +26,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 };
 
 
-#pragma mark ==========================================================================================
-#pragma mark CommentViewController
-#pragma mark ==========================================================================================
+#pragma mark - CommentViewController
 
 @interface CommentViewController () <UITableViewDataSource, UITableViewDelegate, ReplyTextViewDelegate, SuggestionsTableViewDelegate>
 
@@ -433,10 +428,10 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     __typeof(self) __weak weakSelf = self;
 
     if (self.comment.isLiked) {
-        [CommentAnalytics trackCommentLikedWithComment:[self comment]];
-    } else {
         [CommentAnalytics trackCommentUnLikedWithComment:[self comment]];
         [[UINotificationFeedbackGenerator new] notificationOccurred:UINotificationFeedbackTypeSuccess];
+    } else {
+        [CommentAnalytics trackCommentLikedWithComment:[self comment]];
     }
 
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
@@ -457,11 +452,18 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     [CommentAnalytics trackCommentApprovedWithComment:[self comment]];
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
-    [commentService approveComment:self.comment success:nil failure:^(NSError *error) {
-        [weakSelf reloadData];
+
+    [commentService approveComment:self.comment success:^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.navigationController popViewControllerAnimated:YES];
+        });
+    } failure:^(NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf displayNoticeWithTitle:NSLocalizedString(@"Error approving comment", @"Message shown when approving a Comment fails.") message:nil];
+            DDLogError(@"Error approving comment: %@", error.localizedDescription);
+            [weakSelf reloadData];
+        });
     }];
-    
-    [self reloadData];
 }
 
 - (void)unapproveComment
@@ -471,11 +473,18 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     [CommentAnalytics trackCommentUnApprovedWithComment:[self comment]];
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
-    [commentService unapproveComment:self.comment success:nil failure:^(NSError *error) {
-        [weakSelf reloadData];
-    }];
     
-    [self reloadData];
+    [commentService unapproveComment:self.comment success:^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.navigationController popViewControllerAnimated:YES];
+        });
+    } failure:^(NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf displayNoticeWithTitle:NSLocalizedString(@"Error unapproving comment", @"Message shown when unapproving a Comment fails.") message:nil];
+            DDLogError(@"Error unapproving comment: %@", error.localizedDescription);
+            [weakSelf reloadData];
+        });
+    }];
 }
 
 - (void)trashComment
@@ -491,7 +500,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Cancel")
                                                            style:UIAlertActionStyleCancel
-                                                         handler:^(UIAlertAction *action){}];
+                                                         handler:nil];
     
     UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Delete", @"Delete")
                                                            style:UIAlertActionStyleDestructive
@@ -504,30 +513,23 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     [self presentViewController:alertController animated:YES completion:nil];
 }
 
-- (void) deleteAction
+- (void)deleteAction
 {
     __typeof(self) __weak weakSelf = self;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
     
-    NSError *error = nil;
-    Comment *reloadedComment = (Comment *)[context existingObjectWithID:self.comment.objectID error:&error];
-    
-    if (error) {
-        DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
-        return;
-    }
-    
     [CommentAnalytics trackCommentTrashedWithComment:[self comment]];
     
-    [commentService deleteComment:reloadedComment success:^{
+    [commentService deleteComment:self.comment success:^{
         dispatch_async(dispatch_get_main_queue(), ^{
-            [weakSelf displayNoticeWithTitle:NSLocalizedString(@"Successfully deleted comment", @"Message shown when a Comment is successfully deleted.") message:nil];
+            [weakSelf.navigationController popViewControllerAnimated:YES];
         });
     } failure:^(NSError *error) {
-        DDLogError(@"Error deleting comment: %@", error);
         dispatch_async(dispatch_get_main_queue(), ^{
-            [weakSelf displayNoticeWithTitle:NSLocalizedString(@"Error deleting comment", @"Message shown when a Comment deletion fails.") message:nil];
+            [weakSelf displayNoticeWithTitle:NSLocalizedString(@"Error deleting comment", @"Message shown when deleting a Comment fails.") message:nil];
+            DDLogError(@"Error deleting comment: %@", error.localizedDescription);
+            [weakSelf reloadData];
         });
     }];
 }
@@ -546,30 +548,38 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Cancel")
                                                            style:UIAlertActionStyleCancel
-                                                         handler:^(UIAlertAction *action){}];
+                                                         handler:nil];
     
     UIAlertAction *spamAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Spam", @"Spam")
                                                          style:UIAlertActionStyleDestructive
                                                        handler:^(UIAlertAction *action) {
-                                                           NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-                                                           CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
-                                                           
-                                                           NSError *error = nil;
-                                                           Comment *reloadedComment = (Comment *)[context existingObjectWithID:weakSelf.comment.objectID error:&error];
-
-                                                           if (error) {
-                                                               DDLogError(@"Comment was deleted while awaiting for alertView confirmation");
-                                                               return;
-                                                           }
-
-                                                           [CommentAnalytics trackCommentSpammedWithComment:reloadedComment];
-                                                           [commentService spamComment:reloadedComment success:nil failure:nil];
+                                                            [weakSelf spamAction];
                                                        }];
     [alertController addAction:cancelAction];
     [alertController addAction:spamAction];
     [self presentViewController:alertController animated:YES completion:nil];
 }
 
+- (void)spamAction
+{
+    __typeof(self) __weak weakSelf = self;
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:context];
+    
+    [CommentAnalytics trackCommentSpammedWithComment:[self comment]];
+    
+    [commentService spamComment:self.comment success:^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf.navigationController popViewControllerAnimated:YES];
+        });
+    } failure:^(NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf displayNoticeWithTitle:NSLocalizedString(@"Error marking comment as spam", @"Message shown when marking a Comment as spam fails.") message:nil];
+            DDLogError(@"Error marking comment as spam: %@", error.localizedDescription);
+            [weakSelf reloadData];
+        });
+    }];
+}
 
 #pragma mark - Editing comment
 


### PR DESCRIPTION
Fixes #16431 

This fixes an issue that would cause the app to crash after marking a Comment as Spam, then attempting to Approve/Unapprove it.
- `CommentAnalytics` now checks for the existence of `comment.blog` and `comment.postID`.
- Besides the aforementioned crash, multiple moderation actions on a Comment resulted in some weird states. So now the Comment details view is dismissed after any Comment moderation action (approve, unapprove, trash, spam).
- The [previously added](https://github.com/wordpress-mobile/WordPress-iOS/pull/16639) toast message when deleting Comment has been removed as it's now unnecessary.

To test:
- Go to My Site > Comments.
- Select any Comment.
- Perform a moderation action (approve, unapprove, spam, trash).
- Verify the Comment detail view is dismissed.
- Verify the Comment appears in the correct filter.
- Verify these Comment events are logged correctly:
  - comment_viewed
  - comment_replied_to
  - comment_editor_opened
  - comment_edited
  - comment_unliked
  - comment_liked
  - comment_unapproved
  - comment_approved
  - comment_spammed
  - comment_trashed

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Approved, unapproved, trashed, spammed Comments. Verified views were dismissed as expected, and Comment states were updated as expected (i.e. they appeared in the correct filters).

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
