### PR TITLE
Correct helpButton accessibilityIdentifier

### DIFF
--- a/WordPress/WordPressUITests/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/Unified/GetStartedScreen.swift
@@ -5,7 +5,7 @@ private struct ElementStringIDs {
     static let navBar = "WordPress.GetStartedView"
     static let emailTextField = "Email address"
     static let continueButton = "Get Started Email Continue Button"
-    static let helpButton = "help-button" //added for support test
+    static let helpButton = "authenticator-help-button"
 }
 
 class GetStartedScreen: BaseScreen {
@@ -32,7 +32,6 @@ class GetStartedScreen: BaseScreen {
         return PasswordScreen()
     }
 
-    // Taps "Help" to enter the Support modal
     func selectHelp() -> SupportScreen {
         helpButton.tap()
 


### PR DESCRIPTION
Fixes UI Test failure in CI, which was initially caused after merge of https://github.com/wordpress-mobile/WordPress-iOS/pull/16837. 
The incorrect accessibilityIdentifier, `help-button`, was referenced on GetStartedScreen. 
This PR fixes that, making it `authenticator-help-button`.
