### PR TITLE
Comment: address ObjC public methods

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 17.9
 -----
 * [internal] Redirect Terms and service to open the page in an external web view [#16907]
-* [internal] Converted parts of Comment model to Swift. Should be no functional changes, but could cause regressions. [#16898, #16905, #16908]
+* [internal] Converted Comment model methods to Swift. Should be no functional changes, but could cause regressions. [#16898, #16905, #16908, #16913]
 * [*] Enables Support for Global Style Colors with Full Site Editing Themes [#16823]
 
 17.8

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -39,7 +39,6 @@
 
 /// Helper methods
 ///
-- (NSString *)sectionIdentifier;
 - (BOOL)authorIsPostAuthor;
 
 @end

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -39,7 +39,6 @@
 
 /// Helper methods
 ///
-- (BOOL)hasAuthorUrl;
 - (BOOL)isApproved;
 - (NSString *)sectionIdentifier;
 - (BOOL)isReadOnly;

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -40,7 +40,6 @@
 /// Helper methods
 ///
 - (NSString *)sectionIdentifier;
-- (BOOL)isReadOnly;
 - (BOOL)authorIsPostAuthor;
 
 @end

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -39,7 +39,6 @@
 
 /// Helper methods
 ///
-- (NSString *)authorUrlForDisplay;
 - (BOOL)hasAuthorUrl;
 - (BOOL)isApproved;
 - (NSString *)sectionIdentifier;

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -39,7 +39,6 @@
 
 /// Helper methods
 ///
-+ (NSString *)titleForStatus:(NSString *)status;
 - (NSString *)authorUrlForDisplay;
 - (BOOL)hasAuthorUrl;
 - (BOOL)isApproved;

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -45,6 +45,5 @@
 - (NSString *)sectionIdentifier;
 - (BOOL)isReadOnly;
 - (BOOL)authorIsPostAuthor;
-- (NSNumber *)numberOfLikes;
 
 @end

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -39,7 +39,6 @@
 
 /// Helper methods
 ///
-- (BOOL)isApproved;
 - (NSString *)sectionIdentifier;
 - (BOOL)isReadOnly;
 - (BOOL)authorIsPostAuthor;

--- a/WordPress/Classes/Models/Comment.h
+++ b/WordPress/Classes/Models/Comment.h
@@ -37,8 +37,4 @@
 @property (nonatomic, assign) BOOL isNew;
 @property (nonatomic) BOOL canModerate;
 
-/// Helper methods
-///
-- (BOOL)authorIsPostAuthor;
-
 @end

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -33,16 +33,6 @@
 
 #pragma mark - Helper methods
 
-+ (NSString *)titleForStatus:(NSString *)status
-{
-    if ([status isEqualToString:[Comment descriptionFor:CommentStatusTypePending]]) {
-        return NSLocalizedString(@"Pending moderation", @"Comment status");
-    } else if ([status isEqualToString:[Comment descriptionFor:CommentStatusTypeApproved]]) {
-        return NSLocalizedString(@"Comments", @"Comment status");
-    }
-
-    return status;
-}
 
 - (NSString *)sectionIdentifier
 {

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -73,9 +73,5 @@
     return [[self authorURL] isEqual:[self.post authorURL]];
 }
 
-- (NSNumber *)numberOfLikes
-{
-    return self.likeCount ?: @(0);
-}
 
 @end

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -33,15 +33,6 @@
 
 #pragma mark - Helper methods
 
-
-- (NSString *)sectionIdentifier
-{
-    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-    formatter.dateStyle = NSDateFormatterLongStyle;
-    formatter.timeStyle = NSDateFormatterNoStyle;
-    return [formatter stringFromDate:self.dateCreated];
-}
-
 - (BOOL)authorIsPostAuthor
 {
     return [[self authorURL] isEqual:[self.post authorURL]];

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -43,10 +43,6 @@
 }
 
 
-- (BOOL)hasAuthorUrl
-{
-    return self.author_url && ![self.author_url isEqualToString:@""];
-}
 
 - (BOOL)isApproved
 {

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -42,17 +42,6 @@
     return [formatter stringFromDate:self.dateCreated];
 }
 
-- (BOOL)isReadOnly
-{
-    // If the current user cannot moderate the comment, they can only Like and Reply if the comment is Approved.
-    if ((self.blog.isHostedAtWPcom || self.blog.isAtomic)
-        && !self.canModerate && !self.isApproved) {
-        return YES;
-    }
-
-    return NO;
-}
-
 - (BOOL)authorIsPostAuthor
 {
     return [[self authorURL] isEqual:[self.post authorURL]];

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -31,12 +31,4 @@
 @synthesize isNew;
 @synthesize attributedContent;
 
-#pragma mark - Helper methods
-
-- (BOOL)authorIsPostAuthor
-{
-    return [[self authorURL] isEqual:[self.post authorURL]];
-}
-
-
 @end

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -42,13 +42,6 @@
     return [formatter stringFromDate:self.dateCreated];
 }
 
-
-
-- (BOOL)isApproved
-{
-    return [self.status isEqualToString:[Comment descriptionFor:CommentStatusTypeApproved]];
-}
-
 - (BOOL)isReadOnly
 {
     // If the current user cannot moderate the comment, they can only Like and Reply if the comment is Approved.

--- a/WordPress/Classes/Models/Comment.m
+++ b/WordPress/Classes/Models/Comment.m
@@ -42,10 +42,6 @@
     return [formatter stringFromDate:self.dateCreated];
 }
 
-- (NSString *)authorUrlForDisplay
-{
-    return self.author_url.hostname;
-}
 
 - (BOOL)hasAuthorUrl
 {

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -32,6 +32,9 @@ extension Comment {
     }
 }
 
+    func numberOfLikes() -> Int {
+        return likeCount.intValue
+    }
 
 private extension Comment {
 

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -39,6 +39,9 @@ extension Comment {
         return likeCount.intValue
     }
 
+    func hasAuthorUrl() -> Bool {
+        return author_url != nil && !author_url.isEmpty
+    }
 private extension Comment {
 
     func decodedContent() -> String {

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -35,6 +35,10 @@ extension Comment {
         return authorURL()?.host ?? String()
     }
 
+    @objc func isApproved() -> Bool {
+        return status.isEqual(to: CommentStatusType.approved.description)
+    }
+
     func numberOfLikes() -> Int {
         return likeCount.intValue
     }

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -71,19 +71,6 @@ extension Comment: PostContentProvider {
         return displayAuthor.isEmpty ? String() : displayAuthor
     }
 
-    public func blogNameForDisplay() -> String? {
-        return author_url
-    }
-
-    public func statusForDisplay() -> String {
-        var status = Comment.title(forStatus: status) ?? ""
-        if status.isEqual(to: NSLocalizedString("Comments", comment: "Comment status")) {
-            status = ""
-        }
-
-        return status
-    }
-
     public func contentForDisplay() -> String {
         return decodedContent()
     }

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -44,6 +44,13 @@ extension Comment {
         return (blog.isHostedAtWPcom || blog.isAtomic()) && !canModerate && !isApproved()
     }
 
+    @objc func sectionIdentifier() -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        formatter.timeStyle = .none
+        return formatter.string(from: dateCreated)
+    }
+
     func numberOfLikes() -> Int {
         return likeCount.intValue
     }

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -27,10 +27,11 @@ import Foundation
 }
 
 extension Comment {
+
     @objc static func descriptionFor(_ commentStatus: CommentStatusType) -> String {
         return commentStatus.description
     }
-}
+
     @objc func authorUrlForDisplay() -> String {
         return authorURL()?.host ?? String()
     }
@@ -58,6 +59,20 @@ extension Comment {
     func hasAuthorUrl() -> Bool {
         return author_url != nil && !author_url.isEmpty
     }
+
+    func authorIsPostAuthor() -> Bool {
+        guard let commentAuthor = author_url,
+              !commentAuthor.isEmpty,
+            let readerPost = (post as? ReaderPost),
+            let postAuthor = readerPost.authorURL() else {
+            return false
+        }
+
+        return commentAuthor.isEqual(to: postAuthor)
+    }
+
+}
+
 private extension Comment {
 
     func decodedContent() -> String {

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -39,6 +39,11 @@ extension Comment {
         return status.isEqual(to: CommentStatusType.approved.description)
     }
 
+    @objc func isReadOnly() -> Bool {
+        // If the current user cannot moderate the comment, they can only Like and Reply if the comment is Approved.
+        return (blog.isHostedAtWPcom || blog.isAtomic()) && !canModerate && !isApproved()
+    }
+
     func numberOfLikes() -> Int {
         return likeCount.intValue
     }

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -31,6 +31,9 @@ extension Comment {
         return commentStatus.description
     }
 }
+    @objc func authorUrlForDisplay() -> String {
+        return authorURL()?.host ?? String()
+    }
 
     func numberOfLikes() -> Int {
         return likeCount.intValue

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -60,17 +60,6 @@ extension Comment {
         return author_url != nil && !author_url.isEmpty
     }
 
-    func authorIsPostAuthor() -> Bool {
-        guard let commentAuthor = author_url,
-              !commentAuthor.isEmpty,
-            let readerPost = (post as? ReaderPost),
-            let postAuthor = readerPost.authorURL() else {
-            return false
-        }
-
-        return commentAuthor.isEqual(to: postAuthor)
-    }
-
 }
 
 private extension Comment {

--- a/WordPress/Classes/Models/PostContentProvider.h
+++ b/WordPress/Classes/Models/PostContentProvider.h
@@ -3,14 +3,14 @@
 @protocol PostContentProvider <NSObject>
 - (NSString *)titleForDisplay;
 - (NSString *)authorForDisplay;
-- (NSString *)blogNameForDisplay;
-- (NSString *)statusForDisplay;
 - (NSString *)contentForDisplay;
 - (NSString *)contentPreviewForDisplay;
 - (NSURL *)avatarURLForDisplay; // Some providers use a hardcoded URL or blavatar URL
 - (NSString *)gravatarEmailForDisplay;
 - (NSDate *)dateForDisplay;
 @optional
+- (NSString *)blogNameForDisplay;
+- (NSString *)statusForDisplay;
 - (BOOL)unreadStatusForDisplay;
 - (NSURL *)featuredImageURLForDisplay;
 - (NSURL *)authorURL;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -184,9 +184,7 @@ class ReaderCommentCell: UITableViewCell {
         authorButton.setTitleColor(.primaryLight, for: .highlighted)
         authorButton.setTitleColor(.neutral(.shade60), for: .disabled)
 
-        if comment.authorIsPostAuthor() {
-            authorButton.setTitleColor(.accent, for: .normal)
-        } else if comment.hasAuthorUrl() {
+        if comment.hasAuthorUrl() {
             authorButton.setTitleColor(.primary, for: .normal)
         } else {
             authorButton.isEnabled = false

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -225,9 +225,17 @@ class ReaderCommentCell: UITableViewCell {
         actionBar.isHidden = !enableLoggedInFeatures
         replyButton.isHidden = !showReply
 
-        let likesCount = comment.numberOfLikes().intValue
-        let likesTitleFormat = likesCount == 1 ? LikesTitles.singular : LikesTitles.plural
-        let likesTitle = String(format: likesTitleFormat, likesCount)
+        let likesCount = comment.numberOfLikes()
+
+        let likesTitle: String = {
+            if likesCount == 0 {
+                return LikesTitles.none
+            }
+
+            let likesTitleFormat = likesCount == 1 ? LikesTitles.singular : LikesTitles.plural
+            return String(format: likesTitleFormat, likesCount)
+        }()
+
         likeButton.setTitle(likesTitle, for: .normal)
         likeButton.isSelected = comment.isLiked
     }
@@ -235,6 +243,7 @@ class ReaderCommentCell: UITableViewCell {
     private struct LikesTitles {
         static let plural = NSLocalizedString("%1$d Likes", comment: "Plural button title to Like a comment. %1$d is a placeholder for the number of Likes.")
         static let singular = NSLocalizedString("%1$d Like", comment: "Singular button title to Like a comment. %1$d is a placeholder for the number of Likes.")
+        static let none = NSLocalizedString("Like", comment: "Button title to Like a comment.")
 
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -381,7 +381,7 @@ private extension ReaderPostCardCell {
             configureArrowImage()
         }
 
-        blogNameLabel.text = contentProvider.blogNameForDisplay()
+        blogNameLabel.text = blogName()
         blogHostNameLabel.text = contentProvider.siteHostNameForDisplay()
 
         let dateString: String = datePublished()
@@ -910,7 +910,7 @@ private extension ReaderPostCardCell {
     }
 
     func blogName() -> String {
-        return contentProvider?.blogNameForDisplay() ?? ""
+        return contentProvider?.blogNameForDisplay?() ?? ""
     }
 
     func postAuthor() -> String {


### PR DESCRIPTION
Ref: #16876 

This converts the ObjC `Comment` public methods to Swift. Plus these goodies:
- `statusForDisplay` and `blogNameForDisplay` were not used for Comments. Made them optional in the `PostContentProvider` protocol, and removed from `Comment`.
- Reader > post comments > comments Like button label: fixed an issue I introduced with [this](https://github.com/wordpress-mobile/WordPress-iOS/pull/16898/files#diff-2bee401a37e2812bcb276e9ea5a5e5c415ccd20e4b988dd0ecf621b52eb97c98) change. If there are no likes, the number should not be displayed (i.e. just `Like` instead of `0 Likes`).
- `authorIsPostAuthor`: This didn't actually work before. I've removed it for now as more investigation is required.

To test:

Reader > post card:
- Verify the displayed blog name is correct.

Reader > post comments:
- Verify the Like button label for each comment is correct. 
  - No likes = `Like`
  - One like = `1 Like`
  - More than one = `xxx Likes`
- Verify comment author names are blue and tappable if the author has a URL.

Comment Notifications > Comment details:
- Verify the author's URL after the comment date is correct (ex: `yesterday . my.blog`).

My Site > Comments list:
- Swipe left on a comment. verify the correct option is presented (Approve or Unapprove).
- With the `unifiedCommentsAndNotificationsList` feature disabled, verify comments are grouped by day, and the dates are correct.

My Site > Comments > comment details:
- On a site where you cannot moderate comments (your role is Author or Contributor), verify you can only Like and Reply on Approved comments.



## Regression Notes
1. Potential unintended areas of impact
Any of the above could be incorrect. 😄 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Compared with previous version of the app, verified all look the same.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
