### PR TITLE
[Tooling] Fix GitHub releases for intermediate betas

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -346,7 +346,7 @@ platform :ios do
 
     build_and_upload_internal(skip_prechecks: true, skip_confirm: options[:skip_confirm]) if options[:beta_release]
     build_and_upload_itc(skip_prechecks: true, skip_confirm: options[:skip_confirm],
-                         final: !options[:beta_release], create_release: options[:create_gh_release])
+                         beta_release: options[:beta_release], create_release: options[:create_gh_release])
   end
 
   #####################################################################################
@@ -477,13 +477,13 @@ platform :ios do
   # This lane builds the app and upload it for external distribution
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane build_and_upload_itc [skip_confirm:<skip confirm>] [create_release:<Create release on GH> ]
+  # bundle exec fastlane build_and_upload_itc [skip_confirm:<skip confirm>] [create_release:<Create release on GH>] [beta_release:<intermediate beta?>]
   #
   # Example:
   # bundle exec fastlane build_and_upload_itc
   # bundle exec fastlane build_and_upload_itc skip_confirm:true
   # bundle exec fastlane build_and_upload_itc create_release:true
-  # bundle exec fastlane build_and_upload_itc create_release:true final:true
+  # bundle exec fastlane build_and_upload_itc create_release:true beta_release:true
   #####################################################################################
   desc 'Builds and uploads for distribution'
   lane :build_and_upload_itc do |options|
@@ -518,13 +518,13 @@ platform :ios do
       archive_zip_path = File.join(PROJECT_ROOT_FOLDER, 'WordPress.xarchive.zip')
       zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
 
-      version = options[:final] ? ios_get_app_version : ios_get_build_version
+      version = options[:beta_release] ? ios_get_build_version : ios_get_app_version
       create_release(
         repository: GHHELPER_REPO,
         version: version,
         release_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'),
         release_assets: archive_zip_path.to_s,
-        prerelease: !options[:final]
+        prerelease: options[:beta_release]
       )
 
       FileUtils.rm_rf(archive_zip_path)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -107,7 +107,7 @@ platform :ios do
     ios_bump_version_release
     new_version = ios_get_app_version
     extract_release_notes_for_version(version: new_version,
-      release_notes_file_path: FIle.join(ENV["PROJECT_ROOT_FOLDER"], 'RELEASE-NOTES.txt'),
+      release_notes_file_path: File.join(ENV["PROJECT_ROOT_FOLDER"], 'RELEASE-NOTES.txt'),
       extracted_notes_file_path: './WooCommerce/Resources/release_notes.txt')
     ios_update_release_notes(new_version: new_version)
     get_prs_list(repository: GHHELPER_REPO, milestone: new_version.to_s,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,7 +108,7 @@ platform :ios do
     new_version = ios_get_app_version
     extract_release_notes_for_version(version: new_version,
       release_notes_file_path: File.join(ENV["PROJECT_ROOT_FOLDER"], 'RELEASE-NOTES.txt'),
-      extracted_notes_file_path: './WooCommerce/Resources/release_notes.txt')
+      extracted_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'))
     ios_update_release_notes(new_version: new_version)
     get_prs_list(repository: GHHELPER_REPO, milestone: new_version.to_s,
                  report_path: "#{File.expand_path('~')}/wpios_prs_list_#{old_version}_#{new_version}.txt")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -106,6 +106,9 @@ platform :ios do
 
     ios_bump_version_release
     new_version = ios_get_app_version
+    extract_release_notes_for_version(version: new_version,
+      release_notes_file_path: FIle.join(ENV["PROJECT_ROOT_FOLDER"], 'RELEASE-NOTES.txt'),
+      extracted_notes_file_path: './WooCommerce/Resources/release_notes.txt')
     ios_update_release_notes(new_version: new_version)
     get_prs_list(repository: GHHELPER_REPO, milestone: new_version.to_s,
                  report_path: "#{File.expand_path('~')}/wpios_prs_list_#{old_version}_#{new_version}.txt")
@@ -223,8 +226,8 @@ platform :ios do
   #####################################################################################
   # finalize_release
   # -----------------------------------------------------------------------------------
-  # This lane finalize a release: updates store metadata, pushes the final tag and
-  # cleans all the temp ones
+  # This lane finalize a release: updates store metadata, bump final version number,
+  # remove branch protection and close milestone, then trigger the final release on CI
   # -----------------------------------------------------------------------------------
   # Usage:
   # bundle exec fastlane finalize_release [skip_confirm:<skip confirm>] [version:<version>]
@@ -233,7 +236,7 @@ platform :ios do
   # bundle exec fastlane finalize_release
   # bundle exec fastlane finalize_release skip_confirm:true
   #####################################################################################
-  desc 'Removes all the temp tags and puts the final one'
+  desc 'Trigger the final release build on CI'
   lane :finalize_release do |options|
     ios_finalize_prechecks(options)
     unless ios_current_branch_is_hotfix
@@ -244,7 +247,6 @@ platform :ios do
 
     # Wrap up
     version = ios_get_app_version
-    # ios_clear_intermediate_tags(version: version)
     removebranchprotection(repository: GHHELPER_REPO, branch: "release/#{version}")
     setfrozentag(repository: GHHELPER_REPO, milestone: version, freeze: false)
     create_new_milestone(repository: GHHELPER_REPO)
@@ -344,7 +346,7 @@ platform :ios do
 
     build_and_upload_internal(skip_prechecks: true, skip_confirm: options[:skip_confirm]) if options[:beta_release]
     build_and_upload_itc(skip_prechecks: true, skip_confirm: options[:skip_confirm],
-                         create_release: options[:create_gh_release])
+                         final: !options[:beta_release], create_release: options[:create_gh_release])
   end
 
   #####################################################################################
