### PR TITLE
Fixes broken tests in merge release 17.8 beta 3 into develop 

### DIFF
--- a/WordPress/WordPressTest/BlockEditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/BlockEditorSettingsServiceTests.swift
@@ -233,8 +233,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     }
 
     func testFetchBlockEditorSettings_OrgSite_NoPlugin() {
-        blog = BlogBuilder(context).build()
-
         try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
         let mockOrgRemoteApi = MockWordPressOrgRestApi()
@@ -257,8 +255,6 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     }
 
     func testFetchBlockEditorSettings_OrgSite() {
-        blog = BlogBuilder(context).build()
-
         try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
         let mockOrgRemoteApi = MockWordPressOrgRestApi()
@@ -278,6 +274,7 @@ class BlockEditorSettingsServiceTests: XCTestCase {
 
     func testFetchBlockEditorSettings_Com5_8Site() {
         blog = BlogBuilder(context)
+            .with(wordPressVersion: "5.8")
             .withAnAccount()
             .build()
 
@@ -298,6 +295,13 @@ class BlockEditorSettingsServiceTests: XCTestCase {
     }
 
     func testFetchBlockEditorSettings_Com5_9Site() {
+        blog = BlogBuilder(context)
+            .with(wordPressVersion: "5.9")
+            .withAnAccount()
+            .build()
+
+        service = BlockEditorSettingsService(blog: blog, remoteAPI: mockRemoteApi, context: context)
+
         try! FeatureFlagOverrideStore().override(FeatureFlag.globalStyleSettings, withValue: true)
         let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
         let waitExpectation = expectation(description: "Theme should be successfully fetched")


### PR DESCRIPTION
## Description
Fixes [broken tests](https://github.com/wordpress-mobile/WordPress-iOS/pull/16901/commits/3821589767e27915f5ad431e4516c12d8c57d7ed) in merge release 17.8 beta 3 into develop 

To test:
Verify that the `BlockEditorSettingsServiceTests` tests are successful (ci should do that) 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
