### PR TITLE
UC: Add extra top space to Notifications and Comments list

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -62,6 +62,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     [self configureRefreshControl];
     [self configureSyncHelper];
     [self configureTableView];
+    [self configureTableViewHeader];
     [self configureTableViewFooter];
     [self configureTableViewHandler];
 }
@@ -144,6 +145,17 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
         NSString *nibName = [CommentsTableViewCell classNameWithoutNamespaces];
         UINib *nibInstance = [UINib nibWithNibName:nibName bundle:[NSBundle mainBundle]];
         [self.tableView registerNib:nibInstance forCellReuseIdentifier:CommentsTableViewCell.reuseIdentifier];
+    }
+}
+
+- (void)configureTableViewHeader
+{
+    // Add an extra 10pt space on top of the first header view when displaying comments using the new unified list.
+    // The conditional should be removed when the feature is fully rolled out. See: https://git.io/JBQlU
+    if ([self usesUnifiedList]) {
+        UIView *tableHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.tableView.frame.size.width, 10)];
+        tableHeaderView.backgroundColor = [UIColor systemBackgroundColor];
+        self.tableView.tableHeaderView = tableHeaderView;
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -28,6 +28,12 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     ///
     @IBOutlet weak var filterTabBar: FilterTabBar!
 
+    /// The unified list requires an extra 10pt space on top of the list, but returns to the original padding
+    /// while scrolled and stickied. This should be removed once the unified list is fully rolled out.
+    /// See: https://git.io/JBQlU
+    ///
+    @IBOutlet private weak var filterTabBarBottomConstraint: NSLayoutConstraint!
+
     /// Inline Prompt Header View
     ///
     @IBOutlet var inlinePromptView: AppFeedbackPromptView!
@@ -105,6 +111,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
             // the value has changed in `viewWillAppear`. If so, reload the table view to use the correct design.
             if usesUnifiedList != oldValue {
                 reloadTableViewPreservingSelection()
+                updateFilterBarConstraints()
             }
         }
     }
@@ -579,6 +586,14 @@ private extension NotificationsViewController {
 
         filterTabBar.items = Filter.allFilters
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
+        updateFilterBarConstraints()
+    }
+
+    /// If notifications are displayed with the new unified list, add an extra space below the filter tab bar.
+    /// Once unified list is fully rolled out, this should be applied in Notifications.storyboard instead.
+    /// See: https://git.io/JBQlU
+    func updateFilterBarConstraints() {
+        filterTabBarBottomConstraint.constant = usesUnifiedList ? Constants.filterTabBarBottomSpace : 0
     }
 }
 
@@ -1854,6 +1869,8 @@ extension NotificationsViewController: UIViewControllerTransitioningDelegate {
         // number of notifications after which the second alert will show up
         static let secondNotificationsAlertThreshold = 10
         static let secondNotificationsAlertDisabled = -1
+        /// the amount of bottom padding added to the filter tab bar. To be used with unified list.
+        static let filterTabBarBottomSpace: CGFloat = 10.0
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="doV-5W-Rtg">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="doV-5W-Rtg">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -23,6 +23,7 @@
                     </tableView>
                     <connections>
                         <outlet property="filterTabBar" destination="p6x-Ny-2wu" id="Wui-ck-Vlw"/>
+                        <outlet property="filterTabBarBottomConstraint" destination="wg2-sw-4xq" id="yWl-kb-3Pv"/>
                         <outlet property="inlinePromptView" destination="SZM-LE-bID" id="ovr-0R-gdo"/>
                         <outlet property="tableHeaderView" destination="V09-JZ-6RQ" id="ga5-UG-6nB"/>
                         <segue destination="veA-Pg-QAw" kind="showDetail" identifier="NotificationDetailsViewController" id="qci-jy-59F"/>


### PR DESCRIPTION
Refs #16738, https://github.com/wordpress-mobile/WordPress-iOS/pull/16885#issuecomment-883824926

Based on the suggestion from @ScoutHarris and @mattmiklic, this PR adds an extra 10pt of space on the top of the first headers of unified list. Here's how it looks:

  | Top position | Scrolled position
--|--|--
Notifications |  ![notifications_top](https://user-images.githubusercontent.com/1299411/127834927-6ee6112f-d9e8-4798-83f5-d63b69239301.png) | ![notifications_scrolled](https://user-images.githubusercontent.com/1299411/127834933-9fb77ba5-ee7c-43ad-9bcf-4e8270d9712d.png)
Comments | ![comments_top](https://user-images.githubusercontent.com/1299411/127834961-106a583d-9279-419f-959c-5e970a692476.png) | ![comments_scrolled](https://user-images.githubusercontent.com/1299411/127834953-a0b809a0-e6c9-4b1b-bacf-93a336990697.png) 

Since the padding only exists at the top most and gone when scrolled, it's not possible to add the padding on the `ListTableHeaderView` – since doing this would also increase the padding when the view is stickied. Therefore, `tableHeaderView` property is utilized for this.

Also, cc-ing @mattmiklic to verify the designs, thank you!

To test:

- Go to Notifications, verify that the top padding is there.
- Go to Comments, verify that the top padding is there.
- Switch off the feature flag for unified list, and go to Notifications. Verify that the top padding does not affect the old design.
- Switch off the feature flag for unified list, and go to Comments. Verify that the top padding does not affect the old design.

## Regression Notes
1. Potential unintended areas of impact
Change may affect the old design.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Made sure that the padding is only active when the feature flag is on. Manually tested.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
