### PR TITLE
Issue/16710 - Implement logic for referrer details scene

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -177,22 +177,6 @@ protocol StatsPeriodStoreDelegate: AnyObject {
     func changingSpamStateForReferrerDomainFailed(oldValue: Bool)
 }
 
-extension StatsPeriodStoreDelegate where Self: UIViewController {
-    func didChangeSpamState(for referrerDomain: String, isSpam: Bool) {
-        let markedText = NSLocalizedString("marked as spam", comment: "Indicating that referrer was marked as spam")
-        let unmarkedText = NSLocalizedString("unmarked as spam", comment: "Indicating that referrer was unmarked as spam")
-        let text = isSpam ? markedText : unmarkedText
-        displayNotice(title: "\(referrerDomain) \(text)")
-    }
-
-    func changingSpamStateForReferrerDomainFailed(oldValue: Bool) {
-        let markText = NSLocalizedString("Couldn't mark as spam", comment: "Indicating that referrer couldn't be marked as spam")
-        let unmarkText = NSLocalizedString("Couldn't unmark as spam", comment: "Indicating that referrer couldn't be unmarked as spam")
-        let text = oldValue ? unmarkText : markText
-        displayNotice(title: text)
-    }
-}
-
 class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
     private typealias PeriodOperation = StatsPeriodAsyncOperation
     private typealias PublishedPostOperation = StatsPublishedPostsAsyncOperation

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -314,7 +314,7 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
 
 extension SiteStatsPeriodTableViewController: SiteStatsReferrerDelegate {
     func showReferrerDetails(_ data: StatsTotalRowData) {
-        show(ReferrerDetailsTableViewController(), sender: nil)
+        show(ReferrerDetailsTableViewController(data: data), sender: nil)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -132,8 +132,7 @@ private extension SiteStatsPeriodTableViewController {
                                              selectedDate: selectedDate,
                                              selectedPeriod: selectedPeriod,
                                              periodDelegate: self,
-                                             referrerDelegate: self,
-                                             storeDelegate: self)
+                                             referrerDelegate: self)
         viewModel?.statsBarChartViewDelegate = self
         addViewModelListeners()
         viewModel?.startFetchingOverview()
@@ -212,12 +211,6 @@ private extension SiteStatsPeriodTableViewController {
     func viewIsVisible() -> Bool {
         return isViewLoaded && view.window != nil
     }
-}
-
-// MARK: - StatsPeriodStoreDelegate
-
-extension SiteStatsPeriodTableViewController: StatsPeriodStoreDelegate {
-    /* using default implementation in protocol extension */
 }
 
 // MARK: - NoResultsViewHost

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -332,24 +332,3 @@ extension SiteStatsPeriodTableViewController: SiteStatsTableHeaderDateButtonDele
         }
     }
 }
