### PR TITLE
Prevent hotfix failure because of missing Deliverfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,22 @@
+GIT
+  remote: git@github.com:wordpress-mobile/release-toolkit
+  revision: 111ffc070787a9375f9d5899892a9ebfe425dac6
+  branch: add-skip-deliver-in-ios-hotfix-version-bump
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (1.3.1)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (~> 12.3)
+      rake-compiler (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -91,7 +110,7 @@ GEM
     ethon (0.14.0)
       ffi (>= 1.15.0)
     excon (0.82.0)
-    faraday (1.5.0)
+    faraday (1.6.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -99,6 +118,7 @@ GEM
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-cookie_jar (0.0.7)
@@ -109,8 +129,9 @@ GEM
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
+    faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     fastimage (2.2.4)
@@ -161,19 +182,6 @@ GEM
       trainer
       xcodeproj
       xctest_list (>= 1.2.1)
-    fastlane-plugin-wpmreleasetoolkit (1.3.1)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      progress_bar (~> 1.3)
-      rake (~> 12.3)
-      rake-compiler (~> 1.0)
     ffi (1.15.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -249,7 +257,7 @@ GEM
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.12.0)
+    oj (3.12.2)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)
@@ -275,7 +283,7 @@ GEM
     ruby-enum (0.9.0)
       i18n
     ruby-macho (1.4.0)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.0)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
@@ -336,7 +344,7 @@ DEPENDENCIES
   fastlane-plugin-appcenter (~> 1.8)
   fastlane-plugin-sentry
   fastlane-plugin-test_center
-  fastlane-plugin-wpmreleasetoolkit (~> 1.3.1)
+  fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)
   rake
   rmagick (~> 3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,10 +34,10 @@ GEM
     bigdecimal (1.4.4)
     chroma (0.2.0)
     claide (1.0.3)
-    cocoapods (1.10.1)
+    cocoapods (1.10.2)
       addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.10.1)
+      cocoapods-core (= 1.10.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -52,7 +52,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.4)
       xcodeproj (>= 1.19.0, < 2.0)
-    cocoapods-core (1.10.1)
+    cocoapods-core (1.10.2)
       activesupport (> 5.0, < 6)
       addressable (~> 2.6)
       algoliasearch (~> 1.0)
@@ -174,7 +174,7 @@ GEM
       progress_bar (~> 1.3)
       rake (~> 12.3)
       rake-compiler (~> 1.0)
-    ffi (1.15.0)
+    ffi (1.15.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -312,12 +312,13 @@ GEM
     unicode-display_width (1.7.0)
     webrick (1.7.0)
     word_wrap (1.0.0)
-    xcodeproj (1.19.0)
+    xcodeproj (1.20.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
+      rexml (~> 3.2.4)
     xcpretty (0.3.0)
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
@@ -342,4 +343,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.2.21
+   2.2.23

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -247,7 +247,11 @@ platform :ios do
   desc 'Creates a new hotfix branch for the given version:x.y.z. The branch will be cut from the tag x.y of the previous release'
   lane :new_hotfix_release do |options|
     prev_ver = ios_hotfix_prechecks(options)
-    ios_bump_version_hotfix(previous_version: prev_ver, version: options[:version])
+    ios_bump_version_hotfix(
+      previous_version: prev_ver,
+      version: options[:version],
+      skip_deliver: true
+    )
   end
 
   #####################################################################################

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,9 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.3.1'
+gem 'fastlane-plugin-wpmreleasetoolkit',
+  git: 'git@github.com:wordpress-mobile/release-toolkit',
+  branch: 'add-skip-deliver-in-ios-hotfix-version-bump'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'


### PR DESCRIPTION
Updates the `new_hotfix_release` lane to work with the new repo setup that doesn't include a `Deliverfile`.

Tested as part of https://github.com/wordpress-mobile/release-toolkit/pull/287.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**