### PR TITLE
Fixes a memory issue in our share extension.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,6 +17,7 @@
 * [*] The quick action buttons will be hidden when iOS is using a accessibility font sizes. [#16701]
 * [*] Block Editor: Improve unsupported block message for reusable block. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3621]
 * [**] Block Editor: Fix incorrect block insertion point after blurring the post title field. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3640]
+* [*] Fixed a crash when sharing photos to WordPress [#16737]
 
 17.5
 -----

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -276,7 +276,7 @@ private extension TypeBasedExtensionContentExtractor {
     }
 
     func saveToSharedContainer(image: UIImage) -> URL? {
-        guard let encodedMedia = image.resizeWithMaximumSize(maximumImageSize).JPEGEncoded(),
+        guard let encodedMedia = image.resizeWithMaximumSize(maximumImageSize)?.JPEGEncoded(),
             let fullPath = tempPath(for: "jpg") else {
                 return nil
         }

--- a/WordPress/WordPressShareExtension/UIImage+Extensions.swift
+++ b/WordPress/WordPressShareExtension/UIImage+Extensions.swift
@@ -1,5 +1,5 @@
 import Foundation
-
+import ImageIO
 
 extension UIImage {
     convenience init?(contentsOfURL url: URL) {
@@ -10,8 +10,22 @@ extension UIImage {
         self.init(data: rawImage)
     }
 
-    func resizeWithMaximumSize(_ maximumSize: CGSize) -> UIImage {
-        return resizedImage(with: .scaleAspectFit, bounds: maximumSize, interpolationQuality: .high)
+    func resizeWithMaximumSize(_ maximumSize: CGSize) -> UIImage? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageIfAbsent: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maximumSize,
+        ]
+
+        guard let imageData = pngData() as CFData?,
+              let imageSource = CGImageSourceCreateWithData(imageData, nil),
+              let image = CGImageSourceCreateImageAtIndex(imageSource, 0, options as CFDictionary) else {
+
+            return nil
+        }
+
+        return UIImage(cgImage: image)
     }
 
     func JPEGEncoded(_ quality: CGFloat = 0.8) -> Data? {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/16731

Fixes a crasher in the Share Extension.

## To test:

Execute the steps in the original issue, which I report here to make the review simpler:

1. Take a screenshot
2. Tap on the screenshot in the bottom left corner
3. Share
4. WP
5. Crash

## Regression Notes

1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.