### PR TITLE
Jetpack App: Fix app review link for Jetpack

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -2,6 +2,7 @@ import Foundation
 import WordPressAuthenticator
 
 @objc class AppConstants: NSObject {
+    static let itunesAppID = "335703880"
     static let productTwitterHandle = "@WordPressiOS"
     static let productTwitterURL = "https://twitter.com/WordPressiOS"
     static let productBlogURL = "https://blog.wordpress.com"

--- a/WordPress/Classes/Utility/Ratings/AppRatingsUtility.swift
+++ b/WordPress/Classes/Utility/Ratings/AppRatingsUtility.swift
@@ -382,7 +382,7 @@ class AppRatingUtility: NSObject {
     }
 
     private enum Constants {
-        static let defaultAppReviewURL = URL(string: "https://itunes.apple.com/app/id335703880?mt=8&action=write-review")!
+        static let defaultAppReviewURL = URL(string: "https://itunes.apple.com/app/id\(AppConstants.itunesAppID)?mt=8&action=write-review")!
         static let promptDisabledURL = URL(string: "https://api.wordpress.org/iphoneapp/app-review-prompt-check/1.0/")!
     }
 }

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 @objc class AppConstants: NSObject {
+    static let itunesAppID = "1565481562"
     static let productTwitterHandle = "@jetpack"
     static let productTwitterURL = "https://twitter.com/jetpack"
     static let productBlogURL = "https://jetpack.com/blog"


### PR DESCRIPTION
Fixes #16808 

## Description

This PR fixes an issue on the Jetpack app where tapping on "Rate us on the App Store" would lead to the WordPress app listing on the App Store.

## How to test

**Test on both JP and WP**
1. Go to My Site > Me > App Settings > About `<App Name>` for iOS
2. Tap on Rate us on the App Store
3. Tap Cancel
4. ✅ The review should be for the correct app (WP, if coming from the WP app / JP, if coming from the JP app)

## Regression Notes
1. Potential unintended areas of impact
WordPress app rating

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested the above flow and made sure WP leads to WP

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
