### PR TITLE
Add lane to download localized metadata for Jetpack

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -217,7 +217,7 @@ platform :ios do
   desc 'Updates a release branch for a new beta release'
   lane :new_beta_release do |options|
     ios_betabuild_prechecks(options)
-    ios_update_metadata(options)
+    download_localized_strings_and_metadata(options)
     # This is disabled due to GlotPress outputting an invalid `.strings` file for some locales
     # ios_lint_localizations(input_dir: 'WordPress/Resources', allow_retry: true)
     ios_bump_version_beta
@@ -264,7 +264,7 @@ platform :ios do
         glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/dev/',
         abort_on_violations: false
       )
-      ios_update_metadata(options)
+      download_localized_strings_and_metadata(options)
       # ios_lint_localizations(input_dir: 'WordPress/Resources', allow_retry: true)
       ios_bump_version_beta
     end
@@ -296,6 +296,25 @@ platform :ios do
     ios_finalize_prechecks(options)
     version = ios_get_app_version
     trigger_release_build(branch_to_build: "release/#{version}")
+  end
+
+  #####################################################################################
+  # download_localized_strings_and_metadata
+  # -----------------------------------------------------------------------------------
+  # Downloads localized app strings and App Store Connect metadata from GlotPress.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane download_localized_strings_and_metadata
+  #####################################################################################
+  desc 'Downloads localized metadata for App Store Connect from GlotPress'
+  lane :download_localized_strings_and_metadata do |options|
+    # WordPress: leverage the default release toolkit setup.
+    # It's not clear in the action name, but this downloads both `.strings`
+    # translations for the app and App Store Connect metadata.
+    ios_update_metadata(options)
+    # Jetpack: use the custom setup. Notice that we don't need extra steps to
+    # download `.strings` because Jetpack uses the same codebase as WordPress.
+    download_jetpack_localized_app_store_metadata
   end
 
   #####################################################################################

--- a/fastlane/Jetpack-Fastfile
+++ b/fastlane/Jetpack-Fastfile
@@ -144,6 +144,28 @@ lane :update_jetpack_appstore_strings do |options|
   )
 end
 
+#####################################################################################
+# download_jetpack_localized_metadata
+# -----------------------------------------------------------------------------------
+# Downloads localized metadata for App Store Connect from GlotPress.
+# -----------------------------------------------------------------------------------
+# Usage:
+# bundle exec fastlane download_localized_metadata
+#####################################################################################
+desc 'Downloads localized metadata for App Store Connect from GlotPress'
+lane :download_jetpack_localized_app_store_metadata do
+  # No need to `cd` into `fastlane` because of how Fastlane manages its paths
+  # internally.
+  sh './download_metadata.swift jetpack'
+
+  jetpack_metadata_glob = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'jetpack_metadata/**/*.txt')
+  sh "git add #{jetpack_metadata_glob}"
+  git_commit(
+    path: jetpack_metadata_glob,
+    message: 'Update Jetpack metadata translations'
+  )
+end
+
 ########################################################################
 # Jetpack Fastlane match code signing
 ########################################################################

--- a/fastlane/Jetpack-Fastfile
+++ b/fastlane/Jetpack-Fastfile
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+APP_IDENTIFIER = 'com.automattic.jetpack'
+
   #####################################################################################
   # build_and_upload_installable_build
   # -----------------------------------------------------------------------------------
@@ -166,7 +170,7 @@ private_lane :jetpack_appstore_code_signing do |options|
     type: "appstore",
     team_id: get_required_env("EXT_EXPORT_TEAM_ID"),
     readonly: true,
-    app_identifier: "com.automattic.jetpack"
+    app_identifier: APP_IDENTIFIER
   )
 end
 

