### PR TITLE
Reader Post: Update likes summary text to include like from self

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -96,7 +96,7 @@ private extension ReaderDetailLikesView {
     func updateSummaryLabel() {
         switch (displaysSelfAvatar, totalLikes) {
         case (true, 0):
-            summaryLabel.attributedText = .init(string: SummaryLabelFormats.onlySelf)
+            summaryLabel.text = SummaryLabelFormats.onlySelf
         case (true, 1):
             summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singularWithSelf, totalLikes))
         case (true, _) where totalLikes > 1:

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -96,7 +96,7 @@ private extension ReaderDetailLikesView {
     func updateSummaryLabel() {
         switch (displaysSelfAvatar, totalLikes) {
         case (true, 0):
-            summaryLabel.text = SummaryLabelFormats.onlySelf
+            summaryLabel.attributedText = highlightedText(SummaryLabelFormats.onlySelf)
         case (true, 1):
             summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singularWithSelf, totalLikes))
         case (true, _) where totalLikes > 1:
@@ -157,13 +157,13 @@ private extension ReaderDetailLikesView {
     }
 
     struct SummaryLabelFormats {
-        static let onlySelf = NSLocalizedString("You like this.",
+        static let onlySelf = NSLocalizedString("You_ like this.",
                                                 comment: "Describes that the current user is the only one liking the post.")
-        static let singularWithSelf = NSLocalizedString("You and _%1$d blogger_ like this.",
+        static let singularWithSelf = NSLocalizedString("You and %1$d blogger_ like this.",
                                                         comment: "Singular format string for displaying the number of post likes, including the like from self."
                                                             + " %1$d is the number of likes, excluding the like by current user."
                                                             + " The underscore denotes underline and is not displayed.")
-        static let pluralWithSelf = NSLocalizedString("You and _%1$d bloggers_ like this.",
+        static let pluralWithSelf = NSLocalizedString("You and %1$d bloggers_ like this.",
                                                       comment: "Plural format string for displaying the number of post likes, including the like from self."
                                                         + " %1$d is the number of likes, excluding the like by current user."
                                                         + " The underscore denotes underline and is not displayed.")
@@ -177,25 +177,14 @@ private extension ReaderDetailLikesView {
 
     func highlightedText(_ text: String) -> NSAttributedString {
         let labelParts = text.components(separatedBy: "_")
-        let indexToUnderline: Int = {
-            switch labelParts.count {
-            case 2: // handles singular and plural SummaryLabelFormats.
-                return 0
-            case 3: // handles singularWithSelf and pluralWithSelf SummaryLabelFormats.
-                return 1
-            default: // for other cases, do not apply the underline style.
-                return -1
-            }
-        }()
+        let countPart = labelParts.first ?? ""
+        let likesPart = labelParts.last ?? ""
 
-        let normalAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.secondaryLabel]
         let underlineAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.primary,
                                                                   .underlineStyle: NSUnderlineStyle.single.rawValue]
 
-        let attributedString = NSMutableAttributedString()
-        for (index, string) in labelParts.enumerated() {
-            attributedString.append(.init(string: string, attributes: index == indexToUnderline ? underlineAttributes : normalAttributes))
-        }
+        let attributedString = NSMutableAttributedString(string: countPart, attributes: underlineAttributes)
+        attributedString.append(NSAttributedString(string: likesPart, attributes: [.foregroundColor: UIColor.secondaryLabel]))
 
         return attributedString
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -94,8 +94,18 @@ private extension ReaderDetailLikesView {
     }
 
     func updateSummaryLabel() {
-        let summaryFormat = totalLikesForDisplay == 1 ? SummaryLabelFormats.singular : SummaryLabelFormats.plural
-        summaryLabel.attributedText = highlightedText(String(format: summaryFormat, totalLikesForDisplay))
+        switch (displaysSelfAvatar, totalLikes) {
+        case (true, 0):
+            summaryLabel.attributedText = .init(string: SummaryLabelFormats.onlySelf)
+        case (true, 1):
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singularWithSelf, totalLikes))
+        case (true, _) where totalLikes > 1:
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.pluralWithSelf, totalLikes))
+        case (false, 1):
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singular, totalLikes))
+        default:
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.plural, totalLikes))
+        }
     }
 
     func updateAvatars(with urlStrings: [String]) {
@@ -147,22 +157,45 @@ private extension ReaderDetailLikesView {
     }
 
     struct SummaryLabelFormats {
+        static let onlySelf = NSLocalizedString("You like this.",
+                                                comment: "Describes that the current user is the only one liking the post.")
+        static let singularWithSelf = NSLocalizedString("You and _%1$d blogger_ like this.",
+                                                        comment: "Singular format string for displaying the number of post likes, including the like from self."
+                                                            + " %1$d is the number of likes, excluding the like by current user."
+                                                            + " The underscore denotes underline and is not displayed.")
+        static let pluralWithSelf = NSLocalizedString("You and _%1$d bloggers_ like this.",
+                                                      comment: "Plural format string for displaying the number of post likes, including the like from self."
+                                                        + " %1$d is the number of likes, excluding the like by current user."
+                                                        + " The underscore denotes underline and is not displayed.")
         static let singular = NSLocalizedString("%1$d blogger_ likes this.",
-                                                comment: "Singular format string for displaying the number of post likes. %1$d is the number of likes. The underscore denotes underline and is not displayed.")
+                                                comment: "Singular format string for displaying the number of post likes."
+                                                    + " %1$d is the number of likes. The underscore denotes underline and is not displayed.")
         static let plural = NSLocalizedString("%1$d bloggers_ like this.",
-                                              comment: "Plural format string for displaying the number of post likes. %1$d is the number of likes. The underscore denotes underline and is not displayed.")
+                                              comment: "Plural format string for displaying the number of post likes."
+                                                + " %1$d is the number of likes. The underscore denotes underline and is not displayed.")
     }
 
     func highlightedText(_ text: String) -> NSAttributedString {
         let labelParts = text.components(separatedBy: "_")
-        let countPart = labelParts.first ?? ""
-        let likesPart = labelParts.last ?? ""
+        let indexToUnderline: Int = {
+            switch labelParts.count {
+            case 2: // handles singular and plural SummaryLabelFormats.
+                return 0
+            case 3: // handles singularWithSelf and pluralWithSelf SummaryLabelFormats.
+                return 1
+            default: // for other cases, do not apply the underline style.
+                return -1
+            }
+        }()
 
+        let normalAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.secondaryLabel]
         let underlineAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.primary,
                                                                   .underlineStyle: NSUnderlineStyle.single.rawValue]
 
