### PR TITLE
Use VMs to build on Macs

### DIFF
--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+echo "--- :rubygems: Setting up Gems"
+restore_cache "$(hash_file .ruby-version)-$(hash_file Gemfile.lock)"
+gem install bundler
+bundle install
+save_cache vendor/bundle "$(hash_file .ruby-version)-$(hash_file Gemfile.lock)"
+
+echo "--- :cocoapods: Setting up Pods"
+
+# Caching the specs repos and global pod cache can dramatically improve Pod times
+restore_cache "$BUILDKITE_PIPELINE_SLUG-specs-repos"
+restore_cache "$BUILDKITE_PIPELINE_SLUG-global-pod-cache"
+
+restore_cache "$(hash_file Podfile.lock)"
+bundle exec pod install || bundle exec pod install --repo-update --verbose
+save_cache Pods "$(hash_file Podfile.lock)"
+
+save_cache ~/.cocoapods "$BUILDKITE_PIPELINE_SLUG-specs-repo"
+save_cache ~/Library/Caches/CocoaPods/ "$BUILDKITE_PIPELINE_SLUG-global-pod-cache"
+
+echo "--- :writing_hand: Copy Files"
+cp fastlane/env/project.env-example .configure-files/project.env
+
+echo "--- :hammer_and_wrench: Building"
+bundle exec fastlane build_for_testing
+
+echo "--- :arrow_up: Upload Build Products"
+tar -cf build-products.tar DerivedData/Build/Products/
+buildkite-agent artifact upload build-products.tar

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -22,7 +22,9 @@ save_cache ~/.cocoapods "$BUILDKITE_PIPELINE_SLUG-specs-repo"
 save_cache ~/Library/Caches/CocoaPods/ "$BUILDKITE_PIPELINE_SLUG-global-pod-cache"
 
 echo "--- :writing_hand: Copy Files"
-cp fastlane/env/project.env-example .configure-files/project.env
+cp -v fastlane/env/project.env-example .configure-files/project.env
+mkdir -pv ~/.configure/wordpress-ios/secrets
+cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/project.env
 
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_for_testing

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,37 +1,30 @@
-
 # This is the default pipeline – it will build and test the app
 steps:
-
   #################
   # Build the app
   #################
   - label: ":pipeline: Build"
     key: "build"
-    command: |
-      echo "--- 🔧 Setting up Gems"
-      gem install bundler
-      bundle install
-      echo "--- 🔨 Setting up Pods"
-      bundle exec pod install --repo-update
-      echo "--- ✍️ Copy Files"
-      cp fastlane/env/project.env-example .configure-files/project.env
-      echo "--- 🛠 Building"
-      bundle exec fastlane build_for_testing
-      echo "--- 🗜 Zip Build Products"
-      tar -cf build-products.tar DerivedData/Build/Products/
-    artifact_paths:
-      - build-products.tar
+    command: ".buildkite/commands/build-for-testing.sh"
+    plugins:
+      - automattic/bash-cache#v1.0.0: ~
+    env:
+      IMAGE_ID: xcode-12.5.1
 
   #################
   # Run Unit Tests
   #################
   - label: "🧪 Unit Tests"
     command: |
+      echo "--- 📦 Downloading Build Artifacts"
       buildkite-agent artifact download build-products.tar .
       tar -xf build-products.tar
+      echo "--- 🧪 Testing"
       bundle install
       bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
     depends_on: "build"
+    env:
+      IMAGE_ID: xcode-12.5.1
 
   #################
   # Lint Translations
@@ -49,24 +42,28 @@ steps:
   #################
   - label: "🧪 UI Tests (iPhone)"
     command: |
+      echo "--- 📦 Downloading Build Artifacts"
       buildkite-agent artifact download build-products.tar .
       tar -xf build-products.tar
       bundle install
       bundle exec pod install
+      echo "--- 🧪 Testing"
       rake mocks &
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPhone 11" ios-version:"14.1"
     depends_on: "build"
-    agents:
-      os: "macOS"
+    env:
+      IMAGE_ID: xcode-12.5.1
 
   - label: "🧪 UI Tests (iPad)"
     command: |
