### PR TITLE
Extract swift secret files outside of repo

### DIFF
--- a/.configure
+++ b/.configure
@@ -20,22 +20,22 @@
     },
     {
       "file": "iOS/WPiOS/Secrets.swift",
-      "destination": ".configure-files/WordPress-Secrets.swift",
+      "destination": "~/.configure/wordpress-ios/secrets/WordPress-Secrets.swift",
       "encrypt": true
     },
     {
       "file": "iOS/WPiOS/Secrets-Internal.swift",
-      "destination": ".configure-files/WordPress-Secrets-Internal.swift",
+      "destination": "~/.configure/wordpress-ios/secrets/WordPress-Secrets-Internal.swift",
       "encrypt": true
     },
     {
       "file": "iOS/WPiOS/Secrets-Alpha.swift",
-      "destination": ".configure-files/WordPress-Secrets-Alpha.swift",
+      "destination": "~/.configure/wordpress-ios/secrets/WordPress-Secrets-Alpha.swift",
       "encrypt": true
     },
     {
       "file": "iOS/JPiOS/Jetpack-Secrets.swift",
-      "destination": ".configure-files/Jetpack-Secrets.swift",
+      "destination": "~/.configure/wordpress-ios/secrets/Jetpack-Secrets.swift",
       "encrypt": true
     }
   ],

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -3,7 +3,7 @@
 set -e
 
 # The Secrets File Sources
-SECRETS_ROOT="${PROJECT_ROOT}/.configure-files"
+SECRETS_ROOT="${HOME}/.configure/wordpress-ios/secrets"
 
 PRODUCTION_SECRETS_FILE="${SECRETS_ROOT}/WordPress-Secrets.swift"
 INTERNAL_SECRETS_FILE="${SECRETS_ROOT}/WordPress-Secrets-Internal.swift"

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -65,35 +65,35 @@ mkdir -p $(dirname "$SECRETS_DESTINATION_FILE")
 # If the WordPress Production Secrets are available for WordPress, use them
 if [ -f "$PRODUCTION_SECRETS_FILE" ] && [ "$BUILD_SCHEME" == "WordPress" ]; then
     echo "Applying Production Secrets"
-    cp -v $PRODUCTION_SECRETS_FILE "${SECRETS_DESTINATION_FILE}"
+    cp -v "$PRODUCTION_SECRETS_FILE" "${SECRETS_DESTINATION_FILE}"
     exit 0
 fi
 
 # If the WordPress Internal Secrets are available, use them
 if [ -f "$INTERNAL_SECRETS_FILE" ] && [ "${BUILD_SCHEME}" == "WordPress Internal" ]; then
     echo "Applying Internal Secrets"
-    cp -v $INTERNAL_SECRETS_FILE "${SECRETS_DESTINATION_FILE}"
+    cp -v "$INTERNAL_SECRETS_FILE" "${SECRETS_DESTINATION_FILE}"
     exit 0
 fi
 
 # If the WordPress Alpha Secrets are available, use them
 if [ -f "$ALPHA_SECRETS_FILE" ] && [ "${BUILD_SCHEME}" == "WordPress Alpha" ]; then
     echo "Applying Alpha Secrets"
-    cp -v $ALPHA_SECRETS_FILE "${SECRETS_DESTINATION_FILE}"
+    cp -v "$ALPHA_SECRETS_FILE" "${SECRETS_DESTINATION_FILE}"
     exit 0
 fi
 
 # If the Jetpack Secrets are available (and if we're building Jetpack) use them
 if [ -f "$JETPACK_SECRETS_FILE" ] && [ "${BUILD_SCHEME}" == "Jetpack" ]; then
     echo "Applying Jetpack Secrets"
-    cp -v $JETPACK_SECRETS_FILE "${SECRETS_DESTINATION_FILE}"
+    cp -v "$JETPACK_SECRETS_FILE" "${SECRETS_DESTINATION_FILE}"
     exit 0
 fi
 
 # If the developer has a local secrets file, use it
 if [ -f "$LOCAL_SECRETS_FILE" ]; then
     echo "Applying Local Secrets"
-    cp -v $LOCAL_SECRETS_FILE "${SECRETS_DESTINATION_FILE}"
+    cp -v "$LOCAL_SECRETS_FILE" "${SECRETS_DESTINATION_FILE}"
     exit 0
 fi
 
