### PR TITLE
Adds the sandbox store secret debug menu item.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -30,7 +30,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .debugMenu:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .readerCSS:
             return false
         case .homepageSettings:

--- a/WordPress/Classes/ViewRelated/Developer/StoreSandboxSecretScreen.swift
+++ b/WordPress/Classes/ViewRelated/Developer/StoreSandboxSecretScreen.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct StoreSandboxSecretScreen: View {
+    private static let storeSandboxSecretKey = "store_sandbox"
+
+    @SwiftUI.Environment(\.presentationMode) var presentationMode
+    @State private var secret: String
+    private let cookieJar: CookieJar
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading) {
+                Text("Enter the Store Sandbox Secret:")
+                TextField("Secret", text: $secret)
+                    .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+                    .border(Color.black)
+                Spacer()
+            }
+            .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+        }
+        .onDisappear() {
+            // This seems to be necessary do to an iOS bug where
+            // accessing presentationMode.wrappedValue crashes.
+            DispatchQueue.main.async {
+                if(self.presentationMode.wrappedValue.isPresented == false) {
+                    if let cookie = HTTPCookie(properties: [
+                        .name: StoreSandboxSecretScreen.storeSandboxSecretKey,
+                        .value: secret,
+                        .domain: ".wordpress.com",
+                        .path: "/"
+                    ]) {
+                        cookieJar.setCookies([cookie]) {}
+                    }
+                }
+            }
+        }
+    }
+
+    init(cookieJar: CookieJar) {
+        var cookies: [HTTPCookie] = []
+
+        self.cookieJar = cookieJar
+
+        cookieJar.getCookies { jarCookies in
+            cookies = jarCookies
+        }
+
+        if let cookie = cookies.first(where: { $0.name == StoreSandboxSecretScreen.storeSandboxSecretKey }) {
+            _secret = State(initialValue: cookie.value)
+        } else {
+            _secret = State(initialValue: "")
+        }
+    }
+}
+
+struct StoreSandboxSecretScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        StoreSandboxSecretScreen(cookieJar: HTTPCookieStorage.shared)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Developer/StoreSandboxSecretScreen.swift
+++ b/WordPress/Classes/ViewRelated/Developer/StoreSandboxSecretScreen.swift
@@ -19,18 +19,17 @@ struct StoreSandboxSecretScreen: View {
             .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
         }
         .onDisappear() {
-            // This seems to be necessary do to an iOS bug where
+            // This seems to be necessary due to an iOS bug where
             // accessing presentationMode.wrappedValue crashes.
             DispatchQueue.main.async {
-                if(self.presentationMode.wrappedValue.isPresented == false) {
-                    if let cookie = HTTPCookie(properties: [
-                        .name: StoreSandboxSecretScreen.storeSandboxSecretKey,
-                        .value: secret,
-                        .domain: ".wordpress.com",
-                        .path: "/"
-                    ]) {
-                        cookieJar.setCookies([cookie]) {}
-                    }
+                if(self.presentationMode.wrappedValue.isPresented == false),
+                  let cookie = HTTPCookie(properties: [
+                    .name: StoreSandboxSecretScreen.storeSandboxSecretKey,
+                    .value: secret,
+                    .domain: ".wordpress.com",
+                    .path: "/"
+                  ]) {
+                    cookieJar.setCookies([cookie]) {}
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/Developer/StoreSandboxSecretScreen.swift
+++ b/WordPress/Classes/ViewRelated/Developer/StoreSandboxSecretScreen.swift
@@ -10,7 +10,7 @@ struct StoreSandboxSecretScreen: View {
     var body: some View {
         NavigationView {
             VStack(alignment: .leading) {
-                Text("Enter the Store Sandbox Secret:")
+                Text("Enter the Store Sandbox Cookie Secret:")
                 TextField("Secret", text: $secret)
                     .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
                     .border(Color.black)

--- a/WordPress/Classes/ViewRelated/Developer/StoreSandboxSecretScreen.swift
+++ b/WordPress/Classes/ViewRelated/Developer/StoreSandboxSecretScreen.swift
@@ -22,7 +22,7 @@ struct StoreSandboxSecretScreen: View {
             // This seems to be necessary due to an iOS bug where
             // accessing presentationMode.wrappedValue crashes.
             DispatchQueue.main.async {
-                if(self.presentationMode.wrappedValue.isPresented == false),
+                if self.presentationMode.wrappedValue.isPresented == false,
                   let cookie = HTTPCookie(properties: [
                     .name: StoreSandboxSecretScreen.storeSandboxSecretKey,
                     .value: secret,

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -71,7 +71,7 @@ class DebugMenuViewController: UITableViewController {
             ButtonRow(title: Strings.quickStartRow, action: { [weak self] _ in
                 self?.displayBlogPickerForQuickStart()
             }),
-            ButtonRow(title: "Use Store Sandbox", action: { [weak self] _ in
+            ButtonRow(title: Strings.sandboxStoreCookieSecretRow, action: { [weak self] _ in
                 self?.displayStoreSandboxSecretInserter()
             })
         ]
@@ -165,6 +165,7 @@ class DebugMenuViewController: UITableViewController {
         static let overridden = NSLocalizedString("Overridden", comment: "Used to indicate a setting is overridden in debug builds of the app")
         static let featureFlags = NSLocalizedString("Feature flags", comment: "Title of the Feature Flags screen used in debug builds of the app")
         static let tools = NSLocalizedString("Tools", comment: "Title of the Tools section of the debug screen used in debug builds of the app")
+        static let sandboxStoreCookieSecretRow = NSLocalizedString("Use Sandbox Store", comment: "Title of a row displayed on the debug screen used to configure the sandbox store use in the App.")
         static let quickStartRow = NSLocalizedString("Enable Quick Start for Site", comment: "Title of a row displayed on the debug screen used in debug builds of the app")
         static let sendTestCrash = NSLocalizedString("Send Test Crash", comment: "Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly")
         static let sendLogMessage = NSLocalizedString("Send Log Message", comment: "Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly")

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import AutomatticTracks
+import SwiftUI
 
 class DebugMenuViewController: UITableViewController {
     private var blogService: BlogService {
@@ -70,6 +71,9 @@ class DebugMenuViewController: UITableViewController {
             ButtonRow(title: Strings.quickStartRow, action: { [weak self] _ in
                 self?.displayBlogPickerForQuickStart()
             }),
+            ButtonRow(title: "Use Store Sandbox", action: { [weak self] _ in
+                self?.displayStoreSandboxSecretInserter()
+            })
         ]
     }
 
@@ -126,6 +130,13 @@ class DebugMenuViewController: UITableViewController {
 
         let navigationController = UINavigationController(rootViewController: selectorViewController)
         present(navigationController, animated: true)
+    }
+
+    private func displayStoreSandboxSecretInserter() {
+        let view = StoreSandboxSecretScreen(cookieJar: HTTPCookieStorage.shared)
+        let viewController = UIHostingController(rootView: view)
+
+        self.navigationController?.pushViewController(viewController, animated: true)
     }
 
     private func enableQuickStart(for blog: Blog) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2444,6 +2444,7 @@
 		F1C197A62670DDB100DE1FF7 /* BloggingRemindersTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C197A52670DDB100DE1FF7 /* BloggingRemindersTracker.swift */; };
 		F1C197A72670DDB100DE1FF7 /* BloggingRemindersTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C197A52670DDB100DE1FF7 /* BloggingRemindersTracker.swift */; };
 		F1C740BF26B18E42005D0809 /* StoreSandboxSecretScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C740BE26B18E42005D0809 /* StoreSandboxSecretScreen.swift */; };
+		F1C740C026B1D4D2005D0809 /* StoreSandboxSecretScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C740BE26B18E42005D0809 /* StoreSandboxSecretScreen.swift */; };
 		F1CBEB2A256F122A0031EBBC /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 433840C622C2BA5B00CB13F8 /* AppImages.xcassets */; };
 		F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
@@ -20199,6 +20200,7 @@
 				FABB25FC2602FC2C00C8785C /* StreakInsightStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB25FD2602FC2C00C8785C /* JetpackRemoteInstallState.swift in Sources */,
 				FABB25FE2602FC2C00C8785C /* Scheduler.swift in Sources */,
+				F1C740C026B1D4D2005D0809 /* StoreSandboxSecretScreen.swift in Sources */,
 				FABB25FF2602FC2C00C8785C /* RegisterDomainDetailsViewModel+RowDefinitions.swift in Sources */,
 				98E082A02637545C00537BF1 /* PostService+Likes.swift in Sources */,
 				FABB26002602FC2C00C8785C /* GravatarProfile.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2443,6 +2443,7 @@
 		F1B1E7A324098FA100549E2A /* BlogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B1E7A224098FA100549E2A /* BlogTests.swift */; };
 		F1C197A62670DDB100DE1FF7 /* BloggingRemindersTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C197A52670DDB100DE1FF7 /* BloggingRemindersTracker.swift */; };
 		F1C197A72670DDB100DE1FF7 /* BloggingRemindersTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C197A52670DDB100DE1FF7 /* BloggingRemindersTracker.swift */; };
+		F1C740BF26B18E42005D0809 /* StoreSandboxSecretScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C740BE26B18E42005D0809 /* StoreSandboxSecretScreen.swift */; };
 		F1CBEB2A256F122A0031EBBC /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 433840C622C2BA5B00CB13F8 /* AppImages.xcassets */; };
 		F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
@@ -7278,6 +7279,7 @@
 		F1B1E7A224098FA100549E2A /* BlogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogTests.swift; sourceTree = "<group>"; };
 		F1BBA95E243BEFC500E9E5E6 /* WordPress 95.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 95.xcdatamodel"; sourceTree = "<group>"; };
 		F1C197A52670DDB100DE1FF7 /* BloggingRemindersTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingRemindersTracker.swift; sourceTree = "<group>"; };
+		F1C740BE26B18E42005D0809 /* StoreSandboxSecretScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreSandboxSecretScreen.swift; sourceTree = "<group>"; };
 		F1D690141F828FF000200E30 /* BuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfiguration.swift; sourceTree = "<group>"; };
 		F1D690151F828FF000200E30 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		F1DB8D282288C14400906E2F /* Uploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Uploader.swift; sourceTree = "<group>"; };
@@ -10843,6 +10845,7 @@
 		8584FDB31923EF4F0019C02E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				F1C740BD26B18DEA005D0809 /* Developer */,
 				1717139D265FE56A00F3A022 /* Reusable SwiftUI Views */,
 				987E79C9261F8857000192B7 /* User Profile Sheet */,
 				7E3E9B6E2177C9C300FD5797 /* Gutenberg */,
@@ -13910,6 +13913,14 @@
 				F1ACDF4A256D6B2B0005AE9B /* WordPressIntents-Bridging-Header.h */,
 			);
 			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		F1C740BD26B18DEA005D0809 /* Developer */ = {
+			isa = PBXGroup;
+			children = (
+				F1C740BE26B18E42005D0809 /* StoreSandboxSecretScreen.swift */,
+			);
+			path = Developer;
 			sourceTree = "<group>";
 		};
 		F1D690131F828FF000200E30 /* BuildInformation */ = {
@@ -17725,6 +17736,7 @@
 				3FD83CBF246C751800381999 /* CoreDataIterativeMigrator.swift in Sources */,
 				17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */,
 				400A2C832217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift in Sources */,
+				F1C740BF26B18E42005D0809 /* StoreSandboxSecretScreen.swift in Sources */,
 				5D42A3E2175E7452005CFF05 /* ReaderPost.m in Sources */,
 				D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */,
 				46183CF4251BD658004F9AFD /* PageTemplateLayout+CoreDataClass.swift in Sources */,


### PR DESCRIPTION
Adds the Store Sandbox secret debug menu item.

This PR also makes the debug menu available for internal releases.

## To test:

### Prerequisites:

- Make sure you have Store Sandbox credits.
- Make sure you have the Store Sandbox secret.

Please ping me if you have trouble with these.

### Steps:

1. Run the app.
2. Go to Me > App Settings > Debug > Use Store Sandbox
3. Fill in the Store Sandbox secret
4. Go to a blog of yours that has a plan that you can use to purchase a free domain.
5. Register a domain.
6. The flow will not complete because the domain can't be set as the primary domain, but you should otherwise see that it was successfully registered.  You can check this directly in the Store Sandbox.  Let me know if you need help.

## Regression Notes

1. Potential unintended areas of impact

None.  This feature is not user-facing and doesn't change anything that the users can trigger.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
