### PR TITLE
Update to use WPKit changes.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,7 +47,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.36.0-beta'
+    pod 'WordPressKit', '~> 4.37.0-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -452,7 +452,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.36.0-beta.2):
+  - WordPressKit (4.37.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.39.0-beta.1)
-  - WordPressKit (~> 4.36.0-beta)
+  - WordPressKit (~> 4.37.0-beta)
   - WordPressMocks (~> 0.0.13)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.1-beta)
@@ -810,7 +810,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: ba4038742d62a70482bfbad71dafe367b1a6f8d6
-  WordPressKit: f9ce5b4aa9854facc409dfd2bcca62e2733f6323
+  WordPressKit: 924add6f31db3ceb3cf96ec73ecb9f313ebcacf8
   WordPressMocks: dfac50a938ac74dddf5f7cce5a9110126408dd19
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: cf3b3ef744663811a8d8a9844f42386e1826f512
@@ -826,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 76cacceb956b6338211035c2a3dbe6287b739c8c
+PODFILE CHECKSUM: caa5508b379c00d8ef2dcb4774b8cb2ed4798f09
 
 COCOAPODS: 1.10.1

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsServiceProxy.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsServiceProxy.swift
@@ -17,11 +17,11 @@ protocol RegisterDomainDetailsServiceProxyProtocol {
     func getDomainContactInformation(success: @escaping (DomainContactInformation) -> Void,
                                      failure: @escaping (Error) -> Void)
 
-    func getSupportedCountries(success: @escaping ([Country]) -> Void,
+    func getSupportedCountries(success: @escaping ([WPCountry]) -> Void,
                                failure: @escaping (Error) -> Void)
 
     func getStates(for countryCode: String,
-                   success: @escaping ([State]) -> Void,
+                   success: @escaping ([WPState]) -> Void,
                    failure: @escaping (Error) -> Void)
 
     func createShoppingCart(siteID: Int,
@@ -76,14 +76,14 @@ class RegisterDomainDetailsServiceProxy: RegisterDomainDetailsServiceProxyProtoc
                                                          failure: failure)
     }
 
-    func getSupportedCountries(success: @escaping ([Country]) -> Void,
+    func getSupportedCountries(success: @escaping ([WPCountry]) -> Void,
                                failure: @escaping (Error) -> Void) {
         transactionsServiceRemote.getSupportedCountries(success: success,
                                                         failure: failure)
     }
 
     func getStates(for countryCode: String,
-                   success: @escaping ([State]) -> Void,
+                   success: @escaping ([WPState]) -> Void,
                    failure: @escaping (Error) -> Void) {
         domainsServiceRemote.getStates(for: countryCode,
                                        success: success,

--- a/WordPress/WordPressTest/RegisterDomainDetailsServiceProxyMock.swift
+++ b/WordPress/WordPressTest/RegisterDomainDetailsServiceProxyMock.swift
@@ -84,32 +84,32 @@ class RegisterDomainDetailsServiceProxyMock: RegisterDomainDetailsServiceProxyPr
         }
     }
 
-    func getSupportedCountries(success: @escaping ([Country]) -> Void,
+    func getSupportedCountries(success: @escaping ([WPCountry]) -> Void,
                                failure: @escaping (Error) -> Void) {
         guard validateDomainContactInformationSuccess else {
             failure(NSError())
             return
         }
-        let country1 = Country()
+        let country1 = WPCountry()
         country1.code = "TR"
         country1.name = "Turkey"
-        let country2 = Country()
+        let country2 = WPCountry()
         country2.code = MockData.countryCode
         country2.name = MockData.countryName
         success([country1, country2])
     }
 
     func getStates(for countryCode: String,
-                   success: @escaping ([State]) -> Void,
+                   success: @escaping ([WPState]) -> Void,
                    failure: @escaping (Error) -> Void) {
         guard validateDomainContactInformationSuccess else {
             failure(NSError())
             return
         }
-        let state1 = State()
+        let state1 = WPState()
         state1.code = MockData.stateCode
         state1.name = MockData.stateName
-        let state2 = State()
+        let state2 = WPState()
         state2.code = "AK"
         state2.name = "Alaska"
         success([state1, state2])


### PR DESCRIPTION
Fixes #n/a
Ref: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/412

This updates WPKit to the latest version, and updates the objects renamed in the referenced WPKit PR  so WPiOS will build.

To test:
Verify the app builds and runs.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
