### PR TITLE
Jetpack Section: do not show Restore when not available

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,17 +17,24 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xW5-sj-AVr" customClass="MultilineButton" customModule="WordPress" customModuleProvider="target">
+                                <rect key="frame" x="16" y="330.5" width="343" height="30"/>
+                                <state key="normal" title="Button"/>
+                                <connections>
+                                    <action selector="warningTapped:" destination="yav-nF-cx7" eventType="touchUpInside" id="XPM-6H-44L"/>
+                                </connections>
+                            </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2EY-TD-6V1" userLabel="container view">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="361"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="314.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="mSI-6P-kcW">
-                                        <rect key="frame" x="16" y="16" width="343" height="329"/>
+                                        <rect key="frame" x="16" y="16" width="343" height="282.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="DDN-1Y-KHk" userLabel="header">
-                                                <rect key="frame" x="0.0" y="0.0" width="343" height="38.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="343" height="37"/>
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="PGi-rI-w2P" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="1.5" width="36" height="36"/>
+                                                        <rect key="frame" x="0.0" y="0.5" width="36" height="36"/>
                                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="36" id="8ZE-h3-4gO"/>
@@ -35,16 +42,16 @@
                                                         </constraints>
                                                     </imageView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="TYq-jP-lSb" userLabel="name nad role stack view">
-                                                        <rect key="frame" x="46" y="0.0" width="254" height="38.5"/>
+                                                        <rect key="frame" x="46" y="0.0" width="256" height="37"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aJZ-Nu-hmA" userLabel="name">
-                                                                <rect key="frame" x="0.0" y="0.0" width="254" height="20.5"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="256" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hWd-Yt-cp5" userLabel="role">
-                                                                <rect key="frame" x="0.0" y="22.5" width="254" height="16"/>
+                                                                <rect key="frame" x="0.0" y="22.5" width="256" height="14.5"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -52,16 +59,16 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="RtK-ZD-5sa" userLabel="date and time stack view">
-                                                        <rect key="frame" x="310" y="2.5" width="33" height="34"/>
+                                                        <rect key="frame" x="312" y="3" width="31" height="31"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YIh-B5-5mX">
-                                                                <rect key="frame" x="0.0" y="0.0" width="33" height="16"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="31" height="14.5"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cqx-0J-WUT">
-                                                                <rect key="frame" x="0.0" y="18" width="33" height="16"/>
+                                                                <rect key="frame" x="0.0" y="16.5" width="31" height="14.5"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
@@ -71,7 +78,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="jlr-kR-xzq" userLabel="content">
-                                                <rect key="frame" x="0.0" y="68.5" width="343" height="230.5"/>
+                                                <rect key="frame" x="0.0" y="67" width="343" height="185.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZGb-bM-Y2p" customClass="RichTextVIew">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="20.5"/>
@@ -80,14 +87,14 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3sW-BH-Aq9">
-                                                        <rect key="frame" x="0.0" y="28.5" width="343" height="176"/>
+                                                        <rect key="frame" x="0.0" y="28.5" width="343" height="134.5"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                     </textView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ASx-wD-w08">
-                                                        <rect key="frame" x="0.0" y="212.5" width="343" height="18"/>
+                                                        <rect key="frame" x="0.0" y="171" width="343" height="14.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" red="0.40000000000000002" green="0.55686274509803924" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -95,7 +102,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="i00-9l-xYk">
-                                                <rect key="frame" x="0.0" y="329" width="343" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="282.5" width="343" height="0.0"/>
                                                 <subviews>
                                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ouv-sN-axZ" userLabel="rewind">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="44.5"/>
@@ -161,7 +168,10 @@
                         <viewLayoutGuide key="safeArea" id="fnA-qw-vPe"/>
                         <constraints>
                             <constraint firstItem="fnA-qw-vPe" firstAttribute="trailing" secondItem="2EY-TD-6V1" secondAttribute="trailing" id="36M-yw-daV"/>
