### PR TITLE
Jetpack: fix tapping on notifications

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -195,7 +195,7 @@ abstract_target 'Apps' do
 
     # Production
 
-    pod 'Automattic-Tracks-iOS', '~> 0.9.0'
+    pod 'Automattic-Tracks-iOS', '~> 0.9.1'
     # While in PR
     # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => ''
     # Local Development

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - AppCenter/Core
   - AppCenter/Distribute (4.1.1):
     - AppCenter/Core
-  - Automattic-Tracks-iOS (0.9.0):
+  - Automattic-Tracks-iOS (0.9.1):
     - CocoaLumberjack (~> 3)
     - Reachability (~> 3)
     - Sentry (~> 6)
@@ -489,7 +489,7 @@ DEPENDENCIES:
   - AMScrollingNavbar (= 5.6.0)
   - AppCenter (= 4.1.1)
   - AppCenter/Distribute (= 4.1.1)
-  - Automattic-Tracks-iOS (~> 0.9.0)
+  - Automattic-Tracks-iOS (~> 0.9.1)
   - BVLinearGradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.57.0-alpha1/third-party-podspecs/BVLinearGradient.podspec.json`)
   - Charts (~> 3.2.2)
   - CocoaLumberjack (~> 3.0)
@@ -735,7 +735,7 @@ SPEC CHECKSUMS:
   AMScrollingNavbar: cf0ec5a5ee659d76ba2509f630bf14fba7e16dc3
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
   AppCenter: cd53e3ed3563cc720bcb806c9731a12389b40d44
-  Automattic-Tracks-iOS: f6ece12d2e630b55b701bac8bcf4301fcce9a327
+  Automattic-Tracks-iOS: f5a6188ad8d00680748111466beabb0aea11f856
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: eee4f8a06f66d85cc3f3288760ac28407ac7f46b
   Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
@@ -826,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 8b2c79935a27e464f11211a1f22df322659267d1
+PODFILE CHECKSUM: fce9ab6c18069b970f72937a5ed53260ce219000
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -489,7 +489,7 @@ DEPENDENCIES:
   - AMScrollingNavbar (= 5.6.0)
   - AppCenter (= 4.1.1)
   - AppCenter/Distribute (= 4.1.1)
-  - Automattic-Tracks-iOS (~> 0.9.0)
+  - Automattic-Tracks-iOS (~> 0.9.1)
   - BVLinearGradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.57.0-alpha2/third-party-podspecs/BVLinearGradient.podspec.json`)
   - Charts (~> 3.2.2)
   - CocoaLumberjack (~> 3.0)
@@ -826,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 9f11d7f048a052247d41c4d90624a12b2c6c48cc
+PODFILE CHECKSUM: 6c88ae6293deee1e82da5f64bace33961985ba32
 
 COCOAPODS: 1.10.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 17.8
 -----
 * [*] Authors and Contributors can now view a site's Comments via My Site > Comments. [#16783]
+* [*] [Jetpack-only] Fix bugs when tapping to notifications
 
 17.7
 -----

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -24,8 +24,8 @@ import WordPressAuthenticator
 // MARK: - Tab bar order
 @objc enum WPTab: Int {
     case mySites
-    case notifications
     case reader
+    case notifications
 }
 
 // MARK: - Localized Strings

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -21,6 +21,13 @@ import WordPressAuthenticator
     #endif
 }
 
+// MARK: - Tab bar order
+@objc enum WPTab: Int {
+    case mySites
+    case notifications
+    case reader
+}
+
 // MARK: - Localized Strings
 extension AppConstants {
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -16,7 +16,7 @@ extension WPTabBarController {
             let newSpotlight = QuickStartSpotlightView()
             self?.view.addSubview(newSpotlight)
 
-            guard let tabButton = self?.getTabButton(at: Int(WPTabType.reader.rawValue)) else {
+            guard let tabButton = self?.getTabButton(at: Int(WPTab.reader.rawValue)) else {
                 return
             }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -2,7 +2,7 @@
 // MARK: - Tab Access Tracking
 
 extension WPTabBarController {
-    private static let tabIndexToStatMap: [WPTabType: WPAnalyticsStat] = [.mySites: .mySitesTabAccessed, .reader: .readerAccessed]
+    private static let tabIndexToStatMap: [WPTab: WPAnalyticsStat] = [.mySites: .mySitesTabAccessed, .reader: .readerAccessed]
 
     private struct AssociatedKeys {
         static var shouldTrackTabAccessOnViewDidAppear = 0
@@ -79,7 +79,7 @@ extension WPTabBarController {
             return false
         }
 
-        guard let tabType = WPTabType(rawValue: UInt(tabIndex)),
+        guard let tabType = WPTab(rawValue: Int(tabIndex)),
             let stat = WPTabBarController.tabIndexToStatMap[tabType] else {
                 return false
         }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -6,12 +6,6 @@ extern NSString * const WPTabBarCurrentlySelectedScreenSites;
 extern NSString * const WPTabBarCurrentlySelectedScreenReader;
 extern NSString * const WPTabBarCurrentlySelectedScreenNotifications;
 
-typedef NS_ENUM(NSUInteger, WPTabType) {
-    WPTabMySites,
-    WPTabReader,
-    WPTabNotifications
-};
-
 @class AbstractPost;
 @class Blog;
 @class BlogListViewController;

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -20,6 +20,14 @@ import Foundation
     #endif
 }
 
+// MARK: - Tab bar order
+@objc enum WPTab: Int {
+    case mySites
+    case notifications
+    // Reader on Jetpack is not displayed, but we keep it here to avoid adding conditionals on existing code
+    case reader
+}
+
 // MARK: - Localized Strings
 extension AppConstants {
 


### PR DESCRIPTION
The Jetpack app has been presenting some issues regarding notifications:

* It doesn't change to the Notifications tab
* Sometimes notifications appear blank

### To test:

**After a TestFlight is release**

1. Check that when tapping on Notifications they open the Notifications tab with the correctly content

**While we don't have a TestFlight release**

I couldn't find a reliable way to test this using notification due to certificates and etc. The best way to test it is to add this to `WordPressAppDelegate.application(didFinishLaunchingWithOptions:)`:

```swift
        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
            WPTabBarController.sharedInstance().showNotificationsTab()
        }
```

Run both WordPress and Jetpack and make sure that after 5 seconds the app displays the Notifications tab.

## Regression Notes
1. Potential unintended areas of impact
WordPress

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Explained above

3. What automated tests I added (or what prevented me from doing so)
None, this would require UI tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
