### PR TITLE
Notifications: Disable swipe actions while the undo overlay is shown

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -365,7 +365,9 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     }
 
     override func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        guard let note = tableViewHandler.resultsController.object(at: indexPath) as? Notification else {
+        // skip when the notification is marked for deletion.
+        guard let note = tableViewHandler.resultsController.object(at: indexPath) as? Notification,
+              deletionRequestForNoteWithID(note.objectID) == nil else {
             return nil
         }
 
@@ -387,8 +389,10 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     }
 
     override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        // skip when the notification is marked for deletion.
         guard let note = tableViewHandler.resultsController.object(at: indexPath) as? Notification,
-            let block: FormattableCommentContent = note.contentGroup(ofKind: .comment)?.blockOfKind(.comment) else {
+            let block: FormattableCommentContent = note.contentGroup(ofKind: .comment)?.blockOfKind(.comment),
+            deletionRequestForNoteWithID(note.objectID) == nil else {
             return nil
         }
 


### PR DESCRIPTION
This PR disables swipe action on notification item that has been marked from deletion (i.e. when the undo overlay is displayed). Here's a screenshot of the current behavior, depicting the bug:

Leading swipe | Trailing swipe
--|--
![Simulator Screen Shot - iPhone 8 - 2021-07-19 at 20 50 04](https://user-images.githubusercontent.com/1299411/126172363-718d80cd-0cbc-42e4-a393-440743dfc2a9.png) | ![Simulator Screen Shot - iPhone 8 - 2021-07-19 at 20 49 59](https://user-images.githubusercontent.com/1299411/126172361-c734f4f2-0ae6-4dab-9640-7b9d5c9fe14a.png)

Note: If this is actually an intended behavior, just let me know and I'll close this PR. Thanks! 🙂  

## To test
- Go to the notifications tab, and prepare a notification to be trashed (preferably test contents).
- Delete the notification.
- While the undo overlay is showing, perform a swipe (either to the left or right direction).
- Verify that the swipe actions are not shown.

## Regression Notes
1. Potential unintended areas of impact
Swipe action not working at all.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested on normal notifications, and confirmed that the swipe action works as expected.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
