### PR TITLE
Move Fastlane secrets outside of repository

### DIFF
--- a/.configure
+++ b/.configure
@@ -15,7 +15,7 @@
     },
     {
       "file": "iOS/app_store_connect_fastlane_api_key.json",
-      "destination": ".configure-files/app_store_connect_fastlane_api_key.json",
+      "destination": "~/.configure/wordpress-ios/secrets/app_store_connect_fastlane_api_key.json",
       "encrypt": true
     },
     {

--- a/.configure
+++ b/.configure
@@ -10,7 +10,7 @@
     },
     {
       "file": "iOS/WPiOS/project.env",
-      "destination": ".configure-files/project.env",
+      "destination": "~/.configure/wordpress-ios/secrets/project.env",
       "encrypt": true
     },
     {

--- a/.configure
+++ b/.configure
@@ -5,7 +5,7 @@
   "files_to_copy": [
     {
       "file": "shared/google_cloud_keys.json",
-      "destination": ".configure-files/google_cloud_keys.json",
+      "destination": "~/.configure/wordpress-ios/secrets/google_cloud_keys.json",
       "encrypt": true
     },
     {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,7 @@ BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'Artifacts')
 # Env file paths to load
 ENV_FILE_NAME = '.wpios-env.default'
 USER_ENV_FILE_PATH = File.join(Dir.home, ENV_FILE_NAME)
-PROJECT_ENV_FILE_PATH = File.join(PROJECT_ROOT_FOLDER, '.configure-files', 'project.env')
+PROJECT_ENV_FILE_PATH = File.join(Dir.home, '.configure', 'wordpress-ios', 'secrets', 'project.env')
 
 # Other defines used across multiple lanes
 REPOSITORY_NAME = 'WordPress-iOS'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,10 +54,12 @@ before_all do |lane|
 
   # Check that the env files exist
   unless is_ci || File.file?(USER_ENV_FILE_PATH)
-    UI.user_error!("~/.wpios-env.default not found: Please copy fastlane/env/user.env-example to #{USER_ENV_FILE_PATH} and fill in the values")
+    example_path = 'fastlane/env/user.env-example '
+    msg = "#{ENV_FILE_NAME} not found: Please copy #{example_path} to #{USER_ENV_FILE_PATH} and fill in the values"
+    UI.user_error!(msg)
   end
   unless File.file?(PROJECT_ENV_FILE_PATH)
-    UI.user_error!("project.env not found: Make sure your configuration is up to date with `rake dependencies`")
+    UI.user_error!("project.env not found at #{PROJECT_ENV_FILE_PATH}: Make sure your configuration is up to date with `rake dependencies`")
   end
 
   # This allows code signing to work on CircleCI

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,7 +16,8 @@ BUILD_PRODUCTS_PATH = File.join(PROJECT_ROOT_FOLDER, 'Artifacts')
 # Env file paths to load
 ENV_FILE_NAME = '.wpios-env.default'
 USER_ENV_FILE_PATH = File.join(Dir.home, ENV_FILE_NAME)
-PROJECT_ENV_FILE_PATH = File.join(Dir.home, '.configure', 'wordpress-ios', 'secrets', 'project.env')
+SECRETS_DIR = File.join(Dir.home, '.configure', 'wordpress-ios', 'secrets')
+PROJECT_ENV_FILE_PATH = File.join(SECRETS_DIR, 'project.env')
 
 # Other defines used across multiple lanes
 REPOSITORY_NAME = 'WordPress-iOS'
@@ -549,7 +550,8 @@ platform :ios do
 
     testflight(
       skip_waiting_for_build_processing: true,
-      team_id: '299112'
+      team_id: '299112',
+      api_key_path: File.join(SECRETS_DIR, 'app_store_connect_fastlane_api_key.json')
     )
 
     sentry_upload_dsym(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,8 +56,7 @@ before_all do |lane|
   # Check that the env files exist
   unless is_ci || File.file?(USER_ENV_FILE_PATH)
     example_path = 'fastlane/env/user.env-example '
-    msg = "#{ENV_FILE_NAME} not found: Please copy #{example_path} to #{USER_ENV_FILE_PATH} and fill in the values"
-    UI.user_error!(msg)
+    UI.user_error! "#{ENV_FILE_NAME} not found: Please copy #{example_path} to #{USER_ENV_FILE_PATH} and fill in the values."
   end
   unless File.file?(PROJECT_ENV_FILE_PATH)
     UI.user_error!("project.env not found at #{PROJECT_ENV_FILE_PATH}: Make sure your configuration is up to date with `rake dependencies`")

--- a/fastlane/Jetpack-Fastfile
+++ b/fastlane/Jetpack-Fastfile
@@ -94,7 +94,7 @@ APP_IDENTIFIER = 'com.automattic.jetpack'
     testflight(
       skip_waiting_for_build_processing: true,
       team_id: "299112",
-      api_key_path: File.join(PROJECT_ROOT_FOLDER, '.configure-files', 'app_store_connect_fastlane_api_key.json'),
+      api_key_path: File.join(SECRETS_DIR, 'app_store_connect_fastlane_api_key.json')
     )
 
     sentry_upload_dsym(

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -9,3 +9,5 @@ google_cloud_bucket_name('a8c-fastlane-match')
 secrets_dir = File.join(Dir.home, '.configure', 'wordpress-ios', 'secrets')
 
 google_cloud_keys_file(File.join(secrets_dir, 'google_cloud_keys.json'))
+
+api_key_path(File.join(secrets_dir, 'app_store_connect_fastlane_api_key.json'))

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -5,4 +5,7 @@
 # Store certs/profiles encrypted in Google Cloud
 storage_mode('google_cloud')
 google_cloud_bucket_name('a8c-fastlane-match')
-google_cloud_keys_file(File.join(Dir.home, '.configure', 'wordpress-ios', 'secrets', 'google_cloud_keys.json'))
+
+secrets_dir = File.join(Dir.home, '.configure', 'wordpress-ios', 'secrets')
+
+google_cloud_keys_file(File.join(secrets_dir, 'google_cloud_keys.json'))

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -5,4 +5,4 @@
 # Store certs/profiles encrypted in Google Cloud
 storage_mode('google_cloud')
 google_cloud_bucket_name('a8c-fastlane-match')
-google_cloud_keys_file('.configure-files/google_cloud_keys.json')
+google_cloud_keys_file(File.join(Dir.home, '.configure', 'wordpress-ios', 'secrets', 'google_cloud_keys.json'))


### PR DESCRIPTION
This moves all the secrets used by our Fastlane automation outside of the repo.

I'm targeting `release/17.7` because I have some ASC automation work (see #16764) that I'd like to get in here, and it will need to use the key in the new location. Targeting the release branch and then merging release into `develop` to propagate the changes to the feature devs seems better than opening the PR against `develop` and _remembering_ to update the new ASC-related code from the release branch to use the key at a different location during or after the finalized release merge into `develop`.

## To test

- Checkout this branch
- Run `bundle exec fastlane run configure_apply`
- Run `ls ~/.configure/wordpress-ios/secrets`, you should see

```
app_store_connect_fastlane_api_key.json
google_cloud_keys.json
project.env
```

I opened a [test PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/16779) which runs the lanes that exercise the code touched by this changed. It passed, or rather, [it failed](https://github.com/wordpress-mobile/WordPress-iOS/pull/16779#issuecomment-871131350) as expected (follow link for more details).

If you have time to spare, you can test each locally:

- Run any of the `_code_signing` lanes for WordPress and Jetpack, e.g. `alpha_code_signing` and `jetpack_alpha_code_signing`.
- Run the lanes that uploads WordPress and Jetpack to TestFlight: `build_and_upload_itc` and `build_and_upload_jetpack_for_app_store`.

## Regression Notes
1. Potential unintended areas of impact
The Developer Portal and ASC automation

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See the tests described above

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**