### PR TITLE
[Tooling] Fix hotfix lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -236,19 +236,36 @@ platform :ios do
   #####################################################################################
   # new_hotfix_release
   # -----------------------------------------------------------------------------------
-  # This lane creates the release branch for a new hotix release.
+  # This lane updates the release branch for a new hotfix release.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane new_hotfix_release [skip_confirm:<skip confirm>] [version:<version>]
+  # bundle exec fastlane new_hotfix_release [skip_confirm:<skip confirm>] [version:<x.y.z>]
   #
   # Example:
   # bundle exec fastlane new_hotfix_release version:10.6.1
-  # bundle exec fastlane new_hotfix_release skip_confirm:true version:10.6.1
   #####################################################################################
-  desc 'Creates a new hotfix branch from the given tag'
+  desc 'Creates a new hotfix branch for the given version:x.y.z. The branch will be cut from the tag x.y of the previous release'
   lane :new_hotfix_release do |options|
     prev_ver = ios_hotfix_prechecks(options)
     ios_bump_version_hotfix(previous_version: prev_ver, version: options[:version])
+  end
+
+  #####################################################################################
+  # finalize_hotfix_release
+  # -----------------------------------------------------------------------------------
+  # This lane finalizes the hotfix branch.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane finalize_hotfix_release [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane finalize_hotfix_release skip_confirm:true
+  #####################################################################################
+  desc 'Performs the final checks and trigger a release build for the hotfix in the current branch'
+  lane :finalize_hotfix_release do |options|
+    ios_finalize_prechecks(options)
+    version = ios_get_app_version
+    trigger_release_build(branch_to_build: "release/#{version}")
   end
 
   #####################################################################################
@@ -353,24 +370,6 @@ platform :ios do
       screenshots_path: File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'promo-screenshots'),
       skip_screenshots: skip_screenshots
     )
-  end
-
-  #####################################################################################
-  # finalize_hotfix_release
-  # -----------------------------------------------------------------------------------
-  # This lane finalizes the hotfix branch.
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane finalize_hotfix_release [skip_confirm:<skip confirm>]
-  #
-  # Example:
-  # bundle exec fastlane finalize_hotfix_release skip_confirm:true
-  #####################################################################################
-  desc 'Performs the final checks and tags the hotfix in the current branch'
-  lane :finalize_hotfix_release do |options|
-    ios_finalize_prechecks(options)
-    version = ios_get_app_version
-    trigger_release_build(branch_to_build: "release/#{version}")
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -261,7 +261,7 @@ platform :ios do
   # Example:
   # bundle exec fastlane finalize_hotfix_release skip_confirm:true
   #####################################################################################
-  desc 'Performs the final checks and trigger a release build for the hotfix in the current branch'
+  desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
   lane :finalize_hotfix_release do |options|
     ios_finalize_prechecks(options)
     version = ios_get_app_version

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,9 +112,11 @@ platform :ios do
 
     ios_bump_version_release(skip_deliver: true)
     new_version = ios_get_app_version
-    extract_release_notes_for_version(version: new_version,
-      release_notes_file_path: File.join(ENV["PROJECT_ROOT_FOLDER"], 'RELEASE-NOTES.txt'),
-      extracted_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'))
+    extract_release_notes_for_version(
+      version: new_version,
+      release_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'RELEASE-NOTES.txt'),
+      extracted_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt')
+    )
     ios_update_release_notes(new_version: new_version)
     get_prs_list(repository: GHHELPER_REPO, milestone: new_version.to_s,
                  report_path: "#{File.expand_path('~')}/wpios_prs_list_#{old_version}_#{new_version}.txt")
@@ -223,7 +225,8 @@ platform :ios do
   lane :new_beta_release do |options|
     ios_betabuild_prechecks(options)
     download_localized_strings_and_metadata(options)
-    # This is disabled due to GlotPress outputting an invalid `.strings` file for some locales
+    # FIXME: (2021.06.17) This is disabled because we currently have a >256 chars string which GlotPress truncates when exporting  the `.strings` files,
+    #   leading to incorrect key for it and (rightful) linter failure. We need to split that key into 2 smaller copies before we can re-enable this.
     # ios_lint_localizations(input_dir: 'WordPress/Resources', allow_retry: true)
     ios_bump_version_beta
     version = ios_get_app_version
@@ -284,6 +287,8 @@ platform :ios do
       )
 
       download_localized_strings_and_metadata(options)
