### PR TITLE
Improves large text support throughout Blogging Reminders.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -229,7 +229,7 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
             let formattedDays = formatter.string(from: markedUpDays) ?? ""
             text = String(format: TextContent.completionPromptPlural, "<strong>\(selectedDays.count)</strong>", formattedDays)
         }
-        
+
         let htmlData = NSString(string: text).data(using: String.Encoding.unicode.rawValue) ?? Data()
         let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [.documentType: NSAttributedString.DocumentType.html]
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -220,26 +220,24 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
             .foregroundColor: UIColor.text,
         ]
 
-        let attributedString: NSMutableAttributedString
+        let text: String
 
         if selectedDays.count == 1 {
-            let text = String(format: TextContent.completionPromptSingular, markedUpDays.first ?? "")
-
-            attributedString = NSMutableAttributedString(string: text, attributes: defaultAttributes)
+            text = String(format: TextContent.completionPromptSingular, markedUpDays.first ?? "")
         } else {
             let formatter = ListFormatter()
             let formattedDays = formatter.string(from: markedUpDays) ?? ""
-            let text = String(format: TextContent.completionPromptPlural, "<strong>\(selectedDays.count)</strong>", formattedDays)
-
-            let htmlData = NSString(string: text).data(using: String.Encoding.unicode.rawValue) ?? Data()
-            let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [.documentType: NSAttributedString.DocumentType.html]
-
-            attributedString = (try? NSMutableAttributedString(data: htmlData,
-                                                               options: options,
-                                                               documentAttributes: nil)) ?? NSMutableAttributedString()
-
-            attributedString.addAttributes(defaultAttributes, range: NSRange(location: 0, length: attributedString.length))
+            text = String(format: TextContent.completionPromptPlural, "<strong>\(selectedDays.count)</strong>", formattedDays)
         }
+        
+        let htmlData = NSString(string: text).data(using: String.Encoding.unicode.rawValue) ?? Data()
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [.documentType: NSAttributedString.DocumentType.html]
+
+        let attributedString = (try? NSMutableAttributedString(data: htmlData,
+                                                           options: options,
+                                                           documentAttributes: nil)) ?? NSMutableAttributedString()
+
+        attributedString.addAttributes(defaultAttributes, range: NSRange(location: 0, length: attributedString.length))
 
         // This loop applies the default font to the whole text, while keeping any symbolic attributes the previous font may
         // have had (such as bold style).

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -37,7 +37,7 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
         label.adjustsFontForContentSizeCategory = true
         label.adjustsFontSizeToFitWidth = true
         label.font = .preferredFont(forTextStyle: .body)
