### PR TITLE
Add blogging reminder frequency to site settings

### DIFF
--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -2,25 +2,107 @@ import Foundation
 
 struct BloggingRemindersScheduleFormatter {
     let schedule: BloggingRemindersScheduler.Schedule
+    let calendar: Calendar
+
+    init(schedule: BloggingRemindersScheduler.Schedule, calendar: Calendar? = nil) {
+        self.schedule = schedule
+        self.calendar = calendar ?? {
+            var calendar = Calendar.current
+            calendar.locale = Locale.autoupdatingCurrent
+            return calendar
+        }()
+    }
 
     /// Description string of the current schedule for the specified blog.
     ///
     var shortIntervalDescription: String {
         switch schedule {
         case .none:
-            return NSLocalizedString("None set", comment: "Title shown on table row where no blogging reminders have been set up yet")
+            return TextContent.shortNoRemindersDescription
         case .weekdays(let days):
-            switch days.count {
-            case 1:
-                return NSLocalizedString("Once a week", comment: "Short title telling the user they will receive a blogging reminder once per week.")
-            case 2:
-                return NSLocalizedString("Twice a week", comment: "Short title telling the user they will receive a blogging reminder two times a week.")
-            case 7:
-                return NSLocalizedString("Every day", comment: "Short title telling the user they will receive a blogging reminder every day of the week.")
-            default:
-                return String(format: NSLocalizedString("%d times a week",
-                                                        comment: "A short description of how many times a week the user will receive a blogging reminder. The placeholder will be populated with a count of the number of times a week they'll be reminded."), days.count)
-            }
+            return Self.shortIntervalDescription(for: days.count)
         }
+    }
+
+    static func shortIntervalDescription(for days: Int) -> String {
+        switch days {
+        case 1:
+            return NSLocalizedString("Once a week", comment: "Short title telling the user they will receive a blogging reminder once per week.")
+        case 2:
+            return NSLocalizedString("Twice a week", comment: "Short title telling the user they will receive a blogging reminder two times a week.")
+        case 7:
+            return NSLocalizedString("Every day", comment: "Short title telling the user they will receive a blogging reminder every day of the week.")
+        default:
+            return String(format: NSLocalizedString("%d times a week",
+                                                    comment: "A short description of how many times a week the user will receive a blogging reminder. The placeholder will be populated with a count of the number of times a week they'll be reminded."), days)
+        }
+    }
+
+    var longScheduleDescription: NSAttributedString {
+        switch schedule {
+        case .none:
+            return NSAttributedString(string: TextContent.longNoRemindersDescription)
+        case .weekdays(let days):
+            // We want the days sorted by their localized index because under some locale configurations
+            // Sunday is the first day of the week, whereas in some other localizations Monday comes first.
+            let sortedDays = days.sorted { (first, second) -> Bool in
+                let firstIndex = self.calendar.localizedWeekdayIndex(unlocalizedWeekdayIndex: first.rawValue)
+                let secondIndex = self.calendar.localizedWeekdayIndex(unlocalizedWeekdayIndex: second.rawValue)
+
+                return firstIndex < secondIndex
+            }
+
+            let markedUpDays: [String] = sortedDays.compactMap({ day in
+                return "<strong>\(self.calendar.weekdaySymbols[day.rawValue])</strong>"
+            })
+
+            let text: String
+
+            if days.count == 1 {
+                text = String(format: TextContent.longNoRemindersDescriptionSingular, markedUpDays.first ?? "")
+            } else {
+                let formatter = ListFormatter()
+                let formattedDays = formatter.string(from: markedUpDays) ?? ""
+                text = String(format: TextContent.longNoRemindersDescriptionPlural, "<strong>\(days.count)</strong>", formattedDays)
+            }
+
+            let htmlData = NSString(string: text).data(using: String.Encoding.unicode.rawValue) ?? Data()
+            let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [.documentType: NSAttributedString.DocumentType.html]
+
+            let attributedString = (try? NSMutableAttributedString(data: htmlData,
+                                                                   options: options,
+                                                                   documentAttributes: nil)) ?? NSMutableAttributedString()
+
+            // This loop applies the default font to the whole text, while keeping any symbolic attributes the previous font may
+            // have had (such as bold style).
+            attributedString.enumerateAttribute(.font, in: NSRange(location: 0, length: attributedString.length)) { (value, range, stop) in
+
+                guard let oldFont = value as? UIFont,
+                      let newDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body)
+                        .withSymbolicTraits(oldFont.fontDescriptor.symbolicTraits) else {
+
+                    return
+                }
+
+                let newFont = UIFont(descriptor: newDescriptor, size: 0)
+
+                attributedString.addAttributes([.font: newFont], range: range)
+            }
+
+            return attributedString
+        }
+    }
+
+    private enum TextContent {
+        static let shortNoRemindersDescription = NSLocalizedString("None set", comment: "Title shown on table row where no blogging reminders have been set up yet")
+
+        static let longNoRemindersDescription = NSLocalizedString("You have no reminders set.", comment: "Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders.")
+
+        // Ideally we should use stringsdict to translate plurals, but GlotPress currently doesn't support this.
+        static let longNoRemindersDescriptionSingular = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@.",
+                                                              comment: "Blogging Reminders description confirming a user's choices. The placeholder will be replaced at runtime with a day of the week. The HTML markup is used to bold the word 'once'.")
+
+        static let longNoRemindersDescriptionPlural = NSLocalizedString("You'll get reminders to blog %@ times a week on %@.",
+                                                              comment: "Blogging Reminders description confirming a user's choices. The first placeholder will be populated with a count of the number of times a week they'll be reminded. The second will be a formatted list of days. For example: 'You'll get reminders to blog 2 times a week on Monday and Tuesday.")
     }
 }

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct BloggingRemindersScheduleFormatter {
+    let schedule: BloggingRemindersScheduler.Schedule
+
+    /// Description string of the current schedule for the specified blog.
+    ///
+    var shortIntervalDescription: String {
+        switch schedule {
+        case .none:
+            return NSLocalizedString("None set", comment: "Title shown on table row where no blogging reminders have been set up yet")
+        case .weekdays(let days):
+            switch days.count {
+            case 1:
+                return NSLocalizedString("Once a week", comment: "Short title telling the user they will receive a blogging reminder once per week.")
+            case 2:
+                return NSLocalizedString("Twice a week", comment: "Short title telling the user they will receive a blogging reminder two times a week.")
+            case 7:
+                return NSLocalizedString("Every day", comment: "Short title telling the user they will receive a blogging reminder every day of the week.")
+            default:
+                return String(format: NSLocalizedString("%d times a week",
+                                                        comment: "A short description of how many times a week the user will receive a blogging reminder. The placeholder will be populated with a count of the number of times a week they'll be reminded."), days.count)
+            }
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -74,12 +74,12 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
 
     // MARK: - Initializers
 
+    let blog: Blog
     let calendar: Calendar
-    let selectedDays: [BloggingRemindersScheduler.Weekday]
     let tracker: BloggingRemindersTracker
 
-    init(selectedDays: [BloggingRemindersScheduler.Weekday], tracker: BloggingRemindersTracker, calendar: Calendar? = nil) {
-        self.selectedDays = selectedDays
+    init(blog: Blog, tracker: BloggingRemindersTracker, calendar: Calendar? = nil) {
+        self.blog = blog
         self.tracker = tracker
 
         self.calendar = calendar ?? {
@@ -178,27 +178,12 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
     // Populates the prompt label with formatted text detailing the reminders set by the user.
     //
     private func configurePromptLabel() {
-        guard selectedDays.isEmpty == false else {
-            promptLabel.text = TextContent.noRemindersPrompt
+        guard let scheduler = try? BloggingRemindersScheduler() else {
             return
         }
 
-        // We want the days sorted by their localized index because under some locale configurations
-        // Sunday is the first day of the week, whereas in some other localizations Monday comes first.
-        let sortedDays = selectedDays.sorted { (first, second) -> Bool in
-            let firstIndex = self.calendar.localizedWeekdayIndex(unlocalizedWeekdayIndex: first.rawValue)
-            let secondIndex = self.calendar.localizedWeekdayIndex(unlocalizedWeekdayIndex: second.rawValue)
-
-            return firstIndex < secondIndex
-        }
-
-        let markedUpDays: [String] = sortedDays.compactMap({ [weak self] day in
-            guard let self = self else {
-                return nil
-            }
-
-            return "<strong>\(self.calendar.weekdaySymbols[day.rawValue])</strong>"
-        })
+        let schedule = scheduler.schedule(for: blog)
+        let formatter = BloggingRemindersScheduleFormatter(schedule: schedule)
 
         let style = NSMutableParagraphStyle()
         style.lineSpacing = Metrics.promptTextLineSpacing
@@ -216,42 +201,10 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
             .foregroundColor: UIColor.text,
         ]
 
-        let text: String
-
-        if selectedDays.count == 1 {
-            text = String(format: TextContent.completionPromptSingular, markedUpDays.first ?? "")
-        } else {
-            let formatter = ListFormatter()
-            let formattedDays = formatter.string(from: markedUpDays) ?? ""
-            text = String(format: TextContent.completionPromptPlural, "<strong>\(selectedDays.count)</strong>", formattedDays)
+        if let promptText = formatter.longScheduleDescription.mutableCopy() as? NSMutableAttributedString {
+            promptText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: promptText.length))
+            promptLabel.attributedText = promptText
         }
-
-        let htmlData = NSString(string: text).data(using: String.Encoding.unicode.rawValue) ?? Data()
-        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [.documentType: NSAttributedString.DocumentType.html]
-
-        let attributedString = (try? NSMutableAttributedString(data: htmlData,
-                                                           options: options,
-                                                           documentAttributes: nil)) ?? NSMutableAttributedString()
-
-        attributedString.addAttributes(defaultAttributes, range: NSRange(location: 0, length: attributedString.length))
-
-        // This loop applies the default font to the whole text, while keeping any symbolic attributes the previous font may
-        // have had (such as bold style).
-        attributedString.enumerateAttribute(.font, in: NSRange(location: 0, length: attributedString.length)) { (value, range, stop) in
-
-            guard let oldFont = value as? UIFont,
-                  let newDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body)
-                    .withSymbolicTraits(oldFont.fontDescriptor.symbolicTraits) else {
-
-                return
-            }
-
-            let newFont = UIFont(descriptor: newDescriptor, size: 0)
-
-            attributedString.addAttributes([.font: newFont], range: range)
-        }
-
-        promptLabel.attributedText = attributedString
     }
 }
 
@@ -286,15 +239,6 @@ extension BloggingRemindersFlowCompletionViewController: ChildDrawerPositionable
 
 private enum TextContent {
     static let completionTitle = NSLocalizedString("All set!", comment: "Title of the completion screen of the Blogging Reminders Settings screen.")
-
-    // Ideally we should use stringsdict to translate plurals, but GlotPress currently doesn't support this.
-    static let completionPromptSingular = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@.",
-                                                          comment: "Blogging Reminders description confirming a user's choices. The placeholder will be replaced at runtime with a day of the week. The HTML markup is used to bold the word 'once'.")
-
-    static let completionPromptPlural = NSLocalizedString("You'll get reminders to blog %@ times a week on %@.",
-                                                          comment: "Blogging Reminders description confirming a user's choices. The first placeholder will be populated with a count of the number of times a week they'll be reminded. The second will be a formatted list of days. For example: 'You'll get reminders to blog 2 times a week on Monday and Tuesday.")
-
-    static let noRemindersPrompt = NSLocalizedString("You have no reminders set.", comment: "Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders.")
 
     static let completionUpdateHint = NSLocalizedString("You can update this any time via My Site > Site Settings",
                                                         comment: "Prompt shown on the completion screen of the Blogging Reminders Settings screen.")

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -394,7 +394,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     // MARK: - Completion Paths
 
     private func presentCompletionViewController() {
-        let viewController = BloggingRemindersFlowCompletionViewController(selectedDays: weekdays, tracker: tracker, calendar: calendar)
+        let viewController = BloggingRemindersFlowCompletionViewController(blog: blog, tracker: tracker, calendar: calendar)
         navigationController?.pushViewController(viewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -327,7 +327,7 @@ extension SiteSettingsViewController {
 
         if let scheduler = try? BloggingRemindersScheduler() {
             let formatter = BloggingRemindersScheduleFormatter(schedule: scheduler.schedule(for: blog))
-            cell.textValue = formatter.shortIntervalDescription
+            cell.textValue = formatter.shortIntervalDescription.string
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -323,8 +323,12 @@ extension SiteSettingsViewController {
 
     private func configureCellForBloggingReminders(_ cell: SettingTableViewCell) {
         cell.editable = true
-        cell.textLabel?.text = NSLocalizedString("Blogging Goals", comment: "Label for the blogging goals setting")
-        cell.textValue = "Undefined"
+        cell.textLabel?.text = NSLocalizedString("Blogging Reminders", comment: "Label for the blogging reminders setting")
+
+        if let scheduler = try? BloggingRemindersScheduler() {
+            let formatter = BloggingRemindersScheduleFormatter(schedule: scheduler.schedule(for: blog))
+            cell.textValue = formatter.shortIntervalDescription
+        }
     }
 
     // MARK: - Handling General Setting Cell Taps

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -325,6 +325,8 @@
 		17E4CD0C238C33F300C56916 /* DebugMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E4CD0B238C33F300C56916 /* DebugMenuViewController.swift */; };
 		17EFD3742578201100AB753C /* ValueTransformers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EFD3732578201100AB753C /* ValueTransformers.swift */; };
 		17F0E1DA20EBDC0A001E9514 /* Routes+Me.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */; };
+		17F11EDB268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F11EDA268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift */; };
+		17F11EDC268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F11EDA268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift */; };
 		17F52DB72315233300164966 /* WPStyleGuide+FilterTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F52DB62315233300164966 /* WPStyleGuide+FilterTabBar.swift */; };
 		17F67C56203D81430072001E /* PostCardStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F67C55203D81430072001E /* PostCardStatusViewModel.swift */; };
 		17F7C24922770B68002E5C2E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F7C24822770B68002E5C2E /* main.swift */; };
