### PR TITLE
Likes List: track when more Likes fetched

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -173,6 +173,9 @@ import Foundation
     // Likes list shown from Reader Post details
     case likeListOpened
 
+    // When Likes list is scrolled
+    case likeListFetchedMore
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -471,6 +474,10 @@ import Foundation
         // Likes list shown from Reader Post details
         case .likeListOpened:
             return "like_list_opened"
+
+        // When Likes list is scrolled
+        case .likeListFetchedMore:
+            return "like_list_fetched_more"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -83,7 +83,7 @@ class LikesListController: NSObject {
     }
 
     private var analyticsProperties: [String: Any] {
-        return showingNotificationLikes ? ["source": "like_notification_list"] : ["source": "like_reader_list"]
+        return showingNotificationLikes ? ["source": "notifications"] : ["source": "reader"]
     }
 
     // MARK: Init

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -82,6 +82,10 @@ class LikesListController: NSObject {
         return showingNotificationLikes ? 2 : 1
     }
 
+    private var analyticsProperties: [String: Any] {
+        return showingNotificationLikes ? ["source": "like_notification_list"] : ["source": "like_reader_list"]
+    }
+
     // MARK: Init
 
     /// Init with Notification
@@ -172,6 +176,8 @@ class LikesListController: NSObject {
         fetchLikes(success: { [weak self] users, totalLikes in
             if self?.isFirstLoad == true {
                 self?.delegate?.updatedTotalLikes?(totalLikes)
+            } else {
+                WPAnalytics.track(.likeListFetchedMore, properties: self?.analyticsProperties ?? [:])
             }
 
             self?.likingUsers = users

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -174,19 +174,25 @@ class LikesListController: NSObject {
         }
 
         fetchLikes(success: { [weak self] users, totalLikes in
-            if self?.isFirstLoad == true {
-                self?.delegate?.updatedTotalLikes?(totalLikes)
-            } else {
-                WPAnalytics.track(.likeListFetchedMore, properties: self?.analyticsProperties ?? [:])
+            guard let self = self else {
+                return
             }
 
-            self?.likingUsers = users
-            self?.totalLikes = totalLikes
-            self?.totalLikesFetched = users.count
-            self?.lastFetchedDate = users.last?.dateLikedString
-            self?.isFirstLoad = false
-            self?.isLoadingContent = false
-            self?.trackUsersToExclude()
+            if self.isFirstLoad {
+                self.delegate?.updatedTotalLikes?(totalLikes)
+            }
+
+            if !self.isFirstLoad && !users.isEmpty {
+                WPAnalytics.track(.likeListFetchedMore, properties: self.analyticsProperties)
+            }
+
+            self.likingUsers = users
+            self.totalLikes = totalLikes
+            self.totalLikesFetched = users.count
+            self.lastFetchedDate = users.last?.dateLikedString
+            self.isFirstLoad = false
+            self.isLoadingContent = false
+            self.trackUsersToExclude()
         }, failure: { [weak self] _ in
             self?.isLoadingContent = false
             self?.delegate?.showErrorView()


### PR DESCRIPTION
Fixes #16726 

This adds a track event when more Likes are fetched, i.e. the list is scrolled past the initially fetched Likes.

To test:

Reader:
- Go to the Reader. Select a post with more than 90 likes.
- Tap the Likes summary to display the list.
- Scroll past the first batch of Likes to fetch more.
- Verify this is logged: `🔵 Tracked: like_list_fetched_more <source: like_reader_list>`

Like Notifications:
- Go to the Notifications > Likes. Select one with more than 90 likes.
- Scroll past the first batch of Likes to fetch more.
- Verify this is logged: `🔵 Tracked: like_list_fetched_more <source: like_notification_list>`

Hack Tip:
If you don't have a lot of Likes, you can add a `count` parameter to the [fetch methods](https://github.com/wordpress-mobile/WordPress-iOS/blob/af5f627a23f74e6552c2b2a60c85a65234d9ca73/WordPress/Classes/ViewRelated/Likes/LikesListController.swift#L220) to fetch less at a time.

```
postService.getLikesFor(postID: postID,
                        siteID: siteID,
                        count: 10,

commentService.getLikesFor(commentID: commentID,
                         siteID: siteID,
                         count: 10,
```

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
