### PR TITLE
Jetpack App: Show error if the stats module is disabled

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -226,6 +226,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 - (BOOL)supports:(BlogFeature)feature;
 - (BOOL)supportsPublicize;
 - (BOOL)supportsShareButtons;
+- (BOOL)supportsStats;
 - (BOOL)hasMappedDomain;
 
 /**

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -226,7 +226,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 - (BOOL)supports:(BlogFeature)feature;
 - (BOOL)supportsPublicize;
 - (BOOL)supportsShareButtons;
-- (BOOL)supportsStats;
+- (BOOL)isStatsActive;
 - (BOOL)hasMappedDomain;
 
 /**

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -21,6 +21,7 @@ static NSInteger const JetpackProfessionalMonthlyPlanId = 2001;
 
 NSString * const BlogEntityName = @"Blog";
 NSString * const PostFormatStandard = @"standard";
+NSString * const ActiveModulesKeyStats = @"stats";
 NSString * const ActiveModulesKeyPublicize = @"publicize";
 NSString * const ActiveModulesKeySharingButtons = @"sharedaddy";
 NSString * const OptionsKeyActiveModules = @"active_modules";
@@ -617,6 +618,11 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     }
 }
 
+- (BOOL)supportsStats
+{
+    return [self jetpackStatsModuleEnabled];
+}
+
 - (BOOL)supportsPushNotifications
 {
     return [self accountIsDefaultAccount];
@@ -842,6 +848,11 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 {
     NSArray *activeModules = (NSArray *)[self getOptionValue:OptionsKeyActiveModules];
     return [activeModules containsObject:moduleName] ?: NO;
+}
+
+- (BOOL)jetpackStatsModuleEnabled
+{
+    return [self jetpackActiveModule:ActiveModulesKeyStats];
 }
 
 - (BOOL)jetpackPublicizeModuleEnabled

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -618,7 +618,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     }
 }
 
-- (BOOL)supportsStats
+- (BOOL)isStatsActive
 {
     return [self jetpackStatsModuleEnabled];
 }

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/NoResultsViewController+StatsModule.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/NoResultsViewController+StatsModule.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+// Empty states for Stats
+
+extension NoResultsViewController {
+
+    @objc func configureForStatsModuleDisabled() {
+        configure(title: Strings.statsModuleDisabled.title,
+                  buttonTitle: Strings.statsModuleDisabled.buttonTitle,
+                  subtitle: Strings.statsModuleDisabled.subtitle,
+                  image: Constants.statsImageName)
+    }
+
+    @objc func configureForActivatingStatsModule() {
+        configure(title: Strings.activatingStatsModule.title, accessoryView: NoResultsViewController.loadingAccessoryView())
+        view.layoutIfNeeded()
+    }
+
+    private enum Constants {
+        static let statsImageName = "wp-illustration-stats"
+    }
+
+    private enum Strings {
+
+        enum statsModuleDisabled {
+            static let title = NSLocalizedString("Looking for stats?", comment: "Title for the error view when the stats module is disabled.")
+            static let subtitle = NSLocalizedString("Enable site stats to see detailed information about your traffic, likes, comments, and subscribers.", comment:
+                                                      "Error message shown when trying to view Stats and the stats module is disabled.")
+            static let buttonTitle = NSLocalizedString("Enable Site Stats", comment: "Title for the button that will enable the site stats module.")
+
+        }
+
+        enum activatingStatsModule {
+            static let title = NSLocalizedString("Enabling Site Stats...", comment: "Text displayed while activating the site stats module.")
+        }
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/StatsViewController+JetpackSettings.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/StatsViewController+JetpackSettings.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension StatsViewController {
+
+    @objc func activateStatsModule(success: @escaping () -> Void, failure: @escaping (Error?) -> Void) {
+        guard let context = blog.settings?.managedObjectContext else {
+            return
+        }
+
+        let service = BlogJetpackSettingsService(managedObjectContext: context)
+
+        service.updateJetpackModuleActiveSettingForBlog(blog,
+                                                        module: Constants.statsModule,
+                                                        active: true,
+                                                        success: success,
+                                                        failure: failure)
+
+    }
+
+    private enum Constants {
+        static let statsModule = "stats"
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/StatsViewController+JetpackSettings.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/StatsViewController+JetpackSettings.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 extension StatsViewController {
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -95,7 +95,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 - (void)initStats
 {
-    if (![self.blog supportsStats]) {
+    if (![self.blog isStatsActive]) {
         [self showStatsModuleDisabled];
         return;
     }

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -95,6 +95,11 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 - (void)initStats
 {
+    if (![self.blog supportsStats]) {
+        [self showStatsModuleDisabled];
+        return;
+    }
+    
     SiteStatsInformation.sharedInstance.siteTimeZone = [self.blog timeZone];
 
     // WordPress.com + Jetpack REST
@@ -186,13 +191,14 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 }
 
 
-- (void)showNoResults
+- (void)showStatsModuleDisabled
 {
     [self.noResultsViewController removeFromView];
 
-    NSString *title = NSLocalizedString(@"No Connection", @"Title for the error view when there's no connection");
-    NSString *subtitle = NSLocalizedString(@"An active internet connection is required to view stats",
-                                           @"Error message shown when trying to view Stats and there is no internet connection.");
+    NSString *title = NSLocalizedString(@"Looking for stats?", @"Title for the error view when the stats module is disabled.");
+    NSString *subtitle = NSLocalizedString(@"Enable site stats to see detailed information about your traffic, likes, comments, and subscribers.",
+                                           @"Error message shown when trying to view Stats and the stats module is disabled.");
+    NSString *image = @"wp-illustration-stats";
 
     self.noResultsViewController = [NoResultsViewController controllerWithTitle:title
                                                                 attributedTitle:nil
@@ -200,7 +206,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
                                                                        subtitle:subtitle
                                                              attributedSubtitle:nil
                                                 attributedSubtitleConfiguration:nil
-                                                                          image:nil
+                                                                          image:image
                                                                   subtitleImage:nil
                                                                   accessoryView:nil];
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2627,6 +2627,8 @@
 		FAB8FD6E25AEB23600D5D54A /* JetpackBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8FD6D25AEB23600D5D54A /* JetpackBackupService.swift */; };
 		FAB9826E2697038700B172A3 /* StatsViewController+JetpackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB9826D2697038700B172A3 /* StatsViewController+JetpackSettings.swift */; };
 		FAB9826F2697038700B172A3 /* StatsViewController+JetpackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB9826D2697038700B172A3 /* StatsViewController+JetpackSettings.swift */; };
