### PR TITLE
Reader: Fixes an issue with reader comments being incorrectly rendered.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.37.0'
+    # pod 'WordPressKit', '~> 4.37.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/store-both-comment-content-fields'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.37.0'
+    pod 'WordPressKit', '~> 4.37.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/store-both-comment-content-fields'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -452,7 +452,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.37.0):
+  - WordPressKit (4.37.1-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.39.0)
-  - WordPressKit (~> 4.37.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `fix/store-both-comment-content-fields`)
   - WordPressMocks (~> 0.0.13)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.1)
@@ -604,7 +604,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -711,6 +710,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.57.1
+  WordPressKit:
+    :branch: fix/store-both-comment-content-fields
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.57.1/third-party-podspecs/Yoga.podspec.json
 
@@ -726,6 +728,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.57.1
+  WordPressKit:
+    :commit: f3923073f7b348865cba278d98ffe9be25756933
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -810,7 +815,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: c50b9737d6f459b1010bd07daa9885d19505c504
-  WordPressKit: bd2386909067b48b5525569cefac206bc4234eb5
+  WordPressKit: f0a5abfee5326cb5380f9316c3f4769dda4ca167
   WordPressMocks: dfac50a938ac74dddf5f7cce5a9110126408dd19
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 414bf3a7d007618f94a1c7969d6e849779877d5d
@@ -826,6 +831,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: ba40d32d91e8970f2f61181c9f50c7d9c96f40ba
+PODFILE CHECKSUM: fc1ef493aea15b8046f4c05999fc0faa47fe280d
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -452,7 +452,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.37.1-beta.1):
+  - WordPressKit (4.37.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.39.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `fix/store-both-comment-content-fields`)
+  - WordPressKit (~> 4.37.0)
   - WordPressMocks (~> 0.0.13)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.1)
@@ -565,6 +565,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressKit
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -710,9 +711,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.57.1
-  WordPressKit:
-    :branch: fix/store-both-comment-content-fields
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.57.1/third-party-podspecs/Yoga.podspec.json
 
@@ -728,9 +726,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.57.1
-  WordPressKit:
-    :commit: f3923073f7b348865cba278d98ffe9be25756933
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -815,7 +810,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: c50b9737d6f459b1010bd07daa9885d19505c504
-  WordPressKit: f0a5abfee5326cb5380f9316c3f4769dda4ca167
+  WordPressKit: eef10a39080a07cb3565fcdfa0ee2fcfe5730b6a
   WordPressMocks: dfac50a938ac74dddf5f7cce5a9110126408dd19
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 414bf3a7d007618f94a1c7969d6e849779877d5d
@@ -831,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: fc1ef493aea15b8046f4c05999fc0faa47fe280d
+PODFILE CHECKSUM: ba40d32d91e8970f2f61181c9f50c7d9c96f40ba
 
 COCOAPODS: 1.10.1

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -1004,7 +1004,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 
 - (void)updateCommentAndSave:(Comment *)comment withRemoteComment:(RemoteComment *)remoteComment
 {
-    [self updateComment:comment withRemoteComment:remoteComment];
+    [self updateReaderComment:comment withRemoteComment:remoteComment];
     // Find its parent comment (if it exists)
     Comment *parentComment;
     if (comment.parentID) {
@@ -1035,7 +1035,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
             comment = [NSEntityDescription insertNewObjectForEntityForName:entityName inManagedObjectContext:self.managedObjectContext];
         }
 
-        [self updateComment:comment withRemoteComment:remoteComment];
+        [self updateReaderComment:comment withRemoteComment:remoteComment];
 
         // Calculate hierarchy and depth.
         ancestors = [self ancestorsForCommentWithParentID:comment.parentID andCurrentAncestors:ancestors];
@@ -1132,6 +1132,39 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 #pragma mark - Transformations
 
 - (void)updateComment:(Comment *)comment withRemoteComment:(RemoteComment *)remoteComment
+{
+    comment.commentID = remoteComment.commentID;
+    comment.author = remoteComment.author;
+    comment.author_email = remoteComment.authorEmail;
+    comment.author_url = remoteComment.authorUrl;
+    comment.authorAvatarURL = remoteComment.authorAvatarURL;
+    // Ref: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/413
+    // Use raw_content for blog comments so
+    // This is a temporary mixmatch of properties for a frozen branch bug fix that we'll sort out properly in develop.
+    // - @aerych
+    comment.content = remoteComment.rawContent;
+    comment.dateCreated = remoteComment.date;
+    comment.link = remoteComment.link;
+    comment.parentID = remoteComment.parentID;
+    comment.postID = remoteComment.postID;
+    comment.postTitle = remoteComment.postTitle;
+    comment.status = remoteComment.status;
+    comment.type = remoteComment.type;
+    comment.isLiked = remoteComment.isLiked;
+    comment.likeCount = remoteComment.likeCount;
+    comment.canModerate = remoteComment.canModerate;
+
+    // if the post for the comment is not set, check if that post is already stored and associate them
+    if (!comment.post) {
+        PostService *postService = [[PostService alloc] initWithManagedObjectContext:self.managedObjectContext];
+        comment.post = [postService findPostWithID:comment.postID inBlog:comment.blog];
+    }
+}
+
+// Temporary duplication of [updateComment:withRemoteComment:] to address an issue in a frozen branch
+// We'll sort it out properly in develop.
+// - @aerych
+- (void)updateReaderComment:(Comment *)comment withRemoteComment:(RemoteComment *)remoteComment
 {
     comment.commentID = remoteComment.commentID;
     comment.author = remoteComment.author;


### PR DESCRIPTION
This PR is part of a bug fix for WPiOS `release/17.8`. 
More in p1626841091202200-slack-hummingbird

WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/419

In https://github.com/wordpress-mobile/WordPressKit-iOS/pull/413 we made a change to consume `raw_content` rather than `content` field from the Comments endpoints.  This [resolved](https://github.com/wordpress-mobile/WordPress-iOS/pull/16768) an [issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/16685) with Authors and Contributors not being able to view Comment content.  However, we missed that it created a new issue with comments in the Reader being incorrectly rendered in many cases as the `raw_comment` field does not include html mark up for non-P2 WordPress sites.  P2s that use the block editor for comments were rendered correctly.  We were unaware of this difference between P2 and non-P2 comments.  The reader's caching behavior likely contributed to missing the regression. 

Example of the badness. Note the cropped lines of text:
![Simulator Screen Shot - iPhone 11 - 2021-07-20 at 23 12 22](https://user-images.githubusercontent.com/1435271/126558810-7ee0e22d-6513-4a28-879a-1cba628e4407.png)


This PR adopts changes in WordPressKit to consume both `content` and `raw_content` fields returned by the comments endpoint.  Blog comments that are wrangled by the My Site and Notifications feature continue to use the `raw_content` value.  Reader comments are assigned the `content` value to preserve the expected HTML mark up and restore the correct rendering behavior.   The changes are a temporary measure that we'd like to improve in a subsequent update.

### Testing Details
Switch to this branch and test the following: 
- Confirm that reader comments are correctly rendered.  
- Confirm that comments in My Sites are correctly rendered.
- Confirm that authors and contributors can still view comments under My Sites.
- Confirm that comments under Notifications are correctly rendered.
- Confirm that replying to a reader comment works as expected and there are no layout issues. 
- Confirm that editing a my sites or notifications comment works as expected.

## Regression Notes
1. Potential unintended areas of impact
Non-reader comments.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Smoke tested Notifications and My Site comments.

3. What automated tests I added (or what prevented me from doing so)
Requires a visual evaluation.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
