### PR TITLE
Implement List component for Comments

### DIFF
--- a/WordPress/Classes/Extensions/Comment+Interface.swift
+++ b/WordPress/Classes/Extensions/Comment+Interface.swift
@@ -1,0 +1,75 @@
+/// Allows comment objects to be sectioned by relative date.
+///
+/// This implementation is copied from Notification+Interface.swift. It pains me having to copy paste code,
+/// but we should be able clean this up once `Comment` and the view controller displaying it is rewritten in Swift.
+/// i.e.: Introduce a protocol with default implementation. Protocol extension doesn't work with @objc!
+///
+extension Comment {
+    /// Returns a Section Identifier that can be sorted. Note that this string is not human
+    /// readable, and you should use the *descriptionForSectionIdentifier* method
+    /// as well!
+    ///
+    @objc func relativeDateSectionIdentifier() -> String {
+        // Normalize Dates: Time must not be considered. Just the raw dates
+        let fromDate = dateCreated.normalizedDate()
+        let toDate = Date().normalizedDate()
+
+        // Analyze the Delta-Components
+        let calendar = Calendar.current
+        let components = [.day, .weekOfYear, .month] as Set<Calendar.Component>
+        let dateComponents = calendar.dateComponents(components, from: fromDate, to: toDate)
+        let identifier: Sections
+
+        // Months
+        if let month = dateComponents.month, month >= 1 {
+            identifier = .Months
+        // Weeks
+        } else if let week = dateComponents.weekOfYear, week >= 1 {
+            identifier = .Weeks
+        // Days
+        } else if let day = dateComponents.day, day > 1 {
+            identifier = .Days
+        } else if let day = dateComponents.day, day == 1 {
+            identifier = .Yesterday
+        } else {
+            identifier = .Today
+        }
+
+        return identifier.rawValue
+    }
+
+    /// Translates a relative date section identifier into a human-readable string.
+    ///
+    @objc static func descriptionForSectionIdentifier(_ identifier: String) -> String {
+        guard let section = Sections(rawValue: identifier) else {
+            return String()
+        }
+
+        return section.description
+    }
+
+    // MARK: - Private Helpers
+
+    private enum Sections: String {
+        case Months     = "0"
+        case Weeks      = "2"
+        case Days       = "4"
+        case Yesterday  = "5"
+        case Today      = "6"
+
+        var description: String {
+            switch self {
+            case .Months:
+                return NSLocalizedString("Older than a Month", comment: "Comments Months Section Header")
+            case .Weeks:
+                return NSLocalizedString("Older than a Week", comment: "Comments Weeks Section Header")
+            case .Days:
+                return NSLocalizedString("Older than 2 days", comment: "Comments +2 Days Section Header")
+            case .Yesterday:
+                return NSLocalizedString("Yesterday", comment: "Comments Yesterday Section Header")
+            case .Today:
+                return NSLocalizedString("Today", comment: "Comments Today Section Header")
+            }
+        }
+    }
+}

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -21,6 +21,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case siteIconCreator
     case globalStyleSettings
     case editorOnboardingHelpMenu
+    case unifiedCommentsAndNotificationsList
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -66,6 +67,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .globalStyleSettings:
             return false
         case .editorOnboardingHelpMenu:
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+        case .unifiedCommentsAndNotificationsList:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         }
     }
@@ -131,6 +134,8 @@ extension FeatureFlag {
             return "Global Style Settings"
         case .editorOnboardingHelpMenu:
             return "Editor Onboarding Help Menu"
+        case .unifiedCommentsAndNotificationsList:
+            return "Unified List for Comments and Notifications"
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -69,7 +69,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .editorOnboardingHelpMenu:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .unifiedCommentsAndNotificationsList:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return false
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -178,10 +178,16 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
         return nil;
     }
 
