### PR TITLE
Improve logging for site icon download errors

### DIFF
--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -258,13 +258,12 @@ private extension UIImageView {
     }
 
     private func logURLOptimization(from original: String, to optimized: URL, for blog: Blog) {
-        let blogInfo: String = {
-            guard blog.isAccessibleThroughWPCom() else {
-                return "self-hosted with url: \(blog.url ?? "unknown")"
-            }
-
-            return "dot-com-accessible: \(blog.url ?? "unknown"), id: \(blog.dotComID ?? 0)"
-        }()
+        let blogInfo: String
+        if blog.isAccessibleThroughWPCom() 
+            blogInfo = "dot-com-accessible: \(blog.url ?? "unknown"), id: \(blog.dotComID ?? 0)"
+        } else {
+            blogInfo = "self-hosted with url: \(blog.url ?? "unknown")"
+        }
 
         DDLogInfo("URL optimized from \(original) to \(optimized.absoluteString) for blog \(blogInfo)")
     }

--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -258,7 +258,7 @@ private extension UIImageView {
 
     private func logURLOptimization(from original: String, to optimized: URL, for blog: Blog) {
         let blogInfo: String
-        if blog.isAccessibleThroughWPCom()
+        if blog.isAccessibleThroughWPCom() {
             blogInfo = "dot-com-accessible: \(blog.url ?? "unknown"), id: \(blog.dotComID ?? 0)"
         } else {
             blogInfo = "self-hosted with url: \(blog.url ?? "unknown")"

--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -95,7 +95,6 @@ extension UIImageView {
                 if case .requestCancelled = (error as? AFIError) {
                     // Do not log intentionally cancelled requests as errors.
                 } else {
-                    WordPressAppDelegate.crashLogging?.logError(error)
                     DDLogError(error.localizedDescription)
                 }
             }
@@ -259,7 +258,7 @@ private extension UIImageView {
 
     private func logURLOptimization(from original: String, to optimized: URL, for blog: Blog) {
         let blogInfo: String
-        if blog.isAccessibleThroughWPCom() 
+        if blog.isAccessibleThroughWPCom()
             blogInfo = "dot-com-accessible: \(blog.url ?? "unknown"), id: \(blog.dotComID ?? 0)"
         } else {
             blogInfo = "self-hosted with url: \(blog.url ?? "unknown")"


### PR DESCRIPTION
We're having a really large number of errors caused by issues in downloading site icons.  These errors are not crashes though, so I decided to log them to the local log file instead of directly to Sentry.

The reason I'm aiming this at 17.7 is because there's a huge number logs for this error (No 1 in the last 14 days), and if we assume it to be a crash, it looks much more important than it really is.

I'm also adding some logs to try and narrow down what the actual issue is.

## To test:

Simply build and make sure everything works as before.  I just  changed how we're logging some errors.

## Regression Notes

1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
