### PR TITLE
Reader Detail: Hide the author section when the author name is empty / missing

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.swift
@@ -19,6 +19,7 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
     @IBOutlet weak var titleBottomPaddingView: UIView!
     @IBOutlet weak var byLabel: UILabel!
     @IBOutlet weak var authorLabel: UILabel!
+    @IBOutlet weak var authorSeparatorLabel: UILabel!
     @IBOutlet weak var dateLabel: UILabel!
     @IBOutlet weak var followButton: UIButton!
     @IBOutlet weak var iPadFollowButton: UIButton!
@@ -168,8 +169,23 @@ class ReaderDetailHeaderView: UIStackView, NibLoadable {
     }
 
     private func configureAuthorLabel() {
+        guard
+            let displayName = post?.authorDisplayName,
+            !displayName.isEmpty
+        else {
+            authorLabel.isHidden = true
+            authorSeparatorLabel.isHidden = true
+            byLabel.isHidden = true
+            return
+        }
+
         authorLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .bold)
-        authorLabel.text = post?.authorDisplayName
+        authorLabel.text = displayName
+
+        authorLabel.isHidden = false
+        authorSeparatorLabel.isHidden = false
+        byLabel.isHidden = false
+
     }
 
     private func configureDateLabel() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -69,7 +69,7 @@
                             </userDefinedRuntimeAttributes>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="www.blogname.com" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LdR-mh-skh">
-                            <rect key="frame" x="66" y="22" width="304" height="16"/>
+                            <rect key="frame" x="66" y="22" width="304" height="14.5"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <accessibility key="accessibilityConfiguration">
                                 <bool key="isElement" value="NO"/>
@@ -162,25 +162,25 @@
                     <rect key="frame" x="16" y="181" width="382" height="19"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="By " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jmd-NR-EOk">
-                            <rect key="frame" x="0.0" y="0.0" width="22" height="19"/>
+                            <rect key="frame" x="0.0" y="0.0" width="18" height="19"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9vn-tU-OV2">
-                            <rect key="frame" x="22" y="0.0" width="46" height="19"/>
+                            <rect key="frame" x="18" y="0.0" width="38" height="19"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text=" · " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sev-Gx-i9y">
-                            <rect key="frame" x="68" y="0.0" width="14.5" height="19"/>
+                            <rect key="frame" x="56" y="0.0" width="14.5" height="19"/>
                             <fontDescription key="fontDescription" name=".SFUI-Regular" family=".AppleSystemUIFont" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CJe-cC-zGx">
-                            <rect key="frame" x="82.5" y="0.0" width="299.5" height="19"/>
+                            <rect key="frame" x="70.5" y="0.0" width="311.5" height="19"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -204,6 +204,7 @@
             </constraints>
             <connections>
                 <outlet property="authorLabel" destination="9vn-tU-OV2" id="GCo-Yk-Zr1"/>
+                <outlet property="authorSeparatorLabel" destination="sev-Gx-i9y" id="GUX-tE-Cs8"/>
                 <outlet property="blavatarImageView" destination="kSE-xw-mlu" id="vAD-l5-b6W"/>
                 <outlet property="blogNameButton" destination="nBe-4U-XT8" id="XDf-iB-EKh"/>
                 <outlet property="blogURLLabel" destination="LdR-mh-skh" id="Jpq-BT-i1D"/>


### PR DESCRIPTION
Fixes #16890 

Adds a check that hides the author section ( `By AUTHOR_NAME  ·` ) that appears under the site information on the Reader Detail when the author value coming from the API is null or empty. 

| Before | After |
|:---:|:---:|
| <img width="383" alt="Screen Shot 2021-07-19 at 6 05 26 PM" src="https://user-images.githubusercontent.com/793774/126233439-f2fd6f9d-8328-44cd-b18e-13f7c6a0a73f.png"> | <img width="376" alt="Screen Shot 2021-07-19 at 5 30 34 PM" src="https://user-images.githubusercontent.com/793774/126230870-2718973a-926c-4274-9def-c8250418d2fc.png"> |



### To test:
1. Open the app
2. Tap on the Reader
3. Search for 'make.wordpress.org'
4. Tap the sites section
5. Tap on one of their posts
6. Verify the author section is hidden
7. Go to Discover
8. Tap on a post
9. Verify the Author section is displayed

## Regression Notes
1. Potential unintended areas of impact
None, this is only used by Reader Detail.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
