### PR TITLE
Removes some unnecessary conditions for presenting blogging reminders after posting.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -188,13 +188,13 @@ class EditPostViewController: UIViewController {
 
         var dismissPostPostImmediately = true
         if showPostEpilogue && shouldShowPostPost(hasChanges: changesSaved) {
-            showPostPost(afterSavingChangesInTheEditor: true)
+            showPostPost(afterSavingChangesInTheEditor: changesSaved)
             dismissPostPostImmediately = false
         }
 
         dismiss(animated: true) {
             if dismissPostPostImmediately {
-                self.closePostPost(animated: false)
+                self.closePostPost(animated: false, afterSavingChangesInTheEditor: changesSaved)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -258,9 +258,7 @@ class EditPostViewController: UIViewController {
                 return
             }
             self.afterDismiss?()
-            guard let post = self.post,
-                  post.isPublished(),
-                  !self.editingExistingPost,
+            guard !self.editingExistingPost,
                   let controller = presentingController else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -249,7 +249,7 @@ class EditPostViewController: UIViewController {
         postPost.present(navWrapper, animated: true) {}
     }
 
-    @objc func closePostPost(animated: Bool, afterSavingChangesInTheEditor: Bool) {
+    @objc func closePostPost(animated: Bool, afterSavingChangesInTheEditor: Bool = false) {
         // this reference is needed in the completion
         let presentingController = self.presentingViewController
         // will dismiss self

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -188,7 +188,7 @@ class EditPostViewController: UIViewController {
 
         var dismissPostPostImmediately = true
         if showPostEpilogue && shouldShowPostPost(hasChanges: changesSaved) {
-            showPostPost()
+            showPostPost(afterSavingChangesInTheEditor: true)
             dismissPostPostImmediately = false
         }
 
@@ -199,14 +199,14 @@ class EditPostViewController: UIViewController {
         }
     }
 
-    private func showPostPost() {
+    private func showPostPost(afterSavingChangesInTheEditor: Bool = false) {
         guard let post = post else {
             return
         }
 
         postPost.setup(post: post)
         postPost.onClose = {
-            self.closePostPost(animated: true)
+            self.closePostPost(animated: true, afterSavingChangesInTheEditor: afterSavingChangesInTheEditor)
         }
         postPost.reshowEditor = {
             self.showEditor()
@@ -249,7 +249,7 @@ class EditPostViewController: UIViewController {
         postPost.present(navWrapper, animated: true) {}
     }
 
-    @objc func closePostPost(animated: Bool) {
+    @objc func closePostPost(animated: Bool, afterSavingChangesInTheEditor: Bool) {
         // this reference is needed in the completion
         let presentingController = self.presentingViewController
         // will dismiss self
@@ -258,7 +258,8 @@ class EditPostViewController: UIViewController {
                 return
             }
             self.afterDismiss?()
-            guard !self.editingExistingPost,
+            guard afterSavingChangesInTheEditor,
+                  !self.editingExistingPost,
                   let controller = presentingController else {
                 return
             }


### PR DESCRIPTION
Removes some unnecessary conditions for presenting blogging reminders after posting.

We don't need to know that a post was published - it should be enough to know the user's intent to publish to present blogging reminders.

## To test:

1. Go to a site where blogging reminders hasn't been shown yet or Perform a fresh install to make sure there are no saved settings on the device.
2. Publish a post.
3. Make sure blogging reminders is shown.

## Regression Notes

1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