@@ -114,6 +114,6 @@ case $CONFIGURATION in
   *)
     echo "warning: $COULD_NOT_FIND_SECRET_MSG. Falling back to $EXAMPLE_SECRETS_FILE. In a Release build, this would be an error. $INTERNAL_CONTRIBUTOR_MSG and try again. If you are an external contributor, you can ignore this warning."
     echo "Applying Example Secrets"
-    cp -v $EXAMPLE_SECRETS_FILE $SECRETS_DESTINATION_FILE
+    cp -v "$EXAMPLE_SECRETS_FILE" "$SECRETS_DESTINATION_FILE"
     ;;
 esac

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -1,6 +1,4 @@
-#!/bin/sh
-
-set -e
+#!/bin/sh -euo pipefail
 
 # The Secrets File Sources
 SECRETS_ROOT="${HOME}/.configure/wordpress-ios/secrets"

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -79,7 +79,7 @@ if [ -f "$INTERNAL_SECRETS_FILE" ] && [ "${BUILD_SCHEME}" == "WordPress Internal
 fi
 
 # If the WordPress Alpha Secrets are available, use them
-if [ -f "$INTERNAL_SECRETS_FILE" ] && [ "${BUILD_SCHEME}" == "WordPress Alpha" ]; then
+if [ -f "$ALPHA_SECRETS_FILE" ] && [ "${BUILD_SCHEME}" == "WordPress Alpha" ]; then
     echo "Applying Alpha Secrets"
     cp -v $ALPHA_SECRETS_FILE "${SECRETS_DESTINATION_FILE}"
     exit 0

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -52,6 +52,19 @@ if [ -f "$LOCAL_SECRETS_FILE" ]; then
     exit 0
 fi
 
-# Use the example secrets file as a last resort
-echo "Applying Example Secrets"
-cp -v $EXAMPLE_SECRETS_FILE $SECRETS_DESTINATION_FILE
+# None of the above secrets was found. Use the example secrets file as a last
+# resort, unless building for Release.
+case $CONFIGURATION in
+  # There are three release configurations: Release, Release-Alpha, and
+  # Release-Internal. Since they all start with "Release" we can use a pattern
+  # to check for them.
+  Release*)
+    echo "error: Could not find secrets at $SECRETS_ROOT. Cannot continue release build."
+    exit 1
+    ;;
+  *)
+    echo "Applying Example Secrets"
+    echo "warning: Could not find secrets at $SECRETS_ROOT, falling back to $EXAMPLE_SECRETS_FILE. In a release build, this would be an error."
+    cp -v $EXAMPLE_SECRETS_FILE $SECRETS_DESTINATION_FILE
+    ;;
+esac

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -13,7 +13,7 @@ EXAMPLE_SECRETS_FILE="${SRCROOT}/Credentials/Secrets-example.swift"
 
 # The Secrets file destination
 SECRETS_DESTINATION_FILE="${BUILD_DIR}/Secrets/Secrets.swift"
-mkdir -p "basename $SECRETS_DESTINATION_FILE"
+mkdir -p $(dirname $SECRETS_DESTINATION_FILE)
 
 # If the WordPress Production Secrets are available for WordPress, use them
 if [ -f "$PRODUCTION_SECRETS_FILE" ] && [ "$BUILD_SCHEME" == "WordPress" ]; then

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -5,13 +5,60 @@ set -e
 # The Secrets File Sources
 SECRETS_ROOT="${HOME}/.configure/wordpress-ios/secrets"
 
