### PR TITLE
Add UI test to verify self-hosted site can be added after logging into WordPress.com

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -93,6 +93,7 @@ static NSInteger HideSearchMinSites = 3;
     self.addSiteButton.accessibilityIdentifier = @"add-site-button";
 
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelTapped)];
+    self.navigationItem.leftBarButtonItem.accessibilityIdentifier = @"cancel-button";
 
     self.navigationItem.title = NSLocalizedString(@"My Sites", @"");
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -90,6 +90,7 @@ static NSInteger HideSearchMinSites = 3;
     self.addSiteButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd
                                                                        target:self
                                                                        action:@selector(addSite)];
+    self.addSiteButton.accessibilityIdentifier = @"add-site-button";
 
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelTapped)];
 

--- a/WordPress/WordPressUITests/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LoginEpilogueScreen.swift
@@ -29,7 +29,8 @@ class LoginEpilogueScreen: BaseScreen {
         return MySiteScreen()
     }
 
-    //Used by "Self-Hosted after WordPress.com login" test. When a site is added from the Sites List, the Sites List modal remains active after the epilogue "done" button is tapped.
+    // Used by "Self-Hosted after WordPress.com login" test. When a site is added from the Sites List, the Sites List modal (MySitesScreen)
+    // remains active after the epilogue "done" button is tapped.
     func continueWithSelfHostedSiteAddedFromSitesList() -> MySitesScreen {
         continueButton.tap()
         return MySitesScreen()

--- a/WordPress/WordPressUITests/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LoginEpilogueScreen.swift
@@ -29,6 +29,12 @@ class LoginEpilogueScreen: BaseScreen {
         return MySiteScreen()
     }
 
+    //Used by "Self-Hosted after WordPress.com login" test. When a site is added from the Sites List, the Sites List modal remains active after the epilogue "done" button is tapped.
+    func continueWithSelfHostedSiteAddedFromSitesList() -> MySitesScreen {
+        continueButton.tap()
+        return MySitesScreen()
+    }
+
     func connectSite() {
         connectSiteButton.tap()
     }

--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -15,7 +15,7 @@ private struct ElementStringIDs {
     static let createButton = "floatingCreateButton"
     static let ReaderButton = "Reader"
     static let switchSiteButton = "SwitchSiteButton"
-    static let addNewSiteButton = "Add new site Button" // doesn't exist, not sure why this is here. It actually appears on the Switch Site modal.
+    static let addNewSiteButton = "Add new site Button" // doesn't exist, not sure why this is here. It actually appears on the Switch Site modal. (MySitesScreen)
 }
 
 class MySiteScreen: BaseScreen {

--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -17,7 +17,7 @@ private struct ElementStringIDs {
     static let switchSiteButton = "SwitchSiteButton"
 }
 
-///This screen object represents the My Site screen. This is the home-base screen for an individual site. It is used in many of our UI tests.
+/// The home-base screen for an individual site. Used in many of our UI tests.
 class MySiteScreen: BaseScreen {
     let tabBar: TabNavComponent
     let navBar: XCUIElement

--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -15,7 +15,7 @@ private struct ElementStringIDs {
     static let createButton = "floatingCreateButton"
     static let ReaderButton = "Reader"
     static let switchSiteButton = "SwitchSiteButton"
-    static let addNewSiteButton = "Add new site Button"
+    static let addNewSiteButton = "Add new site Button" // doesn't exist, not sure why this is here. It actually appears on the Switch Site modal.
 }
 
 class MySiteScreen: BaseScreen {

--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -15,9 +15,9 @@ private struct ElementStringIDs {
     static let createButton = "floatingCreateButton"
     static let ReaderButton = "Reader"
     static let switchSiteButton = "SwitchSiteButton"
-    static let addNewSiteButton = "Add new site Button" // doesn't exist, not sure why this is here. It actually appears on the Switch Site modal. (MySitesScreen)
 }
 
+///This screen object represents the My Site screen. This is the home-base screen for an individual site. It is used in many of our UI tests.
 class MySiteScreen: BaseScreen {
     let tabBar: TabNavComponent
     let navBar: XCUIElement

--- a/WordPress/WordPressUITests/Screens/MySitesScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySitesScreen.swift
@@ -8,7 +8,7 @@ private struct ElementStringIDs {
     static let addSelfHostedSiteButton = "Add self-hosted site"
 }
 
-/// This screen object is for the My Sites screen, aka site switcher or blog list. In the app, it's a modal we can get to from My Site by tapping the down arrow next to the site title.
+/// The site switcher aka blog list. In the app, it's a modal we can get to from My Site by tapping the down arrow next to the site title.
 class MySitesScreen: BaseScreen {
     let blogsTable: XCUIElement
     let cancelButton: XCUIElement

--- a/WordPress/WordPressUITests/Screens/MySitesScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySitesScreen.swift
@@ -2,12 +2,13 @@ import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {
-    static let blogsTable = "Blogs" // there's not actually static text here. we'll need an accessibilityID
+    static let blogsTable = "Blogs"
     static let cancelButton = "cancel-button"
     static let plusButton = "add-site-button"
     static let addSelfHostedSiteButton = "Add self-hosted site"
 }
 
+/// This screen object is for the My Sites screen, aka site switcher or blog list. In the app, it's a modal we can get to from My Site by tapping the down arrow next to the site title.
 class MySitesScreen: BaseScreen {
     let blogsTable: XCUIElement
     let cancelButton: XCUIElement
@@ -20,18 +21,9 @@ class MySitesScreen: BaseScreen {
         cancelButton = app.buttons[ElementStringIDs.cancelButton]
         plusButton = app.buttons[ElementStringIDs.plusButton]
         addSelfHostedSiteButton = app.buttons[ElementStringIDs.addSelfHostedSiteButton]
-        // need to add "+" button here for Add Site options. Something like:
-        // let plusButton = XCUIApplication().buttons["+"] accessibility inspector says it has the Label: "Add", but no accessibilityIdentifier
-        // And then the action sheet "add Self-hosted site" option.
-        // then we'll need a function to tap + and "add self-hosted site", which should return the self-hosted login flow - LoginSiteAddressScreen
 
-        super.init(element: plusButton) // using plusButton for the super.init since blogsTable isn't identified
+        super.init(element: plusButton)
     }
-
-   // func tapPlusButton() {
-     //   plusButton.tap()
-        // seems like this needs to somehow return the action sheet so that the "Add self-hosted site" button is available for addSelfHostedSite(). ActionSheetComponent exists, but presents options for adding a blog post or page. Maybe I can copy ActionSheetComponent and make BlogListActionSheetComponent? Of course I need to be able to access the "add" button before any of that matters.
- //   }
 
     func addSelfHostedSite() -> LoginSiteAddressScreen {
         plusButton.tap()
@@ -42,10 +34,6 @@ class MySitesScreen: BaseScreen {
     func closeModal() -> MySiteScreen {
         cancelButton.tap()
         return MySiteScreen()
-    }
-
-    static func isLoaded() -> Bool {
-        return XCUIApplication().tables["Blogs"].exists // oh. so because this is defined in the init just to be used by the super.init, it's not in scope to be used outside the init? Ok, so yes I should re-write
     }
 
     @discardableResult

--- a/WordPress/WordPressUITests/Screens/MySitesScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySitesScreen.swift
@@ -2,7 +2,7 @@ import UITestsFoundation
 import XCTest
 
 private struct ElementStringIDs {
-    static let blogsTable = "Blogs"
+    static let blogsTable = "Blogs" // there's not actually static text here. we'll need an accessibilityID
     static let plusButton = "add-site-button"
     static let addSelfHostedSiteButton = "Add self-hosted site"
 }
@@ -22,15 +22,16 @@ class MySitesScreen: BaseScreen {
         // And then the action sheet "add Self-hosted site" option.
         // then we'll need a function to tap + and "add self-hosted site", which should return the self-hosted login flow - LoginSiteAddressScreen
 
-        super.init(element: blogsTable)
+        super.init(element: plusButton) // using plusButton for the super.init since blogsTable isn't identified
     }
 
-    func tapPlusButton() {
-        XCUIApplication().buttons["Add"].tap()
-        // seems like this needs to somehow return the action sheet so that the "Add self-hosted site" button is available for addSelfHostedSite().
-    }
+   // func tapPlusButton() {
+     //   plusButton.tap()
+        // seems like this needs to somehow return the action sheet so that the "Add self-hosted site" button is available for addSelfHostedSite(). ActionSheetComponent exists, but presents options for adding a blog post or page. Maybe I can copy ActionSheetComponent and make BlogListActionSheetComponent? Of course I need to be able to access the "add" button before any of that matters.
+ //   }
 
     func addSelfHostedSite() -> LoginSiteAddressScreen {
+        plusButton.tap()
         XCUIApplication().buttons["Add self-hosted site"].tap()
         return LoginSiteAddressScreen()
     }

--- a/WordPress/WordPressUITests/Screens/MySitesScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySitesScreen.swift
@@ -3,18 +3,21 @@ import XCTest
 
 private struct ElementStringIDs {
     static let blogsTable = "Blogs" // there's not actually static text here. we'll need an accessibilityID
+    static let cancelButton = "cancel-button"
     static let plusButton = "add-site-button"
     static let addSelfHostedSiteButton = "Add self-hosted site"
 }
 
 class MySitesScreen: BaseScreen {
     let blogsTable: XCUIElement
+    let cancelButton: XCUIElement
     let plusButton: XCUIElement
     let addSelfHostedSiteButton: XCUIElement
 
     init() {
         let app = XCUIApplication()
         blogsTable = app.staticTexts[ElementStringIDs.blogsTable]
+        cancelButton = app.buttons[ElementStringIDs.cancelButton]
         plusButton = app.buttons[ElementStringIDs.plusButton]
         addSelfHostedSiteButton = app.staticTexts[ElementStringIDs.addSelfHostedSiteButton]
         // need to add "+" button here for Add Site options. Something like:
@@ -34,6 +37,11 @@ class MySitesScreen: BaseScreen {
         plusButton.tap()
         XCUIApplication().buttons["Add self-hosted site"].tap()
         return LoginSiteAddressScreen()
+    }
+
+    func closeModal() -> MySiteScreen {
+        cancelButton.tap()
+        return MySiteScreen()
     }
 
     static func isLoaded() -> Bool {

--- a/WordPress/WordPressUITests/Screens/MySitesScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySitesScreen.swift
@@ -3,7 +3,7 @@ import XCTest
 
 private struct ElementStringIDs {
     static let blogsTable = "Blogs"
-    static let plusButton = "Add"
+    static let plusButton = "add-site-button"
     static let addSelfHostedSiteButton = "Add self-hosted site"
 }
 
@@ -15,7 +15,7 @@ class MySitesScreen: BaseScreen {
     init() {
         let app = XCUIApplication()
         blogsTable = app.staticTexts[ElementStringIDs.blogsTable]
-        plusButton = app.staticTexts[ElementStringIDs.plusButton]
+        plusButton = app.buttons[ElementStringIDs.plusButton]
         addSelfHostedSiteButton = app.staticTexts[ElementStringIDs.addSelfHostedSiteButton]
         // need to add "+" button here for Add Site options. Something like:
         // let plusButton = XCUIApplication().buttons["+"] accessibility inspector says it has the Label: "Add", but no accessibilityIdentifier

--- a/WordPress/WordPressUITests/Screens/MySitesScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySitesScreen.swift
@@ -1,11 +1,22 @@
 import UITestsFoundation
 import XCTest
 
+private struct ElementStringIDs {
+    static let blogsTable = "Blogs"
+    static let plusButton = "Add"
+    static let addSelfHostedSiteButton = "Add self-hosted site"
+}
+
 class MySitesScreen: BaseScreen {
+    let blogsTable: XCUIElement
+    let plusButton: XCUIElement
+    let addSelfHostedSiteButton: XCUIElement
+
     init() {
-        let blogsTable = XCUIApplication().tables["Blogs"]
-        let plusButton = XCUIApplication().buttons["Add"]
-        let addSelfHostedSiteButton = XCUIApplication().buttons["Add self-hosted site"]
+        let app = XCUIApplication()
+        blogsTable = app.staticTexts[ElementStringIDs.blogsTable]
+        plusButton = app.staticTexts[ElementStringIDs.plusButton]
+        addSelfHostedSiteButton = app.staticTexts[ElementStringIDs.addSelfHostedSiteButton]
         // need to add "+" button here for Add Site options. Something like:
         // let plusButton = XCUIApplication().buttons["+"] accessibility inspector says it has the Label: "Add", but no accessibilityIdentifier
         // And then the action sheet "add Self-hosted site" option.

--- a/WordPress/WordPressUITests/Screens/MySitesScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySitesScreen.swift
@@ -4,6 +4,9 @@ import XCTest
 class MySitesScreen: BaseScreen {
     init() {
         let blogsTable = XCUIApplication().tables["Blogs"]
+        // need to add "+" button here for Add Site options. Something like:
+        // let plusButton = XCUIApplication().buttons["+"]
+        // And then the bottom-sheet "add Self-hosted site" option.
 
         super.init(element: blogsTable)
     }

--- a/WordPress/WordPressUITests/Screens/MySitesScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySitesScreen.swift
@@ -19,7 +19,7 @@ class MySitesScreen: BaseScreen {
         blogsTable = app.staticTexts[ElementStringIDs.blogsTable]
         cancelButton = app.buttons[ElementStringIDs.cancelButton]
         plusButton = app.buttons[ElementStringIDs.plusButton]
-        addSelfHostedSiteButton = app.staticTexts[ElementStringIDs.addSelfHostedSiteButton]
+        addSelfHostedSiteButton = app.buttons[ElementStringIDs.addSelfHostedSiteButton]
         // need to add "+" button here for Add Site options. Something like:
         // let plusButton = XCUIApplication().buttons["+"] accessibility inspector says it has the Label: "Add", but no accessibilityIdentifier
         // And then the action sheet "add Self-hosted site" option.
@@ -35,7 +35,7 @@ class MySitesScreen: BaseScreen {
 
     func addSelfHostedSite() -> LoginSiteAddressScreen {
         plusButton.tap()
-        XCUIApplication().buttons["Add self-hosted site"].tap()
+        addSelfHostedSiteButton.tap()
         return LoginSiteAddressScreen()
     }
 

--- a/WordPress/WordPressUITests/Screens/MySitesScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySitesScreen.swift
@@ -4,15 +4,28 @@ import XCTest
 class MySitesScreen: BaseScreen {
     init() {
         let blogsTable = XCUIApplication().tables["Blogs"]
+        let plusButton = XCUIApplication().buttons["Add"]
+        let addSelfHostedSiteButton = XCUIApplication().buttons["Add self-hosted site"]
         // need to add "+" button here for Add Site options. Something like:
-        // let plusButton = XCUIApplication().buttons["+"]
-        // And then the bottom-sheet "add Self-hosted site" option.
+        // let plusButton = XCUIApplication().buttons["+"] accessibility inspector says it has the Label: "Add", but no accessibilityIdentifier
+        // And then the action sheet "add Self-hosted site" option.
+        // then we'll need a function to tap + and "add self-hosted site", which should return the self-hosted login flow - LoginSiteAddressScreen
 
         super.init(element: blogsTable)
     }
 
+    func tapPlusButton() {
+        XCUIApplication().buttons["Add"].tap()
+        // seems like this needs to somehow return the action sheet so that the "Add self-hosted site" button is available for addSelfHostedSite().
+    }
+
+    func addSelfHostedSite() -> LoginSiteAddressScreen {
+        XCUIApplication().buttons["Add self-hosted site"].tap()
+        return LoginSiteAddressScreen()
+    }
+
     static func isLoaded() -> Bool {
-        return XCUIApplication().tables["Blogs"].exists
+        return XCUIApplication().tables["Blogs"].exists // oh. so because this is defined in the init just to be used by the super.init, it's not in scope to be used outside the init? Ok, so yes I should re-write
     }
 
     @discardableResult

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -146,18 +146,24 @@ class LoginTests: XCTestCase {
             .proceedWith(password: WPUITestCredentials.testWPcomPassword)
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite() //returns MySite screen
+
+            //From here, bring up the sites list and choose to add a new self-hosted site.
             .showSiteSwitcher()
-//            .tapPlusButton() // .addSelfHostedSite now includes plusButton.tap, so this should be redundant
             .addSelfHostedSite()
-            // and then we'll direct to the self-hosted login flow:
-            //.selectSiteAddress() this is reduntant with .addSelfHostedSite which returns the same screen
+
+            //Then, go through the self-hosted login flow:
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
             .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .continueWithSelfHostedSiteAddedFromSitesList()
+
+            //Login flow returns MySites modal, which needs to be closed.
             .closeModal()
+
+            //TODO: rewrite logoutIfNeeded() to handle logging out of a self-hosted site and then WordPress.com
+            //Currently, logoutIfNeeded() cannot handle logging out of both self-hosted and WordPress.com during tearDown(). So, we remove the self-hosted site before tearDown() starts.
             .removeSelfHostedSite()
 
-            //not sure if we need an XTCAssert() here, given we have verifyEpilogueDisplays()? And if we used one, when does it check that, for instance, PrologueScreen().isLoaded() ? Maybe it could verify that the newly added site appears in MySitesScreen? But is that redundance since we just did verifyEpilogueDisplays()? Ok actually on some tests we do verify something like MySiteScreen.isLoaded(), but some we verify that prologue.isLoaded(), aka verify that we successfully signed out.
+        XCTAssert(MySiteScreen().isLoaded())
     }
 }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -154,9 +154,10 @@ class LoginTests: XCTestCase {
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
             .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .continueWithSelectedSite()
-            .removeSelfHostedSite() // this doesn't exist in this view; continueWithSelectedSite() returns us to MySites (site switcher) and the test doesn't know how to get out. Possibly returning MySitesScreen instead of MySiteScreen because MySitesScreen is really a modal?
+            .continueWithSelfHostedSiteAddedFromSitesList()
+            .closeModal()
+            .removeSelfHostedSite()
 
-            //not sure if we need an XTCAssert() here, given we have verifyEpilogueDisplays()? And if we used one, when does it check that, for instance, PrologueScreen().isLoaded() ?
+            //not sure if we need an XTCAssert() here, given we have verifyEpilogueDisplays()? And if we used one, when does it check that, for instance, PrologueScreen().isLoaded() ? Maybe it could verify that the newly added site appears in MySitesScreen? But is that redundance since we just did verifyEpilogueDisplays()? Ok actually on some tests we do verify something like MySiteScreen.isLoaded(), but some we verify that prologue.isLoaded(), aka verify that we successfully signed out.
     }
 }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -63,7 +63,7 @@ class LoginTests: XCTestCase {
         XCTAssert(welcomeScreen.isLoaded())
     }
 
-    // Unified WordPress.com login/out
+    // Unified WordPress.com login
     // Replaces testWpcomUsernamePasswordLogin
     func testWPcomLogin() {
         _ = PrologueScreen().selectContinue()

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -141,7 +141,7 @@ class LoginTests: XCTestCase {
     // Self-Hosted after WordPress.com login.
     // Login to a WordPress.com account, open site switcher, then add a self-hosted site.
     func testAddSelfHostedSiteAfterWPcomLogin() {
-        _ = PrologueScreen().selectContinue()
+        PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWith(password: WPUITestCredentials.testWPcomPassword)
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -138,8 +138,8 @@ class LoginTests: XCTestCase {
             .verifyLoginError()
     }
 
-    //Self-Hosted after WordPress.com login
-    //Login to a WordPress.com account, then add a self-hosted site.
+    // Self-Hosted after WordPress.com login.
+    // Login to a WordPress.com account, open site switcher, then add a self-hosted site.
     func testAddSelfHostedSiteAfterWPcomLogin() {
         _ = PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
@@ -147,21 +147,22 @@ class LoginTests: XCTestCase {
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite() //returns MySite screen
 
-            //From here, bring up the sites list and choose to add a new self-hosted site.
+            // From here, bring up the sites list and choose to add a new self-hosted site.
             .showSiteSwitcher()
             .addSelfHostedSite()
 
-            //Then, go through the self-hosted login flow:
+            // Then, go through the self-hosted login flow:
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
             .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .continueWithSelfHostedSiteAddedFromSitesList()
 
-            //Login flow returns MySites modal, which needs to be closed.
+            // Login flow returns MySites modal, which needs to be closed.
             .closeModal()
 
-            //TODO: rewrite logoutIfNeeded() to handle logging out of a self-hosted site and then WordPress.com
-            //Currently, logoutIfNeeded() cannot handle logging out of both self-hosted and WordPress.com during tearDown(). So, we remove the self-hosted site before tearDown() starts.
+            // TODO: rewrite logoutIfNeeded() to handle logging out of a self-hosted site and then WordPress.com account.
+            // Currently, logoutIfNeeded() cannot handle logging out of both self-hosted and WordPress.com during tearDown().
+            // So, we remove the self-hosted site before tearDown() starts.
             .removeSelfHostedSite()
 
         XCTAssert(MySiteScreen().isLoaded())

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -147,15 +147,15 @@ class LoginTests: XCTestCase {
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite() //returns MySite screen
             .showSiteSwitcher()
-            // .addSiteButton (however we name this function)
-            // .selectSelf-Hosted
+            // .tapPlusButton() this seems unnecessary for some reason? nope, just not done correctly. This runs if you tap the + button yourself during the test.
+            .addSelfHostedSite()
             // and then we'll direct to the self-hosted login flow:
-            //.selectSiteAddress()
-            //    .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            //    .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
-              //  .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-              //  .continueWithSelectedSite()
-              //  .removeSelfHostedSite()
+            //.selectSiteAddress() this is reduntant with .addSelfHostedSite which returns the same screen
+            .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
+            .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
+            .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
+            .continueWithSelectedSite()
+            .removeSelfHostedSite() // this doesn't exist in this view; continueWithSelectedSite() returns us to MySites (site switcher) and the test doesn't know how to get out. Possibly returning MySitesScreen instead of MySiteScreen because MySitesScreen is really a modal?
 
             //not sure if we need an XTCAssert() here, given we have verifyEpilogueDisplays()? And if we used one, when does it check that, for instance, PrologueScreen().isLoaded() ?
     }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -147,7 +147,7 @@ class LoginTests: XCTestCase {
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite() //returns MySite screen
             .showSiteSwitcher()
-            // .tapPlusButton() this seems unnecessary for some reason? nope, just not done correctly. This runs if you tap the + button yourself during the test.
+            .tapPlusButton()
             .addSelfHostedSite()
             // and then we'll direct to the self-hosted login flow:
             //.selectSiteAddress() this is reduntant with .addSelfHostedSite which returns the same screen

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -137,4 +137,26 @@ class LoginTests: XCTestCase {
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()
     }
+
+    //Self-Hosted after WordPress.com login
+    //Login to a WordPress.com account, then add a self-hosted site.
+    func testAddSelfHostedSiteAfterWPcomLogin() {
+        _ = PrologueScreen().selectContinue()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
+            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .continueWithSelectedSite() //returns MySite screen
+            .showSiteSwitcher()
+            // .addSiteButton (however we name this function)
+            // .selectSelf-Hosted
+            // and then we'll direct to the self-hosted login flow:
+            //.selectSiteAddress()
+            //    .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
+            //    .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
+              //  .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
+              //  .continueWithSelectedSite()
+              //  .removeSelfHostedSite()
+
+            //not sure if we need an XTCAssert() here, given we have verifyEpilogueDisplays()? And if we used one, when does it check that, for instance, PrologueScreen().isLoaded() ?
+    }
 }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -147,7 +147,7 @@ class LoginTests: XCTestCase {
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite() //returns MySite screen
             .showSiteSwitcher()
-            .tapPlusButton()
+//            .tapPlusButton() // .addSelfHostedSite now includes plusButton.tap, so this should be redundant
             .addSelfHostedSite()
             // and then we'll direct to the self-hosted login flow:
             //.selectSiteAddress() this is reduntant with .addSelfHostedSite which returns the same screen


### PR DESCRIPTION
This PR is part of updating our login tests to account for the Unified Login & Signup flows. Context & status: paaHJt-1Kx-p2
This PR adds a new UI test, `testAddSelfHostedSiteAfterWPcomLogin`, to check that it's possible to add a self-hosted site after being logged into WordPress.com.

Since both the WordPress.com login flow and self-hosted login flow are covered in other tests, this test is mostly checking the transition between the two: tap the down arrow next to your site's title to open the site switcher, tap the "+" button, and choose "add self-hosted site".

To test:
Run `testAddSelfHostedSiteAfterWPcomLogin` from SignupTests.swift in Xcode.

Please comment on implementation as well as code quality! ❤️