### PR TITLE
Temporarily skip EditorGutenbergTests because of missing Blogging Reminders support

### DIFF
--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -22,7 +22,8 @@ class EditorGutenbergTests: XCTestCase {
         super.tearDown()
     }
 
-    func testTextPostPublish() {
+    func testTextPostPublish() throws {
+        try XCTSkipIf(true, "need to update all editor tests for Blogging Reminders")
         let title = getRandomPhrase()
         let content = getRandomContent()
         editorScreen
@@ -35,7 +36,8 @@ class EditorGutenbergTests: XCTestCase {
             .done()
     }
 
-    func testBasicPostPublish() {
+    func testBasicPostPublish() throws {
+        try XCTSkipIf(true, "need to update all editor tests for Blogging Reminders")
         let title = getRandomPhrase()
         let content = getRandomContent()
         let category = getCategory()

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -23,7 +23,8 @@ class EditorGutenbergTests: XCTestCase {
     }
 
     func testTextPostPublish() throws {
-        try XCTSkipIf(true, "need to update all editor tests for Blogging Reminders")
+        try skipTillBloggingRemindersAreHandled()
+
         let title = getRandomPhrase()
         let content = getRandomContent()
         editorScreen
@@ -37,7 +38,8 @@ class EditorGutenbergTests: XCTestCase {
     }
 
     func testBasicPostPublish() throws {
-        try XCTSkipIf(true, "need to update all editor tests for Blogging Reminders")
+        try skipTillBloggingRemindersAreHandled()
+
         let title = getRandomPhrase()
         let content = getRandomContent()
         let category = getCategory()
@@ -61,5 +63,9 @@ class EditorGutenbergTests: XCTestCase {
             .viewPublishedPost(withTitle: title)
             .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .done()
+    }
+
+    func skipTillBloggingRemindersAreHandled(file: StaticString = #file, line: UInt = #line) throws {
+        try XCTSkipIf(true, "Skipping test because we haven't added support for Blogging Reminders. See https://github.com/wordpress-mobile/WordPress-iOS/issues/16797.", file: file, line: line)
     }
 }


### PR DESCRIPTION
_@startuptester and I async-paired on this, which is always fun 👩‍💻🌎☁️🌏👨‍💻_

Since the introduction of the new blogging reminders feature, our UI tests started failing (e.g. [this](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-iOS/22603/workflows/712983ac-3548-4e69-b4cb-785175261983/jobs/52000?invite=true#step-106-479) and [this](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-iOS/22603/workflows/712983ac-3548-4e69-b4cb-785175261983/jobs/52000?invite=true#step-106-479)) because there is no backed-in way to dismiss the blogging reminder notice after publishing a post.

<img width="300" alt="Screen Shot 2021-07-02 at 5 33 50 pm" src="https://user-images.githubusercontent.com/1218433/124238667-35bd3a80-db5c-11eb-928b-b0ba70270615.png">

This PR skips the affected tests for the time being, while we work on supporting Blogging Reminders in the UI tests.

## To test

I unblocked the UI tests in CI, so if that passes we're good.

You can verify the tests are skipped and the suite behaves as expected by the testing "WordPressUITests" scheme locally.

## Regression Notes
1. Potential unintended areas of impact
With this approach, we're making the compromise of losing test coverage in the interest of regaining trust in the results our UI tests give us.

This action **has to** be promptly followed by work to add support for Blogging Reminders in the UI tests.

I opened https://github.com/wordpress-mobile/WordPress-iOS/issues/16797 to serve as a hub node to discuss the work and collect all the related PRs.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**