### PR TITLE
Issue/16710 - Add referrer details scene

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -231,6 +231,7 @@ extension WPStyleGuide {
         static let negativeColor = UIColor.error
 
         static let gridiconSize = CGSize(width: 24, height: 24)
+        static let standardCellSpacing: CGFloat = 16
 
         struct PostingActivityColors {
             static let range1 = UIColor(light: .neutral(.shade5), dark: .neutral(.shade10))

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -73,6 +73,10 @@ extension WPStyleGuide {
             label.font = subTitleFont
         }
 
+        static func configureLabelAsLink(_ label: UILabel) {
+            label.textColor = actionTextColor
+        }
+
         static func configureLabelItemDetail(_ label: UILabel) {
             label.textColor = itemDetailTextColor
         }

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -231,7 +231,6 @@ extension WPStyleGuide {
         static let negativeColor = UIColor.error
 
         static let gridiconSize = CGSize(width: 24, height: 24)
-        static let standardCellSpacing: CGFloat = 16
 
         struct PostingActivityColors {
             static let range1 = UIColor(light: .neutral(.shade5), dark: .neutral(.shade10))
@@ -265,6 +264,11 @@ extension WPStyleGuide {
             let numberOfColumns = max(1, trunc(width / minimumColumnWidth))
             let columnWidth = trunc(width / numberOfColumns)
             return columnWidth
+        }
+
+        // MARK: - Referrer Details
+        struct ReferrerDetails {
+            static let standardCellSpacing: CGFloat = 16
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -314,7 +314,7 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
 
 extension SiteStatsPeriodTableViewController: SiteStatsReferrerDelegate {
     func showReferrerDetails(_ data: StatsTotalRowData) {
-        // TODO: implement
+        show(ReferrerDetailsTableViewController(), sender: nil)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -4,7 +4,7 @@ final class ReferrerDetailsCell: UITableViewCell {
     private let referrerLabel = UILabel()
     private let viewsLabel = UILabel()
     private let separatorView = UIView()
-    private typealias Constants = ReferrerDetailsTableViewController.Constants
+    private typealias Style = WPStyleGuide.Stats
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -34,35 +34,35 @@ private extension ReferrerDetailsCell {
     }
 
     func setupReferrerLabel() {
-        WPStyleGuide.Stats.configureLabelAsLink(referrerLabel)
+        Style.configureLabelAsLink(referrerLabel)
         referrerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
-            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.standardCellSpacing),
+            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.standardCellSpacing),
             referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
 
     func setupViewsLabel() {
-        WPStyleGuide.Stats.configureLabelAsChildRowTitle(viewsLabel)
+        Style.configureLabelAsChildRowTitle(viewsLabel)
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([
-            viewsLabel.leadingAnchor.constraint(greaterThanOrEqualTo: referrerLabel.trailingAnchor, constant: Constants.standardCellSpacing),
-            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.standardCellSpacing),
+            viewsLabel.leadingAnchor.constraint(greaterThanOrEqualTo: referrerLabel.trailingAnchor, constant: Style.standardCellSpacing),
+            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.standardCellSpacing),
             viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
 
     func setupSeparatorView() {
-        separatorView.backgroundColor = WPStyleGuide.Stats.separatorColor
+        separatorView.backgroundColor = Style.separatorColor
         separatorView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(separatorView)
         NSLayoutConstraint.activate([
             separatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
             separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
             separatorView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            separatorView.heightAnchor.constraint(equalToConstant: WPStyleGuide.Stats.separatorHeight)
+            separatorView.heightAnchor.constraint(equalToConstant: Style.separatorHeight)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -4,6 +4,7 @@ final class ReferrerDetailsCell: UITableViewCell {
     private let referrerLabel = UILabel()
     private let viewsLabel = UILabel()
     private let separatorView = UIView()
+    private typealias Constants = ReferrerDetailsTableViewController.Constants
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -37,7 +38,7 @@ private extension ReferrerDetailsCell {
         referrerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
-            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.standardCellSpacing),
             referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
@@ -47,8 +48,8 @@ private extension ReferrerDetailsCell {
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([
-            viewsLabel.leadingAnchor.constraint(greaterThanOrEqualTo: referrerLabel.trailingAnchor, constant: 16),
-            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            viewsLabel.leadingAnchor.constraint(greaterThanOrEqualTo: referrerLabel.trailingAnchor, constant: Constants.standardCellSpacing),
+            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.standardCellSpacing),
             viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -3,6 +3,7 @@ import UIKit
 final class ReferrerDetailsCell: UITableViewCell {
     private let referrerLabel = UILabel()
     private let viewsLabel = UILabel()
+    private let separatorView = UIView()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -19,9 +20,7 @@ extension ReferrerDetailsCell {
     func configure(isLast: Bool) {
         referrerLabel.text = "Test"
         viewsLabel.text = "123"
-        if isLast {
-            separatorInset = .zero
-        }
+        separatorView.isHidden = !isLast
     }
 }
 
@@ -30,6 +29,7 @@ private extension ReferrerDetailsCell {
     func setupViews() {
         setupReferrerLabel()
         setupViewsLabel()
+        setupSeparatorView()
     }
 
     func setupReferrerLabel() {
@@ -50,6 +50,18 @@ private extension ReferrerDetailsCell {
             viewsLabel.leadingAnchor.constraint(greaterThanOrEqualTo: referrerLabel.trailingAnchor, constant: 16),
             viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+
+    func setupSeparatorView() {
+        separatorView.backgroundColor = WPStyleGuide.Stats.separatorColor
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(separatorView)
+        NSLayoutConstraint.activate([
+            separatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            separatorView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: WPStyleGuide.Stats.separatorHeight)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -1,0 +1,52 @@
+import UIKit
+
+final class ReferrerDetailsCell: UITableViewCell {
+    private let referrerLabel = UILabel()
+    private let viewsLabel = UILabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Public Methods
+extension ReferrerDetailsCell {
+    func configure() {
+        referrerLabel.text = "Test"
+        viewsLabel.text = "123"
+    }
+}
+
+// MARK: - Private methods
+private extension ReferrerDetailsCell {
+    func setupViews() {
+        setupReferrerLabel()
+        setupViewsLabel()
+    }
+
+    func setupReferrerLabel() {
+        WPStyleGuide.Stats.configureLabelAsLink(referrerLabel)
+        referrerLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(referrerLabel)
+        NSLayoutConstraint.activate([
+            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+
+    func setupViewsLabel() {
+        WPStyleGuide.Stats.configureLabelAsChildRowTitle(viewsLabel)
+        viewsLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(viewsLabel)
+        NSLayoutConstraint.activate([
+            viewsLabel.leadingAnchor.constraint(greaterThanOrEqualTo: referrerLabel.trailingAnchor, constant: 16),
+            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -16,9 +16,12 @@ final class ReferrerDetailsCell: UITableViewCell {
 
 // MARK: - Public Methods
 extension ReferrerDetailsCell {
-    func configure() {
+    func configure(isLast: Bool) {
         referrerLabel.text = "Test"
         viewsLabel.text = "123"
+        if isLast {
+            separatorInset = .zero
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -38,7 +38,7 @@ private extension ReferrerDetailsCell {
         referrerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
-            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.standardCellSpacing),
+            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
             referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
@@ -48,8 +48,8 @@ private extension ReferrerDetailsCell {
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([
-            viewsLabel.leadingAnchor.constraint(greaterThanOrEqualTo: referrerLabel.trailingAnchor, constant: Style.standardCellSpacing),
-            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.standardCellSpacing),
+            viewsLabel.leadingAnchor.constraint(greaterThanOrEqualTo: referrerLabel.trailingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
+            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
             viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -3,6 +3,7 @@ import UIKit
 final class ReferrerDetailsHeaderCell: UITableViewCell {
     private let referrerLabel = UILabel()
     private let viewsLabel = UILabel()
+    private typealias Constants = ReferrerDetailsTableViewController.Constants
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -36,7 +37,7 @@ private extension ReferrerDetailsHeaderCell {
         referrerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
-            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.standardCellSpacing),
             referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
@@ -46,7 +47,7 @@ private extension ReferrerDetailsHeaderCell {
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([
-            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.standardCellSpacing),
             viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -1,0 +1,52 @@
+import UIKit
+
+final class ReferrerDetailsHeaderCell: UITableViewCell {
+    private let referrerLabel = UILabel()
+    private let viewsLabel = UILabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Public Methods
+extension ReferrerDetailsHeaderCell {
+    func configure(with section: StatSection) {
+        referrerLabel.text = section.itemSubtitle
+        viewsLabel.text = section.dataSubtitle
+    }
+}
+
+// MARK: - Private methods
+private extension ReferrerDetailsHeaderCell {
+    func setupViews() {
+        isUserInteractionEnabled = false
+        setupReferrerLabel()
+        setupViewsLabel()
+    }
+
+    func setupReferrerLabel() {
+        WPStyleGuide.Stats.configureLabelAsSubtitle(referrerLabel)
+        referrerLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(referrerLabel)
+        NSLayoutConstraint.activate([
+            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+
+    func setupViewsLabel() {
+        WPStyleGuide.Stats.configureLabelAsSubtitle(viewsLabel)
+        viewsLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(viewsLabel)
+        NSLayoutConstraint.activate([
+            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -3,7 +3,7 @@ import UIKit
 final class ReferrerDetailsHeaderCell: UITableViewCell {
     private let referrerLabel = UILabel()
     private let viewsLabel = UILabel()
-    private typealias Constants = ReferrerDetailsTableViewController.Constants
+    private typealias Style = WPStyleGuide.Stats
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -33,21 +33,21 @@ private extension ReferrerDetailsHeaderCell {
     }
 
     func setupReferrerLabel() {
-        WPStyleGuide.Stats.configureLabelAsSubtitle(referrerLabel)
+        Style.configureLabelAsSubtitle(referrerLabel)
         referrerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
-            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.standardCellSpacing),
+            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.standardCellSpacing),
             referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
 
     func setupViewsLabel() {
-        WPStyleGuide.Stats.configureLabelAsSubtitle(viewsLabel)
+        Style.configureLabelAsSubtitle(viewsLabel)
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([
-            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.standardCellSpacing),
+            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.standardCellSpacing),
             viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -37,7 +37,7 @@ private extension ReferrerDetailsHeaderCell {
         referrerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
-            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.standardCellSpacing),
+            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
             referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
@@ -47,7 +47,7 @@ private extension ReferrerDetailsHeaderCell {
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([
-            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.standardCellSpacing),
+            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
             viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -26,6 +26,7 @@ extension ReferrerDetailsHeaderCell {
 private extension ReferrerDetailsHeaderCell {
     func setupViews() {
         isUserInteractionEnabled = false
+        separatorInset = .zero
         setupReferrerLabel()
         setupViewsLabel()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderRow.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct ReferrerDetailsHeaderRow: ImmuTableRow {
+    private typealias CellType = ReferrerDetailsHeaderCell
+
+    static var cell = ImmuTableCell.class(CellType.self)
+    var action: ImmuTableAction?
+
+    func configureCell(_ cell: UITableViewCell) {
+        guard let cell = cell as? CellType else {
+            return
+        }
+        cell.configure(with: section)
+    }
+}
+
+// MARK: - Private Computed Properties
+private extension ReferrerDetailsHeaderRow {
+    var section: StatSection {
+        StatSection.periodReferrers
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderRow.swift
@@ -5,6 +5,7 @@ struct ReferrerDetailsHeaderRow: ImmuTableRow {
 
     static var cell = ImmuTableCell.class(CellType.self)
     var action: ImmuTableAction?
+    static var customHeight: Float? = 30
 
     func configureCell(_ cell: UITableViewCell) {
         guard let cell = cell as? CellType else {

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsRow.swift
@@ -5,11 +5,12 @@ struct ReferrerDetailsRow: ImmuTableRow {
 
     static var cell = ImmuTableCell.class(CellType.self)
     var action: ImmuTableAction?
+    var isLast = false
 
     func configureCell(_ cell: UITableViewCell) {
         guard let cell = cell as? CellType else {
             return
         }
-        cell.configure()
+        cell.configure(isLast: isLast)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsRow.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct ReferrerDetailsRow: ImmuTableRow {
+    private typealias CellType = ReferrerDetailsCell
+
+    static var cell = ImmuTableCell.class(CellType.self)
+    var action: ImmuTableAction?
+
+    func configureCell(_ cell: UITableViewCell) {
+        guard let cell = cell as? CellType else {
+            return
+        }
+        cell.configure()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -3,6 +3,7 @@ import UIKit
 final class ReferrerDetailsSpamActionCell: UITableViewCell {
     private let actionLabel = UILabel()
     private let separatorView = UIView()
+    private typealias Constants = ReferrerDetailsTableViewController.Constants
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -40,8 +41,8 @@ private extension ReferrerDetailsSpamActionCell {
         actionLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(actionLabel)
         NSLayoutConstraint.activate([
-            actionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-            actionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            actionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.standardCellSpacing),
+            actionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.standardCellSpacing),
             actionLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -41,8 +41,8 @@ private extension ReferrerDetailsSpamActionCell {
         actionLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(actionLabel)
         NSLayoutConstraint.activate([
-            actionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.standardCellSpacing),
-            actionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.standardCellSpacing),
+            actionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
+            actionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
             actionLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+final class ReferrerDetailsSpamActionCell: UITableViewCell {
+    private let actionLabel = UILabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Public Methods
+extension ReferrerDetailsSpamActionCell {
+    func configure(markAsSpam: Bool) {
+        if markAsSpam {
+            actionLabel.text = "Mark as spam"
+            actionLabel.textColor = WPStyleGuide.Stats.negativeColor
+        } else {
+            actionLabel.text = "Mark as not spam"
+            actionLabel.textColor = WPStyleGuide.Stats.positiveColor
+        }
+    }
+}
+
+// MARK: - Private methods
+private extension ReferrerDetailsSpamActionCell {
+    func setupViews() {
+        separatorInset = .zero
+        setupActionLabel()
+    }
+
+    func setupActionLabel() {
+        actionLabel.textAlignment = .center
+        actionLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(actionLabel)
+        NSLayoutConstraint.activate([
+            actionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            actionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            actionLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -18,10 +18,10 @@ final class ReferrerDetailsSpamActionCell: UITableViewCell {
 extension ReferrerDetailsSpamActionCell {
     func configure(markAsSpam: Bool) {
         if markAsSpam {
-            actionLabel.text = "Mark as spam"
+            actionLabel.text = NSLocalizedString("Mark as spam", comment: "Action title for marking referrer as spam")
             actionLabel.textColor = WPStyleGuide.Stats.negativeColor
         } else {
-            actionLabel.text = "Mark as not spam"
+            actionLabel.text = NSLocalizedString("Mark as not spam", comment: "Action title for unmarking referrer as spam")
             actionLabel.textColor = WPStyleGuide.Stats.positiveColor
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -2,6 +2,7 @@ import UIKit
 
 final class ReferrerDetailsSpamActionCell: UITableViewCell {
     private let actionLabel = UILabel()
+    private let separatorView = UIView()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -31,6 +32,7 @@ private extension ReferrerDetailsSpamActionCell {
     func setupViews() {
         separatorInset = .zero
         setupActionLabel()
+        setupSeparatorView()
     }
 
     func setupActionLabel() {
@@ -41,6 +43,18 @@ private extension ReferrerDetailsSpamActionCell {
             actionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             actionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             actionLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+
+    func setupSeparatorView() {
+        separatorView.backgroundColor = WPStyleGuide.Stats.separatorColor
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(separatorView)
+        NSLayoutConstraint.activate([
+            separatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            separatorView.topAnchor.constraint(equalTo: topAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: WPStyleGuide.Stats.separatorHeight)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -3,7 +3,7 @@ import UIKit
 final class ReferrerDetailsSpamActionCell: UITableViewCell {
     private let actionLabel = UILabel()
     private let separatorView = UIView()
-    private typealias Constants = ReferrerDetailsTableViewController.Constants
+    private typealias Style = WPStyleGuide.Stats
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -20,10 +20,10 @@ extension ReferrerDetailsSpamActionCell {
     func configure(markAsSpam: Bool) {
         if markAsSpam {
             actionLabel.text = NSLocalizedString("Mark as spam", comment: "Action title for marking referrer as spam")
-            actionLabel.textColor = WPStyleGuide.Stats.negativeColor
+            actionLabel.textColor = Style.negativeColor
         } else {
             actionLabel.text = NSLocalizedString("Mark as not spam", comment: "Action title for unmarking referrer as spam")
-            actionLabel.textColor = WPStyleGuide.Stats.positiveColor
+            actionLabel.textColor = Style.positiveColor
         }
     }
 }
@@ -41,21 +41,21 @@ private extension ReferrerDetailsSpamActionCell {
         actionLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(actionLabel)
         NSLayoutConstraint.activate([
-            actionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.standardCellSpacing),
-            actionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.standardCellSpacing),
+            actionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.standardCellSpacing),
+            actionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.standardCellSpacing),
             actionLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
 
     func setupSeparatorView() {
-        separatorView.backgroundColor = WPStyleGuide.Stats.separatorColor
+        separatorView.backgroundColor = Style.separatorColor
         separatorView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(separatorView)
         NSLayoutConstraint.activate([
             separatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
             separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
             separatorView.topAnchor.constraint(equalTo: topAnchor),
-            separatorView.heightAnchor.constraint(equalToConstant: WPStyleGuide.Stats.separatorHeight)
+            separatorView.heightAnchor.constraint(equalToConstant: Style.separatorHeight)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionRow.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct ReferrerDetailsSpamActionRow: ImmuTableRow {
+    private typealias CellType = ReferrerDetailsSpamActionCell
+
+    static var cell = ImmuTableCell.class(CellType.self)
+    var action: ImmuTableAction?
+    var isSpam: Bool
+
+    func configureCell(_ cell: UITableViewCell) {
+        guard let cell = cell as? CellType else {
+            return
+        }
+        cell.configure(markAsSpam: !isSpam)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -39,6 +39,7 @@ private extension ReferrerDetailsTableViewController {
 private extension ReferrerDetailsTableViewController {
     var rows: [ImmuTableRow.Type] {
         [ReferrerDetailsHeaderRow.self,
-         ReferrerDetailsRow.self]
+         ReferrerDetailsRow.self,
+         ReferrerDetailsSpamActionRow.self]
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -22,6 +22,7 @@ private extension ReferrerDetailsTableViewController {
 // MARK: - Private Computed Properties
 private extension ReferrerDetailsTableViewController {
     var rows: [ImmuTableRow.Type] {
-        [ReferrerDetailsHeaderRow.self]
+        [ReferrerDetailsHeaderRow.self,
+         ReferrerDetailsRow.self]
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -7,6 +7,7 @@ final class ReferrerDetailsTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         WPStyleGuide.Stats.configureTable(tableView)
+        ImmuTable.registerRows(rows, tableView: tableView)
         buildViewModel()
     }
 }
@@ -14,6 +15,13 @@ final class ReferrerDetailsTableViewController: UITableViewController {
 // MARK: - Private Methods
 private extension ReferrerDetailsTableViewController {
     func buildViewModel() {
+        tableHandler.viewModel = viewModel.tableViewModel
+    }
+}
 
+// MARK: - Private Computed Properties
+private extension ReferrerDetailsTableViewController {
+    var rows: [ImmuTableRow.Type] {
+        [ReferrerDetailsHeaderRow.self]
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+final class ReferrerDetailsTableViewController: UITableViewController {
+    private lazy var tableHandler = ImmuTableViewHandler(takeOver: self)
+    private let viewModel = ReferrerDetailsViewModel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        WPStyleGuide.Stats.configureTable(tableView)
+        buildViewModel()
+    }
+}
+
+// MARK: - Private Methods
+private extension ReferrerDetailsTableViewController {
+    func buildViewModel() {
+
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -6,14 +6,30 @@ final class ReferrerDetailsTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        WPStyleGuide.Stats.configureTable(tableView)
-        ImmuTable.registerRows(rows, tableView: tableView)
+        setupViews()
         buildViewModel()
+    }
+}
+
+// MARK: - UITableViewDelegate
+extension ReferrerDetailsTableViewController {
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        .zero
+    }
+
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        .zero
     }
 }
 
 // MARK: - Private Methods
 private extension ReferrerDetailsTableViewController {
+    func setupViews() {
+        tableView.backgroundColor = WPStyleGuide.Stats.tableBackgroundColor
+        tableView.tableFooterView = UIView()
+        ImmuTable.registerRows(rows, tableView: tableView)
+    }
+
     func buildViewModel() {
         tableHandler.viewModel = viewModel.tableViewModel
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -18,7 +18,21 @@ extension ReferrerDetailsTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        .zero
+        switch section {
+        case tableView.numberOfSections - 1:
+            return .zero
+        default:
+            return UITableView.automaticDimension
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        switch section {
+        case tableView.numberOfSections - 1:
+            return nil
+        default:
+            return UIView()
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -57,3 +57,10 @@ private extension ReferrerDetailsTableViewController {
          ReferrerDetailsSpamActionRow.self]
     }
 }
+
+// MARK: - Types
+extension ReferrerDetailsTableViewController {
+    struct Constants {
+        static let standardCellSpacing: CGFloat = 16
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -57,10 +57,3 @@ private extension ReferrerDetailsTableViewController {
          ReferrerDetailsSpamActionRow.self]
     }
 }
-
-// MARK: - Types
-extension ReferrerDetailsTableViewController {
-    struct Constants {
-        static let standardCellSpacing: CGFloat = 16
-    }
-}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -16,10 +16,9 @@ extension ReferrerDetailsViewModel {
         rows.append(ReferrerDetailsRow())
         rows.append(ReferrerDetailsRow(action: nil, isLast: true))
 
-        rows.append(ReferrerDetailsSpamActionRow(action: nil, isSpam: false))
-
         return ImmuTable(sections: [
-            ImmuTableSection(rows: rows)
+            ImmuTableSection(rows: rows),
+            ImmuTableSection(rows: [ReferrerDetailsSpamActionRow(action: nil, isSpam: false)])
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class ReferrerDetailsViewModel {
-    
+    // TODO: implement
 }
 
 // MARK: - Public Computed Properties

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -10,10 +10,13 @@ extension ReferrerDetailsViewModel {
         var rows = [ImmuTableRow]()
 
         rows.append(ReferrerDetailsHeaderRow())
+
         rows.append(ReferrerDetailsRow())
         rows.append(ReferrerDetailsRow())
         rows.append(ReferrerDetailsRow())
         rows.append(ReferrerDetailsRow(action: nil, isLast: true))
+
+        rows.append(ReferrerDetailsSpamActionRow(action: nil, isSpam: false))
 
         return ImmuTable(sections: [
             ImmuTableSection(rows: rows)

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -10,6 +10,7 @@ extension ReferrerDetailsViewModel {
         var rows = [ImmuTableRow]()
 
         rows.append(ReferrerDetailsHeaderRow())
+        rows.append(ReferrerDetailsRow())
 
         return ImmuTable(sections: [
             ImmuTableSection(rows: rows)

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+final class ReferrerDetailsViewModel {
+    
+}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -11,6 +11,9 @@ extension ReferrerDetailsViewModel {
 
         rows.append(ReferrerDetailsHeaderRow())
         rows.append(ReferrerDetailsRow())
+        rows.append(ReferrerDetailsRow())
+        rows.append(ReferrerDetailsRow())
+        rows.append(ReferrerDetailsRow(action: nil, isLast: true))
 
         return ImmuTable(sections: [
             ImmuTableSection(rows: rows)

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -3,3 +3,16 @@ import Foundation
 final class ReferrerDetailsViewModel {
     
 }
+
+// MARK: - Public Computed Properties
+extension ReferrerDetailsViewModel {
+    var tableViewModel: ImmuTable {
+        var rows = [ImmuTableRow]()
+
+        rows.append(ReferrerDetailsHeaderRow())
+
+        return ImmuTable(sections: [
+            ImmuTableSection(rows: rows)
+        ])
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -321,7 +321,7 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
 
 extension SiteStatsDetailTableViewController: SiteStatsReferrerDelegate {
     func showReferrerDetails(_ data: StatsTotalRowData) {
-        // TODO: implement
+        show(ReferrerDetailsTableViewController(), sender: nil)
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1367,6 +1367,12 @@
 		930F09171C7D110E00995926 /* ShareExtensionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930F09161C7D110E00995926 /* ShareExtensionService.swift */; };
 		930F09191C7E1C1E00995926 /* ShareExtensionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930F09161C7D110E00995926 /* ShareExtensionService.swift */; };
 		931215E1267DE1C0008C3B69 /* StatsTotalRowDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215E0267DE1C0008C3B69 /* StatsTotalRowDataTests.swift */; };
+		931215E4267F5003008C3B69 /* ReferrerDetailsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215E3267F5003008C3B69 /* ReferrerDetailsTableViewController.swift */; };
+		931215E6267F5192008C3B69 /* ReferrerDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215E5267F5192008C3B69 /* ReferrerDetailsViewModel.swift */; };
+		931215E8267F52A6008C3B69 /* ReferrerDetailsHeaderRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215E7267F52A6008C3B69 /* ReferrerDetailsHeaderRow.swift */; };
+		931215EA267F59CB008C3B69 /* ReferrerDetailsHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215E9267F59CB008C3B69 /* ReferrerDetailsHeaderCell.swift */; };
+		931215EC267F5F45008C3B69 /* ReferrerDetailsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215EB267F5F45008C3B69 /* ReferrerDetailsRow.swift */; };
+		931215EE267F6799008C3B69 /* ReferrerDetailsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215ED267F6799008C3B69 /* ReferrerDetailsCell.swift */; };
 		931430201E68B9C50014B6C6 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E1C5B2131E54C28C00052319 /* Localizable.strings */; };
 		931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E150520B16CAC5C400D3DDDC /* BlogJetpackTest.m */; };
 		931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 930FD0A519882742000CC81D /* BlogServiceTest.m */; };
@@ -5983,6 +5989,12 @@
 		930F09161C7D110E00995926 /* ShareExtensionService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShareExtensionService.swift; sourceTree = "<group>"; };
 		930FD0A519882742000CC81D /* BlogServiceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogServiceTest.m; sourceTree = "<group>"; };
 		931215E0267DE1C0008C3B69 /* StatsTotalRowDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTotalRowDataTests.swift; sourceTree = "<group>"; };
+		931215E3267F5003008C3B69 /* ReferrerDetailsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsTableViewController.swift; sourceTree = "<group>"; };
+		931215E5267F5192008C3B69 /* ReferrerDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsViewModel.swift; sourceTree = "<group>"; };
+		931215E7267F52A6008C3B69 /* ReferrerDetailsHeaderRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsHeaderRow.swift; sourceTree = "<group>"; };
+		931215E9267F59CB008C3B69 /* ReferrerDetailsHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsHeaderCell.swift; sourceTree = "<group>"; };
+		931215EB267F5F45008C3B69 /* ReferrerDetailsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsRow.swift; sourceTree = "<group>"; };
+		931215ED267F6799008C3B69 /* ReferrerDetailsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsCell.swift; sourceTree = "<group>"; };
 		931D26FF19EDAE8600114F17 /* CoreDataMigrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreDataMigrationTests.m; sourceTree = "<group>"; };
 		931DF4D718D09A2F00540BDD /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		931DF4D918D09A9B00540BDD /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -8746,6 +8758,7 @@
 				98747674219644E40080967F /* Helpers */,
 				98747671219638BF0080967F /* Insights */,
 				984B138C21F65F680004B6A2 /* Period Stats */,
+				931215E2267F4F92008C3B69 /* Referrer Details */,
 				98F89D47219E008600190EE6 /* Shared Views */,
 				98E58A2D2360D1FD00E5534B /* Today Widgets */,
 				981C348F2183871100FC2683 /* SiteStatsDashboard.storyboard */,
@@ -11098,6 +11111,19 @@
 				8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */,
 			);
 			name = "Prepublishing Nudges";
+			sourceTree = "<group>";
+		};
+		931215E2267F4F92008C3B69 /* Referrer Details */ = {
+			isa = PBXGroup;
+			children = (
+				931215ED267F6799008C3B69 /* ReferrerDetailsCell.swift */,
+				931215E9267F59CB008C3B69 /* ReferrerDetailsHeaderCell.swift */,
+				931215E7267F52A6008C3B69 /* ReferrerDetailsHeaderRow.swift */,
+				931215EB267F5F45008C3B69 /* ReferrerDetailsRow.swift */,
+				931215E3267F5003008C3B69 /* ReferrerDetailsTableViewController.swift */,
+				931215E5267F5192008C3B69 /* ReferrerDetailsViewModel.swift */,
+			);
+			path = "Referrer Details";
 			sourceTree = "<group>";
 		};
 		932225A81C7CE50300443B02 /* WordPressShareExtension */ = {
@@ -17121,10 +17147,12 @@
 				F5D399302541F25B0058D0AB /* SheetActions.swift in Sources */,
 				8B7F51C924EED804008CF5B5 /* ReaderTracker.swift in Sources */,
 				E6F2788421BC1A4A008B4DB5 /* PlanFeature.swift in Sources */,
+				931215E4267F5003008C3B69 /* ReferrerDetailsTableViewController.swift in Sources */,
 				3F421DF524A3EC2B00CA9B9E /* Spotlightable.swift in Sources */,
 				D8A3A5AF206A442800992576 /* StockPhotosDataSource.swift in Sources */,
 				F53FF3A323EA3E45001AD596 /* BlogDetailsViewController+Header.swift in Sources */,
 				8B24C4E3249A4C3E0005E8A5 /* OfflineReaderWebView.swift in Sources */,
+				931215E6267F5192008C3B69 /* ReferrerDetailsViewModel.swift in Sources */,
 				9A5C854822B3E42800BEE7A3 /* CountriesMapCell.swift in Sources */,
 				B5B410B61B1772B000CFCF8D /* NavigationTitleView.swift in Sources */,
 				8BAD53D6241922B900230F4B /* WPAnalyticsEvent.swift in Sources */,
@@ -17657,6 +17685,7 @@
 				9A4E271A22EF0C78001F6A6B /* ChangeUsernameViewModel.swift in Sources */,
 				172797D91CE5D0CD00CB8057 /* PlansLoadingIndicatorView.swift in Sources */,
 				FA7AA45325BFD9BC005E7200 /* JetpackScanThreatDetailsViewController.swift in Sources */,
+				931215EA267F59CB008C3B69 /* ReferrerDetailsHeaderCell.swift in Sources */,
 				7EFF208A20EADCB6009C4699 /* NotificationTextContent.swift in Sources */,
 				F1A38F212678C4DA00849843 /* BloggingRemindersFlow.swift in Sources */,
 				91DCE84821A6C58C0062F134 /* PostEditor+Publish.swift in Sources */,
@@ -17668,6 +17697,7 @@
 				F59AAC10235E430F00385EE6 /* ChosenValueRow.swift in Sources */,
 				B54E1DF11A0A7BAA00807537 /* ReplyTextView.swift in Sources */,
 				40EE94802213213F00CD264F /* PublicizeConnectionStatsRecordValue+CoreDataProperties.swift in Sources */,
+				931215EE267F6799008C3B69 /* ReferrerDetailsCell.swift in Sources */,
 				08216FCA1CDBF96000304BA7 /* MenuItemEditingFooterView.m in Sources */,
 				E6D3E8491BEBD871002692E8 /* ReaderCrossPostCell.swift in Sources */,
 				E10290741F30615A00DAC588 /* Role.swift in Sources */,
@@ -17685,9 +17715,11 @@
 				7E3E7A5720E44D130075D159 /* HeaderContentStyles.swift in Sources */,
 				9A38DC69218899FB006A409B /* Revision.swift in Sources */,
 				403269922027719C00608441 /* PluginDirectoryAccessoryItem.swift in Sources */,
+				931215EC267F5F45008C3B69 /* ReferrerDetailsRow.swift in Sources */,
 				FFB1FAA01BF0EC4E0090C761 /* PHAsset+Exporters.swift in Sources */,
 				465B097A24C877E500336B6C /* GutenbergLightNavigationController.swift in Sources */,
 				8298F38F1EEF2B15008EB7F0 /* AppFeedbackPromptView.swift in Sources */,
+				931215E8267F52A6008C3B69 /* ReferrerDetailsHeaderRow.swift in Sources */,
 				F17A2A1E23BFBD72001E96AC /* UIView+ExistingConstraints.swift in Sources */,
 				400A2C892217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift in Sources */,
 				F1450CF32437DA3E00A28BFE /* MediaRequestAuthenticator.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1373,6 +1373,8 @@
 		931215EA267F59CB008C3B69 /* ReferrerDetailsHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215E9267F59CB008C3B69 /* ReferrerDetailsHeaderCell.swift */; };
 		931215EC267F5F45008C3B69 /* ReferrerDetailsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215EB267F5F45008C3B69 /* ReferrerDetailsRow.swift */; };
 		931215EE267F6799008C3B69 /* ReferrerDetailsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215ED267F6799008C3B69 /* ReferrerDetailsCell.swift */; };
+		931215F2267FE162008C3B69 /* ReferrerDetailsSpamActionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215F1267FE162008C3B69 /* ReferrerDetailsSpamActionRow.swift */; };
+		931215F4267FE177008C3B69 /* ReferrerDetailsSpamActionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931215F3267FE177008C3B69 /* ReferrerDetailsSpamActionCell.swift */; };
 		931430201E68B9C50014B6C6 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E1C5B2131E54C28C00052319 /* Localizable.strings */; };
 		931D26F519ED7E6D00114F17 /* BlogJetpackTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E150520B16CAC5C400D3DDDC /* BlogJetpackTest.m */; };
 		931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 930FD0A519882742000CC81D /* BlogServiceTest.m */; };
@@ -5995,6 +5997,8 @@
 		931215E9267F59CB008C3B69 /* ReferrerDetailsHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsHeaderCell.swift; sourceTree = "<group>"; };
 		931215EB267F5F45008C3B69 /* ReferrerDetailsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsRow.swift; sourceTree = "<group>"; };
 		931215ED267F6799008C3B69 /* ReferrerDetailsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsCell.swift; sourceTree = "<group>"; };
+		931215F1267FE162008C3B69 /* ReferrerDetailsSpamActionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsSpamActionRow.swift; sourceTree = "<group>"; };
+		931215F3267FE177008C3B69 /* ReferrerDetailsSpamActionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsSpamActionCell.swift; sourceTree = "<group>"; };
 		931D26FF19EDAE8600114F17 /* CoreDataMigrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreDataMigrationTests.m; sourceTree = "<group>"; };
 		931DF4D718D09A2F00540BDD /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		931DF4D918D09A9B00540BDD /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -11120,6 +11124,8 @@
 				931215E9267F59CB008C3B69 /* ReferrerDetailsHeaderCell.swift */,
 				931215E7267F52A6008C3B69 /* ReferrerDetailsHeaderRow.swift */,
 				931215EB267F5F45008C3B69 /* ReferrerDetailsRow.swift */,
+				931215F3267FE177008C3B69 /* ReferrerDetailsSpamActionCell.swift */,
+				931215F1267FE162008C3B69 /* ReferrerDetailsSpamActionRow.swift */,
 				931215E3267F5003008C3B69 /* ReferrerDetailsTableViewController.swift */,
 				931215E5267F5192008C3B69 /* ReferrerDetailsViewModel.swift */,
 			);
@@ -17297,6 +17303,7 @@
 				E678FC151C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift in Sources */,
 				7EFF208620EAD918009C4699 /* FormattableUserContent.swift in Sources */,
 				436D56262117312700CEAA33 /* RegisterDomainDetailsViewController+HeaderFooter.swift in Sources */,
+				931215F2267FE162008C3B69 /* ReferrerDetailsSpamActionRow.swift in Sources */,
 				E66EB6F91C1B7A76003DABC5 /* ReaderSpacerView.swift in Sources */,
 				B55853F31962337500FAF6C3 /* NSScanner+Helpers.m in Sources */,
 				B560914C208A671F00399AE4 /* WPStyleGuide+SiteCreation.swift in Sources */,
@@ -17565,6 +17572,7 @@
 				E14694071F3459E2004052C8 /* PluginListViewController.swift in Sources */,
 				FF0D8146205809C8000EE505 /* PostCoordinator.swift in Sources */,
 				7EA30DB621ADA20F0092F894 /* AztecAttachmentDelegate.swift in Sources */,
+				931215F4267FE177008C3B69 /* ReferrerDetailsSpamActionCell.swift in Sources */,
 				82B67B361FC726CD006FB593 /* Memoize.swift in Sources */,
 				9AA0ADB3235F11DC0027AB5D /* StatsPeriodAsyncOperation.swift in Sources */,
 				B5DBE4FE1D21A700002E81D3 /* NotificationsViewController.swift in Sources */,


### PR DESCRIPTION
Part of [#16710](https://github.com/wordpress-mobile/WordPress-iOS/issues/16710)
Depends on [#16714](https://github.com/wordpress-mobile/WordPress-iOS/pull/16714)

This PR includes addition of referrer details scene. Dummy data is currently displayed. Real data passing will be implemented in the next PR.

### To test:

1. Tap on 'Stats' button located in 'My Site' tab.
2. Scroll down to referrers section.
3. Tapping on a referrer displays referrer details scene.
4. Tapping on 'View more', and then on a referrer also displays referrer details scene.

### Outcome:

<img width="438" alt="122753674-e1c87100-d292-11eb-906d-18cbe4858b33" src="https://user-images.githubusercontent.com/12729242/122832405-90000500-d2eb-11eb-9aec-9b797121411b.png">


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
