### PR TITLE
Fix: always shows Stats for sites hosted in WP.com

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -620,7 +620,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 - (BOOL)isStatsActive
 {
-    return [self jetpackStatsModuleEnabled];
+    return [self jetpackStatsModuleEnabled] || [self isHostedAtWPcom];
 }
 
 - (BOOL)supportsPushNotifications

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -79,6 +79,22 @@ final class BlogBuilder {
         return self
     }
 
+    func isHostedAtWPcom() -> Self {
+        blog.isHostedAtWPcom = true
+
+        return self
+    }
+
+    func isNotHostedAtWPcom() -> Self {
+        blog.isHostedAtWPcom = false
+
+        return self
+    }
+
+    func with(modules: [String]) -> Self {
+        set(blogOption: "active_modules", value: modules)
+    }
+
     func build() -> Blog {
         return blog
     }

--- a/WordPress/WordPressTest/BlogTests.swift
+++ b/WordPress/WordPressTest/BlogTests.swift
@@ -135,4 +135,31 @@ final class BlogTests: XCTestCase {
 
         XCTAssertFalse(blog.supports(.pluginManagement))
     }
+
+    func testStatsActiveForSitesHostedAtWPCom() {
+        let blog = BlogBuilder(context)
+            .isHostedAtWPcom()
+            .with(modules: [""])
+            .build()
+
+        XCTAssertTrue(blog.isStatsActive())
+    }
+
+    func testStatsActiveForSitesNotHotedAtWPCom() {
+        let blog = BlogBuilder(context)
+            .isNotHostedAtWPcom()
+            .with(modules: ["stats"])
+            .build()
+
+        XCTAssertTrue(blog.isStatsActive())
+    }
+
+    func testStatsNotActiveForSitesNotHotedAtWPCom() {
+        let blog = BlogBuilder(context)
+            .isNotHostedAtWPcom()
+            .with(modules: [""])
+            .build()
+
+        XCTAssertFalse(blog.isStatsActive())
+    }
 }


### PR DESCRIPTION
In https://github.com/wordpress-mobile/WordPress-iOS/pull/16822 we introduced a check to show or not show Stats based on a response. This caused a regression in which sites hosted on WP.com **never** show Stats.

In order to fix it, I changed this logic and added unit tests to cover the multiple possibilities.

### To test

I recommend having `17.7` and comparing sites with `17.8`:

1. Test that for WP.com and P2 sites stats are always visible
2. Turn off Stats for an Atomic site and check that Stats is not visible, but the user might enable it
3. Turn off Stats for sites hosted outside WP.com and check that Stats is not visible, but the user is able to enable it


## Regression Notes
1. Potential unintended areas of impact
Stats for all sites.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested in all kinds of WordPress sites and added unit tests to cover the logic added in this PR.

3. What automated tests I added (or what prevented me from doing so)
Stated above.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Thanks so much, @ScoutHarris for spotting that!