### PR TITLE
Issues/16599 follow conversation from post

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [**] (Don't apply to Jetpack app): Self hosted sites that do not use Jetpack can now manage (install, uninstall, activate, and deactivate) their plugins [#16675]
 
 * [*] Upgraded the Zendesk SDK to version 5.3.0
+* [*] You can now subscribe to conversations by email from Reader lists and articles. [#16599]
 
 17.6
 -----

--- a/WordPress/Classes/Models/ReaderPost.m
+++ b/WordPress/Classes/Models/ReaderPost.m
@@ -125,6 +125,8 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     post.sortDate = remotePost.sortDate;
     post.isSeen = remotePost.isSeen;
     post.isSeenSupported = remotePost.isSeenSupported;
+    post.isSubscribedComments = remotePost.isSubscribedComments;
+    post.canSubscribeComments = remotePost.canSubscribeComments;
 
     if (existing && [topic isKindOfClass:[ReaderSearchTopic class]]) {
         // Failsafe.  The `read/search` endpoint might return the same post on

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -350,23 +350,15 @@ struct ReaderPostMenuButtonTitles {
     class func dispatchToggleSubscribeCommentMessage(subscribing: Bool, success: Bool) {
         let title: String
         if success {
-            title = subscribing ?
-                NSLocalizedString("Successfully followed conversation", comment: "The app successfully subscribed to the comments for the post") :
-                NSLocalizedString("Successfully unfollowed conversation", comment: "The app successfully unsubscribed from the comments for the post")
-
+            title = subscribing ? NoticeMessages.commentFollowSuccess : NoticeMessages.commentUnfollowSuccess
         } else {
-            title = subscribing ?
-                NSLocalizedString("Unable to follow conversation", comment: "The app failed to subscribe to the comments for the post") :
-                NSLocalizedString("Failed to unfollow conversation", comment: "The app failed to unsubscribe from the comments for the post")
+            title = subscribing ? NoticeMessages.commentFollowFail : NoticeMessages.commentUnfollowFail
         }
         dispatchNotice(Notice(title: title))
     }
 
     class func dispatchToggleSubscribeCommentErrorMessage(subscribing: Bool) {
-        let title = subscribing ?
-            NSLocalizedString("Could not subscribe to comments", comment: "The app failed to subscribe to the comments for the post") :
-            NSLocalizedString("Could not unsubscribe from comments", comment: "The app failed to unsubscribe from the comments for the post")
-
+        let title = subscribing ? NoticeMessages.commentFollowError : NoticeMessages.commentUnfollowError
         dispatchNotice(Notice(title: title))
     }
 
@@ -440,6 +432,12 @@ struct ReaderPostMenuButtonTitles {
         static let enableButtonLabel = NSLocalizedString("Enable", comment: "Button title for the enable site notifications action.")
         static let blockSiteSuccess = NSLocalizedString("Blocked site", comment: "Notice title when blocking a site succeeds.")
         static let blockSiteFail = NSLocalizedString("Unable to block site", comment: "Notice title when blocking a site fails.")
+        static let commentFollowSuccess = NSLocalizedString("Successfully followed conversation", comment: "The app successfully subscribed to the comments for the post")
+        static let commentUnfollowSuccess = NSLocalizedString("Successfully unfollowed conversation", comment: "The app successfully unsubscribed from the comments for the post")
+        static let commentFollowFail = NSLocalizedString("Unable to follow conversation", comment: "The app failed to subscribe to the comments for the post")
+        static let commentUnfollowFail = NSLocalizedString("Failed to unfollow conversation", comment: "The app failed to unsubscribe from the comments for the post")
+        static let commentFollowError = NSLocalizedString("Could not subscribe to comments", comment: "The app failed to subscribe to the comments for the post")
+        static let commentUnfollowError = NSLocalizedString("Could not unsubscribe from comments", comment: "The app failed to unsubscribe from the comments for the post")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -49,6 +49,8 @@ struct ReaderPostMenuButtonTitles {
     static let unsubscribe = NSLocalizedString("Turn off site notifications", comment: "Verb. An option to switch off site notifications.")
     static let markSeen = NSLocalizedString("Mark as seen", comment: "An option to mark a post as seen.")
     static let markUnseen = NSLocalizedString("Mark as unseen", comment: "An option to mark a post as unseen.")
+    static let followConversation = NSLocalizedString("Follow conversation by email", comment: "Verb. Button title. Follow the comments on a post.")
+    static let unFollowConversation = NSLocalizedString("Unfollow conversation by email", comment: "Verb. Button title. The user is following the comments on a post.")
 }
 
 /// A collection of helper methods used by the Reader.
@@ -343,6 +345,29 @@ struct ReaderPostMenuButtonTitles {
 
     class func dispatchToggleFollowSiteMessage(topic: ReaderSiteTopic, success: Bool) {
         dispatchToggleFollowSiteMessage(siteTitle: topic.title, siteID: topic.siteID, following: topic.following, success: success)
+    }
+
+    class func dispatchToggleSubscribeCommentMessage(subscribing: Bool, success: Bool) {
+        let title: String
+        if success {
+            title = subscribing ?
+                NSLocalizedString("Successfully followed conversation", comment: "The app successfully subscribed to the comments for the post") :
+                NSLocalizedString("Successfully unfollowed conversation", comment: "The app successfully unsubscribed from the comments for the post")
+
+        } else {
+            title = subscribing ?
+                NSLocalizedString("Unable to follow conversation", comment: "The app failed to subscribe to the comments for the post") :
+                NSLocalizedString("Failed to unfollow conversation", comment: "The app failed to unsubscribe from the comments for the post")
+        }
+        dispatchNotice(Notice(title: title))
+    }
+
+    class func dispatchToggleSubscribeCommentErrorMessage(subscribing: Bool) {
+        let title = subscribing ?
+            NSLocalizedString("Could not subscribe to comments", comment: "The app failed to subscribe to the comments for the post") :
+            NSLocalizedString("Could not unsubscribe from comments", comment: "The app failed to unsubscribe from the comments for the post")
+
+        dispatchNotice(Notice(title: title))
     }
 
     private class func dispatchToggleFollowSiteMessage(siteTitle: String, siteID: NSNumber, following: Bool, success: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -93,24 +93,6 @@ final class ReaderShowMenuAction {
                                                })
         }
 
-        // Comment Subscription (Follow Comments by Email)
-        if post.canSubscribeComments {
-            let buttonTitle = post.isSubscribedComments ? ReaderPostMenuButtonTitles.unFollowConversation : ReaderPostMenuButtonTitles.followConversation
-            alertController.addActionWithTitle(buttonTitle,
-                                               style: .default,
-                                               handler: { (action: UIAlertAction) in
-                                                if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
-                                                    ReaderSubscribeCommentsAction().execute(with: post,
-                                                                                 context: context,
-                                                                                 completion: {
-                                                                                    // No op
-                                                                                 }, failure: { _ in
-                                                                                    // No op.
-                                                                                 })
-                                                }
-            })
-        }
-
         // Seen
         if post.isSeenSupported {
             alertController.addActionWithTitle(post.isSeen ? ReaderPostMenuButtonTitles.markUnseen : ReaderPostMenuButtonTitles.markSeen,
@@ -149,6 +131,24 @@ final class ReaderShowMenuAction {
                                            handler: { (action: UIAlertAction) in
                                             ReaderShareAction().execute(with: post, context: context, anchor: anchor, vc: vc)
         })
+
+        // Comment Subscription (Follow Comments by Email)
+        if post.canSubscribeComments {
+            let buttonTitle = post.isSubscribedComments ? ReaderPostMenuButtonTitles.unFollowConversation : ReaderPostMenuButtonTitles.followConversation
+            alertController.addActionWithTitle(buttonTitle,
+                                               style: .default,
+                                               handler: { (action: UIAlertAction) in
+                                                if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
+                                                    ReaderSubscribeCommentsAction().execute(with: post,
+                                                                                 context: context,
+                                                                                 completion: {
+                                                                                    // No op
+                                                                                 }, failure: { _ in
+                                                                                    // No op.
+                                                                                 })
+                                                }
+            })
+        }
 
         if WPDeviceIdentification.isiPad() {
             alertController.modalPresentationStyle = .popover

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -141,11 +141,8 @@ final class ReaderShowMenuAction {
                                                 if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
                                                     ReaderSubscribeCommentsAction().execute(with: post,
                                                                                  context: context,
-                                                                                 completion: {
-                                                                                    // No op
-                                                                                 }, failure: { _ in
-                                                                                    // No op.
-                                                                                 })
+                                                                                 completion: nil,
+                                                                                 failure: nil)
                                                 }
             })
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -139,10 +139,7 @@ final class ReaderShowMenuAction {
                                                style: .default,
                                                handler: { (action: UIAlertAction) in
                                                 if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
-                                                    ReaderSubscribeCommentsAction().execute(with: post,
-                                                                                 context: context,
-                                                                                 completion: nil,
-                                                                                 failure: nil)
+                                                    ReaderSubscribeCommentsAction().execute(with: post, context: context)
                                                 }
             })
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -93,6 +93,24 @@ final class ReaderShowMenuAction {
                                                })
         }
 
