### PR TITLE
Comments: set moderation actions based on user role

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 17.8
 -----
-
+* [*] Authors and Contributors can now view a site's Comments via My Site > Comments. [#16783]
 
 17.7
 -----

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -55,5 +55,6 @@ extern NSString * const CommentStatusDraft;
 - (BOOL)hasAuthorUrl;
 - (BOOL)isApproved;
 - (NSString *)sectionIdentifier;
+- (BOOL)isReadOnly;
 
 @end

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -156,6 +156,16 @@ NSString * const CommentStatusDraft = @"draft";
     return [self.status isEqualToString:CommentStatusApproved];
 }
 
+- (BOOL)isReadOnly
+{
+    // If the current user cannot moderate the comment, they can only Like and Reply if the comment is Approved.
+    if (self.blog.isHostedAtWPcom && !self.canModerate && !self.isApproved) {
+        return YES;
+    }
+    
+    return NO;
+}
+
 - (NSString *)contentForDisplay
 {
     //Strip HTML from the comment content

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -88,15 +88,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
         [self.tableView registerNib:tableViewCellNib forCellReuseIdentifier:[cellClass reuseIdentifier]];
     }
 
-    // If the current user cannot moderate the comment, they can only Like and Reply if the comment is Approved.
-    if (self.comment.blog.isHostedAtWPcom &&
-        !self.comment.canModerate &&
-        ![self.comment.status isEqualToString:CommentStatusApproved]) {
-        self.userCanLikeAndReply = NO;
-    } else {
-        self.userCanLikeAndReply = YES;
-    }
-    
+    self.userCanLikeAndReply = !self.comment.isReadOnly;
     [self attachSuggestionsTableViewIfNeeded];
     [self attachReplyView];
     [self setupAutolayoutConstraints];

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -116,6 +116,17 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
         }
     }
 
+    /// Indicates if all actions are disabled.
+    ///
+    @objc var allActionsDisabled: Bool {
+        return !isReplyEnabled &&
+            !isLikeEnabled &&
+            !isApproveEnabled &&
+            !isTrashEnabled &&
+            !isSpamEnabled &&
+            !isEditEnabled
+    }
+
     /// Indicates whether Like is in it's "Selected" state, or not
     ///
     @objc var isLikeOn: Bool {


### PR DESCRIPTION
Fixes #16685

This uses the `can_moderate` flag on Comments to determine which actions are shown in Comment details. The actions available match that on the web. If the current user cannot moderate the Comment:
- All moderation actions are hidden.
- Like and Reply are only available on Approved comments.
- For Pending, Spam, and Trashed, no actions are available.

There is no change:
- If the user can moderate Comments.
- If the site is self-hosted.

You can view/modify user roles at wordpress.com/people/team/yoursite.wordpress.com.

Note: the issue noted [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/16768#issuecomment-870951234) still exists.


To test:

---
On a site where you cannot moderate comments (your role is Author or Contributor):
- Go to My Site > Comments.
- Verify you cannot Approve, Spam, or Trash any comment type.
- Verify you can Like and Reply to Approved comments.
- Verify you cannot Like or Reply to any other comment type (Pending, Spam, Trashed).
  - Since no actions are available, the action bar is hidden.
  - Since you cannot Reply, the Reply bar at the bottom is hidden.


| Approved | Pending |
|--------|-------|
| ![approved](https://user-images.githubusercontent.com/1816888/124014594-f1d20600-d9a0-11eb-99ab-6da155ab4ae0.png) | ![pending](https://user-images.githubusercontent.com/1816888/124014607-f696ba00-d9a0-11eb-933d-6eedcb0f7c0d.png) |

---
On a site where you can moderate comments (your role is Editor or Administrator):
- Verify you can moderate, like, and reply to all comments.

<kbd>![god_mode](https://user-images.githubusercontent.com/1816888/124015014-72910200-d9a1-11eb-97eb-422be7a122ce.png)</kbd>

---
Self-hosted site:
- Verify you can moderate and reply to all comments.

<kbd>![self_hosted](https://user-images.githubusercontent.com/1816888/124015036-77ee4c80-d9a1-11eb-816f-987575c1e0b5.png)</kbd>

---
## Regression Notes
1. Potential unintended areas of impact
- Administrators/Editors ability to moderate comments.
- Comment moderation on self-hosted sites.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested moderation ability for all roles on all Comment types, on WP and self-hosted sites.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
