### PR TITLE
Enables blogging reminders for all users.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 17.7
 -----
+* [***] New Blogging Reminders!
 * [**] (Don't apply to Jetpack app): Self hosted sites that do not use Jetpack can now manage (install, uninstall, activate, and deactivate) their plugins [#16675]
 * [*] Upgraded the Zendesk SDK to version 5.3.0
 * [*] You can now subscribe to conversations by email from Reader lists and articles. [#16599]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 17.7
 -----
-* [***] New Blogging Reminders!
+* [***] Added blogging reminders. Choose which days you'd like to be reminded, and we'll send you a notification prompting you to post on your site
 * [**] (Don't apply to Jetpack app): Self hosted sites that do not use Jetpack can now manage (install, uninstall, activate, and deactivate) their plugins [#16675]
 * [*] Upgraded the Zendesk SDK to version 5.3.0
 * [*] You can now subscribe to conversations by email from Reader lists and articles. [#16599]

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -59,7 +59,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .newLikeNotifications:
             return true
         case .bloggingReminders:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .readerPostLikes:
             return true
         case .siteIconCreator:


### PR DESCRIPTION
Enabled blogging reminders for all users.

## Regression Notes

1. Potential unintended areas of impact

Enabling a new feature which will need to be tested thoroughly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

This is just the final step in enabling the feature.  It's been reviewed throughout several PRs, and will need to be tested during the code freeze next sprint.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
