### PR TITLE
Fix Blogging Reminders flow when called from Site Settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
@@ -16,8 +16,8 @@ class BloggingRemindersFlow {
         let tracker = BloggingRemindersTracker(blogType: blogType)
         tracker.flowStarted(source: source)
 
-        let flowIntroViewController = BloggingRemindersFlowIntroViewController(for: blog, tracker: tracker, source: source)
-        let navigationController = BloggingRemindersNavigationController(rootViewController: flowIntroViewController)
+        let flowStartViewController = makeStartViewController(for: blog, tracker: tracker, source: source)
+        let navigationController = BloggingRemindersNavigationController(rootViewController: flowStartViewController)
 
         let bottomSheet = BottomSheetViewController(childViewController: navigationController,
                                                     customHeaderSpacing: 0)
@@ -25,6 +25,19 @@ class BloggingRemindersFlow {
         NoticesDispatch.lock()
         bottomSheet.show(from: viewController)
         setHasShownWeeklyRemindersFlow(for: blog)
+    }
+
+    /// if the flow has never been seen, it starts with the intro. Otherwise it starts with the calendar settings
+    private static func makeStartViewController(for blog: Blog,
+                                                tracker: BloggingRemindersTracker,
+                                                source: BloggingRemindersTracker.FlowStartSource) -> UIViewController {
+
+        guard hasShownWeeklyRemindersFlow(for: blog) else {
+            return BloggingRemindersFlowIntroViewController(for: blog, tracker: tracker, source: source)
+        }
+
+        return (try? BloggingRemindersFlowSettingsViewController(for: blog, tracker: tracker)) ??
+            BloggingRemindersFlowIntroViewController(for: blog, tracker: tracker, source: source)
     }
 
     // MARK: - Weekly reminders flow presentation status

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -102,8 +102,6 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
         configureStackView()
         configureConstraints()
         promptLabel.text = introDescription
-
-        navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -198,6 +198,8 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         configureConstraints()
         populateCalendarDays()
         refreshNextButton()
+
+        navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -198,8 +198,6 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         configureConstraints()
         populateCalendarDays()
         refreshNextButton()
-
-        navigationController?.setNavigationBarHidden(true, animated: false)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
@@ -9,6 +9,7 @@ class BloggingRemindersNavigationController: LightNavigationController {
     override init(rootViewController: UIViewController) {
         super.init(rootViewController: rootViewController)
         delegate = self
+        setNavigationBarHidden(true, animated: false)
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Fixes #NA

When tapping on "Blogging Reminders" in "Site Settings", the prologue screen will only appear the first time the user sees the Blogging Reminders flow. After that, the flow will start with the "Blogging Reminders Settings" screen.

The behavior of the blogging reminders flow after post publishing is unchanged.

To test:
Make sure you have more than one site with no blogging reminders set (or delete and re-install the app)
Test on iPhone and iPad
- Build/run and select a site where you had not previously seen the Blogging Reminders flow
- Go to "Site Settings" then tap "Blogging Reminders" and make sure the prologue screens shows up
- Dismiss the flow (by completing the flow or dismissing any of the screens)
- Tap again on "Blogging Reminders" and verify that this time the prologue is not presented and the flow starts from the settings screen
- Publish a post (from the editor or from the draft list) and verify that the Blogging Reminders flow is not presented after publishing
- Select another site where you had not seen the Blogging Reminders yet
- Publish a post and make sure the Blogging Reminders flow starts, and the post publishing prologue is the first screen

Note: this is targeting `develop` since this is not a user blocker

## Regression Notes
1. Potential unintended areas of impact
None. This change only configures the starting point of the Blogging Reminders flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Test that the blogging reminders flow works as expected in all the use cases.

3. What automated tests I added (or what prevented me from doing so)
none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