+# To help the Xcode build system optimize the build, we want to ensure each of
+# the secrets we want to copy is defined as an input file for the run script
+# build phase.
+#
+# > The Xcode Build System will use [these files] to determine if your run
+# > scripts should actually run or not. So this should include any file that
+# > your run script phase, the script content, is actually going to read or
+# > look at during its process.
+#
+# > If you have no input files declared, the Xcode build system will need to
+# > run your run script phase on every single build.
+#
+# https://developer.apple.com/videos/play/wwdc2018/408/
+function ensure_is_in_input_files_list() {
+  # Loop through the file input lists looking for $1. If not found, fail the
+  # build.
+  if [ -z "$1" ]; then
+    echo "error: Input file list verification needs a path to verify!"
+    exit 1
+  fi
+
+  i=0
+  found=false
+  while [[ $i -lt $SCRIPT_INPUT_FILE_LIST_COUNT && "$found" = false ]]
+  do
+    # Need this two step process to access the input at index
+    file_list_resolved_var_name=SCRIPT_INPUT_FILE_LIST_${i}
+    # The following reads the processed xcfilelist line by line and
+    while read input_file; do
+      if [ "$1" == "$input_file" ]; then
+        found=true
+        break
+      fi
+    done <"${!file_list_resolved_var_name}"
+    let i=i+1
+  done
+  if [ "$found" = false ]; then
+    echo "error: Could not find $1 as an input to the build phase. Add $1 to the input files list using the .xcfilelist."
+    exit 1
+  fi
+}
+
 PRODUCTION_SECRETS_FILE="${SECRETS_ROOT}/WordPress-Secrets.swift"
+ensure_is_in_input_files_list $PRODUCTION_SECRETS_FILE
 INTERNAL_SECRETS_FILE="${SECRETS_ROOT}/WordPress-Secrets-Internal.swift"
+ensure_is_in_input_files_list $INTERNAL_SECRETS_FILE
 ALPHA_SECRETS_FILE="${SECRETS_ROOT}/WordPress-Secrets-Alpha.swift"
+ensure_is_in_input_files_list $ALPHA_SECRETS_FILE
 JETPACK_SECRETS_FILE="${SECRETS_ROOT}/Jetpack-Secrets.swift"
+ensure_is_in_input_files_list $JETPACK_SECRETS_FILE
 
 LOCAL_SECRETS_FILE="${SRCROOT}/Credentials/Secrets.swift"
 EXAMPLE_SECRETS_FILE="${SRCROOT}/Credentials/Secrets-example.swift"
+ensure_is_in_input_files_list $EXAMPLE_SECRETS_FILE
 
 # The Secrets file destination
 SECRETS_DESTINATION_FILE="${BUILD_DIR}/Secrets/Secrets.swift"

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -15,7 +15,7 @@ EXAMPLE_SECRETS_FILE="${SRCROOT}/Credentials/Secrets-example.swift"
 
 # The Secrets file destination
 SECRETS_DESTINATION_FILE="${BUILD_DIR}/Secrets/Secrets.swift"
-mkdir -p $(dirname $SECRETS_DESTINATION_FILE)
+mkdir -p $(dirname "$SECRETS_DESTINATION_FILE")
 
 # If the WordPress Production Secrets are available for WordPress, use them
 if [ -f "$PRODUCTION_SECRETS_FILE" ] && [ "$BUILD_SCHEME" == "WordPress" ]; then

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -1,10 +1,13 @@
 #!/bin/sh
 
 # The Secrets File Sources
-PRODUCTION_SECRETS_FILE="${PROJECT_ROOT}/.configure-files/WordPress-Secrets.swift"
-INTERNAL_SECRETS_FILE="${PROJECT_ROOT}/.configure-files/WordPress-Secrets-Internal.swift"
-ALPHA_SECRETS_FILE="${PROJECT_ROOT}/.configure-files/WordPress-Secrets-Alpha.swift"
-JETPACK_SECRETS_FILE="${PROJECT_ROOT}/.configure-files/Jetpack-Secrets.swift"
+SECRETS_ROOT="${PROJECT_ROOT}/.configure-files"
+
+PRODUCTION_SECRETS_FILE="${SECRETS_ROOT}/WordPress-Secrets.swift"
+INTERNAL_SECRETS_FILE="${SECRETS_ROOT}/WordPress-Secrets-Internal.swift"
+ALPHA_SECRETS_FILE="${SECRETS_ROOT}/WordPress-Secrets-Alpha.swift"
+JETPACK_SECRETS_FILE="${SECRETS_ROOT}/Jetpack-Secrets.swift"
+
 LOCAL_SECRETS_FILE="${SRCROOT}/Credentials/Secrets.swift"
 EXAMPLE_SECRETS_FILE="${SRCROOT}/Credentials/Secrets-example.swift"
 

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -99,17 +99,21 @@ fi
 
 # None of the above secrets was found. Use the example secrets file as a last
 # resort, unless building for Release.
