### PR TITLE
Use ScreenObject Swift package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,12 @@ commands:
 
             # Prevent fastlane from checking for updates, also removing the verbose fastlane changelog at the end of each invocation.
             echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
+  fix-swift-packages-ssh-github-fetching:
+    steps:
+      - run:
+          name: Fix SSH setup to fetch Swift packages from GitHub
+          command: |
+            for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
 
 jobs:
   Build Tests:
@@ -65,6 +71,7 @@ jobs:
       <<: *xcode_version
     steps:
       - fix-image
+      - fix-swift-packages-ssh-github-fetching
       - git/shallow-checkout
       - ios/install-dependencies:
             bundle-install: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,6 @@ commands:
 
             # Prevent fastlane from checking for updates, also removing the verbose fastlane changelog at the end of each invocation.
             echo "export FASTLANE_SKIP_UPDATE_CHECK=1" >> $BASH_ENV
-  fix-swift-packages-ssh-github-fetching:
-    steps:
       - run:
           name: Fix SSH setup to fetch Swift packages from GitHub
           command: |
@@ -71,7 +69,6 @@ jobs:
       <<: *xcode_version
     steps:
       - fix-image
-      - fix-swift-packages-ssh-github-fetching
       - git/shallow-checkout
       - ios/install-dependencies:
             bundle-install: true
@@ -317,7 +314,6 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - fix-image
-      - fix-swift-packages-ssh-github-fetching
       - git/shallow-checkout
       - ios/install-dependencies:
             bundle-install: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,6 +317,7 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - fix-image
+      - fix-swift-packages-ssh-github-fetching
       - git/shallow-checkout
       - ios/install-dependencies:
             bundle-install: true

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "trunk",
-          "revision": "201ace5a0e5eb7ed2005a34763041b7022625f43",
+          "revision": "8de3def0a24c2cfe9d9f714b3e72a507526ef97a",
           "version": null
         }
       }

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": "trunk",
-          "revision": "8de3def0a24c2cfe9d9f714b3e72a507526ef97a",
-          "version": null
+          "branch": null,
+          "revision": "df8ee4983e674b583b546bb0640ec83428be2465",
+          "version": "0.1.0"
         }
       }
     ]

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "ScreenObject",
+        "repositoryURL": "https://github.com/Automattic/ScreenObject",
+        "state": {
+          "branch": "trunk",
+          "revision": "201ace5a0e5eb7ed2005a34763041b7022625f43",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -558,6 +558,7 @@
 		3FE3D1FF26A6F56700F3CD10 /* Comment+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE02F95E269DC14A00752A44 /* Comment+Interface.swift */; };
 		3FE77C8325B0CA89007DE9E5 /* LocalizableStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE77C8225B0CA89007DE9E5 /* LocalizableStrings.swift */; };
 		3FEC241525D73E8B007AFE63 /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC241425D73E8B007AFE63 /* ConfettiView.swift */; };
+		3FF14430266F3C2400138163 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF1442F266F3C2400138163 /* ScreenObject */; };
 		3FF1A853242D5FCB00373F5D /* WPTabBarController+ReaderTabNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1A852242D5FCB00373F5D /* WPTabBarController+ReaderTabNavigation.swift */; };
 		400199AB222590E100EB0906 /* AllTimeStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400199AA222590E100EB0906 /* AllTimeStatsRecordValueTests.swift */; };
 		400199AD22259FF300EB0906 /* AnnualAndMostPopularTimeStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400199AC22259FF300EB0906 /* AnnualAndMostPopularTimeStatsRecordValueTests.swift */; };
@@ -7774,6 +7775,7 @@
 			files = (
 				3FA640612670CE210064401E /* UITestsFoundation.framework in Frameworks */,
 				4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */,
+				3FF14430266F3C2400138163 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14773,6 +14775,9 @@
 				FF2716951CAAC87B0006E2D4 /* PBXTargetDependency */,
 			);
 			name = WordPressUITests;
