### PR TITLE
Address new Xcode 12.5 deprecated 'class' for protocol inheritance warning

### DIFF
--- a/WordPress/Classes/Networking/Pinghub.swift
+++ b/WordPress/Classes/Networking/Pinghub.swift
@@ -8,7 +8,7 @@ import Starscream
 /// The delegate of a PinghubClient must adopt the PinghubClientDelegate
 /// protocol. The client will inform the delegate of any relevant events.
 ///
-public protocol PinghubClientDelegate: class {
+public protocol PinghubClientDelegate: AnyObject {
     /// The client connected successfully.
     ///
     func pingubDidConnect(_ client: PinghubClient)

--- a/WordPress/Classes/Networking/Pinghub.swift
+++ b/WordPress/Classes/Networking/Pinghub.swift
@@ -222,7 +222,7 @@ extension PinghubClient {
 // MARK: - Socket
 
 
-internal protocol Socket: class {
+internal protocol Socket: AnyObject {
     func connect()
     func disconnect()
     var onConnect: (() -> Void)? { get set }

--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -453,7 +453,7 @@ extension UITableView: CellRegistrar {
 
 // MARK: - UITableViewController conformance
 
-@objc public protocol TableViewContainer: class {
+@objc public protocol TableViewContainer: AnyObject {
     var tableView: UITableView! { get set }
 }
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTypeSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTypeSelectorViewController.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WordPressFlux
 
-protocol ActivityTypeSelectorDelegate: class {
+protocol ActivityTypeSelectorDelegate: AnyObject {
     func didCancel(selectorViewController: ActivityTypeSelectorViewController)
     func didSelect(selectorViewController: ActivityTypeSelectorViewController, groups: [ActivityGroup])
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift
@@ -1,6 +1,6 @@
 import WordPressAuthenticator
 
-protocol JetpackRemoteInstallStateViewDelegate: class {
+protocol JetpackRemoteInstallStateViewDelegate: AnyObject {
     func mainButtonDidTouch()
     func customerSupportButtonDidTouch()
 }

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosDataLoader.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosDataLoader.swift
@@ -1,5 +1,5 @@
 /// Implementations of this protocol will be notified when data is loaded from the StockPhotosService
-protocol StockPhotosDataLoaderDelegate: class {
+protocol StockPhotosDataLoaderDelegate: AnyObject {
     func didLoad(media: [StockPhotosMedia], reset: Bool)
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -7,7 +7,7 @@ import WordPressShared
 
 ///
 ///
-protocol NotificationsNavigationDataSource: class {
+protocol NotificationsNavigationDataSource: AnyObject {
     func notification(succeeding note: Notification) -> Notification?
     func notification(preceding note: Notification) -> Notification?
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -141,7 +141,7 @@ public enum PostEditorAction {
     }
 }
 
-public protocol PostEditorStateContextDelegate: class {
+public protocol PostEditorStateContextDelegate: AnyObject {
     func context(_ context: PostEditorStateContext, didChangeAction: PostEditorAction)
     func context(_ context: PostEditorStateContext, didChangeActionAllowed: Bool)
 }

--- a/WordPress/Classes/ViewRelated/Post/Revisions/ShowRevisionsListManger.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/ShowRevisionsListManger.swift
@@ -1,4 +1,4 @@
-protocol RevisionsView: class {
+protocol RevisionsView: AnyObject {
     func stopLoading(success: Bool, error: Error?)
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 typealias RelatedPostsSection = (postType: RemoteReaderSimplePost.PostType, posts: [RemoteReaderSimplePost])
 
-protocol ReaderDetailView: class {
+protocol ReaderDetailView: AnyObject {
     func render(_ post: ReaderPost)
     func renderRelatedPosts(_ posts: [RemoteReaderSimplePost])
     func showLoading()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -3,7 +3,7 @@ import Foundation
 import WordPressShared
 import Gridicons
 
-protocol ReaderTopicsChipsDelegate: class {
+protocol ReaderTopicsChipsDelegate: AnyObject {
     func didSelect(topic: String)
     func heightDidChange()
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -350,7 +350,7 @@ class ReaderSiteSearchHeaderView: UIView {
 /// The delegate can then use this to re-set and resize the associated
 /// tableview's footer view property.
 ///
-protocol ReaderSiteSearchFooterViewDelegate: class {
+protocol ReaderSiteSearchFooterViewDelegate: AnyObject {
     func readerSiteSearchFooterViewDidChangeFrame(_ footerView: ReaderSiteSearchFooterView)
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
@@ -168,6 +168,6 @@ private class ReaderTopicsTableView: UITableView {
     }
 }
 
-protocol ReaderTopicsTableCardCellDelegate: class {
+protocol ReaderTopicsTableCardCellDelegate: AnyObject {
     func didSelect(topic: ReaderAbstractTopic)
 }

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -45,7 +45,7 @@ extension NetworkAwareUI where Self: UIViewController {
 }
 
 /// Implementations of this protocol will be notified when the network connection status changes. Implementations of this protocol must call the observeNetworkStatus method.
-protocol NetworkStatusDelegate: class {
+protocol NetworkStatusDelegate: AnyObject {
     func observeNetworkStatus()
 
     /// This method will be called, on the main thread, when the network connection changes status.

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -700,7 +700,7 @@ extension UIViewController {
 /// in fullscreen until the `navigationController(_:willShowViewController:animated:)`
 /// delegate method detects that there are no fullscreen view controllers left
 /// in the stack.
-protocol PrefersFullscreenDisplay: class {}
+protocol PrefersFullscreenDisplay: AnyObject {}
 
 /// Used to indicate whether a view controller varies its preferred status bar style.
 ///

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -704,7 +704,7 @@ protocol PrefersFullscreenDisplay: AnyObject {}
 
 /// Used to indicate whether a view controller varies its preferred status bar style.
 ///
-protocol DefinesVariableStatusBarStyle: class {}
+protocol DefinesVariableStatusBarStyle: AnyObject {}
 
 // MARK: - WPSplitViewControllerDetailProvider Protocol
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -43,7 +43,7 @@ public enum ThemeType {
  *  @brief      Publicly exposed theme interaction support
  *  @details    Held as weak reference by owned subviews
  */
-public protocol ThemePresenter: class {
+public protocol ThemePresenter: AnyObject {
     var filterType: ThemeType { get set }
 
     var screenshotWidth: Int { get }

--- a/WordPressFlux/Sources/WordPressFlux/Receipt.swift
+++ b/WordPressFlux/Sources/WordPressFlux/Receipt.swift
@@ -1,7 +1,7 @@
 /// An Unsubscribable class can take a receipt and remove an associated
 /// subscription.
 ///
-public protocol Unsubscribable: class {
+public protocol Unsubscribable: AnyObject {
     /// Unregisters the subscription associated with the given Receipt.
     func unsubscribe(receipt: Receipt)
 }


### PR DESCRIPTION
Xcode 12.5 says:

> Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead

And that's what this PR does.

I don't think there's any manual testing required this is a Swift semantic change.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**