@@ -4803,6 +4805,7 @@
 		17EFD2D82577B61900AB753C /* WordPress 104.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 104.xcdatamodel"; sourceTree = "<group>"; };
 		17EFD3732578201100AB753C /* ValueTransformers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueTransformers.swift; sourceTree = "<group>"; };
 		17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Me.swift"; sourceTree = "<group>"; };
+		17F11EDA268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingRemindersScheduleFormatter.swift; sourceTree = "<group>"; };
 		17F2A5D020ACC70D00F0BE10 /* WordPress 76.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 76.xcdatamodel"; sourceTree = "<group>"; };
 		17F52DB62315233300164966 /* WPStyleGuide+FilterTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+FilterTabBar.swift"; sourceTree = "<group>"; };
 		17F67C55203D81430072001E /* PostCardStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardStatusViewModel.swift; sourceTree = "<group>"; };
@@ -13793,6 +13796,7 @@
 			children = (
 				F117B11F265C53AB00D2CAA9 /* BloggingRemindersScheduler.swift */,
 				F111B87726580FCE00057942 /* BloggingRemindersStore.swift */,
+				17F11EDA268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift */,
 			);
 			path = "Blogging Reminders";
 			sourceTree = "<group>";
@@ -17592,6 +17596,7 @@
 				4353BFB221A376BF0009CED3 /* UntouchableWindow.swift in Sources */,
 				FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */,
 				D8A3A5B5206A4C7800992576 /* StockPhotosPicker.swift in Sources */,