+		FAB985C12697550C00B172A3 /* NoResultsViewController+StatsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB985C02697550C00B172A3 /* NoResultsViewController+StatsModule.swift */; };
+		FAB985C22697550C00B172A3 /* NoResultsViewController+StatsModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB985C02697550C00B172A3 /* NoResultsViewController+StatsModule.swift */; };
 		FABB1FAB2602FC2C00C8785C /* ReaderCardDiscoverAttributionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BA77BCA2482C52A00E1EBBF /* ReaderCardDiscoverAttributionView.xib */; };
 		FABB1FAC2602FC2C00C8785C /* PostingActivityCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9826AE8F21B5D3CD00C851FA /* PostingActivityCell.xib */; };
 		FABB1FAE2602FC2C00C8785C /* QuickStartCongratulationsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 43DDFE8F21785EAC008BE72F /* QuickStartCongratulationsCell.xib */; };
@@ -7393,6 +7395,7 @@
 		FAB8FD4F25AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupStatusCoordinator.swift; sourceTree = "<group>"; };
 		FAB8FD6D25AEB23600D5D54A /* JetpackBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupService.swift; sourceTree = "<group>"; };
 		FAB9826D2697038700B172A3 /* StatsViewController+JetpackSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsViewController+JetpackSettings.swift"; sourceTree = "<group>"; };
+		FAB985C02697550C00B172A3 /* NoResultsViewController+StatsModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NoResultsViewController+StatsModule.swift"; sourceTree = "<group>"; };
 		FABB26522602FC2C00C8785C /* Jetpack.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Jetpack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FABB26872602FCCA00C8785C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FABB28462603067C00C8785C /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
@@ -11442,6 +11445,7 @@
 				986DD19B218D002500D28061 /* WPStyleGuide+Stats.swift */,
 				98487E3921EE8FB500352B4E /* UITableViewCell+Stats.swift */,
 				FAB9826D2697038700B172A3 /* StatsViewController+JetpackSettings.swift */,
+				FAB985C02697550C00B172A3 /* NoResultsViewController+StatsModule.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -17582,6 +17586,7 @@
 				FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */,
 				7E7947AD210BAC7B005BB851 /* FormattableNoticonRange.swift in Sources */,
 				46F583AB2624CE790010A723 /* BlockEditorSettings+CoreDataProperties.swift in Sources */,
+				FAB985C12697550C00B172A3 /* NoResultsViewController+StatsModule.swift in Sources */,
 				B55086211CC15CCB004EADB4 /* PromptViewController.swift in Sources */,
 				40C403EC2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift in Sources */,
 				82FC612C1FA8B7FC00A1757E /* ActivityListRow.swift in Sources */,
@@ -19202,6 +19207,7 @@
 				FABB22A42602FC2C00C8785C /* TopCommentsAuthorStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB22A52602FC2C00C8785C /* SignupEpilogueViewController.swift in Sources */,
 				FABB22A62602FC2C00C8785C /* TenorPicker.swift in Sources */,
