### PR TITLE
Enable Global Style Support

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 17.9
 -----
-
+* [*] Enables Support for Global Style Colors with Full Site Editing Themes [#16823]
 
 17.8
 -----

--- a/WordPress/Classes/Models/Blog+BlockEditorSettings.swift
+++ b/WordPress/Classes/Models/Blog+BlockEditorSettings.swift
@@ -10,7 +10,6 @@ extension Blog {
 
     @objc
     func supportsBlockEditorSettings() -> Bool {
-        guard FeatureFlag.globalStyleSettings.enabled else { return false }
         return hasRequiredWordPressVersion("5.8")
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,7 +17,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case milestoneNotifications
     case bloggingReminders
     case siteIconCreator
-    case globalStyleSettings
     case editorOnboardingHelpMenu
     case unifiedCommentsAndNotificationsList
 
@@ -58,8 +57,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .siteIconCreator:
             return BuildConfiguration.current != .appStore
-        case .globalStyleSettings:
-            return false
         case .editorOnboardingHelpMenu:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .unifiedCommentsAndNotificationsList:
@@ -120,8 +117,6 @@ extension FeatureFlag {
             return "Blogging Reminders"
         case .siteIconCreator:
             return "Site Icon Creator"
-        case .globalStyleSettings:
-            return "Global Style Settings"
         case .editorOnboardingHelpMenu:
             return "Editor Onboarding Help Menu"
         case .unifiedCommentsAndNotificationsList:

--- a/WordPress/WordPressTest/BlockEditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/BlockEditorSettingsServiceTests.swift
@@ -21,16 +21,21 @@ class BlockEditorSettingsServiceTests: XCTestCase {
         context = contextManager.mainContext
         mockRemoteApi = MockWordPressComRestApi()
         blog = BlogBuilder(context)
+            .with(wordPressVersion: "5.8")
             .with(isHostedAtWPCom: true)
             .build()
 
         service = BlockEditorSettingsService(blog: blog, remoteAPI: mockRemoteApi, context: context)
-
-        try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: false)
     }
 
     // MARK: Editor `theme_supports` support
     func testThemeSupportsNewTheme() {
+        blog = BlogBuilder(context)
+            .with(wordPressVersion: "5.7")
+            .with(isHostedAtWPCom: true)
+            .build()
+
+        service = BlockEditorSettingsService(blog: blog, remoteAPI: mockRemoteApi, context: context)
         let mockedResponse = mockedData(withFilename: twentytwentyoneResponseFilename)
         let waitExpectation = expectation(description: "Theme should be successfully fetched")
         service.fetchSettings { result in
@@ -52,6 +57,13 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     }
 
     func testThemeSupportsThemeChange() {
+        blog = BlogBuilder(context)
+            .with(wordPressVersion: "5.7")
+            .with(isHostedAtWPCom: true)
+            .build()
+
+        service = BlockEditorSettingsService(blog: blog, remoteAPI: mockRemoteApi, context: context)
+
         setData(withFilename: twentytwentyResponseFilename)
         let originalChecksum = blog.blockEditorSettings?.checksum ?? ""
 
@@ -76,6 +88,13 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     }
 
     func testThemeSupportsThemeIsTheSame() {
+        blog = BlogBuilder(context)
+            .with(wordPressVersion: "5.7")
+            .with(isHostedAtWPCom: true)
+            .build()
+
+        service = BlockEditorSettingsService(blog: blog, remoteAPI: mockRemoteApi, context: context)
+
         setData(withFilename: twentytwentyoneResponseFilename)
         let originalChecksum = blog.blockEditorSettings?.checksum ?? ""
         let mockedResponse = mockedData(withFilename: twentytwentyoneResponseFilename)
@@ -108,7 +127,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
 
     // MARK: Editor Global Styles support
     func testFetchBlockEditorSettingsNotThemeJSON() {
-        try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
         let waitExpectation = expectation(description: "Theme should be successfully fetched")
         service.fetchSettings { result in
@@ -130,7 +148,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     }
 
     func testFetchBlockEditorSettingsThemeJSON() {
-        try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
         let waitExpectation = expectation(description: "Theme should be successfully fetched")
         service.fetchSettings { result in
@@ -155,7 +172,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
         setData(withFilename: twentytwentyoneResponseFilename)
         let originalChecksum = blog.blockEditorSettings?.checksum ?? ""
 
-        try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
         let waitExpectation = expectation(description: "Theme should be successfully fetched")
         service.fetchSettings { result in
@@ -182,7 +198,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
         setData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
         let originalChecksum = blog.blockEditorSettings?.checksum ?? ""
 
-        try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
         let waitExpectation = expectation(description: "Theme should be successfully fetched")
         service.fetchSettings { result in
@@ -205,7 +220,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     }
 
     func testFetchBlockEditorSettingsNoChange() {
-        try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
 
         setData(withFilename: blockSettingsThemeJSONResponseFilename)
         let originalChecksum = blog.blockEditorSettings?.checksum ?? ""
@@ -234,7 +248,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     func testFetchBlockEditorSettings_OrgSite_NoPlugin() {
         blog = BlogBuilder(context).build()
 
-        try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
         let mockOrgRemoteApi = MockWordPressOrgRestApi()
         service = BlockEditorSettingsService(blog: blog, remoteAPI: mockOrgRemoteApi, context: context)
@@ -258,7 +271,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     func testFetchBlockEditorSettings_OrgSite() {
         blog = BlogBuilder(context).build()
 
-        try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
         let mockOrgRemoteApi = MockWordPressOrgRestApi()
         service = BlockEditorSettingsService(blog: blog, remoteAPI: mockOrgRemoteApi, context: context)
@@ -282,7 +294,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
 
         service = BlockEditorSettingsService(blog: blog, remoteAPI: mockRemoteApi, context: context)
 
-        try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
         let waitExpectation = expectation(description: "Theme should be successfully fetched")
         service.fetchSettings { _ in
@@ -297,7 +308,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     }
 
     func testFetchBlockEditorSettings_Com5_9Site() {
-        try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
         let waitExpectation = expectation(description: "Theme should be successfully fetched")
         service.fetchSettings { _ in


### PR DESCRIPTION
## Description:
This enables Global Style Support for FSE sites.

## To test:
For each of these cases, it'll be enough to open the editor and validate that the correct color options are available. It would also be useful to test using a network monitoring tool to make sure the correct paths are called. This will help ensure you aren't seeing cached data if you're reusing the same site for testing.

- Self-Hosted Site with WP 5.8 and Gutenberg 11.1
    - Expect the request to be made with `/wp-block-editor/v1`
- Self-Hosted Site with Gutenberg version <= 11.0
    - Expect the request to be made with `/wp-block-editor/v1` which will fail, so the fallback of `wp/v2/themes` should be used
- WPCom or Jetpack connected site with WP 5.8 and Gutenberg 11.0
    - Expect the request to be made with `/wp-block-editor/v1`
    - This will need to be tested with D63704 until that's deployed
- WPCom or Jetpack connected site with WP 5.8 and Gutenberg version >= 11.1
    - Expect the request to be made with `/wp-block-editor/v1`=
    - This will need to be tested with D63704 until that's deployed

## Regression Notes
1. Potential unintended areas of impact
This is making the feature added in https://github.com/wordpress-mobile/WordPress-iOS/pull/16823 available to everyone. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Leveraged the existing tests

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
