### PR TITLE
Fixes keyboard avoidance for the Stories prepublishing sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PrepublishingViewController.swift
@@ -59,6 +59,8 @@ class PrepublishingViewController: UITableViewController {
         return nuxButton
     }()
 
+    private weak var titleField: UITextField?
+
     /// Determines whether the text has been first responder already. If it has, don't force it back on the user unless it's been selected by them.
     private var hasSelectedText: Bool = false
 
@@ -117,6 +119,14 @@ class PrepublishingViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
+
+        // Setting titleField first resonder alongside our transition to avoid layout issues.
+        transitionCoordinator?.animateAlongsideTransition(in: nil, animation: { [weak self] _ in
+            if self?.hasSelectedText == false {
+                self?.titleField?.becomeFirstResponder()
+                self?.hasSelectedText = true
+            }
+        })
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -239,10 +249,7 @@ class PrepublishingViewController: UITableViewController {
         cell.textField.heightAnchor.constraint(equalToConstant: 40).isActive = true
         cell.textField.autocorrectionType = .yes
         cell.textField.autocapitalizationType = .sentences
-        if !hasSelectedText {
-            cell.textField.becomeFirstResponder()
-            hasSelectedText = true
-        }
+        titleField = cell.textField
     }
 
     // MARK: - Tags


### PR DESCRIPTION
Fixes an issue identified in 17.5 regression where the Stories prepublishing sheet stays in compact mode obscured by the keyboard.

There were some recent changes to Bottom Sheet which I think ended up triggering this but animating the first responder status for the title field solves the layout contention with the same animation as before.

| Before | After |
| ------ | ----- |
| <a href="https://user-images.githubusercontent.com/3250/121595423-7d3c2500-c9fb-11eb-9425-3312ffec677b.jpeg"><img src="https://user-images.githubusercontent.com/3250/121595423-7d3c2500-c9fb-11eb-9425-3312ffec677b.jpeg" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/121595200-47973c00-c9fb-11eb-844f-61e1113c53ed.PNG"><img src="https://user-images.githubusercontent.com/3250/121595200-47973c00-c9fb-11eb-844f-61e1113c53ed.PNG" width="300"></a> |


## Testing

**Physical iOS Device must be used since the Story editor will not export using the simulator.**

* Create a new Story post
* Add media or take a photo
* Hit the Publishing arrow
* Verify that the keyboard appears and the Title field is visible and being edited.

## Regression Notes
1. Potential unintended areas of impact

Other Prepublishing sheet appearances (blog posts, site pages)

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested each of these and did not notice any behavior changes.

3. What automated tests I added (or what prevented me from doing so)

Started to add a UI Test but the Story editor crashes in the simulator due to a difference in OpenGL rendering.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