+				17F11EDB268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift in Sources */,
 				F1112AA3255C2D4100F1F746 /* BlogDetailHeader.swift in Sources */,
 				176E194725C465F70058F1C5 /* UnifiedPrologueViewController.swift in Sources */,
 				E60C2ED71DE5075100488630 /* ReaderCommentCell.swift in Sources */,
@@ -19690,6 +19695,7 @@
 				FABB24922602FC2C00C8785C /* PingHubManager.swift in Sources */,
 				FABB24932602FC2C00C8785C /* MediaVideoExporter.swift in Sources */,
 				FABB24942602FC2C00C8785C /* PluginViewController.swift in Sources */,
+				17F11EDC268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift in Sources */,
 				FABB24952602FC2C00C8785C /* ReaderSiteTopic.swift in Sources */,
 				FABB24962602FC2C00C8785C /* JetpackBackupCompleteViewController.swift in Sources */,
 				FABB24972602FC2C00C8785C /* JetpackLoginViewController.swift in Sources */,


### PR DESCRIPTION
This PR adds a blogging frequency value to the Blogging Reminders row in site settings. This value is produced as an attributed string, so we can reuse it to populate a label below the day toggles on the reminders settings screen. It also extracts the summary formatting from the completion view of the reminders flow into the same formatter.

