### PR TITLE
Update release toolkit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
       trainer
       xcodeproj
       xctest_list (>= 1.2.1)
-    fastlane-plugin-wpmreleasetoolkit (1.3.0)
+    fastlane-plugin-wpmreleasetoolkit (1.3.1)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
       chroma (= 0.2.0)
@@ -174,7 +174,7 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    git (1.8.1)
+    git (1.9.1)
       rchardet (~> 1.8)
     google-apis-androidpublisher_v3 (0.5.0)
       google-apis-core (~> 0.1)
@@ -245,7 +245,7 @@ GEM
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.11.7)
+    oj (3.12.0)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)
@@ -331,7 +331,7 @@ DEPENDENCIES
   fastlane-plugin-appcenter (~> 1.8)
   fastlane-plugin-sentry
   fastlane-plugin-test_center
-  fastlane-plugin-wpmreleasetoolkit (~> 1.1)
+  fastlane-plugin-wpmreleasetoolkit (~> 1.3.1)
   octokit (~> 4.0)
   rake
   rmagick (~> 3.2.0)

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.3.1'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'


### PR DESCRIPTION
This PR updates the `release-toolkit` to `1.3.1` in order to fix an issue where the calculated value of the progress of the translation on GlotPress may be not accurate when there are `Waiting` strings which are updates and/or improvements to translations already in the database.

Since this is an edge case, the check is a not blocking warning and the miscalculation always shows a worse scenario (so there can be an extra warning to check, but not a missed warning), I'm targeting `develop` because it doesn't seem to be worthy a change to the frozen branch.   
 
## Regression Notes
1. Potential unintended areas of impact
 - The update also brings in some other fixes to the release toolkit, but they are related to Android actions, so shouldn't impact WPiOS.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-

3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
