### PR TITLE
Remove double import of AutomatticTracks from app delegate

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -5,7 +5,6 @@ import AutomatticTracks
 import WordPressAuthenticator
 import WordPressShared
 import AlamofireNetworkActivityIndicator
-import AutomatticTracks
 
 #if APPCENTER_ENABLED
 import AppCenter


### PR DESCRIPTION
If the app compiles on CI, we're good because this just a redundant `import` removal, no functionality has been changed.

## Regression Notes
1. Potential unintended areas of impact
N.A.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.


3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**