![Simulator Screen Shot - iPhone 12 Pro - 2021-06-25 at 16 12 06](https://user-images.githubusercontent.com/4780/123482808-afee3c00-d5fd-11eb-8a62-cfcce5f900c1.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-25 at 16 23 23](https://user-images.githubusercontent.com/4780/123482813-b086d280-d5fd-11eb-9566-4914db9afa05.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-25 at 16 23 36](https://user-images.githubusercontent.com/4780/123482814-b11f6900-d5fd-11eb-972d-8e2e429b030a.png)
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-25 at 16 23 52](https://user-images.githubusercontent.com/4780/123482818-b11f6900-d5fd-11eb-8aa6-fd5a5ab2033a.png)

**Known issues**

* The label beneath the day toggles in the Settings screen hasn't been added yet
* If you edit reminders via Site Settings, the row doesn't update automatically. We'll need to detect the setting change or the flow being dismissed to do this.

**To test:**

Test the Site Settings "Blogging Reminders" row value label for each of the following scenarios:

- No reminders set
- One reminder set
- Two reminders set
- Three reminders set
- Every day set

Also verify that the formatted label on the completion screen of the settings flow still looks as expected.

## Regression Notes
1. Potential unintended areas of impact

The label on the final screen of the settings flow has had its formatting refactored, but the above testing steps should cover that.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
