### PR TITLE
[Gallery Refactor] Analytics

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -894,13 +894,13 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 
     func gutenbergDidMount(unsupportedBlockNames: [String]) {
         if !editorSession.started {
-            let galleryRefactor = gutenbergEditorSettings()?.galleryRefactor
+            let galleryWithImageBlocks = gutenbergEditorSettings()?.galleryWithImageBlocks
 
             // Note that this method is also used to track startup performance
             // It assumes this is being called when the editor has finished loading
             // If you need to refactor this, please ensure that the startup_time_ms property
             // is still reflecting the actual startup time of the editor
-            editorSession.start(unsupportedBlocks: unsupportedBlockNames, canViewEditorOnboarding: canViewEditorOnboarding(), galleryRefactor: galleryRefactor)
+            editorSession.start(unsupportedBlocks: unsupportedBlockNames, canViewEditorOnboarding: canViewEditorOnboarding(), galleryWithImageBlocks: galleryWithImageBlocks)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -894,11 +894,13 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 
     func gutenbergDidMount(unsupportedBlockNames: [String]) {
         if !editorSession.started {
+            let galleryRefactor = gutenbergEditorSettings()?.galleryRefactor
+
             // Note that this method is also used to track startup performance
             // It assumes this is being called when the editor has finished loading
             // If you need to refactor this, please ensure that the startup_time_ms property
             // is still reflecting the actual startup time of the editor
-            editorSession.start(unsupportedBlocks: unsupportedBlockNames, canViewEditorOnboarding: canViewEditorOnboarding())
+            editorSession.start(unsupportedBlocks: unsupportedBlockNames, canViewEditorOnboarding: canViewEditorOnboarding(), galleryRefactor: galleryRefactor)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -18,17 +18,17 @@ struct PostEditorAnalyticsSession {
         contentType = ContentType(post: post).rawValue
     }
 
-    mutating func start(unsupportedBlocks: [String] = [], canViewEditorOnboarding: Bool = false) {
+    mutating func start(unsupportedBlocks: [String] = [], canViewEditorOnboarding: Bool = false, galleryRefactor: Bool? = nil) {
         assert(!started, "An editor session was attempted to start more than once")
         hasUnsupportedBlocks = !unsupportedBlocks.isEmpty
 
-        let properties = startEventProperties(with: unsupportedBlocks, canViewEditorOnboarding: canViewEditorOnboarding)
+        let properties = startEventProperties(with: unsupportedBlocks, canViewEditorOnboarding: canViewEditorOnboarding, galleryRefactor: galleryRefactor)
 
         WPAppAnalytics.track(.editorSessionStart, withProperties: properties)
         started = true
     }
 
-    private func startEventProperties(with unsupportedBlocks: [String], canViewEditorOnboarding: Bool) -> [String: Any] {
+    private func startEventProperties(with unsupportedBlocks: [String], canViewEditorOnboarding: Bool, galleryRefactor: Bool?) -> [String: Any] {
         // On Android, we are tracking this in milliseconds, which seems like a good enough time scale
         // Let's make sure to round the value and send an integer for consistency
         let startupTimeNanoseconds = DispatchTime.now().uptimeNanoseconds - startTime
@@ -42,6 +42,12 @@ struct PostEditorAnalyticsSession {
         }
 
         properties[Property.canViewEditorOnboarding] = canViewEditorOnboarding
+
+        if let galleryRefactor = galleryRefactor {
+            properties[Property.experimentalGalleryRefactor] = "\(galleryRefactor)"
+        } else {
+            properties[Property.experimentalGalleryRefactor] = "unknown"
+        }
 
         return properties.merging(commonProperties, uniquingKeysWith: { $1 })
     }
@@ -87,6 +93,7 @@ private extension PostEditorAnalyticsSession {
         static let template = "template"
         static let startupTime = "startup_time_ms"
         static let canViewEditorOnboarding = "can_view_editor_onboarding"
+        static let experimentalGalleryRefactor = "experimentalGalleryRefactor"
     }
 
     var commonProperties: [String: String] {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -18,17 +18,17 @@ struct PostEditorAnalyticsSession {
         contentType = ContentType(post: post).rawValue
     }
 
-    mutating func start(unsupportedBlocks: [String] = [], canViewEditorOnboarding: Bool = false, galleryRefactor: Bool? = nil) {
+    mutating func start(unsupportedBlocks: [String] = [], canViewEditorOnboarding: Bool = false, galleryWithImageBlocks: Bool? = nil) {
         assert(!started, "An editor session was attempted to start more than once")
         hasUnsupportedBlocks = !unsupportedBlocks.isEmpty
 
-        let properties = startEventProperties(with: unsupportedBlocks, canViewEditorOnboarding: canViewEditorOnboarding, galleryRefactor: galleryRefactor)
+        let properties = startEventProperties(with: unsupportedBlocks, canViewEditorOnboarding: canViewEditorOnboarding, galleryWithImageBlocks: galleryWithImageBlocks)
 
         WPAppAnalytics.track(.editorSessionStart, withProperties: properties)
         started = true
     }
 
-    private func startEventProperties(with unsupportedBlocks: [String], canViewEditorOnboarding: Bool, galleryRefactor: Bool?) -> [String: Any] {
+    private func startEventProperties(with unsupportedBlocks: [String], canViewEditorOnboarding: Bool, galleryWithImageBlocks: Bool?) -> [String: Any] {
         // On Android, we are tracking this in milliseconds, which seems like a good enough time scale
         // Let's make sure to round the value and send an integer for consistency
         let startupTimeNanoseconds = DispatchTime.now().uptimeNanoseconds - startTime
@@ -43,10 +43,10 @@ struct PostEditorAnalyticsSession {
 
         properties[Property.canViewEditorOnboarding] = canViewEditorOnboarding
 
-        if let galleryRefactor = galleryRefactor {
-            properties[Property.experimentalGalleryRefactor] = "\(galleryRefactor)"
+        if let galleryWithImageBlocks = galleryWithImageBlocks {
+            properties[Property.unstableGalleryWithImageBlocks] = "\(galleryWithImageBlocks)"
         } else {
-            properties[Property.experimentalGalleryRefactor] = "unknown"
+            properties[Property.unstableGalleryWithImageBlocks] = "unknown"
         }
 
         return properties.merging(commonProperties, uniquingKeysWith: { $1 })
@@ -93,7 +93,7 @@ private extension PostEditorAnalyticsSession {
         static let template = "template"
         static let startupTime = "startup_time_ms"
         static let canViewEditorOnboarding = "can_view_editor_onboarding"
-        static let experimentalGalleryRefactor = "experimentalGalleryRefactor"
+        static let unstableGalleryWithImageBlocks = "unstableGalleryWithImageBlocks"
     }
 
     var commonProperties: [String: String] {


### PR DESCRIPTION
## Description

This adds the results of the `unstableGalleryWithImageBlocks` setting to the `editor_session_start` event so that we can monitor how many of our users have migrated to the new gallery refactor over time.

This builds off of https://github.com/wordpress-mobile/WordPress-iOS/pull/16832

## To test:
### Setup
1. A site running Gutenberg generated from https://github.com/WordPress/gutenberg/pull/33314. You can use wp-env start or generate a new bundle.
2. On your site enable the Gallery Refactor by going to Gutenberg > Experminents > Check "Gallery Refactor"

### Enable Gallery Refactor
1. Navigate to the Editor 
2. Expect to see the event `editor_session_start` contain the property `unstableGalleryWithImageBlocks` with the value `true`

### Disable Gallery Refactor
1. Navigate to the Editor 
2. Expect to see the event `editor_session_start` contain the property `unstableGalleryWithImageBlocks` with the value `false`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
