### PR TITLE
Tracks when the blogging reminders notification is tapped.

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -9,29 +9,29 @@ import WordPressFlux
 /// UNNotificationAction instantiation, along with the required handlers.
 ///
 final class InteractiveNotificationsManager: NSObject {
-    
+
     class EventTracker {
         enum Event: String {
             case notificationTapped = "notification_tapped"
         }
-        
+
         enum Properties: String {
             case notificationType = "notification_type"
         }
-        
+
         enum NotificationType: String {
             case bloggingReminders = "blogging_reminders"
         }
-        
+
         private let track: (AnalyticsEvent) -> Void
-        
+
         init(trackMethod track: @escaping (AnalyticsEvent) -> Void = WPAnalytics.track) {
             self.track = track
         }
-        
+
         func notificationTapped(type: NotificationType) {
             let event = AnalyticsEvent(name: Event.notificationTapped.rawValue, properties: [Properties.notificationType.rawValue: type.rawValue])
-                                       
+
             track(event)
         }
     }
@@ -39,7 +39,7 @@ final class InteractiveNotificationsManager: NSObject {
     /// Returns the shared InteractiveNotificationsManager instance.
     ///
     @objc static let shared = InteractiveNotificationsManager()
-    
+
     /// The analytics event tracker.
     ///
     private let eventTracker = EventTracker()
@@ -231,7 +231,7 @@ final class InteractiveNotificationsManager: NSObject {
                 // specific notification type for now in a way that matches Android, but using a mechanism that
                 // is extensible to track other notification types in the future.
                 eventTracker.notificationTapped(type: .bloggingReminders)
-                
+
                 if identifier == UNNotificationDefaultActionIdentifier {
                     let targetBlog: Blog? = blog(from: threadId)
 


### PR DESCRIPTION
Adds tracking for taps to the blogging reminders notifications.

## To test:

### Setup:

Change `BloggingRemindersScheduler.swift:255` to become:

dateComponents.hour = Date().dateAndTimeComponents().hour
dateComponents.minute = (Date().dateAndTimeComponents().minute ?? 0) + 1

This makes the notification come up 1 minute after it was scheduled.

### Steps:

1. Set a breakpoint in `InteractiveNotificationsManager:235`.
2. Schedule blogging reminders on the same day as the day you're testing (today it'd be Tuesday).
3. Background the App.
4. When the notification comes up, tap on it.
5. When the breakpoint hits, you should see the following tracked event in the console:

:large_blue_circle: Tracked: notification_tapped <notification_type: blogging_reminders>

## Regression Notes

1. Potential unintended areas of impact

None, as the code that was added only adds a tracking call in a very specific place we're directly testing.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