+      # FIXME: (2021.06.17) This is disabled because we currently have a >256 chars string which GlotPress truncates when exporting  the `.strings` files,
+      #   leading to incorrect key for it and (rightful) linter failure. We need to split that key into 2 smaller copies before we can re-enable this.
       # ios_lint_localizations(input_dir: 'WordPress/Resources', allow_retry: true)
       ios_bump_version_beta
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -266,32 +266,33 @@ platform :ios do
   #####################################################################################
   desc 'Trigger the final release build on CI'
   lane :finalize_release do |options|
+    UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
+
     ios_finalize_prechecks(options)
-    unless ios_current_branch_is_hotfix
-      UI.message('Checking app strings translation status...')
-      check_translation_progress(
-        glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/dev/',
-        abort_on_violations: false
-      )
+    
+    UI.message('Checking app strings translation status...')
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/dev/',
+      abort_on_violations: false
+    )
 
-      UI.message("Checking WordPress release notes strings translation status...")
-      check_translation_progress(
-        glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/release-notes/',
-        abort_on_violations: false
-      )
+    UI.message("Checking WordPress release notes strings translation status...")
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/release-notes/',
+      abort_on_violations: false
+    )
 
-      UI.message("Checking Jetpack release notes strings translation status...")
-      check_translation_progress(
-        glotpress_url: 'https://translate.wordpress.com/projects/jetpack/apps/ios/release-notes/',
-        abort_on_violations: false
-      )
+    UI.message("Checking Jetpack release notes strings translation status...")
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.com/projects/jetpack/apps/ios/release-notes/',
+      abort_on_violations: false
+    )
 
-      download_localized_strings_and_metadata(options)
-      # FIXME: (2021.06.17) This is disabled because we currently have a >256 chars string which GlotPress truncates when exporting  the `.strings` files,
-      #   leading to incorrect key for it and (rightful) linter failure. We need to split that key into 2 smaller copies before we can re-enable this.
-      # ios_lint_localizations(input_dir: 'WordPress/Resources', allow_retry: true)
-      ios_bump_version_beta
-    end
+    download_localized_strings_and_metadata(options)
+    # FIXME: (2021.06.17) This is disabled because we currently have a >256 chars string which GlotPress truncates when exporting  the `.strings` files,
+    #   leading to incorrect key for it and (rightful) linter failure. We need to split that key into 2 smaller copies before we can re-enable this.
+    # ios_lint_localizations(input_dir: 'WordPress/Resources', allow_retry: true)
+    ios_bump_version_beta
 
     # Wrap up
     version = ios_get_app_version


### PR DESCRIPTION
Part of the paaHJt-1WQ-p2 project.

## To test

 - Checkout this branch, run `bundle install`
 - Run `bundle exec fastlane new_hotfix_release version:17.6.1` (⚠️  don't use `17.7.1`, there's already one pending for this one – pbArwn-2uE-p2)
 - Verify that it cut a `release/17.6.1` branch from the `17.6` tag
 - Verify that it bumped the version in `Version.internal.xcconfig`, `Version.public.xcconfig` and `fastlane/Deliverfile` (*)
 - cherry-pick all the commits from this PR on top of the `release/17.6.1` branch. This is because we are gonna test the updated finalize lanes, and need to be on the hotfix release branch to test them. You might get conflicts, keep left (commits from this PR) every time.
 - [Open the CircleCI page for WPiOS](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-iOS) in advance, to be ready to cancel the release build
 - Run `bundle exec fastlane finalize_release` (reply no when it suggests to update release toolkit). You should get an error telling you that you should use `finalize_hotfix_release` for hotfix branches instead.
 - Run `bundle exec fastlane finalize_hotfix_release` and verify that it triggered a release build, and that is is building it from the release/~7.0.1~ 17.6.1 hotfix branch. Cancel the CI build immediately ~(NB: `231` is a version code that already exists so in case you fail to cancel it, the build should fail to upload to playstore anyway)~
 - Delete the `release/17.6.1` branch (from both local and remote)

---

(*) @mokagio you might want to make sure that your changes about getting rid of `Deliverfile` in the repos won't be impacted by those version bumps btw. This test scenario, since it was exerced on the codebase from back in `17.6`, still found a `Deliverfile` back then, so that worked, but not sure about the impact of your changes there in other lanes. Especially, even the `new_beta_release` and `new_hotfix_release` might benefit from the similar change that you seem to have done on the `code_freeze` lane which adds `skip_deliver: true` to the version bump action call. So you may want to replicate that change you did to all places, not just code freeze.