### PR TITLE
Copy review of Blogging Reminders.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
@@ -16,7 +16,7 @@ class BloggingRemindersFlow {
         let tracker = BloggingRemindersTracker(blogType: blogType)
         tracker.flowStarted(source: source)
 
-        let flowIntroViewController = BloggingRemindersFlowIntroViewController(for: blog, tracker: tracker)
+        let flowIntroViewController = BloggingRemindersFlowIntroViewController(for: blog, tracker: tracker, source: source)
         let navigationController = BloggingRemindersNavigationController(rootViewController: flowIntroViewController)
 
         let bottomSheet = BottomSheetViewController(childViewController: navigationController,
@@ -42,7 +42,7 @@ class BloggingRemindersFlow {
     private static func weeklyRemindersKey(for blog: Blog) -> String {
         // weekly reminders key prefix
         let prefix = "blogging-reminder-weekly-"
-         return prefix + blog.objectID.uriRepresentation().absoluteString
+        return prefix + blog.objectID.uriRepresentation().absoluteString
     }
 
     /// By making this private we ensure this can't be instantiated.

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 class BloggingRemindersFlow {
-    static let weeklyRemindersKeyPrefix = "blogging-reminder-weekly-"
 
     static func present(from viewController: UIViewController,
                         for blog: Blog,
@@ -17,7 +16,6 @@ class BloggingRemindersFlow {
         let tracker = BloggingRemindersTracker(blogType: blogType)
         tracker.flowStarted(source: source)
 
-        // TODO: Check whether we've already presented this flow to the user. @frosty
         let flowIntroViewController = BloggingRemindersFlowIntroViewController(for: blog, tracker: tracker)
         let navigationController = BloggingRemindersNavigationController(rootViewController: flowIntroViewController)
 
@@ -29,14 +27,22 @@ class BloggingRemindersFlow {
         setHasShownWeeklyRemindersFlow(for: blog)
     }
 
+    // MARK: - Weekly reminders flow presentation status
+    //
+    // stores a key for each blog in UserDefaults to determine if
+    // the flow was presented for the given blog.
     private static func hasShownWeeklyRemindersFlow(for blog: Blog) -> Bool {
-        let key = Self.weeklyRemindersKeyPrefix + blog.objectID.uriRepresentation().absoluteString
-        return UserDefaults.standard.bool(forKey: key)
+        UserDefaults.standard.bool(forKey: weeklyRemindersKey(for: blog))
     }
 
     private static func setHasShownWeeklyRemindersFlow(for blog: Blog) {
-        let key = Self.weeklyRemindersKeyPrefix + blog.objectID.uriRepresentation().absoluteString
-        UserDefaults.standard.setValue(true, forKey: key)
+        UserDefaults.standard.setValue(true, forKey: weeklyRemindersKey(for: blog))
+    }
+
+    private static func weeklyRemindersKey(for blog: Blog) -> String {
+        // weekly reminders key prefix
+        let prefix = "blogging-reminder-weekly-"
+         return prefix + blog.objectID.uriRepresentation().absoluteString
     }
 
     /// By making this private we ensure this can't be instantiated.

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -108,6 +108,7 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
         configureStackView()
         configureConstraints()
         configurePromptLabel()
+        configureTitleLabel()
 
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
@@ -254,6 +255,14 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
         promptLabel.attributedText = attributedString
     }
 
+    private func configureTitleLabel() {
+        if selectedDays.isEmpty {
+            titleLabel.text = TextContent.remindersRemovedTitle
+        } else {
+            titleLabel.text = TextContent.completionTitle
+        }
+    }
+
     // MARK: - Actions
 
     @objc func doneButtonTapped() {
@@ -287,6 +296,8 @@ extension BloggingRemindersFlowCompletionViewController: ChildDrawerPositionable
 
 private enum TextContent {
     static let completionTitle = NSLocalizedString("All set!", comment: "Title of the completion screen of the Blogging Reminders Settings screen.")
+
+    static let remindersRemovedTitle = NSLocalizedString("Reminders removed", comment: "Title of the completion screen of the Blogging Reminders Settings screen when the reminders are removed.")
 
     // Ideally we should use stringsdict to translate plurals, but GlotPress currently doesn't support this.
     static let completionPromptSingular = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@.",

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -38,7 +38,6 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
         label.adjustsFontForContentSizeCategory = true
         label.adjustsFontSizeToFitWidth = true
         label.font = .preferredFont(forTextStyle: .body)
-        label.text = TextContent.introDescription
         label.numberOfLines = 5
         label.textAlignment = .center
         return label
@@ -65,10 +64,22 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
 
     private let blog: Blog
     private let tracker: BloggingRemindersTracker
+    private let source: BloggingRemindersTracker.FlowStartSource
 
-    init(for blog: Blog, tracker: BloggingRemindersTracker) {
+    private var introDescription: String {
+        switch source {
+        case .publishFlow:
+            return TextContent.PostPublishingintroDescription
+        case .blogSettings:
+            return TextContent.siteSettingsIntroDescription
+
+        }
+    }
+
+    init(for blog: Blog, tracker: BloggingRemindersTracker, source: BloggingRemindersTracker.FlowStartSource) {
         self.blog = blog
         self.tracker = tracker
+        self.source = source
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -90,6 +101,7 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
 
         configureStackView()
         configureConstraints()
+        promptLabel.text = introDescription
 
         navigationController?.setNavigationBarHidden(true, animated: false)
     }
@@ -197,8 +209,11 @@ private enum TextContent {
     static let introTitle = NSLocalizedString("Set your blogging reminders",
                                               comment: "Title of the Blogging Reminders Settings screen.")
 
-    static let introDescription = NSLocalizedString("Your post is publishing... in the meantime, set up your blogging reminders on days you want to post.",
-                                                    comment: "Description on the first screen of the Blogging Reminders Settings flow.")
+    static let PostPublishingintroDescription = NSLocalizedString("Your post is publishing... in the meantime, set up your blogging reminders on days you want to post.",
+                                                    comment: "Description on the first screen of the Blogging Reminders Settings flow called aftet post publishing.")
+
+    static let siteSettingsIntroDescription = NSLocalizedString("Set up your blogging reminders on days you want to post.",
+                                                            comment: "Description on the first screen of the Blogging Reminders Settings flow called from site settings.")
 
     static let introButtonTitle = NSLocalizedString("Set reminders",
                                                     comment: "Title of the set goals button in the Blogging Reminders Settings flow.")

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -69,7 +69,7 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
     private var introDescription: String {
         switch source {
         case .publishFlow:
-            return TextContent.PostPublishingintroDescription
+            return TextContent.postPublishingintroDescription
         case .blogSettings:
             return TextContent.siteSettingsIntroDescription
 
@@ -209,7 +209,7 @@ private enum TextContent {
     static let introTitle = NSLocalizedString("Set your blogging reminders",
                                               comment: "Title of the Blogging Reminders Settings screen.")
 
-    static let PostPublishingintroDescription = NSLocalizedString("Your post is publishing... in the meantime, set up your blogging reminders on days you want to post.",
+    static let postPublishingintroDescription = NSLocalizedString("Your post is publishing... in the meantime, set up your blogging reminders on days you want to post.",
                                                     comment: "Description on the first screen of the Blogging Reminders Settings flow called aftet post publishing.")
 
     static let siteSettingsIntroDescription = NSLocalizedString("Set up your blogging reminders on days you want to post.",

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -193,13 +193,13 @@ extension BloggingRemindersFlowIntroViewController: ChildDrawerPositionable {
 // MARK: - Constants
 
 private enum TextContent {
-    static let introTitle = NSLocalizedString("Set your blogging goals",
+    static let introTitle = NSLocalizedString("Set your blogging reminders",
                                               comment: "Title of the Blogging Reminders Settings screen.")
 
-    static let introDescription = NSLocalizedString("Your post is publishing... in the meantime, set up your blogging goals to get reminders, and track your progress.",
+    static let introDescription = NSLocalizedString("Your post is publishing... in the meantime, set up your blogging reminders on days you want to post.",
                                                     comment: "Description on the first screen of the Blogging Reminders Settings flow.")
 
-    static let introButtonTitle = NSLocalizedString("Set goals",
+    static let introButtonTitle = NSLocalizedString("Set reminders",
                                                     comment: "Title of the set goals button in the Blogging Reminders Settings flow.")
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -138,12 +138,13 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     private let scheduler: BloggingRemindersScheduler
     private var weekdays: [BloggingRemindersScheduler.Weekday] {
         didSet {
-            // If this is a new configuration, only enable the button once days have been selected
-            if button.title(for: .normal) == TextContent.nextButtonTitle {
-                button.isEnabled = !weekdays.isEmpty
-            }
+            refreshNextButton()
         }
     }
+
+    /// The weekdays that have been saved / scheduled in a previous blogging reminders configuration.
+    ///
+    private let previousWeekdays: [BloggingRemindersScheduler.Weekday]
 
     // MARK: - Initializers
 
@@ -168,10 +169,12 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
         switch self.scheduler.schedule(for: blog) {
         case .none:
-            weekdays = []
+            previousWeekdays = []
         case .weekdays(let scheduledWeekdays):
-            weekdays = scheduledWeekdays
+            previousWeekdays = scheduledWeekdays
         }
+
+        weekdays = previousWeekdays
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -194,7 +197,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         configureStackView()
         configureConstraints()
         populateCalendarDays()
-        configureNextButton()
+        refreshNextButton()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -328,12 +331,16 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         daysBottomInnerStackView.addArrangedSubviews(bottomRow.compactMap({ createCalendarDayToggleButton(localizedWeekdayDayIndex: $0) }))
     }
 
-    private func configureNextButton() {
-        if weekdays.isEmpty {
+    private func refreshNextButton() {
+        if previousWeekdays.isEmpty {
             button.setTitle(TextContent.nextButtonTitle, for: .normal)
-            button.isEnabled = false
+            button.isEnabled = !weekdays.isEmpty
+        } else if weekdays == previousWeekdays {
+            button.setTitle(TextContent.nextButtonTitle, for: .normal)
+            button.isEnabled = true
         } else {
             button.setTitle(TextContent.updateButtonTitle, for: .normal)
+            button.isEnabled = true
         }
     }
 
@@ -430,6 +437,7 @@ private enum TextContent {
                                                         comment: "Prompt shown on the Blogging Reminders Settings screen.")
 
     static let nextButtonTitle = NSLocalizedString("Notify me", comment: "Title of button to navigate to the next screen of the blogging reminders flow, setting up push notifications.")
+
     static let updateButtonTitle = NSLocalizedString("Update", comment: "(Verb) Title of button confirming updating settings for blogging reminders.")
 
     static let tipPanelTitle = NSLocalizedString("Tip", comment: "Title of a panel shown in the Blogging Reminders Settings screen, providing the user with a helpful tip.")

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -323,7 +323,8 @@ extension SiteSettingsViewController {
 
     private func configureCellForBloggingReminders(_ cell: SettingTableViewCell) {
         cell.editable = true
-        cell.textLabel?.text = NSLocalizedString("Blogging Goals", comment: "Label for the blogging goals setting")
+        cell.accessoryType = .none
+        cell.textLabel?.text = NSLocalizedString("Blogging Reminders", comment: "Label for the blogging reminders setting")
         cell.textValue = "Undefined"
     }
 


### PR DESCRIPTION
Updates the text messages throughout Blogging Reminders to follow our designs. The intro description is now different depending on where the flow is called from (site settings or after publishing a post, see screenshots below)

This PR also includes a small refactor to `BloggingRemindersFlow` to make it more clear how we handle the presentation state for each site in `UserDefaults`

## List of changes:

### Flow intro:

- Updated the title to remove the word "goal"
- Updated the description to remove the word "goal"
- Updated the description to be configured depending on the source (see screenshots below)
- Updated the button title to remove the word "goal"

post publishing | site settings
-- | --
<img width="400" src="https://user-images.githubusercontent.com/34376330/123469864-3b91a980-d5b9-11eb-93e0-48b78158f3a0.png"> | <img width="400" src="https://user-images.githubusercontent.com/34376330/123469912-4a785c00-d5b9-11eb-9da6-6458df695b3f.png">



### Day picker:

- When updating an existing blogging reminders configuration, the button is named "Update" only if the configuration changes from what's stored.

### Enable Push Notifications:

- No changes

### Flow completion:

- We're now using an updated title when the user removes all blogging reminders from a previous configuration.

### Site Settings:

- Renamed the setting to "Blogging Reminders"
- Removed the disclosure indicator since we're not navigating when opening Blogging Reminders.

## To test:

- Make sure the text updates reported below match our designs.
- Make sure the logic for the button title updates in the day picker work fine.
    - Make sure the button is disabled if there is no previous configuration, and no days are selected.
    - Make sure the title reads "Notify me" when there is no previous configuration, and 1 or more days have been selected.
    - Make sure the title reads "Notify me" when there is a previous configuration, but you haven't changed the selected days.
    - Make sure the title reads "Update" when there is a previous configuration, and you're changing the days in any way.
- Make sure the completion screen title describes your reminder selection.
    - Make sure the title reads "All Set!" if you've selected 1 or more days.
    - Make sure the title reads "Reminders removed" if you've disabled blogging reminders.
- Start the weekly reminders flow from site settings and make sure the intro description says `Set up your blogging reminders on days you want to post.`
- Publish a post from a site where the weekly reminders flow was never seen before and make sure that after publishing, the flow starts and the intro description says: `Your post is publishing... in the meantime, set up your blogging reminders on days you want to post.`

## Regression Notes
1. Potential unintended areas of impact

Only within blogging reminders - but that's an unreleased feature we're still testing and this PR is part of the project.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
