### PR TITLE
Fixes an issue with the SignUp epilogue not dismissing sometimes.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 * [*] Block editor: Tablet view fixes for inserter button. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3602]
 * [*] Block editor: Tweaks to the badge component's styling, including change of background color and reduced padding. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3642]
 * [***] Block editor: New block Layout grid. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3513]
+* [*] Fixed an issue where the SignUp flow could not be dismissed sometimes. [#16824]
 
 17.6
 -----

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -351,11 +351,18 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         epilogueViewController.credentials = credentials
         epilogueViewController.socialService = service
         epilogueViewController.onContinue = { [weak self] in
+            guard let self = self else {
+                return
+            }
+
             if PostSignUpInterstitialViewController.shouldDisplay() {
-                self?.presentPostSignUpInterstitial(in: navigationController)
+                self.presentPostSignUpInterstitial(in: navigationController)
             } else {
-                // Signup is only ever shown in fullscreen
-                self?.windowManager.dismissFullscreenSignIn()
+                if self.windowManager.isShowingFullscreenSignIn {
+                    self.windowManager.dismissFullscreenSignIn()
+                } else {
+                    navigationController.dismiss(animated: true)
+                }
             }
 
             UserDefaults.standard.set(false, forKey: UserDefaults.standard.welcomeNotificationSeenKey)


### PR DESCRIPTION
Fixes #16824

This PR fixes an issue that was causing the WPcom SignUp epilogue not to dismiss sometimes.

## To test:

Test in both iPhone and iPad.

### Test the regular SignUp flow dismisses:

- Install the app from scratch
- Sign up through WPCom
- Make sure the signup epilogue can be dismissed just fine.

### Test the original issue

- Install the app from scratch or logout
- Add at least a self hosted site if necessary
- Signup with a new WPcom account
- Tap "Done" on the signup epilogue and verify that it does not dismiss

## Regression Notes

1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
