### PR TITLE
Try/fix notices lock issue

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersActions.swift
@@ -11,7 +11,6 @@ extension BloggingRemindersActions {
                  tracker: BloggingRemindersTracker) {
 
         tracker.buttonPressed(button: button, screen: screen)
-        NoticesDispatch.unlock()
         dismiss(animated: true, completion: nil)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
@@ -22,7 +22,10 @@ class BloggingRemindersFlow {
         let flowStartViewController = makeStartViewController(for: blog, tracker: tracker, source: source)
         let navigationController = BloggingRemindersNavigationController(
             rootViewController: flowStartViewController,
-            onDismiss: onDismiss)
+            onDismiss: {
+                NoticesDispatch.unlock()
+                onDismiss?()
+            })
 
         let bottomSheet = BottomSheetViewController(childViewController: navigationController,
                                                     customHeaderSpacing: 0)


### PR DESCRIPTION
Fixes an issue we were seeing where notices would sometimes stop showing after publishing a post.

## Reproduce original issue:

For reproducing the original issue either make sure you use 17.7.0.3 or earlier 17.x, or if  you want to set breakpoints in the code, use `release/17.7` before this PR is merged.

[Optional] Place a breakpoint here:

https://github.com/wordpress-mobile/WordPress-iOS/blob/19dc1f2a495e6b32e6612323a061b6c8595dd87b/WordPress/Classes/ViewRelated/Blog/Blogging%20Reminders/BloggingRemindersFlow.swift#L30

[Optional] Place a breakpoint here (optional):

https://github.com/wordpress-mobile/WordPress-iOS/blob/19dc1f2a495e6b32e6612323a061b6c8595dd87b/WordPress/Classes/ViewRelated/Blog/Blogging%20Reminders/BloggingRemindersActions.swift#L14

1. Go into My Site and select a site where you have never seen the blogging reminders prompt. (alternatively you can uninstall / install the app from scratch)
2. Publish a post.
3. When blogging reminders comes up (first breakpoint hit), dismiss it by tapping outside of the blogging reminders sheet (this step is important because if you dismiss by tapping X, you won't be able to reproduce the issue).
4. After dismissing the blogging reminders sheet you will not see the publish success / failure toast notice.  Also the second breakpoint should never hit, unless you tapped on the X dismiss button.

## To test:

Repeat the reproduction steps in this branch.  You will see the notice should come up regardless of how you dismiss the blogging reminders sheet.

## Regression Notes

1. Potential unintended areas of impact

None.  This is really an atomic and riskless (IMO) change.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
