### PR TITLE
Blogging Reminders: Notification copy and action

### DIFF
--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -19,8 +19,6 @@ extension InteractiveNotificationsManager: PushNotificationAuthorizer {
 ///
 class BloggingRemindersScheduler {
 
-    static let notificationCategoryIdentifier = "blogging-reminder-weekly"
-
     // MARK: - Convenience Typealiases
 
     typealias BlogIdentifier = BloggingRemindersStore.BlogIdentifier
@@ -243,7 +241,7 @@ class BloggingRemindersScheduler {
             content.title = TextContent.noTitleNotificationTitle
         }
         content.body = TextContent.notificationBody
-        content.categoryIdentifier = BloggingRemindersScheduler.notificationCategoryIdentifier
+        content.categoryIdentifier = InteractiveNotificationsManager.NoteCategoryDefinition.bloggingReminderWeekly.rawValue
         if let blogID = blog.dotComID?.stringValue {
             content.threadIdentifier = blogID
         }

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -19,6 +19,8 @@ extension InteractiveNotificationsManager: PushNotificationAuthorizer {
 ///
 class BloggingRemindersScheduler {
 
+    static let notificationCategoryIdentifier = "blogging-reminder-weekly"
+
     // MARK: - Convenience Typealiases
 
     typealias BlogIdentifier = BloggingRemindersStore.BlogIdentifier
@@ -194,7 +196,7 @@ class BloggingRemindersScheduler {
         case .none:
             scheduledReminders = .none
         case .weekdays(let days):
-            scheduledReminders = .weekdays(scheduled(days))
+            scheduledReminders = .weekdays(scheduled(days, for: blog))
         }
 
         do {
@@ -215,8 +217,8 @@ class BloggingRemindersScheduler {
     ///
     /// - Returns: the weekdays with the associated notification IDs.
     ///
-    private func scheduled(_ weekdays: [Weekday]) -> [ScheduledWeekday] {
-        weekdays.map { scheduled($0) }
+    private func scheduled(_ weekdays: [Weekday], for blog: Blog) -> [ScheduledWeekday] {
+        weekdays.map { scheduled($0, for: blog) }
     }
 
     /// Schedules a notification for the passed day, and returns the day with the associated notification ID.
@@ -226,17 +228,25 @@ class BloggingRemindersScheduler {
     ///
     /// - Returns: the weekday with the associated notification ID.
     ///
-    private func scheduled(_ weekday: Weekday) -> ScheduledWeekday {
-        let notificationID = scheduleNotification(for: weekday)
+    private func scheduled(_ weekday: Weekday, for blog: Blog) -> ScheduledWeekday {
+        let notificationID = scheduleNotification(for: weekday, blog: blog)
         return ScheduledWeekday(weekday: weekday, notificationID: notificationID)
     }
 
     /// Schedules a notification for the specified weekday.
     ///
-    private func scheduleNotification(for weekday: Weekday) -> String {
+    private func scheduleNotification(for weekday: Weekday, blog: Blog) -> String {
         let content = UNMutableNotificationContent()
-        content.title = "Blogging Reminder"
-        content.body = "It's time to post!"
+        if let title = blog.title {
+            content.title = String(format: TextContent.notificationTitle, title)
+        } else {
+            content.title = TextContent.noTitleNotificationTitle
+        }
+        content.body = TextContent.notificationBody
+        content.categoryIdentifier = BloggingRemindersScheduler.notificationCategoryIdentifier
+        if let blogID = blog.dotComID?.stringValue {
+            content.threadIdentifier = blogID
+        }
 
         var dateComponents = DateComponents()
         let calendar = Calendar.current
@@ -294,5 +304,12 @@ class BloggingRemindersScheduler {
 
     private func scheduledReminders(for blog: Blog) -> ScheduledReminders {
         store.scheduledReminders(for: blog.objectID.uriRepresentation())
+    }
+
+    private enum TextContent {
+        static let noTitleNotificationTitle = NSLocalizedString("It's time to blog!", comment: "Title of a notification displayed prompting the user to create a new blog post")
+        static let notificationTitle = NSLocalizedString("It's time to blog on %@!",
+                                                         comment: "Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title.")
+        static let notificationBody = NSLocalizedString("This is your reminder to blog today ✍️", comment: "The body of a notification displayed to the user prompting them to create a new blog post. The emoji should ideally remain, as part of the text.")
     }
 }

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -53,10 +53,7 @@ final class InteractiveNotificationsManager: NSObject {
             WPAnalytics.track(.pushNotificationOSAlertShown)
         }
 
-        var options: UNAuthorizationOptions = [.badge, .sound, .alert]
-        if #available(iOS 12.0, *) {
-            options.insert(.providesAppNotificationSettings)
-        }
+        let options: UNAuthorizationOptions = [.badge, .sound, .alert, .providesAppNotificationSettings]
 
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.requestAuthorization(options: options) { (allowed, _)  in
@@ -80,10 +77,10 @@ final class InteractiveNotificationsManager: NSObject {
     /// - Returns: True on success
     ///
     @objc @discardableResult
-    func handleAction(with identifier: String, category: String, userInfo: NSDictionary, responseText: String?) -> Bool {
+    func handleAction(with identifier: String, category: String, threadId: String?, userInfo: NSDictionary, responseText: String?) -> Bool {
         if let noteCategory = NoteCategoryDefinition(rawValue: category),
             noteCategory.isLocalNotification {
-            return handleLocalNotificationAction(with: identifier, category: category, userInfo: userInfo, responseText: responseText)
+            return handleLocalNotificationAction(with: identifier, category: category, threadId: threadId, userInfo: userInfo, responseText: responseText)
         }
 
         if NoteActionDefinition.approveLogin == NoteActionDefinition(rawValue: identifier) {
@@ -141,7 +138,7 @@ final class InteractiveNotificationsManager: NSObject {
         return true
     }
 
-    func handleLocalNotificationAction(with identifier: String, category: String, userInfo: NSDictionary, responseText: String?) -> Bool {
+    func handleLocalNotificationAction(with identifier: String, category: String, threadId: String?, userInfo: NSDictionary, responseText: String?) -> Bool {
         if let noteCategory = NoteCategoryDefinition(rawValue: category) {
             switch noteCategory {
             case .mediaUploadSuccess, .mediaUploadFailure:
@@ -195,11 +192,26 @@ final class InteractiveNotificationsManager: NSObject {
                     ShareNoticeNavigationCoordinator.navigateToBlogDetails(with: userInfo)
                     return true
                 }
+            case .bloggingReminderWeekly:
+                if identifier == UNNotificationDefaultActionIdentifier {
+                    let targetBlog: Blog? = blog(from: threadId)
+                    
+                    WPTabBarController.sharedInstance()?.mySitesCoordinator.showCreateSheet(for: targetBlog)
+                }
             default: break
             }
         }
 
         return true
+    }
+
+    private func blog(from threadId: String?) -> Blog? {
+        if let threadId = threadId,
+           let blogId = Int(threadId) {
+            return try? Blog.lookup(withID: blogId, in: ContextManager.shared.mainContext)
+        }
+
+        return nil
     }
 }
 
@@ -307,6 +319,7 @@ private extension InteractiveNotificationsManager {
         case shareUploadSuccess     = "share-upload-success"
         case shareUploadFailure     = "share-upload-failure"
         case login                  = "push_auth"
+        case bloggingReminderWeekly = "blogging-reminder-weekly"
 
         var actions: [NoteActionDefinition] {
             switch self {
@@ -332,6 +345,8 @@ private extension InteractiveNotificationsManager {
                 return []
             case .login:
                 return [.approveLogin, .denyLogin]
+            case .bloggingReminderWeekly:
+                return []
             }
         }
 
@@ -351,8 +366,8 @@ private extension InteractiveNotificationsManager {
                 options: [])
         }
 
-        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike, mediaUploadSuccess, mediaUploadFailure, postUploadSuccess, postUploadFailure, shareUploadSuccess, shareUploadFailure, login]
-        static var localDefinitions = [mediaUploadSuccess, mediaUploadFailure, postUploadSuccess, postUploadFailure, shareUploadSuccess, shareUploadFailure]
+        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike, mediaUploadSuccess, mediaUploadFailure, postUploadSuccess, postUploadFailure, shareUploadSuccess, shareUploadFailure, login, bloggingReminderWeekly]
+        static var localDefinitions = [mediaUploadSuccess, mediaUploadFailure, postUploadSuccess, postUploadFailure, shareUploadSuccess, shareUploadFailure, bloggingReminderWeekly]
     }
 
 
@@ -481,6 +496,16 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
             return
         }
 
+        // If it's a blogging reminder notification, display it in-app
+        if notification.request.content.categoryIdentifier == NoteCategoryDefinition.bloggingReminderWeekly.rawValue {
+            if #available(iOS 14.0, *) {
+                completionHandler([.banner, .list, .sound])
+            } else {
+                completionHandler([.alert, .sound])
+            }
+            return
+        }
+
         // Otherwise a share notification
         let category = notification.request.content.categoryIdentifier
 
@@ -513,6 +538,7 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
 
         if handleAction(with: response.actionIdentifier,
                         category: response.notification.request.content.categoryIdentifier,
+                        threadId: response.notification.request.content.threadIdentifier,
                         userInfo: userInfo,
                         responseText: textInputResponse?.userText) {
             completionHandler()

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -195,7 +195,7 @@ final class InteractiveNotificationsManager: NSObject {
             case .bloggingReminderWeekly:
                 if identifier == UNNotificationDefaultActionIdentifier {
                     let targetBlog: Blog? = blog(from: threadId)
-                    
+
                     WPTabBarController.sharedInstance()?.mySitesCoordinator.showCreateSheet(for: targetBlog)
                 }
             default: break
@@ -302,7 +302,7 @@ private extension InteractiveNotificationsManager {
 
 // MARK: - Nested Types
 //
-private extension InteractiveNotificationsManager {
+extension InteractiveNotificationsManager {
 
     /// Describes information about Custom Actions that WPiOS can perform, as a response to
     /// a Push Notification event.

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -359,6 +359,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         return blogDetailsViewController
     }
 
+    func presentCreateSheet() {
+        blogDetailsViewController?.createButtonCoordinator?.showCreateSheet()
+    }
+
     // MARK: - Model Changes
 
     private func subscribeToModelChanges() {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -10,6 +10,19 @@ class MySitesCoordinator: NSObject {
     let becomeActiveTab: () -> Void
 
     @objc
+    var currentBlog: Blog? {
+        if Feature.enabled(.newNavBarAppearance) {
+            return mySiteViewController.blog
+        } else {
+            if let blogDetailsVC = navigationController.viewControllers.first(where: { $0 is BlogDetailsViewController }) as? BlogDetailsViewController {
+                return blogDetailsVC.blog
+            }
+        }
+
+        return nil
+    }
+
+    @objc
     init(meScenePresenter: ScenePresenter, onBecomeActiveTab becomeActiveTab: @escaping () -> Void) {
         self.meScenePresenter = meScenePresenter
         self.becomeActiveTab = becomeActiveTab
@@ -187,6 +200,15 @@ class MySitesCoordinator: NSObject {
     // MARK: - Post creation
 
     func showCreateSheet(for blog: Blog?) {
+        let context = ContextManager.shared.mainContext
+        let service = BlogService(managedObjectContext: context)
+        guard let targetBlog = blog ?? service.lastUsedOrFirstBlog() else {
+            return
+        }
+
+        showBlogDetails(for: targetBlog)
+
+        mySiteViewController.presentCreateSheet()
     }
 
     // MARK: - My Sites

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -184,6 +184,11 @@ class MySitesCoordinator: NSObject {
         mySiteViewController.presentInterfaceForAddingNewSite()
     }
 
+    // MARK: - Post creation
+
+    func showCreateSheet(for blog: Blog?) {
+    }
+
     // MARK: - My Sites
 
     func showPages(for blog: Blog) {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -116,7 +116,7 @@ import WordPressFlux
 
     private var currentTourElement: QuickStartTourElement?
 
-    @objc private func showCreateSheet() {
+    @objc func showCreateSheet() {
         didDismissTooltip = true
         hideNotice()
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -420,10 +420,14 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         return nil;
     }
 
-    BlogDetailsViewController *blogDetailsController = (BlogDetailsViewController *)[[self.mySitesCoordinator.navigationController.viewControllers wp_filter:^BOOL(id obj) {
-        return [obj isKindOfClass:[BlogDetailsViewController class]];
-    }] firstObject];
-    return blogDetailsController.blog;
+    if ([Feature enabled:FeatureFlagNewNavBarAppearance]) {
+        return [self.mySitesCoordinator currentBlog];
+    } else {
+        BlogDetailsViewController *blogDetailsController = (BlogDetailsViewController *)[[self.mySitesCoordinator.navigationController.viewControllers wp_filter:^BOOL(id obj) {
+            return [obj isKindOfClass:[BlogDetailsViewController class]];
+        }] firstObject];
+        return blogDetailsController.blog;
+    }
 }
 
 - (Blog *)currentOrLastBlog


### PR DESCRIPTION
This PR updates the copy of Blogging Reminder notifications and implements the action to be performed when a user taps on them.

<img src="https://user-images.githubusercontent.com/4780/123326076-b19dfe00-d530-11eb-85be-811a2a2bde57.png" width=300>

![reminders-notes-1](https://user-images.githubusercontent.com/4780/123326007-9f23c480-d530-11eb-81fc-ff9a81cfe2c3.gif)

### To Test

* To make this easier to test, I updated the lines in BloggingRemindersScheduler.swift that control the timing of the swift (around line 256) to make the next notification appear at the start of the next minute after creating the notifications:

```
        let date = Date()
        let comps = date.dateAndTimeComponents()
        dateComponents.hour = Weekday.defaultHour
        dateComponents.hour = comps.hour 
        dateComponents.minute = comps.minute! + 1
```

* Build and run

#### 1: In-app, same site visible

* Using the reminders card and the code above, schedule a notification for a site on the current day.
* Remain on the My Site screen, and you should see the notification pop in at the correct time.
* Tap it, and you should see the bottom sheet. Tap Blog post, and check the correct site is selected in the editor.

#### 2: In-app, different site visible

* Follow the instructions above, but after scheduling the notification, quickly switch to a different site in My Site, and perhaps even to a different tab
* When the notification comes in, interact with it and ensure the correct site is displayed in My Site and the editor is shown for the correct site.

#### 3: Out of app, same site

* Perform the same test as test 1, but leave the app after scheduling the post.

#### 4: Out of app, different site

* Perform the same test as test 2, but leave the app after scheduling the post

## Regression Notes

1. Potential unintended areas of impact

This is mostly confined to blogging reminders, however I noticed a bug in `currentlyVisibleBlog` of `WPTabBarController`, where it wasn't working with the new My Site hierarchy.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I checked the code where this was used, and as it's only in a handful of places I tested it manually.

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
