### PR TITLE
Dismiss suggestions on space keystroke

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergSuggestionsViewController.swift
@@ -114,6 +114,24 @@ extension GutenbergSuggestionsViewController: UITextFieldDelegate {
             return true
         }
         let searchWord = nsString.replacingCharacters(in: range, with: string)
+
+        // This feels a bit hacky, so I'll explain what's being done here:
+        //     1. If the user types "@ ", the so-called "dismiss sequence",
+        //        the user probably typed the space in order to dismiss the
+        //        suggestions UI.
+        //     2. So when this happens, we call the success handler and
+        //        pass in an empty string.
+        // We pass in an empty string because on the RN side here, the success
+        // handler inserts the @, followed by the username, followed by a space.
+        // Since we're essentially passing in an empty username, the result is
+        // that a "@ " is inserted into the post, which is the desired result.
+        // The same applies for cross-posts, with "+ " instead of "@ ".
+        let dismissSequence = suggestionType.trigger + " "
+        guard searchWord != dismissSequence else {
+            onCompletion?(.success(""))
+            return true
+        }
+
         if searchWord.hasPrefix(suggestionType.trigger) {
             suggestionsView.showSuggestions(forWord: searchWord)
         } else {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -971,7 +971,7 @@ extension GutenbergViewController {
             }
 
             var didSelectSuggestion = false
-            if case .success = result {
+            if case let .success(text) = result, !text.isEmpty {
                 didSelectSuggestion = true
             }
 


### PR DESCRIPTION
Addresses https://github.com/WordPress/gutenberg/issues/24425 (for iOS)

_**Note: This PR replaces https://github.com/wordpress-mobile/WordPress-iOS/pull/16601 which [was reverted](https://github.com/wordpress-mobile/WordPress-iOS/pull/16641) after [it was found](https://github.com/wordpress-mobile/WordPress-iOS/pull/16601#discussion_r646606449) that the PR overlooked updating analytics events.**_

This PR allows users to easily dismiss the suggestion UI by typing a space character after triggering the UI. This means it will now be easier to add a `@` character to a post without triggering the mentions suggestions UI, or add a `+` character without triggering the cross-post suggestions UI.

I added this change to suggestions in the block editor, but didn't apply it to other parts of the app (e.g. comments, notification replies, etc) because that felt too far out-of-scope here. It would also make the testing steps much longer.

## To test:

```
- [ ] Verify user can dismiss @-mention suggestions on space keystroke
  - Type a space after a `@` character, expect the mentions suggestions list to be dismissed
  - Expect that the `wpios_suggestion_session_finished` Tracks event fires with the `did_select_suggestion` custom property set to `false`
- [ ] Verify user can dismiss cross-post suggestions on space keystroke  
  - Type a space after a `+` character, expect the cross-positing suggestions list to be dismissed
  - Expect that the `wpios_suggestion_session_finished` Tracks event fires with the `did_select_suggestion` custom property set to `false`
- [ ] Verify user can still @-mention another user
  - Expect the recipient of the @-mention to be notified
  - Expect that the `wpios_suggestion_session_finished` Tracks event fires with the `did_select_suggestion` custom property set to `true`
- [ ] Verify user can still cross-post to another site
  - Expect the recipient site to receive the cross-post
  - Expect the `wpios_suggestion_session_finished` Tracks event fires with the `did_select_suggestion` custom property set to `false`
```

## Regression Notes

1. Potential unintended areas of impact

This change could conceivably break suggestions (both mentions and cross-posting).

2. What I did to test those areas of impact (or what existing automated tests I relied on)

The above manual tests.

3. What automated tests I added (or what prevented me from doing so)

This change affects the UI so a UI test would be best, but we only add UI tests to core flows.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
