### PR TITLE
Post: Use a post's titleForDisplay for notices.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Updated the header text sizes to better support large texts on Choose a Domain and Choose a Design flows. [#16923]
 * [internal] Made a change to how Comment content is displayed. Should be no visible changes, but could cause regressions. [#16933]
+* [*] Posts: Ampersands are correctly decoded in publishing notices instead of showing as HTML entites. [#16972]
 
 17.9
 -----

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -126,7 +126,7 @@ struct PostNoticeViewModel {
 
     private var message: String {
         let title = post.titleForDisplay() ?? ""
-        if title.count > 0 {
+        if !title.isEmpty {
             return title
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -125,7 +125,7 @@ struct PostNoticeViewModel {
     }
 
     private var message: String {
-        let title = post.postTitle ?? ""
+        let title = post.titleForDisplay() ?? ""
         if title.count > 0 {
             return title
         }


### PR DESCRIPTION
Fixes #16776

This PR uses `.titleForDisplay()` for notices instead of `.postTitle`.  The `.titleForDisplay()` method handles decoding XML and other HTML entities. With this change post publish notices should no longer show `&amp;` where instead they should show `&`. 

![Simulator Screen Shot - iPhone 11 - 2021-08-03 at 16 32 26](https://user-images.githubusercontent.com/1435271/128090416-646f6cd8-e8b4-4e08-b862-784504c040e5.png)
![Simulator Screen Shot - iPhone 11 - 2021-08-03 at 16 33 16](https://user-images.githubusercontent.com/1435271/128090420-ab52bb44-ec2b-4116-8edd-f76d54e94ca7.png)


To test:
Follow the steps to reproduce outlined in the issue.  Confirm that ampersands are correctly displayed.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
