### PR TITLE
Cherry-pick "Fix follow site button refresh issue (#16819)"

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -117,8 +117,8 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
 - (void)toggleFollowingForPost:(ReaderPost *)post
-                       success:(void (^)(void))success
-                       failure:(void (^)(NSError *error))failure;
+                       success:(void (^)(BOOL follow))success
+                       failure:(void (^)(BOOL follow, NSError *error))failure;
 
 /**
  Toggle the saved for later status of the specified post.

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -324,15 +324,15 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 }
 
 - (void)toggleFollowingForPost:(ReaderPost *)post
-                       success:(void (^)(void))success
-                       failure:(void (^)(NSError *error))failure
+                       success:(void (^)(BOOL follow))success
+                       failure:(void (^)(BOOL follow, NSError *error))failure
 {
     // Get a the post in our own context
     NSError *error;
     ReaderPost *readerPost = (ReaderPost *)[self.managedObjectContext existingObjectWithID:post.objectID error:&error];
     if (error) {
         if (failure) {
-            failure(error);
+            failure(true, error);
         }
         return;
     }
@@ -379,7 +379,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
             [self refreshPostsForFollowedTopic];
         }
         if (success) {
-            success();
+            success(follow);
         }
         
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -395,7 +395,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
         [self setFollowing:oldValue forPostsFromSiteWithID:post.siteID andURL:post.blogURL];
 
         if (failure) {
-            failure(error);
+            failure(follow, error);
         }
     };
 

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -140,7 +140,9 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  @param success block called on a successful change.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
-- (void)toggleFollowingForSite:(ReaderSiteTopic *)topic success:(void (^)(void))success failure:(void (^)(NSError *error))failure;
+- (void)toggleFollowingForSite:(ReaderSiteTopic *)topic
+                       success:(void (^)(BOOL follow))success
+                       failure:(void (^)(BOOL follow, NSError *error))failure;
 
 /**
  Mark a site topic as unfollowed in core data only. Should be called after unfollowing

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -473,14 +473,16 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     }];
 }
 
-- (void)toggleFollowingForSite:(ReaderSiteTopic *)siteTopic success:(void (^)(void))success failure:(void (^)(NSError *error))failure
+- (void)toggleFollowingForSite:(ReaderSiteTopic *)siteTopic
+                       success:(void (^)(BOOL follow))success
+                       failure:(void (^)(BOOL follow, NSError *error))failure
 {
     NSError *error;
     ReaderSiteTopic *topic = (ReaderSiteTopic *)[self.managedObjectContext existingObjectWithID:siteTopic.objectID error:&error];
     if (error) {
         DDLogError(error.localizedDescription);
         if (failure) {
-            failure(error);
+            failure(true, error);
         }
         return;
     }
@@ -509,19 +511,29 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
         [self refreshPostsForFollowedTopic];
         
         if (success) {
-            success();
+            success(newFollowValue);
         }
     };
 
     // Define failure block
     void (^failureBlock)(NSError *error) = ^void(NSError *error) {
-        // Revert changes on failure
+        BOOL alreadyFollowing = newFollowValue && error.domain == ReaderSiteServiceErrorDomain && error.code == ReaderSiteServiceErrorAlreadyFollowingSite;
+        BOOL alreadyUnsubscribed = !newFollowValue && [error.userInfo[WordPressComRestApi.ErrorKeyErrorCode] isEqual:@"are_not_subscribed"];
+        BOOL successWithoutChanges = alreadyFollowing || alreadyUnsubscribed;
+            
+        if (successWithoutChanges) {
+            successBlock();
+            return;
+        }
+     
+        // Revert changes on failure, unless the error is that we're already following
+        // a site.
         topic.following = oldFollowValue;
         [postService setFollowing:oldFollowValue forPostsFromSiteWithID:siteIDForPostService andURL:siteURLForPostService];
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
 
         if (failure) {
-            failure(error);
+            failure(newFollowValue, error);
         }
     };
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -451,20 +451,22 @@ class ReaderDetailCoordinator {
         viewController?.present(controller, animated: true)
     }
 
-    private func followSite() {
+    private func followSite(completion: @escaping () -> Void) {
         guard let post = post else {
             return
         }
 
         ReaderFollowAction().execute(with: post,
                                      context: coreDataStack.mainContext,
-                                     completion: { [weak self] in
-                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: true)
-                                         self?.view?.updateHeader()
+                                     completion: { [weak self] follow in
+                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: true)
+                                        self?.view?.updateHeader()
+                                        completion()
                                      },
-                                     failure: { [weak self] _ in
-                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: false)
-                                         self?.view?.updateHeader()
+                                     failure: { [weak self] follow, _ in
+                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: false)
+                                        self?.view?.updateHeader()
+                                        completion()
                                      })
     }
 
@@ -604,8 +606,8 @@ extension ReaderDetailCoordinator: ReaderDetailHeaderViewDelegate {
         previewSite()
     }
 
-    func didTapFollowButton() {
-        followSite()
+    func didTapFollowButton(completion: @escaping () -> Void) {
+        followSite(completion: completion)
     }
 
     func didSelectTopic(_ topic: String) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
@@ -5,7 +5,7 @@ protocol ReaderDetailHeaderViewDelegate {
     func didTapBlogName()
     func didTapMenuButton(_ sender: UIView)
     func didTapHeaderAvatar()
-    func didTapFollowButton()
+    func didTapFollowButton(completion: @escaping () -> Void)
     func didSelectTopic(_ topic: String)
 }
 
@@ -78,8 +78,11 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
     @IBAction func didTapFollowButton(_ sender: Any) {
         followButton.isSelected = !followButton.isSelected
         iPadFollowButton.isSelected = !followButton.isSelected
+        followButton.isUserInteractionEnabled = false
 
-        delegate?.didTapFollowButton()
+        delegate?.didTapFollowButton() { [weak self] in
+            self?.followButton.isUserInteractionEnabled = true
+        }
     }
 
     @objc func didTapHeaderAvatar(_ gesture: UITapGestureRecognizer) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowAction.swift
@@ -2,8 +2,8 @@
 final class ReaderFollowAction {
     func execute(with post: ReaderPost,
                  context: NSManagedObjectContext,
-                 completion: (() -> Void)? = nil,
-                 failure: ((Error?) -> Void)? = nil) {
+                 completion: ((Bool) -> Void)? = nil,
+                 failure: ((Bool, Error?) -> Void)? = nil) {
 
         if post.isFollowing {
             ReaderSubscribingNotificationAction().execute(for: post.siteID, context: context, subscribe: false)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -213,7 +213,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
                                         userInfo: [ReaderNotificationKeys.topic: site])
 
         let service = ReaderTopicService(managedObjectContext: managedObjectContext())
-        service.toggleFollowing(forSite: site, success: { [weak self] in
+        service.toggleFollowing(forSite: site, success: { [weak self] follow in
             let siteURL = URL(string: site.siteURL)
             let notice = Notice(title: NSLocalizedString("Unfollowed site", comment: "User unfollowed a site."),
                                 message: siteURL?.host,
@@ -222,7 +222,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
 
             self?.syncSites()
             self?.refreshFollowedPosts()
-        }, failure: { [weak self] (error) in
+        }, failure: { [weak self] (follow, error) in
             DDLogError("Could not unfollow site: \(String(describing: error))")
 
             let notice = Notice(title: NSLocalizedString("Could not unfollow site", comment: "Title of a prompt."),

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -339,12 +339,12 @@ struct ReaderPostMenuButtonTitles {
         dispatchNotice(notice)
     }
 
-    class func dispatchToggleFollowSiteMessage(post: ReaderPost, success: Bool) {
-        dispatchToggleFollowSiteMessage(siteTitle: post.blogNameForDisplay(), siteID: post.siteID, following: post.isFollowing, success: success)
+    class func dispatchToggleFollowSiteMessage(post: ReaderPost, follow: Bool, success: Bool) {
+        dispatchToggleFollowSiteMessage(siteTitle: post.blogNameForDisplay(), siteID: post.siteID, follow: follow, success: success)
     }
 
-    class func dispatchToggleFollowSiteMessage(topic: ReaderSiteTopic, success: Bool) {
-        dispatchToggleFollowSiteMessage(siteTitle: topic.title, siteID: topic.siteID, following: topic.following, success: success)
+    class func dispatchToggleFollowSiteMessage(site: ReaderSiteTopic, follow: Bool, success: Bool) {
+        dispatchToggleFollowSiteMessage(siteTitle: site.title, siteID: site.siteID, follow: follow, success: success)
     }
 
     class func dispatchToggleSubscribeCommentMessage(subscribing: Bool, success: Bool) {
@@ -362,15 +362,15 @@ struct ReaderPostMenuButtonTitles {
         dispatchNotice(Notice(title: title))
     }
 
-    private class func dispatchToggleFollowSiteMessage(siteTitle: String, siteID: NSNumber, following: Bool, success: Bool) {
+    class func dispatchToggleFollowSiteMessage(siteTitle: String, siteID: NSNumber, follow: Bool, success: Bool) {
         var notice: Notice
 
         if success {
-            notice = following ?
-                followedSiteNotice(siteTitle: siteTitle, siteID: siteID) :
-                Notice(title: NoticeMessages.unfollowSuccess, message: siteTitle)
+            notice = follow
+                ? followedSiteNotice(siteTitle: siteTitle, siteID: siteID)
+                : Notice(title: NoticeMessages.unfollowSuccess, message: siteTitle)
         } else {
-            notice = Notice(title: following ? NoticeMessages.unfollowFail : NoticeMessages.followFail)
+            notice = Notice(title: follow ? NoticeMessages.followFail : NoticeMessages.unfollowFail)
         }
 
         dispatchNotice(notice)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -108,12 +108,10 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
     private func toggleFollowingForPost(_ post: ReaderPost) {
         ReaderFollowAction().execute(with: post,
                                      context: context,
-                                     completion: {
-                                        if post.isFollowing {
-                                            ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: true)
-                                        }
-                                     }, failure: { _ in
-                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: false)
+                                     completion: { follow in
+                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: true)
+                                     }, failure: { follow, _ in
+                                        ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: false)
                                      })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -77,17 +77,18 @@ final class ReaderShowMenuAction {
         // Following
         if isLoggedIn {
             let buttonTitle = post.isFollowing ? ReaderPostMenuButtonTitles.unfollow : ReaderPostMenuButtonTitles.follow
+
             alertController.addActionWithTitle(buttonTitle,
                                                style: .default,
                                                handler: { (action: UIAlertAction) in
                                                 if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
                                                     ReaderFollowAction().execute(with: post,
                                                                                  context: context,
-                                                                                 completion: {
-                                                                                    ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: true)
+                                                                                 completion: { follow in
+                                                                                    ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: true)
                                                                                     (vc as? ReaderStreamViewController)?.updateStreamHeaderIfNeeded()
-                                                                                 }, failure: { _ in
-                                                                                    ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, success: false)
+                                                                                 }, failure: { follow, _ in
+                                                                                    ReaderHelpers.dispatchToggleFollowSiteMessage(post: post, follow: follow, success: false)
                                                                                  })
                                                 }
                                                })

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -130,7 +130,11 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     // MARK: - Actions
 
     @IBAction func didTapFollowButton(_ sender: UIButton) {
-        delegate?.handleFollowActionForHeader(self)
+        followButton.isUserInteractionEnabled = false
+
+        delegate?.handleFollowActionForHeader(self) { [weak self] in
+            self?.followButton.isUserInteractionEnabled = true
+        }
     }
 
     // MARK: - Private: Helpers

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamHeader.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public protocol ReaderStreamHeaderDelegate: NSObjectProtocol {
-    func handleFollowActionForHeader(_ header: ReaderStreamHeader)
+    func handleFollowActionForHeader(_ header: ReaderStreamHeader, completion: @escaping () -> Void)
 }
 
 public protocol ReaderStreamHeader: NSObjectProtocol {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1281,11 +1281,11 @@ import WordPressFlux
         }
 
         let service = ReaderTopicService(managedObjectContext: topic.managedObjectContext!)
-        service.toggleFollowing(forSite: topic, success: {
-            ReaderHelpers.dispatchToggleFollowSiteMessage(topic: topic, success: true)
+        service.toggleFollowing(forSite: topic, success: { follow in
+            ReaderHelpers.dispatchToggleFollowSiteMessage(site: topic, follow: follow, success: true)
             completion?(true)
-        }, failure: { (error: Error?) in
-            ReaderHelpers.dispatchToggleFollowSiteMessage(topic: topic, success: false)
+        }, failure: { (follow, error) in
+            ReaderHelpers.dispatchToggleFollowSiteMessage(site: topic, follow: follow, success: false)
             completion?(false)
         })
     }
@@ -1296,13 +1296,14 @@ import WordPressFlux
 
 extension ReaderStreamViewController: ReaderStreamHeaderDelegate {
 
-    func handleFollowActionForHeader(_ header: ReaderStreamHeader) {
+    func handleFollowActionForHeader(_ header: ReaderStreamHeader, completion: @escaping () -> Void) {
         toggleFollowingForTopic(readerTopic) { [weak self] success in
             if success {
                 self?.syncHelper?.syncContent()
             }
 
             self?.updateStreamHeaderIfNeeded()
+            completion()
         }
 
         updateStreamHeaderIfNeeded()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -53,6 +53,10 @@ import WordPressShared
     // MARK: - Actions
 
     @IBAction func didTapFollowButton(_ sender: UIButton) {
-        delegate?.handleFollowActionForHeader(self)
+        followButton.isUserInteractionEnabled = false
+
+        delegate?.handleFollowActionForHeader(self, completion: { [weak self] in
+            self?.followButton.isUserInteractionEnabled = true
+        })
     }
 }


### PR DESCRIPTION
Like the titles says, it cherry-picks @diegoreymendez excellent work from #16819, which has already been reviewed and approved by @aerych, into the 17.7 release branch.

**Why?** The issue with the refresh button has been identified as a regression in 17.7 and it seemed appropriate to address it ASAP. It would have been different if it had been a long standing issue. The bug itself seemed important enough to grant this last minute addition to the release branch. Finally, it was possible to cherry-pick the changes cleanly (`git cherry-pick -n -m1 e8fe22c`, with `-n` to not commit immediately and give me a chance to discard the release notes change). cc @startuptester.

If you look at this diff side by side with #16819, you'll see that, other than for the `RELEASE-NOTES.txt` change which would be inappropriate in this branch, they are exactly the same. That should come as no surprise given the clean cherry-pick mentioned above, but is worth pointing out because it means there's no need to code review as it's been already done in the parent PR, and it's only necessary to manually verify the fix apply here too (I've done that, of course, but can always do with an extra set of eyes).

Following are the testing instructions and regression notes copied from #16819. P.S. You'll need the Network Link Conditioner. If, like me, you forgot how to set it up, [these instructions](https://medium.com/macoclock/how-to-simulate-poor-network-conditions-on-ios-simulator-and-iphone-faf35f0da1b5) will be helpful.

## To test:

### Notifications Tab:

1. Go going into a comment notification, and tapping on top until you get to the post.
2. Then tap the follow site button, on or many times.
3. The button should not work until the result of the previous tap is processed.

### Reader Tab:

1. Go to Reader > Top Right Gear Icon > Followed Sites > Select a site to go into the detail for it.
2. Then tap the follow site button, on or many times.
3. The button should not work until the result of the previous tap is processed.

## Regression Notes

1. Potential unintended areas of impact

Any location where there's a follow button.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I've tested manually extensively. [Me too, I even ended up unfollowing a site directly from the reader screen and now I don't remember which one it is and I'm very sad about it –@mokagio]

3. What automated tests I added (or what prevented me from doing so)

None, as I don't believe this is something that can be tested automatically.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.