### PR TITLE
Comments: update alert to indicate a Comment will be permanently deleted.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -491,18 +491,27 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 {
     __typeof(self) __weak weakSelf = self;
 
-    NSString *message = NSLocalizedString(@"Are you sure you want to delete this comment?",
-                                          @"Message asking for confirmation on comment deletion");
+    // If the Comment is currently Spam or Trash, the Trash action will permanently delete the Comment.
+    // Set the displayed messages accordingly.
+    BOOL willBePermanentlyDeleted = [self.comment.status isEqualToString:CommentStatusSpam] ||
+                                    [self.comment.status isEqualToString:CommentStatusUnapproved];
+    
+    NSString *trashMessage = NSLocalizedString(@"Are you sure you want to mark this comment as Trash?",
+                                               @"Message asking for confirmation before marking a comment as trash");
+    NSString *deleteMessage = NSLocalizedString(@"Are you sure you want to permanently delete this comment?",
+                                                @"Message asking for confirmation on comment deletion");
+    NSString *trashTitle = NSLocalizedString(@"Trash", @"Trash button title");
+    NSString *deleteTitle = NSLocalizedString(@"Delete", @"Delete button title");
     
     UIAlertController *alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Confirm", @"Confirm")
-                                                                             message:message
+                                                                             message:willBePermanentlyDeleted ? deleteMessage : trashMessage
                                                                       preferredStyle:UIAlertControllerStyleAlert];
     
     UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Cancel")
                                                            style:UIAlertActionStyleCancel
                                                          handler:nil];
     
-    UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Delete", @"Delete")
+    UIAlertAction *deleteAction = [UIAlertAction actionWithTitle:willBePermanentlyDeleted ? deleteTitle : trashTitle
                                                            style:UIAlertActionStyleDestructive
                                                          handler:^(UIAlertAction *action) {
                                                             [weakSelf deleteAction];


### PR DESCRIPTION
Fixes #n/a

When selecting the `Trash` action on a Comment:
- If the comment is already Spam or Trash, the alert indicates the comment will be permanently deleted.
- Otherwise, the alert indicates the comment will be marked as Trash.

I didn't change the `Trash` moderation button title as that's a bit more convoluted, and we're going to fix it with Comment Unification anyway. So I just updated the alerts to be clearer about what's happening.

To test:
- Go to Comments.
- On a Comment that is _not_ Spam or Trash, select `Trash`.
- Verify the alert confirms marking as Trash.

<kbd><img width="303" alt="confirm_trash" src="https://user-images.githubusercontent.com/1816888/121424671-d38f6200-c92e-11eb-8cd9-bf248ddf6cc6.png"></kbd>

- On a Comment that is Spam or Trash, select `Trash`.
- Verify the alert confirms permanent deletion.

<kbd><img width="302" alt="confirm_delete" src="https://user-images.githubusercontent.com/1816888/121424809-ffaae300-c92e-11eb-9c48-e83363a210e2.png"></kbd>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
