### PR TITLE
Fix rake:credentials

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -505,9 +505,7 @@ namespace :credentials do
 
   #user given app id and secret and create a new wpcom_app_credentials file
   task :set_app_secrets do
-    create_secrets_file
     set_app_secrets(get_client_id, get_client_secret)
-    remove_temp_file
   end
 
   def get_client_id
@@ -520,30 +518,18 @@ namespace :credentials do
     STDIN.gets.strip
   end
 
-  #create temporary secrets file from example file
-  def create_secrets_file
-    sh "cp WordPress/Credentials/wpcom_app_credentials-example .configure-files/temp_wpcom_app_credentials", verbose: false
-  end
-
-  #create a new wpcom_app_credentials file combining the app secret and app id
+  # Duplicate the example file and add the new app secret and app id
   def set_app_secrets(id, secret)
-    puts "Creating credentials file"
-    new_file = File.new(".configure-files/wpcom_app_credentials", "w")
-    File.open(".configure-files/temp_wpcom_app_credentials") do |file|
-      file.each_line do |line|
-        if line.include? "WPCOM_APP_ID="
-          new_file.puts("WPCOM_APP_ID=#{id}")
-        elsif line.include? "WPCOM_APP_SECRET="
-          new_file.puts("WPCOM_APP_SECRET=#{secret}")
-        else
-          new_file.write(line)
-        end
-      end
-    end
-  end
+    puts 'Writing App ID and App Secret to secrets file'
 
-  def remove_temp_file
-    sh "rm .configure-files/temp_wpcom_app_credentials", verbose: false
+    replaced_text = File.read('WordPress/Credentials/Secrets-example.swift')
+      .gsub('let client = "0"', "let client=\"#{id}\"")
+      .gsub('let secret = "your-secret-here"', "let secret=\"#{secret}\"")
+
+    File.open('.configure-files/WordPress-Secrets.swift', 'w') { |file| 
+      file.puts replaced_text
+    }
+
   end
 end
 


### PR DESCRIPTION
Fixes an issue when running `rake credentials:setup`

**To test:**
- Run `rake credentials:setup` from the project root
- Enter in any example value
- Ensure that when the process is finished, the file at `.configure-files/WordPress-secrets.swift` contains the values you entered.

## Regression Notes
1. Potential unintended areas of impact
Could further break `rake credentials:setup`

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested it with several different input strings

3. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