-        label.numberOfLines = 4
+        label.numberOfLines = 6
         label.textAlignment = .center
         label.textColor = .text
         return label

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -137,11 +137,7 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
-            hintLabel.isHidden = true
-        } else {
-            hintLabel.isHidden = false
-        }
+        hintLabel.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
     }
 
     func calculatePreferredContentSize() {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -24,8 +24,10 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
 
     private let titleLabel: UILabel = {
         let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         label.font = WPStyleGuide.serifFontForTextStyle(.title1, fontWeight: .semibold)
-        label.numberOfLines = 0
+        label.numberOfLines = 2
         label.textAlignment = .center
         label.text = TextContent.introTitle
         return label
@@ -33,9 +35,11 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
 
     private let promptLabel: UILabel = {
         let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         label.font = .preferredFont(forTextStyle: .body)
         label.text = TextContent.introDescription
-        label.numberOfLines = 0
+        label.numberOfLines = 5
         label.textAlignment = .center
         return label
     }()
@@ -116,6 +120,12 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
         preferredContentSize = view.systemLayoutSizeFitting(size)
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        view.setNeedsLayout()
+    }
+
     // MARK: - View Configuration
 
     private func configureStackView() {
@@ -136,7 +146,7 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
             stackView.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.edgeMargins.top),
             stackView.bottomAnchor.constraint(lessThanOrEqualTo: view.safeBottomAnchor, constant: -Metrics.edgeMargins.bottom),
 
-            getStartedButton.heightAnchor.constraint(equalToConstant: Metrics.getStartedButtonHeight),
+            getStartedButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.getStartedButtonHeight),
             getStartedButton.widthAnchor.constraint(equalTo: stackView.widthAnchor),
 
             dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.edgeMargins.right),

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -24,8 +24,11 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
     let titleLabel: UILabel = {
         let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.75
         label.font = WPStyleGuide.serifFontForTextStyle(.title1, fontWeight: .semibold)
-        label.numberOfLines = 0
+        label.numberOfLines = 3
         label.textAlignment = .center
         label.text = TextContent.settingsPrompt
         return label
@@ -33,9 +36,12 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
     let promptLabel: UILabel = {
         let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.75
         label.font = .preferredFont(forTextStyle: .body)
         label.text = TextContent.settingsUpdatePrompt
-        label.numberOfLines = 0
+        label.numberOfLines = 2
         label.textAlignment = .center
         label.textColor = .secondaryLabel
         label.setContentHuggingPriority(.defaultLow, for: .vertical)
@@ -54,6 +60,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         daysOuterStack.axis = .vertical
         daysOuterStack.alignment = .center
         daysOuterStack.spacing = Metrics.innerStackSpacing
+        daysOuterStack.distribution = .fillEqually
         return daysOuterStack
     }()
 
@@ -209,6 +216,16 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         calculatePreferredContentSize()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            bottomTipPanel.isHidden = true
+        } else {
+            bottomTipPanel.isHidden = false
+        }
+    }
+
     private func calculatePreferredContentSize() {
         let size = CGSize(width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height)
         preferredContentSize = view.systemLayoutSizeFitting(size)
@@ -250,7 +267,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
             stackView.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.edgeMargins.top),
             stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: -Metrics.edgeMargins.bottom),
 
-            button.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
+            button.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.buttonHeight),
             button.widthAnchor.constraint(equalTo: stackView.widthAnchor),
 
             dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.edgeMargins.right),
@@ -276,8 +293,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         }
 
         let isSelected = weekdays.contains(weekday)
-
-        return CalendarDayToggleButton(
+        let button = CalendarDayToggleButton(
             weekday: weekday,
             dayName: calendar.shortWeekdaySymbols[weekdayIndex].uppercased(),
             isSelected: isSelected) { [weak self] button in
@@ -294,6 +310,10 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
                 }
             }
         }
+
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
+
+        return button
     }
 
     private func populateCalendarDays() {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -108,11 +108,13 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         innerStack.addArrangedSubviews([trophy, rightStack])
 
         let tipLabel = UILabel()
+        tipLabel.adjustsFontForContentSizeCategory = true
         tipLabel.textColor = .secondaryLabel
         tipLabel.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold)
         tipLabel.text = TextContent.tipPanelTitle
 
         let tipDescriptionLabel = UILabel()
+        tipDescriptionLabel.adjustsFontForContentSizeCategory = true
         tipDescriptionLabel.textColor = .secondaryLabel
         tipDescriptionLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
         tipDescriptionLabel.text = TextContent.tipPanelDescription
@@ -219,11 +221,8 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
-            bottomTipPanel.isHidden = true
-        } else {
-            bottomTipPanel.isHidden = false
-        }
+        bottomTipPanel.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        imageView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
     }
 
     private func calculatePreferredContentSize() {
@@ -266,6 +265,8 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.edgeMargins.right),
             stackView.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.edgeMargins.top),
             stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: -Metrics.edgeMargins.bottom),
+
+            imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor),
 
             button.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.buttonHeight),
             button.widthAnchor.constraint(equalTo: stackView.widthAnchor),