+
+COULD_NOT_FIND_SECRET_MSG="Could not find secrets file at ${SECRETS_DESTINATION_FILE}. This is likely due to the source secrets being missing from ${SECRETS_ROOT}"
+INTERNAL_CONTRIBUTOR_MSG="If you are an internal contributor, run \`bundle exec fastlane run configure_apply\` to update your secrets"
+
 case $CONFIGURATION in
-  # There are three release configurations: Release, Release-Alpha, and
-  # Release-Internal. Since they all start with "Release" we can use a pattern
-  # to check for them.
   Release*)
-    echo "error: Could not find secrets at $SECRETS_ROOT. Cannot continue release build."
+    # There are three release configurations: Release, Release-Alpha, and
+    # Release-Internal. Since they all start with "Release" we can use a
+    # pattern to check for them.
+    echo "error: $COULD_NOT_FIND_SECRET_MSG. Cannot continue Release build. $INTERNAL_CONTRIBUTOR_MSG and try again. External contributors should not need to perform a Release build."
     exit 1
     ;;
   *)
+    echo "warning: $COULD_NOT_FIND_SECRET_MSG. Falling back to $EXAMPLE_SECRETS_FILE. In a Release build, this would be an error. $INTERNAL_CONTRIBUTOR_MSG and try again. If you are an external contributor, you can ignore this warning."
     echo "Applying Example Secrets"