--- a/fastlane/download_metadata.swift
+++ b/fastlane/download_metadata.swift
@@ -40,6 +40,7 @@ let languages = [
     "es-ES": "es",
     "es-MX": "es-mx",
     "fr-FR": "fr",
+    "he": "he",
     "id": "id",
     "it": "it",
     "ja": "ja",

--- a/fastlane/download_metadata.swift
+++ b/fastlane/download_metadata.swift
@@ -157,10 +157,6 @@ languages.forEach { (key: String, value: String) in
     downloadTranslation(languageCode: value, folderName: key)
 }
 
-extension Array where Element == String {
-
-    var second: String? {
-        guard count >= 2 else { return .none }
-        return self[1]
-    }
+extension Array {
+    var second: Element? { dropFirst().first }
 }

--- a/fastlane/download_metadata.swift
+++ b/fastlane/download_metadata.swift
@@ -6,7 +6,26 @@ let glotPressSubtitleKey = "app_store_subtitle"
 let glotPressWhatsNewKey = "v17.7-whats-new"
 let glotPressDescriptionKey = "app_store_desc"
 let glotPressKeywordsKey = "app_store_keywords"
-let baseFolder = "./metadata"
+
+struct Config {
+    let baseFolder: String
+    let baseURLString: String
+
+    static let wordPress = Config(
+        baseFolder: "./metadata",
+        baseURLString: "https://translate.wordpress.org/projects/apps/ios/release-notes/"
+    )
+
+    static let jetpack = Config(
+        baseFolder: "./jetpack_metadata",
+        baseURLString: "https://translate.wordpress.com/projects/jetpack/apps/ios/release-notes/"
+    )
+
+    static func config(for argument: String?) -> Config {
+        guard let argument = argument else { return .wordPress }
+        return argument == "jetpack" ?  .jetpack : .wordPress
+    }
+}
 
 // iTunes Connect language code: GlotPress code
 let languages = [
@@ -37,9 +56,13 @@ let languages = [
     "zh-Hant": "zh-tw",
 ]
 
-func downloadTranslation(languageCode: String, folderName: String) {
+func downloadTranslation(
+    config: Config = .config(for: CommandLine.arguments.second),
+    languageCode: String,
+    folderName: String
+) {
     let languageCodeOverride = languageCode == "en-us" ? "en-gb" : languageCode
-    let glotPressURL = "https://translate.wordpress.org/projects/apps/ios/release-notes/\(languageCodeOverride)/default/export-translations?format=json"
+    let glotPressURL = "\(config.baseURLString)\(languageCodeOverride)/default/export-translations?format=json"
     let requestURL: URL = URL(string: glotPressURL)!
     let urlRequest: URLRequest = URLRequest(url: requestURL)
     let session = URLSession.shared
@@ -73,7 +96,7 @@ func downloadTranslation(languageCode: String, folderName: String) {
 
         jsonDict.forEach({ (key: String, value: Any) in
 
-            guard let index = key.index(of: Character(UnicodeScalar(0004))) else {
+            guard let index = key.firstIndex(of: Character(UnicodeScalar(0004))) else {
             	return
             }
 
@@ -103,7 +126,7 @@ func downloadTranslation(languageCode: String, folderName: String) {
             }
         })
 
-        let languageFolder = "\(baseFolder)/\(folderName)"
+        let languageFolder = "\(config.baseFolder)/\(folderName)"
 
         let fileManager = FileManager.default
         try? fileManager.createDirectory(atPath: languageFolder, withIntermediateDirectories: true, attributes: nil)
@@ -132,4 +155,12 @@ func downloadTranslation(languageCode: String, folderName: String) {
 
 languages.forEach { (key: String, value: String) in
     downloadTranslation(languageCode: value, folderName: key)
+}
+
+extension Array where Element == String {
+
+    var second: String? {
+        guard count >= 2 else { return .none }
+        return self[1]
+    }
 }


### PR DESCRIPTION
Adds the tooling required to download the localized metadata.

This is a spin-off of #16733, because in the original PR there are a few open question on code that is unrelated to this feature (which is a nice reminder that even when you think your PR is small, it's always best to keep it focused on doing one thing).

## How to test

1. Checkout this branch
3. Run `bundle exec fastlane download_localized_strings_and_metadata`
4. The lane should succeed and you should see a new commit that deleted all of the `a/fastlane/jetpack_metadata/**/release_notes.txt` file because `download_metadata.swift` it looking for the 17.7 translations, which are not available yet.

You can also change the `glotPressWhatsNewKey` to use 17.6 and run the lane again, you should see some of the `release_notes.txt` changing.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**