### PR TITLE
Issues/fixes likes glitch

### DIFF
--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -95,12 +95,12 @@ private extension CommentService {
 
         derivedContext.perform {
 
-            if purgeExisting {
-                self.deleteExistingUsersFor(commentID: commentID, siteID: siteID, from: derivedContext)
+            let likers = remoteLikeUsers.map { remoteUser in
+                LikeUserHelper.createOrUpdateFrom(remoteUser: remoteUser, context: derivedContext)
             }
 
-            remoteLikeUsers.forEach {
-                LikeUserHelper.createUserFrom(remoteUser: $0, context: derivedContext)
+            if purgeExisting {
+                self.deleteExistingUsersFor(commentID: commentID, siteID: siteID, from: derivedContext, likesToKeep: likers)
             }
 
             ContextManager.shared.save(derivedContext) {
@@ -111,9 +111,9 @@ private extension CommentService {
         }
     }
 
-    func deleteExistingUsersFor(commentID: NSNumber, siteID: NSNumber, from context: NSManagedObjectContext) {
+    func deleteExistingUsersFor(commentID: NSNumber, siteID: NSNumber, from context: NSManagedObjectContext, likesToKeep: [LikeUser]) {
         let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
-        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@", siteID, commentID)
+        request.predicate = NSPredicate(format: "likedSiteID = %@ AND likedCommentID = %@ AND NOT (self IN %@)", siteID, commentID, likesToKeep)
 
         do {
             let users = try context.fetch(request)

--- a/WordPress/Classes/Services/LikeUserHelpers.swift
+++ b/WordPress/Classes/Services/LikeUserHelpers.swift
@@ -32,7 +32,7 @@ import Foundation
 
         let request = LikeUser.fetchRequest() as NSFetchRequest<LikeUser>
         request.predicate = NSPredicate(format: "userID = %@ AND likedSiteID = %@ AND likedPostID = %@ AND likedCommentID = %@",
-                                        argumentArray: [userID, siteID, postID, commentID])
+                                        userID, siteID, postID, commentID)
         return try? context.fetch(request).first
     }
 

--- a/WordPress/Classes/Services/LikeUserHelpers.swift
+++ b/WordPress/Classes/Services/LikeUserHelpers.swift
@@ -6,22 +6,22 @@ import Foundation
 @objc class LikeUserHelper: NSObject {
 
     @objc class func createOrUpdateFrom(remoteUser: RemoteLikeUser, context: NSManagedObjectContext) -> LikeUser {
-        let likeUser = likeUser(for: remoteUser, context: context) ?? LikeUser(context: context)
+        let liker = likeUser(for: remoteUser, context: context) ?? LikeUser(context: context)
 
-        likeUser.userID = remoteUser.userID.int64Value
-        likeUser.username = remoteUser.username
-        likeUser.displayName = remoteUser.displayName
-        likeUser.primaryBlogID = remoteUser.primaryBlogID?.int64Value ?? 0
-        likeUser.avatarUrl = remoteUser.avatarURL
-        likeUser.bio = remoteUser.bio ?? ""
-        likeUser.dateLikedString = remoteUser.dateLiked ?? ""
-        likeUser.dateLiked = DateUtils.date(fromISOString: likeUser.dateLikedString)
-        likeUser.likedSiteID = remoteUser.likedSiteID?.int64Value ?? 0
-        likeUser.likedPostID = remoteUser.likedPostID?.int64Value ?? 0
-        likeUser.likedCommentID = remoteUser.likedCommentID?.int64Value ?? 0
-        likeUser.preferredBlog = createPreferredBlogFrom(remotePreferredBlog: remoteUser.preferredBlog, forUser: likeUser, context: context)
-        likeUser.dateFetched = Date()
-        return likeUser
+        liker.userID = remoteUser.userID.int64Value
+        liker.username = remoteUser.username
+        liker.displayName = remoteUser.displayName
+        liker.primaryBlogID = remoteUser.primaryBlogID?.int64Value ?? 0
+        liker.avatarUrl = remoteUser.avatarURL
+        liker.bio = remoteUser.bio ?? ""
+        liker.dateLikedString = remoteUser.dateLiked ?? ""
+        liker.dateLiked = DateUtils.date(fromISOString: liker.dateLikedString)
+        liker.likedSiteID = remoteUser.likedSiteID?.int64Value ?? 0
+        liker.likedPostID = remoteUser.likedPostID?.int64Value ?? 0
+        liker.likedCommentID = remoteUser.likedCommentID?.int64Value ?? 0
+        liker.preferredBlog = createPreferredBlogFrom(remotePreferredBlog: remoteUser.preferredBlog, forUser: liker, context: context)
+        liker.dateFetched = Date()
+        return liker
     }
 
     class func likeUser(for remoteUser: RemoteLikeUser, context: NSManagedObjectContext) -> LikeUser? {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -147,8 +147,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        fetchLikes()
-
         configureFeaturedImage()
 
         featuredImage.configure(scrollView: scrollView,
@@ -217,6 +215,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         featuredImage.configure(for: post, with: self)
         toolbar.configure(for: post, in: self)
         header.configure(for: post)
+        fetchLikes()
 
         if let postURLString = post.permaLink,
            let postURL = URL(string: postURLString) {


### PR DESCRIPTION
Refs: p1625015997228100-wpmobile-slack

This patch addresses a reported issue with the likes list and likes train.   To reproduce the issue: 

1. Tap on a like notification for a post
2. Tap the header to view the post
3. Note that the the train of likers is missing from the post.
4. Tap to view the post's comments, then tap the back button.
5. Note that the train of likers is now visible.
6. Tap Back again to return to the list of likers.
7. Note that the rows now only show an "@" character.

### The missing likers train
At first I thought this was going to be an issue with layout not refreshing as it should, but the actual issue was `fetchLikes` was called before the detail had a post.  Moving the call to the `render` method ensures that a post has been assigned to the reader detail and resolves the issue. 

### The @ symbol
This was happening because the original set of likes was being deleted by the purge logic when the second likes list was opened.  We've been deleting all likes on a first load so data was always fresh.  This approach has worked well up til we discovered the particular set of steps leading the the reported glitch. 

There were a couple of ways to address this. For example, the likes list could have checked for another likers list in the navigation stack and only fetched local posts. I didn't like this option as it's better for controllers to not worry about what else is in the nav stack.  The list could have skipped refreshing if there were already recently fetched likes, but this risks stale data so I rejected this approach as well.  I settled on a slight refactor of the service to update, rather than delete any existing likers on the first fetch. I like this approach as it keeps data concerns contained within the service layer, letting the view layer query for what it needs without a care. 

To test:
Attempt to reproduce the error. 
Confirm the likers train appears when expected.
Confirm that the original likes list looks as expected after navigating back from a secondary likes list.
Smoke test the likes list in the reader and other notifications. Confirm you find no regressions.

## Regression Notes
1. Potential unintended areas of impact
Other parts of the Likes feature

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Smoke tested.

3. What automated tests I added (or what prevented me from doing so)
N/a
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
