### PR TITLE
Add translation progress check for release notes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -265,10 +265,24 @@ platform :ios do
   lane :finalize_release do |options|
     ios_finalize_prechecks(options)
     unless ios_current_branch_is_hotfix
+      UI.message('Checking app strings translation status...')
       check_translation_progress(
         glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/dev/',
         abort_on_violations: false
       )
+
+      UI.message("Checking WordPress release notes strings translation status...")
+      check_translation_progress(
+        glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/release-notes/',
+        abort_on_violations: false
+      )
+
+      UI.message("Checking Jetpack release notes strings translation status...")
+      check_translation_progress(
+        glotpress_url: 'https://translate.wordpress.com/projects/jetpack/apps/ios/release-notes/',
+        abort_on_violations: false
+      )
+
       download_localized_strings_and_metadata(options)
       # ios_lint_localizations(input_dir: 'WordPress/Resources', allow_retry: true)
       ios_bump_version_beta


### PR DESCRIPTION
Following up to @AliSoftware's suggestion in related PRs on other apps, this PR implements checking the translation progress of the release notes.

Since the change is small and I can't think about any downside or unintended impact, but it can be useful during the release finalization, I'm targeting the release branch with this PR. 

Please, let me know if you think that targeting `develop` is better.  

## Regression Notes
1. Potential unintended areas of impact
None that I can think of. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
 -

3. What automated tests I added (or what prevented me from doing so)
 -
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
