### PR TITLE
Only extract author info on a new Post / Page if the user can query for authors.

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -54,8 +54,8 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     post.postType = Post.typeDefaultIdentifier;
 
     BlogAuthor *author = [blog getAuthorWithId:blog.userID];
-    post.authorID = author.userID ?: blog.account.userID;
-    post.author = author.displayName ?: blog.account.displayName;
+    post.authorID = author.userID;
+    post.author = author.displayName;
 
     [blog.managedObjectContext obtainPermanentIDsForObjects:@[post] error:nil];
     NSAssert(![post.objectID isTemporaryID], @"The new post for this blog must have a permanent ObjectID");
@@ -77,8 +77,8 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     page.remoteStatus = AbstractPostRemoteStatusSync;
 
     BlogAuthor *author = [blog getAuthorWithId:blog.userID];
-    page.authorID = author.userID ?: blog.account.userID;
-    page.author = author.displayName ?: blog.account.displayName;
+    page.authorID = author.userID;
+    page.author = author.displayName;
 
     [blog.managedObjectContext obtainPermanentIDsForObjects:@[page] error:nil];
     NSAssert(![page.objectID isTemporaryID], @"The new page for this blog must have a permanent ObjectID");


### PR DESCRIPTION
Fixes #16858

This change addresses a bug where Atomic site users who had limited permissions (e.g. Authors, Contributors) couldn't create new Posts or Pages. This occurred because we were always passing the `blog.account.userID` to the API as the `author` value on [new Post and Page API requests](P2gHKz-g-p2.2/post/sites/%24site/posts/new/). We learned that for Atomic sites this ID - which is their wp.com user ID - is not accepted by the backend. We should have instead been sending their ID that is local to the Atomic site.

This fix drops sending the author's user ID unless the user has permissions to query for other authors on the site, and can populate `blog.authors`. In the `blog.authors` array, the user ID is always the correct ID for the site, e.g. the ID for a user on the Atomic site and not necessarily always their wp.com user ID.

## To test:

**Note:** If the app's logged in user's role is downgraded, leftover state (e.g. previously downloaded authors) may remain, resulting in failures of the tests below. It's recommended to test user role changes by going from lowest up, or by wiping the app state clean each time. This should be considered a bug and an issue will be created.

### Prerequisites for all test sites
- Add multiple authors: At least one Administrator role and one Author role

### Non-Jetpack self-hosted sites
There is a discrepancy for the Editor role. On web, an Editor can choose new authors. On WPiOS, the client cannot query for the list of users, and thus can't populate the authors, so the user will not have the Author option. In other words, for self-hosted sites the user role must be Administrator to use this feature.

#### Administrator role
- [ ] Creating a new Post.
- [ ] Creating a new Post and setting a different author.
- [ ] Creating a new Page.
- [ ] Creating a new Page and setting a different author.
- [ ] Updating an existing Post.
- [ ] Updating an existing Page.
- [ ] Updating an existing Post and changing the author.
- [ ] Updating an existing Page and changing the author.

#### Author role
- [ ] Creating a new Post.
- [ ] Updating an existing Post.

### Jetpack self-hosted sites
There is a discrepancy for the Editor role. On web, an Editor can choose new authors. On WPiOS, the client cannot query for the list of users, and thus can't populate the authors, so the user will not have the Author option. In other words, for self-hosted sites the user role must be Administrator to use this feature.

#### Administrator role
- [ ] Creating a new Post.
- [ ] Creating a new Post and setting a different author.
- [ ] Creating a new Page.
- [ ] Creating a new Page and setting a different author.
- [ ] Updating an existing Post.
- [ ] Updating an existing Page.
- [ ] Updating an existing Post and changing the author.
- [ ] Updating an existing Page and changing the author.

#### Author role
- [ ] Creating a new Post.
- [ ] Updating an existing Post.

### WordPress.com Simple sites

#### Administrator role
- [ ] Creating a new Post.
- [ ] Creating a new Post and setting a different author.
- [ ] Creating a new Page.
- [ ] Creating a new Page and setting a different author.
- [ ] Updating an existing Post.
- [ ] Updating an existing Page.
- [ ] Updating an existing Post and changing the author.
- [ ] Updating an existing Page and changing the author.

#### Author role
- [ ] Creating a new Post.
- [ ] Updating an existing Post.

### WordPress.com Atomic sites

#### Administrator role
- [ ] Creating a new Post.
- [ ] Creating a new Post and setting a different author.
- [ ] Creating a new Page.
- [ ] Creating a new Page and setting a different author.
- [ ] Updating an existing Post.
- [ ] Updating an existing Page.
- [ ] Updating an existing Post and changing the author.
- [ ] Updating an existing Page and changing the author.

#### Author role
- [ ] Creating a new Post.
- [ ] Updating an existing Post.

---

**Creating with author change**

1. Create a new Post or Page on a site that has multiple users.
2. Access the Post or Page settings by tapping the horizontal ellipses (More Options) icon at the top right and choosing Settings.
3. Observe that "Author" appears as the top row under the "Publish" section.
4. Tap on the row and observe that authors are shown by their Display Name sorted alphabetically. 
5. Select a new author and publish or save the Post or Page.
6. Observe in the app and on the web that the new Post or Page has the chosen author.

**Updating with author change**

1. Select an existing Post or Page on a site that has multiple users.
2. Access the Post or Page settings by tapping the horizontal ellipses (More Options) icon at the top right and choosing Settings.
3. Observe that "Author" appears as the top row under the "Publish" section.
4. Tap on the row and observe that authors are shown by their Display Name sorted alphabetically.
5. Select a new author and update the Post or Page.
6. Observe in the app and on the web that the new Post or Page has the chosen author.

**Creating without author change**

1. Create a new Post or Page on a site that has multiple users.
2. Fill in test content
3. Publish the Post or Page
4. Observe in the app and on the web that the new Post or Page has the author that created it.

**Updating without author change**

1. Select an existing Post or Page by the author that is logged in.
2. Edit content on the Post or Page
3. Update the Post or Page
4. Observe in the app and on the web that the Post or Page reflects the updated content.

## Regression Notes
1. Potential unintended areas of impact
- Creating a new post
- Creating a new page
- Creating a new post with a different author
- Creating a new page with a different author
- Updating an existing post
- Updating an existing page
- Choosing a new author for an existing post
- Choosing a new author for an existing page

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Worked with @guarani to complete the test cases provided in this PR.

3. What automated tests I added (or what prevented me from doing so)
No new tests were added for this change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.