-    echo "warning: Could not find secrets at $SECRETS_ROOT, falling back to $EXAMPLE_SECRETS_FILE. In a release build, this would be an error."
     cp -v $EXAMPLE_SECRETS_FILE $SECRETS_DESTINATION_FILE
     ;;
 esac

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # The Secrets File Sources
 SECRETS_ROOT="${PROJECT_ROOT}/.configure-files"
 

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -23,6 +23,7 @@ function ensure_is_in_input_files_list() {
     echo "error: Input file list verification needs a path to verify!"
     exit 1
   fi
+  file_to_find=$1
 
   i=0
   found=false
@@ -30,9 +31,10 @@ function ensure_is_in_input_files_list() {
   do
     # Need this two step process to access the input at index
     file_list_resolved_var_name=SCRIPT_INPUT_FILE_LIST_${i}
-    # The following reads the processed xcfilelist line by line and
+    # The following reads the processed xcfilelist line by line looking for
+    # the given file
     while read input_file; do
-      if [ "$1" == "$input_file" ]; then
+      if [ "$file_to_find" == "$input_file" ]; then
         found=true
         break
       fi
@@ -40,7 +42,7 @@ function ensure_is_in_input_files_list() {
     let i=i+1
   done
   if [ "$found" = false ]; then
-    echo "error: Could not find $1 as an input to the build phase. Add $1 to the input files list using the .xcfilelist."
+    echo "error: Could not find $file_to_find as an input to the build phase. Add $file_to_find to the input files list using the .xcfilelist."
     exit 1
   fi
 }

--- a/Scripts/BuildPhases/ApplyConfiguration.sh
+++ b/Scripts/BuildPhases/ApplyConfiguration.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -euo pipefail
+#!/bin/bash -euo pipefail
 
 # The Secrets File Sources
 SECRETS_ROOT="${HOME}/.configure/wordpress-ios/secrets"

--- a/WordPress/Credentials/secrets-manifest.xcfilelist
+++ b/WordPress/Credentials/secrets-manifest.xcfilelist
@@ -1,6 +1,0 @@
-#  secrets-manifest.xcfilelist
-
-$(SRCROOT)/../.configure-files/Secrets.swift
-$(SRCROOT)/../.configure-files/Secrets-Alpha.swift
-$(SRCROOT)/../.configure-files/Secrets-Internal.swift
-

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -16397,10 +16397,8 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"$(SRCROOT)/Credentials/secrets-manifest.xcfilelist",
 			);
 			inputPaths = (
-				"$(SRCROOT)/../Scripts/BuildPhases/ApplyConfiguration.sh",
 			);
 			name = "Apply Configuration Secrets";
 			outputPaths = (

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -15764,6 +15764,7 @@
 			files = (
 			);
 			inputFileListPaths = (
+				"$(SRCROOT)/secrets-manifest.xcfilelist",
 			);
 			inputPaths = (
 			);
@@ -16397,6 +16398,7 @@
 			files = (
 			);
 			inputFileListPaths = (
+				"$(SRCROOT)/secrets-manifest.xcfilelist",
 			);
 			inputPaths = (
 			);

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -15764,10 +15764,8 @@
 			files = (
 			);
 			inputFileListPaths = (
-				"$(SRCROOT)/Credentials/secrets-manifest.xcfilelist",
 			);
 			inputPaths = (
-				"$(SRCROOT)/../Scripts/BuildPhases/ApplyConfiguration.sh",
 			);
 			name = "Apply Configuration Secrets";
 			outputFileListPaths = (

--- a/WordPress/secrets-manifest.xcfilelist
+++ b/WordPress/secrets-manifest.xcfilelist
@@ -9,3 +9,7 @@ ${HOME}/.configure/wordpress-ios/secrets/Jetpack-Secrets.swift
 # That usually happens on new machines, to external contributors, or in CI
 # builds that don't need access to secrets, such as the unit tests.
 ${SRCROOT}/Credentials/Secrets-example.swift
+
+# Add the script that uses this file as a source, so that, if the script
+# changes, Xcode will run it again on the next build.
+${SRCROOT}/../Scripts/BuildPhases/ApplyConfiguration.sh

--- a/WordPress/secrets-manifest.xcfilelist
+++ b/WordPress/secrets-manifest.xcfilelist
@@ -1,0 +1,11 @@
+# Lists of input files for the script that populates the app's secrets with the
+# correct values for the current scheme and build configuration.
+${HOME}/.configure/wordpress-ios/secrets/WordPress-Secrets.swift
+${HOME}/.configure/wordpress-ios/secrets/WordPress-Secrets-Internal.swift
+${HOME}/.configure/wordpress-ios/secrets/WordPress-Secrets-Alpha.swift
+${HOME}/.configure/wordpress-ios/secrets/Jetpack-Secrets.swift
+
+# Example secrets file, we fallback to this if none of the above is avaiable.
+# That usually happens on new machines, to external contributors, or in CI
+# builds that don't need access to secrets, such as the unit tests.
+${SRCROOT}/Credentials/Secrets-example.swift


### PR DESCRIPTION
Follow up on _PR_ to extract the remaining secrets outside of the repository. These secrets are `.swift` file containing values that the app needs at build time.

I built on top of the already existing "Run Script" Build Phase, with the following modifications:

- Moved all the code to a dedicated script to make it easier to modify and review
- The automation now looks for the secrets in the new `~/.configure/wordpress-ios/secrets/` folder
- If secrets cannot be found in a Debug build, fall back to the example ones. In a Release build, fail the build early.

~~_Note that this PR is based on top of `move-fastlane-secrets-outside-repository` for ease of review. Ideally, we should land this into 17.7 (see milestone) to test it end-to-end in CI, but it's okay if we don't get there._~~

## How to test

1. Checkout this branch and run a build in one, some, or all of the "WordPress", "WordPress-Alpha", "WordPress-Internal", and "Jetpack" schemes.
2. Verify it shows the example secrets warning:

<img width="1920" alt="Screen Shot 2021-07-05 at 12 10 52 pm" src="https://user-images.githubusercontent.com/1218433/124410561-1b6aa300-dd8e-11eb-9d1d-8aacc4650a5b.png">

3. Try to archive the project in the same scheme
4. Verify the build fails with the error from the script:

<img width="1083" alt="Screen Shot 2021-07-05 at 12 15 29 pm" src="https://user-images.githubusercontent.com/1218433/124410568-1f96c080-dd8e-11eb-80c1-ba1a971e1dbc.png">

5. Run `bundle exec fastlane run configure_apply`
6. Repeat the tests above and verify they succeed

## Regression Notes
1. Potential unintended areas of impact

All the steps above represent a build from Xcode. Interestingly, I found that an extra step was required for the automated build via Fastlane (see inline comments). It's possible there are other steps that might not work in an automated build which I'm not aware of.


2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested the build locally and ensured it worked. I also run the installable build step for both WordPress and Jetpack and saw them both [succeed](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-iOS/23471/workflows/a4c75067-a5c4-41e0-8186-4fb27c8ff37b).

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**