### PR TITLE
Let http handle cookies when downloading images.

### DIFF
--- a/WordPress/Classes/Services/AccountService+Cookies.swift
+++ b/WordPress/Classes/Services/AccountService+Cookies.swift
@@ -9,7 +9,7 @@ extension AccountService {
         guard
             let account = service.defaultWordPressComAccount(),
             let auth = RequestAuthenticator(account: account),
-            let url = URL(string:WPComDomain)
+            let url = URL(string: WPComDomain)
         else {
             return
         }

--- a/WordPress/Classes/Services/AccountService+Cookies.swift
+++ b/WordPress/Classes/Services/AccountService+Cookies.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension AccountService {
+
+    /// Loads the default WordPress account's cookies into shared cookie storage.
+    ///
+    static func loadDefaultAccountCookies() {
+        let service = AccountService(managedObjectContext: ContextManager.shared.mainContext)
+        guard
+            let account = service.defaultWordPressComAccount(),
+            let auth = RequestAuthenticator(account: account),
+            let url = URL(string:WPComDomain)
+        else {
+            return
+        }
+        auth.request(url: url, cookieJar: HTTPCookieStorage.shared) { _ in
+            // no op
+        }
+    }
+
+}

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -293,6 +293,8 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         shortcutCreator.createShortcutsIf3DTouchAvailable(AccountHelper.isLoggedIn)
 
+        AccountService.loadDefaultAccountCookies()
+
         windowManager.showUI()
         setupNoticePresenter()
     }
@@ -710,6 +712,7 @@ extension WordPressAppDelegate {
             setupShareExtensionToken()
             configureNotificationExtension()
             startObservingAppleIDCredentialRevoked()
+            AccountService.loadDefaultAccountCookies()
         } else {
             trackLogoutIfNeeded()
             removeTodayWidgetConfiguration()

--- a/WordPress/Classes/Utility/Media/ImageDownloader.swift
+++ b/WordPress/Classes/Utility/Media/ImageDownloader.swift
@@ -42,7 +42,6 @@ class ImageDownloader {
     @discardableResult
     func downloadImage(at url: URL, completion: @escaping (UIImage?, Error?) -> Void) -> ImageDownloaderTask {
         var request = URLRequest(url: url)
-        request.httpShouldHandleCookies = false
         request.addValue("image/*", forHTTPHeaderField: "Accept")
 
         return downloadImage(for: request, completion: completion)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2307,6 +2307,8 @@
 		E62AFB6C1DC8E593007484FC /* WPRichTextFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62AFB671DC8E593007484FC /* WPRichTextFormatter.swift */; };
 		E62AFB6D1DC8E593007484FC /* WPTextAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62AFB681DC8E593007484FC /* WPTextAttachment.swift */; };
 		E62AFB6E1DC8E593007484FC /* WPTextAttachmentManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62AFB691DC8E593007484FC /* WPTextAttachmentManager.swift */; };
+		E62CE58E26B1D14200C9D147 /* AccountService+Cookies.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62CE58D26B1D14200C9D147 /* AccountService+Cookies.swift */; };
+		E62CE58F26B1D14200C9D147 /* AccountService+Cookies.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62CE58D26B1D14200C9D147 /* AccountService+Cookies.swift */; };
 		E6311C411EC9FF4A00122529 /* UsersService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6311C401EC9FF4A00122529 /* UsersService.swift */; };
 		E6311C431ECA017E00122529 /* UserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6311C421ECA017E00122529 /* UserProfile.swift */; };
 		E6374DC01C444D8B00F24720 /* PublicizeConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6374DBD1C444D8B00F24720 /* PublicizeConnection.swift */; };
