### PR TITLE
Only prefetch suggestions on supported sites

### DIFF
--- a/WordPress/Classes/Services/SiteSuggestionService.swift
+++ b/WordPress/Classes/Services/SiteSuggestionService.swift
@@ -37,9 +37,14 @@ class SiteSuggestionService {
 
     /**
      If no suggestions already in Core Data, fetch them from the network and store them in Core Data.
+     Aborts and calls callback if the site does not support suggestions.
      @param blog The blog/site to prefetch suggestions for
      */
-    func prefetchSuggestions(for blog: Blog, completion: @escaping () -> Void) {
+    func prefetchSuggestionsIfNeeded(for blog: Blog, completion: @escaping () -> Void) {
+        guard shouldShowSuggestions(for: blog) else {
+            completion()
+            return
+        }
         let persistedSuggestions = retrievePersistedSuggestions(for: blog)
         if persistedSuggestions == nil || persistedSuggestions?.isEmpty == true {
             fetchAndPersistSuggestions(for: blog, completion: { _ in

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -442,7 +442,7 @@ class GutenbergViewController: UIViewController, PostEditor {
         setTitle(post.postTitle ?? "")
         setHTML(content)
 
-        SiteSuggestionService.shared.prefetchSuggestions(for: self.post.blog) { [weak self] in
+        SiteSuggestionService.shared.prefetchSuggestionsIfNeeded(for: post.blog) { [weak self] in
             self?.gutenberg.updateCapabilities()
         }
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3683

The app wasn't checking if a site supported cross-posts before it tried to fetch cross-posts suggestions from the server.

To test:
1. Put a breakpoint on [this line](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Services/SiteSuggestionService.swift#L70) of `SiteSuggestionService.swift:70` and made sure it isn't hit when using the block editor on a self-hosted site accessed via its site username/password (not its WP.com credentials).
2. Repeat the above on a WP.com site and ensure that the breakpoint is hit and cross-posts work (i.e. that you can cross-post to another site).

## Regression Notes
1. Potential unintended areas of impact

The code that's modified only touches upon code paths that the cross-posting functionality uses. It doesn't affect mentions or any other app functionality.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

See test instructions above.

3. What automated tests I added (or what prevented me from doing so)

I can't see a way to easily inject a mock API into `SiteSuggestionService` without making significant modifications.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
