### PR TITLE
Notifications: Adds scrolling to the selected comment

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -1,7 +1,7 @@
 
 protocol ContentCoordinator {
     func displayReaderWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws
-    func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws
+    func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?, commentID: NSNumber?) throws
     func displayStatsWithSiteID(_ siteID: NSNumber?, url: URL?) throws
     func displayFollowersWithSiteID(_ siteID: NSNumber?, expirationTime: TimeInterval) throws
     func displayStreamWithSiteID(_ siteID: NSNumber?) throws
@@ -17,7 +17,6 @@ protocol ContentCoordinator {
 /// like Posts, Site streams, Comments, etc...
 ///
 struct DefaultContentCoordinator: ContentCoordinator {
-
     enum DisplayError: Error {
         case missingParameter
         case unsupportedFeature
@@ -41,12 +40,13 @@ struct DefaultContentCoordinator: ContentCoordinator {
         controller?.navigationController?.pushFullscreenViewController(readerViewController, animated: true)
     }
 
-    func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws {
+    func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?, commentID: NSNumber?) throws {
         guard let postID = postID, let siteID = siteID else {
             throw DisplayError.missingParameter
         }
 
         let commentsViewController = ReaderCommentsViewController(postID: postID, siteID: siteID)
+        commentsViewController?.navigateToCommentID = commentID
         commentsViewController?.allowsPushingPostDetails = true
         controller?.navigationController?.pushViewController(commentsViewController!, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
@@ -30,7 +30,8 @@ struct ActivityContentRouter: ContentRouter {
             }
             let postID = commentRange.postID as NSNumber
             let siteID = commentRange.siteID as NSNumber
-            try? coordinator.displayCommentsWithPostId(postID, siteID: siteID)
+            let commentID = commentRange.commentID as NSNumber
+            try? coordinator.displayCommentsWithPostId(postID, siteID: siteID, commentID: commentID)
         case .plugin:
             guard let pluginRange = range as? ActivityPluginRange else {
                 fallthrough

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
@@ -54,7 +54,10 @@ struct NotificationContentRouter {
         case .comment:
             fallthrough
         case .commentLike:
-            try coordinator.displayCommentsWithPostId(notification.metaPostID, siteID: notification.metaSiteID)
+            let commentID = notification.metaCommentID ?? notification.metaReplyID
+            try coordinator.displayCommentsWithPostId(notification.metaPostID,
+                                                      siteID: notification.metaSiteID,
+                                                      commentID: commentID)
         default:
             throw DefaultContentCoordinator.DisplayError.unsupportedType
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
@@ -54,6 +54,7 @@ struct NotificationContentRouter {
         case .comment:
             fallthrough
         case .commentLike:
+            // Focus on the primary comment, and default to the reply ID if its set
             let commentID = notification.metaCommentID ?? notification.metaReplyID
             try coordinator.displayCommentsWithPostId(notification.metaPostID,
                                                       siteID: notification.metaSiteID,

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
@@ -75,7 +75,9 @@ struct NotificationContentRouter {
         case .post:
             try coordinator.displayReaderWithPostId(range.postID, siteID: range.siteID)
         case .comment:
-            try coordinator.displayCommentsWithPostId(range.postID, siteID: range.siteID)
+            // Focus on the comment reply if it's set over the primary comment ID
+            let commentID = notification.metaReplyID ?? notification.metaCommentID
+            try coordinator.displayCommentsWithPostId(range.postID, siteID: range.siteID, commentID: commentID)
         case .stats:
             /// Backup notifications are configured as "stat" notifications
             /// For now this is just a workaround to fix the routing

--- a/WordPress/WordPressTest/MockContentCoordinator.swift
+++ b/WordPress/WordPressTest/MockContentCoordinator.swift
@@ -15,7 +15,7 @@ class MockContentCoordinator: ContentCoordinator {
     var commentsWasDisplayed = false
     var commentPostID: NSNumber?
     var commentSiteID: NSNumber?
-    func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws {
+    func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?, commentID: NSNumber?) throws {
         commentsWasDisplayed = true
         commentPostID = postID
         commentSiteID = siteID


### PR DESCRIPTION
Fixes #5540

This PR adds automatic scrolling to a comment from the notifications view when tapping:
- The comment header
- The 'You replied to this comment' button

## To test:

1. Tap on the Notifications tab
2. Locate a comment notification such as: "_someone_ replied to you a comment ..."
3. Note: testing works best with longer comment threads
3. Tap on it to view the comment details
4. Tap on the comment detail header that is located at the top of the view
5. 👀 The comments should be scrolled so the comment from the notification is visible
6. Go back to the Notifications view
7. Locate another comment notification that includes a comment that you replied to
8. Tap on it to view the comment details
9. Locate the 'You replied to this comment' section at the bottom of the view
10. Tap on it
11. 👀 The comments should be scrolled so the comment you is visible


## Regression Notes
1. Potential unintended areas of impact
None. This change is localized to the notifications content view.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
I updated the existing unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
