### PR TITLE
Try/address some warnings

### DIFF
--- a/WordPress/Classes/Extensions/UIViewController+NoResults.swift
+++ b/WordPress/Classes/Extensions/UIViewController+NoResults.swift
@@ -1,4 +1,4 @@
-protocol NoResultsViewHost: class { }
+protocol NoResultsViewHost: AnyObject { }
 
 extension NoResultsViewHost where Self: UIViewController {
     typealias NoResultsCustomizationBlock = (NoResultsViewController) -> Void

--- a/WordPress/Classes/Utility/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTableViewController.swift
@@ -3,7 +3,7 @@ import WordPressShared
 
 typealias ImmuTableRowControllerGenerator = (ImmuTableRow) -> UIViewController
 
-protocol ImmuTablePresenter: class {
+protocol ImmuTablePresenter: AnyObject {
     func push(_ controllerGenerator: @escaping ImmuTableRowControllerGenerator) -> ImmuTableAction
     func present(_ controllerGenerator: @escaping ImmuTableRowControllerGenerator) -> ImmuTableAction
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -1,6 +1,6 @@
 import WordPressFlux
 
-protocol ActivityPresenter: class {
+protocol ActivityPresenter: AnyObject {
     func presentDetailsFor(activity: FormattableActivity)
     func presentBackupOrRestoreFor(activity: Activity, from sender: UIButton)
     func presentRestoreFor(activity: Activity, from: String?)

--- a/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol CalendarViewControllerDelegate: class {
+protocol CalendarViewControllerDelegate: AnyObject {
     func didCancel(calendar: CalendarViewController)
     func didSelect(calendar: CalendarViewController, startDate: Date?, endDate: Date?)
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Media Progress Coordinator Delegate comunicates changes on media progress.
 ///
 @objc
-public protocol MediaProgressCoordinatorDelegate: class {
+public protocol MediaProgressCoordinatorDelegate: AnyObject {
     func mediaProgressCoordinator(_ mediaProgressCoordinator: MediaProgressCoordinator, progressDidChange progress: Double)
     func mediaProgressCoordinatorDidStartUploading(_ mediaProgressCoordinator: MediaProgressCoordinator)
     func mediaProgressCoordinatorDidFinishUpload(_ mediaProgressCoordinator: MediaProgressCoordinator)

--- a/WordPress/Classes/ViewRelated/Blog/Domain Credit/DomainCreditRedemptionSuccessViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Domain Credit/DomainCreditRedemptionSuccessViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol DomainCreditRedemptionSuccessViewControllerDelegate: class {
+protocol DomainCreditRedemptionSuccessViewControllerDelegate: AnyObject {
     func continueButtonPressed()
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageSelectorViewController.swift
@@ -3,7 +3,7 @@ import WordPressShared
 
 /// Defines the methods implemented by the LanguageSelectorViewController delegate
 ///
-protocol LanguageSelectorDelegate: class {
+protocol LanguageSelectorDelegate: AnyObject {
 
     /// Called when the user tapped on a language.
     ///

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WordPressAuthenticator
 
-@objc protocol InlineEditableNameValueCellDelegate: class {
+@objc protocol InlineEditableNameValueCellDelegate: AnyObject {
     @objc optional func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell,
                                                     valueTextFieldDidChange value: String)
     @objc optional func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell,

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collabsable Header Filter Bar/CollapsableHeaderFilterBar.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collabsable Header Filter Bar/CollapsableHeaderFilterBar.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol CollapsableHeaderFilterBarDelegate: class {
+protocol CollapsableHeaderFilterBarDelegate: AnyObject {
     func numberOfFilters() -> Int
     func filter(forIndex: Int) -> CategorySection
     func didSelectFilter(withIndex selectedIndex: IndexPath, withSelectedIndexes selectedIndexes: [IndexPath])

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Gutenberg
 
-protocol CategorySectionTableViewCellDelegate: class {
+protocol CategorySectionTableViewCellDelegate: AnyObject {
     func didSelectItemAt(_ position: Int, forCell cell: CategorySectionTableViewCell, slug: String)
     func didDeselectItem(forCell cell: CategorySectionTableViewCell)
     func accessibilityElementDidBecomeFocused(forCell cell: CategorySectionTableViewCell)

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -1,6 +1,6 @@
 import WordPressAuthenticator
 
-protocol JetpackRemoteInstallDelegate: class {
+protocol JetpackRemoteInstallDelegate: AnyObject {
     func jetpackRemoteInstallCompleted()
     func jetpackRemoteInstallCanceled()
     func jetpackRemoteInstallWebviewFallback()

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackBackupStatusViewController.swift
@@ -3,7 +3,7 @@ import CocoaLumberjack
 import WordPressShared
 import WordPressUI
 
-protocol JetpackBackupStatusViewControllerDelegate: class {
+protocol JetpackBackupStatusViewControllerDelegate: AnyObject {
     func didFinishViewing()
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/JetpackRestoreStatusViewController.swift
@@ -3,7 +3,7 @@ import CocoaLumberjack
 import WordPressShared
 import WordPressUI
 
-protocol JetpackRestoreStatusViewControllerDelegate: class {
+protocol JetpackRestoreStatusViewControllerDelegate: AnyObject {
     func didFinishViewing(_ controller: JetpackRestoreStatusViewController)
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WordPressFlux
 
-protocol JetpackScanThreatDetailsViewControllerDelegate: class {
+protocol JetpackScanThreatDetailsViewControllerDelegate: AnyObject {
     func willFixThreat(_ threat: JetpackScanThreat, controller: JetpackScanThreatDetailsViewController)
     func willIgnoreThreat(_ threat: JetpackScanThreat, controller: JetpackScanThreatDetailsViewController)
 }

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -7,7 +7,7 @@ import WordPressKit
 /// This is intended to be used as replacement for table view delegate and data source.
 
 
-@objc protocol LikesListControllerDelegate: class {
+@objc protocol LikesListControllerDelegate: AnyObject {
     /// Reports to the delegate that the header cell has been tapped.
     @objc optional func didSelectHeader()
 

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorDataLoader.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorDataLoader.swift
@@ -1,5 +1,5 @@
 /// Implementations of this protocol will be notified when data is loaded from the TenorService
-protocol TenorDataLoaderDelegate: class {
+protocol TenorDataLoaderDelegate: AnyObject {
     func didLoad(media: [TenorMedia], reset: Bool)
 }
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import WordPressFlux
 import Gridicons
 
-protocol PluginListPresenter: class {
+protocol PluginListPresenter: AnyObject {
     func present(site: JetpackSiteRef, query: PluginQuery)
 }
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
@@ -1,7 +1,7 @@
 import WordPressKit
 import WordPressFlux
 
-protocol PluginPresenter: class {
+protocol PluginPresenter: AnyObject {
     func present(plugin: Plugin, capabilities: SitePluginCapabilities)
     func present(directoryEntry: PluginDirectoryEntry)
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -1,6 +1,6 @@
 import Gridicons
 
-protocol PostEditorNavigationBarManagerDelegate: class {
+protocol PostEditorNavigationBarManagerDelegate: AnyObject {
     var publishButtonText: String { get }
     var isPublishButtonEnabled: Bool { get }
     var uploadingButtonSize: CGSize { get }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Gridicons
 
-protocol PrepublishingHeaderViewDelegate: class {
+protocol PrepublishingHeaderViewDelegate: AnyObject {
     func closeButtonTapped()
 }
 

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Diffs/RevisionDiffsPageManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Diffs/RevisionDiffsPageManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 
-protocol RevisionDiffsPageManagerDelegate: class {
+protocol RevisionDiffsPageManagerDelegate: AnyObject {
     func currentIndex() -> Int
     func pageWillScroll(to direction: UIPageViewController.NavigationDirection)
     func pageDidFinishAnimating(completed: Bool)

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingCalendarViewController.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Gridicons
 
-protocol DateCoordinatorHandler: class {
+protocol DateCoordinatorHandler: AnyObject {
     var coordinator: DateCoordinator? { get set }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol ReaderDetailFeaturedImageViewDelegate: class {
+protocol ReaderDetailFeaturedImageViewDelegate: AnyObject {
     func didTapFeaturedImage(_ sender: CachedAnimatedImageView)
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -1,4 +1,4 @@
-protocol ReaderSavedPostCellActionsDelegate: class {
+protocol ReaderSavedPostCellActionsDelegate: AnyObject {
     func willRemove(_ cell: ReaderPostCardCell)
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -3,7 +3,7 @@ import Charts
 
 // MARK: - StatsBarChartViewDelegate
 
-protocol StatsBarChartViewDelegate: class {
+protocol StatsBarChartViewDelegate: AnyObject {
     func statsBarChartValueSelected(_ statsBarChartView: StatsBarChartView, entryIndex: Int, entryCount: Int)
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol PostingActivityDayDelegate: class {
+protocol PostingActivityDayDelegate: AnyObject {
     func daySelected(_ day: PostingActivityDay)
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol SiteStatsTableHeaderDelegate: class {
+protocol SiteStatsTableHeaderDelegate: AnyObject {
     func dateChangedTo(_ newDate: Date?)
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol ViewMoreRowDelegate: class {
+protocol ViewMoreRowDelegate: AnyObject {
     func viewMoreSelectedForStatSection(_ statSection: StatSection)
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsForegroundObservable.swift
+++ b/WordPress/Classes/ViewRelated/Stats/StatsForegroundObservable.swift
@@ -1,4 +1,4 @@
-protocol StatsForegroundObservable: class {
+protocol StatsForegroundObservable: AnyObject {
     func addWillEnterForegroundObserver()
     func removeWillEnterForegroundObserver()
     func reloadStatsData()

--- a/WordPress/Classes/ViewRelated/Wizards/WizardDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Wizards/WizardDelegate.swift
@@ -1,3 +1,3 @@
-protocol WizardDelegate: class {
+protocol WizardDelegate: AnyObject {
     func nextStep()
 }


### PR DESCRIPTION
This is a follow-up to @mokagio 's [recent PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/16788) but this time resolving the warnings for the Jetpack App.

This PR resolves several warnings due to `class` protocol inheritance being deprecated.  The replacement with `AnyObject` is as recommended by the warnings.

Automerge is enabled.

## To test:

Just make sure the changes in the code are OK.  Our tools should make sure the Jetpack App still builds fine.

## Regression Notes

1. Potential unintended areas of impact

There's no change in the logic, so none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
