### PR TITLE
Stats Overview card: wrap labels if using accessibility text size

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -95,6 +95,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
     // MARK: - Properties
 
     @IBOutlet weak var topSeparatorLine: UIView!
+    @IBOutlet weak var labelsStackView: UIStackView!
     @IBOutlet weak var selectedLabel: UILabel!
     @IBOutlet weak var selectedData: UILabel!
     @IBOutlet weak var differenceLabel: UILabel!
@@ -120,7 +121,12 @@ class OverviewCell: UITableViewCell, NibLoadable {
         applyStyles()
     }
 
-    func configure(tabsData: [OverviewTabData], barChartData: [BarChartDataConvertible] = [], barChartStyling: [BarChartStyling] = [], period: StatsPeriodUnit? = nil, statsBarChartViewDelegate: StatsBarChartViewDelegate? = nil, barChartHighlightIndex: Int? = nil) {
+    func configure(tabsData: [OverviewTabData],
+                   barChartData: [BarChartDataConvertible] = [],
+                   barChartStyling: [BarChartStyling] = [],
+                   period: StatsPeriodUnit? = nil,
+                   statsBarChartViewDelegate: StatsBarChartViewDelegate? = nil,
+                   barChartHighlightIndex: Int? = nil) {
         self.tabsData = tabsData
         self.chartData = barChartData
         self.chartStyling = barChartStyling
@@ -128,10 +134,12 @@ class OverviewCell: UITableViewCell, NibLoadable {
         self.chartHighlightIndex = barChartHighlightIndex
         self.period = period
 
+        configureLabelsStackView()
         configureChartView()
         setupFilterBar()
         updateLabels()
     }
+
 }
 
 // MARK: - Private Extension
@@ -144,20 +152,6 @@ private extension OverviewCell {
         Style.configureLabelForOverview(selectedData)
         Style.configureViewAsSeparator(topSeparatorLine)
         Style.configureViewAsSeparator(bottomSeparatorLine)
-        configureFonts()
-    }
-
-    /// This method squelches two Xcode warnings that I encountered:
-    /// 1. Attribute Unavailable: Large Title font text style before iOS 11.0
-    /// 2. Automatically Adjusts Font requires using a Dynamic Type text style
-    /// The second emerged as part of my attempt to resolve the first.
-    ///
-    func configureFonts() {
-
-        let prevailingFont = WPStyleGuide.fontForTextStyle(UIFont.TextStyle.largeTitle)
-        selectedData.font = prevailingFont
-
-        selectedData.adjustsFontForContentSizeCategory = true   // iOS 10
     }
 
     func setupFilterBar() {
@@ -196,6 +190,21 @@ private extension OverviewCell {
         selectedData.text = tabData.tabData.abbreviatedString(forHeroNumber: true)
         differenceLabel.text = tabData.differenceLabel
         differenceLabel.textColor = tabData.differenceTextColor
+    }
+
+    func configureLabelsStackView() {
+        // If isAccessibilityCategory, display the labels vertically.
+        // This makes the differenceLabel "wrap" and appear under the selectedLabel.
+
+        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            labelsStackView.axis = .vertical
+            labelsStackView.alignment = .leading
+            labelsStackView.distribution = .fill
+        } else {
+            labelsStackView.axis = .horizontal
+            labelsStackView.alignment = .fill
+            labelsStackView.distribution = .equalSpacing
+        }
     }
 
     // MARK: Chart support

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -202,7 +202,7 @@ private extension OverviewCell {
             labelsStackView.distribution = .fill
         } else {
             labelsStackView.axis = .horizontal
-            labelsStackView.alignment = .fill
+            labelsStackView.alignment = .firstBaseline
             labelsStackView.distribution = .equalSpacing
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -24,10 +24,10 @@
                             <constraint firstAttribute="height" constant="0.5" id="Pdm-u4-3uG"/>
                         </constraints>
                     </view>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="dS7-nd-qwQ" userLabel="Labels Stack View">
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="firstBaseline" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="dS7-nd-qwQ" userLabel="Labels Stack View">
                         <rect key="frame" x="16" y="24.5" width="422" height="33.5"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="L0M-TW-gHu" userLabel="Selected Data Stack View">
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="firstBaseline" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="L0M-TW-gHu" userLabel="Selected Data Stack View">
                                 <rect key="frame" x="0.0" y="0.0" width="146.5" height="33.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKw-lF-4O8" userLabel="Selected Data">
@@ -37,7 +37,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jZK-cD-I2s" userLabel="Selected Label">
-                                        <rect key="frame" x="101" y="0.0" width="45.5" height="33.5"/>
+                                        <rect key="frame" x="101" y="10.5" width="45.5" height="20.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -45,7 +45,7 @@
                                 </subviews>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+2,500 (5%)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mh8-GY-DEC" userLabel="Difference Label">
-                                <rect key="frame" x="325.5" y="0.0" width="96.5" height="33.5"/>
+                                <rect key="frame" x="325.5" y="10.5" width="96.5" height="20.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="360" id="KGk-i7-Jjw" customClass="OverviewCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="454" height="304"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="375" id="KGk-i7-Jjw" customClass="OverviewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="454" height="319"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="454" height="303.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="454" height="319"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sij-a6-mJ5" userLabel="Top Separator Line">
@@ -26,42 +24,52 @@
                             <constraint firstAttribute="height" constant="0.5" id="Pdm-u4-3uG"/>
                         </constraints>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKw-lF-4O8" userLabel="Selected Data">
-                        <rect key="frame" x="16" y="24" width="100.5" height="36"/>
-                        <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jZK-cD-I2s" userLabel="Selected Label">
-                        <rect key="frame" x="124.5" y="34.5" width="45.5" height="20.5"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+2,500 (5%)" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mh8-GY-DEC" userLabel="Difference Label">
-                        <rect key="frame" x="342" y="34.5" width="96" height="20.5"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="dS7-nd-qwQ" userLabel="Labels Stack View">
+                        <rect key="frame" x="16" y="24.5" width="422" height="33.5"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="L0M-TW-gHu" userLabel="Selected Data Stack View">
+                                <rect key="frame" x="0.0" y="0.0" width="146.5" height="33.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKw-lF-4O8" userLabel="Selected Data">
+                                        <rect key="frame" x="0.0" y="0.0" width="93" height="33.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jZK-cD-I2s" userLabel="Selected Label">
+                                        <rect key="frame" x="101" y="0.0" width="45.5" height="33.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+2,500 (5%)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mh8-GY-DEC" userLabel="Difference Label">
+                                <rect key="frame" x="325.5" y="0.0" width="96.5" height="33.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LXK-k6-Sxa" userLabel="Chart View">
-                        <rect key="frame" x="16" y="76" width="422" height="150"/>
+                        <rect key="frame" x="16" y="74" width="422" height="150"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="150" id="SdW-hH-eUG"/>
                         </constraints>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="OOf-64-W6S" userLabel="Filter Bar Stack View">
-                        <rect key="frame" x="0.0" y="242" width="454" height="61.5"/>
+                        <rect key="frame" x="0.0" y="240" width="454" height="79"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0aY-pl-E5I" customClass="FilterTabBar" customModule="WordPress">
-                                <rect key="frame" x="0.0" y="0.0" width="454" height="61.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="454" height="79"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JKw-M5-MmY" userLabel="Bottom Separator Line">
-                        <rect key="frame" x="0.0" y="303" width="454" height="0.5"/>
+                        <rect key="frame" x="0.0" y="318.5" width="454" height="0.5"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.5" id="9YE-mu-3ZR"/>
@@ -76,19 +84,15 @@
                     <constraint firstAttribute="trailing" secondItem="LXK-k6-Sxa" secondAttribute="trailing" constant="16" id="454-qg-2dp"/>
                     <constraint firstItem="OOf-64-W6S" firstAttribute="top" secondItem="LXK-k6-Sxa" secondAttribute="bottom" priority="999" constant="16" id="45u-jA-D6l"/>
                     <constraint firstAttribute="trailing" secondItem="sij-a6-mJ5" secondAttribute="trailing" id="4tM-Kt-WmO"/>
+                    <constraint firstItem="dS7-nd-qwQ" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="7JK-Ya-T6s"/>
                     <constraint firstAttribute="bottom" secondItem="JKw-M5-MmY" secondAttribute="bottom" id="7ie-6i-dY4"/>
-                    <constraint firstItem="gKw-lF-4O8" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="24" id="9FM-On-UC6"/>
-                    <constraint firstItem="mh8-GY-DEC" firstAttribute="bottom" secondItem="jZK-cD-I2s" secondAttribute="bottom" id="B5Q-FJ-CHg"/>
-                    <constraint firstAttribute="trailing" secondItem="mh8-GY-DEC" secondAttribute="trailing" constant="16" id="DHi-ub-ILb"/>
+                    <constraint firstItem="dS7-nd-qwQ" firstAttribute="top" secondItem="sij-a6-mJ5" secondAttribute="bottom" constant="24" id="A6y-9C-9qS"/>
                     <constraint firstItem="LXK-k6-Sxa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="HS3-PH-hEI"/>
-                    <constraint firstItem="jZK-cD-I2s" firstAttribute="leading" secondItem="gKw-lF-4O8" secondAttribute="trailing" constant="8" id="dru-cE-A0o"/>
-                    <constraint firstItem="jZK-cD-I2s" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="-5" id="dwL-lH-n2U"/>
-                    <constraint firstItem="mh8-GY-DEC" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="jZK-cD-I2s" secondAttribute="trailing" constant="5" id="lU5-Jo-nfk"/>
+                    <constraint firstAttribute="trailing" secondItem="dS7-nd-qwQ" secondAttribute="trailing" constant="16" id="aba-rK-38A"/>
                     <constraint firstAttribute="trailing" secondItem="JKw-M5-MmY" secondAttribute="trailing" id="o73-YK-rux"/>
-                    <constraint firstItem="gKw-lF-4O8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="pOA-dn-Yoy"/>
-                    <constraint firstItem="LXK-k6-Sxa" firstAttribute="top" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="16" id="pZe-NH-yiM"/>
                     <constraint firstItem="OOf-64-W6S" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="r8Y-d5-su4"/>
                     <constraint firstItem="JKw-M5-MmY" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="tUf-r7-46a"/>
+                    <constraint firstItem="LXK-k6-Sxa" firstAttribute="top" secondItem="dS7-nd-qwQ" secondAttribute="bottom" constant="16" id="vzh-XK-S0F"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -98,11 +102,12 @@
                 <outlet property="chartContainerView" destination="LXK-k6-Sxa" id="0yE-3G-QlU"/>
                 <outlet property="differenceLabel" destination="mh8-GY-DEC" id="G27-Xv-ACi"/>
                 <outlet property="filterTabBar" destination="0aY-pl-E5I" id="Mwy-fv-SNw"/>
+                <outlet property="labelsStackView" destination="dS7-nd-qwQ" id="wYt-Ol-DEb"/>
                 <outlet property="selectedData" destination="gKw-lF-4O8" id="aKK-1U-o6H"/>
                 <outlet property="selectedLabel" destination="jZK-cD-I2s" id="rTe-0x-iDM"/>
                 <outlet property="topSeparatorLine" destination="sij-a6-mJ5" id="Rrp-Qf-xtx"/>
             </connections>
-            <point key="canvasLocation" x="-433.60000000000002" y="143.02848575712144"/>
+            <point key="canvasLocation" x="-433.60000000000002" y="149.77511244377811"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
Fixes #n/a

On the Stats Overview card, the top labels now wrap if using accessibility text size.

To test:
- Go to Stats > any period.
- Increase the device's text size to `Accessibility Medium` or higher.
- Verify the difference label now appears under the count label.
- Select tabs across the bottom of the chart.
- Verify the labels are spaced correctly.

| Normal text size | Accessibility text size |
|--------|-------|
| <img width="480" alt="normal_text" src="https://user-images.githubusercontent.com/1816888/124173545-6cb22400-da68-11eb-88f6-01ac1c3980fa.png"> | <img width="480" alt="accessibility_text" src="https://user-images.githubusercontent.com/1816888/124173552-7176d800-da68-11eb-9a5a-1f1d530e3a1b.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