@@ -481,6 +483,7 @@ platform :ios do
   # bundle exec fastlane build_and_upload_itc
   # bundle exec fastlane build_and_upload_itc skip_confirm:true
   # bundle exec fastlane build_and_upload_itc create_release:true
+  # bundle exec fastlane build_and_upload_itc create_release:true final:true
   #####################################################################################
   desc 'Builds and uploads for distribution'
   lane :build_and_upload_itc do |options|
@@ -515,12 +518,13 @@ platform :ios do
       archive_zip_path = File.join(PROJECT_ROOT_FOLDER, 'WordPress.xarchive.zip')
       zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
 
-      version = ios_get_app_version
+      version = options[:final] ? ios_get_app_version : ios_get_build_version
       create_release(
         repository: GHHELPER_REPO,
         version: version,
         release_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'),
-        release_assets: archive_zip_path.to_s
+        release_assets: archive_zip_path.to_s,
+        prerelease: !options[:final]
       )
 
       FileUtils.rm_rf(archive_zip_path)


### PR DESCRIPTION
### Why?

_Similar PR than WCiOS's https://github.com/woocommerce/woocommerce-ios/pull/4404_

Fix the GitHub releases drafts being incorrect for intermediate betas:
 - They used the final version number (`x.y`) for the release name and tag instead of the build number (`x.y.0.N`)
 - They had the incorrect release notes (used the previous ones for any beta — including the first one — created before we manually update the notes with Editorial copy)
 - They didn't have the "Pre-release" checkbox checked on them


### To Test

Not easy to test from start to finish without creating a new beta… we're close to do the `finalize_release` for this Sprint later today, so not worth create a new beta just couple of minutes ago I guess, so not sure if there's a way to dry-run/test this 😒 

So maybe the best way to test this besides just reviewing the code is to test this during the next cycle…


## Regression Notes
1. Potential unintended areas of impact
-
2. What I did to test those areas of impact (or what existing automated tests I relied on)
-
3. What automated tests I added (or what prevented me from doing so)
-

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
