### PR TITLE
The blogging reminders configuration is refreshed in Site Settings.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
@@ -2,11 +2,13 @@ import Foundation
 
 class BloggingRemindersFlow {
 
+    typealias DismissClosure = () -> Void
+
     static func present(from viewController: UIViewController,
                         for blog: Blog,
                         source: BloggingRemindersTracker.FlowStartSource,
                         alwaysShow: Bool = true,
-                        onDismiss: BloggingRemindersNavigationController.DismissClosure? = nil) {
+                        onDismiss: DismissClosure? = nil) {
 
         guard alwaysShow || !hasShownWeeklyRemindersFlow(for: blog) else {
             return

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
@@ -5,7 +5,8 @@ class BloggingRemindersFlow {
     static func present(from viewController: UIViewController,
                         for blog: Blog,
                         source: BloggingRemindersTracker.FlowStartSource,
-                        alwaysShow: Bool = true) {
+                        alwaysShow: Bool = true,
+                        onDismiss: BloggingRemindersNavigationController.DismissClosure? = nil) {
 
         guard alwaysShow || !hasShownWeeklyRemindersFlow(for: blog) else {
             return
@@ -17,7 +18,9 @@ class BloggingRemindersFlow {
         tracker.flowStarted(source: source)
 
         let flowIntroViewController = BloggingRemindersFlowIntroViewController(for: blog, tracker: tracker, source: source)
-        let navigationController = BloggingRemindersNavigationController(rootViewController: flowIntroViewController)
+        let navigationController = BloggingRemindersNavigationController(
+            rootViewController: flowIntroViewController,
+            onDismiss: onDismiss)
 
         let bottomSheet = BottomSheetViewController(childViewController: navigationController,
                                                     customHeaderSpacing: 0)

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
@@ -6,13 +6,28 @@ protocol ChildDrawerPositionable {
 
 class BloggingRemindersNavigationController: LightNavigationController {
 
-    override init(rootViewController: UIViewController) {
+    typealias DismissClosure = () -> ()
+
+    private let onDismiss: DismissClosure?
+
+    required init(rootViewController: UIViewController, onDismiss: DismissClosure? = nil) {
+        self.onDismiss = onDismiss
+
         super.init(rootViewController: rootViewController)
+
         delegate = self
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        if isBeingDismissedDirectlyOrByAncestor() {
+            onDismiss?()
+        }
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersNavigationController.swift
@@ -6,7 +6,7 @@ protocol ChildDrawerPositionable {
 
 class BloggingRemindersNavigationController: LightNavigationController {
 
-    typealias DismissClosure = () -> ()
+    typealias DismissClosure = () -> Void
 
     private let onDismiss: DismissClosure?
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -325,11 +325,18 @@ extension SiteSettingsViewController {
         cell.editable = true
         cell.textLabel?.text = NSLocalizedString("Blogging Reminders", comment: "Label for the blogging reminders setting")
         cell.accessoryType = .none
+        cell.textValue = schedule(for: blog)
+    }
 
-        if let scheduler = try? BloggingRemindersScheduler() {
-            let formatter = BloggingRemindersScheduleFormatter(schedule: scheduler.schedule(for: blog))
-            cell.textValue = formatter.shortIntervalDescription.string
+    // MARK: - Schedule Description
+
+    private func schedule(for blog: Blog) -> String {
+        guard let scheduler = try? BloggingRemindersScheduler() else {
+            return ""
         }
+
+        let formatter = BloggingRemindersScheduleFormatter(schedule: scheduler.schedule(for: blog))
+        return formatter.shortIntervalDescription.string
     }
 
     // MARK: - Handling General Setting Cell Taps
@@ -394,7 +401,14 @@ extension SiteSettingsViewController {
     }
 
     private func presentBloggingRemindersFlow(indexPath: IndexPath) {
-        BloggingRemindersFlow.present(from: self, for: blog, source: .blogSettings)
+        BloggingRemindersFlow.present(from: self, for: blog, source: .blogSettings) { [weak self] in
+            guard let self = self,
+                  let cell = self.tableView.cellForRow(at: indexPath) as? SettingTableViewCell else {
+                return
+            }
+
+            cell.textValue = self.schedule(for: self.blog)
+        }
 
         tableView.deselectRow(at: indexPath, animated: true)
     }


### PR DESCRIPTION
Same as https://github.com/wordpress-mobile/WordPress-iOS/pull/16781 but for 17.7.

## To test:

Follow the testing steps in the referenced PR.

## Regression Notes

1. Potential unintended areas of impact
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
