### PR TITLE
Comment: convert ObjC statuses to Swift

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 17.9
 -----
-* [internal] Converted part of Comment model to Swift. Should be no functional changes. [#16898]
+* [internal] Converted parts of Comment model to Swift. Should be no functional changes, but could cause regressions. [#16898, #16905]
 * [*] Enables Support for Global Style Colors with Full Site Editing Themes [#16823]
 
 17.8

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -220,7 +220,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 - (NSString *)loginUrl;
 - (NSString *)urlWithPath:(NSString *)path;
 - (NSString *)adminUrlWithPath:(NSString *)path;
-- (NSUInteger)numberOfPendingComments;
 - (NSDictionary *) getImageResizeDimensions;
 - (BOOL)supportsFeaturedImages;
 - (BOOL)supports:(BlogFeature)feature;

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -226,26 +226,6 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     return [NSString stringWithFormat:@"%@%@", adminBaseUrl, path];
 }
 
-- (NSUInteger)numberOfPendingComments
-{
-    NSUInteger pendingComments = 0;
-    if ([self hasFaultForRelationshipNamed:@"comments"]) {
-        NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"Comment"];
-        [request setPredicate:[NSPredicate predicateWithFormat:@"blog = %@ AND status like 'hold'", self]];
-        [request setIncludesSubentities:NO];
-        NSError *error;
-        pendingComments = [self.managedObjectContext countForFetchRequest:request error:&error];
-    } else {
-        for (Comment *element in self.comments) {
-            if ( [CommentStatusPending isEqualToString:element.status] ) {
-                pendingComments++;
-            }
-        }
-    }
-
-    return pendingComments;
-}
-
 - (NSArray *)sortedCategories
 {
     NSSortDescriptor *sortNameDescriptor = [[NSSortDescriptor alloc] initWithKey:@"categoryName"

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -5,14 +5,6 @@
 @class BasePost;
 
 
-extern NSString * const CommentStatusPending;
-extern NSString * const CommentStatusApproved;
-extern NSString * const CommentStatusUnapproved;
-extern NSString * const CommentStatusSpam;
-// Draft status is for comments that have not yet been successfully published
-// we can use this status to restore comment replies that the user has written
-extern NSString * const CommentStatusDraft;
-
 @interface Comment: NSManagedObject
 
 @property (nonatomic, strong) Blog *blog;

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -4,8 +4,6 @@
 @class Blog;
 @class BasePost;
 
-// This is the notification name used with NSNotificationCenter
-extern NSString * const CommentUploadFailedNotification;
 
 extern NSString * const CommentStatusPending;
 extern NSString * const CommentStatusApproved;

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -35,9 +35,9 @@
 
 + (NSString *)titleForStatus:(NSString *)status
 {
-    if ([status isEqualToString:CommentStatusPending]) {
+    if ([status isEqualToString:[Comment descriptionFor:CommentStatusTypePending]]) {
         return NSLocalizedString(@"Pending moderation", @"Comment status");
-    } else if ([status isEqualToString:CommentStatusApproved]) {
+    } else if ([status isEqualToString:[Comment descriptionFor:CommentStatusTypeApproved]]) {
         return NSLocalizedString(@"Comments", @"Comment status");
     }
 
@@ -116,7 +116,7 @@
 
 - (BOOL)isApproved
 {
-    return [self.status isEqualToString:CommentStatusApproved];
+    return [self.status isEqualToString:[Comment descriptionFor:CommentStatusTypeApproved]];
 }
 
 - (BOOL)isReadOnly

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -5,7 +5,6 @@
 #import <WordPressShared/NSString+XMLExtensions.h>
 #import "WordPress-Swift.h"
 
-NSString * const CommentUploadFailedNotification = @"CommentUploadFailed";
 
 NSString * const CommentStatusPending = @"hold";
 NSString * const CommentStatusApproved = @"approve";

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -2,17 +2,8 @@
 #import "ContextManager.h"
 #import "Blog.h"
 #import "BasePost.h"
-#import <WordPressShared/NSString+XMLExtensions.h>
 #import "WordPress-Swift.h"
 
-
-NSString * const CommentStatusPending = @"hold";
-NSString * const CommentStatusApproved = @"approve";
-NSString * const CommentStatusUnapproved = @"trash";
-NSString * const CommentStatusSpam = @"spam";
-
-// draft is used for comments that have been composed but not succesfully uploaded yet
-NSString * const CommentStatusDraft = @"draft";
 
 @implementation Comment
 

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -1,5 +1,38 @@
 import Foundation
 
+// When CommentViewController and CommentService are converted to Swift, this can be simplified to a String enum.
+@objc enum CommentStatusType: Int {
+    case pending
+    case approved
+    case unapproved
+    case spam
+    // Draft status is for comments that have not yet been successfully published/uploaded.
+    // We can use this status to restore comment replies that the user has written.
+    case draft
+
+    var description: String {
+        switch self {
+        case .pending:
+            return "hold"
+        case .approved:
+            return "approve"
+        case .unapproved:
+            return "trash"
+        case .spam:
+            return "spam"
+        case .draft:
+            return "draft"
+        }
+    }
+}
+
+extension Comment {
+    @objc static func descriptionFor(_ commentStatus: CommentStatusType) -> String {
+        return commentStatus.description
+    }
+}
+
+
 private extension Comment {
     func decodedContent() -> String {
         return content.stringByDecodingXMLCharacters().trim().strippingHTML().normalizingWhitespace() ?? String()

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -111,7 +111,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     reply.postID = comment.postID;
     reply.post = comment.post;
     reply.parentID = comment.commentID;
-    reply.status = CommentStatusApproved;
+    reply.status = [Comment descriptionFor:CommentStatusTypeApproved];
     return reply;
 }
 
@@ -119,7 +119,10 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 - (Comment *)restoreReplyForComment:(Comment *)comment
 {
     NSFetchRequest *existingReply = [NSFetchRequest fetchRequestWithEntityName:NSStringFromClass([Comment class])];
-    existingReply.predicate = [NSPredicate predicateWithFormat:@"status == %@ AND parentID == %@", CommentStatusDraft, comment.commentID];
+    NSString *draft = [Comment descriptionFor:CommentStatusTypeDraft];
+    existingReply.predicate = [NSPredicate predicateWithFormat:@"status == %@ AND parentID == %@",
+                               draft,
+                               comment.commentID];
     existingReply.fetchLimit = 1;
 
     NSError *error;
@@ -133,8 +136,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
         reply = [self createReplyForComment:comment];
     }
 
-    reply.status = CommentStatusDraft;
-
+    reply.status = draft;
     return reply;
 }
 
@@ -394,7 +396,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
                failure:(void (^)(NSError *error))failure
 {
     [self moderateComment:comment
-               withStatus:CommentStatusApproved
+               withStatus:CommentStatusTypeApproved
                   success:success
                   failure:failure];
 }
@@ -405,7 +407,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
                  failure:(void (^)(NSError *error))failure
 {
     [self moderateComment:comment
-               withStatus:CommentStatusPending
+               withStatus:CommentStatusTypePending
                   success:success
                   failure:failure];
 }
@@ -417,7 +419,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 {
     NSManagedObjectID *commentID = comment.objectID;
     [self moderateComment:comment
-               withStatus:CommentStatusSpam
+               withStatus:CommentStatusTypeSpam
                   success:^{
                       Comment *commentInContext = (Comment *)[self.managedObjectContext existingObjectWithID:commentID error:nil];
                       [self.managedObjectContext deleteObject:commentInContext];
@@ -721,7 +723,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 {
     CommentServiceRemoteREST *remote = [self restRemoteForSite:siteID];
     [remote moderateCommentWithID:commentID
-                           status:CommentStatusSpam
+                           status:[Comment descriptionFor:CommentStatusTypeSpam]
                           success:success
                           failure:failure];
 }
@@ -801,19 +803,21 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 #pragma mark - Blog centric methods
 // Generic moderation
 - (void)moderateComment:(Comment *)comment
-             withStatus:(NSString *)status
+             withStatus:(int)status
                 success:(void (^)(void))success
                 failure:(void (^)(NSError *error))failure
 {
+    NSString *currentStatus = [Comment descriptionFor:status];
     NSString *prevStatus = comment.status;
-    if ([prevStatus isEqualToString:status]) {
+
+    if ([prevStatus isEqualToString:currentStatus]) {
         if (success) {
             success();
         }
         return;
     }
 
-    comment.status = status;
+    comment.status = currentStatus;
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
     id <CommentServiceRemote> remote = [self remoteForBlog:comment.blog];
     RemoteComment *remoteComment = [self remoteCommentWithComment:comment];
@@ -954,7 +958,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     comment.parentID = parentID;
     comment.postID = postID;
     comment.postTitle = post.postTitle;
-    comment.status = CommentStatusDraft;
+    comment.status = [Comment descriptionFor:CommentStatusTypeDraft];
     comment.post = post;
 
     // Increment the post's comment count. 

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -803,7 +803,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 #pragma mark - Blog centric methods
 // Generic moderation
 - (void)moderateComment:(Comment *)comment
-             withStatus:(int)status
+             withStatus:(CommentStatusType)status
                 success:(void (^)(void))success
                 failure:(void (^)(NSError *error))failure
 {

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -346,7 +346,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     cell.timestamp = [self.comment.dateCreated mediumString];
     cell.site = self.comment.authorUrlForDisplay;
     cell.commentText = [self.comment contentForDisplay];
-    cell.isApproved = [self.comment.status isEqualToString:CommentStatusApproved];
+    cell.isApproved = [self.comment.status isEqualToString:[Comment descriptionFor:CommentStatusTypeApproved]];
      __typeof(self) __weak weakSelf = self;
     cell.onTimeStampLongPress = ^(void) {
         NSURL *url = [NSURL URLWithString:weakSelf.comment.link];
@@ -400,7 +400,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
         return;
     }
 
-    cell.isApproveOn = [self.comment.status isEqualToString:CommentStatusApproved];
+    cell.isApproveOn = [self.comment.status isEqualToString:[Comment descriptionFor:CommentStatusTypeApproved]];
     cell.isLikeOn = self.comment.isLiked;
 
     // Setup the Callbacks
@@ -533,8 +533,8 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
     // If the Comment is currently Spam or Trash, the Trash action will permanently delete the Comment.
     // Set the displayed messages accordingly.
-    BOOL willBePermanentlyDeleted = [self.comment.status isEqualToString:CommentStatusSpam] ||
-                                    [self.comment.status isEqualToString:CommentStatusUnapproved];
+    BOOL willBePermanentlyDeleted = [self.comment.status isEqualToString:[Comment descriptionFor:CommentStatusTypeSpam]] ||
+                                    [self.comment.status isEqualToString:[Comment descriptionFor:CommentStatusTypeUnapproved]];
     
     NSString *trashMessage = NSLocalizedString(@"Are you sure you want to mark this comment as Trash?",
                                                @"Message asking for confirmation before marking a comment as trash");

--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -36,7 +36,7 @@ open class CommentsTableViewCell: WPTableViewCell {
 
     @objc func configureWithComment(_ comment: Comment) {
         author = comment.authorForDisplay()
-        pending = (comment.status == CommentStatusPending)
+        pending = (comment.status == CommentStatusType.pending.description)
         postTitle = comment.titleForDisplay()
         content = comment.contentPreviewForDisplay()
 

--- a/WordPress/Classes/ViewRelated/Comments/ListTableViewCell+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ListTableViewCell+Comments.swift
@@ -5,7 +5,7 @@ extension ListTableViewCell {
     @objc func configureWithComment(_ comment: Comment) {
         // indicator view
         indicatorColor = Style.pendingIndicatorColor
-        showsIndicator = (comment.status == CommentStatusPending)
+        showsIndicator = (comment.status == CommentStatusType.pending.description)
 
         // avatar image
         placeholderImage = Style.gravatarPlaceholderImage


### PR DESCRIPTION
Ref: #16876

This moves the Comment statuses from ObjC `const`s to a Swift `enum`.

Notes:
- Naming the enum `CommentStatus` led to ObjC files trying to find the status in the `CommentStatusFilter` enum instead of the new one. So I went with `CommentStatusType`. 
- `CommentUploadFailedNotification` was not used, so it's been removed.
- `numberOfPendingComments` was not used, so it's been removed.

To test:
My Site > Comments:
- Verify comments are the correct status (i.e in the correct filters).
- Verify Pending comments have pending indicators.

My Site > Comments > comment details:
- Verify the Approve/Unapprove moderation button is the correct state.
- Moderate comments (Approve, Unapprove, Spam, Trash). Verify the status is updated correctly.
- Reply to a comment. Verify the status of your reply is Approved.

## Regression Notes
1. Potential unintended areas of impact
Comment statuses could be incorrect.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Compared comment statuses with prior app version to verify they are the same.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