@@ -311,6 +312,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
             }
         }
 
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.adjustsFontSizeToFitWidth = true
 
         return button

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersPushPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersPushPromptViewController.swift
@@ -153,11 +153,7 @@ class BloggingRemindersPushPromptViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
-            hintLabel.isHidden = true
-        } else {
-            hintLabel.isHidden = false
-        }
+        hintLabel.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
     }
 
     private func calculatePreferredContentSize() {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersPushPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersPushPromptViewController.swift
@@ -24,8 +24,10 @@ class BloggingRemindersPushPromptViewController: UIViewController {
 
     private let titleLabel: UILabel = {
         let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         label.font = WPStyleGuide.serifFontForTextStyle(.title1, fontWeight: .semibold)
-        label.numberOfLines = 0
+        label.numberOfLines = 2
         label.textAlignment = .center
         label.text = TextContent.title
         return label
@@ -33,9 +35,11 @@ class BloggingRemindersPushPromptViewController: UIViewController {
 
     private let promptLabel: UILabel = {
         let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         label.font = .preferredFont(forTextStyle: .body)
         label.text = TextContent.prompt
-        label.numberOfLines = 0
+        label.numberOfLines = 4
         label.textAlignment = .center
         label.textColor = .secondaryLabel
         return label
@@ -43,9 +47,11 @@ class BloggingRemindersPushPromptViewController: UIViewController {
 
     private let hintLabel: UILabel = {
         let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         label.font = .preferredFont(forTextStyle: .body)
         label.text = TextContent.hint
-        label.numberOfLines = 0
+        label.numberOfLines = 4
         label.textAlignment = .center
         label.textColor = .secondaryLabel
         return label
@@ -57,6 +63,7 @@ class BloggingRemindersPushPromptViewController: UIViewController {
         button.isPrimary = true
         button.setTitle(TextContent.turnOnButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(turnOnButtonTapped), for: .touchUpInside)
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
         return button
     }()
 
@@ -143,6 +150,16 @@ class BloggingRemindersPushPromptViewController: UIViewController {
         calculatePreferredContentSize()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            hintLabel.isHidden = true
+        } else {
+            hintLabel.isHidden = false
+        }
+    }
+
     private func calculatePreferredContentSize() {
         let size = CGSize(width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height)
         preferredContentSize = view.systemLayoutSizeFitting(size)
@@ -173,7 +190,7 @@ class BloggingRemindersPushPromptViewController: UIViewController {
             stackView.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.edgeMargins.top),
             stackView.bottomAnchor.constraint(lessThanOrEqualTo: turnOnNotificationsButton.topAnchor, constant: Metrics.edgeMargins.bottom),
 
-            turnOnNotificationsButton.heightAnchor.constraint(equalToConstant: Metrics.turnOnButtonHeight),
+            turnOnNotificationsButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.turnOnButtonHeight),
             turnOnNotificationsButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Metrics.edgeMargins.left),
             turnOnNotificationsButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.edgeMargins.right),
             turnOnNotificationsButton.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: -Metrics.edgeMargins.bottom),

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/CalendarDayToggleButton.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/CalendarDayToggleButton.swift
@@ -62,8 +62,9 @@ class CalendarDayToggleButton: UIButton {
 
     private func configureConstraints() {
         NSLayoutConstraint.activate([
-            widthAnchor.constraint(equalToConstant: Metrics.toggleSize),
-            heightAnchor.constraint(equalToConstant: Metrics.toggleSize),
+            widthAnchor.constraint(greaterThanOrEqualToConstant: Metrics.toggleSize),
+            heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.toggleSize),
+            widthAnchor.constraint(equalTo: heightAnchor),
         ])
     }
 


### PR DESCRIPTION
This PR adds basic accessibility large-text support for Blogging Reminders.  This PR aims to make it possible to interact with the feature, but it's far from perfect and still presents quite a few visual issues we can work on iteratively.

What this PR does:

- It makes sure all of the text in the view controllers that make up the Blogging Reminders flow support dynamic text.  You can try this out by changing it on the fly, and making sure the text in the VCs adapt to the iOS accessibility setting.
- It makes it possible for the user to interact with all of the UI elements, even at the largest font setting.

What this PR doesn't do:

- It does not offer a perfect experience under the largest font size.  Some of the UI still looks ugly.
- It does not address presentation issues with `BottomSheetViewController`, which still needs to be manually dragged up and down when dynamically changing the iOS accessibility font size.

## Screenshots:

Before and after comparisons, to make it easier to understand the changes.

### Intro Screen

I'm aware that the height seems off.  I couldn't figure out a way to fix that yet.

| Before | After |
| --- | --- |
| <img width=300 src="https://user-images.githubusercontent.com/1836005/123285717-940b6d00-d50d-11eb-9e12-88a24d5e0c7b.png"> | <img width=309 src="https://user-images.githubusercontent.com/1836005/123281602-1e51d200-d50a-11eb-8191-8b1a05531f34.png"> |
| <img width=300 src="https://user-images.githubusercontent.com/1836005/123287747-43950f00-d50f-11eb-9ef4-8b1324512dbf.png"> | <img width=300 src="https://user-images.githubusercontent.com/1836005/123289031-6116a880-d510-11eb-924b-30c3db0e62ce.png"> |

### Day Picker Screen

I'm hiding the tip when showing this with accessibility font sizes.

| Before | After |
| --- | --- |
|  <img width=300 src="https://user-images.githubusercontent.com/1836005/123285855-b604ef80-d50d-11eb-8533-ca0030beecae.png"> | <img width=300 src="https://user-images.githubusercontent.com/1836005/123281879-522cf780-d50a-11eb-9756-5e2a4834f020.png"> |
| <img width=300 src="https://user-images.githubusercontent.com/1836005/123287963-70e1bd00-d50f-11eb-92f4-7adab5805944.png"> | <img width=300 src="https://user-images.githubusercontent.com/1836005/123289109-6ecc2e00-d510-11eb-9c93-ae14a24df826.png"> |

### Enable Push Notifications Screen

On iPad there's a sizing issue here that I believe it caused by `BottomSheetViewController` refreshing issues.
I'm hiding the hint when showing this with accessibility font sizes.

| Before | After |
| --- | --- |
| <img width=300 src="https://user-images.githubusercontent.com/1836005/123280064-bd75ca00-d508-11eb-95d5-842f20b8ec49.png"> | <img width=300 src="https://user-images.githubusercontent.com/1836005/123281045-a4214d80-d509-11eb-91fc-d69dcc198e81.png"> |
| <img width=300 src="https://user-images.githubusercontent.com/1836005/123288048-80f99c80-d50f-11eb-8deb-3ade4f576507.png"> | <img width=300 src="https://user-images.githubusercontent.com/1836005/123289161-7be91d00-d510-11eb-960e-1ceb76026845.png"> |

### All Set! Screen

On iPad there's a sizing issue here that I believe it caused by `BottomSheetViewController` refreshing issues.

| Before | After |
| --- | --- |
| <img width=300 src="https://user-images.githubusercontent.com/1836005/123286571-4fcc9c80-d50e-11eb-8b46-b52653f03310.png"> | <img width=300 src="https://user-images.githubusercontent.com/1836005/123283521-c2884880-d50b-11eb-99fb-53e3c284c35c.png"> |
| <img width=300 src="https://user-images.githubusercontent.com/1836005/123288111-8eaf2200-d50f-11eb-8963-409026bbf3d5.png"> | <img width=300 src="https://user-images.githubusercontent.com/1836005/123289201-886d7580-d510-11eb-8ca1-b13090801a00.png"> |

## To test:

Try out the changes with iPhone and iPad.
Enable and disable large text to see that the font size and UI adapt.

## Regression Notes
1. Potential unintended areas of impact

I could've broken UI elements in the regular navigation, but I've manually tested all scenarios and couldn't find any difference with what we had before.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
