### PR TITLE
Logging: Log upload failure due to missing media as message rather than an error

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -715,8 +715,7 @@ extension MediaCoordinator {
             }
 
             self.cancelUploadAndDeleteMedia(media)
-            WordPressAppDelegate.crashLogging?.logError(mediaError,
-                                  userInfo: ["description": "Deleting a media object that's failed to upload because of a missing local file."])
+            WordPressAppDelegate.crashLogging?.logMessage("Deleting a media object that's failed to upload because of a missing local file. \(mediaError)")
 
         }, for: nil)
     }


### PR DESCRIPTION
Closes #16940
This changes a logError to a logMessage statement to avoid adding noise to crash reports about an informational log statement. 

@mokagio, since you're familiar with the background would you be game to review? 

To test:
Not much to this one. Confirm the app builds with no errors, and that the change is the desired manner of logging. 

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
