### PR TITLE
Issue/16710 - Flatten referrers list

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/UITableViewCell+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/UITableViewCell+Stats.swift
@@ -14,6 +14,7 @@ extension UITableViewCell {
                  forType statType: StatType,
                  limitRowsDisplayed: Bool = true,
                  rowDelegate: StatsTotalRowDelegate? = nil,
+                 referrerDelegate: StatsTotalRowReferrerDelegate? = nil,
                  viewMoreDelegate: ViewMoreRowDelegate? = nil) {
 
         let numberOfDataRows = dataRows.count
@@ -38,7 +39,7 @@ extension UITableViewCell {
         for index in 0..<numberOfRowsToAdd {
             let dataRow = dataRows[index]
             let row = StatsTotalRow.loadFromNib()
-            row.configure(rowData: dataRow, delegate: rowDelegate)
+            row.configure(rowData: dataRow, delegate: rowDelegate, referrerDelegate: referrerDelegate)
 
             // Don't show the separator line on the last row.
             if index == (numberOfRowsToAdd - 1) {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -8,7 +8,10 @@ import WordPressFlux
     @objc optional func expandedRowUpdated(_ row: StatsTotalRow, didSelectRow: Bool)
     @objc optional func viewMoreSelectedForStatSection(_ statSection: StatSection)
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
-    @objc func toggleSpamState(for referrerDomain: String, currentValue: Bool)
+}
+
+protocol SiteStatsReferrerDelegate: AnyObject {
+    func showReferrerDetails(_ data: StatsTotalRowData)
 }
 
 class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoadable {
@@ -129,6 +132,7 @@ private extension SiteStatsPeriodTableViewController {
                                              selectedDate: selectedDate,
                                              selectedPeriod: selectedPeriod,
                                              periodDelegate: self,
+                                             referrerDelegate: self,
                                              storeDelegate: self)
         viewModel?.statsBarChartViewDelegate = self
         addViewModelListeners()
@@ -304,11 +308,13 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
         postStatsTableViewController.configure(postID: postID, postTitle: postTitle, postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
+}
 
-    func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
-        showSpamActionSheet(for: referrerDomain, isSpam: currentValue) { [weak self] in
-            self?.viewModel?.toggleSpamState(for: referrerDomain, currentValue: currentValue)
-        }
+// MARK: - SiteStatsReferrerDelegate
+
+extension SiteStatsPeriodTableViewController: SiteStatsReferrerDelegate {
+    func showReferrerDetails(_ data: StatsTotalRowData) {
+        // TODO: implement
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -11,6 +11,7 @@ class SiteStatsPeriodViewModel: Observable {
     let changeDispatcher = Dispatcher<Void>()
 
     private weak var periodDelegate: SiteStatsPeriodDelegate?
+    private weak var referrerDelegate: SiteStatsReferrerDelegate?
     private let store: StatsPeriodStore
     private var lastRequestedDate: Date
     private var lastRequestedPeriod: StatsPeriodUnit {
@@ -42,8 +43,10 @@ class SiteStatsPeriodViewModel: Observable {
          selectedDate: Date,
          selectedPeriod: StatsPeriodUnit,
          periodDelegate: SiteStatsPeriodDelegate,
+         referrerDelegate: SiteStatsReferrerDelegate,
          storeDelegate: StatsPeriodStoreDelegate) {
         self.periodDelegate = periodDelegate
+        self.referrerDelegate = referrerDelegate
         self.store = store
         self.store.delegate = storeDelegate
         self.lastRequestedDate = selectedDate
@@ -422,7 +425,8 @@ private extension SiteStatsPeriodViewModel {
         tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
                                                  dataSubtitle: StatSection.periodReferrers.dataSubtitle,
                                                  dataRows: referrersDataRows(),
-                                                 siteStatsPeriodDelegate: periodDelegate))
+                                                 siteStatsPeriodDelegate: periodDelegate,
+                                                 siteStatsReferrerDelegate: referrerDelegate))
 
         return tableRows
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -18,6 +18,7 @@ class DetailDataCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var bottomExpandedSeparatorLine: UIView!
 
     private weak var detailsDelegate: SiteStatsDetailsDelegate?
+    private weak var referrerDelegate: SiteStatsReferrerDelegate?
     private var rowData: StatsTotalRowData?
     private typealias Style = WPStyleGuide.Stats
     private var row: StatsTotalRow?
@@ -26,6 +27,7 @@ class DetailDataCell: UITableViewCell, NibLoadable {
 
     func configure(rowData: StatsTotalRowData,
                    detailsDelegate: SiteStatsDetailsDelegate?,
+                   referrerDelegate: SiteStatsReferrerDelegate? = nil,
                    hideIndentedSeparator: Bool = false,
                    hideFullSeparator: Bool = true,
                    expanded: Bool = false,
@@ -36,9 +38,10 @@ class DetailDataCell: UITableViewCell, NibLoadable {
 
         self.rowData = rowData
         self.detailsDelegate = detailsDelegate
+        self.referrerDelegate = referrerDelegate
 
         let row = StatsTotalRow.loadFromNib()
-        row.configure(rowData: rowData, delegate: self, forDetails: true)
+        row.configure(rowData: rowData, delegate: self, referrerDelegate: self, forDetails: true)
 
         bottomExpandedSeparatorLine.isHidden = hideFullSeparator
 
@@ -95,8 +98,12 @@ extension DetailDataCell: StatsTotalRowDelegate {
     func toggleChildRows(for row: StatsTotalRow, didSelectRow: Bool) {
         detailsDelegate?.toggleChildRowsForRow?(row)
     }
+}
 
-    func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
-        detailsDelegate?.toggleSpamState(for: referrerDomain, currentValue: currentValue)
+// MARK: - StatsTotalRowReferrerDelegate
+
+extension DetailDataCell: StatsTotalRowReferrerDelegate {
+    func showReferrerDetails(_ data: StatsTotalRowData) {
+        referrerDelegate?.showReferrerDetails(data)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -7,7 +7,6 @@ import WordPressFlux
     @objc optional func toggleChildRowsForRow(_ row: StatsTotalRow)
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
     @objc optional func displayMediaWithID(_ mediaID: NSNumber)
-    @objc func toggleSpamState(for referrerDomain: String, currentValue: Bool)
 }
 
 class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoadable {
@@ -146,7 +145,9 @@ extension SiteStatsDetailTableViewController: StatsForegroundObservable {
 private extension SiteStatsDetailTableViewController {
 
     func initViewModel() {
-        viewModel = SiteStatsDetailsViewModel(detailsDelegate: self, storeDelegate: self)
+        viewModel = SiteStatsDetailsViewModel(detailsDelegate: self,
+                                              referrerDelegate: self,
+                                              storeDelegate: self)
 
         guard let statSection = statSection else {
             return
@@ -314,11 +315,13 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
             DDLogInfo("Unable to get media when trying to show from Stats details: \(error.localizedDescription)")
         })
     }
+}
 
-    func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
-        showSpamActionSheet(for: referrerDomain, isSpam: currentValue) { [weak self] in
-            self?.viewModel?.toggleSpamState(for: referrerDomain, currentValue: currentValue)
-        }
+// MARK: - SiteStatsReferrerDelegate
+
+extension SiteStatsDetailTableViewController: SiteStatsReferrerDelegate {
+    func showReferrerDetails(_ data: StatsTotalRowData) {
+        // TODO: implement
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -14,6 +14,7 @@ class SiteStatsDetailsViewModel: Observable {
 
     private var statSection: StatSection?
     private weak var detailsDelegate: SiteStatsDetailsDelegate?
+    private weak var referrerDelegate: SiteStatsReferrerDelegate?
 
     private let insightsStore = StoreContainer.shared.statsInsights
     private var insightsReceipt: Receipt?
@@ -32,8 +33,10 @@ class SiteStatsDetailsViewModel: Observable {
     // MARK: - Init
 
     init(detailsDelegate: SiteStatsDetailsDelegate,
+         referrerDelegate: SiteStatsReferrerDelegate,
          storeDelegate: StatsPeriodStoreDelegate) {
         self.detailsDelegate = detailsDelegate
+        self.referrerDelegate = referrerDelegate
         self.periodStore.delegate = storeDelegate
     }
 
@@ -969,6 +972,7 @@ private extension SiteStatsDetailsViewModel {
     func parentRow(rowData: StatsTotalRowData, hideIndentedSeparator: Bool, hideFullSeparator: Bool, expanded: Bool) -> DetailExpandableRow {
         return DetailExpandableRow(rowData: rowData,
                                    detailsDelegate: detailsDelegate,
+                                   referrerDelegate: referrerDelegate,
                                    hideIndentedSeparator: hideIndentedSeparator,
                                    hideFullSeparator: hideFullSeparator,
                                    expanded: expanded)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -133,7 +133,7 @@ class StatsTotalRow: UIView, NibLoadable, Accessible {
 
     var expanded: Bool = false {
         didSet {
-            guard hasChildRows else {
+            guard hasChildRows, rowData?.statSection != .periodReferrers else {
                 return
             }
 
@@ -271,7 +271,7 @@ private extension StatsTotalRow {
     }
 
     func configureDetailDisclosure() {
-        guard hasChildRows, forDetails else {
+        guard hasChildRows, forDetails, rowData?.statSection != .periodReferrers else {
             return
         }
 
@@ -392,27 +392,24 @@ private extension StatsTotalRow {
             return
         }
 
+        if rowData?.statSection == .periodReferrers {
+            // TODO: implement delegate
+            return
+        }
+
         if hasChildRows {
-            if let section = rowData?.statSection,
-               section == .periodReferrers {
-                didTapReferrerCell()
-            } else {
-                toggleExpandedState()
-            }
+            toggleExpandedState()
             return
         }
 
         if let disclosureURL = rowData?.disclosureURL {
             if let statSection = rowData?.statSection,
-                statSection == .periodPostsAndPages {
+               statSection == .periodPostsAndPages {
                 guard let postID = rowData?.postID else {
                     DDLogInfo("No postID available to show Post Stats.")
                     return
                 }
                 delegate?.showPostStats?(postID: postID, postTitle: rowData?.name, postURL: rowData?.disclosureURL)
-            } else if let section = rowData?.statSection,
-                      section == .periodReferrers {
-                didTapReferrerCell()
             } else {
                 delegate?.displayWebViewWithURL?(disclosureURL)
             }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -234,16 +234,6 @@ private extension StatsTotalRow {
         Style.configureViewAsSeparator(separatorLine)
         Style.configureViewAsSeparator(topExpandedSeparatorLine)
         Style.configureViewAsDataBar(dataBar)
-
-        if let data = rowData, data.statSection == .periodReferrers {
-            if parentRow == nil && data.canMarkReferrerAsSpam {
-                itemLabel.textColor = .systemBlue
-            }
-
-            if data.isReferrerSpam {
-                Style.configureLabelAsNoData(itemLabel)
-            }
-        }
     }
 
     func configureDisclosureButton() {
@@ -297,7 +287,6 @@ private extension StatsTotalRow {
     }
 
     func configureIcon() {
-
         guard let rowData = rowData else {
             return
         }
@@ -350,7 +339,6 @@ private extension StatsTotalRow {
     }
 
     func configureDataBar() {
-
         guard let dataBarPercent = rowData?.dataBarPercent else {
             dataBarView.isHidden = true
             return
@@ -382,7 +370,6 @@ private extension StatsTotalRow {
     }
 
     @IBAction func didTapDisclosureButton(_ sender: UIButton) {
-
         if let statSection = rowData?.statSection {
             captureAnalyticsEventsFor(statSection)
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -107,9 +107,6 @@ class StatsTotalRow: UIView, NibLoadable, Accessible {
     private var forDetails = false
     private(set) weak var parentRow: StatsTotalRow?
 
-    // NOTE: temporary implementation, until design is defined
-    private let moreButton = UIButton()
-
     // This view is modified by the containing cell, to show/hide
     // child rows when a parent row is selected.
     weak var childRowsView: StatsChildRowsView?
@@ -260,20 +257,6 @@ private extension StatsTotalRow {
         // Add Insight doesn't have a disclosure icon, but it needs a tap action.
         if rowData.statSection == .insightsAddInsight {
             disclosureButton.isEnabled = true
-        }
-
-        // NOTE: temporary implementation, until design is defined
-        if rowData.statSection == .periodReferrers {
-            moreButton.addTarget(self, action: #selector(didTapMoreButton), for: .touchUpInside)
-            moreButton.translatesAutoresizingMaskIntoConstraints = false
-            addSubview(moreButton)
-
-            NSLayoutConstraint.activate([
-                moreButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
-                moreButton.topAnchor.constraint(equalTo: topAnchor, constant: 4),
-                moreButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
-                moreButton.widthAnchor.constraint(equalTo: moreButton.heightAnchor)
-            ])
         }
     }
 
@@ -442,47 +425,6 @@ private extension StatsTotalRow {
         }
 
         DDLogInfo("Stat row selection action not supported.")
-    }
-
-    @objc func didTapMoreButton() {
-        if parentRow == nil, hasChildRows {
-            toggleExpandedState()
-        } else if let disclosureURL = rowData?.disclosureURL {
-            delegate?.displayWebViewWithURL?(disclosureURL)
-        }
-    }
-
-    func didTapReferrerCell() {
-        guard let data = rowData else {
-            return
-        }
-
-        if parentRow == nil {
-            if data.canMarkReferrerAsSpam {
-                let referrerDomain: String?
-                let isSpam = data.isReferrerSpam
-
-                if hasChildRows {
-                    referrerDomain = data.childRows?.first?.disclosureURL?.host
-                } else {
-                    referrerDomain = data.disclosureURL?.host
-                }
-
-                guard let domain = referrerDomain else {
-                    return
-                }
-
-                delegate?.toggleSpamState?(for: domain, currentValue: isSpam)
-            } else {
-                if hasChildRows {
-                    toggleExpandedState()
-                } else if let disclosureURL = data.disclosureURL {
-                    delegate?.displayWebViewWithURL?(disclosureURL)
-                }
-            }
-        } else if let disclosureURL = data.disclosureURL {
-            delegate?.displayWebViewWithURL?(disclosureURL)
-        }
     }
 
     func toggleExpandedState() {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -65,7 +65,10 @@ struct StatsTotalRowData {
     @objc optional func toggleChildRows(for row: StatsTotalRow, didSelectRow: Bool)
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
     @objc optional func showAddInsight()
-    @objc optional func toggleSpamState(for referrerDomain: String, currentValue: Bool)
+}
+
+protocol StatsTotalRowReferrerDelegate: AnyObject {
+    func showReferrerDetails(_ data: StatsTotalRowData)
 }
 
 class StatsTotalRow: UIView, NibLoadable, Accessible {
@@ -104,6 +107,7 @@ class StatsTotalRow: UIView, NibLoadable, Accessible {
     private var dataBarMaxTrailing: Float = 0.0
     private typealias Style = WPStyleGuide.Stats
     private weak var delegate: StatsTotalRowDelegate?
+    private weak var referrerDelegate: StatsTotalRowReferrerDelegate?
     private var forDetails = false
     private(set) weak var parentRow: StatsTotalRow?
 
@@ -157,10 +161,12 @@ class StatsTotalRow: UIView, NibLoadable, Accessible {
 
     func configure(rowData: StatsTotalRowData,
                    delegate: StatsTotalRowDelegate? = nil,
+                   referrerDelegate: StatsTotalRowReferrerDelegate? = nil,
                    forDetails: Bool = false,
                    parentRow: StatsTotalRow? = nil) {
         self.rowData = rowData
         self.delegate = delegate
+        self.referrerDelegate = referrerDelegate
         self.forDetails = forDetails
         self.parentRow = parentRow
 
@@ -379,8 +385,8 @@ private extension StatsTotalRow {
             return
         }
 
-        if rowData?.statSection == .periodReferrers {
-            // TODO: implement delegate
+        if rowData?.statSection == .periodReferrers, let data = rowData {
+            referrerDelegate?.showReferrerDetails(data)
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -27,6 +27,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
     private var subtitlesProvided = true
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
+    private weak var siteStatsReferrerDelegate: SiteStatsReferrerDelegate?
     private weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
     private weak var postStatsDelegate: PostStatsDelegate?
     private typealias Style = WPStyleGuide.Stats
@@ -38,6 +39,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
                    dataRows: [StatsTotalRowData],
                    siteStatsInsightsDelegate: SiteStatsInsightsDelegate? = nil,
                    siteStatsPeriodDelegate: SiteStatsPeriodDelegate? = nil,
+                   siteStatsReferrerDelegate: SiteStatsReferrerDelegate? = nil,
                    siteStatsDetailsDelegate: SiteStatsDetailsDelegate? = nil,
                    postStatsDelegate: PostStatsDelegate? = nil,
                    limitRowsDisplayed: Bool = true,
@@ -48,6 +50,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
         self.dataRows = dataRows
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         self.siteStatsPeriodDelegate = siteStatsPeriodDelegate
+        self.siteStatsReferrerDelegate = siteStatsReferrerDelegate
         self.siteStatsDetailsDelegate = siteStatsDetailsDelegate
         self.postStatsDelegate = postStatsDelegate
         self.limitRowsDisplayed = limitRowsDisplayed
@@ -59,6 +62,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
                     forType: siteStatsPeriodDelegate != nil ? .period : .insights,
                     limitRowsDisplayed: limitRowsDisplayed,
                     rowDelegate: self,
+                    referrerDelegate: self,
                     viewMoreDelegate: self)
 
             initChildRows()
@@ -308,9 +312,13 @@ extension TopTotalsCell: StatsTotalRowDelegate {
     func showAddInsight() {
         siteStatsInsightsDelegate?.showAddInsight?()
     }
+}
 
-    func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
-        siteStatsPeriodDelegate?.toggleSpamState(for: referrerDomain, currentValue: currentValue)
+// MARK: - StatsTotalRowReferrerDelegate
+
+extension TopTotalsCell: StatsTotalRowReferrerDelegate {
+    func showReferrerDetails(_ data: StatsTotalRowData) {
+        siteStatsReferrerDelegate?.showReferrerDetails(data)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -318,6 +318,7 @@ struct TopTotalsPeriodStatsRow: ImmuTableRow {
     let dataSubtitle: String
     let dataRows: [StatsTotalRowData]
     weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
+    weak var siteStatsReferrerDelegate: SiteStatsReferrerDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -329,7 +330,8 @@ struct TopTotalsPeriodStatsRow: ImmuTableRow {
         cell.configure(itemSubtitle: itemSubtitle,
                        dataSubtitle: dataSubtitle,
                        dataRows: dataRows,
-                       siteStatsPeriodDelegate: siteStatsPeriodDelegate)
+                       siteStatsPeriodDelegate: siteStatsPeriodDelegate,
+                       siteStatsReferrerDelegate: siteStatsReferrerDelegate)
     }
 }
 
@@ -513,6 +515,7 @@ struct DetailExpandableRow: ImmuTableRow {
 
     let rowData: StatsTotalRowData
     weak var detailsDelegate: SiteStatsDetailsDelegate?
+    weak var referrerDelegate: SiteStatsReferrerDelegate?
     let hideIndentedSeparator: Bool
     let hideFullSeparator: Bool
     let expanded: Bool
@@ -526,6 +529,7 @@ struct DetailExpandableRow: ImmuTableRow {
 
         cell.configure(rowData: rowData,
                        detailsDelegate: detailsDelegate,
+                       referrerDelegate: referrerDelegate,
                        hideIndentedSeparator: hideIndentedSeparator,
                        hideFullSeparator: hideFullSeparator,
                        expanded: expanded)


### PR DESCRIPTION
Part of [#16710](https://github.com/wordpress-mobile/WordPress-iOS/issues/16710)

This PR flattens referrers card view and list view, so expanding / collapsing functionality is no longer used. Tap on a referrer should open a referrer details scene, which will be implemented in the next PR.

### To test:

1. Tap on 'Stats' button located in 'My Site' tab
2. Scroll down to referrers section
3. Tapping on a referrer currently does nothing
4. Tapping on 'View more' button displays list of referrers (which is flattened too)

### Outcome:

<img width="827" alt="122666898-478ffc80-d1b0-11eb-9002-81285c507e04" src="https://user-images.githubusercontent.com/12729242/122831326-03a11280-d2ea-11eb-8953-57aa2f45050a.png">


### Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