+        // Comment Subscription (Follow Comments by Email)
+        if post.canSubscribeComments {
+            let buttonTitle = post.isSubscribedComments ? ReaderPostMenuButtonTitles.unFollowConversation : ReaderPostMenuButtonTitles.followConversation
+            alertController.addActionWithTitle(buttonTitle,
+                                               style: .default,
+                                               handler: { (action: UIAlertAction) in
+                                                if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
+                                                    ReaderSubscribeCommentsAction().execute(with: post,
+                                                                                 context: context,
+                                                                                 completion: {
+                                                                                    // No op
+                                                                                 }, failure: { _ in
+                                                                                    // No op.
+                                                                                 })
+                                                }
+            })
+        }
+
         // Seen
         if post.isSeenSupported {
             alertController.addActionWithTitle(post.isSeen ? ReaderPostMenuButtonTitles.markUnseen : ReaderPostMenuButtonTitles.markSeen,

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSubscribeCommentsAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSubscribeCommentsAction.swift
@@ -1,0 +1,17 @@
+/// Encapsulates a command to subscribe or unsubscribe to a posts comments.
+final class ReaderSubscribeCommentsAction {
+    func execute(with post: ReaderPost,
+                 context: NSManagedObjectContext,
+                 completion: (() -> Void)? = nil,
+                 failure: ((Error?) -> Void)? = nil) {
+
+        let subscribing = !post.isSubscribedComments
+        let service = FollowCommentsService(post: post)
+        service?.toggleSubscribed(post.isSubscribedComments, success: { success in
+            ReaderHelpers.dispatchToggleSubscribeCommentMessage(subscribing: subscribing, success: success)
+        }, failure: { error in
+            DDLogError("Error toggling comment subscription status: \(error.debugDescription)")
+            ReaderHelpers.dispatchToggleSubscribeCommentErrorMessage(subscribing: subscribing)
+        })
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2357,6 +2357,8 @@
 		E6D3B1431D1C702600008D4B /* ReaderFollowedSitesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D3B1421D1C702600008D4B /* ReaderFollowedSitesViewController.swift */; };
 		E6D3E8491BEBD871002692E8 /* ReaderCrossPostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D3E8481BEBD871002692E8 /* ReaderCrossPostCell.swift */; };
 		E6D3E84B1BEBD888002692E8 /* ReaderCrossPostCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6D3E84A1BEBD888002692E8 /* ReaderCrossPostCell.xib */; };
+		E6D6A1302683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D6A12F2683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift */; };
+		E6D6A1312683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D6A12F2683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift */; };
 		E6DAABDD1CF632EC0069D933 /* ReaderSearchSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DAABDC1CF632EC0069D933 /* ReaderSearchSuggestionsViewController.swift */; };
 		E6DE44671B90D251000FA7EF /* ReaderHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DE44661B90D251000FA7EF /* ReaderHelpers.swift */; };
 		E6E27D621C6144DB0063F821 /* SharingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E27D611C6144DB0063F821 /* SharingButton.swift */; };
