### PR TITLE
Fix wpios_blogging_reminders_flow_dismissed event not showing

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersTracker.swift
@@ -54,7 +54,7 @@ class BloggingRemindersTracker {
     enum Property: String {
         case button = "button"
         case daysOfWeek = "days_of_week_count"
-        case flowDismissSource, flowStartSource = "source"
+        case source = "source"
         case screen = "screen"
     }
 
@@ -88,11 +88,11 @@ class BloggingRemindersTracker {
     }
 
     func flowDismissed(source: FlowDismissSource) {
-        track(event(.flowDismissed, properties: [Property.flowDismissSource.rawValue: source.rawValue]))
+        track(event(.flowDismissed, properties: [Property.source.rawValue: source.rawValue]))
     }
 
     func flowStarted(source: FlowStartSource) {
-        track(event(.flowStart, properties: [Property.flowStartSource.rawValue: source.rawValue]))
+        track(event(.flowStart, properties: [Property.source.rawValue: source.rawValue]))
 
     }
 


### PR DESCRIPTION

Fixes #NA

To test:

- build/run and trigger the blogging reminders flow, either after post publishing or from site settings
- dismiss the flow in all possible scenarios (tapping on the x from the intro screen or day picker screen, dismiss the modal by dragging or tapping outside the screen, on iPad
- In the console, filter the log for the event `blogging_reminders_flow_dismissed`
- Go in the tracks live view and make sure that the same events show up: look for events `wpios_blogging_reminders_flow_dismissed` and make sure they match what you found in the console.
- Go back in the console and filter for the event `blogging_reminders_flow_start`
- Back in the tracks live view, also make sure that the events `wpios_logging_reminders_flow_start` still appear in there

**Note: it may take 5 to 10 minutes for the events to show in the live view**

## Regression Notes
1. Potential unintended areas of impact
none - this is a small change that only affects a property in a tracked event

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @mokagio 
