### PR TITLE
Like Enhancements: remove feature flags

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,7 +17,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case milestoneNotifications
     case newLikeNotifications
     case bloggingReminders
-    case readerPostLikes
     case siteIconCreator
     case globalStyleSettings
     case editorOnboardingHelpMenu
@@ -59,8 +58,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .newLikeNotifications:
             return true
         case .bloggingReminders:
-            return true
-        case .readerPostLikes:
             return true
         case .siteIconCreator:
             return BuildConfiguration.current != .appStore
@@ -126,8 +123,6 @@ extension FeatureFlag {
             return "New Like Notifications"
         case .bloggingReminders:
             return "Blogging Reminders"
-        case .readerPostLikes:
-            return "Reader Post Likes"
         case .siteIconCreator:
             return "Site Icon Creator"
         case .globalStyleSettings:

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -15,7 +15,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case siteCreationHomePagePicker
     case todayWidget
     case milestoneNotifications
-    case newLikeNotifications
     case bloggingReminders
     case siteIconCreator
     case globalStyleSettings
@@ -54,8 +53,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .todayWidget:
             return true
         case .milestoneNotifications:
-            return true
-        case .newLikeNotifications:
             return true
         case .bloggingReminders:
             return true
@@ -119,8 +116,6 @@ extension FeatureFlag {
             return "iOS 14 Today Widget"
         case .milestoneNotifications:
             return "Milestone notifications"
-        case .newLikeNotifications:
-            return "New Like Notifications"
         case .bloggingReminders:
             return "Blogging Reminders"
         case .siteIconCreator:

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -423,20 +423,15 @@ extension NotificationDetailsViewController {
             tableView.register(nib, forCellReuseIdentifier: cellClass.reuseIdentifier())
         }
 
-        if FeatureFlag.newLikeNotifications.enabled {
-            tableView.register(LikeUserTableViewCell.defaultNib,
-                               forCellReuseIdentifier: LikeUserTableViewCell.defaultReuseID)
-        }
+        tableView.register(LikeUserTableViewCell.defaultNib,
+                           forCellReuseIdentifier: LikeUserTableViewCell.defaultReuseID)
+
     }
 
     /// Configure the delegate and data source for the table view based on notification type.
     /// This method may be called several times, especially upon previous/next button click
     /// since notification kind may change.
     func setupTableDelegates() {
-        guard FeatureFlag.newLikeNotifications.enabled else {
-            return
-        }
-
         if note.kind == .like || note.kind == .commentLike,
            let likesListController = LikesListController(tableView: tableView, notification: note, delegate: self) {
             tableView.delegate = likesListController

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -419,8 +419,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func fetchLikes() {
-        guard FeatureFlag.readerPostLikes.enabled,
-              let post = post else {
+        guard let post = post else {
             return
         }
 
@@ -428,11 +427,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func configureLikesSummary() {
-        guard FeatureFlag.readerPostLikes.enabled else {
-            hideLikesView()
-            return
-        }
-
         likesSummary.delegate = coordinator
         likesContainerView.addSubview(likesSummary)
         likesContainerView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Fixes #n/a

This removes both feature flags associated with Like Enhancements.
- `newLikeNotifications`
- `readerPostLikes`

To test:

`newLikeNotifications`:
- Go to Notifications > All (be sure you have some Like notifications).
- Tap the Next and Previous buttons on the nav bar.
- Verify all the notifications appear as expected.
- On a Like notification, verify the likers list appears as expected.

`readerPostLikes`:
- Go to the Reader. 
- Select a post with Likes.
- Verify the Likes summary is displayed. 
- Select a post with no Likes.
- Verify the Likes summary is not displayed. 

## Regression Notes
1. Potential unintended areas of impact
N/A. Both features have been in production for a few releases, so there should be no impact.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified both still work as expected.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