@@ -7163,6 +7165,7 @@
 		E6D3B1421D1C702600008D4B /* ReaderFollowedSitesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderFollowedSitesViewController.swift; sourceTree = "<group>"; };
 		E6D3E8481BEBD871002692E8 /* ReaderCrossPostCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderCrossPostCell.swift; sourceTree = "<group>"; };
 		E6D3E84A1BEBD888002692E8 /* ReaderCrossPostCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderCrossPostCell.xib; sourceTree = "<group>"; };
+		E6D6A12F2683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSubscribeCommentsAction.swift; sourceTree = "<group>"; };
 		E6DAABDC1CF632EC0069D933 /* ReaderSearchSuggestionsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSearchSuggestionsViewController.swift; sourceTree = "<group>"; };
 		E6DE44661B90D251000FA7EF /* ReaderHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderHelpers.swift; sourceTree = "<group>"; };
 		E6E27D611C6144DB0063F821 /* SharingButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingButton.swift; sourceTree = "<group>"; };
@@ -13122,6 +13125,7 @@
 				D8212CB620AA7703008E8AE8 /* ReaderShareAction.swift */,
 				D8212CBE20AA7B7F008E8AE8 /* ReaderShowAttributionAction.swift */,
 				D8212CC020AA7C58008E8AE8 /* ReaderShowMenuAction.swift */,
+				E6D6A12F2683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift */,
 				D8212CB420AA68D5008E8AE8 /* ReaderSubscribingNotificationAction.swift */,
 				D8212CBC20AA7A7A008E8AE8 /* ReaderVisitSiteAction.swift */,
 			);
@@ -17720,6 +17724,7 @@
 				7435CE7320A4B9170075A1B9 /* AnimatedImageCache.swift in Sources */,
 				43AB7C5E1D3E70510066CB6A /* PostListFilterSettings.swift in Sources */,
 				CE46018B21139E8300F242B6 /* FooterTextContent.swift in Sources */,