-        let attributedString = NSMutableAttributedString(string: countPart, attributes: underlineAttributes)
-        attributedString.append(NSAttributedString(string: likesPart, attributes: [.foregroundColor: UIColor.secondaryLabel]))
+        let attributedString = NSMutableAttributedString()
+        for (index, string) in labelParts.enumerated() {
+            attributedString.append(.init(string: string, attributes: index == indexToUnderline ? underlineAttributes : normalAttributes))
+        }
 
         return attributedString
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
@@ -65,7 +65,7 @@
                         <constraint firstAttribute="height" constant="32" id="deH-0r-cgY"/>
                     </constraints>
                 </stackView>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilc-NW-l0X" userLabel="Summary Label">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilc-NW-l0X" userLabel="Summary Label">
                     <rect key="frame" x="160" y="0.0" width="0.0" height="42"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                     <color key="textColor" systemColor="secondaryLabelColor"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.xib
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -67,7 +68,7 @@
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ilc-NW-l0X" userLabel="Summary Label">
                     <rect key="frame" x="160" y="0.0" width="0.0" height="42"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <color key="textColor" systemColor="secondaryLabelColor"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
@@ -93,5 +94,8 @@
     </objects>
     <resources>
         <image name="gravatar" width="85" height="85"/>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
Refs: `pbArwn-2mK-p2#comment-3436`
Depends on #16936 

## Summary

This change introduces the "You and... " part when the post is liked by self. Here's some screenshots:

Scenario | Screenshot
--|--
The only liker of the post | ![only_self](https://user-images.githubusercontent.com/1299411/127496043-8cda5cf6-8c20-4211-a6e1-e3c49bbaf8d1.png)
Liked by self and one other person | ![singular_self](https://user-images.githubusercontent.com/1299411/127496050-accaae2b-a1ff-4408-9364-59ac37150b81.png)
Liked by self and several people | ![plural_self](https://user-images.githubusercontent.com/1299411/127496047-1dc1cd23-454d-4cfa-b2c0-d0aa0a337232.png)
Liked by one person | ![singular](https://user-images.githubusercontent.com/1299411/127496053-0c92b1ba-fe67-4761-9a52-16f75f9d774a.png)
Liked by several people | ![plural](https://user-images.githubusercontent.com/1299411/127496055-ac77757a-f7b6-41d0-af6d-fc8a4c7a78b4.png)

## To Test

- Open a post with only one like from you. Verify that the displayed text is "You like this".
- Open a post with likes from you and one other person. Verify that the displayed text is "You and 1 blogger like this".
- Open a post with likes from you and several people. Verify that the displayed text is "You and N bloggers like this".
- Open a post with likes from one person. Verify the displayed text is "1 blogger likes this". 
- Open a post with likes from several people. Verify the displayed text is "N bloggers like this".  

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
The changes are scoped only to `ReaderDetailLikesView`, which is only used by `ReaderDetailViewController`.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