+    // fetch the section information
+    id<NSFetchedResultsSectionInfo> sectionInfo = [self.tableViewHandler.resultsController.sections objectAtIndex:section];
+    if (!sectionInfo) {
+        return nil;
+    }
+
     ListTableHeaderView *headerView = (ListTableHeaderView *)[self.tableView dequeueReusableHeaderFooterViewWithIdentifier:ListTableHeaderView.reuseIdentifier];
+
     if (headerView) {
-        // TODO: Enable relative date section identifier for Comment objects.
-        headerView.title = @"Section Header";
+        headerView.title = [Comment descriptionForSectionIdentifier:sectionInfo.name];
     }
 
     return headerView;
@@ -397,7 +403,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
 - (NSString *)sectionNameKeyPath
 {
-    return @"sectionIdentifier";
+    return [self usesUnifiedList] ? @"relativeDateSectionIdentifier" : @"sectionIdentifier";
 }
 
 #pragma mark - Predicate Wrangling

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -131,18 +131,20 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 {
     self.tableView.accessibilityIdentifier  = @"Comments Table";
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
-    
-    // Register the cells
-    NSString *nibName = [CommentsTableViewCell classNameWithoutNamespaces];
-    UINib *nibInstance = [UINib nibWithNibName:nibName bundle:[NSBundle mainBundle]];
-    [self.tableView registerNib:nibInstance forCellReuseIdentifier:CommentsTableViewCell.reuseIdentifier];
 
-    // Register unified list components
-    UINib *listCellNibInstance = [UINib nibWithNibName:[ListTableViewCell classNameWithoutNamespaces] bundle:[NSBundle mainBundle]];
-    [self.tableView registerNib:listCellNibInstance forCellReuseIdentifier:ListTableViewCell.reuseIdentifier];
+    if ([self usesUnifiedList]) {
+        // Register unified list components
+        UINib *listCellNibInstance = [UINib nibWithNibName:[ListTableViewCell classNameWithoutNamespaces] bundle:[NSBundle mainBundle]];
+        [self.tableView registerNib:listCellNibInstance forCellReuseIdentifier:ListTableViewCell.reuseIdentifier];
 
-    UINib *listHeaderNibInstance = [UINib nibWithNibName:[ListTableHeaderView classNameWithoutNamespaces] bundle:[NSBundle mainBundle]];
-    [self.tableView registerNib:listHeaderNibInstance forHeaderFooterViewReuseIdentifier:ListTableHeaderView.reuseIdentifier];
+        UINib *listHeaderNibInstance = [UINib nibWithNibName:[ListTableHeaderView classNameWithoutNamespaces] bundle:[NSBundle mainBundle]];
+        [self.tableView registerNib:listHeaderNibInstance forHeaderFooterViewReuseIdentifier:ListTableHeaderView.reuseIdentifier];
+    } else {
+        // Register the cells
+        NSString *nibName = [CommentsTableViewCell classNameWithoutNamespaces];
+        UINib *nibInstance = [UINib nibWithNibName:nibName bundle:[NSBundle mainBundle]];
+        [self.tableView registerNib:nibInstance forCellReuseIdentifier:CommentsTableViewCell.reuseIdentifier];
+    }
 }
 
 - (void)configureTableViewFooter

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -188,11 +188,11 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     }
 
     ListTableHeaderView *headerView = (ListTableHeaderView *)[self.tableView dequeueReusableHeaderFooterViewWithIdentifier:ListTableHeaderView.reuseIdentifier];
-
-    if (headerView) {
-        headerView.title = [Comment descriptionForSectionIdentifier:sectionInfo.name];
+    if (!headerView) {
+        headerView = [[ListTableHeaderView alloc] initWithReuseIdentifier:ListTableHeaderView.reuseIdentifier];
     }
 
+    headerView.title = [Comment descriptionForSectionIdentifier:sectionInfo.name];
     return headerView;
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -165,7 +165,8 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     return [self.tableViewHandler tableView:tableView numberOfRowsInSection:section];
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section {
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
     // if the unified list feature is enabled, return the estimated height of the new table header view.
     // otherwise, returning -1 will revert to the default estimated height value.
     return [self usesUnifiedList] ? ListTableHeaderView.estimatedRowHeight : -1;

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -148,7 +148,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 - (void)configureTableViewFooter
 {
     // Hide the cellSeparators when the table is empty
-    self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];
+    self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.tableView.frame.size.width, 1)];
 }
 
 - (void)configureTableViewHandler

