### PR TITLE
Blogging Reminders is available for any user that can edit a post.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -194,7 +194,7 @@ extension SiteSettingsViewController {
             rows.append(.timezone)
         }
 
-        if Feature.enabled(.bloggingReminders) {
+        if Feature.enabled(.bloggingReminders) && blog.isUserCapableOf(.EditPosts) {
             rows.append(.bloggingReminders)
         }
 
@@ -232,27 +232,16 @@ extension SiteSettingsViewController {
 
     @objc
     func tableView(_ tableView: UITableView, didSelectInGeneralSettingsAt indexPath: IndexPath) {
-        guard blog.isAdmin else {
-            // For context about these lines of code, this was the result of a migration from ObjC to Swift.
-            // It's not entirely clear to me why we are showing these options to a non admin, and then bailing
-            // out when the user selects these options.  I'm pretty sure we need to review this, but it's beyond
-            // the scope of my current work, and I don't want to go down the rabbit hole.  For these reasons I'm
-            // maintaining the original logic in my migration.
-            //
-            // - diegoreymendez
-            return
-        }
-
         switch generalSettingsRows[indexPath.row] {
-        case .title:
+        case .title where blog.isAdmin:
             showEditSiteTitleController(indexPath: indexPath)
-        case .tagline:
+        case .tagline where blog.isAdmin:
             showEditSiteTaglineController(indexPath: indexPath)
-        case .privacy:
+        case .privacy where blog.isAdmin:
             showPrivacySelector()
-        case .language:
+        case .language where blog.isAdmin:
             showLanguageSelector(for: blog)
-        case .timezone:
+        case .timezone where blog.isAdmin:
             showTimezoneSelector()
         case .bloggingReminders:
             presentBloggingRemindersFlow(indexPath: indexPath)


### PR DESCRIPTION
Fixes a bug where only site admins could enable blogging reminders.

Blogging Reminders is abailable for any user that can edit a post.

## To test:

1. Launch the app with a user that has post-edit capabilities in a testing blog (Admin, Editor, Author, Contributor).
2. Go to site settings for that blog.
3. Make sure blogging reminders is visible and can be configured.

Once you change your role to one that's not allowed to edit posts, the site will no longer be selectable in the site picker, so we can't really test that the Blogging Reminders row is hidden - but if this changed for any reason in the future, the row will be hidden if the user didn't have post-editing capabilities.  You can briefly check this with these steps (a bit hackish):

1. Keep the blog selected in WPiOS
2. Go to the web admin for the site, and make your user become Subscriber, Shop manager or Customer.
3. Go back to WPiOS, tap on site settings (blogging reminders will still be there since it didn't refresh).
4. Pull down to refresh.
5. Tap back.
6. Go back into Site Settings and Blogging Reminders should be gone.

## Regression Notes

1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