+                            <constraint firstItem="xW5-sj-AVr" firstAttribute="top" secondItem="2EY-TD-6V1" secondAttribute="bottom" constant="16" id="3Cu-TX-FLB"/>
+                            <constraint firstItem="xW5-sj-AVr" firstAttribute="width" secondItem="2EY-TD-6V1" secondAttribute="width" multiplier="0.914667" id="CQu-jj-lR9"/>
                             <constraint firstItem="2EY-TD-6V1" firstAttribute="top" secondItem="fnA-qw-vPe" secondAttribute="top" id="KcE-uG-uhl"/>
+                            <constraint firstItem="xW5-sj-AVr" firstAttribute="centerX" secondItem="2EY-TD-6V1" secondAttribute="centerX" id="alD-65-Gzc"/>
                             <constraint firstItem="2EY-TD-6V1" firstAttribute="leading" secondItem="fnA-qw-vPe" secondAttribute="leading" id="uy5-pe-WY6"/>
                         </constraints>
                     </view>
@@ -182,6 +192,7 @@
                         <outlet property="textLabel" destination="ZGb-bM-Y2p" id="qUF-RI-rlQ"/>
                         <outlet property="textView" destination="3sW-BH-Aq9" id="6w7-jX-TJa"/>
                         <outlet property="timeLabel" destination="Cqx-0J-WUT" id="vaU-Gy-hCg"/>
