### PR TITLE
Fix a few typos in the WordPressFlux docs

### DIFF
--- a/WordPressFlux/README.md
+++ b/WordPressFlux/README.md
@@ -191,7 +191,7 @@ These usage examples are meant to showcase the different components from WordPre
 
 Previous to this, the WordPress app handled data through `Service` classes. A `Service` class would provide all the operations relevant to a specific entity, like syncing or modifying objects. Services would be in charge of calling the appropriate `Remote` classes when they needed to talk to the network.
 
-The instances of the Service class were meant to be short-lived, and a View Controller would instantiate one, perform a request and dispose of it. This made usage easy, but it meas there was no shared state, and nothing to prevent duplicate or conflicting requests.
+The instances of the Service class were meant to be short-lived, and a View Controller would instantiate one, perform a request and dispose of it. This made usage easy, but it means there was no shared state, and nothing to prevent duplicate or conflicting requests.
 
 The most common scenario for loading objects from the network would be:
 

--- a/WordPressFlux/README.md
+++ b/WordPressFlux/README.md
@@ -1,6 +1,6 @@
 # WordPressFlux - A Flux-inspired data flow architecture
 
-WordPressFlux provides the tools to build a data flow architecture similar to [Flux][1].
+WordPressFlux provides the tools to build a data flow architecture similar to [Flux](https://github.com/facebook/flux).
 
 The main design goal for this is to decouple how data is acquired, how it’s modified, and who is interested in the data.
 

--- a/WordPressFlux/Sources/WordPressFlux/Dispatcher.swift
+++ b/WordPressFlux/Sources/WordPressFlux/Dispatcher.swift
@@ -17,7 +17,7 @@ public struct DispatchToken: Hashable, Equatable {
 /// A Dispatcher broadcasts a Payload to all registered subscribers.
 ///
 /// You can think of it as a strongly typed NotificationCenter, if it had been
-/// written for Swift instead of Objective-C.
+/// written for Objective-C instead of Swift.
 ///
 /// Dispatcher is not thread safe yet, and it expects its methods to be called
 /// from the main thread only.


### PR DESCRIPTION
Reading through the WordPressFlux docs and spotted a few typos. Thought I may as well fix these for the next person!

I've assumed Facebook's Flux repo is a reasonable destination for the unlinked "Flux" tag.

No potential unintended effects – docs only.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
