### PR TITLE
Adds a frequency label to the day picker for blogging reminders.

### DIFF
--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -1,11 +1,9 @@
 import Foundation
 
 struct BloggingRemindersScheduleFormatter {
-    let schedule: BloggingRemindersScheduler.Schedule
     let calendar: Calendar
 
-    init(schedule: BloggingRemindersScheduler.Schedule, calendar: Calendar? = nil) {
-        self.schedule = schedule
+    init(calendar: Calendar? = nil) {
         self.calendar = calendar ?? {
             var calendar = Calendar.current
             calendar.locale = Locale.autoupdatingCurrent
@@ -15,11 +13,15 @@ struct BloggingRemindersScheduleFormatter {
 
     /// Attributed description string of the current schedule for the specified blog.
     ///
-    var shortIntervalDescription: NSAttributedString {
+    func shortIntervalDescription(for schedule: BloggingRemindersScheduler.Schedule) -> NSAttributedString {
         switch schedule {
         case .none:
             return Self.stringToAttributedString(TextContent.shortNoRemindersDescription)
         case .weekdays(let days):
+            guard days.count > 0 else {
+                return shortIntervalDescription(for: .none)
+            }
+
             return Self.shortIntervalDescription(for: days.count)
         }
     }
@@ -42,11 +44,15 @@ struct BloggingRemindersScheduleFormatter {
         return Self.stringToAttributedString(text)
     }
 
-    var longScheduleDescription: NSAttributedString {
+    func longScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule) -> NSAttributedString {
         switch schedule {
         case .none:
             return NSAttributedString(string: TextContent.longNoRemindersDescription)
         case .weekdays(let days):
+            guard days.count > 0 else {
+                return longScheduleDescription(for: .none)
+            }
+
             // We want the days sorted by their localized index because under some locale configurations
             // Sunday is the first day of the week, whereas in some other localizations Monday comes first.
             let sortedDays = days.sorted { (first, second) -> Bool in

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -184,7 +184,7 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
         }
 
         let schedule = scheduler.schedule(for: blog)
-        let formatter = BloggingRemindersScheduleFormatter(schedule: schedule)
+        let formatter = BloggingRemindersScheduleFormatter()
 
         let style = NSMutableParagraphStyle()
         style.lineSpacing = Metrics.promptTextLineSpacing
@@ -202,10 +202,10 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
             .foregroundColor: UIColor.text,
         ]
 
-        if let promptText = formatter.longScheduleDescription.mutableCopy() as? NSMutableAttributedString {
-            promptText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: promptText.length))
-            promptLabel.attributedText = promptText
-        }
+        let promptText = NSMutableAttributedString(attributedString: formatter.longScheduleDescription(for: schedule))
+
+        promptText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: promptText.length))
+        promptLabel.attributedText = promptText
     }
 
     private func configureTitleLabel() {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -78,6 +78,17 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         return stackView
     }()
 
+    private lazy var frequencyLabel: UILabel = {
+        let label = UILabel()
+
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.numberOfLines = 2
+        label.textAlignment = .center
+
+        return label
+    }()
+
     lazy var bottomTipPanel: UIView = {
         let view = UIView()
         view.backgroundColor = .quaternaryBackground
@@ -136,6 +147,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
     private let calendar: Calendar
     private let scheduler: BloggingRemindersScheduler
+    private let scheduleFormatter = BloggingRemindersScheduleFormatter()
     private var weekdays: [BloggingRemindersScheduler.Weekday] {
         didSet {
             refreshNextButton()
@@ -198,6 +210,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         configureConstraints()
         populateCalendarDays()
         refreshNextButton()
+        refreshFrequencyLabel()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -251,6 +264,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
             titleLabel,
             promptLabel,
             daysOuterStackView,
+            frequencyLabel,
             fillerView,
             bottomTipPanel,
             bottomPadding,
@@ -313,6 +327,8 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
                     weekday == button.weekday
                 }
             }
+
+            self.refreshFrequencyLabel()
         }
 
         button.titleLabel?.adjustsFontForContentSizeCategory = true
@@ -342,6 +358,26 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
             button.setTitle(TextContent.updateButtonTitle, for: .normal)
             button.isEnabled = true
         }
+    }
+
+    private func refreshFrequencyLabel() {
+        guard weekdays.count > 0 else {
+            frequencyLabel.isHidden = true
+            return
+        }
+
+        frequencyLabel.isHidden = false
+
+        let defaultAttributes: [NSAttributedString.Key: AnyObject] = [
+            .foregroundColor: UIColor.text,
+        ]
+
+        let frequencyDescription = scheduleFormatter.shortIntervalDescription(for: .weekdays(weekdays))
+        let attributedText = NSMutableAttributedString(attributedString: frequencyDescription)
+        attributedText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: attributedText.length))
+
+        frequencyLabel.attributedText = attributedText
+        frequencyLabel.sizeToFit()
     }
 
     // MARK: - Actions

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -327,8 +327,8 @@ extension SiteSettingsViewController {
         cell.accessoryType = .none
 
         if let scheduler = try? BloggingRemindersScheduler() {
-            let formatter = BloggingRemindersScheduleFormatter(schedule: scheduler.schedule(for: blog))
-            cell.textValue = formatter.shortIntervalDescription.string
+            let formatter = BloggingRemindersScheduleFormatter()
+            cell.textValue = formatter.shortIntervalDescription(for: scheduler.schedule(for: blog)).string
         }
     }
 


### PR DESCRIPTION
Adds a frequency label to the day picker for blogging reminders.

I changed the schedule formatter a bit to make a single instance be able to format more than one schedule.

## To test:

Test in light and dark modes.  iPad and iPhone.  Regular and accessibility font sizes.

1. Check that the cell value in Site Settings is correct.
2. Check that the day picker properly shows the selected frequency and updates it in real time.
3. Make sure the completion screen shows the appropriate long description for the chosen schedule.

## Regression Notes

1. Potential unintended areas of impact

Make sure the steps above are all checked.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
