### PR TITLE
Fix html tag

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -373,7 +373,11 @@ FeaturedImageViewControllerDelegate>
     [self.tableView reloadData];
 }
 
-
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
+{
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self reloadData];
+}
 #pragma mark - TextField Delegate Methods
 
 - (BOOL)textFieldShouldEndEditing:(UITextField *)textField
@@ -702,6 +706,7 @@ FeaturedImageViewControllerDelegate>
     textCell.textField.placeholder = NSLocalizedString(@"Enter a password", @"");
     textCell.textField.clearButtonMode = UITextFieldViewModeWhileEditing;
     textCell.textField.secureTextEntry = YES;
+    textCell.textField.textColor = self.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark ? UIColor.whiteColor : UIColor.blackColor;
     
     textCell.tag = PostSettingsRowPassword;
     

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -127,7 +127,7 @@ class ReaderTopicCollectionViewCoordinator: NSObject {
         ReaderInterestsStyleGuide.applyCompactCellLabelStyle(label: cell.label)
 
         cell.layer.cornerRadius = Constants.cellCornerRadius
-        cell.label.text = title
+        cell.label.text = NSAttributedString.attributedStringWithHTML(title, attributes: nil).string
         cell.label.accessibilityHint = Strings.accessbilityHint
         cell.label.accessibilityTraits = .button
     }


### PR DESCRIPTION
The ReaderInterestsCollectionViewCell was rendering the tag as plain text. This created problems when certain tags had HTML characters.

Now the tag name is first transformed into an attributed string with HTML. After, it is transformed into a string again, so the design (font, text color) is not impacted.

An attempt to fix: [wordpress-mobile#14913](https://github.com/wordpress-mobile/WordPress-iOS/issues/14913)
Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
