### PR TITLE
Jetpack: show title after login when no Jetpack sites are present

### DIFF
--- a/WordPress/Jetpack/Classes/ViewRelated/Login Error/JetpackLoginErrorViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/Login Error/JetpackLoginErrorViewController.swift
@@ -5,6 +5,7 @@ class JetpackLoginErrorViewController: UIViewController {
 
     // IBOutlets
     @IBOutlet weak var imageView: UIImageView!
+    @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var primaryButton: UIButton!
     @IBOutlet weak var secondaryButton: UIButton!
@@ -27,6 +28,7 @@ class JetpackLoginErrorViewController: UIViewController {
         super.viewDidLoad()
 
         configureImageView()
+        configureTitleLabel()
         configureDescriptionLabel()
         configurePrimaryButton()
         configureSecondaryButton()
@@ -45,6 +47,15 @@ extension JetpackLoginErrorViewController {
         }
 
         imageView.image = image
+    }
+
+    private func configureTitleLabel() {
+        guard let title = viewModel.title else {
+            return
+        }
+
+        titleLabel.isHidden = false
+        titleLabel.text = title
     }
 
     private func configureDescriptionLabel() {

--- a/WordPress/Jetpack/Classes/ViewRelated/Login Error/JetpackLoginErrorViewController.xib
+++ b/WordPress/Jetpack/Classes/ViewRelated/Login Error/JetpackLoginErrorViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -15,6 +15,7 @@
                 <outlet property="imageView" destination="31P-iz-jd7" id="Rsp-zK-rfw"/>
                 <outlet property="primaryButton" destination="c2a-kB-DHJ" id="ntt-OQ-adb"/>
                 <outlet property="secondaryButton" destination="C6I-HH-kiP" id="rBg-LT-Meq"/>
+                <outlet property="titleLabel" destination="eJJ-cp-I3F" id="IPu-Ur-DfI"/>
                 <outlet property="view" destination="RDV-rd-NgA" id="k3T-k9-oD4"/>
             </connections>
         </placeholder>
@@ -24,20 +25,26 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="5JF-4N-1bo" userLabel="Description ">
-                    <rect key="frame" x="34" y="239.99999999999997" width="346" height="386.33333333333326"/>
+                    <rect key="frame" x="34" y="218.66666666666663" width="346" height="429"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="site-creation-error" translatesAutoresizingMaskIntoConstraints="NO" id="31P-iz-jd7" userLabel="Error Image View">
                             <rect key="frame" x="0.0" y="0.0" width="346" height="116"/>
                         </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eJJ-cp-I3F">
+                            <rect key="frame" x="0.0" y="148.00000000000003" width="346" height="23"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fob-oH-Upm" userLabel="Error Description Label">
-                            <rect key="frame" x="0.0" y="148" width="346" height="86.333333333333314"/>
+                            <rect key="frame" x="0.0" y="203.00000000000003" width="346" height="73.999999999999972"/>
                             <string key="text">Qui eum est quo et recusandae ut. Hic cupiditate nobis et pariatur quidem dolorum. Doloribus est tempora ipsam eius. Quos ab et aspernatur velit corporis aut rem.</string>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <color key="textColor" systemColor="secondaryLabelColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="66u-Sn-miR">
-                            <rect key="frame" x="0.0" y="266.33333333333331" width="346" height="120"/>
+                            <rect key="frame" x="0.0" y="309" width="346" height="120"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="c2a-kB-DHJ" customClass="FancyButton" customModule="WordPressUI">
                                     <rect key="frame" x="0.0" y="0.0" width="346" height="50"/>
@@ -53,7 +60,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="C6I-HH-kiP" customClass="FancyButton" customModule="WordPressUI">
-                                    <rect key="frame" x="0.0" y="70.000000000000057" width="346" height="50"/>
+                                    <rect key="frame" x="0.0" y="70" width="346" height="50"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="21I-1c-69H"/>
                                     </constraints>

--- a/WordPress/Jetpack/Classes/ViewRelated/Login Error/View Models/JetpackErrorViewModel.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/Login Error/View Models/JetpackErrorViewModel.swift
@@ -5,6 +5,10 @@ protocol JetpackErrorViewModel {
     /// If this is nil the image will be hidden
     var image: UIImage? { get }
 
+    /// The title for the error description
+    /// If nil, title will be hidden
+    var title: String? { get }
+
     /// The error description text
     var description: FormattedStringProvider { get }
 

--- a/WordPress/Jetpack/Classes/ViewRelated/Login Error/View Models/JetpackNoSitesErrorViewModel.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/Login Error/View Models/JetpackNoSitesErrorViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct JetpackNoSitesErrorViewModel: JetpackErrorViewModel {
     let image: UIImage? = UIImage(named: "jetpack-empty-state-illustration")
+    var title: String? = Constants.title
     var description: FormattedStringProvider = FormattedStringProvider(string: Constants.description)
     var primaryButtonTitle: String? = Constants.primaryButtonTitle
     var secondaryButtonTitle: String? = Constants.secondaryButtonTitle
@@ -22,6 +23,9 @@ struct JetpackNoSitesErrorViewModel: JetpackErrorViewModel {
     }
 
     private struct Constants {
+        static let title = NSLocalizedString("No Jetpack sites found",
+                                            comment: "Title when users have no Jetpack sites.")
+
         static let description = NSLocalizedString("If you already have a site, you’ll need to install the free Jetpack plugin and connect it to your WordPress.com account.",
                                                    comment: "Message explaining that they will need to install Jetpack on one of their sites.")
 

--- a/WordPress/Jetpack/Classes/ViewRelated/Login Error/View Models/JetpackNotFoundErrorViewModel.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/Login Error/View Models/JetpackNotFoundErrorViewModel.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 struct JetpackNotFoundErrorViewModel: JetpackErrorViewModel {
+    let title: String? = nil
     let image: UIImage? = UIImage(named: "jetpack-empty-state-illustration")
     var description: FormattedStringProvider {
         let siteName = siteURL

--- a/WordPress/Jetpack/Classes/ViewRelated/Login Error/View Models/JetpackNotWPErrorViewModel.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/Login Error/View Models/JetpackNotWPErrorViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 struct JetpackNotWPErrorViewModel: JetpackErrorViewModel {
+    let title: String? = nil
     let image: UIImage? = UIImage(named: "jetpack-empty-state-illustration")
     var description: FormattedStringProvider = FormattedStringProvider(string: Constants.description)
     var primaryButtonTitle: String? = Constants.primaryButtonTitle


### PR DESCRIPTION
Based on @osullivanchris feedback [from here](https://github.com/wordpress-mobile/WordPress-iOS/pull/16435#issuecomment-832583117).

<img src="https://user-images.githubusercontent.com/7040243/124989541-9b566e80-e015-11eb-80da-d39e66e2bbfe.png" width="300">

### To test

1. Open the Jetpack app
2. Login with an account with no Jetpack sites
3. Make sure the title appears

Please test on iPad too.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