+			packageProductDependencies = (
+				3FF1442F266F3C2400138163 /* ScreenObject */,
+			);
 			productName = WordPressUITests;
 			productReference = FF27168F1CAAC87A0006E2D4 /* WordPressUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -14969,6 +14974,9 @@
 				sk,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			packageReferences = (
+				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
+			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -24727,10 +24735,26 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Automattic/ScreenObject";
+			requirement = {
+				branch = trunk;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		24CE2EB0258D687A0000C297 /* WordPressFlux */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = WordPressFlux;
+		};
+		3FF1442F266F3C2400138163 /* ScreenObject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
+			productName = ScreenObject;
 		};
 		FABB1FA62602FC2C00C8785C /* WordPressFlux */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -24740,8 +24740,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				branch = trunk;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -68,7 +68,7 @@ class LoginFlow {
         XCTContext.runActivity(named: "Log out of app if currently logged in") { (activity) in
             if TabNavComponent.isLoaded() {
                 Logger.log(message: "Logging out...", event: .i)
-                let meScreen = TabNavComponent().gotoMeScreen()
+                let meScreen = try! TabNavComponent().gotoMeScreen()
                 if meScreen.isLoggedInToWpcom() {
                     _ = meScreen.logoutToPrologue()
                 } else {

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -5,7 +5,7 @@ class LoginFlow {
 
     @discardableResult
     static func login(email: String, password: String) -> MySiteScreen {
-        logoutIfNeeded()
+        try! logoutIfNeeded()
 
         return PrologueScreen().selectContinue()
             .proceedWith(email: email)
@@ -17,7 +17,7 @@ class LoginFlow {
     // Login with self-hosted site via Site Address.
     @discardableResult
     static func login(siteUrl: String, username: String, password: String) -> MySiteScreen {
-        logoutIfNeeded()
+        try! logoutIfNeeded()
 
         return PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: siteUrl)
@@ -38,7 +38,7 @@ class LoginFlow {
     // Login with WP site via Site Address.
     @discardableResult
     static func login(siteUrl: String, email: String, password: String) -> MySiteScreen {
-        logoutIfNeeded()
+        try! logoutIfNeeded()
 
         return PrologueScreen().selectSiteAddress()
             .proceedWithWP(siteUrl: siteUrl)
@@ -64,11 +64,11 @@ class LoginFlow {
         return TabNavComponent()
     }
 
-    static func logoutIfNeeded() {
-        XCTContext.runActivity(named: "Log out of app if currently logged in") { (activity) in
+    static func logoutIfNeeded() throws {
+        try XCTContext.runActivity(named: "Log out of app if currently logged in") { (activity) in
             if TabNavComponent.isLoaded() {
                 Logger.log(message: "Logging out...", event: .i)
-                let meScreen = try! TabNavComponent().gotoMeScreen()
+                let meScreen = try TabNavComponent().gotoMeScreen()
                 if meScreen.isLoggedInToWpcom() {
                     _ = meScreen.logoutToPrologue()
                 } else {

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -4,8 +4,8 @@ import XCTest
 class LoginFlow {
 
     @discardableResult
-    static func login(email: String, password: String) -> MySiteScreen {
-        try! logoutIfNeeded()
+    static func login(email: String, password: String) throws -> MySiteScreen {
+        try logoutIfNeeded()
 
         return PrologueScreen().selectContinue()
             .proceedWith(email: email)
@@ -16,8 +16,8 @@ class LoginFlow {
 
     // Login with self-hosted site via Site Address.
     @discardableResult
-    static func login(siteUrl: String, username: String, password: String) -> MySiteScreen {
-        try! logoutIfNeeded()
+    static func login(siteUrl: String, username: String, password: String) throws -> MySiteScreen {
+        try logoutIfNeeded()
 
         return PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: siteUrl)
@@ -37,8 +37,8 @@ class LoginFlow {
 
     // Login with WP site via Site Address.
     @discardableResult
-    static func login(siteUrl: String, email: String, password: String) -> MySiteScreen {
-        try! logoutIfNeeded()
+    static func login(siteUrl: String, email: String, password: String) throws -> MySiteScreen {
+        try logoutIfNeeded()
 
         return PrologueScreen().selectSiteAddress()
             .proceedWithWP(siteUrl: siteUrl)
@@ -49,17 +49,17 @@ class LoginFlow {
     }
 
     // Login with self-hosted site via Site Address.
-    static func loginIfNeeded(siteUrl: String, username: String, password: String) -> TabNavComponent {
+    static func loginIfNeeded(siteUrl: String, username: String, password: String) throws -> TabNavComponent {
         guard TabNavComponent.isLoaded() else {
-            return login(siteUrl: siteUrl, username: username, password: password).tabBar
+            return try login(siteUrl: siteUrl, username: username, password: password).tabBar
         }
         return TabNavComponent()
     }
 
     // Login with WP site via Site Address.
-    static func loginIfNeeded(siteUrl: String, email: String, password: String) -> TabNavComponent {
+    static func loginIfNeeded(siteUrl: String, email: String, password: String) throws -> TabNavComponent {
         guard TabNavComponent.isLoaded() else {
-            return login(siteUrl: siteUrl, email: email, password: password).tabBar
+            return try login(siteUrl: siteUrl, email: email, password: password).tabBar
         }
         return TabNavComponent()
     }

--- a/WordPress/WordPressUITests/Screens/MeTabScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MeTabScreen.swift
@@ -1,7 +1,8 @@
+import ScreenObject
 import UITestsFoundation
 import XCTest
 
-class MeTabScreen: BaseScreen {
+class MeTabScreen: ScreenObject {
     let logOutButton: XCUIElement
     let logOutAlert: XCUIElement
     let appSettingsButton: XCUIElement
@@ -10,8 +11,11 @@ class MeTabScreen: BaseScreen {
     let notificationSettingsButton: XCUIElement
     let doneButton: XCUIElement
 
-    init() {
-        let app = XCUIApplication()
+    // TODO: Make this public in ScreenObject
+    let app: XCUIApplication
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        self.app = app
         logOutButton = app.cells["logOutFromWPcomButton"]
         logOutAlert = app.alerts.element(boundBy: 0)
         appSettingsButton = app.cells["appSettings"]
@@ -20,7 +24,7 @@ class MeTabScreen: BaseScreen {
         notificationSettingsButton = app.cells["notificationSettings"]
         doneButton = app.navigationBars.buttons["doneBarButton"]
 
-        super.init(element: appSettingsButton)
+        try super.init(element: appSettingsButton)
     }
 
     func isLoggedInToWpcom() -> Bool {

--- a/WordPress/WordPressUITests/Screens/MeTabScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MeTabScreen.swift
@@ -5,26 +5,24 @@ import XCTest
 class MeTabScreen: ScreenObject {
     let logOutButton: XCUIElement
     let logOutAlert: XCUIElement
-    let appSettingsButton: XCUIElement
+    var appSettingsButton: XCUIElement { expectedElement }
     let myProfileButton: XCUIElement
     let accountSettingsButton: XCUIElement
     let notificationSettingsButton: XCUIElement
     let doneButton: XCUIElement
 
-    // TODO: Make this public in ScreenObject
-    let app: XCUIApplication
-
     init(app: XCUIApplication = XCUIApplication()) throws {
-        self.app = app
         logOutButton = app.cells["logOutFromWPcomButton"]
         logOutAlert = app.alerts.element(boundBy: 0)
-        appSettingsButton = app.cells["appSettings"]
         myProfileButton = app.cells["myProfile"]
         accountSettingsButton = app.cells["accountSettings"]
         notificationSettingsButton = app.cells["notificationSettings"]
         doneButton = app.navigationBars.buttons["doneBarButton"]
 
-        try super.init(element: appSettingsButton)
+        try super.init(
+            expectedElementGetter: { $0.cells["appSettings"] },
+            app: app
+        )
     }
 
     func isLoggedInToWpcom() -> Bool {

--- a/WordPress/WordPressUITests/Screens/TabNavComponent.swift
+++ b/WordPress/WordPressUITests/Screens/TabNavComponent.swift
@@ -15,11 +15,11 @@ class TabNavComponent: BaseScreen {
         super.init(element: mySitesTabButton)
     }
 
-    func gotoMeScreen() -> MeTabScreen {
+    func gotoMeScreen() throws -> MeTabScreen {
         gotoMySiteScreen()
         let meButton = app.navigationBars.buttons["meBarButton"]
         meButton.tap()
-        return try! MeTabScreen()
+        return try MeTabScreen()
     }
 
     @discardableResult

--- a/WordPress/WordPressUITests/Screens/TabNavComponent.swift
+++ b/WordPress/WordPressUITests/Screens/TabNavComponent.swift
@@ -19,7 +19,7 @@ class TabNavComponent: BaseScreen {
         gotoMySiteScreen()
         let meButton = app.navigationBars.buttons["meBarButton"]
         meButton.tap()
-        return MeTabScreen()
+        return try! MeTabScreen()
     }
 
     @discardableResult

--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -3,10 +3,10 @@ import XCTest
 class EditorAztecTests: XCTestCase {
     private var editorScreen: AztecEditorScreen!
 
-    override func setUp() {
+    override func setUpWithError() throws {
         setUpTestSuite()
 
-        _ = LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         editorScreen = EditorFlow
             .toggleBlockEditor(to: .off)
             .goBackToMySite()

--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -14,14 +14,14 @@ class EditorAztecTests: XCTestCase {
             .dismissNotificationAlertIfNeeded(.accept)
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
         if editorScreen != nil && !TabNavComponent.isVisible() {
             EditorFlow.returnToMainEditorScreen()
             editorScreen.closeEditor()
         }
-        LoginFlow.logoutIfNeeded()
-        super.tearDown()
+        try LoginFlow.logoutIfNeeded()
+        try super.tearDownWithError()
     }
 
     // TODO: Re-enable Aztec tests but for editing an existing Aztec post.

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -12,14 +12,14 @@ class EditorGutenbergTests: XCTestCase {
             .tabBar.gotoBlockEditorScreen()
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
         if editorScreen != nil && !TabNavComponent.isVisible() {
             EditorFlow.returnToMainEditorScreen()
             editorScreen.closeEditor()
         }
-        LoginFlow.logoutIfNeeded()
-        super.tearDown()
+        try LoginFlow.logoutIfNeeded()
+        try super.tearDownWithError()
     }
 
     func testTextPostPublish() throws {

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -3,10 +3,10 @@ import XCTest
 class EditorGutenbergTests: XCTestCase {
     private var editorScreen: BlockEditorScreen!
 
-    override func setUp() {
+    override func setUpWithError() throws {
         setUpTestSuite()
 
-        _ = LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         editorScreen = EditorFlow
             .gotoMySiteScreen()
             .tabBar.gotoBlockEditorScreen()

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -2,16 +2,17 @@ import XCTest
 
 class LoginTests: XCTestCase {
 
-    override func setUp() {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         setUpTestSuite()
 
-        LoginFlow.logoutIfNeeded()
+        try LoginFlow.logoutIfNeeded()
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        LoginFlow.logoutIfNeeded()
-        super.tearDown()
+        try LoginFlow.logoutIfNeeded()
+        try super.tearDownWithError()
     }
 
     // Unified email login/out

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -16,8 +16,8 @@ class LoginTests: XCTestCase {
 
     // Unified email login/out
     // Replaces testEmailPasswordLoginLogout
-    func testWordPressLoginLogout() {
-        let prologueScreen = PrologueScreen().selectContinue()
+    func testWordPressLoginLogout() throws {
+        let prologueScreen = try PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWith(password: WPUITestCredentials.testWPcomPassword)
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
@@ -31,8 +31,8 @@ class LoginTests: XCTestCase {
 
     // Old email login/out
     // TODO: remove when unifiedAuth is permanent.
-    func testEmailPasswordLoginLogout() {
-        let welcomeScreen = WelcomeScreen().selectLogin()
+    func testEmailPasswordLoginLogout() throws {
+        let welcomeScreen = try WelcomeScreen().selectLogin()
             .selectEmailLogin()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithPassword()
@@ -49,8 +49,8 @@ class LoginTests: XCTestCase {
     /**
      This test opens safari to trigger the mocked magic link redirect
      */
-    func testEmailMagicLinkLogin() {
-        let welcomeScreen = WelcomeScreen().selectLogin()
+    func testEmailMagicLinkLogin() throws {
+        let welcomeScreen = try WelcomeScreen().selectLogin()
             .selectEmailLogin()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWithLink()

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -11,10 +11,10 @@ class MainNavigationTests: XCTestCase {
          .gotoMySiteScreen()
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        LoginFlow.logoutIfNeeded()
-        super.tearDown()
+        try LoginFlow.logoutIfNeeded()
+        try super.tearDownWithError()
     }
 
     func testTabBarNavigation() {

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -3,10 +3,10 @@ import XCTest
 class MainNavigationTests: XCTestCase {
     private var mySiteScreen: MySiteScreen!
 
-    override func setUp() {
+    override func setUpWithError() throws {
         setUpTestSuite()
 
-        _ = LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         mySiteScreen = TabNavComponent()
          .gotoMySiteScreen()
     }

--- a/WordPress/WordPressUITests/Tests/SignupTests.swift
+++ b/WordPress/WordPressUITests/Tests/SignupTests.swift
@@ -2,16 +2,17 @@ import XCTest
 
 class SignupTests: XCTestCase {
 
-    override func setUp() {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         setUpTestSuite()
 
-        LoginFlow.logoutIfNeeded()
+        try LoginFlow.logoutIfNeeded()
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        LoginFlow.logoutIfNeeded()
-        super.tearDown()
+        try LoginFlow.logoutIfNeeded()
+        try super.tearDownWithError()
     }
 
     func testEmailSignup() {

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -2,15 +2,15 @@ import XCTest
 
 class SupportScreenTests: XCTestCase {
 
-    override func setUp() {
+    override func setUpWithError() throws {
         setUpTestSuite()
 
-        LoginFlow.logoutIfNeeded()
+        try LoginFlow.logoutIfNeeded()
     }
 
-    override func tearDown() {
+    override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        LoginFlow.logoutIfNeeded()
+        try LoginFlow.logoutIfNeeded()
         super.tearDown()
     }
 


### PR DESCRIPTION
This adds the new [`ScreenObject`](https://github.com/Automattic/ScreenObject) Swift package to the project and uses it instead of `BaseScreen` in the `MeTabScreen`. I picked that screen because it was part touched in the login tests flow which we are currently working on (so there's fresher knowledge of them).

To test:

Run the `LoginTests` `XCTestCase` from the WordPressUITests scheme with the mocks (`rake mocks`) running on the terminal, it should build and pass.

## Regression Notes
1. Potential unintended areas of impact
N.A.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
None.

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. N.A.
- [x] I have considered adding accessibility improvements for my changes. N.A.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. N.A.

---

This PR is still a draft, but I would appreciate your [30% feedback](https://www.linkedin.com/pulse/5-30-90-feedback-why-matters-manley-/) on it.
