### PR TITLE
Stats date chooser: let height be dynamic

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -75,6 +75,7 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
         tableView.register(SiteStatsTableHeaderView.defaultNib,
                            forHeaderFooterViewReuseIdentifier: SiteStatsTableHeaderView.defaultNibName)
         tableView.estimatedRowHeight = 500
+        tableView.estimatedSectionHeaderHeight = SiteStatsTableHeaderView.estimatedHeight
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -88,9 +89,6 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
         return cell
     }
 
-    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return SiteStatsTableHeaderView.headerHeight()
-    }
 }
 
 extension SiteStatsPeriodTableViewController: StatsBarChartViewDelegate {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -12,6 +12,8 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
 
     // MARK: - Properties
 
+    static let estimatedHeight: CGFloat = 60
+
     @IBOutlet weak var dateLabel: UILabel!
     @IBOutlet weak var timezoneLabel: UILabel!
     @IBOutlet weak var backArrow: UIImageView!
@@ -53,12 +55,6 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
     private var expectedPeriodCount = SiteStatsTableHeaderView.defaultPeriodCount
     private var backLimit: Int {
         return -(expectedPeriodCount - 1)
-    }
-
-    // MARK: - Class Methods
-
-    class func headerHeight() -> CGFloat {
-        return SiteStatsInformation.sharedInstance.timeZoneMatchesDevice() ? Heights.default : Heights.withTimezone
     }
 
     // MARK: - View
@@ -286,12 +282,6 @@ private extension SiteStatsTableHeaderView {
         }
     }
 
-    // MARK: - Header Heights
-
-    private struct Heights {
-        static let `default`: CGFloat = 44
-        static let withTimezone: CGFloat = 60
-    }
 }
 
 extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -19,17 +19,17 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="60"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="3xC-QJ-pF2" userLabel="Date Stack View">
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="3xC-QJ-pF2" userLabel="Date Stack View">
                     <rect key="frame" x="16" y="9" width="257" height="41.5"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hDF-ds-FAU">
-                            <rect key="frame" x="0.0" y="0.0" width="37.5" height="20.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hDF-ds-FAU">
+                            <rect key="frame" x="0.0" y="0.0" width="257" height="21"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Site timezone (UTC + 10)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u8X-zf-iZc">
-                            <rect key="frame" x="0.0" y="22" width="181.5" height="19.5"/>
+                            <rect key="frame" x="0.0" y="22" width="257" height="19.5"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                             <color key="textColor" name="Gray40"/>
                             <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.xib
@@ -18,6 +18,9 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tc3-qS-cyd" userLabel="Background View">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="60"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="USg-n6-aWH"/>
+                    </constraints>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="3xC-QJ-pF2" userLabel="Date Stack View">
                     <rect key="frame" x="16" y="9" width="257" height="41.5"/>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -35,6 +35,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         super.viewDidLoad()
         navigationItem.title = NSLocalizedString("Post Stats", comment: "Window title for Post Stats view.")
         refreshControl?.addTarget(self, action: #selector(userInitiatedRefresh), for: .valueChanged)
+        tableView.estimatedSectionHeaderHeight = SiteStatsTableHeaderView.estimatedHeight
         Style.configureTable(tableView)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
         tableView.register(SiteStatsTableHeaderView.defaultNib,
@@ -70,10 +71,6 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         cell.animateGhostLayers(viewModel?.isFetchingPostDetails() == true)
         tableHeaderView = cell
         return cell
-    }
-
-    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return SiteStatsTableHeaderView.headerHeight()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -58,6 +58,7 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         clearExpandedRows()
         Style.configureTable(tableView)
         refreshControl?.addTarget(self, action: #selector(refreshData), for: .valueChanged)
+        tableView.estimatedSectionHeaderHeight = SiteStatsTableHeaderView.estimatedHeight
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
         tableView.register(SiteStatsTableHeaderView.defaultNib,
                            forHeaderFooterViewReuseIdentifier: SiteStatsTableHeaderView.defaultNibName)
@@ -128,7 +129,7 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
             return 0
         }
 
-        return SiteStatsTableHeaderView.headerHeight()
+        return UITableView.automaticDimension
     }
 
 }


### PR DESCRIPTION
Fixes #n/a

This changes the Stat date chooser to have a dynamic height.

To test:
- Go to a view that displays the date chooser (see below).
- Change text size.
- Verify the date chooser height adjusts accordingly. Note the minimum height is set to 44.

| Before | After |
|--------|-------|
| <img width="472" alt="before" src="https://user-images.githubusercontent.com/1816888/123489266-cf21a500-d5ce-11eb-8fd2-29b8d560788c.png"> | <img width="471" alt="after" src="https://user-images.githubusercontent.com/1816888/123489271-d21c9580-d5ce-11eb-9b79-d079149ed621.png"> |

The date header is used in 3 different views. Please test in each:
- Stats > any period.
- Stats > any period > Posts and Pages > select a post.
- Stats > Insights > This Year > View more. You may have to add the card via `Add stats card` at the bottom of the Insights table.

Also, please test on sites where:
- The site timezone matches yours (the `Site timezone` label will not display).
- The site timezone does not match yours (the `Site timezone` label will display).


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
