### PR TITLE
Fix: Remove the notice that over laps with the Editor More ActionSheet

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [*] Site Pages: when setting a parent, placeholder text is now displayed for pages with blank titles. [#16661]
 * [***] Block Editor: Audio block now available on WP.com sites on the free plan. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3523]
 * [**] You can now create a Site Icon for your site using an emoji. [#16670] 
+* [*] Fix notice overlapping the ActionSheet that displays the More Actions in the Editor. [#16658]
 
 17.5
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -11,6 +11,8 @@ extension GutenbergViewController {
     }
 
     func displayMoreSheet() {
+        // Dismisses and locks the Notices Store from displaying any new notices.
+        ActionDispatcher.dispatch(NoticeAction.lock)
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         if mode == .richText, let contentInfo = contentInfo {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AutomatticTracks
+import WordPressFlux
 
 /// This extension handles the "more" actions triggered by the top right
 /// navigation bar button of Gutenberg editor.
@@ -24,6 +25,7 @@ extension GutenbergViewController {
 
             alert.addDefaultActionWithTitle(buttonTitle) { _ in
                 self.secondaryPublishButtonTapped()
+                ActionDispatcher.dispatch(NoticeAction.unlock)
             }
         }
 
@@ -37,15 +39,18 @@ extension GutenbergViewController {
 
         alert.addDefaultActionWithTitle(toggleModeTitle) { [unowned self] _ in
             self.toggleEditingMode()
+            ActionDispatcher.dispatch(NoticeAction.unlock)
         }
 
         alert.addDefaultActionWithTitle(MoreSheetAlert.previewTitle) { [weak self] _ in
             self?.displayPreview()
+            ActionDispatcher.dispatch(NoticeAction.unlock)
         }
 
         if (post.revisions ?? []).count > 0 {
             alert.addDefaultActionWithTitle(MoreSheetAlert.historyTitle) { [weak self] _ in
                 self?.displayHistory()
+                ActionDispatcher.dispatch(NoticeAction.unlock)
             }
         }
 
@@ -54,9 +59,12 @@ extension GutenbergViewController {
 
         alert.addDefaultActionWithTitle(settingsTitle) { [weak self] _ in
             self?.displayPostSettings()
+            ActionDispatcher.dispatch(NoticeAction.unlock)
         }
 
-        alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
+        alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle) { _ in
+            ActionDispatcher.dispatch(NoticeAction.unlock)
+        }
 
         if #available(iOS 14.0, *),
             let button = navigationBarManager.moreBarButtonItem.customView {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -798,7 +798,6 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             case .close:
                 cancelEditing()
             case .more:
-                ActionDispatcher.dispatch(NoticeAction.lock)
                 displayMoreSheet()
             case .switchBlog:
                 blogPickerWasPressed()

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -798,6 +798,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             case .close:
                 cancelEditing()
             case .more:
+                ActionDispatcher.dispatch(NoticeAction.lock)
                 displayMoreSheet()
             case .switchBlog:
                 blogPickerWasPressed()


### PR DESCRIPTION
Fixes the notice overlap that currently shows up when you save a post and then click on the three dots. 

To test:
1. Create a new post or page in the editor. 
2. Save the post as draft. 
3. Once the post is done saving notice that when you click on the 3 dots again that the notice that shows up doesn't overlap the ActionSheet that. 

See for how the action sheet works on this PR. 

<table>
<tr><td>Before</td><td>After</td></tr>
<tr><td><img width="300" src="https://user-images.githubusercontent.com/115071/121299501-61753980-c8aa-11eb-9262-8e919afa4dfd.png" /></td><td>

https://user-images.githubusercontent.com/115071/121298625-0b53c680-c8a9-11eb-89d8-2871eb445a6a.mp4

</td></tr>
</table>


The fix is very similar to https://github.com/wordpress-mobile/WordPress-iOS/pull/16609

## Regression Notes
1. Potential unintended areas of impact
Not sure. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
This was tested manually. 

3. What automated tests I added (or what prevented me from doing so)
I don't know how to add automated tests for this. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
