### PR TITLE
Comment: address ObjC private methods

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 17.9
 -----
-* [internal] Converted parts of Comment model to Swift. Should be no functional changes, but could cause regressions. [#16898, #16905]
+* [internal] Converted parts of Comment model to Swift. Should be no functional changes, but could cause regressions. [#16898, #16905, #16908]
 * [*] Enables Support for Global Style Colors with Full Site Editing Themes [#16823]
 
 17.8

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -44,23 +44,6 @@
     return status;
 }
 
-- (NSString *)postTitle
-{
-    NSString *title = nil;
-    if (self.post) {
-        title = self.post.postTitle;
-    } else {
-        [self willAccessValueForKey:@"postTitle"];
-        title = [self primitiveValueForKey:@"postTitle"];
-        [self didAccessValueForKey:@"postTitle"];
-    }
-
-    if (title == nil || [@"" isEqualToString:title]) {
-        title = NSLocalizedString(@"(no title)", @"the post has no title.");
-    }
-    return title;
-
-}
 
 - (NSDate *)dateCreated
 {

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -62,21 +62,6 @@
 
 }
 
-- (NSString *)author
-{
-    NSString *authorName = nil;
-
-    [self willAccessValueForKey:@"author"];
-    authorName = [self primitiveValueForKey:@"author"];
-    [self didAccessValueForKey:@"author"];
-
-    if (authorName == nil || [@"" isEqualToString:authorName]) {
-        authorName = NSLocalizedString(@"Anonymous", @"the comment has an anonymous author.");
-    }
-    return authorName;
-
-}
-
 - (NSDate *)dateCreated
 {
     NSDate *date = nil;

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -44,32 +44,12 @@
     return status;
 }
 
-
-- (NSDate *)dateCreated
-{
-    NSDate *date = nil;
-
-    [self willAccessValueForKey:@"dateCreated"];
-    date = [self primitiveValueForKey:@"dateCreated"];
-    [self didAccessValueForKey:@"dateCreated"];
-
-    return date;
-}
-
 - (NSString *)sectionIdentifier
 {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     formatter.dateStyle = NSDateFormatterLongStyle;
     formatter.timeStyle = NSDateFormatterNoStyle;
     return [formatter stringFromDate:self.dateCreated];
-}
-
-- (BOOL)isPrivateContent
-{
-    if ([self.post respondsToSelector:@selector(isPrivateAtWPCom)]) {
-        return (BOOL)[self.post performSelector:@selector(isPrivateAtWPCom)];
-    }
-    return NO;
 }
 
 - (NSString *)authorUrlForDisplay

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -34,9 +34,20 @@ extension Comment {
 
 
 private extension Comment {
+
     func decodedContent() -> String {
         return content.stringByDecodingXMLCharacters().trim().strippingHTML().normalizingWhitespace() ?? String()
     }
+
+    func authorName() -> String {
+        guard let authorName = author,
+              !authorName.isEmpty else {
+            return NSLocalizedString("Anonymous", comment: "the comment has an anonymous author.")
+        }
+
+        return authorName
+    }
+
 }
 
 extension Comment: PostContentProvider {
@@ -52,7 +63,7 @@ extension Comment: PostContentProvider {
     }
 
     public func authorForDisplay() -> String {
-        var displayAuthor = author.stringByDecodingXMLCharacters().trim()
+        var displayAuthor = authorName().stringByDecodingXMLCharacters().trim()
 
         if displayAuthor.isEmpty {
             displayAuthor = author_email.trim()

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -53,13 +53,12 @@ private extension Comment {
 extension Comment: PostContentProvider {
 
     public func titleForDisplay() -> String {
-        let title = postTitle.stringByDecodingXMLCharacters()
-
-        guard !title.isEmpty else {
+        guard let title = post?.postTitle ?? postTitle,
+              !title.isEmpty else {
             return NSLocalizedString("(No Title)", comment: "Empty Post Title")
         }
 
-        return title
+        return title.stringByDecodingXMLCharacters()
     }
 
     public func authorForDisplay() -> String {


### PR DESCRIPTION
Ref: #16876
Depends on (branched off of): #16905

This addresses the ObjC `Comment` private methods.
- `postTitle` - logic added to Swift `titleForDisplay` method.
- `author` - moved to Swift `authorName` method.
- `dateCreated` - removed. Made redundant by Swift `dateForDisplay`.
- `isPrivateContent` - removed. It was not used.

To test:

My Site > Comments list:
- Verify the author name is correct.
- Verify the post title is correct.
- Comment on a post with no title. In the Comments list, verify the post title is "(No Title)".

Reader > post comments:
- Verify the date created is correct (ex: `5 days ago`).

## Regression Notes
1. Potential unintended areas of impact
The components listed above could be displayed incorrectly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Compared with a previous app version and verified they appear the same.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
