### PR TITLE
Hides the quick action buttons when using accessibility font sizes.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 * [***] Block Editor: Audio block now available on WP.com sites on the free plan. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3523]
 * [**] You can now create a Site Icon for your site using an emoji. [#16670] 
 * [*] Fix notice overlapping the ActionSheet that displays the More Actions in the Editor. [#16658]
+* [*] The quick action buttons will be hidden when iOS is using a accessibility font sizes. [#16701]
 
 17.5
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/ActionRow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/ActionRow.swift
@@ -92,7 +92,7 @@ class ActionRow: UIStackView {
         distribution = .equalCentering
         spacing = Constants.minimumSpacing
         translatesAutoresizingMaskIntoConstraints = false
-        refreshStackViewAxis()
+        refreshStackViewVisibility()
     }
 
     // MARK: - Accessibility
@@ -100,14 +100,16 @@ class ActionRow: UIStackView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        refreshStackViewAxis()
+        refreshStackViewVisibility()
     }
 
-    private func refreshStackViewAxis() {
-        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
-            axis = .vertical
-        } else {
-            axis = .horizontal
+    private func refreshStackViewVisibility() {
+        for view in arrangedSubviews {
+            if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+                view.isHidden = true
+            } else {
+                view.isHidden = false
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/NewBlogDetailHeaderView.swift
@@ -140,6 +140,8 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
 
     // MARK: - Constraints
 
+    private var topActionRowConstraint: NSLayoutConstraint?
+
     private func setupConstraintsForChildViews(_ showsActionRow: Bool) {
         let actionRowConstraints = constraintsForActionRow(showsActionRow)
         let titleViewContraints = constraintsForTitleView()
@@ -151,8 +153,11 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
         let widthConstraint = actionRow.widthAnchor.constraint(equalToConstant: LayoutSpacing.maxButtonWidth)
         widthConstraint.priority = .defaultHigh
 
+        let topActionRowConstraint = actionRow.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: LayoutSpacing.betweenTitleViewAndActionRow(showsActionRow))
+        self.topActionRowConstraint = topActionRowConstraint
+
         return [
-            actionRow.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: LayoutSpacing.betweenTitleViewAndActionRow(showsActionRow)),
+            topActionRowConstraint,
             actionRow.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -LayoutSpacing.belowActionRow),
             actionRow.leadingAnchor.constraint(greaterThanOrEqualTo: titleView.leadingAnchor),
             actionRow.trailingAnchor.constraint(lessThanOrEqualTo: titleView.trailingAnchor),
@@ -187,6 +192,20 @@ class NewBlogDetailHeaderView: UIView, BlogDetailHeader {
     @objc
     private func subtitleButtonTapped() {
         delegate?.visitSiteTapped()
+    }
+
+    // MARK: - Accessibility
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        refreshStackViewVisibility()
+    }
+
+    private func refreshStackViewVisibility() {
+        let showsActionRow = !traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+
+        topActionRowConstraint?.constant = LayoutSpacing.betweenTitleViewAndActionRow(showsActionRow)
     }
 }
 


### PR DESCRIPTION
Hides the quick action buttons in the blog details view, when using accessibility font sizes.

| Before | After |
| --- | --- |
| <img width="275" src="https://user-images.githubusercontent.com/1836005/122435638-75025d80-cf98-11eb-8fac-2860608b03ae.jpg"> | <img width="275" alt="Screenshot 2021-06-17 at 18 14 33" src="https://user-images.githubusercontent.com/1836005/122435402-42586500-cf98-11eb-8155-cf04ae5a3e11.png"> |

## To test:

1. Switch between accessibility font sizes and regular ones.
2. Make sure whenever using accessibility font sizes the quick action buttons are hidden in "My Site".

## Regression Notes

1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
