### PR TITLE
Like User Profile: add more bottom padding for iPhone.

### DIFF
--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -41,7 +41,8 @@ class UserProfileSheetViewController: UITableViewController {
 
         // Apply a slight padding to the bottom of the view to give it some space to breathe
         // when being presented in a popover or bottom sheet
-        size.height += Constants.tableBottomPadding
+        let bottomPadding = WPDeviceIdentification.isiPad() ? Constants.iPadBottomPadding : Constants.iPhoneBottomPadding
+        size.height += bottomPadding
 
         preferredContentSize = size
         presentedVC?.presentedView?.layoutIfNeeded()
@@ -205,7 +206,8 @@ private extension UserProfileSheetViewController {
     enum Constants {
         static let userInfoSection = 0
         static let siteSectionTitle = NSLocalizedString("Site", comment: "Header for a single site, shown in Notification user profile.").localizedUppercase
-        static let tableBottomPadding: CGFloat = 10
+        static let iPadBottomPadding: CGFloat = 10
+        static let iPhoneBottomPadding: CGFloat = 40
     }
 
 }


### PR DESCRIPTION
Fixes #n/a
Ref p5T066-2lo#comment-8609

This adds a bit more bottom padding to the User Profile sheet on iPhone.

To test:
- On a iPhone, go to Notifications > Likes.
- Tap on a user.
- Verify there is more space at the bottom of the user profile.

| Before | After |
|--------|-------|
| <img width="473" alt="before" src="https://user-images.githubusercontent.com/1816888/121266287-74bae180-c877-11eb-8a75-8d1c9d4144d5.png"> | <img width="475" alt="after" src="https://user-images.githubusercontent.com/1816888/121266293-784e6880-c877-11eb-876b-646adb0d34c0.png"> |

- Do the same on the iPad.
- Verify the bottom margin has not changed.

<kbd><img width="451" alt="ipad" src="https://user-images.githubusercontent.com/1816888/121266336-92884680-c877-11eb-919d-a9567f36c987.png"></kbd>


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
