### PR TITLE
Try/fix xmlrpc url crash

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -210,7 +210,15 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 {
     NSError *error = nil;
     NSRegularExpression *xmlrpc = [NSRegularExpression regularExpressionWithPattern:@"xmlrpc.php$" options:NSRegularExpressionCaseInsensitive error:&error];
-    return [xmlrpc stringByReplacingMatchesInString:self.xmlrpc options:0 range:NSMakeRange(0, [self.xmlrpc length]) withTemplate:path];
+    
+    NSString *xmlrpcURL = self.xmlrpc;
+    
+    // Quick fix for a crash that was being caused by self.xmlrpc being nil.
+    if (xmlrpcURL == nil) {
+        return nil;
+    }
+    
+    return [xmlrpc stringByReplacingMatchesInString:xmlrpcURL options:0 range:NSMakeRange(0, [xmlrpcURL length]) withTemplate:path];
 }
 
 - (NSString *)adminUrlWithPath:(NSString *)path


### PR DESCRIPTION
This PR offers a workaround for a crash we're sometimes seeing when logging out.

The issue is caused by the App being in a bad state, so this is just a patch to prevent this specific crash from happening, but there's a possibility we'll see the crash appear elsewhere (as the underlying issue is truly the bad App state).

## To test:

Unfortunately this can't be tested easily, but the logic change is quite straightforward and should be easy to review.

## Regression Notes

1. Potential unintended areas of impact

None, as we're adding a simple `nil` check.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
