### PR TITLE
Centralize Xcode version definition in Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,4 @@
-use_plugins: &use_plugins
+x_use_plugins: &use_plugins
     plugins:
       - automattic/bash-cache#v1.0.0: ~
       - automattic/git-s3-cache#add/vm-host-support:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,9 @@ use_plugins: &use_plugins
           bucket: "a8c-repo-mirrors"
           repo: "wordpress-mobile/wordpress-ios/"
 
+xcode_version: &xcode_version
+  IMAGE_ID: xcode-12.5.1
+
 # This is the default pipeline – it will build and test the app
 steps:
   #################
@@ -13,8 +16,7 @@ steps:
   - label: ":pipeline: Build"
     key: "build"
     command: ".buildkite/commands/build-for-testing.sh"
-    env:
-      IMAGE_ID: xcode-12.5.1
+    env: *xcode_version
     <<: *use_plugins
 
   #################
@@ -29,8 +31,7 @@ steps:
       bundle install
       bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
     depends_on: "build"
-    env:
-      IMAGE_ID: xcode-12.5.1
+    env: *xcode_version
     <<: *use_plugins
 
   #################
@@ -67,8 +68,7 @@ steps:
       rake mocks &
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPhone 11" ios-version:"14.1"
     depends_on: "build"
-    env:
-      IMAGE_ID: xcode-12.5.1
+    env: *xcode_version
     <<: *use_plugins
 
   - label: "🧪 UI Tests (iPad)"
@@ -91,6 +91,5 @@ steps:
       rake mocks &
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPad Air (4th generation)" ios-version:"14.1"
     depends_on: "build"
-    env:
-      IMAGE_ID: xcode-12.5.1
+    env: *xcode_version
     <<: *use_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,11 @@
-x_use_plugins: &use_plugins
-    plugins:
-      - automattic/bash-cache#v1.0.0: ~
-      - automattic/git-s3-cache#add/vm-host-support:
-          bucket: "a8c-repo-mirrors"
-          repo: "wordpress-mobile/wordpress-ios/"
-
 # Nodes with values to reuse in the pipeline.
 common_params:
+  # Common plugin settings to use with the `plugins` key.
+  - &common_plugins
+    - automattic/bash-cache#v1.0.0: ~
+    - automattic/git-s3-cache#add/vm-host-support:
+        bucket: "a8c-repo-mirrors"
+        repo: "wordpress-mobile/wordpress-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-12.5.1
@@ -20,7 +19,7 @@ steps:
     key: "build"
     command: ".buildkite/commands/build-for-testing.sh"
     env: *common_env
-    <<: *use_plugins
+    plugins: *common_plugins
 
   #################
   # Run Unit Tests
@@ -35,7 +34,7 @@ steps:
       bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
     depends_on: "build"
     env: *common_env
-    <<: *use_plugins
+    plugins: *common_plugins
 
   #################
   # Lint Translations
@@ -72,7 +71,7 @@ steps:
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPhone 11" ios-version:"14.1"
     depends_on: "build"
     env: *common_env
-    <<: *use_plugins
+    plugins: *common_plugins
 
   - label: "🧪 UI Tests (iPad)"
     command: |
@@ -95,4 +94,4 @@ steps:
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPad Air (4th generation)" ios-version:"14.1"
     depends_on: "build"
     env: *common_env
-    <<: *use_plugins
+    plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,21 +5,11 @@ x_use_plugins: &use_plugins
           bucket: "a8c-repo-mirrors"
           repo: "wordpress-mobile/wordpress-ios/"
 
-# Common environment values for the `env` key.
-#
-# To add more, simply add another entry at the same indentation as `IMAGE_ID`.
-#
-# Usage in a step with only these values:
-#
-#   env: *common_env
-#
-# Usage in a step with other values:
-#
-#   env:
-#     <<: *common_env
-#     other_key: "other value"
-x_common_env: &common_env
-  IMAGE_ID: xcode-12.5.1
+# Nodes with values to reuse in the pipeline.
+common_params:
+  # Common environment values to use with the `env` key.
+  - &common_env
+    IMAGE_ID: xcode-12.5.1
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,14 @@ use_plugins: &use_plugins
 xcode_version: &xcode_version
   IMAGE_ID: xcode-12.5.1
 
+env: &env
+  # If you'll need more than one key-value, update to:
+  #
+  # env:
+  #   <<: *xcode_version
+  #   other_key: other_value
+  env: *xcode_version
+
 # This is the default pipeline – it will build and test the app
 steps:
   #################
@@ -16,7 +24,7 @@ steps:
   - label: ":pipeline: Build"
     key: "build"
     command: ".buildkite/commands/build-for-testing.sh"
-    env: *xcode_version
+    <<: *env
     <<: *use_plugins
 
   #################
@@ -31,7 +39,7 @@ steps:
       bundle install
       bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
     depends_on: "build"
-    env: *xcode_version
+    <<: *env
     <<: *use_plugins
 
   #################
@@ -68,7 +76,7 @@ steps:
       rake mocks &
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPhone 11" ios-version:"14.1"
     depends_on: "build"
-    env: *xcode_version
+    <<: *env
     <<: *use_plugins
 
   - label: "🧪 UI Tests (iPad)"
@@ -91,5 +99,5 @@ steps:
       rake mocks &
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPad Air (4th generation)" ios-version:"14.1"
     depends_on: "build"
-    env: *xcode_version
+    <<: *env
     <<: *use_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,16 +5,21 @@ use_plugins: &use_plugins
           bucket: "a8c-repo-mirrors"
           repo: "wordpress-mobile/wordpress-ios/"
 
-xcode_version: &xcode_version
+# Common environment values for the `env` key.
+#
+# To add more, simply add another entry at the same indentation as `IMAGE_ID`.
+#
+# Usage in a step with only these values:
+#
+#   env: *common_env
+#
+# Usage in a step with other values:
+#
+#   env:
+#     <<: *common_env
+#     other_key: "other value"
+x_common_env: &common_env
   IMAGE_ID: xcode-12.5.1
-
-env: &env
-  # If you'll need more than one key-value, update to:
-  #
-  # env:
-  #   <<: *xcode_version
-  #   other_key: other_value
-  env: *xcode_version
 
 # This is the default pipeline – it will build and test the app
 steps:
@@ -24,7 +29,7 @@ steps:
   - label: ":pipeline: Build"
     key: "build"
     command: ".buildkite/commands/build-for-testing.sh"
-    <<: *env
+    env: *common_env
     <<: *use_plugins
 
   #################
@@ -39,7 +44,7 @@ steps:
       bundle install
       bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
     depends_on: "build"
-    <<: *env
+    env: *common_env
     <<: *use_plugins
 
   #################
@@ -76,7 +81,7 @@ steps:
       rake mocks &
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPhone 11" ios-version:"14.1"
     depends_on: "build"
-    <<: *env
+    env: *common_env
     <<: *use_plugins
 
   - label: "🧪 UI Tests (iPad)"
@@ -99,5 +104,5 @@ steps:
       rake mocks &
       bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:"iPad Air (4th generation)" ios-version:"14.1"
     depends_on: "build"
-    <<: *env
+    env: *common_env
     <<: *use_plugins


### PR DESCRIPTION
See discussion at https://github.com/wordpress-mobile/WordPress-iOS/pull/16787#discussion_r676240991

If [Buildkite runs fine](https://buildkite.com/wordpress-mobile/wordpress-ios/builds/1674#755fd55d-af8b-4f85-9811-b9af6edc023a), then we're good to go.

I verified it locally by parsing the YML to see if all the anchors were resolved correctly.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**