### PR TITLE
Site Comments: swipe moderation options honor user role

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -277,6 +277,12 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 - (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
     
     Comment *comment = [self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
+    
+    // If the current user cannot moderate comments, don't show the actions.
+    if (!comment.canModerate) {
+        return nil;
+    }
+
     __typeof(self) __weak weakSelf = self;
     NSMutableArray *actions = [NSMutableArray array];
     


### PR DESCRIPTION
Fixes #16918

To test:

On a site where you cannot moderate comments (your role is Author or Contributor):
- Go to My Site > Comments.
- Swipe left on a comment.
- Verify no actions are shown.

On a site where you can moderate comments (your role is Admin or Editor):
- Go to My Site > Comments.
- Swipe left on a comment.
- Verify the Approve/Unapprove and Trash options appear.

## Regression Notes
1. Potential unintended areas of impact
Admin swipe options don't show.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested swiping with different roles.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