+      echo "--- 📦 Downloading Build Artifacts"
       buildkite-agent artifact download build-products.tar .
       tar -xf build-products.tar
       bundle install
       bundle exec pod install
+      echo "--- 🧪 Testing"
       rake mocks &
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPad Air (4th generation)" ios-version:"14.1"
     depends_on: "build"
-    agents:
-      os: "macOS"
+    env:
+      IMAGE_ID: xcode-12.5.1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,8 +52,13 @@ steps:
       echo "--- 📦 Downloading Build Artifacts"
       buildkite-agent artifact download build-products.tar .
       tar -xf build-products.tar
+
+      echo "--- :rubygems: Setting up Gems"
       bundle install
+
+      echo "--- :cocoapods: Setting up Pods"
       bundle exec pod install
+
       echo "--- 🧪 Testing"
       rake mocks &
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPhone 11" ios-version:"14.1"
@@ -67,8 +72,13 @@ steps:
       echo "--- 📦 Downloading Build Artifacts"
       buildkite-agent artifact download build-products.tar .
       tar -xf build-products.tar
+
+      echo "--- :rubygems: Setting up Gems"
       bundle install
+
+      echo "--- :cocoapods: Setting up Pods"
       bundle exec pod install
+
       echo "--- 🧪 Testing"
       rake mocks &
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPad Air (4th generation)" ios-version:"14.1"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,6 +53,10 @@ steps:
       buildkite-agent artifact download build-products.tar .
       tar -xf build-products.tar
 
+      echo "--- :wrench: Fixing VM"
+      brew install openjdk@11
+      sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
+
       echo "--- :rubygems: Setting up Gems"
       bundle install
 
@@ -72,6 +76,10 @@ steps:
       echo "--- 📦 Downloading Build Artifacts"
       buildkite-agent artifact download build-products.tar .
       tar -xf build-products.tar
+
+      echo "--- :wrench: Fixing VM"
+      brew install openjdk@11
+      sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
 
       echo "--- :rubygems: Setting up Gems"
       bundle install

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,10 @@
+use_plugins: &use_plugins
+    plugins:
+      - automattic/bash-cache#v1.0.0: ~
+      - automattic/git-s3-cache#add/vm-host-support:
+          bucket: "a8c-repo-mirrors"
+          repo: "wordpress-mobile/wordpress-ios/"
+
 # This is the default pipeline – it will build and test the app
 steps:
   #################
@@ -6,10 +13,9 @@ steps:
   - label: ":pipeline: Build"
     key: "build"
     command: ".buildkite/commands/build-for-testing.sh"
-    plugins:
-      - automattic/bash-cache#v1.0.0: ~
     env:
       IMAGE_ID: xcode-12.5.1
+    <<: *use_plugins
 
   #################
   # Run Unit Tests
@@ -25,6 +31,7 @@ steps:
     depends_on: "build"
     env:
       IMAGE_ID: xcode-12.5.1
+    <<: *use_plugins
 
   #################
   # Lint Translations
@@ -53,6 +60,7 @@ steps:
     depends_on: "build"
     env:
       IMAGE_ID: xcode-12.5.1
+    <<: *use_plugins
 
   - label: "🧪 UI Tests (iPad)"
     command: |
@@ -67,3 +75,4 @@ steps:
     depends_on: "build"
     env:
       IMAGE_ID: xcode-12.5.1
+    <<: *use_plugins

--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: "vendor/bundle"
+BUNDLE_WITHOUT: "screenshots"

--- a/.gitignore
+++ b/.gitignore
@@ -62,9 +62,6 @@ WordPress/Derived Sources/
 */CoverageData/*
 WordPress/Images.xcassets/AppIcon-Internal.appiconset
 
-# Bundler
-.bundle
-
 # Dependencies
 vendor
 


### PR DESCRIPTION
This PR updates WPiOS to use the new VM-based CI system. 

**To test:**
- Ensure [Buildkite CI tasks](https://buildkite.com/wordpress-mobile/wordpress-ios/builds?branch=add%2Fbuildkite-mac-vm) pass

**Known Issues**:
- CocoaPods can be very slow to run in some cases, which will be improved through better caching.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
