### PR TITLE
Reader Comments: Add styles for table to improve readability

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -173,12 +173,16 @@ class WPRichContentView: UITextView {
 private extension WPRichContentView {
     class func formattedAttributedString(for string: String, style: AttributedStringStyle) -> NSAttributedString {
         let styleString = "<style>" +
-            "body { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6; color: #\(style.textColorHex); }" +
+            "body, table { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6; color: #\(style.textColorHex); }" +
             "blockquote { color:#\(style.blockQuoteColorHex); } " +
             "em, i { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; font-style: italic; line-height:1.6; } " +
             "a { color: #\(style.linkColorHex); text-decoration: none; } " +
             "a:active { color: #\(style.linkColorActiveHex); } " +
+            ".wp-block-table { margin: 0; padding: 0; } " +
+            "table { border-collapse: collapse }" +
+            "td { padding: 0.25em 0.25em 0.75em; min-width: 11em; vertical-align: top; } " +
         "</style>"
+
         let html = styleString + string
 
         // Ensure the noto font family is fully loaded or the font defaults to Times New Roman.


### PR DESCRIPTION
Fixes #16821

## Summary
This PR adds basic styling to improve readability of tables in Reader Comments section. Here's a summary of style changes:

- Text are vertically aligned to top.
- Font styles for `body` does not apply to the `table` element somehow. This change ensures that the font style for body is applied properly for table elements.
- Added some padding to allow for some reading space.
- Added `min-width` property to ensure that the columns doesn't get too cramped.

Before | After
--|--
![before](https://user-images.githubusercontent.com/1299411/126803377-3b58235e-9d8c-4c65-a352-ee5ac00cae86.png) | ![after](https://user-images.githubusercontent.com/1299411/126802767-caadf33a-a418-47a4-8c5f-c1b44e4c2b71.png)

Note that table borders are not added yet, due to the strange behavior of attributed string with HTML tables. 😅 .  We'll look into using a web view instead to display comment details in the later part of the iteration.

### How does this look with many columns?

Image | Description
--|--
![Simulator Screen Shot - iPhone 8 - 2021-07-23 at 22 42 27](https://user-images.githubusercontent.com/1299411/126807381-b3485383-362b-4bb8-abcb-768b6273720b.png) | In the browser, this table would be horizontally scrollable. TextKit, however, will force the table to fit its contents within the viewport width. Therefore, the `min-width` property will be ignored in this case.

## To Test
- Open a Reader Post that has table(s) in one of the comments.
- Verify that the tables are displayed according to the changes described in the summary above.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Only Reader Comments render content with attributed string.

3. What automated tests I added (or what prevented me from doing so)
n/a

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