+				FAB985C22697550C00B172A3 /* NoResultsViewController+StatsModule.swift in Sources */,
 				FABB22A72602FC2C00C8785C /* BlogListViewController+Activity.swift in Sources */,
 				3F810A5B2616870C00ADDCC2 /* UnifiedPrologueIntroContentView.swift in Sources */,
 				FABB22A82602FC2C00C8785C /* TableDataCoordinator.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2625,6 +2625,8 @@
 		FAB8F7AA25AD792500D5D54A /* JetpackBackupStatusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8F7A925AD792500D5D54A /* JetpackBackupStatusViewController.swift */; };
 		FAB8FD5025AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8FD4F25AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift */; };
 		FAB8FD6E25AEB23600D5D54A /* JetpackBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8FD6D25AEB23600D5D54A /* JetpackBackupService.swift */; };
+		FAB9826E2697038700B172A3 /* StatsViewController+JetpackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB9826D2697038700B172A3 /* StatsViewController+JetpackSettings.swift */; };
+		FAB9826F2697038700B172A3 /* StatsViewController+JetpackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB9826D2697038700B172A3 /* StatsViewController+JetpackSettings.swift */; };
 		FABB1FAB2602FC2C00C8785C /* ReaderCardDiscoverAttributionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BA77BCA2482C52A00E1EBBF /* ReaderCardDiscoverAttributionView.xib */; };
 		FABB1FAC2602FC2C00C8785C /* PostingActivityCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9826AE8F21B5D3CD00C851FA /* PostingActivityCell.xib */; };
 		FABB1FAE2602FC2C00C8785C /* QuickStartCongratulationsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 43DDFE8F21785EAC008BE72F /* QuickStartCongratulationsCell.xib */; };
@@ -7390,6 +7392,7 @@
 		FAB8F7A925AD792500D5D54A /* JetpackBackupStatusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupStatusViewController.swift; sourceTree = "<group>"; };
 		FAB8FD4F25AEB0F500D5D54A /* JetpackBackupStatusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupStatusCoordinator.swift; sourceTree = "<group>"; };
 		FAB8FD6D25AEB23600D5D54A /* JetpackBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupService.swift; sourceTree = "<group>"; };
+		FAB9826D2697038700B172A3 /* StatsViewController+JetpackSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsViewController+JetpackSettings.swift"; sourceTree = "<group>"; };
 		FABB26522602FC2C00C8785C /* Jetpack.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Jetpack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FABB26872602FCCA00C8785C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FABB28462603067C00C8785C /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
@@ -11438,6 +11441,7 @@
 				981C82B52193A7B900A06E84 /* Double+Stats.swift */,
 				986DD19B218D002500D28061 /* WPStyleGuide+Stats.swift */,
 				98487E3921EE8FB500352B4E /* UITableViewCell+Stats.swift */,
+				FAB9826D2697038700B172A3 /* StatsViewController+JetpackSettings.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -16986,6 +16990,7 @@
 				8350E49611D2C71E00A7B073 /* Media.m in Sources */,
 				D8B9B58F204F4EA1003C6042 /* NetworkAware.swift in Sources */,
 				B54346961C6A707D0010B3AD /* LanguageViewController.swift in Sources */,
+				FAB9826E2697038700B172A3 /* StatsViewController+JetpackSettings.swift in Sources */,
 				43D74AD020F906EE004AD934 /* InlineEditableNameValueCell.swift in Sources */,
 				4089C51122371B120031CE78 /* TodayStatsRecordValue+CoreDataProperties.swift in Sources */,
 				F928EDA3226140620030D451 /* WPCrashLoggingProvider.swift in Sources */,
@@ -19635,6 +19640,7 @@
 				FABB244A2602FC2C00C8785C /* ReaderStreamViewController+Ghost.swift in Sources */,
 				174C11942624C78900346EC6 /* Routes+Start.swift in Sources */,
 				FABB244B2602FC2C00C8785C /* Constants.m in Sources */,
+				FAB9826F2697038700B172A3 /* StatsViewController+JetpackSettings.swift in Sources */,
 				FABB244C2602FC2C00C8785C /* MurielColor.swift in Sources */,
 				FABB244D2602FC2C00C8785C /* RegisterDomainDetailsErrorSectionFooter.swift in Sources */,
 				FABB244E2602FC2C00C8785C /* ImageLoader.swift in Sources */,


### PR DESCRIPTION
Fixes #16753

## Description
This PR fixes an issue where no explicit error screen was being shown if the stats module was disabled.

Before | After 
-- | --
![Simulator Screen Shot - iPhone 12 Pro - 2021-06-22 at 18 02 27](https://user-images.githubusercontent.com/6711616/124793673-22d4ac80-df46-11eb-825d-f5821a8eafc2.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-07-08 at 17 49 19](https://user-images.githubusercontent.com/6711616/124961871-e2dcfa80-e015-11eb-9272-46189a437863.png)

## Note
I wasn't sure whether or not to include a button for the NoResultsViewController. Lmk if you think I should include one.

## How to test
1. Disable the stats module on your website (see: https://jetpack.com/support/control-jetpack-features-on-one-page/)
2. Open the Jetpack app and go to My Site > Stats
3. ✅ Notice a "Looking for Stats?" error is displayed

## Regression Notes
1. Potential unintended areas of impact
WordPress

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the above flow

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
