### PR TITLE
Fix BlockEditorSettingService tests

### DIFF
--- a/WordPress/WordPressTest/BlockEditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/BlockEditorSettingsServiceTests.swift
@@ -215,7 +215,7 @@ class BlockEditorSettingsServiceTests: XCTestCase {
         XCTAssertGreaterThan(colors.count, 0)
 
         guard let gradients = blockEditorSettings.gradients else {
-            XCTFail("Block editor colors should exist at this point")
+            XCTFail("Block editor gradients should exist at this point")
             return
         }
         XCTAssertGreaterThan(gradients.count, 0)

--- a/WordPress/WordPressTest/BlockEditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/BlockEditorSettingsServiceTests.swift
@@ -20,11 +20,10 @@ class BlockEditorSettingsServiceTests: XCTestCase {
         contextManager = TestContextManager()
         context = contextManager.mainContext
         mockRemoteApi = MockWordPressComRestApi()
-        blog = ModelTestHelper.insertDotComBlog(context: context)
-        blog.dotComID = NSNumber(value: 1)
-        blog.account?.authToken = "auth"
-        blog.setValue("5.8", forOption: "software_version")
-
+        blog = BlogBuilder(context)
+            .with(wordPressVersion: "5.8")
+            .withAnAccount()
+            .build()
         service = BlockEditorSettingsService(blog: blog, remoteAPI: mockRemoteApi, context: context)
 
         try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: false)
@@ -85,8 +84,9 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     }
 
     private func validateThemeResponse() {
+        let siteID = blog.dotComID ?? 0
         XCTAssertTrue(self.mockRemoteApi.getMethodCalled)
-        XCTAssertEqual(self.mockRemoteApi.URLStringPassedIn!, "/wp/v2/sites/1/themes")
+        XCTAssertEqual(self.mockRemoteApi.URLStringPassedIn!, "/wp/v2/sites/\(siteID)/themes")
         XCTAssertEqual((self.mockRemoteApi.parametersPassedIn as! [String: String])["status"], "active")
         XCTAssertGreaterThan(self.blog.blockEditorSettings!.colors!.count, 0)
         XCTAssertGreaterThan(self.blog.blockEditorSettings!.gradients!.count, 0)
@@ -202,8 +202,23 @@ class BlockEditorSettingsServiceTests: XCTestCase {
         } else {
             XCTAssertNil(self.blog.blockEditorSettings?.rawStyles)
         }
-        XCTAssertGreaterThan(self.blog.blockEditorSettings!.colors!.count, 0)
-        XCTAssertGreaterThan(self.blog.blockEditorSettings!.gradients!.count, 0)
+
+        guard let blockEditorSettings = blog.blockEditorSettings else {
+            XCTFail("Block editor settings should exist on the blog at this point")
+            return
+        }
+
+        guard let colors = blockEditorSettings.colors else {
+            XCTFail("Block editor colors should exist at this point")
+            return
+        }
+        XCTAssertGreaterThan(colors.count, 0)
+
+        guard let gradients = blockEditorSettings.gradients else {
+            XCTFail("Block editor colors should exist at this point")
+            return
+        }
+        XCTAssertGreaterThan(gradients.count, 0)
     }
 }
 


### PR DESCRIPTION
## Description 

Fixes the test errors in https://github.com/wordpress-mobile/WordPress-iOS/pull/16883 

The error was a result of the code going down an unexpected path because the software version wasn't being properly picked up by the blog anymore. 

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
This PR fixes some tests

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