+                        <outlet property="warningButton" destination="xW5-sj-AVr" id="Bjc-BJ-JWN"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gsR-ne-8K9" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -225,7 +225,7 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
     }
 
     private func showWarningIfNeeded() {
-        guard let isMultiSite = rewindStatus?.isMultiSite() else {
+        guard let isMultiSite = rewindStatus?.isMultisite() else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -144,7 +144,7 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         backupButton.naturalContentHorizontalAlignment = .leading
         backupButton.setImage(.gridicon(.cloudDownload, size: Constants.gridiconSize), for: .normal)
 
-        let attributedTitle = WPStyleGuide.Jetpack.highlightString(RewindStatus.Strings.multisiteNotAvailableHighlight,
+        let attributedTitle = WPStyleGuide.Jetpack.highlightString(RewindStatus.Strings.multisiteNotAvailableSubstring,
                                                                    inString: RewindStatus.Strings.multisiteNotAvailable)
 
         warningButton.setAttributedTitle(attributedTitle, for: .normal)

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -373,7 +373,9 @@ extension BaseActivityListViewController: ActivityPresenter {
     func presentBackupOrRestoreFor(activity: Activity, from sender: UIButton) {
         let rewindStatus = store.state.rewindStatus[site]
 
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let title = rewindStatus?.reason == "multisite_not_supported" ? NSLocalizedString("Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores.", comment: "Message for Jetpack users that have multisite WP installation, thus Restore is not available.") : nil
+
+        let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
 
         if rewindStatus?.state == .active {
             let restoreTitle = NSLocalizedString("Restore", comment: "Title displayed for restore action.")

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -364,6 +364,7 @@ extension BaseActivityListViewController: ActivityPresenter {
         let detailVC = ActivityDetailViewController.loadFromStoryboard()
 
         detailVC.site = site
+        detailVC.rewindStatus = store.state.rewindStatus[site]
         detailVC.formattableActivity = activity
         detailVC.presenter = self
 
@@ -373,7 +374,7 @@ extension BaseActivityListViewController: ActivityPresenter {
     func presentBackupOrRestoreFor(activity: Activity, from sender: UIButton) {
         let rewindStatus = store.state.rewindStatus[site]
 
-        let title = rewindStatus?.reason == "multisite_not_supported" ? NSLocalizedString("Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores.", comment: "Message for Jetpack users that have multisite WP installation, thus Restore is not available.") : nil
+        let title = rewindStatus?.isMultiSite() == true ? RewindStatus.Strings.multisiteNotAvailable : nil
 
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
 
@@ -576,5 +577,20 @@ extension BaseActivityListViewController: ActivityTypeSelectorDelegate {
             selectTypeProperties["num_total_activities_selected"] = totalActivitiesSelected
             WPAnalytics.track(.activitylogFilterbarSelectType, properties: selectTypeProperties)
         }
+    }
+}
+
+extension RewindStatus {
+    func isMultiSite() -> Bool {
+        reason == "multisite_not_supported"
+    }
+
+    func isActive() -> Bool {
+        state == .active
+    }
+
+    enum Strings {
+        static let multisiteNotAvailable = NSLocalizedString("Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. For more information visit our documentation page.", comment: "Message for Jetpack users that have multisite WP installation, thus Restore is not available.")
+        static let multisiteNotAvailableHighlight = NSLocalizedString("visit our documentation page", comment: "Portion of a message for Jetpack users that have multisite WP installation, thus Restore is not available. This part is a link, colored with a different color.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -579,18 +579,3 @@ extension BaseActivityListViewController: ActivityTypeSelectorDelegate {
         }
     }
 }
-
-extension RewindStatus {
-    func isMultiSite() -> Bool {
-        reason == "multisite_not_supported"
-    }
-
-    func isActive() -> Bool {
-        state == .active
-    }
-
-    enum Strings {
-        static let multisiteNotAvailable = NSLocalizedString("Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. For more information visit our documentation page.", comment: "Message for Jetpack users that have multisite WP installation, thus Restore is not available.")
-        static let multisiteNotAvailableHighlight = NSLocalizedString("visit our documentation page", comment: "Portion of a message for Jetpack users that have multisite WP installation, thus Restore is not available. This part is a link, colored with a different color.")
-    }
-}

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -371,18 +371,22 @@ extension BaseActivityListViewController: ActivityPresenter {
     }
 
     func presentBackupOrRestoreFor(activity: Activity, from sender: UIButton) {
+        let rewindStatus = store.state.rewindStatus[site]
+
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        let restoreTitle = NSLocalizedString("Restore", comment: "Title displayed for restore action.")
+        if rewindStatus?.state == .active {
+            let restoreTitle = NSLocalizedString("Restore", comment: "Title displayed for restore action.")
 
-        let restoreOptionsVC = JetpackRestoreOptionsViewController(site: site,
-                                                                   activity: activity,
-                                                                   isAwaitingCredentials: store.isAwaitingCredentials(site: site))
-        restoreOptionsVC.restoreStatusDelegate = self
-        restoreOptionsVC.presentedFrom = configuration.identifier
-        alertController.addDefaultActionWithTitle(restoreTitle, handler: { _ in
-            self.present(UINavigationController(rootViewController: restoreOptionsVC), animated: true)
-        })
+            let restoreOptionsVC = JetpackRestoreOptionsViewController(site: site,
+                                                                       activity: activity,
+                                                                       isAwaitingCredentials: store.isAwaitingCredentials(site: site))
+            restoreOptionsVC.restoreStatusDelegate = self
+            restoreOptionsVC.presentedFrom = configuration.identifier
+            alertController.addDefaultActionWithTitle(restoreTitle, handler: { _ in
+                self.present(UINavigationController(rootViewController: restoreOptionsVC), animated: true)
+            })
+        }
 
         let backupTitle = NSLocalizedString("Download backup", comment: "Title displayed for download backup action.")
         let backupOptionsVC = JetpackBackupOptionsViewController(site: site, activity: activity)

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -374,7 +374,7 @@ extension BaseActivityListViewController: ActivityPresenter {
     func presentBackupOrRestoreFor(activity: Activity, from sender: UIButton) {
         let rewindStatus = store.state.rewindStatus[site]
 
-        let title = rewindStatus?.isMultiSite() == true ? RewindStatus.Strings.multisiteNotAvailable : nil
+        let title = rewindStatus?.isMultisite() == true ? RewindStatus.Strings.multisiteNotAvailable : nil
 
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
 

--- a/WordPress/Classes/ViewRelated/Activity/RewindStatus+multiSite.swift
+++ b/WordPress/Classes/ViewRelated/Activity/RewindStatus+multiSite.swift
@@ -1,7 +1,7 @@
 import WordPressKit
 
 extension RewindStatus {
-    func isMultiSite() -> Bool {
+    func isMultisite() -> Bool {
         reason == "multisite_not_supported"
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/RewindStatus+multiSite.swift
+++ b/WordPress/Classes/ViewRelated/Activity/RewindStatus+multiSite.swift
@@ -1,0 +1,16 @@
+import WordPressKit
+
+extension RewindStatus {
+    func isMultiSite() -> Bool {
+        reason == "multisite_not_supported"
+    }
+
+    func isActive() -> Bool {
+        state == .active
+    }
+
+    enum Strings {
+        static let multisiteNotAvailable = NSLocalizedString("Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. For more information visit our documentation page.", comment: "Message for Jetpack users that have multisite WP installation, thus Restore is not available.")
+        static let multisiteNotAvailableHighlight = NSLocalizedString("visit our documentation page", comment: "Portion of a message for Jetpack users that have multisite WP installation, thus Restore is not available. This part is a link, colored with a different color.")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/RewindStatus+multiSite.swift
+++ b/WordPress/Classes/ViewRelated/Activity/RewindStatus+multiSite.swift
@@ -10,7 +10,9 @@ extension RewindStatus {
     }
 
     enum Strings {
-        static let multisiteNotAvailable = NSLocalizedString("Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. For more information visit our documentation page.", comment: "Message for Jetpack users that have multisite WP installation, thus Restore is not available.")
-        static let multisiteNotAvailableHighlight = NSLocalizedString("visit our documentation page", comment: "Portion of a message for Jetpack users that have multisite WP installation, thus Restore is not available. This part is a link, colored with a different color.")
+        static let multisiteNotAvailable = String(format: Self.multisiteNotAvailableFormat,
+                                                  Self.multisiteNotAvailableSubstring)
+        static let multisiteNotAvailableFormat = NSLocalizedString("Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores. For more information %1$@.", comment: "Message for Jetpack users that have multisite WP installation, thus Restore is not available. %1$@ is a placeholder for the string 'visit our documentation page'.")
+        static let multisiteNotAvailableSubstring = NSLocalizedString("visit our documentation page", comment: "Portion of a message for Jetpack users that have multisite WP installation, thus Restore is not available. This part is a link, colored with a different color.")
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1306,6 +1306,8 @@
 		8B6EA62323FDE50B004BA312 /* PostServiceUploadingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */; };
 		8B749E7225AF522900023F03 /* JetpackCapabilitiesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B749E7125AF522900023F03 /* JetpackCapabilitiesService.swift */; };
 		8B749E9025AF8D2E00023F03 /* JetpackCapabilitiesServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B749E8F25AF8D2E00023F03 /* JetpackCapabilitiesServiceTests.swift */; };
+		8B74A9A8268E3C68003511CE /* RewindStatus+multiSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B74A9A7268E3C68003511CE /* RewindStatus+multiSite.swift */; };
+		8B74A9A9268E3C68003511CE /* RewindStatus+multiSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B74A9A7268E3C68003511CE /* RewindStatus+multiSite.swift */; };
 		8B7623382384373E00AB3EE7 /* PageListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */; };
 		8B7C97E325A8BFA2004A3373 /* JetpackActivityLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7C97E225A8BFA2004A3373 /* JetpackActivityLogViewController.swift */; };
 		8B7F25A724E6EDB4007D82CC /* TopicsCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7F25A624E6EDB4007D82CC /* TopicsCollectionView.swift */; };
@@ -5908,6 +5910,7 @@
 		8B6EA62223FDE50B004BA312 /* PostServiceUploadingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceUploadingList.swift; sourceTree = "<group>"; };
 		8B749E7125AF522900023F03 /* JetpackCapabilitiesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackCapabilitiesService.swift; sourceTree = "<group>"; };
 		8B749E8F25AF8D2E00023F03 /* JetpackCapabilitiesServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackCapabilitiesServiceTests.swift; sourceTree = "<group>"; };
+		8B74A9A7268E3C68003511CE /* RewindStatus+multiSite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RewindStatus+multiSite.swift"; sourceTree = "<group>"; };
 		8B7623372384373E00AB3EE7 /* PageListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewControllerTests.swift; sourceTree = "<group>"; };
 		8B7C97E225A8BFA2004A3373 /* JetpackActivityLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackActivityLogViewController.swift; sourceTree = "<group>"; };
 		8B7F25A624E6EDB4007D82CC /* TopicsCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicsCollectionView.swift; sourceTree = "<group>"; };
@@ -10669,6 +10672,7 @@
 				4019B27020885AB900A0C7EB /* ActivityDetailViewController.storyboard */,
 				4070D75B20E5F55A007CEBDA /* RewindStatusTableViewCell.xib */,
 				8B7C97E225A8BFA2004A3373 /* JetpackActivityLogViewController.swift */,
+				8B74A9A7268E3C68003511CE /* RewindStatus+multiSite.swift */,
 			);
 			path = Activity;
 			sourceTree = "<group>";
@@ -17433,6 +17437,7 @@
 				7ECD5B8120C4D823001AEBC5 /* MediaPreviewHelper.swift in Sources */,
 				F5A738BD244DF75400EDE065 /* OffsetTableViewHandler.swift in Sources */,
 				177E7DAD1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift in Sources */,
+				8B74A9A8268E3C68003511CE /* RewindStatus+multiSite.swift in Sources */,
 				3F5B3EAF23A851330060FF1F /* ReaderReblogPresenter.swift in Sources */,
 				7E3E7A6220E44E6A0075D159 /* BodyContentGroup.swift in Sources */,
 				17AD36D51D36C1A60044B10D /* WPStyleGuide+Search.swift in Sources */,
@@ -19079,6 +19084,7 @@
 				FABB22492602FC2C00C8785C /* FullScreenCommentReplyViewController.swift in Sources */,
 				FABB224A2602FC2C00C8785C /* ReaderFollowedSitesViewController.swift in Sources */,
 				FABB224B2602FC2C00C8785C /* AnnouncementsCache.swift in Sources */,
+				8B74A9A9268E3C68003511CE /* RewindStatus+multiSite.swift in Sources */,
 				FABB224C2602FC2C00C8785C /* GravatarUploader.swift in Sources */,
 				FABB224D2602FC2C00C8785C /* NotificationSettingDetailsViewController.swift in Sources */,
 				FABB224E2602FC2C00C8785C /* AztecMediaPickingCoordinator.swift in Sources */,


### PR DESCRIPTION
Fixes #16754

### To test

1. Go to https://jurassic.ninja/specialops/
2. Pick a Jetpack plan (e.g. Jetpack Complete)
3. Click on Launch Multisite on subdomains
4. Connect to this site and open the app
5. Go to Activity Log and/or Backup
6. Tap the 3 dots on an activity cell
7. Make sure Restore is not available
8. Make sure there's a message saying _"Jetpack Backup for Multisite installations provides downloadable backups, no one-click restores."_
9. Tap the cell
10. Check that in the event detail Restore is not available and a message in the bottom is displayed

<img width="391" alt="Screen Shot 2021-06-28 at 17 12 08" src="https://user-images.githubusercontent.com/7040243/123698160-312f1400-d834-11eb-93dc-425e9477ec75.png">

<img src="https://user-images.githubusercontent.com/7040243/124171610-2fa55c00-da7f-11eb-87c1-58b07469fa1c.png" width="300">


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
I didn't. This change was made on the UIKit layer.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