--- a/WordPress/Classes/ViewRelated/Comments/ListTableViewCell+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ListTableViewCell+Comments.swift
@@ -2,7 +2,7 @@
 ///
 extension ListTableViewCell {
     /// Configures the cell based on the provided `Comment` object.
-    @objc func configure(with comment: Comment) {
+    @objc func configureWithComment(_ comment: Comment) {
         // indicator view
         indicatorColor = Style.pendingIndicatorColor
         showsIndicator = (comment.status == CommentStatusPending)

--- a/WordPress/Classes/ViewRelated/Comments/ListTableViewCell+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ListTableViewCell+Comments.swift
@@ -8,9 +8,12 @@ extension ListTableViewCell {
         showsIndicator = (comment.status == CommentStatusPending)
 
         // avatar image
-        // TODO: Circle back to download avatar from Gravatar email.
         placeholderImage = Style.gravatarPlaceholderImage
-        imageURL = comment.avatarURLForDisplay()
+        if let avatarURL = comment.avatarURLForDisplay() {
+            configureImage(with: avatarURL)
+        } else {
+            configureImageWithGravatarEmail(comment.gravatarEmailForDisplay())
+        }
 
         // title text
         let authorString = comment.authorForDisplay() ?? String()

--- a/WordPress/Classes/ViewRelated/Comments/ListTableViewCell+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ListTableViewCell+Comments.swift
@@ -1,0 +1,56 @@
+/// Encapsulates logic that configures `ListTableViewCell` with `Comment` models.
+///
+extension ListTableViewCell {
+    /// Configures the cell based on the provided `Comment` object.
+    @objc func configure(with comment: Comment) {
+        // indicator view
+        indicatorColor = Style.pendingIndicatorColor
+        showsIndicator = (comment.status == CommentStatusPending)
+
+        // avatar image
+        // TODO: Circle back to download avatar from Gravatar email.
+        placeholderImage = Style.gravatarPlaceholderImage
+        imageURL = comment.avatarURLForDisplay()
+
+        // title text
+        let authorString = comment.authorForDisplay() ?? String()
+        let postTitleString = comment.titleForDisplay() ?? Constants.noTitleString
+        attributedTitleText = attributedTitle(for: authorString, postTitle: postTitleString)
+
+        // snippet text
+        snippetText = comment.contentPreviewForDisplay() ?? String()
+    }
+
+    // MARK: Private Helpers
+
+    private func attributedTitle(for author: String, postTitle: String) -> NSAttributedString {
+        let replacementMap = [
+            "%1$@": NSAttributedString(string: author, attributes: ListStyle.titleBoldAttributes),
+            "%2$@": NSAttributedString(string: postTitle, attributes: ListStyle.titleBoldAttributes)
+        ]
+
+        // Replace Author + Title
+        let attributedTitle = NSMutableAttributedString(string: Constants.titleFormatString, attributes: ListStyle.titleRegularAttributes)
+
+        for (key, attributedString) in replacementMap {
+            let range = (attributedTitle.string as NSString).range(of: key)
+            if range.location != NSNotFound {
+                attributedTitle.replaceCharacters(in: range, with: attributedString)
+            }
+        }
+
+        return attributedTitle
+    }
+}
+
+// MARK: - Constants
+
+private extension ListTableViewCell {
+    typealias Style = WPStyleGuide.Comments
+    typealias ListStyle = WPStyleGuide.List
+
+    struct Constants {
+        static let noTitleString = NSLocalizedString("(No Title)", comment: "Empty Post Title")
+        static let titleFormatString = NSLocalizedString("%1$@ on %2$@", comment: "Label displaying the author and post title for a Comment. %1$@ is a placeholder for the author. %2$@ is a placeholder for the post title.")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
@@ -12,6 +12,9 @@ class ListTableHeaderView: UITableViewHeaderFooterView, NibReusable {
 
     // MARK: Properties
 
+    @objc static let reuseIdentifier = defaultReuseID
+    @objc static let estimatedRowHeight = 26
+
     @objc var title: String? {
         get {
             titleLabel.text

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
@@ -37,7 +37,14 @@ class ListTableHeaderView: UITableViewHeaderFooterView, NibReusable {
         // NSFetchedResultsController. By default, the results controller assigns the
         // value of sectionNameKeyPath to UITableHeaderFooterView's textLabel.
         textLabel?.isHidden = true
-        contentView.backgroundColor = Style.sectionHeaderBackgroundColor
+
+        // Set background color.
+        // Note that we need to set it through `backgroundView`, or Xcode will lash out a warning.
+        backgroundView = {
+            let view = UIView(frame: self.bounds)
+            view.backgroundColor = Style.sectionHeaderBackgroundColor
+            return view
+        }()
 
         // configure title label
         titleLabel.font = Style.sectionHeaderFont

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
@@ -50,7 +50,7 @@ class ListTableHeaderView: UITableViewHeaderFooterView, NibReusable {
         titleLabel.font = Style.sectionHeaderFont
         titleLabel.textColor = Style.sectionHeaderTitleColor
 
-        // configure separators/ view
+        // configure separators view
         separatorsView.bottomColor = Style.separatorColor
         separatorsView.bottomVisible = true
     }

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
@@ -12,7 +12,10 @@ class ListTableHeaderView: UITableViewHeaderFooterView, NibReusable {
 
     // MARK: Properties
 
+    /// Added to provide objc support, since NibReusable protocol methods aren't accessible from objc.
+    /// This should be removed when the caller is rewritten in Swift.
     @objc static let reuseIdentifier = defaultReuseID
+
     @objc static let estimatedRowHeight = 26
 
     @objc var title: String? {

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.xib
@@ -24,7 +24,6 @@
                             <nil key="highlightedColor"/>
                         </label>
                     </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="trailingMargin" secondItem="p0E-c7-EOt" secondAttribute="trailing" id="8Wn-G0-G5I"/>
                         <constraint firstAttribute="bottom" secondItem="p0E-c7-EOt" secondAttribute="bottom" constant="4" id="crp-IW-IaU"/>
@@ -34,7 +33,6 @@
                 </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="Yi2-pb-R3P"/>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="dbR-00-lyK" secondAttribute="trailing" id="Jqb-jy-Hi5"/>
                 <constraint firstItem="dbR-00-lyK" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="Lmd-8D-GOe"/>

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -14,7 +14,10 @@ class ListTableViewCell: UITableViewCell, NibReusable {
 
     // MARK: Properties
 
+    /// Added to provide objc support, since NibReusable protocol methods aren't accessible from objc.
+    /// This should be removed when the caller is rewritten in Swift.
     @objc static let reuseIdentifier = defaultReuseID
+
     @objc static let estimatedRowHeight = 68
 
     /// The color of the indicator circle.

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -85,9 +85,9 @@ private extension ListTableViewCell {
         // indicator view
         indicatorView.layer.cornerRadius = indicatorWidthConstraint.constant / 2
 
-        // TODO: temporary styling. will update this in later PRs.
-        titleLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
-        titleLabel.textColor = UIColor.text
+        // title label
+        titleLabel.font = Style.plainTitleFont
+        titleLabel.textColor = Style.titleTextColor
         titleLabel.numberOfLines = Constants.titleNumberOfLinesWithSnippet
 
         // snippet label

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -14,6 +14,9 @@ class ListTableViewCell: UITableViewCell, NibReusable {
 
     // MARK: Properties
 
+    @objc static let reuseIdentifier = defaultReuseID
+    @objc static let estimatedRowHeight = 68
+
     /// The color of the indicator circle.
     @objc var indicatorColor: UIColor = .clear {
         didSet {

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -31,16 +31,6 @@ class ListTableViewCell: UITableViewCell, NibReusable {
     /// The default placeholder image.
     @objc var placeholderImage: UIImage = Style.placeholderImage
 
-    /// The image URL to be downloaded and displayed on avatarView.
-    @objc var imageURL: URL? {
-        didSet {
-            guard imageURL != oldValue else {
-                return
-            }
-            downloadImage(with: imageURL)
-        }
-    }
-
     /// The attributed string to be displayed in titleLabel.
     /// To keep the styles uniform between List components, refer to regular and bold styles in `WPStyleGuide+List`.
     @objc var attributedTitleText: NSAttributedString? {
@@ -75,6 +65,32 @@ class ListTableViewCell: UITableViewCell, NibReusable {
         super.awakeFromNib()
         configureSubviews()
     }
+
+    // MARK: Public Methods
+
+    /// Configures the avatar image view with the provided URL.
+    /// If the URL does not contain any image, the default placeholder image will be displayed.
+    /// - Parameter url: The URL containing the image.
+    func configureImage(with url: URL?) {
+        if let someURL = url, let gravatar = Gravatar(someURL) {
+            avatarView.downloadGravatar(gravatar, placeholder: placeholderImage, animate: true)
+            return
+        }
+
+        // handle non-gravatar images
+        avatarView.downloadImage(from: url, placeholderImage: placeholderImage)
+    }
+
+    /// Configures the avatar image view from Gravatar based on provided email.
+    /// If the Gravatar image for the provided email doesn't exist, the default placeholder image will be displayed.
+    /// - Parameter gravatarEmail: The email to be used for querying the Gravatar image.
+    func configureImageWithGravatarEmail(_ email: String?) {
+        guard let someEmail = email else {
+            return
+        }
+
+        avatarView.downloadGravatarWithEmail(someEmail, placeholderImage: placeholderImage)
+    }
 }
 
 // MARK: Private Helpers
@@ -103,17 +119,6 @@ private extension ListTableViewCell {
 
     func updateIndicatorColor() {
         indicatorView.backgroundColor = showsIndicator ? indicatorColor : .clear
-    }
-
-    /// Downloads the image to display in avatarView.
-    func downloadImage(with url: URL?) {
-        if let someURL = url, let gravatar = Gravatar(someURL) {
-            avatarView.downloadGravatar(gravatar, placeholder: placeholderImage, animate: true)
-            return
-        }
-
-        // handle non-gravatar images
-        avatarView.downloadImage(from: url, placeholderImage: placeholderImage)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.xib
@@ -10,7 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="82" id="KGk-i7-Jjw" customClass="ListTableViewCell" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="ListTableViewCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="368" height="67"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/WordPress/Classes/ViewRelated/Views/List/WPStyleGuide+List.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/WPStyleGuide+List.swift
@@ -12,7 +12,23 @@ extension WPStyleGuide {
 
         // MARK: Cells
         public static let placeholderImage = UIImage.gravatarPlaceholderImage
-        public static let snippetFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
+        public static let snippetFont = regularTextFont
         public static let snippetTextColor = UIColor.textSubtle
+        public static let plainTitleFont = regularTextFont
+        public static let titleTextColor = UIColor.text
+
+        public static let titleRegularAttributes: [NSAttributedString.Key: Any] = [
+            .font: regularTextFont,
+            .foregroundColor: titleTextColor
+        ]
+
+        public static let titleBoldAttributes: [NSAttributedString.Key: Any] = [
+            .font: boldTextFont,
+            .foregroundColor: titleTextColor
+        ]
+
+        // MARK: Private Styles
+        private static let regularTextFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
+        private static let boldTextFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4298,6 +4298,7 @@
 		FAFF153D1C98962E007D1C90 /* SiteSettingsViewController+SiteManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAFF153C1C98962E007D1C90 /* SiteSettingsViewController+SiteManagement.swift */; };
 		FD21397F13128C5300099582 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FD21397E13128C5300099582 /* libiconv.dylib */; };
 		FD3D6D2C1349F5D30061136A /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD3D6D2B1349F5D30061136A /* ImageIO.framework */; };
+		FE02F95F269DC14A00752A44 /* Comment+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE02F95E269DC14A00752A44 /* Comment+Interface.swift */; };
 		FE39C135269C37C900EFB827 /* ListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FE39C133269C37C900EFB827 /* ListTableViewCell.xib */; };
 		FE39C136269C37C900EFB827 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE39C134269C37C900EFB827 /* ListTableViewCell.swift */; };
 		FEA088012696E7F600193358 /* ListTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088002696E7F600193358 /* ListTableHeaderView.swift */; };
@@ -7435,6 +7436,7 @@
 		FD3D6D2B1349F5D30061136A /* ImageIO.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		FDCB9A89134B75B900E5C776 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		FDFB011916B1EA1C00F589A8 /* WordPress 10.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 10.xcdatamodel"; sourceTree = "<group>"; };
+		FE02F95E269DC14A00752A44 /* Comment+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comment+Interface.swift"; sourceTree = "<group>"; };
 		FE39C133269C37C900EFB827 /* ListTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ListTableViewCell.xib; sourceTree = "<group>"; };
 		FE39C134269C37C900EFB827 /* ListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
 		FEA088002696E7F600193358 /* ListTableHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableHeaderView.swift; sourceTree = "<group>"; };
@@ -12392,6 +12394,7 @@
 				8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */,
 				17C3FA6E25E591D200EFFE12 /* UIFont+Styles.swift */,
 				17C1D6902670E4A2006C8970 /* UIFont+Fitting.swift */,
+				FE02F95E269DC14A00752A44 /* Comment+Interface.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -16634,6 +16637,7 @@
 				985ED0E423C6950600B8D06A /* WidgetStyles.swift in Sources */,
 				57CCB3812358ED07003ECD0C /* WordPress-91-92.xcmappingmodel in Sources */,
 				5D2B30B91B7411C700DA15F3 /* ReaderCardDiscoverAttributionView.swift in Sources */,
+				FE02F95F269DC14A00752A44 /* Comment+Interface.swift in Sources */,
 				E1E89C6C1FD80E74006E7A33 /* Plugin.swift in Sources */,
 				8B7C97E325A8BFA2004A3373 /* JetpackActivityLogViewController.swift in Sources */,
 				7E4123BD20F4097B00DF8486 /* FormattableMediaContent.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4303,6 +4303,8 @@
 		FEA088012696E7F600193358 /* ListTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088002696E7F600193358 /* ListTableHeaderView.swift */; };
 		FEA088032696E81F00193358 /* ListTableHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FEA088022696E81F00193358 /* ListTableHeaderView.xib */; };
 		FEA088052696F7AA00193358 /* WPStyleGuide+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088042696F7AA00193358 /* WPStyleGuide+List.swift */; };
+		FEDA1AD8269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
+		FEDA1AD9269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FF00889B204DF3ED007CCE66 /* Blog+Quota.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00889A204DF3ED007CCE66 /* Blog+Quota.swift */; };
 		FF00889D204DFF77007CCE66 /* MediaQuotaCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FF00889C204DFF77007CCE66 /* MediaQuotaCell.xib */; };
 		FF00889F204E01AE007CCE66 /* MediaQuotaCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00889E204E01AE007CCE66 /* MediaQuotaCell.swift */; };
@@ -7438,6 +7440,7 @@
 		FEA088002696E7F600193358 /* ListTableHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableHeaderView.swift; sourceTree = "<group>"; };
 		FEA088022696E81F00193358 /* ListTableHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ListTableHeaderView.xib; sourceTree = "<group>"; };
 		FEA088042696F7AA00193358 /* WPStyleGuide+List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+List.swift"; sourceTree = "<group>"; };
+		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
 		FEF93A01F06919BDB9486A8E /* Pods-WordPressHomeWidgetToday.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressHomeWidgetToday.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressHomeWidgetToday/Pods-WordPressHomeWidgetToday.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		FF00889A204DF3ED007CCE66 /* Blog+Quota.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Quota.swift"; sourceTree = "<group>"; };
 		FF00889C204DFF77007CCE66 /* MediaQuotaCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MediaQuotaCell.xib; sourceTree = "<group>"; };
@@ -12316,6 +12319,7 @@
 				B5CEEB8D1B7920BE00E7B7B0 /* CommentsTableViewCell.swift */,
 				B5CEEB8F1B79244D00E7B7B0 /* CommentsTableViewCell.xib */,
 				5D6C4AFD1B603CE9005E3C43 /* EditCommentViewController.xib */,
+				FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -17539,6 +17543,7 @@
 				08D978551CD2AF7D0054F19A /* Menu+ViewDesign.m in Sources */,
 				02AC3092226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift in Sources */,
 				E60BD231230A3DD400727E82 /* KeyringAccountHelper.swift in Sources */,
+				FEDA1AD8269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */,
 				E142007A1C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift in Sources */,
 				B535209D1AF7EB9F00B33BA8 /* PushAuthenticationService.swift in Sources */,
 				B57273611B66CCEF000D1C4F /* AlertView.swift in Sources */,
@@ -19898,6 +19903,7 @@
 				FABB251A2602FC2C00C8785C /* HeaderContentStyles.swift in Sources */,
 				FABB251B2602FC2C00C8785C /* Revision.swift in Sources */,
 				FABB251C2602FC2C00C8785C /* PluginDirectoryAccessoryItem.swift in Sources */,
+				FEDA1AD9269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */,
 				FABB251D2602FC2C00C8785C /* PHAsset+Exporters.swift in Sources */,
 				FABB251E2602FC2C00C8785C /* GutenbergLightNavigationController.swift in Sources */,
 				FABB251F2602FC2C00C8785C /* AppFeedbackPromptView.swift in Sources */,


### PR DESCRIPTION
Resolves #16851
Refs #16740, #16741 
Depends on #16843

## Summary
This PR introduces the new List component to Comments list, with a feature flag. Here's a summary of the changes:
- A new feature flag, `unifiedCommentsAndNotificationsList` is added. The default behavior is `true` for **local developer and integration builds**. This is to ease testing for developers and designers, without having to make any manual changes.
- The relative date section identifier for `Comment` is copied from `Notifications+Interface`. Originally, I wanted to create a protocol (`RelativeDateSectionIdentifiable`) with default implementation, but since `Comment` and `CommentsViewController` are still in Objective-C, protocol extensions don't work. Hence the copy paste solution for now. 😢 
- Since `Comment` can pull avatar image either from URL or from gravatar email, I changed the image download approach in `ListTableViewCell` to be similar to `CommentsTableViewCell` – The `imageURL` prop is removed, and two methods are introduced instead: `configureImage(with url:)` that accepts a URL and `configureImageWithGravatarEmail`, that accepts a String.
- The table view footer in `CommentsViewController` is also updated from `CGRectZero` to a UIView with 1pt height. This is to get rid of the separator for the last row _on the last section_. Previously, the last row in the last section was still showing a separator line.

## To Test

#### Scenario 1: With disabled feature flag, Comments list should be displayed with the old design
- Go to My Site > Comments.
- Verify that the comments list is displayed with the old design.
- Verify that the comments are sectioned by individual date, instead of relative date range.

#### Scenario 2: With enabled feature flag, Comments list should be displayed with the new design
- Go back to My Site, click your Avatar, and go to App Settings.
- Select the Debug menu, and scroll down until you find `Unified Comments and Notifications List` feature flag.
- Make sure that the feature flag is **enabled**.
- Go back to My Site > Comments.
- Verify that the comments list is displayed with the new design.
- Verify that the comments are sectioned correctly.

## Regression Notes
1. Potential unintended areas of impact
Comments list not showing correctly when feature flag is turned off.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ensured that the new and old list are displayed correctly when the feature flag is toggled.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
