### PR TITLE
Editor Onboarding: Enable tooltip for 50% of users

### DIFF
--- a/WordPress/Classes/Utility/Editor/GutenbergOnboardingRollout.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergOnboardingRollout.swift
@@ -1,5 +1,3 @@
-import CryptoKit
-
 /// This structs helps encapsulate logic related to Gutenberg editor onboarding rollout phases.
 ///
 struct GutenbergOnboardingRollout {
@@ -10,10 +8,19 @@ struct GutenbergOnboardingRollout {
     }
 
     func convertUserIdToRank(userId: String) -> Int {
-        let inputString = userId + "can_view_editor_onboarding"
-        let inputData = Data(inputString.utf8)
-        let hashed = SHA256.hash(data: inputData)
-        let hashRank = abs(hashed.hashValue) % 100
-        return hashRank
+        let key = userId + "can_view_editor_onboarding"
+        let inputString = key.replacingOccurrences(of: "-", with: "")
+        return abs(inputString.djb2hash) % 100
+    }
+}
+
+extension String {
+    // Ref: http://www.cse.yorku.ca/~oz/hash.html
+    // hash(0) = 5381
+    // hash(i) = hash(i - 1) * 33 ^ str[i];
+    var djb2hash: Int {
+        unicodeScalars.map { $0.value }.reduce(5381) {
+            ($0 << 5) &+ $0 &+ Int($1)
+        }
     }
 }

--- a/WordPress/Classes/Utility/Editor/GutenbergOnboardingRollout.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergOnboardingRollout.swift
@@ -1,9 +1,19 @@
+import CryptoKit
+
 /// This structs helps encapsulate logic related to Gutenberg editor onboarding rollout phases.
 ///
 struct GutenbergOnboardingRollout {
-    private let phasePercentage = 0
+    private let phasePercentage = 50
 
     func isUserIdInPhaseRolloutPercentage(_ userId: Int) -> Bool {
-        return userId % 100 >= (100 - phasePercentage) || BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+        return convertUserIdToRank(userId: String(userId)) >= (100 - phasePercentage) || BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+    }
+
+    func convertUserIdToRank(userId: String) -> Int {
+        let inputString = userId + "can_view_editor_onboarding"
+        let inputData = Data(inputString.utf8)
+        let hashed = SHA256.hash(data: inputData)
+        let hashRank = abs(hashed.hashValue) % 100
+        return hashRank
     }
 }

--- a/WordPress/Classes/Utility/Editor/GutenbergOnboardingRollout.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergOnboardingRollout.swift
@@ -3,12 +3,12 @@
 struct GutenbergOnboardingRollout {
     private let phasePercentage = 50
 
-    func isUserIdInPhaseRolloutPercentage(_ userId: Int) -> Bool {
-        return convertUserIdToRank(userId: String(userId)) >= (100 - phasePercentage) || BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+    func isRolloutIdInPhaseRolloutPercentage(_ uniqueRolloutId: Int) -> Bool {
+        return convertRolloutIdToRank(uniqueRolloutId: String(uniqueRolloutId)) >= (100 - phasePercentage) || BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
     }
 
-    func convertUserIdToRank(userId: String) -> Int {
-        let key = userId + "can_view_editor_onboarding"
+    func convertRolloutIdToRank(uniqueRolloutId: String) -> Int {
+        let key = uniqueRolloutId + "can_view_editor_onboarding"
         let inputString = key.replacingOccurrences(of: "-", with: "")
         return abs(inputString.djb2hash) % 100
     }

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -173,20 +173,14 @@ class GutenbergSettings {
     }
 
     func canViewEditorOnboarding() -> Bool {
-        guard
-            ReachabilityUtils.isInternetReachable()
-        else {
-            return false
-        }
-
-        let userId = AccountService(managedObjectContext: context).defaultWordPressComAccount()?.userID.intValue ?? getAnonymousUserId()
+        let uniqueRolloutId = getUniqueRolloutId()
         let rollout = GutenbergOnboardingRollout()
-        return rollout.isUserIdInPhaseRolloutPercentage(userId)
+        return rollout.isRolloutIdInPhaseRolloutPercentage(uniqueRolloutId)
     }
 
-    /// Temporary for the staged Editor Onboarding tooltip project. This anonymous ID is only used for non-WPcom
-    /// logins.
-    func getAnonymousUserId() -> Int {
+    /// Temporary for the staged Editor Onboarding tooltip project. Generates a unique rollout ID for use in
+    /// determining if the user is in the percentage group that should see the Editor Onboarding Tooltip.
+    func getUniqueRolloutId() -> Int {
         let anonId = database.object(forKey: Key.editorOnboardingAnonID) as? Int ?? UUID().hashValue
         database.set(anonId, forKey: Key.editorOnboardingAnonID)
         return anonId

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -14,7 +14,7 @@ class GutenbergSettings {
         }
         static let focalPointPickerTooltipShown = "kGutenbergFocalPointPickerTooltipShown"
         static let hasLaunchedGutenbergEditor = "kHasLaunchedGutenbergEditor"
-        
+
         // Only generated and saved for non-WPcom logins
         static let editorOnboardingAnonID = "kEditorOnboardingAnonID"
 
@@ -178,7 +178,7 @@ class GutenbergSettings {
         else {
             return false
         }
-        
+
         let userId = AccountService(managedObjectContext: context).defaultWordPressComAccount()?.userID.intValue ?? getAnonymousUserId()
         let rollout = GutenbergOnboardingRollout()
         return rollout.isUserIdInPhaseRolloutPercentage(userId)


### PR DESCRIPTION
Related WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/14897

Enables the editor onboarding tooltip for 50% of users. The process to determine if the user can view the editor onboarding tooltip has been updated to do the following:
1. Get the ID of the user. If the user logged into the app via the site address option for a self-hosted site (i.e - not a WPcom account), then we use an anonymous `userId` generated specifically for this rollout. This `userId` is saved to the `KeyValueDatabase` used by `GutenbergSettings` to guarantee the same value across app launches. 
2. Append "can_view_editor_onboarding" to the `userId` as a seed to keep the calculated hashed result unique to this feature.
3. Hash the `userId+seed` using [djb2hash](http://www.cse.yorku.ca/~oz/hash.html) which conveniently returns an int.
5. Divide the hashed int by 100 to get the _remainder_, which will be a value between 0 and 100. 
6. If the result from step 5 is greater than or equal to 50, then the user can view the onboarding tooltip.

### To test:
The test steps in this section only verify that the onboarding tooltipis displayed properly when the editor is opened for the very first time after a fresh install to ensure nothing was broken in the process of adding the changes included in this PR. 

To actually verify the changes in this PR, add some logging to `GutenbergOnboardingRollout.convertUserIdToRank()` to verify both the `userId` being passed to the method is valid, and the calculated rank.

Repeat the following test steps using a **WPcom account**, and then logging into a **self-hosted site** (non-Jetpacked) **using the site address option**. 

1. Uninstall WordPress from the test device and then install using the build from this PR or branch.
2. Log into the app.
3. Create a new blog post. Verify the **Tap to add content** tooltip appears directly above the inserter button (`+`).
4. Close the editor to return to My Site page. 
5. Tap the button to create another new blog post. Verify the tooltip does not appear. 

## Regression Notes
1. Potential unintended areas of impact
None that I can think of. This is a temporary measure to rollout this feature to only a percentage of users. Once this feature is fully released, all this code will be removed.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
