### PR TITLE
Reader Post: Add animation to train of likes

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -40,7 +40,7 @@ class ReaderDetailCoordinator {
 
     /// An authenticator to ensure any request made to WP sites is properly authenticated
     lazy var authenticator: RequestAuthenticator? = {
-        guard let account = AccountService(managedObjectContext: coreDataStack.mainContext).defaultWordPressComAccount() else {
+        guard let account = accountService.defaultWordPressComAccount() else {
             DDLogInfo("Account not available for Reader authentication")
             return nil
         }
@@ -59,6 +59,9 @@ class ReaderDetailCoordinator {
 
     /// Post Service
     private let postService: PostService
+
+    /// Used for `RequestAuthenticator` creation and likes filtering logic.
+    private let accountService: AccountService
 
     /// Post Sharing Controller
     private let sharingController: PostSharingController
@@ -103,6 +106,7 @@ class ReaderDetailCoordinator {
          readerPostService: ReaderPostService = ReaderPostService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          topicService: ReaderTopicService = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          postService: PostService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext),
+         accountService: AccountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          sharingController: PostSharingController = PostSharingController(),
          readerLinkRouter: UniversalLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes),
          view: ReaderDetailView) {
@@ -110,6 +114,7 @@ class ReaderDetailCoordinator {
         self.readerPostService = readerPostService
         self.topicService = topicService
         self.postService = postService
+        self.accountService = accountService
         self.sharingController = sharingController
         self.readerLinkRouter = readerLinkRouter
         self.view = view

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -166,7 +166,7 @@ class ReaderDetailCoordinator {
                                     let totalLikesExcludingSelf = totalLikes - (post.isLiked ? 1 : 0)
 
                                     // Split off current user's like from the list.
-                                    // Likes from self will always be placed in the sixth position, regardless of the when the post was liked.
+                                    // Likes from self will always be placed in the last position, regardless of the when the post was liked.
                                     if let userID = self?.accountService.defaultWordPressComAccount()?.userID.int64Value,
                                        let userIndex = filteredUsers.firstIndex(where: { $0.userID == userID }) {
                                         currentLikeUser = filteredUsers.remove(at: userIndex)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -162,9 +162,10 @@ class ReaderDetailCoordinator {
                                 siteID: post.siteID,
                                 success: { [weak self] users, totalLikes, _ in
                                     self?.totalLikes = totalLikes
-                                    self?.view?.updateLikes(users: Array(users.prefix(ReaderDetailLikesView.maxAvatarsDisplayed)), totalLikes: totalLikes)
+                                    self?.view?.updateLikes(with: users.prefix(ReaderDetailLikesView.maxAvatarsDisplayed).map { $0.avatarUrl },
+                                                            totalLikes: totalLikes)
                                 }, failure: { [weak self] error in
-                                    self?.view?.updateLikes(users: [LikeUser](), totalLikes: 0)
+                                    self?.view?.updateLikes(with: [String](), totalLikes: 0)
                                     DDLogError("Error fetching Likes for post detail: \(String(describing: error?.localizedDescription))")
                                 })
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -163,6 +163,7 @@ class ReaderDetailCoordinator {
                                 success: { [weak self] users, totalLikes, _ in
                                     var filteredUsers = users
                                     var currentLikeUser: LikeUser? = nil
+                                    let totalLikesFromOthers = totalLikes - (post.isLiked ? 1 : 0)
 
                                     // Split off current user's like from the list.
                                     // Likes from self will always be placed in the sixth position, regardless of the when the post was liked.
@@ -177,7 +178,7 @@ class ReaderDetailCoordinator {
                                         .map { $0.avatarUrl }
 
                                     self?.totalLikes = totalLikes
-                                    self?.view?.updateLikes(with: avatarURLStrings, totalLikes: totalLikes)
+                                    self?.view?.updateLikes(with: avatarURLStrings, totalLikes: totalLikesFromOthers)
                                     self?.view?.updateSelfLike(with: currentLikeUser?.avatarUrl)
 
                                 }, failure: { [weak self] error in
@@ -648,6 +649,17 @@ extension ReaderDetailCoordinator: ReaderDetailFeaturedImageViewDelegate {
 extension ReaderDetailCoordinator: ReaderDetailLikesViewDelegate {
     func didTapLikesView() {
         showLikesList()
+    }
+}
+
+// MARK: - ReaderDetailToolbarDelegate
+extension ReaderDetailCoordinator: ReaderDetailToolbarDelegate {
+    func didTapLikeButton(isLiked: Bool) {
+        guard let userAvatarURL = accountService.defaultWordPressComAccount()?.avatarURL else {
+            return
+        }
+
+        self.view?.updateSelfLike(with: isLiked ? userAvatarURL : nil)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -10,7 +10,20 @@ protocol ReaderDetailView: AnyObject {
     func showErrorWithWebAction()
     func scroll(to: String)
     func updateHeader()
+
+    /// Shows likes view containing avatars of users that liked the post.
+    /// The number of avatars displayed is limited to `ReaderDetailView.maxAvatarDisplayed` plus the current user's avatar.
+    /// Note that the current user's avatar is displayed through a different method.
+    ///
+    /// - Seealso: `updateSelfLike(with avatarURLString: String?)`
+    /// - Parameters:
+    ///   - avatarURLStrings: A list of URL strings for the liking users' avatars.
+    ///   - totalLikes: The total number of likes for this post.
     func updateLikes(with avatarURLStrings: [String], totalLikes: Int)
+
+    /// Updates the likes view to append an additional avatar for the current user, indicating that the post is liked by current user.
+    /// - Parameter avatarURLString: The URL string for the current user's avatar. Optional.
+    func updateSelfLike(with avatarURLString: String?)
 }
 
 class ReaderDetailViewController: UIViewController, ReaderDetailView {
@@ -337,6 +350,15 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         }
 
         likesSummary.configure(with: avatarURLStrings, totalLikes: totalLikes)
+    }
+
+    func updateSelfLike(with avatarURLString: String?) {
+        guard let someURLString = avatarURLString else {
+            likesSummary.removeSelfAvatar()
+            return
+        }
+
+        likesSummary.addSelfAvatar(with: someURLString)
     }
 
     deinit {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -10,7 +10,7 @@ protocol ReaderDetailView: AnyObject {
     func showErrorWithWebAction()
     func scroll(to: String)
     func updateHeader()
-    func updateLikes(users: [LikeUser], totalLikes: Int)
+    func updateLikes(with avatarURLStrings: [String], totalLikes: Int)
 }
 
 class ReaderDetailViewController: UIViewController, ReaderDetailView {
@@ -326,7 +326,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         header.refreshFollowButton()
     }
 
-    func updateLikes(users: [LikeUser], totalLikes: Int) {
+    func updateLikes(with avatarURLStrings: [String], totalLikes: Int) {
         guard totalLikes > 0 else {
             hideLikesView()
             return
@@ -336,7 +336,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             configureLikesSummary()
         }
 
-        likesSummary.configure(users: users, totalLikes: totalLikes)
+        likesSummary.configure(with: avatarURLStrings, totalLikes: totalLikes)
     }
 
     deinit {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -340,6 +340,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func updateLikes(with avatarURLStrings: [String], totalLikes: Int) {
+        // always configure likes summary view first regardless of totalLikes, since it can affected by self likes.
+        likesSummary.configure(with: avatarURLStrings, totalLikes: totalLikes)
+
         guard totalLikes > 0 else {
             hideLikesView()
             return
@@ -348,14 +351,19 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         if likesSummary.superview == nil {
             configureLikesSummary()
         }
-
-        likesSummary.configure(with: avatarURLStrings, totalLikes: totalLikes)
     }
 
     func updateSelfLike(with avatarURLString: String?) {
         guard let someURLString = avatarURLString else {
             likesSummary.removeSelfAvatar()
+            if likesSummary.totalLikesForDisplay == 0 {
+                hideLikesView()
+            }
             return
+        }
+
+        if likesSummary.superview == nil {
+            configureLikesSummary()
         }
 
         likesSummary.addSelfAvatar(with: someURLString)
@@ -482,6 +490,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func configureToolbar() {
+        toolbar.delegate = coordinator
         toolbarContainerView.addSubview(toolbar)
         toolbarContainerView.translatesAutoresizingMaskIntoConstraints = false
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -354,8 +354,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func updateSelfLike(with avatarURLString: String?) {
+        // only animate changes when the view is visible.
+        let shouldAnimate = isVisibleInScrollView(likesSummary)
         guard let someURLString = avatarURLString else {
-            likesSummary.removeSelfAvatar()
+            likesSummary.removeSelfAvatar(animated: shouldAnimate)
             if likesSummary.totalLikesForDisplay == 0 {
                 hideLikesView()
             }
@@ -366,7 +368,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             configureLikesSummary()
         }
 
-        likesSummary.addSelfAvatar(with: someURLString)
+        likesSummary.addSelfAvatar(with: someURLString, animated: shouldAnimate)
     }
 
     deinit {
@@ -885,6 +887,17 @@ private extension ReaderDetailViewController {
         button.addTarget(self, action: action, for: .touchUpInside)
 
         return UIBarButtonItem(customView: button)
+    }
+
+    /// Checks if the view is visible in the viewport.
+    func isVisibleInScrollView(_ view: UIView) -> Bool {
+        guard view.superview != nil, !view.isHidden else {
+            return false
+        }
+
+        let scrollViewFrame = CGRect(origin: scrollView.contentOffset, size: scrollView.frame.size)
+        let convertedViewFrame = scrollView.convert(view.bounds, from: view)
+        return scrollViewFrame.intersects(convertedViewFrame)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -60,7 +60,6 @@ class ReaderDetailLikesView: UIView, NibLoadable {
     }
 
     func removeSelfAvatar(animated: Bool = false) {
-        // removal animation should transition
         // pre-animation state
         selfAvatarImageView.alpha = 1
         self.selfAvatarImageView.transform = .identity

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -9,8 +9,16 @@ class ReaderDetailLikesView: UIView, NibLoadable {
     @IBOutlet weak var avatarStackView: UIStackView!
     @IBOutlet weak var summaryLabel: UILabel!
 
+    /// The UIImageView used to display the current user's avatar image. This view is hidden by default.
+    @IBOutlet private weak var selfAvatarImageView: CircularImageView!
+
     static let maxAvatarsDisplayed = 5
     var delegate: ReaderDetailLikesViewDelegate?
+
+    /// Convenience property that checks whether or not the self avatar image view is being displayed.
+    private var displaysSelfAvatar: Bool {
+        !selfAvatarImageView.isHidden
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -21,6 +29,15 @@ class ReaderDetailLikesView: UIView, NibLoadable {
         updateSummaryLabel(totalLikes: totalLikes)
         updateAvatars(with: avatarURLStrings)
         addTapGesture()
+    }
+
+    func addSelfAvatar(with urlString: String) {
+        downloadGravatar(for: selfAvatarImageView, withURL: urlString)
+        selfAvatarImageView.isHidden = false
+    }
+
+    func removeSelfAvatar() {
+        selfAvatarImageView.isHidden = true
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -17,9 +17,9 @@ class ReaderDetailLikesView: UIView, NibLoadable {
         applyStyles()
     }
 
-    func configure(users: [LikeUser], totalLikes: Int) {
+    func configure(with avatarURLStrings: [String], totalLikes: Int) {
         updateSummaryLabel(totalLikes: totalLikes)
-        updateAvatars(users: users)
+        updateAvatars(with: avatarURLStrings)
         addTapGesture()
     }
 
@@ -45,14 +45,14 @@ private extension ReaderDetailLikesView {
         summaryLabel.attributedText = highlightedText(String(format: summaryFormat, totalLikes))
     }
 
-    func updateAvatars(users: [LikeUser]) {
+    func updateAvatars(with urlStrings: [String]) {
         for (index, subView) in avatarStackView.subviews.enumerated() {
             guard let avatarImageView = subView as? UIImageView else {
                 return
             }
 
-            if let user = users[safe: index] {
-                downloadGravatar(for: avatarImageView, withURL: user.avatarUrl)
+            if let urlString = urlStrings[safe: index] {
+                downloadGravatar(for: avatarImageView, withURL: urlString)
             } else {
                 avatarImageView.isHidden = true
             }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -15,6 +15,14 @@ class ReaderDetailLikesView: UIView, NibLoadable {
     static let maxAvatarsDisplayed = 5
     var delegate: ReaderDetailLikesViewDelegate?
 
+    /// Stores the number of total likes _without_ adding the like from self.
+    private var totalLikes: Int = 0
+
+    /// Convenience property that adds up the total likes and self like for display purposes.
+    var totalLikesForDisplay: Int {
+        return displaysSelfAvatar ? totalLikes + 1 : totalLikes
+    }
+
     /// Convenience property that checks whether or not the self avatar image view is being displayed.
     private var displaysSelfAvatar: Bool {
         !selfAvatarImageView.isHidden
@@ -26,18 +34,21 @@ class ReaderDetailLikesView: UIView, NibLoadable {
     }
 
     func configure(with avatarURLStrings: [String], totalLikes: Int) {
-        updateSummaryLabel(totalLikes: totalLikes)
+        self.totalLikes = totalLikes
+        updateSummaryLabel()
         updateAvatars(with: avatarURLStrings)
         addTapGesture()
     }
 
     func addSelfAvatar(with urlString: String) {
         downloadGravatar(for: selfAvatarImageView, withURL: urlString)
-        selfAvatarImageView.isHidden = false
+        self.selfAvatarImageView.isHidden = false
+        updateSummaryLabel()
     }
 
     func removeSelfAvatar() {
-        selfAvatarImageView.isHidden = true
+        self.selfAvatarImageView.isHidden = true
+        updateSummaryLabel()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -57,9 +68,9 @@ private extension ReaderDetailLikesView {
         }
     }
 
-    func updateSummaryLabel(totalLikes: Int) {
-        let summaryFormat = totalLikes == 1 ? SummaryLabelFormats.singular : SummaryLabelFormats.plural
-        summaryLabel.attributedText = highlightedText(String(format: summaryFormat, totalLikes))
+    func updateSummaryLabel() {
+        let summaryFormat = totalLikesForDisplay == 1 ? SummaryLabelFormats.singular : SummaryLabelFormats.plural
+        summaryLabel.attributedText = highlightedText(String(format: summaryFormat, totalLikesForDisplay))
     }
 
     func updateAvatars(with urlStrings: [String]) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -40,14 +40,40 @@ class ReaderDetailLikesView: UIView, NibLoadable {
         addTapGesture()
     }
 
-    func addSelfAvatar(with urlString: String) {
+    func addSelfAvatar(with urlString: String, animated: Bool = false) {
         downloadGravatar(for: selfAvatarImageView, withURL: urlString)
-        self.selfAvatarImageView.isHidden = false
+
+        // pre-animation state
+        // set initial position from the left in LTR, or from the right in RTL.
+        selfAvatarImageView.alpha = 0
+        let directionalMultiplier: CGFloat = userInterfaceLayoutDirection() == .leftToRight ? -1.0 : 1.0
+        selfAvatarImageView.transform = CGAffineTransform(translationX: Constants.animationDeltaX * directionalMultiplier, y: 0)
+
+        UIView.animate(withDuration: animated ? Constants.animationDuration : 0) {
+            // post-animation state
+            self.selfAvatarImageView.alpha = 1
+            self.selfAvatarImageView.isHidden = false
+            self.selfAvatarImageView.transform = .identity
+        }
+
         updateSummaryLabel()
     }
 
-    func removeSelfAvatar() {
-        self.selfAvatarImageView.isHidden = true
+    func removeSelfAvatar(animated: Bool = false) {
+        // removal animation should transition
+        // pre-animation state
+        selfAvatarImageView.alpha = 1
+        self.selfAvatarImageView.transform = .identity
+
+        UIView.animate(withDuration: animated ? Constants.animationDuration : 0) {
+            // post-animation state
+            // moves to the left in LTR, or to the right in RTL.
+            self.selfAvatarImageView.alpha = 0
+            self.selfAvatarImageView.isHidden = true
+            let directionalMultiplier: CGFloat = self.userInterfaceLayoutDirection() == .leftToRight ? -1.0 : 1.0
+            self.selfAvatarImageView.transform = CGAffineTransform(translationX: Constants.animationDeltaX * directionalMultiplier, y: 0)
+        }
+
         updateSummaryLabel()
     }
 
@@ -77,6 +103,10 @@ private extension ReaderDetailLikesView {
         for (index, subView) in avatarStackView.subviews.enumerated() {
             guard let avatarImageView = subView as? UIImageView else {
                 return
+            }
+
+            if avatarImageView == selfAvatarImageView {
+                continue
             }
 
             if let urlString = urlStrings[safe: index] {
@@ -110,6 +140,11 @@ private extension ReaderDetailLikesView {
         }
 
         delegate?.didTapLikesView()
+    }
+
+    struct Constants {
+        static let animationDuration: TimeInterval = 0.3
+        static let animationDeltaX: CGFloat = 16.0
     }
 
     struct SummaryLabelFormats {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -52,6 +52,13 @@
                                 <constraint firstAttribute="width" secondItem="Fsb-ih-Vxd" secondAttribute="height" multiplier="1:1" id="RMT-Xw-wR0"/>
                             </constraints>
                         </imageView>
+                        <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="Pod-MR-Wzr" userLabel="Self Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="148" y="0.0" width="32" height="32"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="Pod-MR-Wzr" secondAttribute="height" multiplier="1:1" id="a3o-uv-Xqr"/>
+                                <constraint firstAttribute="width" constant="32" id="mtM-Ff-eOI"/>
+                            </constraints>
+                        </imageView>
                     </subviews>
                     <constraints>
                         <constraint firstAttribute="height" constant="32" id="deH-0r-cgY"/>
@@ -78,6 +85,7 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="avatarStackView" destination="ZiQ-mD-QJO" id="hMm-un-1IW"/>
+                <outlet property="selfAvatarImageView" destination="Pod-MR-Wzr" id="jSJ-DS-UWW"/>
                 <outlet property="summaryLabel" destination="ilc-NW-l0X" id="C48-jT-Uq7"/>
             </connections>
             <point key="canvasLocation" x="-1275.3623188405797" y="-395.75892857142856"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -1,5 +1,9 @@
 import UIKit
 
+protocol ReaderDetailToolbarDelegate: AnyObject {
+    func didTapLikeButton(isLiked: Bool)
+}
+
 class ReaderDetailToolbar: UIView, NibLoadable {
     @IBOutlet weak var dividerView: UIView!
     @IBOutlet weak var saveForLaterButton: UIButton!
@@ -21,6 +25,8 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
     /// If we should hide the comments button
     var shouldHideComments = false
+
+    weak var delegate: ReaderDetailToolbarDelegate? = nil
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -44,8 +50,9 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         self.post = post
         self.viewController = viewController
 
-        likeCountObserver = post.observe(\.likeCount, options: .new) { [weak self] _, _ in
+        likeCountObserver = post.observe(\.likeCount, options: .new) { [weak self] updatedPost, _ in
             self?.configureLikeActionButton(true)
+            self?.delegate?.didTapLikeButton(isLiked: updatedPost.isLiked)
         }
 
         commentCountObserver = post.observe(\.commentCount, options: .new) { [weak self] _, _ in

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -249,6 +249,8 @@ class ReaderDetailCoordinatorTests: XCTestCase {
     }
 }
 
+// MARK: - Private Helpers
+
 private class ReaderPostServiceMock: ReaderPostService {
     var didCallFetchPostWithPostID: UInt?
     var didCallFetchPostWithSiteID: UInt?
@@ -329,7 +331,9 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
 
     func updateHeader() { }
 
-    func  updateLikes(users: [LikeUser], totalLikes: Int) { }
+    func updateLikes(with avatarURLStrings: [String], totalLikes: Int) { }
+
+    func updateSelfLike(with avatarURLString: String?) { }
 
     func renderRelatedPosts(_ posts: [RemoteReaderSimplePost]) { }
 


### PR DESCRIPTION
Refs: `pctCYC-8w-p2`

## Summary

This introduces interactivity to the likes view component in the Reader Detail screen. When liking a post, the avatar of the current user is appended at the trailing position. Furthermore, there can be maximum 6 avatars displayed, where up to 5 other bloggers may be displayed, and lastly the current user's avatar is displayed at the end _if_ the user liked the post.

Here's a summary of the code changes:
- Modified the data flow to pass in `[String]` (representing avatar URL strings) instead of `[LikeUser]` objects from the `ReaderDetailCoordinator` instance down to the `ReaderDetailLikesView`.
  - Since the reader post will be interactive (reacting to Like toolbar button taps), it's much easier to pass avatar URL by fetching the value from `WPAccount`, instead of having to create  an unmanaged `LikeUser` instances whenever the user taps the Like button.
- Added a new method in the `ReaderDetailView` protocol: `updateSelfLike(with avatarURLString: String)`, to specifically handle singular like addition / subtraction.
  - The current `updateLikes` method is set up as a one-time setup, while the `updateSelfLike` may be called multiple times while the Reader Post is opened.
- The number of total likes passed from the coordinator to the view is intentionally reduced by 1 if the post is liked by current user. This will be handled by the `ReaderDetailLikesView` where an extra like will be added back if the post is liked.
  - Note that this is a set up to update the summary label text (for adding "You and..." part). Ref: `pbArwn-2mK-p2#comment-3436`
- I'll defer adding the unit tests to the upcoming PR when addressing `pbArwn-2mK-p2#comment-3436`.

Here's a preview of the animation:
  
https://user-images.githubusercontent.com/1299411/127351718-d68a102b-9f61-4157-a1b5-0fdd577e393c.mov
 
Lastly, I _think_ there's a potential race condition when adding/removing likes from a post – which causes a post to have `isLiked == false`, but a `LikeUser` object representing the current user exists in the database. However, I'll investigate this later as this is a separate issue from this PR (and will open an issue later with the repro steps).

## To test

- Open a post with 0 likes. 
  - Verify the likes view is shown when the post is liked.
  - Verify the likes view is hidden when the post is unliked.
- Open a post where you're the only one liking the post.
  - Verify the likes view is hidden when the post is unliked.
  - Verify the likes view is shown when the post is liked.
- Open a post with more than 5 likes from other people. 
  - Verify that it shows 6 avatars when the post is liked.
  - Verify that it shows 5 avatars when the post is unliked.
- Verify that the animation works fine when the post is liked and unliked.
- Verify that the animation direction is correct in RTL language.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
The change is only scoped to Reader Post.

3. What automated tests I added (or what prevented me from doing so)
Will be added in the upcoming PR that addresses `pbArwn-2mK-p2#comment-3436`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