@@ -7123,6 +7125,7 @@
 		E62AFB671DC8E593007484FC /* WPRichTextFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPRichTextFormatter.swift; path = WPRichText/WPRichTextFormatter.swift; sourceTree = "<group>"; };
 		E62AFB681DC8E593007484FC /* WPTextAttachment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPTextAttachment.swift; path = WPRichText/WPTextAttachment.swift; sourceTree = "<group>"; };
 		E62AFB691DC8E593007484FC /* WPTextAttachmentManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WPTextAttachmentManager.swift; path = WPRichText/WPTextAttachmentManager.swift; sourceTree = "<group>"; };
+		E62CE58D26B1D14200C9D147 /* AccountService+Cookies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountService+Cookies.swift"; sourceTree = "<group>"; };
 		E62D4A2425E7FE6600B99550 /* WordPress 114.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 114.xcdatamodel"; sourceTree = "<group>"; };
 		E6311C401EC9FF4A00122529 /* UsersService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersService.swift; sourceTree = "<group>"; };
 		E6311C421ECA017E00122529 /* UserProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserProfile.swift; sourceTree = "<group>"; };
@@ -11242,6 +11245,7 @@
 				F504D2A925D60C5900A2764C /* Stories */,
 				93C1147D18EC5DD500DAC95C /* AccountService.h */,
 				93C1147E18EC5DD500DAC95C /* AccountService.m */,
+				E62CE58D26B1D14200C9D147 /* AccountService+Cookies.swift */,
 				E6C0ED3A231DA23400A08B57 /* AccountService+MergeDuplicates.swift */,
 				E1FD45DF1C030B3800750F4C /* AccountSettingsService.swift */,
 				F1ADCAF6241FEF0C00F150D2 /* AtomicAuthenticationService.swift */,
@@ -17438,6 +17442,7 @@
 				E6431DE51C4E892900FD8D90 /* SharingConnectionsViewController.m in Sources */,
 				5D8D53F119250412003C8859 /* BlogSelectorViewController.m in Sources */,
 				17523381246C4F9200870B4A /* HomepageSettingsViewController.swift in Sources */,
+				E62CE58E26B1D14200C9D147 /* AccountService+Cookies.swift in Sources */,
 				C81CCD7F243BF7A600A83E27 /* TenorMediaGroup.swift in Sources */,
 				B0F2EFBF259378E600C7EB6D /* SiteSuggestionService.swift in Sources */,
 				4388FF0020A4E19C00783948 /* NotificationsViewController+PushPrimer.swift in Sources */,
@@ -19333,6 +19338,7 @@
 				FABB22DC2602FC2C00C8785C /* MenuLocation.m in Sources */,
 				FABB22DD2602FC2C00C8785C /* RevisionsTableViewCell.swift in Sources */,
 				E6D6A1312683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift in Sources */,
+				E62CE58F26B1D14200C9D147 /* AccountService+Cookies.swift in Sources */,
 				FABB22DE2602FC2C00C8785C /* KeyboardInfo.swift in Sources */,
 				FABB22DF2602FC2C00C8785C /* PlanDetailViewModel.swift in Sources */,
 				FABB22E02602FC2C00C8785C /* DebugMenuViewController.swift in Sources */,


### PR DESCRIPTION
Fixes #16926 

This PR resolves the issue described in #16926 by removing `httpShouldHandleCookies = false`. This allows the image loader's NSURLRequests to use any auth cookies that exist in the cookie store.  The result is that image on private sites (like the p2 in the report) to load successfully.

To test:
Under Notifications:
- Identify a comment notification that contains images. I can assist in creating one if needed.
- View the comment notification via this branch.
- Confirm images load correctly as expected.

Under My Sites 
- Create a new post on a private p2 site.
- Add an image from the site's media library.
- After publishing the post, open it in the editor again.
- Confirm the image loads correctly.

@leandroalonso could I trouble you for a review of this one given your familiarity with the GutenbergMediaEditorImage? I'm not sure I've found the best test case to check for regressions and you might know of a better way. 

## Regression Notes
1. Potential unintended areas of impact
The image downloader is also used by Gutenberg.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Smoke tested loading images from a private site in the editor.

3. What automated tests I added (or what prevented me from doing so)
n/a
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
