### PR TITLE
Makes the blogging reminders scheduler work for multiple blogs.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -138,13 +138,15 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
     // MARK: - Initializers
 
-    let tracker: BloggingRemindersTracker
+    private let blog: Blog
+    private let tracker: BloggingRemindersTracker
 
     init(
         for blog: Blog,
         tracker: BloggingRemindersTracker,
         calendar: Calendar? = nil) throws {
 
+        self.blog = blog
         self.tracker = tracker
         self.calendar = calendar ?? {
             var calendar = Calendar.current
@@ -153,9 +155,9 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
             return calendar
         }()
 
-        scheduler = try BloggingRemindersScheduler(blogIdentifier: blog.objectID.uriRepresentation())
+        scheduler = try BloggingRemindersScheduler()
 
-        switch self.scheduler.schedule() {
+        switch self.scheduler.schedule(for: blog) {
         case .none:
             weekdays = []
         case .weekdays(let scheduledWeekdays):
@@ -329,7 +331,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     ///         can also be called when the refrenced VC is already on-screen.
     ///
     private func scheduleReminders(showPushPrompt: Bool = true) {
-        scheduler.schedule(.weekdays(weekdays)) { [weak self] result in
+        scheduler.schedule(.weekdays(weekdays), for: blog) { [weak self] result in
             switch result {
             case .success:
                 DispatchQueue.main.async { [weak self] in

--- a/WordPress/WordPressTest/BloggingRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/BloggingRemindersSchedulerTests.swift
@@ -55,6 +55,9 @@ class BloggingRemindersSchedulerTests: XCTestCase {
         let schedule = BloggingRemindersScheduler.Schedule.weekdays(days)
         let store: BloggingRemindersStore
 
+        let context = TestContextManager().mainContext
+        let blog = BlogBuilder(context).build()
+
         do {
             store = try BloggingRemindersStore(dataFileURL: dataFileURL())
         } catch {
@@ -68,23 +71,20 @@ class BloggingRemindersSchedulerTests: XCTestCase {
         }
 
         let scheduler = BloggingRemindersScheduler(
-            blogIdentifier: blogIdentifier,
             store: store,
             notificationCenter: notificationCenter,
             pushNotificationAuthorizer: PushNotificationsAuthorizerMock())
 
-        scheduler.schedule(schedule) { _ in
+        scheduler.schedule(schedule, for: blog) { _ in
         }
 
-        XCTAssertEqual(scheduler.schedule(), schedule)
+        XCTAssertEqual(scheduler.schedule(for: blog), schedule)
     }
 
     /// Tests that the scheduler does schedule and cancel local notifications.
     ///
     func testLocalNotificationsSchedulingAndCancelling() {
-        let blogIdentifier = URL(fileURLWithPath: "some_blog")
         let store: BloggingRemindersStore
-
         let days = [BloggingRemindersScheduler.Weekday]([.monday, .tuesday, .saturday])
 
         let scheduleExpectation = expectation(description: "The notification is scheduled")
@@ -92,6 +92,9 @@ class BloggingRemindersSchedulerTests: XCTestCase {
 
         let cancelExpectation = expectation(description: "The notification is cancelled")
         cancelExpectation.expectedFulfillmentCount = days.count
+
+        let context = TestContextManager().mainContext
+        let blog = BlogBuilder(context).build()
 
         do {
             store = try BloggingRemindersStore(dataFileURL: dataFileURL())
@@ -108,15 +111,14 @@ class BloggingRemindersSchedulerTests: XCTestCase {
         }
 
         let scheduler = BloggingRemindersScheduler(
-            blogIdentifier: blogIdentifier,
             store: store,
             notificationCenter: notificationCenter,
             pushNotificationAuthorizer: PushNotificationsAuthorizerMock())
 
-        scheduler.schedule(.weekdays(days)) { _ in
+        scheduler.schedule(.weekdays(days), for: blog) { _ in
         }
 
-        scheduler.schedule(.none) { _ in
+        scheduler.schedule(.none, for: blog) { _ in
         }
 
         waitForExpectations(timeout: 0.1) { error in


### PR DESCRIPTION
This is just a technical change to make the blogging reminders scheduler be initializable without specifying a blog, and to make the unscheduling work for multiple blogs.

## To test:

Try scheduling, unscheduling, and make sure the days shown as selected make sense.

## Regression Notes
1. Potential unintended areas of impact

None, as this is an unreleased feature still under testing.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
