### PR TITLE
Check Zendesk Views in Help Section UI test

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -805,6 +805,7 @@ private extension ZendeskUtils {
             textField.delegate = ZendeskUtils.sharedInstance
             textField.isEnabled = false
             textField.keyboardType = .emailAddress
+            textField.accessibilityIdentifier = "contact-alert-email-field"
 
             textField.addTarget(self,
                                 action: #selector(emailTextFieldDidChange),
@@ -820,6 +821,7 @@ private extension ZendeskUtils {
                 textField.text = ZendeskUtils.sharedInstance.userName
                 textField.delegate = ZendeskUtils.sharedInstance
                 textField.isEnabled = false
+                textField.accessibilityIdentifier = "contact-alert-name-field"
                 ZendeskUtils.sharedInstance.alertNameField = textField
             }
         }

--- a/WordPress/WordPressUITests/Screens/Me/SupportScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Me/SupportScreen.swift
@@ -13,6 +13,10 @@ private struct ElementStringIDs {
     static let myTicketsTitle = "My Tickets"
     static let ZDcancelButton = "ZDKbackButton"
     static let ZDticketsCancelButton = "Cancel"
+    // Contact Alert Modal
+    static let contactEmailField = "contact-alert-email-field"
+    static let contactNameField = "contact-alert-name-field"
+    static let alertOkButton = "OK"
 }
 
 /// This screen object is for the Support section. In the app, it's a modal we can get to from Me 
@@ -30,6 +34,10 @@ class SupportScreen: BaseScreen {
     let myTicketsTitle: XCUIElement
     let ZDcancelButton: XCUIElement
     let ZDticketsCancelButton: XCUIElement
+    // Contact Alert Modal
+    let contactEmailField: XCUIElement
+    let contactNameField: XCUIElement
+    let alertOkButton: XCUIElement
 
 
     init() {
@@ -45,6 +53,10 @@ class SupportScreen: BaseScreen {
         myTicketsTitle = app.staticTexts[ElementStringIDs.myTicketsTitle]
         ZDcancelButton = app.buttons[ElementStringIDs.ZDcancelButton]
         ZDticketsCancelButton = app.buttons[ElementStringIDs.ZDticketsCancelButton]
+        // Contact Alert Modal
+        contactEmailField = app.textFields[ElementStringIDs.contactEmailField]
+        contactNameField = app.textFields[ElementStringIDs.contactNameField]
+        alertOkButton = app.buttons[ElementStringIDs.alertOkButton]
 
         super.init(element: activityLogs)
 
@@ -60,8 +72,19 @@ class SupportScreen: BaseScreen {
         closeButton.tap()
     }
 
+    func handleContactAlertModal() {
+        // first, check that the modal is here. Accessibility Inspector doesn't know how to look at the whole modal.
+        contactEmailField.tap()
+        contactEmailField.typeText("email@test.com")
+        contactNameField.tap()
+        contactNameField.typeText("my name")
+        alertOkButton.tap()
+    }
+
     func loadContactUs() {
         contact.tap()
+        // check.emailmodal or something - need to see if that modal is up and fill it if so.
+        handleContactAlertModal()
         XCTAssert(contactSupportTitle.exists)
         ZDcancelButton.tap()
     }

--- a/WordPress/WordPressUITests/Screens/Me/SupportScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Me/SupportScreen.swift
@@ -60,6 +60,18 @@ class SupportScreen: BaseScreen {
         closeButton.tap()
     }
 
+    func loadContactUs() {
+        contact.tap()
+        XCTAssert(contactSupportTitle.exists)
+        ZDcancelButton.tap()
+    }
+
+    func loadMyTickets() {
+        myTickets.tap()
+        XCTAssert(myTicketsTitle.exists)
+        ZDticketsCancelButton.tap()
+    }
+
     static func isLoaded() -> Bool {
         return XCUIApplication().buttons[ElementStringIDs.activityLogs].exists
     }

--- a/WordPress/WordPressUITests/Screens/Me/SupportScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Me/SupportScreen.swift
@@ -8,6 +8,11 @@ private struct ElementStringIDs {
     static let myTickets = "my-tickets-button"
     static let contactEmail = "set-contact-email-button"
     static let activityLogs = "activity-logs-button"
+    // In Zendesk Views
+    static let contactSupportTitle = "Contact us"
+    static let myTicketsTitle = "My Tickets"
+    static let ZDcancelButton = "ZDKbackButton"
+    static let ZDticketsCancelButton = "Cancel"
 }
 
 /// This screen object is for the Support section. In the app, it's a modal we can get to from Me 
@@ -20,6 +25,12 @@ class SupportScreen: BaseScreen {
     let myTickets: XCUIElement
     let contactEmail: XCUIElement
     let activityLogs: XCUIElement
+    // In Zendesk Views
+    let contactSupportTitle: XCUIElement
+    let myTicketsTitle: XCUIElement
+    let ZDcancelButton: XCUIElement
+    let ZDticketsCancelButton: XCUIElement
+
 
     init() {
         let app = XCUIApplication()
@@ -29,6 +40,11 @@ class SupportScreen: BaseScreen {
         myTickets = app.cells[ElementStringIDs.myTickets]
         contactEmail = app.cells[ElementStringIDs.contactEmail]
         activityLogs = app.cells[ElementStringIDs.activityLogs]
+        // In Zendesk Views
+        contactSupportTitle = app.staticTexts[ElementStringIDs.contactSupportTitle]
+        myTicketsTitle = app.staticTexts[ElementStringIDs.myTicketsTitle]
+        ZDcancelButton = app.buttons[ElementStringIDs.ZDcancelButton]
+        ZDticketsCancelButton = app.buttons[ElementStringIDs.ZDticketsCancelButton]
 
         super.init(element: activityLogs)
 

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -15,11 +15,15 @@ class SupportScreenTests: XCTestCase {
     }
 
     // Test Support Section Loads
-    // From Prologue > continue, tap "help" and make sure Support Screen loads
+    // From Prologue > continue, tap "help" and make sure Support Screen loads and Zendesk items are accessible
     func testSupportScreenLoads() {
         let supportScreen = PrologueScreen().selectContinue().selectHelp()
 
         XCTAssert(supportScreen.isLoaded())
+
+        supportScreen.loadContactUs()
+
+        supportScreen.loadMyTickets()
 
         //Dismiss because tearDown() can't handle modals currently
         supportScreen.dismiss()


### PR DESCRIPTION
This PR is part of updating our login tests to account for the Unified Login & Signup flows. Context & status: paaHJt-1Kx-p2
This PR expands a recently-added (see https://github.com/wordpress-mobile/WordPress-iOS/pull/16837) UI test, `testSupportScreenLoads()`, to check that Zendesk Views can be opened.

This test should catch issues like https://github.com/wordpress-mobile/WordPress-iOS/issues/16953 in the future.
So, it's important that the Support page loads, but also that the key items appear.

To test:
Run `testSupportScreenLoads()` from SignupTests.swift in Xcode.