### PR TITLE
Fix blogging reminders for the Jetpack App

### DIFF
--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -112,11 +112,11 @@ class BloggingRemindersScheduler {
     private static var defaultDataFileName = "BloggingReminders.plist"
 
     private static func defaultDataFileURL() throws -> URL {
-        guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName) else {
-            throw Error.cantRetrieveContainerForAppGroup(appGroupName: WPAppGroupName)
-        }
-
-        return url.appendingPathComponent(defaultDataFileName)
+        try FileManager.default.url(for: .documentDirectory,
+                                    in: .userDomainMask,
+                                    appropriateFor: nil,
+                                    create: true)
+            .appendingPathComponent(defaultDataFileName)
     }
 
     // MARK: - Initializers

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -112,7 +112,7 @@ class BloggingRemindersScheduler {
     private static var defaultDataFileName = "BloggingReminders.plist"
 
     private static func defaultDataFileURL() throws -> URL {
-        try FileManager.default.url(for: .documentDirectory,
+        try FileManager.default.url(for: .applicationSupportDirectory,
                                     in: .userDomainMask,
                                     appropriateFor: nil,
                                     create: true)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -23709,7 +23709,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.jetpack;
 				PRODUCT_MODULE_NAME = WordPress;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "WPiOS Development Profile";
+				PROVISIONING_PROFILE_SPECIFIER = "Jetpack iOS Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Fixes #NA

To test:
test on iPhone and iPad 
- Build/run the Jetpack target on a real device
- Select any site then go to "Site Settings"
- Tap on "Blogging Reminders" and make sure you can go through the flow and set some dates in the date picker
- Build/run the WordPress target on a real device, and repeat the steps above to make sure it still works as expected in the WordPress app

cc @mokagio this PR targets `17.7`

## Regression Notes
1. Potential unintended areas of impact
There should be none: this only changes the location of a file, using a standard directory

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Test the feature on real devices

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
