### PR TITLE
Address compiler warnings in UI tests targets

### DIFF
--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -43,7 +43,6 @@ class MySiteScreen: BaseScreen {
 
     init() {
         let app = XCUIApplication()
-        let blogTable = app.tables[ElementStringIDs.blogTable]
         tabBar = TabNavComponent()
         removeSiteButton = app.cells[ElementStringIDs.removeSiteButton]
         removeSiteSheet = app.sheets.buttons.element(boundBy: 0)

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -95,7 +95,7 @@ class LoginTests: XCTestCase {
     // Unified self hosted login/out
     // Replaces testSelfHostedUsernamePasswordLoginLogout
     func testSelfHostedLoginLogout() {
-        _ = PrologueScreen().selectSiteAddress()
+        PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
             .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
@@ -108,7 +108,7 @@ class LoginTests: XCTestCase {
     // Old self hosted login/out
     // TODO: remove when unifiedAuth is permanent.
     func testSelfHostedUsernamePasswordLoginLogout() {
-        _ = WelcomeScreen().selectLogin()
+        WelcomeScreen().selectLogin()
             .goToSiteAddressLogin()
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)


### PR DESCRIPTION
Addresses two minor warnings:

- Using '_' to ignore the result of a Void-returning function is redundant
- Unused `let` assignent

If CI builds the app, we're good.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
