### PR TITLE
Stats: Fix enable stats module flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -99,15 +99,17 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 - (void)initStats
 {
-    if (!self.isActivatingStatsModule && ![self.blog isStatsActive]) {
-        [self showStatsModuleDisabled];
-        return;
-    }
-    
     SiteStatsInformation.sharedInstance.siteTimeZone = [self.blog timeZone];
 
     // WordPress.com + Jetpack REST
     if (self.blog.account) {
+        
+        // Prompt user to enable site stats if stats module is disabled
+        if (!self.isActivatingStatsModule && ![self.blog isStatsActive]) {
+            [self showStatsModuleDisabled];
+            return;
+        }
+        
         SiteStatsInformation.sharedInstance.oauth2Token = self.blog.account.authToken;
         SiteStatsInformation.sharedInstance.siteID = self.blog.dotComID;
         
@@ -115,6 +117,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
         [self initializeStatsWidgetsIfNeeded];
         return;
     }
+
     [self refreshStatus];
 }
 


### PR DESCRIPTION
Fixes #16867

## Description

This fixes a bug introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/16822, where self-hosted sites not connected to Jetpack weren’t able to enter the Jetpack Install / Connect flow.

## What caused the bug / How I fixed it

I was checking if the stats module was disabled in the wrong place. As a result, self-hosted sites that weren't yet connected to Jetpack would only see the Enable Site Stats screen and never have a chance to go through the Jetpack Install / Connect flow.

To fix this, I'm now checking if the stats module is disabled if and only if we know the site is connected to Jetpack (i.e. the blog object has an account associated with it).


## How to test

1. Create a self-hosted site via Jurassic Ninja
2. Don't connect Jetpack yet
3. On the app, add the self-hosted site you just created
4. Go to the Stats screen
5. ✅ The Jetpack Install screen should be displayed
6. Since the Jetpack connection flow is a bit flaky on the app, let's connect Jetpack through a browser (Make sure you activate Jetpack AND connect/authorize your account)
7. On the app, go back to the Stats screen and go through the Jetpack Login screen
8. Once you're logged in, go to the Stats screen
9. ✅ The Stats screen should be displayed

## Regression Notes
1. Potential unintended areas of impact
Jetpack Install / Enable stats module flows

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the above steps

3. What automated tests I added (or what prevented me from doing so)
N/A 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
