### PR TITLE
Update the glotpress validator reference to ECR

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,7 +40,7 @@ steps:
     command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
     plugins:
       - docker#v3.8.0:
-          image: "jkmassel/glotpress-linter:latest"
+          image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
     agents:
       queue: "default"
 


### PR DESCRIPTION
Moves the `glotpress-validator` reference from Docker to ECR.

To test:
- Ensure that the "Lint Translations" check passes

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
