### PR TITLE
Comment list: remove extra spacing

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.xib
@@ -32,17 +32,17 @@
                             <constraint firstAttribute="width" constant="42" id="pBo-eH-W4J"/>
                         </constraints>
                     </imageView>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe" userLabel="Label Stack View">
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe" userLabel="Label Stack View">
                         <rect key="frame" x="74" y="16" width="230" height="75"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq" userLabel="Title Label">
-                                <rect key="frame" x="0.0" y="-4" width="230" height="37"/>
+                                <rect key="frame" x="0.0" y="-4" width="230" height="24"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xkp-oe-UgU">
-                                <rect key="frame" x="0.0" y="38" width="230" height="37"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xkp-oe-UgU">
+                                <rect key="frame" x="0.0" y="25" width="230" height="50"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>


### PR DESCRIPTION
Fixes #16539

This fixes an issue that caused extra spacing in the Comment table cells.

The problem was the label stack view distribution was set to `Fill Equally`, which caused:
- The 1 line title to stretch out when the content was 2 lines.
- The 1 line content to stretch out when the title was 2 lines.

To test:
- Go to My Site > Comments.
-  Find Comments with:
    - 1 line title and 2 line content.
    - 2 line title and 1 line content.
- Verify the cells are not stretched out.

| Before | After |
|--------|-------|
| <img width="472" alt="before_1" src="https://user-images.githubusercontent.com/1816888/121260710-eb9fac80-c86e-11eb-826b-77c3d3f218c6.png"> | <img width="471" alt="after_1" src="https://user-images.githubusercontent.com/1816888/121260732-f2c6ba80-c86e-11eb-8858-ff458ba99c55.png"> |
| <img width="473" alt="before_2" src="https://user-images.githubusercontent.com/1816888/121260753-fa865f00-c86e-11eb-8dc6-05d9de05d4a9.png"> | <img width="473" alt="after_2" src="https://user-images.githubusercontent.com/1816888/121260765-fe19e600-c86e-11eb-959f-0ff28caf88a2.png"> |


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
