### PR TITLE
Likes List: add properties to track event

### DIFF
--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -10,7 +10,10 @@ extension CommentService {
      @param excludingIDs    An array of user IDs to exclude from the returned results. Optional.
      @param purgeExisting   Indicates if existing Likes for the given post and site should be purged before
                             new ones are created. Defaults to true.
-     @param success         A success block
+     @param success         A success block returning:
+                            - Array of LikeUser
+                            - Total number of likes for the given comment
+                            - Number of likes per fetch
      @param failure         A failure block
      */
     func getLikesFor(commentID: NSNumber,
@@ -19,7 +22,7 @@ extension CommentService {
                      before: String? = nil,
                      excludingIDs: [NSNumber]? = nil,
                      purgeExisting: Bool = true,
-                     success: @escaping (([LikeUser], Int) -> Void),
+                     success: @escaping (([LikeUser], Int, Int) -> Void),
                      failure: @escaping ((Error?) -> Void)) {
 
         guard let remote = restRemote(forSite: siteID) else {
@@ -38,7 +41,7 @@ extension CommentService {
                                                             siteID: siteID,
                                                             purgeExisting: purgeExisting) {
                                             let users = self.likeUsersFor(commentID: commentID, siteID: siteID)
-                                            success(users, totalLikes.intValue)
+                                            success(users, totalLikes.intValue, count)
                                             LikeUserHelper.purgeStaleLikes()
                                         }
                                     }, failure: { error in

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -10,7 +10,10 @@ extension PostService {
      @param excludingIDs    An array of user IDs to exclude from the returned results. Optional.
      @param purgeExisting   Indicates if existing Likes for the given post and site should be purged before
                             new ones are created. Defaults to true.
-     @param success         A success block
+     @param success         A success block returning:
+                            - Array of LikeUser
+                            - Total number of likes for the given post
+                            - Number of likes per fetch
      @param failure         A failure block
      */
     func getLikesFor(postID: NSNumber,
@@ -19,7 +22,7 @@ extension PostService {
                      before: String? = nil,
                      excludingIDs: [NSNumber]? = nil,
                      purgeExisting: Bool = true,
-                     success: @escaping (([LikeUser], Int) -> Void),
+                     success: @escaping (([LikeUser], Int, Int) -> Void),
                      failure: @escaping ((Error?) -> Void)) {
 
         guard let remote = postServiceRemoteFactory.restRemoteFor(siteID: siteID, context: managedObjectContext) else {
@@ -38,7 +41,7 @@ extension PostService {
                                                         siteID: siteID,
                                                         purgeExisting: purgeExisting) {
                                         let users = self.likeUsersFor(postID: postID, siteID: siteID)
-                                        success(users, totalLikes.intValue)
+                                        success(users, totalLikes.intValue, count)
                                         LikeUserHelper.purgeStaleLikes()
                                     }
                                  }, failure: { error in

--- a/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Likes/LikesListController.swift
@@ -173,7 +173,7 @@ class LikesListController: NSObject {
             return
         }
 
-        fetchLikes(success: { [weak self] users, totalLikes in
+        fetchLikes(success: { [weak self] users, totalLikes, likesPerPage in
             guard let self = self else {
                 return
             }
@@ -213,7 +213,7 @@ class LikesListController: NSObject {
     /// - Parameters:
     ///   - success: Closure to be called when the fetch is successful.
     ///   - failure: Closure to be called when the fetch failed.
-    private func fetchLikes(success: @escaping ([LikeUser], Int) -> Void, failure: @escaping (Error?) -> Void) {
+    private func fetchLikes(success: @escaping ([LikeUser], Int, Int) -> Void, failure: @escaping (Error?) -> Void) {
 
         var beforeStr = lastFetchedDate
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -155,7 +155,7 @@ class ReaderDetailCoordinator {
         // That way the first page will already be cached if the user displays the full Likes list.
         postService.getLikesFor(postID: postID,
                                 siteID: post.siteID,
-                                success: { [weak self] users, totalLikes in
+                                success: { [weak self] users, totalLikes, _ in
                                     self?.totalLikes = totalLikes
                                     self?.view?.updateLikes(users: Array(users.prefix(ReaderDetailLikesView.maxAvatarsDisplayed)), totalLikes: totalLikes)
                                 }, failure: { [weak self] error in

--- a/WordPress/WordPressTest/CommentServiceTests.swift
+++ b/WordPress/WordPressTest/CommentServiceTests.swift
@@ -62,10 +62,11 @@ extension CommentServiceTests {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes in
+            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes, likesPerPage in
                 // Assert
                 expect(users).toNot(beNil())
                 expect(users.count) == 1
+                expect(likesPerPage) > 0
                 done()
             },
             failure: { _ in
@@ -83,7 +84,7 @@ extension CommentServiceTests {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes in
+            self.service.getLikesFor(commentID: commentID, siteID: siteID, success: { users, totalLikes, likesPerPage in
                 fail("this closure should not be called")
             },
             failure: { _ in

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -266,9 +266,10 @@ class PostServiceWPComTests: XCTestCase {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesFor(postID: postID, siteID: siteID, success: { users, totalLikes in
+            self.service.getLikesFor(postID: postID, siteID: siteID, success: { users, totalLikes, likesPerPage in
                 // Assert
                 expect(users.count) == 1
+                expect(likesPerPage) > 0
                 done()
             },
             failure: { _ in
@@ -286,7 +287,7 @@ class PostServiceWPComTests: XCTestCase {
 
         // Act
         waitUntil(timeout: DispatchTimeInterval.seconds(2)) { done in
-            self.service.getLikesFor(postID: postID, siteID: siteID, success: { users, totalLikes in
+            self.service.getLikesFor(postID: postID, siteID: siteID, success: { users, totalLikes, likesPerPage in
                 fail("this closure should not be called")
             },
             failure: { _ in


### PR DESCRIPTION
Fixes #16850

This adds `page` and `per_page` properties to the `like_list_fetched_more` event.
- `page` - the current page being displayed (just fetched).
- `per_page` - the number of likes shown (fetched) per page.

To test:

**Hack Tip:**
If you don't have a lot of Likes, or want to test with varying `per_page` counts, you can modify the `count` params in the [Post](https://github.com/wordpress-mobile/WordPress-iOS/blob/687917f3eca037370f9d2fa6dbd10cfc44b97f99/WordPress/Classes/Services/PostService%2BLikes.swift#L21) and [Comment](https://github.com/wordpress-mobile/WordPress-iOS/blob/687917f3eca037370f9d2fa6dbd10cfc44b97f99/WordPress/Classes/Services/CommentService%2BLikes.swift#L21) `getLikesFor` methods.

```
    func getLikesFor(postID: NSNumber,
                     siteID: NSNumber,
                     count: Int = 5,
```


**Reader:**
- Go to the Reader. Select a post with more than 90 likes (or the `count` you set).
- Tap the Likes summary to display the list.
- Scroll past the first batch of Likes to fetch more.
- Verify the event has the correct `page` number, and `per_page` is the count fetched (either your overridden value or the default 90).

```
🔵 Tracked: like_list_fetched_more <page: 2, per_page: 5, source: reader>
🔵 Tracked: like_list_fetched_more <page: 3, per_page: 5, source: reader>
```

**Like Notifications:**
- Go to the Notifications > Likes. Select one with more than 90 likes (or the `count` you set).
- Scroll past the first batch of Likes to fetch more.
- Verify the event has the correct `page` number, and `per_page` is the count fetched (either your overridden value or the default 90).

```
🔵 Tracked: like_list_fetched_more <page: 2, per_page: 5, source: notifications>
🔵 Tracked: like_list_fetched_more <page: 3, per_page: 5, source: notifications>
```

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
