### PR TITLE
Fix domain registration not working under some conditions

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.38.0'
+    # pod 'WordPressKit', '~> 4.38.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/domain-registration-cart'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -450,7 +450,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.38.0):
+  - WordPressKit (4.39.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -550,7 +550,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.40.0)
-  - WordPressKit (~> 4.38.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/domain-registration-cart`)
   - WordPressMocks (~> 0.0.13)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.1)
@@ -562,7 +562,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressKit
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -706,6 +705,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.58.0
+  WordPressKit:
+    :branch: issue/domain-registration-cart
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.58.0/third-party-podspecs/Yoga.podspec.json
 
@@ -721,6 +723,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.58.0
+  WordPressKit:
+    :commit: 248d56edb4327f4983d0b2fe694d4af32080ffac
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -804,7 +809,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: eb4c07056677c365476350db5577f577c01ffc60
-  WordPressKit: 4add3f9672e2cd40ab0ed4cf5ec3c5d9dca7ce87
+  WordPressKit: ac1489c2c594fd81d3f1e0457ccf11ab5b37bb28
   WordPressMocks: dfac50a938ac74dddf5f7cce5a9110126408dd19
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 414bf3a7d007618f94a1c7969d6e849779877d5d
@@ -820,6 +825,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 0790320bb31d023144c4427da9aa4d069ce96b18
+PODFILE CHECKSUM: 46b73af46c92222b1bfd522c2fc34d9a23519ed9
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
Fixes #16934

[Related WordPressKit PR](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/424)

To test:
Pre-requisites
- Have a WordPress account with enough available credits to purchase a domain
- Have a paid plan on at least one site of the same account, and no domain associated to that site

1. Go to My Site and select a site that satisfies the above requisites: you should see the "Register Domain" cell (see screenshot below)
2. Tap on Register Domain
3. Choose a domain and then tap "Choose Domain" at the bottom
4. Fill out all the necessary fields, then tap on "Register Domain" at the bottom
5. Make sure that the domain gets registered successfully

<p align=center>
<img width="446" src="https://user-images.githubusercontent.com/34376330/127065772-b7a62d42-a8db-460c-88a0-10018c8125b8.png">
</p>

**Known issues: after the registration completes, you will still see the "Register Domain" cell (needs to be addressed in a separate PR)**

## Regression Notes
1. Potential unintended areas of impact
None: there is no change on WPiOS code, only on WordPressKit, and the call is only used by Domain Registration


2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested that a domain is successfully added

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
