### PR TITLE
Issue/16710 - Add accessibility support

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -269,6 +269,7 @@ extension WPStyleGuide {
         // MARK: - Referrer Details
         struct ReferrerDetails {
             static let standardCellSpacing: CGFloat = 16
+            static let headerCellVerticalPadding: CGFloat = 7
             static let standardCellVerticalPadding: CGFloat = 11
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -269,6 +269,7 @@ extension WPStyleGuide {
         // MARK: - Referrer Details
         struct ReferrerDetails {
             static let standardCellSpacing: CGFloat = 16
+            static let standardCellVerticalPadding: CGFloat = 11
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -22,6 +22,20 @@ extension ReferrerDetailsCell {
         referrerLabel.text = data.name
         viewsLabel.text = data.views
         separatorView.isHidden = !isLast
+        prepareForVoiceOver()
+    }
+}
+
+// MARK: - Accessible
+extension ReferrerDetailsCell: Accessible {
+    func prepareForVoiceOver() {
+        isAccessibilityElement = true
+        if let referrer = referrerLabel.text,
+           let views = viewsLabel.text {
+            accessibilityLabel = "\(referrer), \(views)"
+        }
+        accessibilityTraits = [.staticText, .button]
+        accessibilityHint = NSLocalizedString("Tap to display referrer web page.", comment: "Accessibility hint for referrer details row.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -37,16 +37,19 @@ private extension ReferrerDetailsCell {
 
     func setupReferrerLabel() {
         Style.configureLabelAsLink(referrerLabel)
+        referrerLabel.font = WPStyleGuide.tableviewTextFont()
         referrerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
             referrerLabel.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
-            referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+            referrerLabel.topAnchor.constraint(equalTo: topAnchor, constant: Style.ReferrerDetails.standardCellVerticalPadding),
+            referrerLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Style.ReferrerDetails.standardCellVerticalPadding)
         ])
     }
 
     func setupViewsLabel() {
         Style.configureLabelAsChildRowTitle(viewsLabel)
+        viewsLabel.font = WPStyleGuide.tableviewTextFont()
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -64,6 +64,7 @@ private extension ReferrerDetailsCell {
     func setupViewsLabel() {
         Style.configureLabelAsChildRowTitle(viewsLabel)
         viewsLabel.font = WPStyleGuide.tableviewTextFont()
+        viewsLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -39,7 +39,8 @@ private extension ReferrerDetailsHeaderCell {
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
             referrerLabel.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
-            referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+            referrerLabel.topAnchor.constraint(equalTo: topAnchor, constant: Style.ReferrerDetails.headerCellVerticalPadding),
+            referrerLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Style.ReferrerDetails.headerCellVerticalPadding)
         ])
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderRow.swift
@@ -5,7 +5,6 @@ struct ReferrerDetailsHeaderRow: ImmuTableRow {
 
     static var cell = ImmuTableCell.class(CellType.self)
     var action: ImmuTableAction?
-    static var customHeight: Float? = 30
 
     func configureCell(_ cell: UITableViewCell) {
         guard let cell = cell as? CellType else {

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -45,12 +45,14 @@ private extension ReferrerDetailsSpamActionCell {
 
     func setupActionLabel() {
         actionLabel.textAlignment = .center
+        actionLabel.font = WPStyleGuide.tableviewTextFont()
         actionLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(actionLabel)
         NSLayoutConstraint.activate([
             actionLabel.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
             actionLabel.trailingAnchor.constraint(equalTo: safeTrailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
-            actionLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+            actionLabel.topAnchor.constraint(equalTo: topAnchor, constant: Style.ReferrerDetails.standardCellVerticalPadding),
+            actionLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Style.ReferrerDetails.standardCellVerticalPadding)
         ])
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -5,6 +5,7 @@ final class ReferrerDetailsSpamActionCell: UITableViewCell {
     private let separatorView = UIView()
     private let loader = UIActivityIndicatorView(style: .medium)
     private typealias Style = WPStyleGuide.Stats
+    private var markAsSpam: Bool = false
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -29,6 +30,24 @@ extension ReferrerDetailsSpamActionCell {
             actionLabel.text = NSLocalizedString("Mark as not spam", comment: "Action title for unmarking referrer as spam")
             actionLabel.textColor = Style.positiveColor
         }
+
+        self.markAsSpam = markAsSpam
+        prepareForVoiceOver()
+    }
+}
+
+// MARK: - Accessible
+extension ReferrerDetailsSpamActionCell: Accessible {
+    func prepareForVoiceOver() {
+        isAccessibilityElement = true
+        if let text = actionLabel.text {
+            accessibilityLabel = text
+        }
+        accessibilityTraits = [.button]
+
+        let markHint = NSLocalizedString("Tap to mark referrer as spam.", comment: "Accessibility hint for referrer action row.")
+        let unmarkHint = NSLocalizedString("Tap to mark referrer as not spam.", comment: "Accessibility hint for referrer action row.")
+        accessibilityHint = markAsSpam ? markHint : unmarkHint
     }
 }
 


### PR DESCRIPTION
Part of [#16710](https://github.com/wordpress-mobile/WordPress-iOS/issues/16710)
Depends on [#16716](https://github.com/wordpress-mobile/WordPress-iOS/pull/16716)

This PR adds accessibility support, in terms of Dynamic Type and accessibility hints.

### To test:

1. Enable larger font sizes
2. Tap on 'Stats' button located in 'My Site' tab.
3. Scroll down to referrers section.
4. Tapping on a referrer displays referrer details scene.
5. Tapping on 'View more', and then on a referrer also displays referrer details scene.

### Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
