### PR TITLE
Post likes summary: format count to look like a hyperlink.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -38,13 +38,11 @@ private extension ReaderDetailLikesView {
             subView.layer.borderWidth = 1
             subView.layer.borderColor = UIColor.basicBackground.cgColor
         }
-
-        summaryLabel.textColor = .secondaryLabel
     }
 
     func updateSummaryLabel(totalLikes: Int) {
         let summaryFormat = totalLikes == 1 ? SummaryLabelFormats.singular : SummaryLabelFormats.plural
-        summaryLabel.text = String(format: summaryFormat, totalLikes)
+        summaryLabel.attributedText = highlightedText(String(format: summaryFormat, totalLikes))
     }
 
     func updateAvatars(users: [LikeUser]) {
@@ -87,10 +85,24 @@ private extension ReaderDetailLikesView {
     }
 
     struct SummaryLabelFormats {
-        static let singular = NSLocalizedString("%1$d blogger likes this.",
-                                                comment: "Singular format string for displaying the number of post likes. %1$d is the number of likes.")
-        static let plural = NSLocalizedString("%1$d bloggers like this.",
-                                              comment: "Plural format string for displaying the number of post likes. %1$d is the number of likes.")
+        static let singular = NSLocalizedString("%1$d blogger_ likes this.",
+                                                comment: "Singular format string for displaying the number of post likes. %1$d is the number of likes. The underscore denotes underline and is not displayed.")
+        static let plural = NSLocalizedString("%1$d bloggers_ like this.",
+                                              comment: "Plural format string for displaying the number of post likes. %1$d is the number of likes. The underscore denotes underline and is not displayed.")
+    }
+
+    func highlightedText(_ text: String) -> NSAttributedString {
+        let labelParts = text.components(separatedBy: "_")
+        let countPart = labelParts.first ?? ""
+        let likesPart = labelParts.last ?? ""
+
+        let underlineAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.primary,
+                                                                  .underlineStyle: NSUnderlineStyle.single.rawValue]
+
+        let attributedString = NSMutableAttributedString(string: countPart, attributes: underlineAttributes)
+        attributedString.append(NSAttributedString(string: likesPart, attributes: [.foregroundColor: UIColor.secondaryLabel]))
+
+        return attributedString
     }
 
 }


### PR DESCRIPTION
Fixes #n/a

This formats the `xxx bloggers` part of a post's likes summary to appear as a hyperlink.

To test:
- Go to the Reader.
- Select a post with Likes.
- Scroll down to the likes summary.
- Verify the count portion of the likes summary is highlighted.

| Before | After |
|--------|-------|
| <img width="359" alt="before" src="https://user-images.githubusercontent.com/1816888/125708080-451adde6-ef01-411a-b258-7beb9c7ef6a1.png"> | <img width="357" alt="after" src="https://user-images.githubusercontent.com/1816888/125706948-14158742-9e25-4da9-8d93-eddf16146b9e.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
