### PR TITLE
Improve navigation transitions in the Blogging Reminders setup flow on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersAnimator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersAnimator.swift
@@ -1,0 +1,37 @@
+/// A transition animator that moves in the pushed view controller horizontally.
+/// Does not handle the pop animation since the BloggingReminders setup flow does not allow to navigate back.
+class BloggingRemindersAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        return 0.2
+    }
+
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+
+        guard let sourceViewController =
+                transitionContext
+                .viewController(forKey: UITransitionContextViewControllerKey.from),
+              let destinationViewController =
+                transitionContext
+                .viewController(forKey: UITransitionContextViewControllerKey.to) else {
+
+            return
+        }
+        // final position of the destination view
+        let endFrame = transitionContext.finalFrame(for: destinationViewController)
+
+        // initial position of the destination view
+        let startFrame = endFrame.offsetBy(dx: endFrame.width, dy: .zero)
+        destinationViewController.view.frame = startFrame
+
+        sourceViewController.view.alpha = .zero
+        transitionContext.containerView.insertSubview(destinationViewController.view, aboveSubview: sourceViewController.view)
+
+        UIView.animate(withDuration: transitionDuration(using: transitionContext),
+                       animations: {
+                        destinationViewController.view.frame = endFrame
+                       }, completion: {_ in
+                        transitionContext.completeTransition(true)
+                       })
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersAnimator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersAnimator.swift
@@ -2,8 +2,11 @@
 /// Does not handle the pop animation since the BloggingReminders setup flow does not allow to navigate back.
 class BloggingRemindersAnimator: NSObject, UIViewControllerAnimatedTransitioning {
 
+    private static let animationDuration: TimeInterval = 0.2
+    private static let sourceEndFrameOffset: CGFloat = -60.0
+
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        return 0.2
+        return Self.animationDuration
     }
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
@@ -16,18 +19,20 @@ class BloggingRemindersAnimator: NSObject, UIViewControllerAnimatedTransitioning
             return
         }
         // final position of the destination view
-        let endFrame = transitionContext.finalFrame(for: destinationViewController)
+        let destinationEndFrame = transitionContext.finalFrame(for: destinationViewController)
+        // final position of the source view
+        let sourceEndFrame = transitionContext.initialFrame(for: sourceViewController).offsetBy(dx: Self.sourceEndFrameOffset, dy: .zero)
 
         // initial position of the destination view
-        let startFrame = endFrame.offsetBy(dx: endFrame.width, dy: .zero)
-        destinationViewController.view.frame = startFrame
+        let destinationStartFrame = destinationEndFrame.offsetBy(dx: destinationEndFrame.width, dy: .zero)
+        destinationViewController.view.frame = destinationStartFrame
 
-        sourceViewController.view.alpha = .zero
         transitionContext.containerView.insertSubview(destinationViewController.view, aboveSubview: sourceViewController.view)
 
         UIView.animate(withDuration: transitionDuration(using: transitionContext),
                        animations: {
-                        destinationViewController.view.frame = endFrame
+                        destinationViewController.view.frame = destinationEndFrame
+                        sourceViewController.view.frame = sourceEndFrame
                        }, completion: {_ in
                         transitionContext.completeTransition(true)
                        })

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersAnimator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersAnimator.swift
@@ -9,11 +9,9 @@ class BloggingRemindersAnimator: NSObject, UIViewControllerAnimatedTransitioning
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
 
         guard let sourceViewController =
-                transitionContext
-                .viewController(forKey: UITransitionContextViewControllerKey.from),
+                transitionContext.viewController(forKey: UITransitionContextViewControllerKey.from),
               let destinationViewController =
