### PR TITLE
Issue/16710 - Add unit tests

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -269,6 +269,7 @@ extension WPStyleGuide {
         // MARK: - Referrer Details
         struct ReferrerDetails {
             static let standardCellSpacing: CGFloat = 16
+            static let headerCellVerticalPadding: CGFloat = 7
             static let standardCellVerticalPadding: CGFloat = 11
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -269,6 +269,7 @@ extension WPStyleGuide {
         // MARK: - Referrer Details
         struct ReferrerDetails {
             static let standardCellSpacing: CGFloat = 16
+            static let standardCellVerticalPadding: CGFloat = 11
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -22,6 +22,20 @@ extension ReferrerDetailsCell {
         referrerLabel.text = data.name
         viewsLabel.text = data.views
         separatorView.isHidden = !isLast
+        prepareForVoiceOver()
+    }
+}
+
+// MARK: - Accessible
+extension ReferrerDetailsCell: Accessible {
+    func prepareForVoiceOver() {
+        isAccessibilityElement = true
+        if let referrer = referrerLabel.text,
+           let views = viewsLabel.text {
+            accessibilityLabel = "\(referrer), \(views)"
+        }
+        accessibilityTraits = [.staticText, .button]
+        accessibilityHint = NSLocalizedString("Tap to display referrer web page.", comment: "Accessibility hint for referrer details row.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -37,16 +37,19 @@ private extension ReferrerDetailsCell {
 
     func setupReferrerLabel() {
         Style.configureLabelAsLink(referrerLabel)
+        referrerLabel.font = WPStyleGuide.tableviewTextFont()
         referrerLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
             referrerLabel.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
-            referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+            referrerLabel.topAnchor.constraint(equalTo: topAnchor, constant: Style.ReferrerDetails.standardCellVerticalPadding),
+            referrerLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Style.ReferrerDetails.standardCellVerticalPadding)
         ])
     }
 
     func setupViewsLabel() {
         Style.configureLabelAsChildRowTitle(viewsLabel)
+        viewsLabel.font = WPStyleGuide.tableviewTextFont()
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -64,6 +64,7 @@ private extension ReferrerDetailsCell {
     func setupViewsLabel() {
         Style.configureLabelAsChildRowTitle(viewsLabel)
         viewsLabel.font = WPStyleGuide.tableviewTextFont()
+        viewsLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         viewsLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(viewsLabel)
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -39,7 +39,8 @@ private extension ReferrerDetailsHeaderCell {
         addSubview(referrerLabel)
         NSLayoutConstraint.activate([
             referrerLabel.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
-            referrerLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+            referrerLabel.topAnchor.constraint(equalTo: topAnchor, constant: Style.ReferrerDetails.headerCellVerticalPadding),
+            referrerLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Style.ReferrerDetails.headerCellVerticalPadding)
         ])
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderRow.swift
@@ -5,7 +5,6 @@ struct ReferrerDetailsHeaderRow: ImmuTableRow {
 
     static var cell = ImmuTableCell.class(CellType.self)
     var action: ImmuTableAction?
-    static var customHeight: Float? = 30
 
     func configureCell(_ cell: UITableViewCell) {
         guard let cell = cell as? CellType else {

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -45,12 +45,14 @@ private extension ReferrerDetailsSpamActionCell {
 
     func setupActionLabel() {
         actionLabel.textAlignment = .center
+        actionLabel.font = WPStyleGuide.tableviewTextFont()
         actionLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(actionLabel)
         NSLayoutConstraint.activate([
             actionLabel.leadingAnchor.constraint(equalTo: safeLeadingAnchor, constant: Style.ReferrerDetails.standardCellSpacing),
             actionLabel.trailingAnchor.constraint(equalTo: safeTrailingAnchor, constant: -Style.ReferrerDetails.standardCellSpacing),
-            actionLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+            actionLabel.topAnchor.constraint(equalTo: topAnchor, constant: Style.ReferrerDetails.standardCellVerticalPadding),
+            actionLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Style.ReferrerDetails.standardCellVerticalPadding)
         ])
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -5,6 +5,7 @@ final class ReferrerDetailsSpamActionCell: UITableViewCell {
     private let separatorView = UIView()
     private let loader = UIActivityIndicatorView(style: .medium)
     private typealias Style = WPStyleGuide.Stats
+    private var markAsSpam: Bool = false
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -29,6 +30,24 @@ extension ReferrerDetailsSpamActionCell {
             actionLabel.text = NSLocalizedString("Mark as not spam", comment: "Action title for unmarking referrer as spam")
             actionLabel.textColor = Style.positiveColor
         }
+
+        self.markAsSpam = markAsSpam
+        prepareForVoiceOver()
+    }
+}
+
+// MARK: - Accessible
+extension ReferrerDetailsSpamActionCell: Accessible {
+    func prepareForVoiceOver() {
+        isAccessibilityElement = true
+        if let text = actionLabel.text {
+            accessibilityLabel = text
+        }
+        accessibilityTraits = [.button]
+
+        let markHint = NSLocalizedString("Tap to mark referrer as spam.", comment: "Accessibility hint for referrer action row.")
+        let unmarkHint = NSLocalizedString("Tap to mark referrer as not spam.", comment: "Accessibility hint for referrer action row.")
+        accessibilityHint = markAsSpam ? markHint : unmarkHint
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -6,9 +6,9 @@ protocol ReferrerDetailsViewModelDelegate: AnyObject {
 }
 
 final class ReferrerDetailsViewModel {
-    private var data: StatsTotalRowData
+    private(set) var data: StatsTotalRowData
     private weak var delegate: ReferrerDetailsViewModelDelegate?
-    private var isLoading = false
+    private(set) var isLoading = false
 
     init(data: StatsTotalRowData, delegate: ReferrerDetailsViewModelDelegate) {
         self.data = data

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1395,6 +1395,7 @@
 		937D9A1119F838C2007B9D5F /* AccountToAccount22to23.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937D9A1019F838C2007B9D5F /* AccountToAccount22to23.swift */; };
 		937E3AB61E3EBE1600CDA01A /* PostEditorStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937E3AB51E3EBE1600CDA01A /* PostEditorStateTests.swift */; };
 		937F3E321AD6FDA7006BA498 /* WPAnalyticsTrackerAutomatticTracks.m in Sources */ = {isa = PBXBuildFile; fileRef = 937F3E311AD6FDA7006BA498 /* WPAnalyticsTrackerAutomatticTracks.m */; };
+		938466B92683CA0E00A538DC /* ReferrerDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938466B82683CA0E00A538DC /* ReferrerDetailsViewModelTests.swift */; };
 		938CF3DC1EF1BE6800AF838E /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CF3DB1EF1BE6800AF838E /* CocoaLumberjack.swift */; };
 		938CF3DD1EF1BE7F00AF838E /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CF3DB1EF1BE6800AF838E /* CocoaLumberjack.swift */; };
 		938CF3DE1EF1BE8000AF838E /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CF3DB1EF1BE6800AF838E /* CocoaLumberjack.swift */; };
@@ -6042,6 +6043,7 @@
 		937E3AB51E3EBE1600CDA01A /* PostEditorStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostEditorStateTests.swift; sourceTree = "<group>"; };
 		937F3E301AD6FDA7006BA498 /* WPAnalyticsTrackerAutomatticTracks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = WPAnalyticsTrackerAutomatticTracks.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		937F3E311AD6FDA7006BA498 /* WPAnalyticsTrackerAutomatticTracks.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAnalyticsTrackerAutomatticTracks.m; sourceTree = "<group>"; };
+		938466B82683CA0E00A538DC /* ReferrerDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		938CF3DB1EF1BE6800AF838E /* CocoaLumberjack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CocoaLumberjack.swift; sourceTree = "<group>"; };
 		93A379EB19FFBF7900415023 /* KeychainTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KeychainTest.m; sourceTree = "<group>"; };
 		93A3F7DD1843F6F00082FEEA /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
@@ -9369,6 +9371,7 @@
 				40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */,
 				400A2C942217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift */,
 				400A2C962217B883000A8A59 /* VisitsSummaryStatsRecordValueTests.swift */,
+				938466B82683CA0E00A538DC /* ReferrerDetailsViewModelTests.swift */,
 			);
 			name = Stats;
 			sourceTree = "<group>";
@@ -18609,6 +18612,7 @@
 				E1C545801C6C79BB001CEB0E /* MediaSettingsTests.swift in Sources */,
 				7E987F5A2108122A00CAFB88 /* NotificationUtility.swift in Sources */,
 				7E442FC720F677CB00DEACA5 /* ActivityLogRangesTest.swift in Sources */,
+				938466B92683CA0E00A538DC /* ReferrerDetailsViewModelTests.swift in Sources */,
 				8B25F8DA24B7683A009DD4C9 /* ReaderCSSTests.swift in Sources */,
 				AB2211F425ED6E7A00BF72FC /* CommentServiceTests.swift in Sources */,
 				08E77F471EE9D72F006F9515 /* MediaThumbnailExporterTests.swift in Sources */,

--- a/WordPress/WordPressTest/ReferrerDetailsViewModelTests.swift
+++ b/WordPress/WordPressTest/ReferrerDetailsViewModelTests.swift
@@ -17,26 +17,51 @@ class ReferrerDetailsViewModelTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testUpdateTitle() {
+    func testTitleInitialState() {
         XCTAssertEqual(sut.title, "parent")
+    }
 
+    func testUpdateTitleWithNewData() {
         let newData = StatsTotalRowData(name: "Some other name", data: "Some other data")
         sut.update(with: newData)
 
         XCTAssertEqual(sut.title, "Some other name")
     }
 
-    func testSetLoadingState() {
+    func testInitialLoadingState() {
         XCTAssertFalse(sut.isLoading)
+    }
 
+    func testSetLoadingState() {
         sut.setLoadingState(true)
-
         XCTAssertTrue(sut.isLoading)
     }
 
-    func testTableViewModelOneDetailRow() {
+    func testNumberOfSections() {
         XCTAssertEqual(sut.tableViewModel.sections.count, 2)
+    }
+
+    func testNumberOfSectionsWithNoURL() {
+        let newData = StatsTotalRowData(name: "Some new name", data: "Some new data")
+
+        sut.update(with: newData)
+
+        XCTAssertEqual(sut.tableViewModel.sections.count, 1)
+    }
+
+    func testNumberOfSectionsWithNoChildren() {
+        let newData = StatsTotalRowData(name: "Some new name", data: "Some new data", disclosureURL: URL(string: "https://www.somenewname.com"))
+
+        sut.update(with: newData)
+
+        XCTAssertEqual(sut.tableViewModel.sections.count, 1)
+    }
+
+    func testTableViewModelHeaderRow() {
         XCTAssert(sut.tableViewModel.rowAtIndexPath(IndexPath(row: 0, section: 0)) is ReferrerDetailsHeaderRow)
+    }
+
+    func testFirstDetailsRowIsValid() {
         guard let firstRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 1, section: 0)) as? ReferrerDetailsRow else {
             XCTFail("Expected first ReferrerDetailsRow")
             return
@@ -45,7 +70,7 @@ class ReferrerDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(firstRow.data.name, "Child 1")
     }
 
-    func testTableViewModelTwoDetailRows() {
+    func testSecondDetailsRowIsValid() {
         guard let secondRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 2, section: 0)) as? ReferrerDetailsRow else {
             XCTFail("Expected first ReferrerDetailsRow")
             return
@@ -54,7 +79,7 @@ class ReferrerDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(secondRow.data.name, "Child 2")
     }
 
-    func testActionRow() {
+    func testActionRowIsValid() {
         guard let actionRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 0, section: 1)) as? ReferrerDetailsSpamActionRow else {
             XCTFail("Expected ReferrerDetailsSpamActionRow")
             return

--- a/WordPress/WordPressTest/ReferrerDetailsViewModelTests.swift
+++ b/WordPress/WordPressTest/ReferrerDetailsViewModelTests.swift
@@ -5,7 +5,9 @@ class ReferrerDetailsViewModelTests: XCTestCase {
     var sut: ReferrerDetailsViewModel!
 
     override func setUpWithError() throws {
-        let data = StatsTotalRowData(name: "A name", data: "Some data")
+        let firstChildRow = StatsTotalRowData(name: "Child 1", data: "Child data 1", disclosureURL: URL(string: "https://www.firstchild.com"))
+        let secondChildRow = StatsTotalRowData(name: "Child 2", data: "Child data 2", disclosureURL: URL(string: "https://www.secondchild.com"))
+        let data = StatsTotalRowData(name: "parent", data: "Data", disclosureURL: URL(string: "https://www.parent.com"), childRows: [firstChildRow, secondChildRow], isReferrerSpam: true)
         let delegate = ViewModelDelegate()
         sut = ReferrerDetailsViewModel(data: data, delegate: delegate)
     }
@@ -16,7 +18,7 @@ class ReferrerDetailsViewModelTests: XCTestCase {
     }
 
     func testUpdateTitle() {
-        XCTAssertEqual(sut.title, "A name")
+        XCTAssertEqual(sut.title, "parent")
 
         let newData = StatsTotalRowData(name: "Some other name", data: "Some other data")
         sut.update(with: newData)
@@ -32,30 +34,27 @@ class ReferrerDetailsViewModelTests: XCTestCase {
         XCTAssertTrue(sut.isLoading)
     }
 
-    func testTableViewModel() {
-        XCTAssertEqual(sut.tableViewModel.sections.count, 1)
-
-        let firstChildRow = StatsTotalRowData(name: "Child 1", data: "Child data 1", disclosureURL: URL(string: "https://www.firstchild.com"))
-        let secondChildRow = StatsTotalRowData(name: "Child 2", data: "Child data 2", disclosureURL: URL(string: "https://www.secondchild.com"))
-        let data = StatsTotalRowData(name: "parent", data: "Data", disclosureURL: URL(string: "https://www.parent.com"), childRows: [firstChildRow, secondChildRow], isReferrerSpam: true)
-        sut.update(with: data)
-
+    func testTableViewModelOneDetailRow() {
         XCTAssertEqual(sut.tableViewModel.sections.count, 2)
         XCTAssert(sut.tableViewModel.rowAtIndexPath(IndexPath(row: 0, section: 0)) is ReferrerDetailsHeaderRow)
-        guard let firstDetailsRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 1, section: 0)) as? ReferrerDetailsRow else {
+        guard let firstRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 1, section: 0)) as? ReferrerDetailsRow else {
             XCTFail("Expected first ReferrerDetailsRow")
             return
         }
-        XCTAssertFalse(firstDetailsRow.isLast)
-        XCTAssertEqual(firstDetailsRow.data.name, "Child 1")
+        XCTAssertFalse(firstRow.isLast)
+        XCTAssertEqual(firstRow.data.name, "Child 1")
+    }
 
-        guard let secondDetailsRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 2, section: 0)) as? ReferrerDetailsRow else {
+    func testTableViewModelTwoDetailRows() {
+        guard let secondRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 2, section: 0)) as? ReferrerDetailsRow else {
             XCTFail("Expected first ReferrerDetailsRow")
             return
         }
-        XCTAssertTrue(secondDetailsRow.isLast)
-        XCTAssertEqual(secondDetailsRow.data.name, "Child 2")
+        XCTAssertTrue(secondRow.isLast)
+        XCTAssertEqual(secondRow.data.name, "Child 2")
+    }
 
+    func testActionRow() {
         guard let actionRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 0, section: 1)) as? ReferrerDetailsSpamActionRow else {
             XCTFail("Expected ReferrerDetailsSpamActionRow")
             return

--- a/WordPress/WordPressTest/ReferrerDetailsViewModelTests.swift
+++ b/WordPress/WordPressTest/ReferrerDetailsViewModelTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import WordPress
+
+class ReferrerDetailsViewModelTests: XCTestCase {
+    var sut: ReferrerDetailsViewModel!
+
+    override func setUpWithError() throws {
+        let data = StatsTotalRowData(name: "A name", data: "Some data")
+        let delegate = ViewModelDelegate()
+        sut = ReferrerDetailsViewModel(data: data, delegate: delegate)
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+
+    func testUpdateTitle() {
+        XCTAssertEqual(sut.title, "A name")
+
+        let newData = StatsTotalRowData(name: "Some other name", data: "Some other data")
+        sut.update(with: newData)
+
+        XCTAssertEqual(sut.title, "Some other name")
+    }
+
+    func testSetLoadingState() {
+        XCTAssertFalse(sut.isLoading)
+
+        sut.setLoadingState(true)
+
+        XCTAssertTrue(sut.isLoading)
+    }
+
+    func testTableViewModel() {
+        XCTAssertEqual(sut.tableViewModel.sections.count, 1)
+
+        let firstChildRow = StatsTotalRowData(name: "Child 1", data: "Child data 1", disclosureURL: URL(string: "https://www.firstchild.com"))
+        let secondChildRow = StatsTotalRowData(name: "Child 2", data: "Child data 2", disclosureURL: URL(string: "https://www.secondchild.com"))
+        let data = StatsTotalRowData(name: "parent", data: "Data", disclosureURL: URL(string: "https://www.parent.com"), childRows: [firstChildRow, secondChildRow], isReferrerSpam: true)
+        sut.update(with: data)
+
+        XCTAssertEqual(sut.tableViewModel.sections.count, 2)
+        XCTAssert(sut.tableViewModel.rowAtIndexPath(IndexPath(row: 0, section: 0)) is ReferrerDetailsHeaderRow)
+        guard let firstDetailsRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 1, section: 0)) as? ReferrerDetailsRow else {
+            XCTFail("Expected first ReferrerDetailsRow")
+            return
+        }
+        XCTAssertFalse(firstDetailsRow.isLast)
+        XCTAssertEqual(firstDetailsRow.data.name, "Child 1")
+
+        guard let secondDetailsRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 2, section: 0)) as? ReferrerDetailsRow else {
+            XCTFail("Expected first ReferrerDetailsRow")
+            return
+        }
+        XCTAssertTrue(secondDetailsRow.isLast)
+        XCTAssertEqual(secondDetailsRow.data.name, "Child 2")
+
+        guard let actionRow = sut.tableViewModel.rowAtIndexPath(IndexPath(row: 0, section: 1)) as? ReferrerDetailsSpamActionRow else {
+            XCTFail("Expected ReferrerDetailsSpamActionRow")
+            return
+        }
+
+        XCTAssertTrue(actionRow.isSpam)
+    }
+}
+
+private extension ReferrerDetailsViewModelTests {
+    class ViewModelDelegate: ReferrerDetailsViewModelDelegate {
+        func displayWebViewWithURL(_ url: URL) {
+            /* not implemented */
+        }
+
+        func toggleSpamState(for referrerDomain: String, currentValue: Bool) {
+            /* not implemented */
+        }
+    }
+}


### PR DESCRIPTION
Part of [#16710](https://github.com/wordpress-mobile/WordPress-iOS/issues/16710)
Depends on [#16727](https://github.com/wordpress-mobile/WordPress-iOS/pull/16727)

This PR adds unit tests for `ReferrerDetailsViewModel`.

### To test:
Run tests in `ReferrerDetailsViewModelTests.swift`.

### Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
