### PR TITLE
Stats > Published: fix unicode characters displaying in titles

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -577,7 +577,7 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func publishedDataRows() -> [StatsTotalRowData] {
-        return store.getTopPublished()?.publishedPosts.prefix(10).map { StatsTotalRowData.init(name: $0.title,
+        return store.getTopPublished()?.publishedPosts.prefix(10).map { StatsTotalRowData.init(name: $0.title.stringByDecodingXMLCharacters(),
                                                                                                data: "",
                                                                                                showDisclosure: true,
                                                                                                disclosureURL: $0.postURL,

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -777,7 +777,7 @@ private extension SiteStatsDetailsViewModel {
     }
 
     func publishedRowData() -> [StatsTotalRowData] {
-        return periodStore.getTopPublished()?.publishedPosts.map { StatsTotalRowData(name: $0.title,
+        return periodStore.getTopPublished()?.publishedPosts.map { StatsTotalRowData(name: $0.title.stringByDecodingXMLCharacters(),
                                                                                      data: "",
                                                                                      showDisclosure: true,
                                                                                      disclosureURL: $0.postURL,


### PR DESCRIPTION
Fixes #n/a

This fixes an issue where some `Published` titles had unicode characters in them. The ones I've seen recently are `&8217;` and `&8211;`

To test:
- Go to Stats > any period > scroll down to `Published`.
- Tap `View more` to see the full list.
- Verify titles appear correctly.

FWIW, the ones I noticed were in the The Apps Division p2 > Stats > Weeks > Published > View more. The last two in the list have `&8211;` instead of dashes.


| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/124193802-b14bb880-da84-11eb-9ad5-36ff8f8a6d95.jpeg) | <img width="942" alt="after" src="https://user-images.githubusercontent.com/1816888/124193723-9711da80-da84-11eb-8a7b-9904c3551ac3.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