+				E6D6A1302683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift in Sources */,
 				B5EEDB971C91F10400676B2B /* Blog+Interface.swift in Sources */,
 				982DDF96263238A6002B3904 /* LikeUserPreferredBlog+CoreDataProperties.swift in Sources */,
 				5D839AA8187F0D6B00811F4A /* PostFeaturedImageCell.m in Sources */,
@@ -19233,6 +19238,7 @@
 				FABB22DB2602FC2C00C8785C /* AboutViewController.swift in Sources */,
 				FABB22DC2602FC2C00C8785C /* MenuLocation.m in Sources */,
 				FABB22DD2602FC2C00C8785C /* RevisionsTableViewCell.swift in Sources */,
+				E6D6A1312683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift in Sources */,
 				FABB22DE2602FC2C00C8785C /* KeyboardInfo.swift in Sources */,
 				FABB22DF2602FC2C00C8785C /* PlanDetailViewModel.swift in Sources */,
 				FABB22E02602FC2C00C8785C /* DebugMenuViewController.swift in Sources */,

--- a/WordPress/WordPressTest/FollowCommentsServiceTests.swift
+++ b/WordPress/WordPressTest/FollowCommentsServiceTests.swift
@@ -27,38 +27,20 @@ class FollowCommentsServiceTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testCanFollowConversationIfJetpack() {
+    func testCanFollowConversation() {
         // Arrange
         let remoteMock = ReaderPostServiceRemoteMock()
         seedBlog(isWPForTeams: false)
         let testTopic = seedReaderTeamTopic()
         let testPost = seedReaderPostForTopic(testTopic)
-        testPost.isWPCom = false
-        testPost.isJetpack = true
+        testPost.canSubscribeComments = true
         let followCommentsService = FollowCommentsService(post: testPost, remote: remoteMock)!
 
         // Act
         let canFollowConversation = followCommentsService.canFollowConversation
 
         // Assert
-        XCTAssertTrue(canFollowConversation, "Can follow comments on post if the site is DotCom or Jetpack")
-    }
-
-    func testCanFollowConversationIfDotCom() {
-        // Arrange
-        let remoteMock = ReaderPostServiceRemoteMock()
-        seedBlog(isWPForTeams: false)
-        let testTopic = seedReaderTeamTopic()
-        let testPost = seedReaderPostForTopic(testTopic)
-        testPost.isJetpack = false
-        testPost.isWPCom = true
-        let followCommentsService = FollowCommentsService(post: testPost, remote: remoteMock)!
-
-        // Act
-        let canFollowConversation = followCommentsService.canFollowConversation
-
-        // Assert
-        XCTAssertTrue(canFollowConversation, "Can follow comments on post if the site is DotCom or Jetpack")
+        XCTAssertTrue(canFollowConversation, "Can follow comments on post if canSubscribeComments is true")
     }
 
     func testCannotFollowConversation() {
@@ -67,6 +49,7 @@ class FollowCommentsServiceTests: XCTestCase {
         seedBlog(isWPForTeams: false)
         let testTopic = seedReaderListTopic()
         let testPost = seedReaderPostForTopic(testTopic)
+        testPost.canSubscribeComments = false
         let followCommentsService = FollowCommentsService(post: testPost, remote: remoteMock)!
 
         // Act


### PR DESCRIPTION
Closes #16599 

This PR adds a "Follow conversation by email" option to the Reader post menu and is available from post cards and the post detail.  The menu action leverages the existing `FollowCommentsService`, whose code is modified to update the `isSubscribedComments` property on the relevant post.  Use the menu option to follow or unfollow by email the conversation on a post. 

Example:
![Simulator Screen Shot - iPhone 11 - 2021-06-23 at 14 46 40](https://user-images.githubusercontent.com/1435271/123161127-a82f6b80-d434-11eb-9bfb-aa38bc09a554.png)
![Simulator Screen Shot - iPhone 11 - 2021-06-23 at 14 46 46](https://user-images.githubusercontent.com/1435271/123161134-a9f92f00-d434-11eb-96c6-f37e2cd693af.png)

To test:
- Follow a conversation from the Reader post card menu, and the Reader post detail menu (they are powered by the same code). 
- Confirm you can follow and unfollow successfully. 
- Confirm the correct notice is shown after following/unfollowing
- Confirm that the correct status is shown on the web. The easiest way was to see if the "Follow/Following" button on a P2 post shows the correct status.
- Change status on the web. Refresh the reader post list in the app.  Confirm the menu shows the correct status. 

Note: I've spotted a glitch with some external sites (e.g. msnbc) incorrectly being flagged as subscribe-able.  This is being addressed API side in a separate PR and should not otherwise impact these changes.  The silver lining is they can be used to test the failure prompts ;).  

@ScoutHarris would you be game for a review?

## Regression Notes
1. Potential unintended areas of impact
The existing follow conversation feature available on the reader comments screen.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested to confirm that there were no regressions.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
