### PR TITLE
Several localization fixes for blogging reminders.

### DIFF
--- a/WordPress/Classes/Extensions/NSCalendar+Helpers.swift
+++ b/WordPress/Classes/Extensions/NSCalendar+Helpers.swift
@@ -10,7 +10,34 @@ extension Calendar {
         return components.day!
     }
 
-    public func localizedDayIndex(_ index: Int) -> Int {
-        return (index + firstWeekday - 1) % weekdaySymbols.count
+    /// Converts a localized weekday index (where 0 can be either Sunday or Monday depending on the locale settings)
+    /// into an unlocalized weekday index (where 0 is always Sunday).
+    ///
+    /// - Parameters:
+    ///     - localizedWeekdayIndex: a localized weekday index representing the desired day of
+    ///         the week.  0 could either be Sunday or Monday depending on the `Calendar`'s locale settings.
+    ///
+    /// - Returns: an index where 0 is always Sunday.  This index can be used with methods such as `Calendar.weekdaySymbol`
+    ///     to obtain the name of the day.
+    ///
+    public func unlocalizedWeekdayIndex(localizedWeekdayIndex: Int) -> Int {
+        return (localizedWeekdayIndex + firstWeekday - 1) % weekdaySymbols.count
+    }
+
+    /// Converts an unlocalized weekday index (where 0 is always Sunday)
+    /// into a localized weekday index (where 0 can be either Sunday or Monday depending on the locale settings).
+    ///
+    /// - Parameters:
+    ///     - unlocalizedWeekdayIndex: an unlocalized weekday index representing the desired day of
+    ///         the week.  0 is always Sunday.
+    ///
+    /// - Returns: an index where 0 can be either Sunday or Monday depending on locale settings.
+    ///
+    public func localizedWeekdayIndex(unlocalizedWeekdayIndex: Int) -> Int {
+        let firstZeroBasedWeekday = firstWeekday - 1
+
+        return unlocalizedWeekdayIndex >= firstZeroBasedWeekday
+            ? unlocalizedWeekdayIndex - firstZeroBasedWeekday
+            : unlocalizedWeekdayIndex + weekdaySymbols.count - firstZeroBasedWeekday
     }
 }

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -56,6 +56,9 @@ class BloggingRemindersScheduler {
         }
     }
 
+    /// The raw values have been selected for convenience, so that they perfectly match Apple's
+    /// index for weekday symbol methods, such as `Calendar.weekdaySymbols`.
+    ///
     enum Weekday: Int, Codable, Comparable {
         case sunday = 0
         case monday
@@ -243,9 +246,11 @@ class BloggingRemindersScheduler {
         content.body = "It's time to post!"
 
         var dateComponents = DateComponents()
-        dateComponents.calendar = Calendar.current
+        let calendar = Calendar.current
+        dateComponents.calendar = calendar
 
-        dateComponents.weekday = weekday.rawValue
+        // `DateComponent`'s weekday uses a 1-based index.
+        dateComponents.weekday = weekday.rawValue + 1
         dateComponents.hour = Weekday.defaultHour
 
         let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -172,13 +172,21 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
             return
         }
 
-        let markedUpDays: [String] = selectedDays.sorted().compactMap({ [weak self] day in
+        // We want the days sorted by their localized index because under some locale configurations
+        // Sunday is the first day of the week, whereas in some other localizations Monday comes first.
+        let sortedDays = selectedDays.sorted { (first, second) -> Bool in
+            let firstIndex = self.calendar.localizedWeekdayIndex(unlocalizedWeekdayIndex: first.rawValue)
+            let secondIndex = self.calendar.localizedWeekdayIndex(unlocalizedWeekdayIndex: second.rawValue)
+
+            return firstIndex < secondIndex
+        }
+
+        let markedUpDays: [String] = sortedDays.compactMap({ [weak self] day in
             guard let self = self else {
                 return nil
             }
 
-            let localizedDayIndex = self.calendar.localizedDayIndex(day.rawValue)
-            return "<strong>\(self.calendar.weekdaySymbols[localizedDayIndex])</strong>"
+            return "<strong>\(self.calendar.weekdaySymbols[day.rawValue])</strong>"
         })
 
         let promptText: String

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -266,10 +266,10 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     ///
     /// - Returns: the requested toggle button.
     ///
-    private func createCalendarDayToggleButton(dayIndex: Int) -> CalendarDayToggleButton? {
-        let localizedDayIndex = calendar.localizedDayIndex(dayIndex)
+    private func createCalendarDayToggleButton(localizedWeekdayDayIndex: Int) -> CalendarDayToggleButton? {
+        let weekdayIndex = calendar.unlocalizedWeekdayIndex(localizedWeekdayIndex: localizedWeekdayDayIndex)
 
-        guard let weekday = BloggingRemindersScheduler.Weekday(rawValue: localizedDayIndex) else {
+        guard let weekday = BloggingRemindersScheduler.Weekday(rawValue: weekdayIndex) else {
             return nil
         }
 
@@ -277,7 +277,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
         return CalendarDayToggleButton(
             weekday: weekday,
-            dayName: self.calendar.shortWeekdaySymbols[localizedDayIndex].uppercased(),
+            dayName: calendar.shortWeekdaySymbols[weekdayIndex].uppercased(),
             isSelected: isSelected) { [weak self] button in
 
             guard let self = self else {
@@ -300,8 +300,8 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         let topRow = 0 ..< Metrics.topRowDayCount
         let bottomRow = Metrics.topRowDayCount ..< calendar.shortWeekdaySymbols.count
 
-        daysTopInnerStackView.addArrangedSubviews(topRow.compactMap({ createCalendarDayToggleButton(dayIndex: $0) }))
-        daysBottomInnerStackView.addArrangedSubviews(bottomRow.compactMap({ createCalendarDayToggleButton(dayIndex: $0) }))
+        daysTopInnerStackView.addArrangedSubviews(topRow.compactMap({ createCalendarDayToggleButton(localizedWeekdayDayIndex: $0) }))
+        daysBottomInnerStackView.addArrangedSubviews(bottomRow.compactMap({ createCalendarDayToggleButton(localizedWeekdayDayIndex: $0) }))
     }
 
     private func configureNextButton() {


### PR DESCRIPTION
Addresses several localization issues in Blogging Reminders.

1. Ensures the notification weekday matches the user-selected weekday.
2. Improves some index localization and un-localization methods.
3. The flow completion screen now orders the days based on the locale ordering.

## To test:

### Test that the user-selected week day matches the actual weekday of the notification:

1. Place a breakpoint here: https://github.com/wordpress-mobile/WordPress-iOS/blob/9fb766a82ab274a31d95bee5ff36709f34818d6b/WordPress/Classes/Utility/Blogging%20Reminders/BloggingRemindersScheduler.swift#L258
2. Run the code, and select the days you want to be notified on.
3. Once the breakpoint is hit print out these two values and make sure the weekday matches the next trigger date you get:

```lldb
po weekday
po trigger.nextTriggerDate()
```

### Test that the completion screen shows the days in order:

1. Pick US locale in iOS
2. Schedule reminders for the whole week.
3. Make sure the days are ordered with Sunday first.
4. Pick UK locale in iOS
5. Schedule reminders for the whole week.
6. Make sure the days are ordered with Monday first.

## Regression Notes

1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
