### PR TITLE
Jetpack: fix tapping on notifications in 17.7

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -24,8 +24,8 @@ import WordPressAuthenticator
 // MARK: - Tab bar order
 @objc enum WPTab: Int {
     case mySites
-    case notifications
     case reader
+    case notifications
 }
 
 // MARK: - Localized Strings

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -21,6 +21,13 @@ import WordPressAuthenticator
     #endif
 }
 
+// MARK: - Tab bar order
+@objc enum WPTab: Int {
+    case mySites
+    case notifications
+    case reader
+}
+
 // MARK: - Localized Strings
 extension AppConstants {
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -16,7 +16,7 @@ extension WPTabBarController {
             let newSpotlight = QuickStartSpotlightView()
             self?.view.addSubview(newSpotlight)
 
-            guard let tabButton = self?.getTabButton(at: Int(WPTabType.reader.rawValue)) else {
+            guard let tabButton = self?.getTabButton(at: Int(WPTab.reader.rawValue)) else {
                 return
             }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -2,7 +2,7 @@
 // MARK: - Tab Access Tracking
 
 extension WPTabBarController {
-    private static let tabIndexToStatMap: [WPTabType: WPAnalyticsStat] = [.mySites: .mySitesTabAccessed, .reader: .readerAccessed]
+    private static let tabIndexToStatMap: [WPTab: WPAnalyticsStat] = [.mySites: .mySitesTabAccessed, .reader: .readerAccessed]
 
     private struct AssociatedKeys {
         static var shouldTrackTabAccessOnViewDidAppear = 0
@@ -79,7 +79,7 @@ extension WPTabBarController {
             return false
         }
 
-        guard let tabType = WPTabType(rawValue: UInt(tabIndex)),
+        guard let tabType = WPTab(rawValue: Int(tabIndex)),
             let stat = WPTabBarController.tabIndexToStatMap[tabType] else {
                 return false
         }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -6,12 +6,6 @@ extern NSString * const WPTabBarCurrentlySelectedScreenSites;
 extern NSString * const WPTabBarCurrentlySelectedScreenReader;
 extern NSString * const WPTabBarCurrentlySelectedScreenNotifications;
 
-typedef NS_ENUM(NSUInteger, WPTabType) {
-    WPTabMySites,
-    WPTabReader,
-    WPTabNotifications
-};
-
 @class AbstractPost;
 @class Blog;
 @class BlogListViewController;

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -20,6 +20,14 @@ import Foundation
     #endif
 }
 
+// MARK: - Tab bar order
+@objc enum WPTab: Int {
+    case mySites
+    case notifications
+    // Reader on Jetpack is not displayed, but we keep it here to avoid adding conditionals on existing code
+    case reader
+}
+
 // MARK: - Localized Strings
 extension AppConstants {
 


### PR DESCRIPTION
Apply the changes from https://github.com/wordpress-mobile/WordPress-iOS/pull/16801 to `17.7`

### To test

Changes were already tested in the original PR. So I'll add test steps for after new betas are released:

**For both apps**

1. Make sure they are closed
2. When you receive a notification tap on it
3. Make sure the app opens with the notifications tab being displayed
