### PR TITLE
Fixes a crash when the value returned by Blog.version is not a string

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -446,7 +446,21 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 - (NSString *)version
 {
-    return [self getOptionValue:@"software_version"];
+    // Ensure the value being returned is a string to prevent a crash when using this value in Swift
+    id value = [self getOptionValue:@"software_version"];
+
+    // If its a string, then return its value 🎉
+    if([value isKindOfClass:NSString.class]) {
+        return value;
+    }
+
+    // If its not a string, but can become a string, then convert it
+    if([value respondsToSelector:@selector(stringValue)]) {
+        return [value stringValue];
+    }
+
+    // If the value is an unknown type, and can not become a string, then default to a blank string.
+    return @"";
 }
 
 - (NSString *)password

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -37,9 +37,9 @@ final class BlogBuilder {
 
     func withJetpack(version: String? = nil, username: String? = nil, email: String? = nil) -> Self {
         set(blogOption: "jetpack_client_id", value: 1)
-        set(blogOption: "jetpack_version", value: version)
-        set(blogOption: "jetpack_user_login", value: username)
-        set(blogOption: "jetpack_user_email", value: email)
+        set(blogOption: "jetpack_version", value: version as Any)
+        set(blogOption: "jetpack_user_login", value: username as Any)
+        set(blogOption: "jetpack_user_email", value: email as Any)
         return set(blogOption: "is_automated_transfer", value: false)
     }
 

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -84,7 +84,7 @@ final class BlogBuilder {
     }
 
     @discardableResult
-    private func set(blogOption key: String, value: Any) -> Self {
+    func set(blogOption key: String, value: Any) -> Self {
         var options = blog.options ?? [AnyHashable: Any]()
         options[key] = [
             "value": value

--- a/WordPress/WordPressTest/BlogTests.swift
+++ b/WordPress/WordPressTest/BlogTests.swift
@@ -140,20 +140,22 @@ final class BlogTests: XCTestCase {
     }
 
     // MARK: - Blog.version string conversion testing
-    func testTheVersionIsAStringEvenWhenSetAsANumber() {
+    func testTheVersionIsAStringWhenGivenANumber() {
         let blog = BlogBuilder(context)
             .set(blogOption: "software_version", value: 13.37)
             .build()
 
         XCTAssertTrue((blog.version as Any) is String)
+        XCTAssertEqual(blog.version, "13.37")
     }
 
-    func testTheVersionIsAString() {
+    func testTheVersionIsAStringWhenGivenAString() {
         let blog = BlogBuilder(context)
             .set(blogOption: "software_version", value: "5.5")
             .build()
 
         XCTAssertTrue((blog.version as Any) is String)
+        XCTAssertEqual(blog.version, "5.5")
     }
 
     func testTheVersionDefaultsToAnEmptyStringWhenTheValueIsNotConvertible() {

--- a/WordPress/WordPressTest/BlogTests.swift
+++ b/WordPress/WordPressTest/BlogTests.swift
@@ -150,9 +150,18 @@ final class BlogTests: XCTestCase {
 
     func testTheVersionIsAString() {
         let blog = BlogBuilder(context)
-            .with(wordPressVersion: "5.5")
+            .set(blogOption: "software_version", value: "5.5")
             .build()
 
         XCTAssertTrue((blog.version as Any) is String)
+    }
+
+    func testTheVersionDefaultsToAnEmptyStringWhenTheValueIsNotConvertible() {
+        let blog = BlogBuilder(context)
+            .set(blogOption: "software_version", value: NSObject())
+            .build()
+
+        XCTAssertTrue((blog.version as Any) is String)
+        XCTAssertEqual(blog.version, "")
     }
 }

--- a/WordPress/WordPressTest/BlogTests.swift
+++ b/WordPress/WordPressTest/BlogTests.swift
@@ -16,6 +16,8 @@ final class BlogTests: XCTestCase {
         super.tearDown()
     }
 
+
+    // MARK: - Atomic Tests
     func testIsAtomic() {
         let blog = BlogBuilder(context)
             .with(atomic: true)
@@ -32,6 +34,7 @@ final class BlogTests: XCTestCase {
         XCTAssertFalse(blog.isAtomic())
     }
 
+    // MARK: - Blog Lookup
     func testThatLookupByBlogIDWorks() throws {
         let blog = BlogBuilder(context).build()
         XCTAssertNotNil(blog.dotComID)
@@ -134,5 +137,22 @@ final class BlogTests: XCTestCase {
             .build()
 
         XCTAssertFalse(blog.supports(.pluginManagement))
+    }
+
+    // MARK: - Blog.version string conversion testing
+    func testTheVersionIsAStringEvenWhenSetAsANumber() {
+        let blog = BlogBuilder(context)
+            .set(blogOption: "software_version", value: 13.37)
+            .build()
+
+        XCTAssertTrue((blog.version as Any) is String)
+    }
+
+    func testTheVersionIsAString() {
+        let blog = BlogBuilder(context)
+            .with(wordPressVersion: "5.5")
+            .build()
+
+        XCTAssertTrue((blog.version as Any) is String)
     }
 }


### PR DESCRIPTION
Sentry crash: https://sentry.io/organizations/a8c/issues/2511522132/events/?project=1438083

### To test:

#### Verify the crash
1. Create a self hosted site that is not connected to Jetpack
2. Go to the My Site view
3. Tap the dropdown to view all your sites
4. Tap the + button to add a site
5. Tap Add Self Hosted
6. Add your new site
7. If the app doesn't crash: 

#### Force the crash
1. Open Blog.m
2. Go to line: 449
3. Change it to `return @5.5` 
4. This will force return an NSNumber
5. Relaunch the app
6. It should crash

#### Verify the fix
1. Remove the forced crash
2. Go to Blog.m
3. Line 902
4. Add a line above it for:

```
if([name isEqualToString:@"software_version"]){
    return @5.5;
}
```
This force returns an NSNumber for the software version
5. Relaunch the app
6. It should **not** crash

### Regression Notes
1. Potential unintended areas of impact
- The BlogService calls `[[blog version] floatValue];` since NSString implements this method this will not cause an issue. 
- `hasRequiredWordPressVersion` in Blog.m expects a string anyways

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I did manual testing of that section.

3. What automated tests I added (or what prevented me from doing so)
None. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
