### PR TITLE
Upgrade ZendeskSupportSDK pod from 5.2.0 to 5.3.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -178,7 +178,7 @@ abstract_target 'Apps' do
     pod 'MRProgress', '0.8.3'
     pod 'Starscream', '3.0.6'
     pod 'SVProgressHUD', '2.2.5'
-    pod 'ZendeskSupportSDK', '5.2.0'
+    pod 'ZendeskSupportSDK', '5.3.0'
     pod 'AlamofireImage', '3.5.2'
     pod 'AlamofireNetworkActivityIndicator', '~> 2.4'
     pod 'FSInteractiveMap', :git => 'https://github.com/wordpress-mobile/FSInteractiveMap.git', :tag => '0.2.0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -467,19 +467,19 @@ PODS:
   - WPMediaPicker (1.7.2)
   - wpxmlrpc (0.9.0)
   - Yoga (1.14.0)
-  - ZendeskCommonUISDK (6.1.0)
-  - ZendeskCoreSDK (2.5.0)
-  - ZendeskMessagingAPISDK (3.8.1):
-    - ZendeskSDKConfigurationsSDK (~> 1.1.7)
-  - ZendeskMessagingSDK (3.8.1):
-    - ZendeskCommonUISDK (~> 6.1.0)
-    - ZendeskMessagingAPISDK (~> 3.8.1)
-  - ZendeskSDKConfigurationsSDK (1.1.7)
-  - ZendeskSupportProvidersSDK (5.2.0):
-    - ZendeskCoreSDK (~> 2.5.0)
-  - ZendeskSupportSDK (5.2.0):
-    - ZendeskMessagingSDK (~> 3.8.1)
-    - ZendeskSupportProvidersSDK (~> 5.2.0)
+  - ZendeskCommonUISDK (6.1.1)
+  - ZendeskCoreSDK (2.5.1)
+  - ZendeskMessagingAPISDK (3.8.2):
+    - ZendeskSDKConfigurationsSDK (~> 1.1.8)
+  - ZendeskMessagingSDK (3.8.2):
+    - ZendeskCommonUISDK (~> 6.1.1)
+    - ZendeskMessagingAPISDK (~> 3.8.2)
+  - ZendeskSDKConfigurationsSDK (1.1.8)
+  - ZendeskSupportProvidersSDK (5.3.0):
+    - ZendeskCoreSDK (~> 2.5.1)
+  - ZendeskSupportSDK (5.3.0):
+    - ZendeskMessagingSDK (~> 3.8.2)
+    - ZendeskSupportProvidersSDK (~> 5.3.0)
   - ZIPFoundation (0.9.12)
 
 DEPENDENCIES:
@@ -559,7 +559,7 @@ DEPENDENCIES:
   - WordPressUI (~> 1.12.1-beta)
   - WPMediaPicker (~> 1.7.2)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.56.0-alpha1/third-party-podspecs/Yoga.podspec.json`)
-  - ZendeskSupportSDK (= 5.2.0)
+  - ZendeskSupportSDK (= 5.3.0)
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
@@ -820,15 +820,15 @@ SPEC CHECKSUMS:
   WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
   Yoga: 982b1e7bf7c0873643955853293b269e4487890e
-  ZendeskCommonUISDK: 92ca6b16956430a2cb61c89aeaa6ca123d1f81fd
-  ZendeskCoreSDK: f3d5dcd6a18186dcecbecd56f66296c40fb2fcb4
-  ZendeskMessagingAPISDK: 986919a8f6f11a7019660d1ff798f1efb42fa572
-  ZendeskMessagingSDK: bf9a06f0cbb219617d9cf60a46aba1b68c8f3b30
-  ZendeskSDKConfigurationsSDK: 45fa87ec8418697f7fce5e56bec472052f0aedb5
-  ZendeskSupportProvidersSDK: 5221df6ca45e0b6f12470a5e8e65ccf3ccca17fa
-  ZendeskSupportSDK: e100a7a0a1bb5d7d43abbde3338727d985a4986d
+  ZendeskCommonUISDK: 5808802951ad2bb424f0bed4259dc3c0ce9b52ec
+  ZendeskCoreSDK: 19a18e5ef2edcb18f4dbc0ea0d12bd31f515712a
+  ZendeskMessagingAPISDK: 144e0fb0e633a3c4e73149b781ab65338938d5a8
+  ZendeskMessagingSDK: 500e83d9413481e95180c37ddca0d4ef9d515600
+  ZendeskSDKConfigurationsSDK: 8371b468db0d09e9198f6c5a97818826943ee1ee
+  ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
+  ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 06e96ab71c38e95d03feab07db771d7b6e457616
+PODFILE CHECKSUM: 1c05dc7895c6918ca8cd9f5c49c49912f62e7c5c
 
 COCOAPODS: 1.10.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 17.7
 -----
 
+* [*] Upgraded the Zendesk SDK to version 5.3.0
 
 17.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,7 +12,7 @@
 * [*] Fix notice overlapping the ActionSheet that displays the QuickStart Removal. [#16609]
 * [*] Site Pages: when setting a parent, placeholder text is now displayed for pages with blank titles. [#16661]
 * [***] Block Editor: Audio block now available on WP.com sites on the free plan. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3523]
-* [**] You can now create a Site Icon for your site using an emoji. [#16670] 
+* [**] You can now create a Site Icon for your site using an emoji. [#16670]
 * [*] Fix notice overlapping the ActionSheet that displays the More Actions in the Editor. [#16658]
 
 17.5
@@ -31,7 +31,7 @@
 -----
 * [**] A new author can be chosen for Posts and Pages on multi-author sites. [#16281]
 * [*] Fixed the Follow Sites Quick Start Tour so that Reader Search is highlighted. [#16391]
-* [*] Enabled approving login authentication requests via push notification while the app is in the foreground. [#16075] 
+* [*] Enabled approving login authentication requests via push notification while the app is in the foreground. [#16075]
 * [**] Added pull-to-refresh to the My Site screen when a user has no sites. [#16241]
 * [***] Fixed a bug that was causing uploaded videos to not be viewable in other platforms. [#16548]
 
@@ -74,7 +74,7 @@
 * [**] Block Editor: Added Contact Info block to sites on WPcom or with Jetpack version >= 8.5.
 * [**] We updated the app's color scheme with a brighter new blue used throughout. [#16213, #16207]
 * [**] We updated the login prologue with brand new content and graphics. [#16159, #16177, #16185, #16187, #16200, #16217, #16219, #16221, #16222]
-* [**] We updated the app's color scheme with a brighter new blue used throughout. [#16213, #16207] 
+* [**] We updated the app's color scheme with a brighter new blue used throughout. [#16213, #16207]
 * [**] Updated the app icon to match the new color scheme within the app. [#16220]
 * [*] Fixed an issue where some webview navigation bar controls weren't visible. [#16257]
 
@@ -87,7 +87,7 @@
 * [*] Added a thumbnail device mode selector in the page layout, and use a default setting based on the current device. [#16019]
 * [**] Comments can now be filtered by status (All, Pending, Approved, Trashed, or Spam). [#15955, #16110]
 * [*] Notifications: Enabled the new view milestone notifications [#16144]
-* [***] We updated the app's design, with fresh new headers throughout and a new site switcher in My Site. [#15750] 
+* [***] We updated the app's design, with fresh new headers throughout and a new site switcher in My Site. [#15750]
 
 16.9
 -----
@@ -106,7 +106,7 @@
 -----
 
 * [**] Stories: Fixed an issue which could remove content from a post when a new Story block was edited. [#16059]
- 
+
 16.8
 -----
 * [**] Prevent deleting published homepages which would have the effect of breaking a site. [#15797]


### PR DESCRIPTION
There are no changes that affect us in this minor version bump, as you can see in the [release notes](https://developer.zendesk.com/documentation/classic-sdks/support-sdk/ios/release_notes/#530).

The only change they disclose is the _deprecation_ of `getFlatArticlesWithCallback`. We don't use that method, as you can verify running:

```
git grep getFlatArticlesWithCallback
```

_@momo-ozawa, @ScoutHarris, @emilylaguna GitHub suggested I ask for your review. Sorry if this is spam instead_ 😅

## To test

Really, this PR should not grant any testing. Still, I triggered an installable build and played around with the Zendesk integration. Feel free to do the same.

**Opened a ticket from the app**

<img alt="IMG_5361" src="https://user-images.githubusercontent.com/1218433/122147922-1dcb9280-ce9d-11eb-9ff2-a2c739fcee59.PNG" width=300/>


**Verified it was received from the Zendesk UI**

<img alt="image" src="https://user-images.githubusercontent.com/1218433/122147805-f1b01180-ce9c-11eb-9070-7bbae379b2b1.png" width=300/>


## Regression Notes
1. Potential unintended areas of impact
The Zendesk integration

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See "To test" above.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**