### PR TITLE
Track notification details opened when accessing a notification from up/down arrows

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -7,7 +7,7 @@ import WordPressShared
 
 ///
 ///
-protocol NotificationsNavigationDataSource: class {
+protocol NotificationsNavigationDataSource: AnyObject {
     func notification(succeeding note: Notification) -> Notification?
     func notification(preceding note: Notification) -> Notification?
 }
@@ -1349,10 +1349,7 @@ extension NotificationDetailsViewController {
             return
         }
 
-        hideNoResults()
-        onSelectedNoteChange?(previous)
-        note = previous
-        showConfettiIfNeeded()
+        refreshView(with: previous)
     }
 
     @IBAction func nextNotificationWasPressed() {
@@ -1360,10 +1357,15 @@ extension NotificationDetailsViewController {
             return
         }
 
+        refreshView(with: next)
+    }
+
+    private func refreshView(with note: Notification) {
         hideNoResults()
-        onSelectedNoteChange?(next)
-        note = next
+        onSelectedNoteChange?(note)
+        self.note = note
         showConfettiIfNeeded()
+        trackDetailsOpened(for: note)
     }
 
     var shouldEnablePreviousButton: Bool {
@@ -1439,5 +1441,14 @@ private extension NotificationDetailsViewController {
 
     enum Assets {
         static let confettiBackground       = "notifications-confetti-background"
+    }
+}
+
+// MARK: - Tracks
+extension NotificationDetailsViewController {
+    /// Tracks notification details opened
+    private func trackDetailsOpened(for note: Notification) {
+        let properties = ["notification_type": note.type ?? "unknown"]
+        WPAnalytics.track(.openedNotificationDetails, withProperties: properties)
     }
 }


### PR DESCRIPTION

Fixes #NA

To test:
- build/run and go to Notifications
- open a notification and make sure the `notifications_notification_details_opened` event is tracked
- Move up or down using the arrows on the top/right and make sure the same event is tracked when the next/previous notification shows up

## Regression Notes
1. Potential unintended areas of impact
Very limited, this only adds a tracking event. There's also a small code refactoring but it's pretty safe

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the tracks

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