-                transitionContext
-                .viewController(forKey: UITransitionContextViewControllerKey.to) else {
+                transitionContext.viewController(forKey: UITransitionContextViewControllerKey.to) else {
 
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
@@ -6,6 +6,15 @@ protocol ChildDrawerPositionable {
 
 class BloggingRemindersNavigationController: LightNavigationController {
 
+    override init(rootViewController: UIViewController) {
+        super.init(rootViewController: rootViewController)
+        delegate = self
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return .portrait
     }
@@ -76,5 +85,19 @@ extension BloggingRemindersNavigationController: DrawerPresentable {
 
     func handleDismiss() {
         (children.last as? DrawerPresentable)?.handleDismiss()
+    }
+}
+
+// MARK: - NavigationControllerDelegate
+
+extension BloggingRemindersNavigationController: UINavigationControllerDelegate {
+
+    /// This implementation uses the custom `BloggingRemindersAnimator` to improve screen transitions
+    /// in the blogging reminders setup flow.
+    func navigationController(_ navigationController: UINavigationController,
+                              animationControllerFor operation: UINavigationController.Operation,
+                              from fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+
+        return BloggingRemindersAnimator()
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -539,6 +539,8 @@
 		3FAA18CC25797B85002B1911 /* UnconfiguredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FAA18CB25797B85002B1911 /* UnconfiguredView.swift */; };
 		3FB34ACB25672A90001A74A6 /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB34ACA25672A90001A74A6 /* HomeWidgetTodayData.swift */; };
 		3FB34ADA25672AA5001A74A6 /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB34ACA25672A90001A74A6 /* HomeWidgetTodayData.swift */; };
+		3FBF21B7267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
+		3FBF21B8267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FC7F89E2612341900FD8728 /* UnifiedPrologueStatsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC7F89D2612341900FD8728 /* UnifiedPrologueStatsContentView.swift */; };
 		3FC8D19B244F43B500495820 /* ReaderTabItemsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */; };
 		3FCC8FD9256C911300810295 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -5093,6 +5095,7 @@
 		3FA640652670CEFE0064401E /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		3FAA18CB25797B85002B1911 /* UnconfiguredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnconfiguredView.swift; sourceTree = "<group>"; };
 		3FB34ACA25672A90001A74A6 /* HomeWidgetTodayData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWidgetTodayData.swift; sourceTree = "<group>"; };
+		3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingRemindersAnimator.swift; sourceTree = "<group>"; };
 		3FC7F89D2612341900FD8728 /* UnifiedPrologueStatsContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedPrologueStatsContentView.swift; sourceTree = "<group>"; };
 		3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabItemsStore.swift; sourceTree = "<group>"; };
 		3FCCAA1423F4A1A3004064C0 /* UIBarButtonItem+MeBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+MeBarButton.swift"; sourceTree = "<group>"; };
@@ -8772,6 +8775,7 @@
 		3F170D2A2654615900F6F670 /* Blogging Reminders */ = {
 			isa = PBXGroup;
 			children = (
+				3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */,
 				3F170D2B2654618000F6F670 /* BloggingRemindersCell.swift */,
 				3F170EC22655DD1700F6F670 /* BloggingRemindersCard.swift */,
 				17171373265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift */,
@@ -17343,6 +17347,7 @@
 				E6DAABDD1CF632EC0069D933 /* ReaderSearchSuggestionsViewController.swift in Sources */,
 				8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */,
 				3F170D2C2654618000F6F670 /* BloggingRemindersCell.swift in Sources */,
+				3FBF21B7267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */,
 				C700FAB2258020DB0090938E /* JetpackScanThreatCell.swift in Sources */,
 				D8C31CC62188490000A33B35 /* SiteSegmentsCell.swift in Sources */,
 				E6431DE51C4E892900FD8D90 /* SharingConnectionsViewController.m in Sources */,
@@ -20008,6 +20013,7 @@
 				FABB25C72602FC2C00C8785C /* WPStyleGuide+Gridicon.swift in Sources */,
 				FABB25C82602FC2C00C8785C /* RelatedPostsSettingsViewController.m in Sources */,
 				FABB25C92602FC2C00C8785C /* CreateButtonCoordinator.swift in Sources */,
+				3FBF21B8267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */,
 				FABB25CA2602FC2C00C8785C /* SearchManager.swift in Sources */,
 				FABB25CB2602FC2C00C8785C /* BlogToBlogMigration87to88.swift in Sources */,
 				FABB25CC2602FC2C00C8785C /* WPStyleGuide+Themes.swift in Sources */,


### PR DESCRIPTION
Fixes #NA

This PR improves the navigation in the Blogging Reminders setup flow on iPad.

To test:
- build/run on iPad
- Tap on "Get Started" in the blogging reminders card
- Navigate through the screens (tapping "Setup Goals" then "Next") and make sure the transition animations look smooth (see example below).
- Build/run on iPhone and make sure the same animations still look good

<p align=center>
<img width=450 src=https://user-images.githubusercontent.com/34376330/122297291-f8508000-cec0-11eb-9a2f-bdbd2cf45925.gif>
</p>

## Regression Notes
1. Potential unintended areas of impact
None: this change did not change anything existing, just adds a custom animation to a custom navigation controller (`BloggingRemindersNavigationController`)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-

3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
