### PR TITLE
Likes summary formats: mark the beginning of the underlined text

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -98,11 +98,11 @@ private extension ReaderDetailLikesView {
         case (true, 0):
             summaryLabel.attributedText = highlightedText(SummaryLabelFormats.onlySelf)
         case (true, 1):
-            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singularWithSelf, totalLikes))
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singularWithSelf))
         case (true, _) where totalLikes > 1:
             summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.pluralWithSelf, totalLikes))
         case (false, 1):
-            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singular, totalLikes))
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singular))
         default:
             summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.plural, totalLikes))
         }
@@ -158,21 +158,20 @@ private extension ReaderDetailLikesView {
 
     struct SummaryLabelFormats {
         static let onlySelf = NSLocalizedString("_You_ like this.",
-                                                comment: "Describes that the current user is the only one liking the post.")
-        static let singularWithSelf = NSLocalizedString("_You and %1$d blogger_ like this.",
-                                                        comment: "Singular format string for displaying the number of post likes, including the like from self."
-                                                            + " %1$d is the number of likes, excluding the like by current user."
-                                                            + " The underscore denotes underline and is not displayed.")
+                                                comment: "Describes that the current user is the only one liking a post."
+                                                    + " The underscores denote underline and is not displayed.")
+        static let singularWithSelf = NSLocalizedString("_You and 1 blogger_ like this.",
+                                                        comment: "Describes that the current user and one other user like a post."
+                                                            + " The underscores denote underline and is not displayed.")
         static let pluralWithSelf = NSLocalizedString("_You and %1$d bloggers_ like this.",
-                                                      comment: "Plural format string for displaying the number of post likes, including the like from self."
+                                                      comment: "Plural format string for displaying the number of post likes, including the like from the current user."
                                                         + " %1$d is the number of likes, excluding the like by current user."
-                                                        + " The underscore denotes underline and is not displayed.")
-        static let singular = NSLocalizedString("_%1$d blogger_ likes this.",
-                                                comment: "Singular format string for displaying the number of post likes."
-                                                    + " %1$d is the number of likes. The underscore denotes underline and is not displayed.")
+                                                        + " The underscores denote underline and is not displayed.")
+        static let singular = NSLocalizedString("_1 blogger_ likes this.",
+                                                comment: "Describes that only one user likes a post. The underscores denote underline and is not displayed.")
         static let plural = NSLocalizedString("_%1$d bloggers_ like this.",
                                               comment: "Plural format string for displaying the number of post likes."
-                                                + " %1$d is the number of likes. The underscore denotes underline and is not displayed.")
+                                                + " %1$d is the number of likes. The underscores denote underline and is not displayed.")
     }
 
     func highlightedText(_ text: String) -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -157,34 +157,38 @@ private extension ReaderDetailLikesView {
     }
 
     struct SummaryLabelFormats {
-        static let onlySelf = NSLocalizedString("You_ like this.",
+        static let onlySelf = NSLocalizedString("_You_ like this.",
                                                 comment: "Describes that the current user is the only one liking the post.")
-        static let singularWithSelf = NSLocalizedString("You and %1$d blogger_ like this.",
+        static let singularWithSelf = NSLocalizedString("_You and %1$d blogger_ like this.",
                                                         comment: "Singular format string for displaying the number of post likes, including the like from self."
                                                             + " %1$d is the number of likes, excluding the like by current user."
                                                             + " The underscore denotes underline and is not displayed.")
-        static let pluralWithSelf = NSLocalizedString("You and %1$d bloggers_ like this.",
+        static let pluralWithSelf = NSLocalizedString("_You and %1$d bloggers_ like this.",
                                                       comment: "Plural format string for displaying the number of post likes, including the like from self."
                                                         + " %1$d is the number of likes, excluding the like by current user."
                                                         + " The underscore denotes underline and is not displayed.")
-        static let singular = NSLocalizedString("%1$d blogger_ likes this.",
+        static let singular = NSLocalizedString("_%1$d blogger_ likes this.",
                                                 comment: "Singular format string for displaying the number of post likes."
                                                     + " %1$d is the number of likes. The underscore denotes underline and is not displayed.")
-        static let plural = NSLocalizedString("%1$d bloggers_ like this.",
+        static let plural = NSLocalizedString("_%1$d bloggers_ like this.",
                                               comment: "Plural format string for displaying the number of post likes."
                                                 + " %1$d is the number of likes. The underscore denotes underline and is not displayed.")
     }
 
     func highlightedText(_ text: String) -> NSAttributedString {
         let labelParts = text.components(separatedBy: "_")
-        let countPart = labelParts.first ?? ""
-        let likesPart = labelParts.last ?? ""
 
+        let firstPart = labelParts.first ?? ""
+        let countPart = labelParts[safe: 1] ?? ""
+        let lastPart = labelParts.last ?? ""
+
+        let foregroundAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.secondaryLabel]
         let underlineAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.primary,
                                                                   .underlineStyle: NSUnderlineStyle.single.rawValue]
 
-        let attributedString = NSMutableAttributedString(string: countPart, attributes: underlineAttributes)
-        attributedString.append(NSAttributedString(string: likesPart, attributes: [.foregroundColor: UIColor.secondaryLabel]))
+        let attributedString = NSMutableAttributedString(string: firstPart, attributes: foregroundAttributes)
+        attributedString.append(NSAttributedString(string: countPart, attributes: underlineAttributes))
+        attributedString.append(NSAttributedString(string: lastPart, attributes: foregroundAttributes))
 
         return attributedString
     }


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/pull/16952#discussion_r679885122
Branched from: https://github.com/wordpress-mobile/WordPress-iOS/pull/16946

This updates the Likes Summary string formats to clearly mark the beginning of the underlined text. As @AliSoftware pointed out in the referenced PR, simply marking the end of the underlined text may not work in all languages and could be confusing to translators.

Since the strings have been modified with https://github.com/wordpress-mobile/WordPress-iOS/pull/16946, they aren't translated yet. So below I've put test strings you can use to verify highlighting different parts of the strings.

To test:
- Go to Reader > any post with likes.
- Scroll to the likes summary.
  - Verify the highlighting is as expected.
- Change the strings so the highlighted text is in the middle.
  - Verify the highlighting is as expected.
- Change the strings so the highlighted text is at the end.
  - Verify the highlighting is as expected.

---
Underline within the string:

```
static let onlySelf = NSLocalizedString("Test before _You_ like this.",
                                        comment: "Describes that the current user is the only one liking the post.")
static let singularWithSelf = NSLocalizedString("Test before _You and %1$d blogger_ like this.",
                                                comment: "Singular format string for displaying the number of post likes, including the like from self."
                                                    + " %1$d is the number of likes, excluding the like by current user."
                                                    + " The underscore denotes underline and is not displayed.")
static let pluralWithSelf = NSLocalizedString("Test before _You and %1$d bloggers_ like this.",
                                              comment: "Plural format string for displaying the number of post likes, including the like from self."
                                                + " %1$d is the number of likes, excluding the like by current user."
                                                + " The underscore denotes underline and is not displayed.")
static let singular = NSLocalizedString("Test before _%1$d blogger_ likes this.",
                                        comment: "Singular format string for displaying the number of post likes."
                                            + " %1$d is the number of likes. The underscore denotes underline and is not displayed.")
static let plural = NSLocalizedString("Test before _%1$d bloggers_ like this.",
                                      comment: "Plural format string for displaying the number of post likes."
                                        + " %1$d is the number of likes. The underscore denotes underline and is not displayed.")
```

---
Underline at end of string:

```
static let onlySelf = NSLocalizedString("Test at end _You_",
                                        comment: "Describes that the current user is the only one liking the post.")
static let singularWithSelf = NSLocalizedString("Test at end _You and %1$d blogger_",
                                                comment: "Singular format string for displaying the number of post likes, including the like from self."
                                                    + " %1$d is the number of likes, excluding the like by current user."
                                                    + " The underscore denotes underline and is not displayed.")
static let pluralWithSelf = NSLocalizedString("Test at end _You and %1$d bloggers_",
                                              comment: "Plural format string for displaying the number of post likes, including the like from self."
                                                + " %1$d is the number of likes, excluding the like by current user."
                                                + " The underscore denotes underline and is not displayed.")
static let singular = NSLocalizedString("Test at end _%1$d blogger_",
                                        comment: "Singular format string for displaying the number of post likes."
                                            + " %1$d is the number of likes. The underscore denotes underline and is not displayed.")
static let plural = NSLocalizedString("Test at end _%1$d bloggers_",
                                      comment: "Plural format string for displaying the number of post likes."
                                        + " %1$d is the number of likes. The underscore denotes underline and is not displayed.")
```
---

## Regression Notes
1. Potential unintended areas of impact
Likes summary highlighting could be incorrect.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested various formats.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
