### PR TITLE
Comments: fix crashes

### DIFF
--- a/WordPress/Classes/Extensions/Comment+Interface.swift
+++ b/WordPress/Classes/Extensions/Comment+Interface.swift
@@ -11,7 +11,7 @@ extension Comment {
     ///
     @objc func relativeDateSectionIdentifier() -> String {
         // Normalize Dates: Time must not be considered. Just the raw dates
-        let fromDate = dateCreated.normalizedDate()
+        let fromDate = (dateCreated ?? Date()).normalizedDate()
         let toDate = Date().normalizedDate()
 
         // Analyze the Delta-Components

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -65,7 +65,7 @@ extension Comment {
 private extension Comment {
 
     func decodedContent() -> String {
-        return content.stringByDecodingXMLCharacters().trim().strippingHTML().normalizingWhitespace() ?? String()
+        return content?.stringByDecodingXMLCharacters().trim().strippingHTML().normalizingWhitespace() ?? String()
     }
 
     func authorName() -> String {
@@ -109,11 +109,15 @@ extension Comment: PostContentProvider {
     }
 
     public func avatarURLForDisplay() -> URL? {
-        return URL(string: authorAvatarURL)
+        guard let url = authorAvatarURL,
+              !url.isEmpty else {
+            return nil
+        }
+        return URL(string: url)
     }
 
     public func gravatarEmailForDisplay() -> String {
-        return author_email.trim() ?? String()
+        return author_email?.trim() ?? String()
     }
 
     public func dateForDisplay() -> Date? {

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -1146,7 +1146,8 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     // Use raw_content for blog comments so
     // This is a temporary mixmatch of properties for a frozen branch bug fix that we'll sort out properly in develop.
     // - @aerych
-    comment.content = remoteComment.rawContent;
+    // Also, self-hosted doesn't have rawContent, so default to content.
+    comment.content = remoteComment.rawContent ?: remoteComment.content;
     comment.dateCreated = remoteComment.date;
     comment.link = remoteComment.link;
     comment.parentID = remoteComment.parentID;


### PR DESCRIPTION
Ref: #16876

This fixes the following issues:
- My Site > Comments > where a comment has no body: app crashes.
- My Site > Comments > where a user has no avatar: app crashes.
- My Site > Comments > Comment details > Reply: app crashes.
- Self-hosted > Comments: all the comment bodies are empty.

To test:
- Go to My Site > Comments with comments:
  - That have no body.
  - A commenter has not avatar.
- Verify the app doesn't crash, and the comments appear as expected.
- Reply to a comment. 
- Verify the app doesn't crash and the reply is sent successfully.
- On a self-hosted site, verify the comments have content.


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
