### PR TITLE
Comments: merge fixes from 17.9

### DIFF
--- a/WordPress/Classes/Extensions/Comment+Interface.swift
+++ b/WordPress/Classes/Extensions/Comment+Interface.swift
@@ -11,7 +11,7 @@ extension Comment {
     ///
     @objc func relativeDateSectionIdentifier() -> String {
         // Normalize Dates: Time must not be considered. Just the raw dates
-        let fromDate = dateCreated.normalizedDate()
+        let fromDate = (dateCreated ?? Date()).normalizedDate()
         let toDate = Date().normalizedDate()
 
         // Analyze the Delta-Components

--- a/WordPress/Classes/Models/Comment.swift
+++ b/WordPress/Classes/Models/Comment.swift
@@ -49,7 +49,7 @@ extension Comment {
         let formatter = DateFormatter()
         formatter.dateStyle = .long
         formatter.timeStyle = .none
-        return formatter.string(from: dateCreated)
+        return formatter.string(from: dateCreated ?? Date())
     }
 
     func numberOfLikes() -> Int {
@@ -112,11 +112,15 @@ extension Comment: PostContentProvider {
     }
 
     public func avatarURLForDisplay() -> URL? {
-        return URL(string: authorAvatarURL)
+        guard let url = authorAvatarURL,
+              !url.isEmpty else {
+            return nil
+        }
+        return URL(string: url)
     }
 
     public func gravatarEmailForDisplay() -> String {
-        return author_email.trim() ?? String()
+        return author_email?.trim() ?? String()
     }
 
     public func dateForDisplay() -> Date? {

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -1143,7 +1143,8 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     comment.author_url = remoteComment.authorUrl;
     comment.authorAvatarURL = remoteComment.authorAvatarURL;
     comment.content = remoteComment.content;
-    comment.rawContent = remoteComment.rawContent;
+    // self-hosted doesn't have rawContent, so default to content.
+    comment.rawContent = remoteComment.rawContent ?: remoteComment.content;
     comment.dateCreated = remoteComment.date;
     comment.link = remoteComment.link;
     comment.parentID = remoteComment.parentID;


### PR DESCRIPTION
Ref: #16944

This merges #16944 into develop.

To test:


- Go to My Site > Comments with comments:
  - That have no body.
  - A commenter has not avatar.
- Verify the app doesn't crash, and the comments appear as expected.
- Reply to a comment. 
  - NOTE: If there is not already a comment from today, the app will crash. The reply is created, so when relaunching the app it won't crash again. Silver lining? I'll fix this separately.
- Verify the app doesn't crash and the reply is sent successfully.
- On a self-hosted site, verify the comments have content.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