-
-// MARK: - Mark referrer as spam action sheet
-
-extension UIViewController {
-    func showSpamActionSheet(for referrerDomain: String, isSpam: Bool, action: @escaping () -> Void) {
-        let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-
-        let markTitle = NSLocalizedString("Mark as spam", comment: "Action title for marking referrer as spam")
-        let unmarkTitle = NSLocalizedString("Unmark as spam", comment: "Action title for unmarking referrer as spam")
-
-        let title = isSpam ? unmarkTitle : markTitle
-        let toggleSpamAction = UIAlertAction(title: title, style: .default) { _ in
-            action()
-        }
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
-        [toggleSpamAction, cancelAction].forEach {
-            sheet.addAction($0)
-        }
-        present(sheet, animated: true)
-    }
-}

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -43,12 +43,10 @@ class SiteStatsPeriodViewModel: Observable {
          selectedDate: Date,
          selectedPeriod: StatsPeriodUnit,
          periodDelegate: SiteStatsPeriodDelegate,
-         referrerDelegate: SiteStatsReferrerDelegate,
-         storeDelegate: StatsPeriodStoreDelegate) {
+         referrerDelegate: SiteStatsReferrerDelegate) {
         self.periodDelegate = periodDelegate
         self.referrerDelegate = referrerDelegate
         self.store = store
-        self.store.delegate = storeDelegate
         self.lastRequestedDate = selectedDate
         self.lastRequestedPeriod = selectedPeriod
 
@@ -245,10 +243,6 @@ class SiteStatsPeriodViewModel: Observable {
             currentEntryIndex -= 1
         }
         return chartDate(for: currentEntryIndex)
-    }
-
-    func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
-        store.toggleSpamState(for: referrerDomain, currentValue: currentValue)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -28,6 +28,7 @@ extension ReferrerDetailsCell {
 // MARK: - Private methods
 private extension ReferrerDetailsCell {
     func setupViews() {
+        selectionStyle = .none
         setupReferrerLabel()
         setupViewsLabel()
         setupSeparatorView()

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -18,9 +18,9 @@ final class ReferrerDetailsCell: UITableViewCell {
 
 // MARK: - Public Methods
 extension ReferrerDetailsCell {
-    func configure(isLast: Bool) {
-        referrerLabel.text = "Test"
-        viewsLabel.text = "123"
+    func configure(data: ReferrerDetailsRow.DetailsData, isLast: Bool) {
+        referrerLabel.text = data.name
+        viewsLabel.text = data.views
         separatorView.isHidden = !isLast
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -29,7 +29,7 @@ extension ReferrerDetailsCell {
 private extension ReferrerDetailsCell {
     func setupViews() {
         selectionStyle = .none
-        backgroundColor = .listForeground
+        backgroundColor = Style.cellBackgroundColor
         setupReferrerLabel()
         setupViewsLabel()
         setupSeparatorView()

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -40,7 +40,7 @@ private extension ReferrerDetailsCell {
         referrerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
-            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
+            referrerLabel.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
             referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
@@ -51,7 +51,7 @@ private extension ReferrerDetailsCell {
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([
             viewsLabel.leadingAnchor.constraint(greaterThanOrEqualTo: referrerLabel.trailingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
-            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
+            viewsLabel.trailingAnchor.constraint(equalTo: safeTrailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
             viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -29,6 +29,7 @@ extension ReferrerDetailsCell {
 private extension ReferrerDetailsCell {
     func setupViews() {
         selectionStyle = .none
+        backgroundColor = .listForeground
         setupReferrerLabel()
         setupViewsLabel()
         setupSeparatorView()

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -28,7 +28,7 @@ private extension ReferrerDetailsHeaderCell {
     func setupViews() {
         isUserInteractionEnabled = false
         separatorInset = .zero
-        backgroundColor = .listForeground
+        backgroundColor = Style.cellBackgroundColor
         setupReferrerLabel()
         setupViewsLabel()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -28,6 +28,7 @@ private extension ReferrerDetailsHeaderCell {
     func setupViews() {
         isUserInteractionEnabled = false
         separatorInset = .zero
+        backgroundColor = .listForeground
         setupReferrerLabel()
         setupViewsLabel()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -38,7 +38,7 @@ private extension ReferrerDetailsHeaderCell {
         referrerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
-            referrerLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
+            referrerLabel.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
             referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
@@ -48,7 +48,7 @@ private extension ReferrerDetailsHeaderCell {
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([
-            viewsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
+            viewsLabel.trailingAnchor.constraint(equalTo: safeTrailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
             viewsLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsRow.swift
@@ -5,12 +5,22 @@ struct ReferrerDetailsRow: ImmuTableRow {
 
     static var cell = ImmuTableCell.class(CellType.self)
     var action: ImmuTableAction?
-    var isLast = false
+    let isLast: Bool
+    let data: DetailsData
 
     func configureCell(_ cell: UITableViewCell) {
         guard let cell = cell as? CellType else {
             return
         }
-        cell.configure(isLast: isLast)
+        cell.configure(data: data, isLast: isLast)
+    }
+}
+
+// MARK: - Types
+extension ReferrerDetailsRow {
+    struct DetailsData {
+        let name: String
+        let url: URL
+        let views: String
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -32,6 +32,7 @@ extension ReferrerDetailsSpamActionCell {
 private extension ReferrerDetailsSpamActionCell {
     func setupViews() {
         separatorInset = .zero
+        selectionStyle = .none
         setupActionLabel()
         setupSeparatorView()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -3,6 +3,7 @@ import UIKit
 final class ReferrerDetailsSpamActionCell: UITableViewCell {
     private let actionLabel = UILabel()
     private let separatorView = UIView()
+    private let loader = UIActivityIndicatorView(style: .medium)
     private typealias Style = WPStyleGuide.Stats
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -34,6 +35,7 @@ private extension ReferrerDetailsSpamActionCell {
         separatorInset = .zero
         selectionStyle = .none
         setupActionLabel()
+        setupLoader()
         setupSeparatorView()
     }
 
@@ -45,6 +47,15 @@ private extension ReferrerDetailsSpamActionCell {
             actionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
             actionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
             actionLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+
+    func setupLoader() {
+        loader.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(loader)
+        NSLayoutConstraint.activate([
+            loader.centerXAnchor.constraint(equalTo: centerXAnchor),
+            loader.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -18,7 +18,10 @@ final class ReferrerDetailsSpamActionCell: UITableViewCell {
 
 // MARK: - Public Methods
 extension ReferrerDetailsSpamActionCell {
-    func configure(markAsSpam: Bool) {
+    func configure(markAsSpam: Bool, isLoading: Bool) {
+        isLoading ? loader.startAnimating() : loader.stopAnimating()
+        actionLabel.isHidden = isLoading
+
         if markAsSpam {
             actionLabel.text = NSLocalizedString("Mark as spam", comment: "Action title for marking referrer as spam")
             actionLabel.textColor = Style.negativeColor

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -48,8 +48,8 @@ private extension ReferrerDetailsSpamActionCell {
         actionLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(actionLabel)
         NSLayoutConstraint.activate([
-            actionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
-            actionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
+            actionLabel.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
+            actionLabel.trailingAnchor.constraint(equalTo: safeTrailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
             actionLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -37,7 +37,7 @@ private extension ReferrerDetailsSpamActionCell {
     func setupViews() {
         separatorInset = .zero
         selectionStyle = .none
-        backgroundColor = .listForeground
+        backgroundColor = Style.cellBackgroundColor
         setupActionLabel()
         setupLoader()
         setupSeparatorView()

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -37,6 +37,7 @@ private extension ReferrerDetailsSpamActionCell {
     func setupViews() {
         separatorInset = .zero
         selectionStyle = .none
+        backgroundColor = .listForeground
         setupActionLabel()
         setupLoader()
         setupSeparatorView()

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionRow.swift
@@ -6,11 +6,12 @@ struct ReferrerDetailsSpamActionRow: ImmuTableRow {
     static var cell = ImmuTableCell.class(CellType.self)
     var action: ImmuTableAction?
     var isSpam: Bool
+    var isLoading: Bool
 
     func configureCell(_ cell: UITableViewCell) {
         guard let cell = cell as? CellType else {
             return
         }
-        cell.configure(markAsSpam: !isSpam)
+        cell.configure(markAsSpam: !isSpam, isLoading: isLoading)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 final class ReferrerDetailsTableViewController: UITableViewController {
-    private let data: StatsTotalRowData
+    private var data: StatsTotalRowData
     private lazy var tableHandler = ImmuTableViewHandler(takeOver: self)
     private lazy var viewModel = ReferrerDetailsViewModel(data: data, delegate: self)
     private let periodStore = StoreContainer.shared.statsPeriod
@@ -66,6 +66,9 @@ extension ReferrerDetailsTableViewController: ReferrerDetailsViewModelDelegate {
 // MARK: - StatsPeriodStoreDelegate
 extension ReferrerDetailsTableViewController: StatsPeriodStoreDelegate {
     func didChangeSpamState(for referrerDomain: String, isSpam: Bool) {
+        data.isReferrerSpam = isSpam
+        updateViewModel()
+
         let markedText = NSLocalizedString("marked as spam", comment: "Indicating that referrer was marked as spam")
         let unmarkedText = NSLocalizedString("unmarked as spam", comment: "Indicating that referrer was unmarked as spam")
         let text = isSpam ? markedText : unmarkedText
@@ -93,11 +96,16 @@ private extension ReferrerDetailsTableViewController {
         tableHandler.viewModel = viewModel.tableViewModel
     }
 
+    func updateViewModel() {
+        viewModel.update(with: data)
+        buildViewModel()
+    }
+
     func showSpamActionSheet(for referrerDomain: String, isSpam: Bool, action: @escaping () -> Void) {
         let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         let markTitle = NSLocalizedString("Mark as spam", comment: "Action title for marking referrer as spam")
-        let unmarkTitle = NSLocalizedString("Unmark as spam", comment: "Action title for unmarking referrer as spam")
+        let unmarkTitle = NSLocalizedString("Mark as not spam", comment: "Action title for unmarking referrer as spam")
 
         let title = isSpam ? unmarkTitle : markTitle
         let toggleSpamAction = UIAlertAction(title: title, style: .default) { _ in

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -49,7 +49,9 @@ extension ReferrerDetailsTableViewController {
 // MARK: - ReferrerDetailsViewModelDelegate
 extension ReferrerDetailsTableViewController: ReferrerDetailsViewModelDelegate {
     func displayWebViewWithURL(_ url: URL) {
-        // TODO: implement
+        let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
+        let navController = UINavigationController(rootViewController: webViewController)
+        present(navController, animated: true)
     }
 
     func toggleSpamState(for referrerDomain: String, currentValue: Bool) {

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -4,6 +4,7 @@ final class ReferrerDetailsTableViewController: UITableViewController {
     private let data: StatsTotalRowData
     private lazy var tableHandler = ImmuTableViewHandler(takeOver: self)
     private lazy var viewModel = ReferrerDetailsViewModel(data: data, delegate: self)
+    private let periodStore = StoreContainer.shared.statsPeriod
 
     init(data: StatsTotalRowData) {
         self.data = data
@@ -55,7 +56,9 @@ extension ReferrerDetailsTableViewController: ReferrerDetailsViewModelDelegate {
     }
 
     func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
-        // TODO: implement
+        showSpamActionSheet(for: referrerDomain, isSpam: currentValue) { [weak self] in
+            self?.periodStore.toggleSpamState(for: referrerDomain, currentValue: currentValue)
+        }
     }
 }
 
@@ -70,6 +73,23 @@ private extension ReferrerDetailsTableViewController {
 
     func buildViewModel() {
         tableHandler.viewModel = viewModel.tableViewModel
+    }
+
+    func showSpamActionSheet(for referrerDomain: String, isSpam: Bool, action: @escaping () -> Void) {
+        let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+        let markTitle = NSLocalizedString("Mark as spam", comment: "Action title for marking referrer as spam")
+        let unmarkTitle = NSLocalizedString("Unmark as spam", comment: "Action title for unmarking referrer as spam")
+
+        let title = isSpam ? unmarkTitle : markTitle
+        let toggleSpamAction = UIAlertAction(title: title, style: .default) { _ in
+            action()
+        }
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+        [toggleSpamAction, cancelAction].forEach {
+            sheet.addAction($0)
+        }
+        present(sheet, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -57,9 +57,7 @@ extension ReferrerDetailsTableViewController: ReferrerDetailsViewModelDelegate {
     }
 
     func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
-        showSpamActionSheet(for: referrerDomain, isSpam: currentValue) { [weak self] in
-            self?.periodStore.toggleSpamState(for: referrerDomain, currentValue: currentValue)
-        }
+        periodStore.toggleSpamState(for: referrerDomain, currentValue: currentValue)
     }
 }
 
@@ -99,23 +97,6 @@ private extension ReferrerDetailsTableViewController {
     func updateViewModel() {
         viewModel.update(with: data)
         buildViewModel()
-    }
-
-    func showSpamActionSheet(for referrerDomain: String, isSpam: Bool, action: @escaping () -> Void) {
-        let sheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-
-        let markTitle = NSLocalizedString("Mark as spam", comment: "Action title for marking referrer as spam")
-        let unmarkTitle = NSLocalizedString("Mark as not spam", comment: "Action title for unmarking referrer as spam")
-
-        let title = isSpam ? unmarkTitle : markTitle
-        let toggleSpamAction = UIAlertAction(title: title, style: .default) { _ in
-            action()
-        }
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
-        [toggleSpamAction, cancelAction].forEach {
-            sheet.addAction($0)
-        }
-        present(sheet, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -50,6 +50,7 @@ private extension ReferrerDetailsTableViewController {
     func setupViews() {
         tableView.backgroundColor = WPStyleGuide.Stats.tableBackgroundColor
         tableView.tableFooterView = UIView()
+        title = viewModel.title
         ImmuTable.registerRows(rows, tableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -2,7 +2,16 @@ import UIKit
 
 final class ReferrerDetailsTableViewController: UITableViewController {
     private lazy var tableHandler = ImmuTableViewHandler(takeOver: self)
-    private let viewModel = ReferrerDetailsViewModel()
+    private let viewModel: ReferrerDetailsViewModel
+
+    init(data: StatsTotalRowData) {
+        self.viewModel = ReferrerDetailsViewModel(data: data)
+        super.init(style: .plain)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -57,6 +57,7 @@ extension ReferrerDetailsTableViewController: ReferrerDetailsViewModelDelegate {
     }
 
     func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
+        setLoadingState(true)
         periodStore.toggleSpamState(for: referrerDomain, currentValue: currentValue)
     }
 }
@@ -64,6 +65,7 @@ extension ReferrerDetailsTableViewController: ReferrerDetailsViewModelDelegate {
 // MARK: - StatsPeriodStoreDelegate
 extension ReferrerDetailsTableViewController: StatsPeriodStoreDelegate {
     func didChangeSpamState(for referrerDomain: String, isSpam: Bool) {
+        setLoadingState(false)
         data.isReferrerSpam = isSpam
         updateViewModel()
 
@@ -74,6 +76,8 @@ extension ReferrerDetailsTableViewController: StatsPeriodStoreDelegate {
     }
 
     func changingSpamStateForReferrerDomainFailed(oldValue: Bool) {
+        setLoadingState(false)
+
         let markText = NSLocalizedString("Couldn't mark as spam", comment: "Indicating that referrer couldn't be marked as spam")
         let unmarkText = NSLocalizedString("Couldn't unmark as spam", comment: "Indicating that referrer couldn't be unmarked as spam")
         let text = oldValue ? unmarkText : markText
@@ -96,6 +100,11 @@ private extension ReferrerDetailsTableViewController {
 
     func updateViewModel() {
         viewModel.update(with: data)
+        buildViewModel()
+    }
+
+    func setLoadingState(_ value: Bool) {
+        viewModel.setLoadingState(value)
         buildViewModel()
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -1,11 +1,12 @@
 import UIKit
 
 final class ReferrerDetailsTableViewController: UITableViewController {
+    private let data: StatsTotalRowData
     private lazy var tableHandler = ImmuTableViewHandler(takeOver: self)
-    private let viewModel: ReferrerDetailsViewModel
+    private lazy var viewModel = ReferrerDetailsViewModel(data: data, delegate: self)
 
     init(data: StatsTotalRowData) {
-        self.viewModel = ReferrerDetailsViewModel(data: data)
+        self.data = data
         super.init(style: .plain)
     }
 
@@ -42,6 +43,17 @@ extension ReferrerDetailsTableViewController {
         default:
             return UIView()
         }
+    }
+}
+
+// MARK: - ReferrerDetailsViewModelDelegate
+extension ReferrerDetailsTableViewController: ReferrerDetailsViewModelDelegate {
+    func displayWebViewWithURL(_ url: URL) {
+        // TODO: implement
+    }
+
+    func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
+        // TODO: implement
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -9,6 +9,7 @@ final class ReferrerDetailsTableViewController: UITableViewController {
     init(data: StatsTotalRowData) {
         self.data = data
         super.init(style: .plain)
+        periodStore.delegate = self
     }
 
     required init?(coder: NSCoder) {
@@ -59,6 +60,23 @@ extension ReferrerDetailsTableViewController: ReferrerDetailsViewModelDelegate {
         showSpamActionSheet(for: referrerDomain, isSpam: currentValue) { [weak self] in
             self?.periodStore.toggleSpamState(for: referrerDomain, currentValue: currentValue)
         }
+    }
+}
+
+// MARK: - StatsPeriodStoreDelegate
+extension ReferrerDetailsTableViewController: StatsPeriodStoreDelegate {
+    func didChangeSpamState(for referrerDomain: String, isSpam: Bool) {
+        let markedText = NSLocalizedString("marked as spam", comment: "Indicating that referrer was marked as spam")
+        let unmarkedText = NSLocalizedString("unmarked as spam", comment: "Indicating that referrer was unmarked as spam")
+        let text = isSpam ? markedText : unmarkedText
+        displayNotice(title: "\(referrerDomain) \(text)")
+    }
+
+    func changingSpamStateForReferrerDomainFailed(oldValue: Bool) {
+        let markText = NSLocalizedString("Couldn't mark as spam", comment: "Indicating that referrer couldn't be marked as spam")
+        let unmarkText = NSLocalizedString("Couldn't unmark as spam", comment: "Indicating that referrer couldn't be unmarked as spam")
+        let text = oldValue ? unmarkText : markText
+        displayNotice(title: text)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 final class ReferrerDetailsViewModel {
-    // TODO: implement
+    private let data: StatsTotalRowData
+
+    init(data: StatsTotalRowData) {
+        self.data = data
+    }
 }
 
 // MARK: - Public Computed Properties

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -82,7 +82,10 @@ private extension ReferrerDetailsViewModel {
             case let row as ReferrerDetailsRow:
                 self.delegate?.displayWebViewWithURL(row.data.url)
             case let row as ReferrerDetailsSpamActionRow:
-                print("action, \(row), \(self)")
+                guard let referrerDomain = self.data.disclosureURL?.host ?? self.data.childRows?.first?.disclosureURL?.host else {
+                    return
+                }
+                self.delegate?.toggleSpamState(for: referrerDomain, currentValue: row.isSpam)
             default:
                 break
             }

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -8,6 +8,7 @@ protocol ReferrerDetailsViewModelDelegate: AnyObject {
 final class ReferrerDetailsViewModel {
     private var data: StatsTotalRowData
     private weak var delegate: ReferrerDetailsViewModelDelegate?
+    private var isLoading = false
 
     init(data: StatsTotalRowData, delegate: ReferrerDetailsViewModelDelegate) {
         self.data = data
@@ -19,6 +20,10 @@ final class ReferrerDetailsViewModel {
 extension ReferrerDetailsViewModel {
     func update(with data: StatsTotalRowData) {
         self.data = data
+    }
+
+    func setLoadingState(_ value: Bool) {
+        isLoading = value
     }
 }
 
@@ -34,7 +39,7 @@ extension ReferrerDetailsViewModel {
         firstSectionRows.append(contentsOf: buildDetailsRows(data: data))
 
         var secondSectionRows = [ImmuTableRow]()
-        secondSectionRows.append(ReferrerDetailsSpamActionRow(action: action, isSpam: data.isReferrerSpam))
+        secondSectionRows.append(ReferrerDetailsSpamActionRow(action: action, isSpam: data.isReferrerSpam, isLoading: isLoading))
 
         switch data.canMarkReferrerAsSpam {
         case true:

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -19,14 +19,14 @@ extension ReferrerDetailsViewModel {
         firstSectionRows.append(ReferrerDetailsHeaderRow())
         firstSectionRows.append(contentsOf: buildDetailsRows(data: data))
 
-        var seconSectionRows = [ImmuTableRow]()
-        seconSectionRows.append(ReferrerDetailsSpamActionRow(action: nil, isSpam: data.isReferrerSpam))
+        var secondSectionRows = [ImmuTableRow]()
+        secondSectionRows.append(ReferrerDetailsSpamActionRow(action: action, isSpam: data.isReferrerSpam))
 
         switch data.canMarkReferrerAsSpam {
         case true:
             return ImmuTable(sections: [
                 ImmuTableSection(rows: firstSectionRows),
-                ImmuTableSection(rows: seconSectionRows)
+                ImmuTableSection(rows: secondSectionRows)
             ])
         case false:
             return ImmuTable(sections: [
@@ -46,7 +46,7 @@ private extension ReferrerDetailsViewModel {
                 guard let url = child.disclosureURL else {
                     continue
                 }
-                rows.append(ReferrerDetailsRow(action: nil,
+                rows.append(ReferrerDetailsRow(action: action,
                                                isLast: index == children.count - 1,
                                                data: .init(name: child.name,
                                                            url: url,
@@ -56,7 +56,7 @@ private extension ReferrerDetailsViewModel {
             guard let url = data.disclosureURL else {
                 return []
             }
-            rows.append(ReferrerDetailsRow(action: nil,
+            rows.append(ReferrerDetailsRow(action: action,
                                            isLast: true,
                                            data: .init(name: data.name,
                                                        url: url,
@@ -67,3 +67,18 @@ private extension ReferrerDetailsViewModel {
     }
 }
 
+// MARK: - Private Computed Properties
+private extension ReferrerDetailsViewModel {
+    var action: ((ImmuTableRow) -> Void) {
+        return { [unowned self] row in
+            switch row {
+            case is ReferrerDetailsRow:
+                print("details, \(row), \(self)")
+            case is ReferrerDetailsSpamActionRow:
+                print("action, \(row), \(self)")
+            default:
+                break
+            }
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -79,9 +79,9 @@ private extension ReferrerDetailsViewModel {
     var action: ((ImmuTableRow) -> Void) {
         return { [unowned self] row in
             switch row {
-            case is ReferrerDetailsRow:
-                print("details, \(row), \(self)")
-            case is ReferrerDetailsSpamActionRow:
+            case let row as ReferrerDetailsRow:
+                self.delegate?.displayWebViewWithURL(row.data.url)
+            case let row as ReferrerDetailsSpamActionRow:
                 print("action, \(row), \(self)")
             default:
                 break

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -1,10 +1,17 @@
 import Foundation
 
+protocol ReferrerDetailsViewModelDelegate: AnyObject {
+    func displayWebViewWithURL(_ url: URL)
+    func toggleSpamState(for referrerDomain: String, currentValue: Bool)
+}
+
 final class ReferrerDetailsViewModel {
     private let data: StatsTotalRowData
+    private weak var delegate: ReferrerDetailsViewModelDelegate?
 
-    init(data: StatsTotalRowData) {
+    init(data: StatsTotalRowData, delegate: ReferrerDetailsViewModelDelegate) {
         self.data = data
+        self.delegate = delegate
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -10,19 +10,60 @@ final class ReferrerDetailsViewModel {
 
 // MARK: - Public Computed Properties
 extension ReferrerDetailsViewModel {
+    var title: String {
+        data.name
+    }
+
     var tableViewModel: ImmuTable {
-        var rows = [ImmuTableRow]()
+        var firstSectionRows = [ImmuTableRow]()
+        firstSectionRows.append(ReferrerDetailsHeaderRow())
+        firstSectionRows.append(contentsOf: buildDetailsRows(data: data))
 
-        rows.append(ReferrerDetailsHeaderRow())
+        var seconSectionRows = [ImmuTableRow]()
+        seconSectionRows.append(ReferrerDetailsSpamActionRow(action: nil, isSpam: data.isReferrerSpam))
 
-        rows.append(ReferrerDetailsRow())
-        rows.append(ReferrerDetailsRow())
-        rows.append(ReferrerDetailsRow())
-        rows.append(ReferrerDetailsRow(action: nil, isLast: true))
-
-        return ImmuTable(sections: [
-            ImmuTableSection(rows: rows),
-            ImmuTableSection(rows: [ReferrerDetailsSpamActionRow(action: nil, isSpam: false)])
-        ])
+        switch data.canMarkReferrerAsSpam {
+        case true:
+            return ImmuTable(sections: [
+                ImmuTableSection(rows: firstSectionRows),
+                ImmuTableSection(rows: seconSectionRows)
+            ])
+        case false:
+            return ImmuTable(sections: [
+                ImmuTableSection(rows: firstSectionRows)
+            ])
+        }
     }
 }
+
+// MARK: - Private Methods
+private extension ReferrerDetailsViewModel {
+    func buildDetailsRows(data: StatsTotalRowData) -> [ImmuTableRow] {
+        var rows = [ImmuTableRow]()
+
+        if let children = data.childRows, !children.isEmpty {
+            for (index, child) in children.enumerated() {
+                guard let url = child.disclosureURL else {
+                    continue
+                }
+                rows.append(ReferrerDetailsRow(action: nil,
+                                               isLast: index == children.count - 1,
+                                               data: .init(name: child.name,
+                                                           url: url,
+                                                           views: child.data)))
+            }
+        } else {
+            guard let url = data.disclosureURL else {
+                return []
+            }
+            rows.append(ReferrerDetailsRow(action: nil,
+                                           isLast: true,
+                                           data: .init(name: data.name,
+                                                       url: url,
+                                                       views: data.data)))
+        }
+
+        return rows
+    }
+}
+

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -6,12 +6,19 @@ protocol ReferrerDetailsViewModelDelegate: AnyObject {
 }
 
 final class ReferrerDetailsViewModel {
-    private let data: StatsTotalRowData
+    private var data: StatsTotalRowData
     private weak var delegate: ReferrerDetailsViewModelDelegate?
 
     init(data: StatsTotalRowData, delegate: ReferrerDetailsViewModelDelegate) {
         self.data = data
         self.delegate = delegate
+    }
+}
+
+// MARK: - Public Methods
+extension ReferrerDetailsViewModel {
+    func update(with data: StatsTotalRowData) {
+        self.data = data
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -321,7 +321,7 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
 
 extension SiteStatsDetailTableViewController: SiteStatsReferrerDelegate {
     func showReferrerDetails(_ data: StatsTotalRowData) {
-        show(ReferrerDetailsTableViewController(), sender: nil)
+        show(ReferrerDetailsTableViewController(data: data), sender: nil)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -146,8 +146,7 @@ private extension SiteStatsDetailTableViewController {
 
     func initViewModel() {
         viewModel = SiteStatsDetailsViewModel(detailsDelegate: self,
-                                              referrerDelegate: self,
-                                              storeDelegate: self)
+                                              referrerDelegate: self)
 
         guard let statSection = statSection else {
             return
@@ -267,12 +266,6 @@ private extension SiteStatsDetailTableViewController {
         initViewModel()
     }
 
-}
-
-// MARK: - StatsPeriodStoreDelegate
-
-extension SiteStatsDetailTableViewController: StatsPeriodStoreDelegate {
-    /* using default implementation in protocol extension */
 }
 
 // MARK: - SiteStatsDetailsDelegate Methods

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -33,11 +33,9 @@ class SiteStatsDetailsViewModel: Observable {
     // MARK: - Init
 
     init(detailsDelegate: SiteStatsDetailsDelegate,
-         referrerDelegate: SiteStatsReferrerDelegate,
-         storeDelegate: StatsPeriodStoreDelegate) {
+         referrerDelegate: SiteStatsReferrerDelegate) {
         self.detailsDelegate = detailsDelegate
         self.referrerDelegate = referrerDelegate
-        self.periodStore.delegate = storeDelegate
     }
 
     // MARK: - Data Fetching
@@ -403,10 +401,6 @@ class SiteStatsDetailsViewModel: Observable {
         }
 
         ActionDispatcher.dispatch(PeriodAction.refreshPostStats(postID: postID))
-    }
-
-    func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
-        periodStore.toggleSpamState(for: referrerDomain, currentValue: currentValue)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -386,7 +386,11 @@ private extension StatsTotalRow {
         }
 
         if rowData?.statSection == .periodReferrers, let data = rowData {
-            referrerDelegate?.showReferrerDetails(data)
+            if !data.canMarkReferrerAsSpam, !hasChildRows, let url = data.disclosureURL {
+                delegate?.displayWebViewWithURL?(url)
+            } else {
+                referrerDelegate?.showReferrerDetails(data)
+            }
             return
         }
 


### PR DESCRIPTION
Part of [#16710](https://github.com/wordpress-mobile/WordPress-iOS/issues/16710)
Depends on [#16715](https://github.com/wordpress-mobile/WordPress-iOS/pull/16715)

This PR adds logic for marking / unmarking referrer as spam.

### To test:

1. Tap on 'Stats' button located in 'My Site' tab.
2. Scroll down to referrers section.
3. Tapping on a referrer displays referrer details scene.
4. Tapping on 'View more', and then on a referrer also displays referrer details scene.
5. Tap on 'Mark as spam' or 'Mark as not spam'

### Outcome:


https://user-images.githubusercontent.com/12729242/122833573-7e1f6180-d2ed-11eb-912a-962b50525507.mp4



### Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
